### PR TITLE
Make root directory containing buckets readable

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -288,6 +288,14 @@ type fakeBucketManager struct {
 
 func (bm *fakeBucketManager) ShutDown() {}
 
+func (bm *fakeBucketManager) ListBuckets(
+	ctx context.Context) (names []string, err error) {
+	for name, _ := range bm.buckets {
+		names = append(names, name)
+	}
+	return
+}
+
 func (bm *fakeBucketManager) SetUpBucket(
 	ctx context.Context,
 	name string) (sb gcsx.SyncerBucket, err error) {

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -170,7 +170,19 @@ func (d *baseDirInode) LookUpChild(
 func (d *baseDirInode) ReadEntries(
 	ctx context.Context,
 	tok string) (entries []fuseutil.Dirent, newTok string, err error) {
-	err = fuse.ENOSYS
+	var bucketNames []string
+	bucketNames, err = d.bucketManager.ListBuckets(ctx)
+	if err != nil {
+		return
+	}
+	for _, name := range bucketNames {
+		entry := fuseutil.Dirent{
+			Name: name,
+			Type: fuseutil.DT_Directory,
+		}
+		entries = append(entries, entry)
+	}
+
 	return
 }
 

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -104,6 +104,14 @@ func (bm *fakeBucketManager) SetUpTimes() int {
 	return bm.setupTimes
 }
 
+func (bm *fakeBucketManager) ListBuckets(
+	ctx context.Context) (names []string, err error) {
+	for name, _ := range bm.buckets {
+		names = append(names, name)
+	}
+	return
+}
+
 func (t *BaseDirTest) resetInode() {
 	if t.in != nil {
 		t.in.Unlock()


### PR DESCRIPTION
When the GCS bucket name is omitted, the root directory contains
subdirectories that represent buckets. Currently, reading the root
directory will end up in an error. This commit changes the behavior by
providing a list of bucket names for such operation.

The implementation uses the [official GCS client library](
https://godoc.org/cloud.google.com/go/storage). So, for it to be built, 
you may need to call `go get` to install the dependencies at GOPATH.

For this API to work, 
- It must know the project id, which can be passed  in as 
  `--billing-project=...`.
- The user or the service account must have the permission 
  `storage.buckets.list`.

TEST

The test is done by listing the all buckets on a GCE instance.
