### PR TITLE
Retry for transient backend errors

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -146,6 +146,15 @@ func newApp() (app *cli.App) {
 			// Tuning
 			/////////////////////////
 
+			cli.DurationFlag{
+				Name:  "max-retry-sleep",
+				Value: time.Minute,
+				Usage: "The maximum duration allowed to sleep in a retry loop with " +
+					"exponential backoff for failed requests to GCS backend. Once the " +
+					"backoff duration exceeds this limit, the retry stops. The default " +
+					"of 0 disables retries.",
+			},
+
 			cli.IntFlag{
 				Name:  "stat-cache-capacity",
 				Value: 4096,
@@ -220,6 +229,7 @@ type flagStorage struct {
 	OpRateLimitHz                      float64
 
 	// Tuning
+	MaxRetrySleep     time.Duration
 	StatCacheCapacity int
 	StatCacheTTL      time.Duration
 	TypeCacheTTL      time.Duration
@@ -254,6 +264,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 
 		// Tuning,
+		MaxRetrySleep:     c.Duration("max-retry-sleep"),
 		StatCacheCapacity: c.Int("stat-cache-capacity"),
 		StatCacheTTL:      c.Duration("stat-cache-ttl"),
 		TypeCacheTTL:      c.Duration("type-cache-ttl"),

--- a/main.go
+++ b/main.go
@@ -204,8 +204,9 @@ func getConn(flags *flagStorage) (c gcs.Conn, err error) {
 	// Create the connection.
 	const userAgent = "gcsfuse/0.0"
 	cfg := &gcs.ConnConfig{
-		TokenSource: tokenSrc,
-		UserAgent:   userAgent,
+		TokenSource:     tokenSrc,
+		UserAgent:       userAgent,
+		MaxBackoffSleep: flags.MaxRetrySleep,
 	}
 
 	if flags.DebugHTTP {

--- a/tools/util/flaky_transport.go
+++ b/tools/util/flaky_transport.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/jacobsa/gcloud/httputil"
+)
+
+// NewFlakyTransport return a flaky transport that can have hiccups (service
+// unavailable) at a given rate between [0, 1].
+// This should be used for tests only.
+func NewFlakyTransport(hiccupRate float64) httputil.CancellableRoundTripper {
+	rand.Seed(int64(time.Now().Nanosecond()))
+	transport := http.DefaultTransport.(httputil.CancellableRoundTripper)
+	return &flakyTransport{
+		reliable:   transport,
+		hiccupRate: hiccupRate,
+	}
+}
+
+type flakyTransport struct {
+	reliable   httputil.CancellableRoundTripper
+	hiccupRate float64
+}
+
+func (t *flakyTransport) unavailable() bool {
+	return rand.Float64() < t.hiccupRate
+}
+
+// RoundTrip sends a request.
+func (t *flakyTransport) RoundTrip(
+	req *http.Request) (resp *http.Response, err error) {
+	if t.unavailable() {
+		err = fmt.Errorf("Service Unavailable")
+		fmt.Println("Hiccup injected")
+	} else {
+		resp, err = t.reliable.RoundTrip(req)
+	}
+	return
+}
+
+// CancelRequest cancels the request.
+func (t *flakyTransport) CancelRequest(req *http.Request) {
+	t.reliable.CancelRequest(req)
+}


### PR DESCRIPTION
Transient backend errors (e.g. HTTP 503) can interrupt a large scale
file I/O, causing the user script to fail: #407 #408 #410 

Retry is enabled to avoid that.

TEST

Add flaky_transport.go as test util. 

Manually swap `http.DefaultTransport` with `NewFlakyTransport(0.5)`,
and see the flakiness does not lead to any file I/O failure from the
user's perspective.