### PR TITLE
Print status log messages to a log file with json format

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -20,8 +20,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/urfave/cli"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
+	"github.com/urfave/cli"
 )
 
 // Set up custom help text for gcsfuse; in particular the usage section.
@@ -200,7 +200,7 @@ func newApp() (app *cli.App) {
 			},
 
 			/////////////////////////
-			// Monitoring
+			// Monitoring & Logging
 			/////////////////////////
 
 			cli.IntFlag{
@@ -208,6 +208,14 @@ func newApp() (app *cli.App) {
 				Value: 0,
 				Usage: "The port used to export prometheus metrics for monitoring. " +
 					"The default value 0 indicates no monitoring metrics.",
+			},
+
+			cli.StringFlag{
+				Name:  "log-file",
+				Value: "",
+				Usage: "The file for storing logs that can be parsed by " +
+					"fluentd. When not provided, plain text logs are printed to " +
+					"stdout.",
 			},
 
 			/////////////////////////
@@ -269,6 +277,7 @@ type flagStorage struct {
 
 	// Monitoring
 	MonitoringPort int
+	LogFile        string
 
 	// Debugging
 	DebugFuse       bool
@@ -310,6 +319,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 
 		// Monitoring
 		MonitoringPort: c.Int("monitoring-port"),
+		LogFile:        c.String("log-file"),
 
 		// Debugging,
 		DebugFuse:       c.Bool("debug_fuse"),

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -1,0 +1,79 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logfile
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"time"
+)
+
+// Init creates or opens a log file.
+func Init(filename string) (f io.Writer, err error) {
+	f, err = os.OpenFile(
+		filename,
+		os.O_WRONLY|os.O_CREATE|os.O_APPEND,
+		0644,
+	)
+	f = &fluentdWriter{
+		w: f,
+	}
+	return
+}
+
+type logEntry struct {
+	Name             string `json:"name,omitempty"`
+	LevelName        string `json:"levelname,omitempty"`
+	Severity         string `json:"severity,omitempty"`
+	Message          string `json:"message,omitempty"`
+	TimestampSeconds int64  `json:"timestampSeconds,omitempty"`
+	TimestampNanos   int    `json:"timestampNanos,omitempty"`
+}
+
+// FluentdLogFile is an io.Writer that prints the logs to the file in
+// fluentd-based json format. This is not thread-safe.
+type fluentdWriter struct {
+	w io.Writer
+}
+
+// Write writes log message with formatting.
+func (f *fluentdWriter) Write(p []byte) (n int, err error) {
+	now := time.Now()
+
+	entry := logEntry{
+		Name:             "root",
+		LevelName:        "INFO",
+		Severity:         "INFO",
+		Message:          string(p),
+		TimestampSeconds: now.Unix(),
+		TimestampNanos:   now.Nanosecond(),
+	}
+
+	var buf []byte
+	buf, err = json.Marshal(entry)
+	if err != nil {
+		return
+	}
+
+	buf = append(buf, '\n')
+	_, err = f.w.Write(buf)
+	if err != nil {
+		return
+	}
+
+	n = len(p)
+	return
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/canned"
+	"github.com/googlecloudplatform/gcsfuse/internal/logfile"
 	"github.com/jacobsa/daemonize"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/gcloud/gcs"
@@ -328,6 +329,14 @@ func populateArgs(c *cli.Context) (
 
 func runCLIApp(c *cli.Context) (err error) {
 	flags := populateFlags(c)
+
+	// If log file provided, override the default status output
+	if flags.LogFile != "" {
+		daemonize.StatusWriter, err = logfile.Init(flags.LogFile)
+		if err != nil {
+			return
+		}
+	}
 
 	var bucketName string
 	var mountPoint string


### PR DESCRIPTION
In some applications, the log messages should be printed to a log file with a json format that can be parsed by the fluentd-based Stackdriver agent.

Currently, it's very hard to make all log messages that way. So, this PR starts with the most important messages, ie. the "status" messages printed at mounting time. 

This PR adds an option "--log-file" to specify a log file containing all the status messages in the fluentd json format.

It's tested in both foreground and background running mode. The log file now has these logs:
```
{"name":"root","levelname":"INFO","severity":"INFO","message":"Opening GCS connection...\n","timestampSeconds":1599780949,"timestampNanos":826263000}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Mounting file system...\n","timestampSeconds":1599780950,"timestampNanos":693568000}
{"name":"root","levelname":"INFO","severity":"INFO","message":"File system has been successfully mounted.\n","timestampSeconds":1599780950,"timestampNanos":723616000}
```