### PR TITLE
Monitor the fuse requests

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -153,7 +153,7 @@ func NewServer(
 	// Set up invariant checking.
 	fs.mu = syncutil.NewInvariantMutex(fs.checkInvariants)
 
-	server = fuseutil.NewFileSystemServer(fs)
+	server = fuseutil.NewFileSystemServer(WithMonitoring(fs))
 	return
 }
 

--- a/internal/fs/monitoring_fs.go
+++ b/internal/fs/monitoring_fs.go
@@ -44,14 +44,16 @@ var (
 	)
 	latencyOpenFile = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "gcsfuse_fs_open_file_latency",
-			Help: "The latency of OpenFile file system requests in ms.",
+			Name:    "gcsfuse_fs_open_file_latency",
+			Help:    "The latency of executing an OpenFile request in ms.",
+			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
 		},
 	)
 	latencyReadFile = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "gcsfuse_fs_read_file_latency",
-			Help: "The latency of ReadFile file system requests in ms.",
+			Name:    "gcsfuse_fs_read_file_latency",
+			Help:    "The latency of executing a ReadFile request in ms.",
+			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
 		},
 	)
 )

--- a/internal/fs/monitoring_fs.go
+++ b/internal/fs/monitoring_fs.go
@@ -1,0 +1,247 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"context"
+
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	counterFsRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gcsfuse_fs_requests",
+			Help: "Number of requests per file system API.",
+		},
+		[]string{ // labels
+			"method",
+		},
+	)
+)
+
+// Initialize the prometheus metrics.
+func init() {
+	prometheus.MustRegister(counterFsRequests)
+}
+
+func incrementCounterFsRequests(method string) {
+	counterFsRequests.With(
+		prometheus.Labels{
+			"method": method,
+		},
+	).Inc()
+}
+
+// WithMonitoring takes a FileSystem, returns a FileSystem with monitoring
+// on the counts of requests per API.
+func WithMonitoring(fs fuseutil.FileSystem) fuseutil.FileSystem {
+	return &monitoringFileSystem{
+		wrapped: fs,
+	}
+}
+
+type monitoringFileSystem struct {
+	wrapped fuseutil.FileSystem
+}
+
+func (fs *monitoringFileSystem) Destroy() {
+	incrementCounterFsRequests("Destroy")
+	fs.wrapped.Destroy()
+}
+
+func (fs *monitoringFileSystem) StatFS(
+	ctx context.Context,
+	op *fuseops.StatFSOp) error {
+	incrementCounterFsRequests("StatFS")
+	return fs.wrapped.StatFS(ctx, op)
+}
+
+func (fs *monitoringFileSystem) LookUpInode(
+	ctx context.Context,
+	op *fuseops.LookUpInodeOp) error {
+	incrementCounterFsRequests("LookUpInode")
+	return fs.wrapped.LookUpInode(ctx, op)
+}
+
+func (fs *monitoringFileSystem) GetInodeAttributes(
+	ctx context.Context,
+	op *fuseops.GetInodeAttributesOp) error {
+	incrementCounterFsRequests("GetInodeAttributes")
+	return fs.wrapped.GetInodeAttributes(ctx, op)
+}
+
+func (fs *monitoringFileSystem) SetInodeAttributes(
+	ctx context.Context,
+	op *fuseops.SetInodeAttributesOp) error {
+	incrementCounterFsRequests("SetInodeAttributes")
+	return fs.wrapped.SetInodeAttributes(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ForgetInode(
+	ctx context.Context,
+	op *fuseops.ForgetInodeOp) error {
+	incrementCounterFsRequests("ForgetInode")
+	return fs.wrapped.ForgetInode(ctx, op)
+}
+
+func (fs *monitoringFileSystem) MkDir(
+	ctx context.Context,
+	op *fuseops.MkDirOp) error {
+	incrementCounterFsRequests("MkDir")
+	return fs.wrapped.MkDir(ctx, op)
+}
+
+func (fs *monitoringFileSystem) MkNode(
+	ctx context.Context,
+	op *fuseops.MkNodeOp) error {
+	incrementCounterFsRequests("MkNode")
+	return fs.wrapped.MkNode(ctx, op)
+}
+
+func (fs *monitoringFileSystem) CreateFile(
+	ctx context.Context,
+	op *fuseops.CreateFileOp) error {
+	incrementCounterFsRequests("CreateFile")
+	return fs.wrapped.CreateFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) CreateSymlink(
+	ctx context.Context,
+	op *fuseops.CreateSymlinkOp) error {
+	incrementCounterFsRequests("CreateSymlink")
+	return fs.wrapped.CreateSymlink(ctx, op)
+}
+
+func (fs *monitoringFileSystem) Rename(
+	ctx context.Context,
+	op *fuseops.RenameOp) error {
+	incrementCounterFsRequests("Rename")
+	return fs.wrapped.Rename(ctx, op)
+}
+
+func (fs *monitoringFileSystem) RmDir(
+	ctx context.Context,
+	op *fuseops.RmDirOp) error {
+	incrementCounterFsRequests("RmDir")
+	return fs.wrapped.RmDir(ctx, op)
+}
+
+func (fs *monitoringFileSystem) Unlink(
+	ctx context.Context,
+	op *fuseops.UnlinkOp) error {
+	incrementCounterFsRequests("Unlink")
+	return fs.wrapped.Unlink(ctx, op)
+}
+
+func (fs *monitoringFileSystem) OpenDir(
+	ctx context.Context,
+	op *fuseops.OpenDirOp) error {
+	incrementCounterFsRequests("OpenDir")
+	return fs.wrapped.OpenDir(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ReadDir(
+	ctx context.Context,
+	op *fuseops.ReadDirOp) error {
+	incrementCounterFsRequests("ReadDir")
+	return fs.wrapped.ReadDir(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ReleaseDirHandle(
+	ctx context.Context,
+	op *fuseops.ReleaseDirHandleOp) error {
+	incrementCounterFsRequests("ReleaseDirHandle")
+	return fs.wrapped.ReleaseDirHandle(ctx, op)
+}
+
+func (fs *monitoringFileSystem) OpenFile(
+	ctx context.Context,
+	op *fuseops.OpenFileOp) error {
+	incrementCounterFsRequests("OpenFile")
+	return fs.wrapped.OpenFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ReadFile(
+	ctx context.Context,
+	op *fuseops.ReadFileOp) error {
+	incrementCounterFsRequests("ReadFile")
+	return fs.wrapped.ReadFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) WriteFile(
+	ctx context.Context,
+	op *fuseops.WriteFileOp) error {
+	incrementCounterFsRequests("WriteFile")
+	return fs.wrapped.WriteFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) SyncFile(
+	ctx context.Context,
+	op *fuseops.SyncFileOp) error {
+	incrementCounterFsRequests("SyncFile")
+	return fs.wrapped.SyncFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) FlushFile(
+	ctx context.Context,
+	op *fuseops.FlushFileOp) error {
+	incrementCounterFsRequests("FlushFile")
+	return fs.wrapped.FlushFile(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ReleaseFileHandle(
+	ctx context.Context,
+	op *fuseops.ReleaseFileHandleOp) error {
+	incrementCounterFsRequests("ReleaseFileHandle")
+	return fs.wrapped.ReleaseFileHandle(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ReadSymlink(
+	ctx context.Context,
+	op *fuseops.ReadSymlinkOp) error {
+	incrementCounterFsRequests("ReadSymlink")
+	return fs.wrapped.ReadSymlink(ctx, op)
+}
+
+func (fs *monitoringFileSystem) RemoveXattr(
+	ctx context.Context,
+	op *fuseops.RemoveXattrOp) error {
+	incrementCounterFsRequests("RemoveXattr")
+	return fs.wrapped.RemoveXattr(ctx, op)
+}
+
+func (fs *monitoringFileSystem) GetXattr(
+	ctx context.Context,
+	op *fuseops.GetXattrOp) error {
+	incrementCounterFsRequests("GetXattr")
+	return fs.wrapped.GetXattr(ctx, op)
+}
+
+func (fs *monitoringFileSystem) ListXattr(
+	ctx context.Context,
+	op *fuseops.ListXattrOp) error {
+	incrementCounterFsRequests("ListXattr")
+	return fs.wrapped.ListXattr(ctx, op)
+}
+
+func (fs *monitoringFileSystem) SetXattr(
+	ctx context.Context,
+	op *fuseops.SetXattrOp) error {
+	incrementCounterFsRequests("SetXattr")
+	return fs.wrapped.SetXattr(ctx, op)
+}

--- a/internal/fs/monitoring_fs.go
+++ b/internal/fs/monitoring_fs.go
@@ -44,16 +44,20 @@ var (
 	)
 	latencyOpenFile = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "gcsfuse_fs_open_file_latency",
-			Help:    "The latency of executing an OpenFile request in ms.",
-			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
+			Name: "gcsfuse_fs_open_file_latency",
+			Help: "The latency of executing an OpenFile request in ms.",
+
+			// 32 buckets: [0.1ms, 0.15ms, ..., 28.8s, +Inf]
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 32),
 		},
 	)
 	latencyReadFile = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "gcsfuse_fs_read_file_latency",
-			Help:    "The latency of executing a ReadFile request in ms.",
-			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
+			Name: "gcsfuse_fs_read_file_latency",
+			Help: "The latency of executing a ReadFile request in ms.",
+
+			// 32 buckets: [0.1ms, 0.15ms, ..., 28.8s, +Inf]
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 32),
 		},
 	)
 )

--- a/internal/fs/monitoring_fs.go
+++ b/internal/fs/monitoring_fs.go
@@ -33,6 +33,15 @@ var (
 			"method",
 		},
 	)
+	counterFsErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gcsfuse_fs_errors",
+			Help: "Number of errors per file system API.",
+		},
+		[]string{ // labels
+			"method",
+		},
+	)
 	latencyOpenFile = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name: "gcsfuse_fs_open_file_latency",
@@ -50,6 +59,7 @@ var (
 // Initialize the prometheus metrics.
 func init() {
 	prometheus.MustRegister(counterFsRequests)
+	prometheus.MustRegister(counterFsErrors)
 	prometheus.MustRegister(latencyOpenFile)
 	prometheus.MustRegister(latencyReadFile)
 }
@@ -60,6 +70,15 @@ func incrementCounterFsRequests(method string) {
 			"method": method,
 		},
 	).Inc()
+}
+func incrementCounterFsErrors(method string, err error) {
+	if err != nil {
+		counterFsErrors.With(
+			prometheus.Labels{
+				"method": method,
+			},
+		).Inc()
+	}
 }
 
 func recordLatency(metric prometheus.Histogram, start time.Time) {
@@ -88,105 +107,135 @@ func (fs *monitoringFileSystem) StatFS(
 	ctx context.Context,
 	op *fuseops.StatFSOp) error {
 	incrementCounterFsRequests("StatFS")
-	return fs.wrapped.StatFS(ctx, op)
+	err := fs.wrapped.StatFS(ctx, op)
+	incrementCounterFsErrors("StatFS", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) LookUpInode(
 	ctx context.Context,
 	op *fuseops.LookUpInodeOp) error {
 	incrementCounterFsRequests("LookUpInode")
-	return fs.wrapped.LookUpInode(ctx, op)
+	err := fs.wrapped.LookUpInode(ctx, op)
+	incrementCounterFsErrors("LookUpInode", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) GetInodeAttributes(
 	ctx context.Context,
 	op *fuseops.GetInodeAttributesOp) error {
 	incrementCounterFsRequests("GetInodeAttributes")
-	return fs.wrapped.GetInodeAttributes(ctx, op)
+	err := fs.wrapped.GetInodeAttributes(ctx, op)
+	incrementCounterFsErrors("GetInodeAttributes", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) SetInodeAttributes(
 	ctx context.Context,
 	op *fuseops.SetInodeAttributesOp) error {
 	incrementCounterFsRequests("SetInodeAttributes")
-	return fs.wrapped.SetInodeAttributes(ctx, op)
+	err := fs.wrapped.SetInodeAttributes(ctx, op)
+	incrementCounterFsErrors("SetInodeAttributes", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ForgetInode(
 	ctx context.Context,
 	op *fuseops.ForgetInodeOp) error {
 	incrementCounterFsRequests("ForgetInode")
-	return fs.wrapped.ForgetInode(ctx, op)
+	err := fs.wrapped.ForgetInode(ctx, op)
+	incrementCounterFsErrors("ForgetInode", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) MkDir(
 	ctx context.Context,
 	op *fuseops.MkDirOp) error {
 	incrementCounterFsRequests("MkDir")
-	return fs.wrapped.MkDir(ctx, op)
+	err := fs.wrapped.MkDir(ctx, op)
+	incrementCounterFsErrors("MkDir", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) MkNode(
 	ctx context.Context,
 	op *fuseops.MkNodeOp) error {
 	incrementCounterFsRequests("MkNode")
-	return fs.wrapped.MkNode(ctx, op)
+	err := fs.wrapped.MkNode(ctx, op)
+	incrementCounterFsErrors("MkNode", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) CreateFile(
 	ctx context.Context,
 	op *fuseops.CreateFileOp) error {
 	incrementCounterFsRequests("CreateFile")
-	return fs.wrapped.CreateFile(ctx, op)
+	err := fs.wrapped.CreateFile(ctx, op)
+	incrementCounterFsErrors("CreateFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) CreateSymlink(
 	ctx context.Context,
 	op *fuseops.CreateSymlinkOp) error {
 	incrementCounterFsRequests("CreateSymlink")
-	return fs.wrapped.CreateSymlink(ctx, op)
+	err := fs.wrapped.CreateSymlink(ctx, op)
+	incrementCounterFsErrors("CreateSymlink", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) Rename(
 	ctx context.Context,
 	op *fuseops.RenameOp) error {
 	incrementCounterFsRequests("Rename")
-	return fs.wrapped.Rename(ctx, op)
+	err := fs.wrapped.Rename(ctx, op)
+	incrementCounterFsErrors("Rename", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) RmDir(
 	ctx context.Context,
 	op *fuseops.RmDirOp) error {
 	incrementCounterFsRequests("RmDir")
-	return fs.wrapped.RmDir(ctx, op)
+	err := fs.wrapped.RmDir(ctx, op)
+	incrementCounterFsErrors("RmDir", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) Unlink(
 	ctx context.Context,
 	op *fuseops.UnlinkOp) error {
 	incrementCounterFsRequests("Unlink")
-	return fs.wrapped.Unlink(ctx, op)
+	err := fs.wrapped.Unlink(ctx, op)
+	incrementCounterFsErrors("Unlink", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) OpenDir(
 	ctx context.Context,
 	op *fuseops.OpenDirOp) error {
 	incrementCounterFsRequests("OpenDir")
-	return fs.wrapped.OpenDir(ctx, op)
+	err := fs.wrapped.OpenDir(ctx, op)
+	incrementCounterFsErrors("OpenDir", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ReadDir(
 	ctx context.Context,
 	op *fuseops.ReadDirOp) error {
 	incrementCounterFsRequests("ReadDir")
-	return fs.wrapped.ReadDir(ctx, op)
+	err := fs.wrapped.ReadDir(ctx, op)
+	incrementCounterFsErrors("ReadDir", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ReleaseDirHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseDirHandleOp) error {
 	incrementCounterFsRequests("ReleaseDirHandle")
-	return fs.wrapped.ReleaseDirHandle(ctx, op)
+	err := fs.wrapped.ReleaseDirHandle(ctx, op)
+	incrementCounterFsErrors("ReleaseDirHandle", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) OpenFile(
@@ -194,7 +243,9 @@ func (fs *monitoringFileSystem) OpenFile(
 	op *fuseops.OpenFileOp) error {
 	incrementCounterFsRequests("OpenFile")
 	defer recordLatency(latencyOpenFile, time.Now())
-	return fs.wrapped.OpenFile(ctx, op)
+	err := fs.wrapped.OpenFile(ctx, op)
+	incrementCounterFsErrors("OpenFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ReadFile(
@@ -202,68 +253,88 @@ func (fs *monitoringFileSystem) ReadFile(
 	op *fuseops.ReadFileOp) error {
 	incrementCounterFsRequests("ReadFile")
 	defer recordLatency(latencyReadFile, time.Now())
-	return fs.wrapped.ReadFile(ctx, op)
+	err := fs.wrapped.ReadFile(ctx, op)
+	incrementCounterFsErrors("ReadFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) WriteFile(
 	ctx context.Context,
 	op *fuseops.WriteFileOp) error {
 	incrementCounterFsRequests("WriteFile")
-	return fs.wrapped.WriteFile(ctx, op)
+	err := fs.wrapped.WriteFile(ctx, op)
+	incrementCounterFsErrors("WriteFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) SyncFile(
 	ctx context.Context,
 	op *fuseops.SyncFileOp) error {
 	incrementCounterFsRequests("SyncFile")
-	return fs.wrapped.SyncFile(ctx, op)
+	err := fs.wrapped.SyncFile(ctx, op)
+	incrementCounterFsErrors("SyncFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) FlushFile(
 	ctx context.Context,
 	op *fuseops.FlushFileOp) error {
 	incrementCounterFsRequests("FlushFile")
-	return fs.wrapped.FlushFile(ctx, op)
+	err := fs.wrapped.FlushFile(ctx, op)
+	incrementCounterFsErrors("FlushFile", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ReleaseFileHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseFileHandleOp) error {
 	incrementCounterFsRequests("ReleaseFileHandle")
-	return fs.wrapped.ReleaseFileHandle(ctx, op)
+	err := fs.wrapped.ReleaseFileHandle(ctx, op)
+	incrementCounterFsErrors("ReleaseFileHandle", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ReadSymlink(
 	ctx context.Context,
 	op *fuseops.ReadSymlinkOp) error {
 	incrementCounterFsRequests("ReadSymlink")
-	return fs.wrapped.ReadSymlink(ctx, op)
+	err := fs.wrapped.ReadSymlink(ctx, op)
+	incrementCounterFsErrors("ReadSymlink", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) RemoveXattr(
 	ctx context.Context,
 	op *fuseops.RemoveXattrOp) error {
 	incrementCounterFsRequests("RemoveXattr")
-	return fs.wrapped.RemoveXattr(ctx, op)
+	err := fs.wrapped.RemoveXattr(ctx, op)
+	incrementCounterFsErrors("RemoveXattr", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) GetXattr(
 	ctx context.Context,
 	op *fuseops.GetXattrOp) error {
 	incrementCounterFsRequests("GetXattr")
-	return fs.wrapped.GetXattr(ctx, op)
+	err := fs.wrapped.GetXattr(ctx, op)
+	incrementCounterFsErrors("GetXattr", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) ListXattr(
 	ctx context.Context,
 	op *fuseops.ListXattrOp) error {
 	incrementCounterFsRequests("ListXattr")
-	return fs.wrapped.ListXattr(ctx, op)
+	err := fs.wrapped.ListXattr(ctx, op)
+	incrementCounterFsErrors("ListXattr", err)
+	return err
 }
 
 func (fs *monitoringFileSystem) SetXattr(
 	ctx context.Context,
 	op *fuseops.SetXattrOp) error {
 	incrementCounterFsRequests("SetXattr")
-	return fs.wrapped.SetXattr(ctx, op)
+	err := fs.wrapped.SetXattr(ctx, op)
+	incrementCounterFsErrors("SetXattr", err)
+	return err
 }

--- a/internal/gcsx/monitoring_bucket.go
+++ b/internal/gcsx/monitoring_bucket.go
@@ -58,16 +58,20 @@ var (
 	)
 	latencyNewReader = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "gcsfuse_object_new_reader_latency",
-			Help:    "The latency of creating a GCS object reader in ms.",
-			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
+			Name: "gcsfuse_object_new_reader_latency",
+			Help: "The latency of creating a GCS object reader in ms.",
+
+			// 32 buckets: [0.1ms, 0.15ms, ..., 28.8s, +Inf]
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 32),
 		},
 	)
 	latencyRead = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "gcsfuse_object_read_latency",
-			Help:    "The latency of reading once by the reader in ms.",
-			Buckets: prometheus.ExponentialBuckets(0.01, 10, 8),
+			Name: "gcsfuse_object_read_latency",
+			Help: "The latency of reading once by the reader in ms.",
+
+			// 32 buckets: [0.1ms, 0.15ms, ..., 28.8s, +Inf]
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 32),
 		},
 	)
 )
@@ -124,7 +128,7 @@ func (mb *monitoringBucket) NewReader(
 	ctx context.Context,
 	req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
 	incrementCounterGcsRequests(mb.Name(), "NewReader")
-	defer recordLatency(latencyRead, time.Now())
+	defer recordLatency(latencyNewReader, time.Now())
 
 	rc, err = mb.wrapped.NewReader(ctx, req)
 	if err == nil {


### PR DESCRIPTION
Internally, gcsfuse has a "FileSystem" struct to handle fuse requests. This PR modifies each method of the FileSystem with these monitoring metrics:

- the number of each requests,
- the number of errors,
- the latency of ReadFile and OpenFile requests.

These metrics will be very helpful for debugging performance issues.