### PR TITLE
Cache implicit dirs to reduce ls latency

### DIFF
--- a/internal/fs/inode/type_cache.go
+++ b/internal/fs/inode/type_cache.go
@@ -53,6 +53,14 @@ type typeCache struct {
 	// INVARIANT: dirs.CheckInvariants() does not panic
 	// INVARIANT: Each value is of type time.Time
 	dirs lrucache.Cache
+
+	// A cache mapping implicit directory names to the time at which the entry
+	// should expire.
+	//
+	// INVARIANT: implicitDirs.CheckInvariants() does not panic
+	// INVARIANT: Each value is of type time.Time
+	// INVARIANT: must be a subset of dirs
+	implicitDirs lrucache.Cache
 }
 
 // Create a cache whose information expires with the supplied TTL. If the TTL
@@ -61,9 +69,10 @@ func newTypeCache(
 	perTypeCapacity int,
 	ttl time.Duration) (tc typeCache) {
 	tc = typeCache{
-		ttl:   ttl,
-		files: lrucache.New(perTypeCapacity),
-		dirs:  lrucache.New(perTypeCapacity),
+		ttl:          ttl,
+		files:        lrucache.New(perTypeCapacity),
+		dirs:         lrucache.New(perTypeCapacity),
+		implicitDirs: lrucache.New(perTypeCapacity),
 	}
 
 	return
@@ -81,6 +90,9 @@ func (tc *typeCache) CheckInvariants() {
 
 	// INVARIANT: dirs.CheckInvariants() does not panic
 	tc.dirs.CheckInvariants()
+
+	// INVARIANT: dirs.CheckInvariants() does not panic
+	tc.implicitDirs.CheckInvariants()
 }
 
 // Record that the supplied name is a file. It may still also be a directory.
@@ -103,10 +115,22 @@ func (tc *typeCache) NoteDir(now time.Time, name string) {
 	tc.dirs.Insert(name, now.Add(tc.ttl))
 }
 
+// Record that the supplied name is an implicit directory. It may still also be
+// a file, but must not be a regular directory.
+func (tc *typeCache) NoteImplicitDir(now time.Time, name string) {
+	// Are we disabled?
+	if tc.ttl == 0 {
+		return
+	}
+
+	tc.implicitDirs.Insert(name, now.Add(tc.ttl))
+}
+
 // Erase all information about the supplied name.
 func (tc *typeCache) Erase(name string) {
 	tc.files.Erase(name)
 	tc.dirs.Erase(name)
+	tc.implicitDirs.Erase(name)
 }
 
 // Do we currently think the given name is a file?
@@ -145,6 +169,28 @@ func (tc *typeCache) IsDir(now time.Time, name string) (res bool) {
 	// Has the entry expired?
 	if expiration.Before(now) {
 		tc.dirs.Erase(name)
+		res = false
+		return
+	}
+
+	res = true
+	return
+}
+
+// Do we currently think the given name is an implicit directory?
+func (tc *typeCache) IsImplicitDir(now time.Time, name string) (res bool) {
+	// Is there an entry?
+	val := tc.implicitDirs.LookUp(name)
+	if val == nil {
+		res = false
+		return
+	}
+
+	expiration := val.(time.Time)
+
+	// Has the entry expired?
+	if expiration.Before(now) {
+		tc.implicitDirs.Erase(name)
 		res = false
 		return
 	}


### PR DESCRIPTION
Implicit dirs are the gcs directories that don't have an object to back up.

The dir inodes used to memoize the subdirs, but not distinguishing the implicit subdirs. When it looked up subdir children, it had to issue an gcs ListObject api call to tell if the child was implicit or not, which was very expensive. This PR allows the dir inodes to cache the dirs as implicit dirs, to avoid such expensive api calls.

As a result, the latency of `ls a/b/c/d/` of 1024 files could be reduced from 10 min to 1.5 seconds, due to 4096 api calls avoided.