### PR TITLE
Update the CLI for mount-all-buckets

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -30,7 +30,7 @@ func init() {
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} {{if .Flags}}[global options]{{end}} bucket mountpoint
+   {{.Name}} {{if .Flags}}[global options]{{end}} [bucket] mountpoint
    {{if .Version}}
 VERSION:
    {{.Version}}
@@ -57,7 +57,7 @@ func newApp() (app *cli.App) {
 	app = &cli.App{
 		Name:    "gcsfuse",
 		Version: getVersion(),
-		Usage:   "Mount a GCS bucket locally",
+		Usage:   "Mount a specified GCS bucket or all accessible buckets locally",
 		Writer:  os.Stderr,
 		Flags: []cli.Flag{
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -34,13 +34,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// WildcardBucketName denotes 'all buckets'.
-//
-// When a WildcardBucketName is used, all the accessible buckets will be mounted
-// as subdirectories of the root of the file system. Otherwise, one bucket will
-// be mounted at the root of the file system.
-const WildcardBucketName = "*"
-
 type ServerConfig struct {
 	// A clock used for cache expiration. It is *not* used for inode times, for
 	// which we use the wall clock.
@@ -49,7 +42,8 @@ type ServerConfig struct {
 	// The bucket manager is responsible for setting up buckets.
 	BucketManager gcsx.BucketManager
 
-	// The name of the bucket to be mounted at root, or WildcardBucketName.
+	// The name of the specific GCS bucket to be mounted. If empty, all accessible
+	// GCS buckets are mounted as subdirectories of the FS root.
 	BucketName string
 
 	// The temporary directory to use for local caching, or the empty string to
@@ -135,7 +129,7 @@ func NewServer(
 
 	// Set up root bucket
 	var root inode.DirInode
-	if cfg.BucketName == WildcardBucketName {
+	if cfg.BucketName == "" {
 		root = makeRootForAllBuckets(fs)
 	} else {
 		var syncerBucket gcsx.SyncerBucket

--- a/main.go
+++ b/main.go
@@ -266,21 +266,28 @@ func mountWithArgs(
 	return
 }
 
-func runCLIApp(c *cli.Context) (err error) {
-	flags := populateFlags(c)
-
+func populateArgs(c *cli.Context) (
+	bucketName string,
+	mountPoint string,
+	err error) {
 	// Extract arguments.
-	if len(c.Args()) != 2 {
+	switch len(c.Args()) {
+	case 1:
+		bucketName = ""
+		mountPoint = c.Args()[0]
+
+	case 2:
+		bucketName = c.Args()[0]
+		mountPoint = c.Args()[1]
+
+	default:
 		err = fmt.Errorf(
-			"%s takes exactly two arguments. Run `%s --help` for more info.",
+			"%s takes one or two arguments. Run `%s --help` for more info.",
 			path.Base(os.Args[0]),
 			path.Base(os.Args[0]))
 
 		return
 	}
-
-	bucketName := c.Args()[0]
-	mountPoint := c.Args()[1]
 
 	// Canonicalize the mount point, making it absolute. This is important when
 	// daemonizing below, since the daemon will change its working directory
@@ -288,6 +295,18 @@ func runCLIApp(c *cli.Context) (err error) {
 	mountPoint, err = filepath.Abs(mountPoint)
 	if err != nil {
 		err = fmt.Errorf("canonicalizing mount point: %v", err)
+		return
+	}
+	return
+}
+
+func runCLIApp(c *cli.Context) (err error) {
+	flags := populateFlags(c)
+
+	var bucketName string
+	var mountPoint string
+	bucketName, mountPoint, err = populateArgs(c)
+	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
Since the wildcard `*` is confusing and easily misued with local shell,
it's removed from the CLI. If a bucket name is not specified, the
gcsfuse will mount all accessible buckets as subdirectories.

Before:
```
gcsfuse '*' ~/mnt/gcs
```

After:
```
gcsfuse ~/mnt/gcs
```