### PR TITLE
Benchmarking different reader implementations

### DIFF
--- a/benchmarks/concurrent_read/main.go
+++ b/benchmarks/concurrent_read/main.go
@@ -131,7 +131,7 @@ func run(bucketName string, objectNames []string) {
 
 	for i := 0; i < *fIterations; i++ {
 		stats := testReader(rf, objectNames)
-		stats.report(httpVersion, readerVersion)
+		stats.report(httpVersion, *fConnsPerHost, readerVersion)
 	}
 }
 
@@ -150,16 +150,18 @@ func (s testStats) throughput() float32 {
 
 func (s testStats) report(
 	httpVersion string,
+	maxConnsPerHost int,
 	readerVersion string,
 ) {
 	fmt.Printf(
 		"# TEST READER %s\n"+
-			"Protocol: %s\n"+
+			"Protocol: %s (%v connections per host)\n"+
 			"Total bytes: %d\n"+
 			"Total files: %d\n"+
 			"Avg Throughput: %.1f MB/s\n\n",
 		readerVersion,
 		httpVersion,
+		maxConnsPerHost,
 		s.totalBytes,
 		s.totalFiles,
 		s.throughput(),

--- a/benchmarks/concurrent_read/main.go
+++ b/benchmarks/concurrent_read/main.go
@@ -1,0 +1,207 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Concurrently read objects on GCS provided by stdin. The user must ensure
+//    (1) all the objects come from the same bucket, and
+//    (2) the script is authorized to read from the bucket.
+// The stdin should contain N lines of object name, in the form of
+// "gs://bucket-name/object-name".
+//
+// This benchmark only tests the internal reader implementation, which
+// doesn't have FUSE involved.
+//
+// Usage Example:
+// 	 gsutil ls 'gs://bucket/prefix*' | go run \
+//      --http=1x50 --reader=official ./benchmark/concurrent_read
+//
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+var fHTTP = flag.String(
+	"http",
+	"1x100",
+	"Protocol and connections per host: 1x10, 1x50, 1x100, 2",
+)
+var fReader = flag.String(
+	"reader",
+	"vendor",
+	"Reader type: vendor, official.",
+)
+
+const (
+	KB = 1024
+	MB = 1024 * KB
+)
+
+func testReader(
+	httpVersion string,
+	readerVersion string,
+	bucketName string,
+	objectNames []string) (stats testStats) {
+	reportDuration := 10 * time.Second
+	ticker := time.NewTicker(reportDuration)
+	defer ticker.Stop()
+
+	doneBytes := make(chan int64)
+	doneFiles := make(chan int)
+	start := time.Now()
+
+	// run readers concurrently
+	transport := getTransport(httpVersion)
+	defer transport.CloseIdleConnections()
+	rf := newReaderFactory(transport, readerVersion, bucketName)
+	for _, objectName := range objectNames {
+		name := objectName
+		go func() {
+			reader := rf.NewReader(name)
+			defer reader.Close()
+			p := make([]byte, 128*1024)
+			for {
+				n, err := reader.Read(p)
+				doneBytes <- int64(n)
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					panic(fmt.Errorf("read %v fails: %v", name, err))
+				}
+			}
+			doneFiles <- 1
+			return
+		}()
+	}
+
+	// collect test stats
+	var lastTotalBytes int64
+	for stats.totalFiles < len(objectNames) {
+		select {
+		case b := <-doneBytes:
+			stats.totalBytes += b
+		case f := <-doneFiles:
+			stats.totalFiles += f
+		case <-ticker.C:
+			readBytes := stats.totalBytes - lastTotalBytes
+			lastTotalBytes = stats.totalBytes
+			mbps := float32(readBytes/MB) / float32(reportDuration/time.Second)
+			stats.mbps = append(stats.mbps, mbps)
+		}
+	}
+	stats.duration = time.Since(start)
+	stats.report(httpVersion, readerVersion)
+	return
+}
+
+func run(bucketName string, objectNames []string) {
+	protocols := map[string]string{
+		"1x10":  http1x10,
+		"1x50":  http1x50,
+		"1x100": http1x100,
+		"2":     http2,
+	}
+	readers := map[string]string{
+		"vendor":   vendorClientReader,
+		"official": officialClientReader,
+	}
+	testReader(
+		protocols[*fHTTP],
+		readers[*fReader],
+		bucketName,
+		objectNames,
+	)
+}
+
+type testStats struct {
+	totalBytes int64
+	totalFiles int
+	mbps       []float32
+	duration   time.Duration
+}
+
+func (s testStats) throughput() float32 {
+	mbs := float32(s.totalBytes) / float32(MB)
+	seconds := float32(s.duration) / float32(time.Second)
+	return mbs / seconds
+}
+
+func (s testStats) report(
+	httpVersion string,
+	readerVersion string,
+) {
+	fmt.Printf(
+		"# TEST READER %s\n"+
+			"Protocol: %s\n"+
+			"Total bytes: %d\n"+
+			"Total files: %d\n"+
+			"Avg Throughput: %.1f\n MB/s",
+		readerVersion,
+		httpVersion,
+		s.totalBytes,
+		s.totalFiles,
+		s.throughput(),
+	)
+}
+
+func getLinesFromStdin() (lines []string) {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				break
+			}
+			panic(fmt.Errorf("Stdin error: %v", err))
+		}
+		lines = append(lines, line)
+	}
+	return
+}
+
+func getObjectNames() (bucketName string, objectNames []string) {
+	uris := getLinesFromStdin()
+	for _, uri := range uris {
+		path := strings.TrimLeft(uri, "gs://")
+		path = strings.TrimRight(path, "\n")
+		segs := strings.Split(path, "/")
+		if len(segs) <= 1 {
+			panic(fmt.Errorf("Not a file name: %v", uri))
+		}
+
+		if bucketName == "" {
+			bucketName = segs[0]
+		} else if bucketName != segs[0] {
+			panic(fmt.Errorf("Multiple buckets: %v, %v", bucketName, segs[0]))
+		}
+
+		objectName := strings.Join(segs[1:], "/")
+		objectNames = append(objectNames, objectName)
+	}
+	return
+}
+
+func main() {
+	flag.Parse()
+	bucketName, objectNames := getObjectNames()
+	run(bucketName, objectNames)
+	return
+}

