### PR TITLE
Include timestamp in the debug logs.

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func getConn(flags *flagStorage) (c gcs.Conn, err error) {
 	}
 
 	if flags.DebugGCS {
-		cfg.GCSDebugLogger = log.New(os.Stdout, "gcs: ", 0)
+		cfg.GCSDebugLogger = log.New(os.Stdout, "gcs: ", log.Flags())
 	}
 
 	return gcs.NewConn(cfg)

--- a/mount.go
+++ b/mount.go
@@ -129,7 +129,7 @@ be interacting with the file system.
 	}
 
 	if flags.DebugFuse {
-		mountCfg.DebugLogger = log.New(os.Stdout, "fuse_debug: ", 0)
+		mountCfg.DebugLogger = log.New(os.Stdout, "fuse_debug: ", log.Flags())
 	}
 
 	mfs, err = fuse.Mount(mountPoint, server, mountCfg)


### PR DESCRIPTION
Include timestamp in the debug logs
The need for this was brought up in issue #262

Tested:
  no