### PR TITLE
Make stat cache capacity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ bandwidth by default.
 
 By default, gcsfuse uses two forms of caching to save round trips to GCS, at the
 cost of consistency guarantees. These caching behaviors can be controlled with
-the flags `--stat-cache-ttl` and `--type-cache-ttl`. See
+the flags `--stat-cache-capacity`, `--stat-cache-ttl` and `--type-cache-ttl`. See
 [semantics.md](docs/semantics.md#caching) for more information.
 
 ## Timeouts

--- a/bucket.go
+++ b/bucket.go
@@ -126,7 +126,7 @@ func setUpBucket(
 
 	// Enable cached StatObject results, if appropriate.
 	if flags.StatCacheTTL != 0 {
-		const cacheCapacity = 4096
+		cacheCapacity := flags.StatCacheCapacity
 		b = gcscaching.NewFastStatBucket(
 			flags.StatCacheTTL,
 			gcscaching.NewStatCache(cacheCapacity),

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -62,6 +62,18 @@ kernel to cache inode attributes. Caching these can help with file system
 performance, since otherwise the kernel must send a request for inode attributes
 to gcsfuse for each call to `write(2)`, `stat(2)`, and others.
 
+The size of the stat cache can also be configured with `--stat-cache-capacity`.
+By default the stat cache will hold up to 4096 items. If you have folders
+containing more than 4096 items (folders or files) you may want to increase this,
+otherwise the caching will not function properly when listing that folder's contents:
+
+* ListObjects will return information on the items within the folder. Each item's data is cached
+* Because there are more objects than cache capacity, the earliest entries will be evicted
+* The linux kernel then asks for a little more information on each file.
+* As the earliest cache entries were evicted, this is a fresh GetObjectDetails request
+* This cycle repeats and sends a GetObjectDetails request for every item in the folder, as though
+  caching were disabled
+
 **Warning**: Using stat caching breaks the consistency guarantees discussed in
 this document. It is safe only in the following situations:
 

--- a/flags.go
+++ b/flags.go
@@ -146,6 +146,12 @@ func newApp() (app *cli.App) {
 			// Tuning
 			/////////////////////////
 
+			cli.IntFlag{
+				Name:  "stat-cache-capacity",
+				Value: 4096,
+				Usage: "How many entries can the stat cache hold (impacts memory consumption)",
+			},
+
 			cli.DurationFlag{
 				Name:  "stat-cache-ttl",
 				Value: time.Minute,
@@ -214,9 +220,10 @@ type flagStorage struct {
 	OpRateLimitHz                      float64
 
 	// Tuning
-	StatCacheTTL time.Duration
-	TypeCacheTTL time.Duration
-	TempDir      string
+	StatCacheCapacity int
+	StatCacheTTL      time.Duration
+	TypeCacheTTL      time.Duration
+	TempDir           string
 
 	// Debugging
 	DebugFuse       bool
@@ -241,15 +248,16 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		OnlyDir:      c.String("only-dir"),
 
 		// GCS,
-		BillingProject: c.String("billing-project"),
-		KeyFile:        c.String("key-file"),
+		BillingProject:                     c.String("billing-project"),
+		KeyFile:                            c.String("key-file"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 
 		// Tuning,
-		StatCacheTTL: c.Duration("stat-cache-ttl"),
-		TypeCacheTTL: c.Duration("type-cache-ttl"),
-		TempDir:      c.String("temp-dir"),
+		StatCacheCapacity: c.Int("stat-cache-capacity"),
+		StatCacheTTL:      c.Duration("stat-cache-ttl"),
+		TypeCacheTTL:      c.Duration("type-cache-ttl"),
+		TempDir:           c.String("temp-dir"),
 
 		// Debugging,
 		DebugFuse:       c.Bool("debug_fuse"),

--- a/flags_test.go
+++ b/flags_test.go
@@ -76,6 +76,7 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq(5, f.OpRateLimitHz)
 
 	// Tuning
+	ExpectEq(4096, f.StatCacheCapacity)
 	ExpectEq(time.Minute, f.StatCacheTTL)
 	ExpectEq(time.Minute, f.TypeCacheTTL)
 	ExpectEq("", f.TempDir)
@@ -145,6 +146,7 @@ func (t *FlagsTest) DecimalNumbers() {
 		"--gid=19",
 		"--limit-bytes-per-sec=123.4",
 		"--limit-ops-per-sec=56.78",
+		"--stat-cache-capacity=8192",
 	}
 
 	f := parseArgs(args)
@@ -152,6 +154,7 @@ func (t *FlagsTest) DecimalNumbers() {
 	ExpectEq(19, f.Gid)
 	ExpectEq(123.4, f.EgressBandwidthLimitBytesPerSecond)
 	ExpectEq(56.78, f.OpRateLimitHz)
+	ExpectEq(8192, f.StatCacheCapacity)
 }
 
 func (t *FlagsTest) OctalNumbers() {


### PR DESCRIPTION
PR to go alongside #350. To quote that original issue:

> Hi folks,
> 
> We've been having some issues with a media manager which browses our gcsfuse-backed folders. The media manager was working absolutely fine until recently, and then at some point it got super slow.
> 
> This turned out to be due to the stat cache's capacity being 4096
> 
> https://github.com/GoogleCloudPlatform/gcsfuse/blob/6ab0a79f97b7481b23c3724cd0c4b323f0627d69/bucket.go#L127-L135
> 
> And with our project, one of our folder's has ballooned from ~3500 files to ~4100 files (using the folder as a dumping ground is a separate problem that we'll be addressing internally). This means that a `ls` operation on that folder takes forever because it blows the stat cache:
> 
> * The `ListObjects` GCS call (unless I am mistaken) populates the stat cache for every single item in that folder. As there's more than 4096, the earliest items get discarded.
> * The kernel (I think?) then tries to stat each individual file, earliest first.
> * The earliest had been discarded from the cache, so that's a fresh API request. That discards the next earliest.
> * This repeats, and we end up with an API request for each of the ~4100 files in that folder.
> 
> Is there a significance to the limit of `4096`? Or would there be any interest in changing it, or making it configurable?
> 
> From an (unfamiliar) browse of the various caching-related code, it looks like the cache is entirely in memory? So the cost would just be increased memory usage?
> 
> Cheers,
> Rob

Definitely open to feedback! Hopefully I haven't made any glaring mistakes 😬 