### PR TITLE
New option to cache files locally for reads

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -165,6 +165,11 @@ func newApp() (app *cli.App) {
 					"inodes.",
 			},
 
+			cli.BoolFlag{
+				Name:  "local-file-cache",
+				Usage: "Cache GCS files on local disk for reads.",
+			},
+
 			cli.StringFlag{
 				Name:  "temp-dir",
 				Value: "",
@@ -223,6 +228,7 @@ type flagStorage struct {
 	StatCacheCapacity int
 	StatCacheTTL      time.Duration
 	TypeCacheTTL      time.Duration
+	LocalFileCache    bool
 	TempDir           string
 
 	// Debugging
@@ -257,6 +263,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		StatCacheCapacity: c.Int("stat-cache-capacity"),
 		StatCacheTTL:      c.Duration("stat-cache-ttl"),
 		TypeCacheTTL:      c.Duration("type-cache-ttl"),
+		LocalFileCache:    c.Bool("local-file-cache"),
 		TempDir:           c.String("temp-dir"),
 
 		// Debugging,

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -52,6 +52,9 @@ type ServerConfig struct {
 	// The name of the bucket to be mounted at root, or WildcardBucketName.
 	BucketName string
 
+	// LocalFileCache
+	LocalFileCache bool
+
 	// The temporary directory to use for local caching, or the empty string to
 	// use the system default.
 	TempDir string
@@ -118,6 +121,7 @@ func NewServer(
 		mtimeClock:             timeutil.RealClock(),
 		cacheClock:             cfg.CacheClock,
 		bucketManager:          cfg.BucketManager,
+		localFileCache:         cfg.LocalFileCache,
 		tempDir:                cfg.TempDir,
 		implicitDirs:           cfg.ImplicitDirectories,
 		inodeAttributeCacheTTL: cfg.InodeAttributeCacheTTL,
@@ -243,6 +247,7 @@ type fileSystem struct {
 	// Constant data
 	/////////////////////////
 
+	localFileCache         bool
 	tempDir                string
 	implicitDirs           bool
 	inodeAttributeCacheTTL time.Duration
@@ -572,6 +577,7 @@ func (fs *fileSystem) mintInode(
 				Mode: fs.fileMode,
 			},
 			bucket,
+			fs.localFileCache,
 			fs.tempDir,
 			fs.mtimeClock)
 	}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -93,6 +93,7 @@ func NewFileInode(
 	o *gcs.Object,
 	attrs fuseops.InodeAttributes,
 	bucket gcsx.SyncerBucket,
+	localFileCache bool,
 	tempDir string,
 	mtimeClock timeutil.Clock) (f *FileInode) {
 	// Set up the basic struct.
@@ -110,6 +111,11 @@ func NewFileInode(
 
 	// Set up invariant checking.
 	f.mu = syncutil.NewInvariantMutex(f.checkInvariants)
+
+	if localFileCache {
+		// The gcs object is cached as local temp file
+		f.ensureContent(context.Background())
+	}
 
 	return
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -110,6 +110,7 @@ func (t *FileTest) createInode() {
 			1, // Append threshold
 			".gcsfuse_tmp/",
 			t.bucket),
+		false, // localFileCache
 		"",
 		&t.clock)
 

--- a/mount.go
+++ b/mount.go
@@ -101,6 +101,7 @@ be interacting with the file system.`)
 		CacheClock:             timeutil.RealClock(),
 		BucketManager:          bm,
 		BucketName:             bucketName,
+		LocalFileCache:         flags.LocalFileCache,
 		TempDir:                flags.TempDir,
 		ImplicitDirectories:    flags.ImplicitDirs,
 		InodeAttributeCacheTTL: flags.StatCacheTTL,


### PR DESCRIPTION
Gcsfuse used have local temp files cached and synced for writes.
However, as the local SSD speeds improve, we may get better performance
reading from local cached files than from GCS backend.

Thus, this commit adds an option `--local-file-cache` that enables
reading from temp files cached at the directory specified by
`--temp-dir`.

Currently, the performance still needs to be optimized. The files are
downloaded in a blocking way to the cache when their inodes are created,
which can be very slow.