### PR TITLE
Preserve http_proxy environment variable when daemonizing

### DIFF
--- a/main.go
+++ b/main.go
@@ -319,6 +319,12 @@ func runCLIApp(c *cli.Context) (err error) {
 		if p, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
 			env = append(env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", p))
 		}
+		// Pass through the http_proxy environment variable, in case an isolated host
+		// requires a HTTP proxy server to reach the GCS endpoint.
+		if p, ok := os.LookupEnv("http_proxy"); ok {
+			env = append(env, fmt.Sprintf("http_proxy=%s", p))
+		}
+								                }
 
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)

--- a/main.go
+++ b/main.go
@@ -319,7 +319,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		if p, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
 			env = append(env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", p))
 		}
-		// Pass through the http_proxy environment variable, in case an isolated host
+		// Pass through the http_proxy environment variable, in case the host
 		// requires a HTTP proxy server to reach the GCS endpoint.
 		if p, ok := os.LookupEnv("http_proxy"); ok {
 			env = append(env, fmt.Sprintf("http_proxy=%s", p))

--- a/main.go
+++ b/main.go
@@ -324,7 +324,6 @@ func runCLIApp(c *cli.Context) (err error) {
 		if p, ok := os.LookupEnv("http_proxy"); ok {
 			env = append(env, fmt.Sprintf("http_proxy=%s", p))
 		}
-								                }
 
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)


### PR DESCRIPTION
On isolated hosts without Internet or direct GCS access, it's possible to access the GCP endpoints through a HTTP proxy server; Go's HTTP libraries respect the http_proxy environment variable.

(Using a proxy server configured as per https://cloud.google.com/vpc/docs/special-configurations#proxyvm)

> [root@localhost mfielding]# export http_proxy=http://10.1.1.1:3128
> [root@localhost mfielding]# gcsfuse --foreground --key-file $PWD/gcs.json gcs-bucket /mnt/gcs &
> [1] 17589
> [root@localhost mfielding]# Using mount point: /mnt/gcs
> Opening GCS connection...
> 
> WARNING: gcsfuse invoked as root. This will cause all files to be owned by
> root. If this is not what you intended, invoke gcsfuse as the user that will
> be interacting with the file system.
> 
> Opening bucket...
> Mounting file system...
> File system has been successfully mounted.
> 
> [root@localhost mfielding]# ls /mnt/gcs
> fuse: 2019/07/26 20:16:27.851453 *fuseops.GetXattrOp error: function not implemented
> file.zip
> [root@localhost mfielding]# umount /mnt/gcs

But without --foreground, http_proxy isn't passed, and we get an error:

> [root@localhost mfielding]# gcsfuse --key-file $PWD/gcs.json gcs-bucket /mnt/gcs
> Using mount point: /mnt/gcs
> Opening GCS connection...
> Opening bucket...
> Mounting file system...
> File system has been successfully mounted.
> [root@localhost mfielding]# cat /proc/$(pgrep gcsfuse)/environ | tr '\0' '\n'
> PATH=/sbin:/bin:/usr/sbin:/usr/bin
> DAEMONIZE_STATUS_FD=3
> [root@localhost mfielding]# ls /mnt/gcs
> ls: reading directory /mnt/gcs: Input/output error

This change propagates http_proxy, if it exists, to the child process, allowing the daemonized process to see it and use the proxy server.
