### PR TITLE
Support for key_file fstab option

### DIFF
--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -22,6 +22,10 @@ Console:
 
     GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json gcsfuse [...]
 
+On OS X and Linux you can also use fstab option in `/etc/fstab` system file:
+
+    my-bucket /mount/point gcsfuse rw,noauto,user,key_file=/path/to/key.json
+
 [gce]: https://cloud.google.com/compute/
 [gce-service-accounts]: https://cloud.google.com/compute/docs/authentication
 [gcloud tool]: https://cloud.google.com/sdk/gcloud/
@@ -97,6 +101,7 @@ with dashes instead of underscores:
 *   `implicit_dirs`
 *   `dir_mode`
 *   `file_mode`
+*   `key_file`
 
 On both OS X and Linux, you can also add entries to your `/etc/fstab` file like
 the following:

--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -22,7 +22,7 @@ Console:
 
     GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json gcsfuse [...]
 
-On OS X and Linux you can also use fstab option in `/etc/fstab` system file:
+When mounting with an fstab entry, you can use the `key_file` option. For example:
 
     my-bucket /mount/point gcsfuse rw,noauto,user,key_file=/path/to/key.json
 

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -87,6 +87,14 @@ func makeGcsfuseArgs(
 			)
 
 		// Special case: support mount-like formatting for gcsfuse string flags.
+		case "key_file":
+			args = append(
+				args,
+				"--"+strings.Replace(name, "_", "-", -1),
+				value,
+			)
+
+		// Special case: support mount-like formatting for gcsfuse string flags.
 		case "dir_mode", "file_mode":
 			args = append(
 				args,


### PR DESCRIPTION
This adds basic support for `key_file` fstab option, which can be used for mounting with specific credentials (like for cross-project buckets and VMs).

It's quite useful, because `mount.gcsfuse` doesn't respect `GOOGLE_APPLICATION_CREDENTIALS` env var, but only `gcsfuse` does. But even if it did, it would be quite hacky to make it work under systems like Puppet, for example.

The option simplifies this by a lot:

```
my-bucket /mount/point gcsfuse rw,noauto,user,key_file=/path/to/key.json
```

it re-uses already existing `--key-file` argument for `gcsfuse`.