### PR TITLE
Update main.go to support passing in temp_dir

### DIFF
--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -102,6 +102,7 @@ with dashes instead of underscores:
 *   `dir_mode`
 *   `file_mode`
 *   `key_file`
+*   `temp_dir`
 
 On both OS X and Linux, you can also add entries to your `/etc/fstab` file like
 the following:

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -93,6 +93,14 @@ func makeGcsfuseArgs(
 				"--"+strings.Replace(name, "_", "-", -1),
 				value,
 			)
+			
+		// Special case: support mount-like formatting for gcsfuse string flags.
+		case "temp_dir":
+			args = append(
+				args,
+				"--"+strings.Replace(name, "_", "-", -1),
+				value,
+			)
 
 		// Special case: support mount-like formatting for gcsfuse string flags.
 		case "dir_mode", "file_mode":

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -87,23 +87,7 @@ func makeGcsfuseArgs(
 			)
 
 		// Special case: support mount-like formatting for gcsfuse string flags.
-		case "key_file":
-			args = append(
-				args,
-				"--"+strings.Replace(name, "_", "-", -1),
-				value,
-			)
-			
-		// Special case: support mount-like formatting for gcsfuse string flags.
-		case "temp_dir":
-			args = append(
-				args,
-				"--"+strings.Replace(name, "_", "-", -1),
-				value,
-			)
-
-		// Special case: support mount-like formatting for gcsfuse string flags.
-		case "dir_mode", "file_mode":
+		case "dir_mode", "file_mode", "key_file", "temp_dir":
 			args = append(
 				args,
 				"--"+strings.Replace(name, "_", "-", -1),


### PR DESCRIPTION
Allows functionality to pass temp_dir as a mount option in fstab