### PR TITLE
Add prometheus metrics for monitoring

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -200,6 +200,17 @@ func newApp() (app *cli.App) {
 			},
 
 			/////////////////////////
+			// Monitoring
+			/////////////////////////
+
+			cli.IntFlag{
+				Name:  "monitoring-port",
+				Value: 0,
+				Usage: "The port used to export prometheus metrics for monitoring. " +
+					"The default value 0 indicates no monitoring metrics.",
+			},
+
+			/////////////////////////
 			// Debugging
 			/////////////////////////
 
@@ -256,6 +267,9 @@ type flagStorage struct {
 	DisableHTTP2      bool
 	MaxConnsPerHost   int
 
+	// Monitoring
+	MonitoringPort int
+
 	// Debugging
 	DebugFuse       bool
 	DebugGCS        bool
@@ -293,6 +307,9 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		TempDir:           c.String("temp-dir"),
 		DisableHTTP2:      c.Bool("disable-http2"),
 		MaxConnsPerHost:   c.Int("max-conns-per-host"),
+
+		// Monitoring
+		MonitoringPort: c.Int("monitoring-port"),
 
 		// Debugging,
 		DebugFuse:       c.Bool("debug_fuse"),

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -212,6 +212,9 @@ func (bm *bucketManager) SetUpBucket(
 	// Enable content type awareness
 	b = NewContentTypeBucket(b)
 
+	// Enable monitoring
+	b = NewMonitoringBucket(b)
+
 	// Enable Syncer
 	if bm.config.TmpObjectPrefix == "" {
 		err = errors.New("You must set TmpObjectPrefix.")

--- a/internal/gcsx/monitoring_bucket.go
+++ b/internal/gcsx/monitoring_bucket.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsx
+
+import (
+	"context"
+	"io"
+
+	"github.com/jacobsa/gcloud/gcs"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	counterGcsRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gcsfuse_gcs_requests",
+			Help: "Number of GCS requests.",
+		},
+		[]string{ // labels
+			"bucket",
+			"method",
+		},
+	)
+)
+
+// Initialize the prometheus metrics.
+func init() {
+	prometheus.MustRegister(counterGcsRequests)
+}
+
+func incrementCounterGcsRequests(bucketName string, method string) {
+	counterGcsRequests.With(
+		prometheus.Labels{
+			"bucket": bucketName,
+			"method": method,
+		},
+	).Inc()
+}
+
+// NewMonitoringBucket returns a gcs.Bucket that exports metrics for monitoring
+func NewMonitoringBucket(b gcs.Bucket) gcs.Bucket {
+	return &monitoringBucket{
+		wrapped: b,
+	}
+}
+
+type monitoringBucket struct {
+	wrapped gcs.Bucket
+}
+
+func (mb *monitoringBucket) Name() string {
+	return mb.wrapped.Name()
+}
+
+func (mb *monitoringBucket) NewReader(
+	ctx context.Context,
+	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
+	incrementCounterGcsRequests(mb.Name(), "NewReader")
+	return mb.wrapped.NewReader(ctx, req)
+}
+
+func (mb *monitoringBucket) CreateObject(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest) (*gcs.Object, error) {
+	incrementCounterGcsRequests(mb.Name(), "CreateObject")
+	return mb.wrapped.CreateObject(ctx, req)
+}
+
+func (mb *monitoringBucket) CopyObject(
+	ctx context.Context,
+	req *gcs.CopyObjectRequest) (*gcs.Object, error) {
+	incrementCounterGcsRequests(mb.Name(), "CopyObject")
+	return mb.wrapped.CopyObject(ctx, req)
+}
+
+func (mb *monitoringBucket) ComposeObjects(
+	ctx context.Context,
+	req *gcs.ComposeObjectsRequest) (*gcs.Object, error) {
+	incrementCounterGcsRequests(mb.Name(), "ComposeObjects")
+	return mb.wrapped.ComposeObjects(ctx, req)
+}
+
+func (mb *monitoringBucket) StatObject(
+	ctx context.Context,
+	req *gcs.StatObjectRequest) (*gcs.Object, error) {
+	incrementCounterGcsRequests(mb.Name(), "StatObject")
+	return mb.wrapped.StatObject(ctx, req)
+}
+
+func (mb *monitoringBucket) ListObjects(
+	ctx context.Context,
+	req *gcs.ListObjectsRequest) (*gcs.Listing, error) {
+	incrementCounterGcsRequests(mb.Name(), "ListObjects")
+	return mb.wrapped.ListObjects(ctx, req)
+}
+
+func (mb *monitoringBucket) UpdateObject(
+	ctx context.Context,
+	req *gcs.UpdateObjectRequest) (*gcs.Object, error) {
+	incrementCounterGcsRequests(mb.Name(), "UpdateObject")
+	return mb.wrapped.UpdateObject(ctx, req)
+}
+
+func (mb *monitoringBucket) DeleteObject(
+	ctx context.Context,
+	req *gcs.DeleteObjectRequest) error {
+	incrementCounterGcsRequests(mb.Name(), "DeleteObject")
+	return mb.wrapped.DeleteObject(ctx, req)
+}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/syncutil"
 	"github.com/kardianos/osext"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -72,6 +73,11 @@ func registerSIGINTHandler(mountPoint string) {
 			}
 		}
 	}()
+}
+
+func handlePrometheusHTTPRequests() {
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":8086", nil)
 }
 
 func handleCPUProfileSignals() {
@@ -438,6 +444,9 @@ func main() {
 	// Set up profiling handlers.
 	go handleCPUProfileSignals()
 	go handleMemoryProfileSignals()
+
+	// Set up prometheus request handlers.
+	go handlePrometheusHTTPRequests()
 
 	// Run.
 	err := run()


### PR DESCRIPTION
This PR adds 4 prometheus metrics:
- number of GCS requests by type,
- number of bytes read,
- number of readers created,
- number of readers closed.

They can be helpful for debugging performance issues as well as tracking the progress of some client application relying on gcsfuse.

TEST

Acquire the stats from localhost:8086 while running gcsfuse:
```
# HELP gcsfuse_bytes_read Number of bytes read from GCS.
# TYPE gcsfuse_bytes_read counter
gcsfuse_bytes_read{bucket="tf-ent-dev",object="datasets/imagenet/combined/train-00001-of-01024"} 1.33300224e+08
# HELP gcsfuse_gcs_requests Number of GCS requests.
# TYPE gcsfuse_gcs_requests counter
gcsfuse_gcs_requests{bucket="tf-ent-dev",method="ListObjects"} 10
gcsfuse_gcs_requests{bucket="tf-ent-dev",method="NewReader"} 1
gcsfuse_gcs_requests{bucket="tf-ent-dev",method="StatObject"} 15
# HELP gcsfuse_object_readers_closed Number of object readers already closed.
# TYPE gcsfuse_object_readers_closed counter
gcsfuse_object_readers_closed 1
# HELP gcsfuse_object_readers_created Number of object readers created.
# TYPE gcsfuse_object_readers_created counter
gcsfuse_object_readers_created 1
```