### PR TITLE
Fixes #89 - Make help text prettier

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -15,11 +15,100 @@
 package main
 
 import (
-	"flag"
 	"time"
 
 	mountpkg "github.com/googlecloudplatform/gcsfuse/mount"
+	"github.com/jgeewax/cli"
 )
+
+func getApp() (app *cli.App) {
+	app = cli.NewApp()
+	app.Name = "gcsfuse"
+	app.Usage = "Mount a GCS bucket locally"
+	app.ArgumentUsage = "bucket mountpoint"
+	app.HideHelp = true
+	app.Version = "0.1.0"
+	app.Flags = []cli.Flag{
+		cli.IntFlag{
+			Name: "dir-mode, d",
+			Usage: "Permissions bits for directories. (default: 0755)",
+			HideDefault: true,
+		},
+		cli.IntFlag{
+			Name: "file-mode, f",
+			Value: 0644,
+			Usage: "Permission bits for files (default: 0644)",
+			HideDefault: true,
+		},
+		cli.IntFlag{
+			Name: "gcs-chunk-size",
+			Value: 1<<24,
+			Usage: "Max chunk size for loading GCS objects.",
+		},
+		cli.IntFlag{
+			Name: "gid",
+			Value: -1,
+			HideDefault: true,
+			Usage: "GID owner of all inodes.",
+		},
+		cli.BoolFlag{
+			Name: "implicit-dirs",
+			Usage: "Implicitly define directories based on content. See" +
+			"docs/semantics.md",
+		},
+		cli.Float64Flag{
+			Name: "limit-bytes-per-sec",
+			Value: -1,
+			Usage: "Bandwidth limit for reading data, measured over a 30-second " +
+			"window. (use -1 for no limit)",
+		},
+		cli.Float64Flag{
+			Name: "limit-ops-per-sec",
+			Value: 5.0,
+			Usage: "Operations per second limit, measured over a 30-second window " +
+			"(use -1 for no limit)",
+		},
+		cli.StringFlag{
+			Name: "mount-options, o",
+			HideDefault: true,
+			Usage: "Additional system-specific mount options. Be careful!",
+		},
+		cli.DurationFlag{
+			Name: "stat-cache-ttl",
+			Value: time.Minute,
+			Usage: "How long to cache StatObject results from GCS.",
+		},
+		cli.DurationFlag{
+			Name: "type-cache-ttl",
+			Value: time.Minute,
+			Usage: "How long to cache name -> file/dir mappings in directory " +
+			"inodes.",
+		},
+		cli.StringFlag{
+			Name: "temp-dir, t",
+			Value: "",
+			HideDefault: true,
+			Usage: "Temporary directory for local GCS object copies. " +
+			"(default: system default, likely /tmp)",
+		},
+		cli.IntFlag{
+			Name: "temp-dir-bytes",
+			Value: 1<<31,
+			Usage: "Size limit of the temporary directory.",
+		},
+		cli.IntFlag{
+			Name: "uid",
+			Value: -1,
+			HideDefault: true,
+			Usage: "UID owner of all inodes.",
+		},
+		cli.BoolFlag{
+			Name: "help, h",
+			Usage: "print this help text",
+		},
+	}
+	return app
+}
 
 type flagStorage struct {
 	MountOptions                       map[string]string
@@ -39,92 +128,21 @@ type flagStorage struct {
 
 // Add the flags accepted by run to the supplied flag set, returning the
 // variables into which the flags will parse.
-func populateFlagSet(fs *flag.FlagSet) (flags *flagStorage) {
+func populateFlags(c *cli.Context) (flags *flagStorage) {
 	flags = new(flagStorage)
-
 	flags.MountOptions = make(map[string]string)
-	fs.Var(
-		mountpkg.OptionValue(flags.MountOptions),
-		"o",
-		"Additional system-specific mount options. Be careful!")
-
-	fs.Int64Var(
-		&flags.Uid,
-		"uid",
-		-1,
-		"If non-negative, the UID that owns all inodes. The default is the UID of "+
-			"the gcsfuse process.")
-
-	fs.Int64Var(
-		&flags.Gid,
-		"gid",
-		-1,
-		"If non-negative, the GID that owns all inodes. The default is the GID of "+
-			"the gcsfuse process.")
-
-	fs.UintVar(
-		&flags.FileMode,
-		"file-mode",
-		0644,
-		"Permissions bits for files. Default is 0644.")
-
-	fs.UintVar(
-		&flags.DirMode,
-		"dir-mode",
-		0755,
-		"Permissions bits for directories. Default is 0755.")
-
-	fs.StringVar(
-		&flags.TempDir,
-		"temp-dir", "",
-		"The temporary directory in which to store local copies of GCS objects. "+
-			"If empty, the system default (probably /tmp) will be used.")
-
-	fs.Int64Var(
-		&flags.TempDirLimit,
-		"temp-dir-bytes", 1<<31,
-		"A desired limit on the number of bytes used in --temp-dir. May be "+
-			"exceeded for dirty files that have not been flushed or closed.")
-
-	fs.Uint64Var(
-		&flags.GCSChunkSize,
-		"gcs-chunk-size", 1<<24,
-		"If set to a non-zero value N, split up GCS objects into multiple "+
-			"chunks of size at most N when reading, and do not read or cache "+
-			"unnecessary chunks.")
-
-	fs.BoolVar(
-		&flags.ImplicitDirs,
-		"implicit-dirs",
-		false,
-		"Implicitly define directories based on their content. See "+
-			"docs/semantics.md.")
-
-	fs.DurationVar(
-		&flags.StatCacheTTL,
-		"stat-cache-ttl",
-		time.Minute,
-		"How long to cache StatObject results from GCS.")
-
-	fs.DurationVar(
-		&flags.TypeCacheTTL,
-		"type-cache-ttl",
-		time.Minute,
-		"How long to cache name -> file/dir type mappings in directory inodes.")
-
-	fs.Float64Var(
-		&flags.OpRateLimitHz,
-		"limit-ops-per-sec",
-		5.0,
-		"If positive, a limit on the rate at which we send requests to GCS, "+
-			"measured over a 30-second window.")
-
-	fs.Float64Var(
-		&flags.EgressBandwidthLimitBytesPerSecond,
-		"limit-bytes-per-sec",
-		-1,
-		"If positive, a limit on the GCS -> gcsfuse bandwidth for reading "+
-			"objects, measured over a 30-second window.")
-
+	mountpkg.OptionValue(flags.MountOptions).Set(c.String("mount-options"))
+	flags.Uid = int64(c.Int("uid"))
+	flags.Gid = int64(c.Int("gid"))
+	flags.FileMode = uint(c.Int("file-mode"))
+	flags.DirMode = uint(c.Int("dir-mode"))
+	flags.TempDir = c.String("temp-dir")
+	flags.TempDirLimit = int64(c.Int("temp-dir-bytes"))
+	flags.GCSChunkSize = uint64(c.Int("gcs-chunk-size"))
+	flags.ImplicitDirs = c.Bool("implicit-dirs")
+	flags.StatCacheTTL = c.Duration("stat-cache-ttl")
+	flags.TypeCacheTTL = c.Duration("type-cache-ttl")
+	flags.OpRateLimitHz = c.Float64("limit-ops-per-sec")
+	flags.EgressBandwidthLimitBytesPerSecond = c.Float64("limit-bytes-per-sec")
 	return
 }


### PR DESCRIPTION
New output:

```
(master)jjg@jjg1:~/projects/gcsfuse$ go build . && ./gcsfuse --help
NAME:
   gcsfuse - Mount a GCS bucket locally

USAGE:
   gcsfuse [global options] bucket mountpoint
   
VERSION:
   0.1.0
   
GLOBAL OPTIONS:
   --dir-mode, -d               Permissions bits for directories. (default: 0755)
   --file-mode, -f              Permission bits for files (default: 0644)
   --gcs-chunk-size             Max chunk size for loading GCS objects. (default: 16777216)
   --gid                        GID owner of all inodes.
   --implicit-dirs              Implicitly define directories based on content. Seedocs/semantics.md
   --limit-bytes-per-sec        Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit) (default: -1)
   --limit-ops-per-sec          Operations per second limit, measured over a 30-second window (use -1 for no limit) (default: 5)
   --mount-options, -o          Additional system-specific mount options. Be careful!
   --stat-cache-ttl             How long to cache StatObject results from GCS. (default: "1m0s")
   --type-cache-ttl             How long to cache name -> file/dir mappings in directory inodes. (default: "1m0s")
   --temp-dir, -t               Temporary directory for local GCS object copies. (default: system default, likely /tmp)
   --temp-dir-bytes             Size limit of the temporary directory. (default: 2147483648)
   --uid                        UID owner of all inodes.
   --help, -h                   print this help text
   --version, -v                print the version
```

I'm using a fork of https://github.com/codegangsta/cli that has a couple extra features. Once we get those merged into the main stream, we can switch this to his version.

Old output:

```
(master)jjg@jjg1:~/projects/gcsfuse$ gcsfuse --help
Usage: gcsfuse [flags] bucket_name mount_point

Flags:
  -dir-mode=493: Permissions bits for directories. Default is 0755.
  -file-mode=420: Permissions bits for files. Default is 0644.
  -fuse.debug=false: Write FUSE debugging messages to stderr.
  -fuse.trace_by_pid=false: Enable a hacky mode that uses reqtrace to group all ops from each individual PID. Not a good idea to use in production; races, bugs, and resource leaks likely lurk.
  -fuseutil.random_delays=false: If set, randomly delay each op received, to help expose concurrency issues.
  -gcs-chunk-size=16777216: If set to a non-zero value N, split up GCS objects into multiple chunks of size at most N when reading, and do not read or cache unnecessary chunks.
  -gcs.debug=false: Write FUSE debugging messages to stderr.
  -gid=-1: If non-negative, the GID that owns all inodes. The default is the GID of the gcsfuse process.
  -httputil.debug=false: Dump information about HTTP requests.
  -implicit-dirs=false: Implicitly define directories based on their content. See docs/semantics.md.
  -limit-bytes-per-sec=-1: If positive, a limit on the GCS -> gcsfuse bandwidth for reading objects, measured over a 30-second window.
  -limit-ops-per-sec=5: If positive, a limit on the rate at which we send requests to GCS, measured over a 30-second window.
  -o=map[]: Additional system-specific mount options. Be careful!
  -reqtrace.enable=false: Collect and print traces.
  -stat-cache-ttl=1m0s: How long to cache StatObject results from GCS.
  -syncutil.check_invariants=false: Crash when registered invariants are violated.
  -temp-dir="": The temporary directory in which to store local copies of GCS objects. If empty, the system default (probably /tmp) will be used.
  -temp-dir-bytes=2147483648: A desired limit on the number of bytes used in --temp-dir. May be exceeded for dirty files that have not been flushed or closed.
  -type-cache-ttl=1m0s: How long to cache name -> file/dir type mappings in directory inodes.
  -uid=-1: If non-negative, the UID that owns all inodes. The default is the UID of the gcsfuse process.
```