--- a/benchmarks/concurrent_read/readers.go
+++ b/benchmarks/concurrent_read/readers.go
@@ -1,0 +1,131 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"github.com/jacobsa/gcloud/gcs"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	vendorClientReader   string = "github.com/jacobsa/gcloud/gcs/read.go"
+	officialClientReader string = "cloud.google/com/go/storage/reader.go"
+)
+
+type readerFactory interface {
+	NewReader(objectName string) io.ReadCloser
+}
+
+func newReaderFactory(
+	transport *http.Transport,
+	readerType string,
+	bucketName string) (rf readerFactory) {
+	switch readerType {
+	case vendorClientReader:
+		rf = newVendorReaderFactory(transport, bucketName)
+	case officialClientReader:
+		rf = newOfficialReaderFactory(transport, bucketName)
+	default:
+		panic(fmt.Errorf("Unknown reader type: %v", readerType))
+	}
+	return
+}
+
+// Vendor reader depends on "github.com/jacobsa/gcloud/gcs"
+type vendorReaderFactory struct {
+	bucket gcs.Bucket
+}
+
+func newVendorReaderFactory(
+	transport *http.Transport,
+	bucketName string) (rf readerFactory) {
+	tokenSrc, err := google.DefaultTokenSource(
+		context.Background(),
+		gcs.Scope_FullControl,
+	)
+	if err != nil {
+		panic(fmt.Errorf("Cannot get token source: %v", err))
+	}
+	config := &gcs.ConnConfig{
+		TokenSource: tokenSrc,
+		UserAgent:   "gcsfuse/0.0",
+		Transport:   transport,
+	}
+	conn, err := gcs.NewConn(config)
+	if err != nil {
+		panic(fmt.Errorf("Cannot create conn: %v", err))
+	}
+	bucket, err := conn.OpenBucket(
+		context.Background(),
+		&gcs.OpenBucketOptions{
+			Name: bucketName,
+		},
+	)
+	if err != nil {
+		panic(fmt.Errorf("Cannot open bucket %v: %v", bucketName, err))
+	}
+	rf = &vendorReaderFactory{
+		bucket: bucket,
+	}
+	return
+}
+
+func (rf *vendorReaderFactory) NewReader(
+	objectName string) io.ReadCloser {
+	r, err := rf.bucket.NewReader(
+		context.Background(),
+		&gcs.ReadObjectRequest{
+			Name: objectName,
+		},
+	)
+	if err != nil {
+		panic(fmt.Errorf("Cannot read %v: %v", objectName, err))
+	}
+	return r
+}
+
+// Official reader depends on "cloud.google.com/go/storage"
+type officialReaderFactory struct {
+	bucket *storage.BucketHandle
+}
+
+func newOfficialReaderFactory(
+	transport *http.Transport,
+	bucketName string) (rf readerFactory) {
+	client, err := storage.NewClient(context.Background())
+	if err != nil {
+		panic(fmt.Errorf("NewClient: %v", err))
+	}
+	bucket := client.Bucket(bucketName)
+	return &officialReaderFactory{
+		bucket: bucket,
+	}
+}
+
+func (rf *officialReaderFactory) NewReader(
+	objectName string) io.ReadCloser {
+	object := rf.bucket.Object(objectName)
+	reader, err := object.NewReader(context.Background())
+	if err != nil {
+		panic(fmt.Errorf("NewReader: %v", err))
+	}
+	return reader
+}

