### PR TITLE
Allow passing debugging options through `mount_gcsfuse`

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -94,6 +94,13 @@ func makeGcsfuseArgs(
 				value,
 			)
 
+			// Special case: support mount-like formatting for gcsfuse debug flags.
+		case "debug_fuse", "debug_gcs", "debug_http", "debug_invariants":
+			args = append(
+				args,
+				"--"+strings,
+			)
+
 		// Pass through everything else.
 		default:
 			var formatted string

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -98,7 +98,7 @@ func makeGcsfuseArgs(
 		case "debug_fuse", "debug_gcs", "debug_http", "debug_invariants":
 			args = append(
 				args,
-				"--"+strings,
+				"--"+name,
 			)
 
 		// Pass through everything else.


### PR DESCRIPTION
Allow passing debugging options like `--debug_gcs` through `mount_gcsfuse` as mount options (e.g., `mount -t gcsfuse -o debug_gcs ...`).

This may be useful when debugging `gcsfuse` mounts from non-interactive sessions like systemd, autofs, or simply `/etc/fstab`.