### PR TITLE
Fix the build of integration tests

### DIFF
--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -70,6 +70,12 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 		}
 	}
 
+	pathEnv, exists := os.LookupEnv("PATH")
+	if !exists {
+		err = fmt.Errorf("$PATH not found in OS")
+		return
+	}
+
 	// Create a directory to become GOPATH for our build below.
 	gopath, err := ioutil.TempDir("", "build_gcsfuse_gopath")
 	if err != nil {
@@ -147,6 +153,7 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 		// Set up environment.
 		cmd.Env = []string{
 			"GO15VENDOREXPERIMENT=1",
+			fmt.Sprintf("PATH=%s", pathEnv),
 			fmt.Sprintf("GOROOT=%s", runtime.GOROOT()),
 			fmt.Sprintf("GOPATH=%s", gopath),
 			fmt.Sprintf("GOCACHE=%s", gocache),

--- a/tools/integration_tests/main_test.go
+++ b/tools/integration_tests/main_test.go
@@ -151,6 +151,23 @@ func buildBuildGcsfuse(dst string) (err error) {
 		srcDir = pkg.Dir
 	}
 
+	// Create a directory to become GOPATH for our build below.
+	gopath, err := ioutil.TempDir("", "build_gcsfuse_gopath")
+	if err != nil {
+		err = fmt.Errorf("TempDir: %v", err)
+		return
+	}
+	defer os.RemoveAll(gopath)
+
+	// Create a directory to become GOCACHE for our build below.
+	var gocache string
+	gocache, err = ioutil.TempDir("", "build_gcsfuse_gocache")
+	if err != nil {
+		err = fmt.Errorf("TempDir: %v", err)
+		return
+	}
+	defer os.RemoveAll(gocache)
+
 	// Build within that directory with no GOPATH -- it should have no external
 	// dependencies besides the standard library.
 	{
@@ -162,6 +179,8 @@ func buildBuildGcsfuse(dst string) (err error) {
 		cmd.Dir = srcDir
 		cmd.Env = []string{
 			fmt.Sprintf("GOROOT=%s", runtime.GOROOT()),
+			fmt.Sprintf("GOPATH=%s", gopath),
+			fmt.Sprintf("GOCACHE=%s", gocache),
 		}
 
 		var output []byte


### PR DESCRIPTION
The integration tests can't be built due to the upgrade of Go.
```
> go test ./tools/integration_tests/
2020/08/28 14:34:14 Building build_gcsfuse at /tmp/gcsfuse_integration_tests718659205/build_gcsfuse
2020/08/28 14:34:14 buildGcsfuse: buildBuildGcsfuse: go build build_gcsfuse: exit status 1
Output:
build cache is required, but could not be located: GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are defined
FAIL	github.com/googlecloudplatform/gcsfuse/tools/integration_tests	0.091s
FAIL
```

This is fixed by adding necessary environment variables:
 - PATH,
 - GOROOT,
 - GOCACHE.

Now, the tests can be run.