--- a/benchmarks/concurrent_read/transport.go
+++ b/benchmarks/concurrent_read/transport.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+const (
+	http1x10  = "HTTP/1.1 (10 Conns Per Host)"
+	http1x50  = "HTTP/1.1 (50 Conns Per Host)"
+	http1x100 = "HTTP/1.1 (100 Conns Per Host)"
+	http2     = "HTTP/2"
+)
+
+func getTransport(transportType string) (transport *http.Transport) {
+	switch transportType {
+	case http1x10:
+		return getTransportHTTP1(10)
+	case http1x50:
+		return getTransportHTTP1(50)
+	case http1x100:
+		return getTransportHTTP1(100)
+	case http2:
+		return http.DefaultTransport.(*http.Transport).Clone()
+	default:
+		panic(fmt.Errorf("Unknown tranport type: %q", transportType))
+	}
+}
+
+func getTransportHTTP1(maxConnsPerHost int) (transport *http.Transport) {
+	return &http.Transport{
+		MaxConnsPerHost: maxConnsPerHost,
+		// This disables HTTP/2 in the transport.
+		TLSNextProto: make(
+			map[string]func(string, *tls.Conn) http.RoundTripper,
+		),
+	}
+}

--- a/benchmarks/concurrent_read/transport.go
+++ b/benchmarks/concurrent_read/transport.go
@@ -21,20 +21,16 @@ import (
 )
 
 const (
-	http1x10  = "HTTP/1.1 (10 Conns Per Host)"
-	http1x50  = "HTTP/1.1 (50 Conns Per Host)"
-	http1x100 = "HTTP/1.1 (100 Conns Per Host)"
-	http2     = "HTTP/2"
+	http1 = "HTTP/1.1"
+	http2 = "HTTP/2"
 )
 
-func getTransport(transportType string) (transport *http.Transport) {
+func getTransport(
+	transportType string,
+	maxConnsPerHost int) (transport *http.Transport) {
 	switch transportType {
-	case http1x10:
-		return getTransportHTTP1(10)
-	case http1x50:
-		return getTransportHTTP1(50)
-	case http1x100:
-		return getTransportHTTP1(100)
+	case http1:
+		return getTransportHTTP1(maxConnsPerHost)
 	case http2:
 		return http.DefaultTransport.(*http.Transport).Clone()
 	default:


### PR DESCRIPTION
This benchmark can test the read throughput of different reader implementation as well as the underlying protocol config. A few examples on GCE n1-highmem-8:

1. HTTP/1.1 100 Conns Per Host +  verdor implementation: 1456.8 MB/s
2. HTTP/2 + vendor implementation: 294.0 MB/s
3. HTTP/1.1 100 Conns Per Host + official implementation: 309.9 MB/s
4. HTTP/2 + official implementation:  273.0 MB/s

Here, "vendor implementation" refers to github.com/jacobsa/gcloud/gcs/read.go, whereas "official implementation" refers to cloud.google/com/go/storage/reader.go. 