### PR TITLE
Update golang version in travis.yml for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.15.2
   - tip
 
 # Use the virtualized Trusty beta Travis is running in order to get support for


### PR DESCRIPTION
The golang version should updated from `1.9` from 2017 to `1.15.2` the latest.