### PR TITLE
Remove unnecessary "yum update" step from CentOS install

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -80,13 +80,7 @@ for [other distributions](#other-distributions) below.
                https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
         EOF
 
-2.  Make the system aware of the new repo:
-
-        sudo yum update
-
-    Be sure to answer "yes" to any questions about adding the GPG signing key.
-
-3.  Install gcsfuse:
+2.  Install gcsfuse:
 
         sudo yum install gcsfuse
 


### PR DESCRIPTION
Unlike apt-get, yum doesn't require an update run before installing a package from a new repo.