### PR TITLE
Fix a broken test caused by API change

### DIFF
--- a/tools/integration_tests/gcsfuse_test.go
+++ b/tools/integration_tests/gcsfuse_test.go
@@ -129,20 +129,14 @@ func (t *GcsfuseTest) BadUsage() {
 		args           []string
 		expectedOutput string
 	}{
-		// Too few args
-		0: {
-			[]string{canned.FakeBucketName},
-			"exactly two arguments",
-		},
-
 		// Too many args
-		1: {
+		0: {
 			[]string{canned.FakeBucketName, "a", "b"},
-			"exactly two arguments",
+			"gcsfuse takes one or two arguments.",
 		},
 
 		// Unknown flag
-		2: {
+		1: {
 			[]string{"--tweak_frobnicator", canned.FakeBucketName, "a"},
 			"not defined.*tweak_frobnicator",
 		},


### PR DESCRIPTION
This fixes all the tests.
```
> go test ./...                                                                                                                                                                                                                                                                                     
ok  	github.com/googlecloudplatform/gcsfuse	(cached)
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/concurrent_read	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/internal/format	[no test files]
ok  	github.com/googlecloudplatform/gcsfuse/benchmarks/internal/percentile	(cached)
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/read_full_file	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/read_within_file	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/stat_files	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/write_locally	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/benchmarks/write_to_gcs	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/internal/canned	[no test files]
ok  	github.com/googlecloudplatform/gcsfuse/internal/fs	(cached)
?   	github.com/googlecloudplatform/gcsfuse/internal/fs/handle	[no test files]
ok  	github.com/googlecloudplatform/gcsfuse/internal/fs/inode	(cached)
ok  	github.com/googlecloudplatform/gcsfuse/internal/gcsx	(cached)
?   	github.com/googlecloudplatform/gcsfuse/internal/logfile	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/internal/mount	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/internal/perms	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/tools/build_gcsfuse	[no test files]
ok  	github.com/googlecloudplatform/gcsfuse/tools/integration_tests	(cached)
?   	github.com/googlecloudplatform/gcsfuse/tools/mount_gcsfuse	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/tools/package_gcsfuse	[no test files]
?   	github.com/googlecloudplatform/gcsfuse/tools/util	[no test files]
```