### PR TITLE
Add another good option for the slow --implicit-dirs parameter

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -202,7 +202,7 @@ You could automate this with a webhook to reduce the delay between creating file
 and them apearing in gcsfuse. [issue-7-bash][Example bash script]
 
 [issue-7-bash]: 
-https://github.com/GoogleCloudPlatform/gcsfuse/issues/7#issuecomment-388220891)
+https://github.com/GoogleCloudPlatform/gcsfuse/issues/7#issuecomment-264221351
 [issue-7]: https://github.com/GoogleCloudPlatform/gcsfuse/issues/7
 
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -197,6 +197,12 @@ more thorough discussion):
     gcsfuse simply ignores this subtlety. Therefore in rare cases an implicitly
     defined directory will fail to appear.
 
+Another option would be to periodically mkdir all missing directory entries. 
+You could automate this with a webhook to reduce the delay between creating files 
+and them apearing in gcsfuse. [issue-7-bash][Example bash script]
+
+[issue-7-bash]: 
+https://github.com/GoogleCloudPlatform/gcsfuse/issues/7#issuecomment-388220891)
 [issue-7]: https://github.com/GoogleCloudPlatform/gcsfuse/issues/7
 
 


### PR DESCRIPTION
This is the option I went with... it's worked really well.

It would be great if such a script was part of gcsfuse. Example: `gcsfuse fix-dirs my-bucket`

You might ask, what about the poor soul who has a bucket named `fix-dirs`? ... well, that's me, and [I give you full permission to ignore me.](https://storage.googleapis.com/fix-dirs/permission.txt)