### PR TITLE
Improve logging message for mounted bucket name

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -134,9 +134,11 @@ func NewServer(
 	// Set up root bucket
 	var root inode.DirInode
 	if cfg.BucketName == "" {
+		fmt.Println("Set up root directory for all accessible buckets")
 		root = makeRootForAllBuckets(fs)
 	} else {
 		var syncerBucket gcsx.SyncerBucket
+		fmt.Println("Set up root directory for bucket " + cfg.BucketName)
 		syncerBucket, err = fs.bucketManager.SetUpBucket(ctx, cfg.BucketName)
 		if err != nil {
 			err = fmt.Errorf("SetUpBucket: %v", err)

--- a/mount.go
+++ b/mount.go
@@ -81,9 +81,6 @@ be interacting with the file system.`)
 		gid = uint32(flags.Gid)
 	}
 
-	// Set up the bucket.
-	status.Println("Opening bucket...")
-
 	bucketCfg := gcsx.BucketConfig{
 		BillingProject:                     flags.BillingProject,
 		OnlyDir:                            flags.OnlyDir,


### PR DESCRIPTION
Mention the bucket name or "all accessible buckets" when printing the
message for setting up buckets.