### PR TITLE
Use _ to represent all buckets in CLI

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -42,8 +42,8 @@ type ServerConfig struct {
 	// The bucket manager is responsible for setting up buckets.
 	BucketManager gcsx.BucketManager
 
-	// The name of the specific GCS bucket to be mounted. If empty, all accessible
-	// GCS buckets are mounted as subdirectories of the FS root.
+	// The name of the specific GCS bucket to be mounted. If it's empty or "_",
+	// all accessible GCS buckets are mounted as subdirectories of the FS root.
 	BucketName string
 
 	// LocalFileCache
@@ -133,7 +133,7 @@ func NewServer(
 
 	// Set up root bucket
 	var root inode.DirInode
-	if cfg.BucketName == "" {
+	if cfg.BucketName == "" || cfg.BucketName == "_" {
 		fmt.Println("Set up root directory for all accessible buckets")
 		root = makeRootForAllBuckets(fs)
 	} else {


### PR DESCRIPTION
Currently, there are two ways to mount gcsfuse:
```
# mount bucket 'foo' to /gcs
gcsfuse foo /gcs 
# mount all buckets to /gcs, and bucket foo will be at /gcs/foo
gcsfuse /gcs 
```

However, the 2nd way can't used by the [kubernetes CSI driver](https://github.com/ofek/csi-gcs), which calls linux `mount` to mount gcsfuse:
```
# mount bucket 'foo' to /gcs
mount -t gcsfuse foo /gcs
# mount all buckets to /gcs. this can't work since `mount` requires a `device_name` argument
mount -t gcsfuse /gcs
```

So, this PR adds a placeholder bucket name for "all buckets" -- "_". When the bucket name is "_", it means "all buckets". Then, we can mount all buckets with gcsfuse this way in kubernetes:
```
mount -t gcsfuse _ /gcs
```