### PR TITLE
Remove "yum update" step from CentOS/RH install

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -80,13 +80,7 @@ for [other distributions](#other-distributions) below.
                https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
         EOF
 
-2.  Make the system aware of the new repo:
-
-        sudo yum update
-
-    Be sure to answer "yes" to any questions about adding the GPG signing key.
-
-3.  Install gcsfuse:
+2.  Install gcsfuse:
 
         sudo yum install gcsfuse
 


### PR DESCRIPTION
Under debian, an "apt-get update" step is required when adding repositories.  This step is not required in CentOS/Red Hat, and actually has a different effect: updating all packages on the system, which may not be what the user intended.  Hre we remove the step entirely, siply adding the repo and then running yum install.