### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/fs/dir_handle.go
+++ b/internal/fs/dir_handle.go
@@ -243,7 +243,7 @@ func (dh *dirHandle) ensureEntries(ctx context.Context) (err error) {
 // Public interface
 ////////////////////////////////////////////////////////////////////////
 
-// Handle a request to read from the directory, without responding.
+// ReadDir handles a request to read from the directory, without responding.
 //
 // Special case: we assume that a zero offset indicates that rewinddir has been
 // called (since fuse gives us no way to intercept and know for sure), and

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -61,7 +61,7 @@ func (fh *FileHandle) Destroy() {
 	}
 }
 
-// Return the inode backing this handle.
+// Inode returns the inode backing this handle.
 func (fh *FileHandle) Inode() *inode.FileInode {
 	return fh.inode
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Does the supplied object name represent a directory (as opposed to a file or
+// IsDirName Does the supplied object name represent a directory (as opposed to a file or
 // symlink)?
 func IsDirName(name string) bool {
 	return name == "" || name[len(name)-1] == '/'
@@ -55,7 +55,7 @@ type LookUpResult struct {
 	ImplicitDir bool
 }
 
-// Return true iff the result indicates that the child exists, explicitly or
+// Exists returns true iff the result indicates that the child exists, explicitly or
 // implicitly.
 func (lr *LookUpResult) Exists() bool {
 	return lr.Object != nil || lr.ImplicitDir

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -225,7 +225,7 @@ func (f *FileInode) Name() string {
 	return f.name
 }
 
-// Return a record for the GCS object from which this inode is branched. The
+// Source returns a record for the GCS object from which this inode is branched. The
 // record is guaranteed not to be modified, and users must not modify it.
 //
 // LOCKS_REQUIRED(f.mu)
@@ -445,7 +445,7 @@ func (f *FileInode) SetMtime(
 	}
 }
 
-// Write out contents to GCS. If this fails due to the generation having been
+// Sync writes out contents to GCS. If this fails due to the generation having been
 // clobbered, treat it as a non-error (simulating the inode having been
 // unlinked).
 //

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -75,7 +75,7 @@ type Generation struct {
 	Metadata int64
 }
 
-// Return -1, 0, or 1 according to whether g is less than, equal to, or greater
+// Compare returns -1, 0, or 1 according to whether g is less than, equal to, or greater
 // than other.
 func (g Generation) Compare(other Generation) int {
 	// Compare first on object generation number.

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -27,7 +27,7 @@ import (
 // this with IsSymlink.
 const SymlinkMetadataKey = "gcsfuse_symlink_target"
 
-// Does the supplied object represent a symlink inode?
+// IsSymlink Does the supplied object represent a symlink inode?
 func IsSymlink(o *gcs.Object) bool {
 	_, ok := o.Metadata[SymlinkMetadataKey]
 	return ok
@@ -107,7 +107,7 @@ func (s *SymlinkInode) Name() string {
 	return s.name
 }
 
-// Return the object generation from which this inode was branched.
+// SourceGeneration returns the object generation from which this inode was branched.
 //
 // LOCKS_REQUIRED(s)
 func (s *SymlinkInode) SourceGeneration() Generation {
@@ -137,7 +137,7 @@ func (s *SymlinkInode) Attributes(
 	return
 }
 
-// Return the target of the symlink.
+// Target returns the target of the symlink.
 func (s *SymlinkInode) Target() (target string) {
 	target = s.target
 	return

--- a/internal/perms/perms.go
+++ b/internal/perms/perms.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 )
 
-// Return the UID and GID of this process.
+// MyUserAndGroup returns the UID and GID of this process.
 func MyUserAndGroup() (uid uint32, gid uint32, err error) {
 	// Ask for the current user.
 	user, err := user.Current()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._