### PR TITLE
Print critical request info in GCS ListObject calls

### DIFF
--- a/vendor/github.com/jacobsa/gcloud/gcs/debug_bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/debug_bucket.go
@@ -201,7 +201,7 @@ func (b *debugBucket) StatObject(
 func (b *debugBucket) ListObjects(
 	ctx context.Context,
 	req *ListObjectsRequest) (listing *Listing, err error) {
-	id, desc, start := b.startRequest("ListObjects()")
+	id, desc, start := b.startRequest("ListObjects(%q)", req.Prefix)
 	defer b.finishRequest(id, desc, start, &err)
 
 	listing, err = b.wrapped.ListObjects(ctx, req)


### PR DESCRIPTION
The prefix of the ListObjectRequest is printed to help debug.