### PR TITLE
Adds support for requester pays buckets.

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -97,7 +97,7 @@ func setUpBucket(
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
 	} else {
-		b, err = conn.OpenBucket(ctx, &gcs.OpenBucketOptions{Name: name})
+		b, err = conn.OpenBucket(ctx, &gcs.OpenBucketOptions{Name: name, BillingProject: flags.BillingProject})
 		if err != nil {
 			err = fmt.Errorf("OpenBucket: %v", err)
 			return

--- a/flags.go
+++ b/flags.go
@@ -55,10 +55,10 @@ func newApp() (app *cli.App) {
 	*fileModeValue = 0644
 
 	app = &cli.App{
-		Name:     "gcsfuse",
-		Version:  getVersion(),
-		Usage:    "Mount a GCS bucket locally",
-		Writer:   os.Stderr,
+		Name:    "gcsfuse",
+		Version: getVersion(),
+		Usage:   "Mount a GCS bucket locally",
+		Writer:  os.Stderr,
 		Flags: []cli.Flag{
 
 			cli.BoolFlag{
@@ -113,6 +113,13 @@ func newApp() (app *cli.App) {
 			/////////////////////////
 			// GCS
 			/////////////////////////
+
+			cli.StringFlag{
+				Name:  "billing-project",
+				Value: "",
+				Usage: "Project to use for billing when accessing requeter pays buckets. " +
+					"(default: none)",
+			},
 
 			cli.StringFlag{
 				Name:  "key-file",
@@ -201,6 +208,7 @@ type flagStorage struct {
 	OnlyDir      string
 
 	// GCS
+	BillingProject                     string
 	KeyFile                            string
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
@@ -233,7 +241,8 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		OnlyDir:      c.String("only-dir"),
 
 		// GCS,
-		KeyFile: c.String("key-file"),
+		BillingProject: c.String("billing-project"),
+		KeyFile:        c.String("key-file"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 

--- a/flags.go
+++ b/flags.go
@@ -117,7 +117,7 @@ func newApp() (app *cli.App) {
 			cli.StringFlag{
 				Name:  "billing-project",
 				Value: "",
-				Usage: "Project to use for billing when accessing requeter pays buckets. " +
+				Usage: "Project to use for billing when accessing requester pays buckets. " +
 					"(default: none)",
 			},
 


### PR DESCRIPTION
These changes add support for requester pays buckets. Some of the changes are in a dependency (vendor/github.com/jacobsa/gcloud/gcs), and I'm not sure whether those changes should be first merged into the vendor repo.