### PR TITLE
Patch for gcsfuse systemd integration

### DIFF
--- a/tools/integration_tests/mount_helper_test.go
+++ b/tools/integration_tests/mount_helper_test.go
@@ -134,6 +134,17 @@ func (t *MountHelperTest) BadUsage() {
 	}
 }
 
+func (t *MountHelperTest) IgnoreMtabFlag() {
+	var err error
+
+	// Mount.
+	args := []string{canned.FakeBucketName, t.dir, "-n"}
+
+	err = t.mount(args)
+	AssertEq(nil, err)
+	unmount(t.dir)
+}
+
 func (t *MountHelperTest) SuccessfulMount() {
 	var err error
 	var fi os.FileInfo

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -147,6 +147,10 @@ func parseArgs(
 				return
 			}
 
+		// Work around for systemd .mount file integration with gcsfuse
+		case s == "-n":
+			continue
+
 		// Is this an options string following a "-o"?
 		case i > 0 && args[i-1] == "-o":
 			mount.ParseOptions(opts, s)

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -147,7 +147,21 @@ func parseArgs(
 				return
 			}
 
-		// Work around for systemd .mount file integration with gcsfuse
+		// Work around for systemd .mount file integration with gcsfuse:
+		//
+		// systemd passes -n (alias --no-mtab) to the mount helper mount.gcsfuse
+		// in the case of using gcsfuse as the type of the filesystem in a
+		// systemd .mount file. This seems to be a result of the new setup on many
+		// Linux systems with /etc/mtab as a symlink pointing to /proc/self/mounts.
+		// /proc/self/mounts is read only so any helper that would normally
+		// write to /etc/mtab should be configured not to do so. Because
+		// systemd does not provide a way to disable this behavior
+		// for mount helpers that do not write to /etc/mtab, this
+		// workaround will allow compatibility between gcsfuse and systemd.
+		//
+		// This patch allows gcsfuse to ignore the -n flag and will
+		// provide an opportunity to set the filesystem type to gcsfuse in
+		// systemd without causing the mount helper to fail.
 		case s == "-n":
 			continue
 


### PR DESCRIPTION
This pull request is meant to enable gcsfuse mounting from systemd. After digging a little bit, it seems systemd supplies the ```-n``` (```--no-mtab```) option to whatever mount executable helper is invoked based on the type of filesystem specified as the mount in the ```.mount``` file. See [this link](https://www.freedesktop.org/software/systemd/man/systemd.mount.html#) for more information on ```.mount``` files but the basic idea is to expose filesystem mounts as a service that is callable from systemd and allows service dependency resolution based on what filesystems have been mounted. While including the ```-n``` flag might make sense in the systemd context given the developments around turning ```/etc/mtab``` into a symlink to ```/proc/self/mounts``` which is read only on my system, gcsfuse sees this as a bad flag so it cannot be integrated into a systemd mount file. There does not seem to be a flag to disable the ```-n``` flag when systemd invokes the mount helper so the simplest solution seems to be to ignore the ```-n``` flag from the gcsfuse mount helper. I'm open to discussion around this but given that ```-n``` is a standard flag in the ```mount``` command, I think it might be beneficial not just for this use case but for others as well to accept and ignore it for compatibility reasons similar to this one. I'm going to add an integration test so this is not yet ready to be merged but have submitted this patch so that we can at least start a discussion in case anyone working on this project is opposed or has other suggestions.