### PR TITLE
Refactor the gcs bucket used in file system

### DIFF
--- a/internal/fs/bucket_manager.go
+++ b/internal/fs/bucket_manager.go
@@ -15,6 +15,7 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -37,6 +38,25 @@ type BucketConfig struct {
 	OpRateLimitHz                      float64
 	StatCacheCapacity                  int
 	StatCacheTTL                       time.Duration
+
+	// Files backed by on object of length at least AppendThreshold that have
+	// only been appended to (i.e. none of the object's contents have been
+	// dirtied) will be written out by "appending" to the object in GCS with this
+	// process:
+	//
+	// 1. Write out a temporary object containing the appended contents whose
+	//    name begins with TmpObjectPrefix.
+	//
+	// 2. Compose the original object and the temporary object on top of the
+	//    original object.
+	//
+	// 3. Delete the temporary object.
+	//
+	// Note that if the process fails or is interrupted the temporary object will
+	// not be cleaned up, so the user must ensure that TmpObjectPrefix is
+	// periodically garbage collected.
+	AppendThreshold int64
+	TmpObjectPrefix string
 }
 
 // BucketManager manages the lifecycle of buckets.
@@ -44,19 +64,28 @@ type BucketManager interface {
 	// Sets up a gcs bucket by its name
 	SetUpBucket(
 		ctx context.Context,
-		name string) (b gcs.Bucket, err error)
+		name string) (b gcsx.SyncerBucket, err error)
+
+	// Shuts down the bucket manager and its buckets
+	ShutDown()
 }
 
 type bucketManager struct {
 	config BucketConfig
 	conn   gcs.Conn
+
+	// Garbage collector
+	gcCtx                 context.Context
+	stopGarbageCollecting func()
 }
 
 func NewBucketManager(config BucketConfig, conn gcs.Conn) BucketManager {
-	return &bucketManager{
+	bm := &bucketManager{
 		config: config,
 		conn:   conn,
 	}
+	bm.gcCtx, bm.stopGarbageCollecting = context.WithCancel(context.Background())
+	return bm
 }
 
 func setUpRateLimiting(
@@ -119,7 +148,8 @@ func setUpRateLimiting(
 // bucket as described in that package.
 func (bm *bucketManager) SetUpBucket(
 	ctx context.Context,
-	name string) (b gcs.Bucket, err error) {
+	name string) (sb gcsx.SyncerBucket, err error) {
+	var b gcs.Bucket
 	// Set up the appropriate backing bucket.
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
@@ -167,6 +197,19 @@ func (bm *bucketManager) SetUpBucket(
 			b)
 	}
 
+	// Enable content type awareness
+	b = gcsx.NewContentTypeBucket(b)
+
+	// Enable Syncer
+	if bm.config.TmpObjectPrefix == "" {
+		err = errors.New("You must set TmpObjectPrefix.")
+		return
+	}
+	sb = gcsx.NewSyncerBucket(
+		bm.config.AppendThreshold,
+		bm.config.TmpObjectPrefix,
+		b)
+
 	// Check whether this bucket works, giving the user a warning early if there
 	// is some problem.
 	{
@@ -176,5 +219,12 @@ func (bm *bucketManager) SetUpBucket(
 		}
 	}
 
+	// Periodically garbage collect temporary objects
+	go garbageCollect(bm.gcCtx, bm.config.TmpObjectPrefix, sb)
+
 	return
+}
+
+func (bm *bucketManager) ShutDown() {
+	bm.stopGarbageCollecting()
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -130,7 +130,7 @@ func NewServer(cfg *ServerConfig) (server fuse.Server, err error) {
 		return
 	}
 
-	syncer := gcsx.NewSyncer(
+	syncerBucket := gcsx.NewSyncerBucket(
 		cfg.AppendThreshold,
 		cfg.TmpObjectPrefix,
 		bucket)
@@ -139,8 +139,7 @@ func NewServer(cfg *ServerConfig) (server fuse.Server, err error) {
 	fs := &fileSystem{
 		mtimeClock:             timeutil.RealClock(),
 		cacheClock:             cfg.CacheClock,
-		bucket:                 bucket,
-		syncer:                 syncer,
+		bucket:                 syncerBucket,
 		tempDir:                cfg.TempDir,
 		implicitDirs:           cfg.ImplicitDirectories,
 		inodeAttributeCacheTTL: cfg.InodeAttributeCacheTTL,
@@ -229,8 +228,7 @@ type fileSystem struct {
 
 	mtimeClock timeutil.Clock
 	cacheClock timeutil.Clock
-	bucket     gcs.Bucket
-	syncer     gcsx.Syncer
+	bucket     gcsx.SyncerBucket
 
 	/////////////////////////
 	// Constant data
@@ -562,7 +560,6 @@ func (fs *fileSystem) mintInode(name string, o *gcs.Object) (in inode.Inode) {
 				Mode: fs.fileMode,
 			},
 			fs.bucket,
-			fs.syncer,
 			fs.tempDir,
 			fs.mtimeClock)
 	}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -40,7 +40,7 @@ type ServerConfig struct {
 	CacheClock timeutil.Clock
 
 	// The bucket manager is responsible for setting up buckets.
-	BucketManager BucketManager
+	BucketManager gcsx.BucketManager
 
 	// The name of the bucket to be mounted at root.
 	BucketName string
@@ -200,7 +200,7 @@ type fileSystem struct {
 
 	mtimeClock    timeutil.Clock
 	cacheClock    timeutil.Clock
-	bucketManager BucketManager
+	bucketManager gcsx.BucketManager
 
 	/////////////////////////
 	// Constant data

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1064,8 +1064,7 @@ func (fs *fileSystem) MkDir(
 	// Create an empty backing object for the child, failing if it already
 	// exists.
 	parent.Lock()
-	childname, o, err := parent.CreateChildDir(ctx, op.Name)
-	bucket := parent.Bucket()
+	bucket, childname, o, err := parent.CreateChildDir(ctx, op.Name)
 	parent.Unlock()
 
 	// Special case: *gcs.PreconditionError means the name already exists.
@@ -1148,8 +1147,7 @@ func (fs *fileSystem) createFile(
 	// Create an empty backing object for the child, failing if it already
 	// exists.
 	parent.Lock()
-	childname, o, err := parent.CreateChildFile(ctx, name)
-	bucket := parent.Bucket()
+	bucket, childname, o, err := parent.CreateChildFile(ctx, name)
 	parent.Unlock()
 
 	// Special case: *gcs.PreconditionError means the name already exists.
@@ -1224,8 +1222,7 @@ func (fs *fileSystem) CreateSymlink(
 
 	// Create the object in GCS, failing if it already exists.
 	parent.Lock()
-	childname, o, err := parent.CreateChildSymlink(ctx, op.Name, op.Target)
-	bucket := parent.Bucket()
+	bucket, childname, o, err := parent.CreateChildSymlink(ctx, op.Name, op.Target)
 	parent.Unlock()
 
 	// Special case: *gcs.PreconditionError means the name already exists.
@@ -1379,7 +1376,7 @@ func (fs *fileSystem) Rename(
 
 	// Clone into the new location.
 	newParent.Lock()
-	_, _, err = newParent.CloneToChildFile(
+	_, _, _, err = newParent.CloneToChildFile(
 		ctx,
 		op.NewName,
 		lr.Object)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -20,14 +20,12 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
-	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/syncutil"
 	"golang.org/x/net/context"
 )
 
 type FileHandle struct {
-	inode  *inode.FileInode
-	bucket gcs.Bucket
+	inode *inode.FileInode
 
 	mu syncutil.InvariantMutex
 
@@ -40,12 +38,9 @@ type FileHandle struct {
 	reader gcsx.RandomReader
 }
 
-func NewFileHandle(
-	inode *inode.FileInode,
-	bucket gcs.Bucket) (fh *FileHandle) {
+func NewFileHandle(inode *inode.FileInode) (fh *FileHandle) {
 	fh = &FileHandle{
-		inode:  inode,
-		bucket: bucket,
+		inode: inode,
 	}
 
 	fh.mu = syncutil.NewInvariantMutex(fh.checkInvariants)
@@ -162,7 +157,7 @@ func (fh *FileHandle) tryEnsureReader() (err error) {
 	}
 
 	// Attempt to create an appropriate reader.
-	rr, err := gcsx.NewRandomReader(fh.inode.Source(), fh.bucket)
+	rr, err := gcsx.NewRandomReader(fh.inode.Source(), fh.inode.Bucket())
 	if err != nil {
 		err = fmt.Errorf("NewRandomReader: %v", err)
 		return

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -66,7 +66,7 @@ func (lr *LookUpResult) Exists() bool {
 // looking up children, and creating and deleting children. Must be locked for
 // any method additional to the Inode interface.
 type DirInode interface {
-	Inode
+	BucketOwnedInode
 
 	// Look up the direct child with the given relative name, returning
 	// information about the object backing the child or whether it exists as an
@@ -596,6 +596,10 @@ func (d *dirInode) Attributes(
 	attrs.Nlink = 1
 
 	return
+}
+
+func (d *dirInode) Bucket() gcsx.SyncerBucket {
+	return d.bucket
 }
 
 // A suffix that can be used to unambiguously tag a file system name.

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/gcloud/gcs"
@@ -154,7 +155,7 @@ type dirInode struct {
 	// Dependencies
 	/////////////////////////
 
-	bucket     gcs.Bucket
+	bucket     gcsx.SyncerBucket
 	mtimeClock timeutil.Clock
 	cacheClock timeutil.Clock
 
@@ -214,7 +215,7 @@ func NewDirInode(
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
 	typeCacheTTL time.Duration,
-	bucket gcs.Bucket,
+	bucket gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock) (d DirInode) {
 	if !IsDirName(name) {
@@ -781,7 +782,7 @@ func (d *dirInode) CloneToChildFile(
 			SrcName:                       src.Name,
 			SrcGeneration:                 src.Generation,
 			SrcMetaGenerationPrecondition: &src.MetaGeneration,
-			DstName: path.Join(d.Name(), name),
+			DstName:                       path.Join(d.Name(), name),
 		})
 
 	if err != nil {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -39,6 +39,9 @@ func IsDirName(name string) bool {
 // The result of looking up a child within a directory inode. See notes on
 // DirInode.LookUpChild for more info.
 type LookUpResult struct {
+	// The GCS bucket where the lookup is performed.
+	Bucket gcsx.SyncerBucket
+
 	// For both object-backed children and implicit directories, the full
 	// canonical name of the child. For example, if the parent inode is "foo/"
 	// and the child is a directory, then this is "foo/bar/".
@@ -261,6 +264,7 @@ func (d *dirInode) checkInvariants() {
 func (d *dirInode) lookUpChildFile(
 	ctx context.Context,
 	name string) (result LookUpResult, err error) {
+	result.Bucket = d.Bucket()
 	result.FullName = d.Name() + name
 	result.Object, err = statObjectMayNotExist(ctx, d.bucket, result.FullName)
 	if err != nil {
@@ -278,6 +282,7 @@ func (d *dirInode) lookUpChildDir(
 
 	// Stat the placeholder object.
 	b.Add(func(ctx context.Context) (err error) {
+		result.Bucket = d.Bucket()
 		result.FullName = d.Name() + name + "/"
 		result.Object, err = statObjectMayNotExist(ctx, d.bucket, result.FullName)
 		if err != nil {

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -658,15 +658,12 @@ func (t *DirTest) CreateChildFile_DoesntExist() {
 	const name = "qux"
 	objName := path.Join(dirInodeName, name)
 
-	var fn inode.Name
-	var o *gcs.Object
-	var err error
-
 	// Call the inode.
-	fn, o, err = t.in.CreateChildFile(t.ctx, name)
+	b, fn, o, err := t.in.CreateChildFile(t.ctx, name)
 	AssertEq(nil, err)
 	AssertNe(nil, o)
 
+	ExpectEq(t.bucket.Name(), b.Name())
 	ExpectEq(fn.GcsObjectName(), o.Name)
 	ExpectEq(objName, o.Name)
 	ExpectFalse(inode.IsSymlink(o))
@@ -688,7 +685,7 @@ func (t *DirTest) CreateChildFile_Exists() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	_, _, err = t.in.CreateChildFile(t.ctx, name)
+	_, _, _, err = t.in.CreateChildFile(t.ctx, name)
 	ExpectThat(err, Error(HasSubstr("Precondition")))
 	ExpectThat(err, Error(HasSubstr("exists")))
 }
@@ -702,7 +699,7 @@ func (t *DirTest) CreateChildFile_TypeCaching() {
 	var err error
 
 	// Create the name.
-	_, _, err = t.in.CreateChildFile(t.ctx, name)
+	_, _, _, err = t.in.CreateChildFile(t.ctx, name)
 	AssertEq(nil, err)
 
 	// Create a backing object for a directory.
@@ -748,7 +745,7 @@ func (t *DirTest) CloneToChildFile_SourceDoesntExist() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	_, _, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	_, _, _, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
 	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 }
 
@@ -756,19 +753,16 @@ func (t *DirTest) CloneToChildFile_DestinationDoesntExist() {
 	const srcName = "blah/baz"
 	dstName := path.Join(dirInodeName, "qux")
 
-	var fn inode.Name
-	var o *gcs.Object
-	var err error
-
 	// Create the source.
 	src, err := gcsutil.CreateObject(t.ctx, t.bucket, srcName, []byte("taco"))
 	AssertEq(nil, err)
 
 	// Call the inode.
-	fn, o, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	b, fn, o, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
 	AssertEq(nil, err)
 	AssertNe(nil, o)
 
+	ExpectEq(t.bucket.Name(), b.Name())
 	ExpectEq(fn.GcsObjectName(), o.Name)
 	ExpectEq(dstName, o.Name)
 	ExpectFalse(inode.IsSymlink(o))
@@ -783,10 +777,6 @@ func (t *DirTest) CloneToChildFile_DestinationExists() {
 	const srcName = "blah/baz"
 	dstName := path.Join(dirInodeName, "qux")
 
-	var fn inode.Name
-	var o *gcs.Object
-	var err error
-
 	// Create the source.
 	src, err := gcsutil.CreateObject(t.ctx, t.bucket, srcName, []byte("taco"))
 	AssertEq(nil, err)
@@ -796,10 +786,11 @@ func (t *DirTest) CloneToChildFile_DestinationExists() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	fn, o, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	b, fn, o, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
 	AssertEq(nil, err)
 	AssertNe(nil, o)
 
+	ExpectEq(t.bucket.Name(), b.Name())
 	ExpectEq(fn.GcsObjectName(), o.Name)
 	ExpectEq(dstName, o.Name)
 	ExpectFalse(inode.IsSymlink(o))
@@ -823,7 +814,7 @@ func (t *DirTest) CloneToChildFile_TypeCaching() {
 	AssertEq(nil, err)
 
 	// Clone to the destination.
-	_, _, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	_, _, _, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
 	AssertEq(nil, err)
 
 	// Create a backing object for a directory.
@@ -858,15 +849,12 @@ func (t *DirTest) CreateChildSymlink_DoesntExist() {
 	const target = "taco"
 	objName := path.Join(dirInodeName, name)
 
-	var fn inode.Name
-	var o *gcs.Object
-	var err error
-
 	// Call the inode.
-	fn, o, err = t.in.CreateChildSymlink(t.ctx, name, target)
+	b, fn, o, err := t.in.CreateChildSymlink(t.ctx, name, target)
 	AssertEq(nil, err)
 	AssertNe(nil, o)
 
+	ExpectEq(t.bucket.Name(), b.Name())
 	ExpectEq(fn.GcsObjectName(), o.Name)
 	ExpectEq(objName, o.Name)
 	ExpectEq(target, o.Metadata[inode.SymlinkMetadataKey])
@@ -884,7 +872,7 @@ func (t *DirTest) CreateChildSymlink_Exists() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	_, _, err = t.in.CreateChildSymlink(t.ctx, name, target)
+	_, _, _, err = t.in.CreateChildSymlink(t.ctx, name, target)
 	ExpectThat(err, Error(HasSubstr("Precondition")))
 	ExpectThat(err, Error(HasSubstr("exists")))
 }
@@ -898,7 +886,7 @@ func (t *DirTest) CreateChildSymlink_TypeCaching() {
 	var err error
 
 	// Create the name.
-	_, _, err = t.in.CreateChildSymlink(t.ctx, name, "")
+	_, _, _, err = t.in.CreateChildSymlink(t.ctx, name, "")
 	AssertEq(nil, err)
 
 	// Create a backing object for a directory.
@@ -932,15 +920,12 @@ func (t *DirTest) CreateChildDir_DoesntExist() {
 	const name = "qux"
 	objName := path.Join(dirInodeName, name) + "/"
 
-	var fn inode.Name
-	var o *gcs.Object
-	var err error
-
 	// Call the inode.
-	fn, o, err = t.in.CreateChildDir(t.ctx, name)
+	b, fn, o, err := t.in.CreateChildDir(t.ctx, name)
 	AssertEq(nil, err)
 	AssertNe(nil, o)
 
+	ExpectEq(t.bucket.Name(), b.Name())
 	ExpectEq(fn.GcsObjectName(), o.Name)
 	ExpectEq(objName, o.Name)
 	ExpectFalse(inode.IsSymlink(o))
@@ -957,7 +942,7 @@ func (t *DirTest) CreateChildDir_Exists() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	_, _, err = t.in.CreateChildDir(t.ctx, name)
+	_, _, _, err = t.in.CreateChildDir(t.ctx, name)
 	ExpectThat(err, Error(HasSubstr("Precondition")))
 	ExpectThat(err, Error(HasSubstr("exists")))
 }
@@ -1060,7 +1045,7 @@ func (t *DirTest) DeleteChildFile_TypeCaching() {
 	var err error
 
 	// Create the name, priming the type cache.
-	_, _, err = t.in.CreateChildFile(t.ctx, name)
+	_, _, _, err = t.in.CreateChildFile(t.ctx, name)
 	AssertEq(nil, err)
 
 	// Create a backing object for a directory. It should be shadowed by the

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/gcloud/gcs"
@@ -47,7 +48,7 @@ const typeCacheTTL = time.Second
 
 type DirTest struct {
 	ctx    context.Context
-	bucket gcs.Bucket
+	bucket gcsx.SyncerBucket
 	clock  timeutil.SimulatedClock
 
 	in inode.DirInode
@@ -61,8 +62,11 @@ func init() { RegisterTestSuite(&DirTest{}) }
 func (t *DirTest) SetUp(ti *TestInfo) {
 	t.ctx = ti.Ctx
 	t.clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
-	t.bucket = gcsfake.NewFakeBucket(&t.clock, "some_bucket")
-
+	bucket := gcsfake.NewFakeBucket(&t.clock, "some_bucket")
+	t.bucket = gcsx.NewSyncerBucket(
+		1, // Append threshold
+		".gcsfuse_tmp/",
+		bucket)
 	// Create the inode. No implicit dirs by default.
 	t.resetInode(false)
 }

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -17,6 +17,7 @@ package inode
 import (
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/timeutil"
@@ -37,7 +38,7 @@ func NewExplicitDirInode(
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
 	typeCacheTTL time.Duration,
-	bucket gcs.Bucket,
+	bucket gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock) (d ExplicitDirInode) {
 	wrapped := NewDirInode(

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -34,6 +34,7 @@ type ExplicitDirInode interface {
 // NewDirInode for more.
 func NewExplicitDirInode(
 	id fuseops.InodeID,
+	name Name,
 	o *gcs.Object,
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
@@ -43,7 +44,7 @@ func NewExplicitDirInode(
 	cacheClock timeutil.Clock) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
-		o.Name,
+		name,
 		attrs,
 		implicitDirs,
 		typeCacheTTL,

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -335,6 +335,10 @@ func (f *FileInode) Attributes(
 	return
 }
 
+func (f *FileInode) Bucket() gcsx.SyncerBucket {
+	return f.bucket
+}
+
 // Serve a read for this file with semantics matching io.ReaderAt.
 //
 // The caller may be better off reading directly from GCS when

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -37,8 +37,7 @@ type FileInode struct {
 	// Dependencies
 	/////////////////////////
 
-	bucket     gcs.Bucket
-	syncer     gcsx.Syncer
+	bucket     gcsx.SyncerBucket
 	mtimeClock timeutil.Clock
 
 	/////////////////////////
@@ -92,14 +91,12 @@ func NewFileInode(
 	id fuseops.InodeID,
 	o *gcs.Object,
 	attrs fuseops.InodeAttributes,
-	bucket gcs.Bucket,
-	syncer gcsx.Syncer,
+	bucket gcsx.SyncerBucket,
 	tempDir string,
 	mtimeClock timeutil.Clock) (f *FileInode) {
 	// Set up the basic struct.
 	f = &FileInode{
 		bucket:     bucket,
-		syncer:     syncer,
 		mtimeClock: mtimeClock,
 		id:         id,
 		name:       o.Name,
@@ -470,7 +467,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	}
 
 	// Write out the contents if they are dirty.
-	newObj, err := f.syncer.SyncObject(ctx, &f.src, f.content)
+	newObj, err := f.bucket.SyncObject(ctx, &f.src, f.content)
 
 	// Special case: a precondition error means we were clobbered, which we treat
 	// as being unlinked. There's no reason to return an error in that case.

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -101,8 +101,7 @@ func (t *FileTest) createInode() {
 			Gid:  gid,
 			Mode: fileMode,
 		},
-		t.bucket,
-		gcsx.NewSyncer(
+		gcsx.NewSyncerBucket(
 			1, // Append threshold
 			".gcsfuse_tmp/",
 			t.bucket),

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -31,11 +31,10 @@ type Inode interface {
 	// Does not require the lock to be held.
 	ID() fuseops.InodeID
 
-	// Return the name of the GCS object backing the inode. This may be "foo/bar"
-	// for a file, or "foo/bar/" for a directory.
+	// Return the name of the GCS object backing the inode.
 	//
 	// Does not require the lock to be held.
-	Name() string
+	Name() Name
 
 	// Increment the lookup count for the inode. For use in fuse operations where
 	// the kernel expects us to remember the inode.

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -17,6 +17,7 @@ package inode
 import (
 	"sync"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
 	"golang.org/x/net/context"
 )
@@ -55,6 +56,14 @@ type Inode interface {
 	//
 	// This method may block. Errors are for logging purposes only.
 	Destroy() (err error)
+}
+
+// An inode owned by a gcs bucket.
+type BucketOwnedInode interface {
+	Inode
+
+	// Return the gcs.Bucket which the dir or file belongs to.
+	Bucket() gcsx.SyncerBucket
 }
 
 // An inode that is backed by a particular generation of a GCS object.

--- a/internal/fs/inode/name.go
+++ b/internal/fs/inode/name.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode
+
+import (
+	"fmt"
+)
+
+// Name is the inode's name that can be interpreted in 2 ways:
+//   (1) LocalName: the name of the inode in the local file system.
+//   (2) GcsObjectName: the name of its gcs object backed by the inode.
+type Name struct {
+	// The gcs object's name in its bucket.
+	objectName string
+}
+
+// NewRootName creates a Name for the root directory of a gcs bucket
+func NewRootName() Name {
+	return Name{""}
+}
+
+// NewDirName creates a new inode name for a directory.
+func NewDirName(parentName Name, dirName string) Name {
+	if parentName.IsFile() || dirName == "" {
+		panic(fmt.Sprintf(
+			"Inode '%s' cannot have child subdirectory '%s'",
+			parentName,
+			dirName))
+	}
+	if dirName[len(dirName)-1] != '/' {
+		dirName = dirName + "/"
+	}
+	return Name{parentName.objectName + dirName}
+}
+
+// NewFileName creates a new inode name for a file.
+func NewFileName(parentName Name, fileName string) Name {
+	if parentName.IsFile() || fileName == "" {
+		panic(fmt.Sprintf(
+			"Inode '%s' cannot have child file '%s'",
+			parentName,
+			fileName))
+	}
+	return Name{parentName.objectName + fileName}
+}
+
+// IsDir returns true if the name represents a directory.
+func (name Name) IsDir() bool {
+	isBucketRoot := (name.objectName == "")
+	return isBucketRoot || name.objectName[len(name.objectName)-1] == '/'
+}
+
+// IsFile returns true if the name represents a file.
+func (name Name) IsFile() bool {
+	return !name.IsDir()
+}
+
+// GcsObjectName returns the name of the gcs object backed by the inode.
+func (name Name) GcsObjectName() string {
+	return name.objectName
+}
+
+// LocalName returns the name of the directory or file in the mounted file system.
+func (name Name) LocalName() string {
+	return name.objectName
+}
+
+// String returns LocalName.
+func (name Name) String() string {
+	return name.LocalName()
+}

--- a/internal/fs/inode/name_test.go
+++ b/internal/fs/inode/name_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode_test
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestName(t *testing.T) {
+	root := inode.NewRootName()
+	ExpectTrue(root.IsDir())
+	ExpectFalse(root.IsFile())
+	ExpectEq("", root.GcsObjectName())
+	ExpectEq("", root.LocalName())
+
+	foo := inode.NewDirName(root, "foo")
+	ExpectTrue(foo.IsDir())
+	ExpectFalse(foo.IsFile())
+	ExpectEq("foo/", foo.GcsObjectName())
+	ExpectEq("foo/", foo.LocalName())
+
+	bar := inode.NewDirName(foo, "bar")
+	ExpectTrue(bar.IsDir())
+	ExpectFalse(bar.IsFile())
+	ExpectEq("foo/bar/", bar.GcsObjectName())
+	ExpectEq("foo/bar/", bar.LocalName())
+
+	baz := inode.NewFileName(root, "baz")
+	ExpectFalse(baz.IsDir())
+	ExpectTrue(baz.IsFile())
+	ExpectEq("baz", baz.GcsObjectName())
+	ExpectEq("baz", baz.LocalName())
+
+	qux := inode.NewFileName(bar, "qux")
+	ExpectFalse(qux.IsDir())
+	ExpectTrue(qux.IsFile())
+	ExpectEq("foo/bar/qux", qux.GcsObjectName())
+	ExpectEq("foo/bar/qux", qux.LocalName())
+}
+
+func TestNameAsMapKey(t *testing.T) {
+	root := inode.NewRootName()
+	foo := inode.NewDirName(root, "foo")
+	foo2 := inode.NewDirName(root, "foo")
+	bar := inode.NewDirName(root, "bar")
+
+	count := make(map[inode.Name]int)
+	count[root]++
+	count[foo]++
+	count[foo2]++
+
+	ExpectEq(1, count[root])
+	ExpectEq(2, count[foo])
+	_, ok := count[bar]
+	ExpectFalse(ok)
+}

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -39,7 +39,7 @@ type SymlinkInode struct {
 	/////////////////////////
 
 	id               fuseops.InodeID
-	name             string
+	name             Name
 	sourceGeneration Generation
 	attrs            fuseops.InodeAttributes
 	target           string
@@ -61,12 +61,13 @@ var _ Inode = &SymlinkInode{}
 // REQUIRES: IsSymlink(o)
 func NewSymlinkInode(
 	id fuseops.InodeID,
+	name Name,
 	o *gcs.Object,
 	attrs fuseops.InodeAttributes) (s *SymlinkInode) {
 	// Create the inode.
 	s = &SymlinkInode{
 		id:   id,
-		name: o.Name,
+		name: name,
 		sourceGeneration: Generation{
 			Object:   o.Generation,
 			Metadata: o.MetaGeneration,
@@ -103,7 +104,7 @@ func (s *SymlinkInode) ID() fuseops.InodeID {
 	return s.id
 }
 
-func (s *SymlinkInode) Name() string {
+func (s *SymlinkInode) Name() Name {
 	return s.name
 }
 

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package gcsx
 
 import (
 	"errors"
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/canned"
-	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/gcloud/gcs/gcscaching"
 	"github.com/jacobsa/ratelimit"
@@ -64,7 +63,7 @@ type BucketManager interface {
 	// Sets up a gcs bucket by its name
 	SetUpBucket(
 		ctx context.Context,
-		name string) (b gcsx.SyncerBucket, err error)
+		name string) (b SyncerBucket, err error)
 
 	// Shuts down the bucket manager and its buckets
 	ShutDown()
@@ -148,7 +147,7 @@ func setUpRateLimiting(
 // bucket as described in that package.
 func (bm *bucketManager) SetUpBucket(
 	ctx context.Context,
-	name string) (sb gcsx.SyncerBucket, err error) {
+	name string) (sb SyncerBucket, err error) {
 	var b gcs.Bucket
 	// Set up the appropriate backing bucket.
 	if name == canned.FakeBucketName {
@@ -169,7 +168,7 @@ func (bm *bucketManager) SetUpBucket(
 
 	// Limit to a requested prefix of the bucket, if any.
 	if bm.config.OnlyDir != "" {
-		b, err = gcsx.NewPrefixBucket(path.Clean(bm.config.OnlyDir)+"/", b)
+		b, err = NewPrefixBucket(path.Clean(bm.config.OnlyDir)+"/", b)
 		if err != nil {
 			err = fmt.Errorf("NewPrefixBucket: %v", err)
 			return
@@ -198,14 +197,14 @@ func (bm *bucketManager) SetUpBucket(
 	}
 
 	// Enable content type awareness
-	b = gcsx.NewContentTypeBucket(b)
+	b = NewContentTypeBucket(b)
 
 	// Enable Syncer
 	if bm.config.TmpObjectPrefix == "" {
 		err = errors.New("You must set TmpObjectPrefix.")
 		return
 	}
-	sb = gcsx.NewSyncerBucket(
+	sb = NewSyncerBucket(
 		bm.config.AppendThreshold,
 		bm.config.TmpObjectPrefix,
 		b)

--- a/internal/gcsx/garbage_collect.go
+++ b/internal/gcsx/garbage_collect.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package gcsx
 
 import (
 	"fmt"

--- a/internal/gcsx/syncer_bucket.go
+++ b/internal/gcsx/syncer_bucket.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsx
+
+import (
+	"github.com/jacobsa/gcloud/gcs"
+)
+
+type SyncerBucket struct {
+	gcs.Bucket
+	Syncer
+}
+
+// NewSyncerBucket creates a SyncerBucket, which can be used either as
+// a gcs.Bucket, or as a Syncer.
+func NewSyncerBucket(
+	appendThreshold int64,
+	tmpObjectPrefix string,
+	bucket gcs.Bucket,
+) SyncerBucket {
+	syncer := NewSyncer(appendThreshold, tmpObjectPrefix, bucket)
+	return SyncerBucket{bucket, syncer}
+}

--- a/mount.go
+++ b/mount.go
@@ -91,10 +91,9 @@ be interacting with the file system.`)
 		StatCacheCapacity:                  flags.StatCacheCapacity,
 		StatCacheTTL:                       flags.StatCacheTTL,
 	}
-	bucket, err := fs.SetUpBucket(
+	bm := fs.NewBucketManager(bucketCfg, conn)
+	bucket, err := bm.SetUpBucket(
 		ctx,
-		bucketCfg,
-		conn,
 		bucketName)
 
 	if err != nil {

--- a/mount.go
+++ b/mount.go
@@ -83,14 +83,22 @@ be interacting with the file system.`)
 	// Set up the bucket.
 	status.Println("Opening bucket...")
 
-	bucket, err := setUpBucket(
+	bucketCfg := fs.BucketConfig{
+		BillingProject:                     flags.BillingProject,
+		OnlyDir:                            flags.OnlyDir,
+		EgressBandwidthLimitBytesPerSecond: flags.EgressBandwidthLimitBytesPerSecond,
+		OpRateLimitHz:                      flags.OpRateLimitHz,
+		StatCacheCapacity:                  flags.StatCacheCapacity,
+		StatCacheTTL:                       flags.StatCacheTTL,
+	}
+	bucket, err := fs.SetUpBucket(
 		ctx,
-		flags,
+		bucketCfg,
 		conn,
 		bucketName)
 
 	if err != nil {
-		err = fmt.Errorf("setUpBucket: %v", err)
+		err = fmt.Errorf("SetUpBucket: %v", err)
 		return
 	}
 

--- a/mount.go
+++ b/mount.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/fs"
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/internal/perms"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fsutil"
@@ -83,7 +84,7 @@ be interacting with the file system.`)
 	// Set up the bucket.
 	status.Println("Opening bucket...")
 
-	bucketCfg := fs.BucketConfig{
+	bucketCfg := gcsx.BucketConfig{
 		BillingProject:                     flags.BillingProject,
 		OnlyDir:                            flags.OnlyDir,
 		EgressBandwidthLimitBytesPerSecond: flags.EgressBandwidthLimitBytesPerSecond,
@@ -93,7 +94,7 @@ be interacting with the file system.`)
 		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
 	}
-	bm := fs.NewBucketManager(bucketCfg, conn)
+	bm := gcsx.NewBucketManager(bucketCfg, conn)
 
 	// Create a file system server.
 	serverCfg := &fs.ServerConfig{

--- a/mount.go
+++ b/mount.go
@@ -92,19 +92,12 @@ be interacting with the file system.`)
 		StatCacheTTL:                       flags.StatCacheTTL,
 	}
 	bm := fs.NewBucketManager(bucketCfg, conn)
-	bucket, err := bm.SetUpBucket(
-		ctx,
-		bucketName)
-
-	if err != nil {
-		err = fmt.Errorf("SetUpBucket: %v", err)
-		return
-	}
 
 	// Create a file system server.
 	serverCfg := &fs.ServerConfig{
 		CacheClock:             timeutil.RealClock(),
-		Bucket:                 bucket,
+		BucketManager:          bm,
+		BucketName:             bucketName,
 		TempDir:                flags.TempDir,
 		ImplicitDirectories:    flags.ImplicitDirs,
 		InodeAttributeCacheTTL: flags.StatCacheTTL,
@@ -118,7 +111,7 @@ be interacting with the file system.`)
 		TmpObjectPrefix: ".gcsfuse_tmp/",
 	}
 
-	server, err := fs.NewServer(serverCfg)
+	server, err := fs.NewServer(ctx, serverCfg)
 	if err != nil {
 		err = fmt.Errorf("fs.NewServer: %v", err)
 		return
@@ -128,8 +121,8 @@ be interacting with the file system.`)
 	status.Println("Mounting file system...")
 
 	mountCfg := &fuse.MountConfig{
-		FSName:      bucket.Name(),
-		VolumeName:  bucket.Name(),
+		FSName:      "gcsfuse",
+		VolumeName:  "gcsfuse",
 		Options:     flags.MountOptions,
 		ErrorLogger: log.New(os.Stderr, "fuse: ", log.Flags()),
 	}

--- a/mount.go
+++ b/mount.go
@@ -90,6 +90,8 @@ be interacting with the file system.`)
 		OpRateLimitHz:                      flags.OpRateLimitHz,
 		StatCacheCapacity:                  flags.StatCacheCapacity,
 		StatCacheTTL:                       flags.StatCacheTTL,
+		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.
+		TmpObjectPrefix:                    ".gcsfuse_tmp/",
 	}
 	bm := fs.NewBucketManager(bucketCfg, conn)
 
@@ -106,9 +108,6 @@ be interacting with the file system.`)
 		Gid:                    gid,
 		FilePerms:              os.FileMode(flags.FileMode),
 		DirPerms:               os.FileMode(flags.DirMode),
-
-		AppendThreshold: 1 << 21, // 2 MiB, a total guess.
-		TmpObjectPrefix: ".gcsfuse_tmp/",
 	}
 
 	server, err := fs.NewServer(ctx, serverCfg)


### PR DESCRIPTION
The refactoring is to make it easier to add the feature of mounting all accessible buckets.

Before this change, the file system is not ready to support multiple buckets, because assumptions of "just one bucket" is prevalent throughout the system. This refactor, however, removes the assumption by

(1) the file system no longer owns a copy of the bucket,
(2) the buckets managed by a new object, BucketManager, allowing dynamically setting up more buckets, 
(3) each inode will inherit its bucket from the parent inode, allowing different buckets for different indoes. 

 