### PR TITLE
Support GKE workload identity by exchanging k8s token with GCP token

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -128,6 +128,12 @@ func newApp() (app *cli.App) {
 					"(default: none, Google application default credentials used)",
 			},
 
+			cli.StringFlag{
+				Name:  "exchange-token",
+				Value: "",
+				Usage: "A token exchanged for an access token for GCS API.",
+			},
+
 			cli.Float64Flag{
 				Name:  "limit-bytes-per-sec",
 				Value: -1,
@@ -262,6 +268,7 @@ type flagStorage struct {
 	// GCS
 	BillingProject                     string
 	KeyFile                            string
+	ExchangeToken                      string
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
 
@@ -304,6 +311,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		// GCS,
 		BillingProject:                     c.String("billing-project"),
 		KeyFile:                            c.String("key-file"),
+		ExchangeToken:                      c.String("exchange-token"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/googlecloudplatform/gcsfuse
 go 1.14
 
 require (
+	cloud.google.com/go v0.56.0
 	cloud.google.com/go/storage v1.6.0
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
 	github.com/jacobsa/fuse v0.0.0-20200706075950-f8927095af03

--- a/internal/auth/exchange_token_source.go
+++ b/internal/auth/exchange_token_source.go
@@ -1,0 +1,168 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/jacobsa/gcloud/httputil"
+	"golang.org/x/oauth2"
+)
+
+func fetchIDPool() (idPool string, err error) {
+	projectID, err := metadata.ProjectID()
+	if err != nil {
+		return
+	}
+
+	idPool = fmt.Sprintf("%s.svc.id.goog", projectID)
+	return
+}
+
+func fetchIDProvider() (provider string, err error) {
+	projectID, err := metadata.ProjectID()
+	if err != nil {
+		return
+	}
+
+	clusterLocation, err := metadata.InstanceAttributeValue("cluster-location")
+	if err != nil {
+		return
+	}
+
+	clusterName, err := metadata.InstanceAttributeValue("cluster-name")
+	if err != nil {
+		return
+	}
+
+	provider = fmt.Sprintf(
+		"https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
+		projectID,
+		clusterLocation,
+		clusterName)
+
+	return
+}
+
+func getAudience() (audience string, err error) {
+	idPool, err := fetchIDPool()
+	if err != nil {
+		err = fmt.Errorf("fetchIDPool: %v", err)
+		return
+	}
+
+	idProvider, err := fetchIDProvider()
+	if err != nil {
+		err = fmt.Errorf("fetchIDProvider: %v", err)
+		return
+	}
+
+	audience = fmt.Sprintf("identitynamespace:%s:%s", idPool, idProvider)
+	return
+}
+
+func newExchangeTokenSource(
+	ctx context.Context,
+	exchangeToken string,
+) (ts oauth2.TokenSource, err error) {
+	audience, err := getAudience()
+	if err != nil {
+		err = fmt.Errorf("getAudience: %v", err)
+		return
+	}
+
+	k8sTs := &identityBindingTokenSource{
+		ctx:           ctx,
+		audience:      audience,
+		exchangeToken: exchangeToken,
+	}
+	ts = oauth2.ReuseTokenSource(nil, k8sTs)
+	return
+}
+
+// Generates identitybindingtoken from securetoken.googleapis.com with
+// the exchangeToken.
+type identityBindingTokenSource struct {
+	ctx           context.Context
+	audience      string
+	exchangeToken string
+}
+
+func (ts *identityBindingTokenSource) Token() (token *oauth2.Token, err error) {
+	body, err := json.Marshal(map[string]string{
+		"grant_type":           "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token_type":   "urn:ietf:params:oauth:token-type:jwt",
+		"requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+		"subject_token":        ts.exchangeToken,
+		"audience":             ts.audience,
+		"scope":                "https://www.googleapis.com/auth/cloud-platform",
+	})
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		"https://securetoken.googleapis.com/v1/identitybindingtoken",
+		bytes.NewBuffer(body),
+	)
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add logging for token client
+	logger := log.New(os.Stdout, "TokenSource: ", 0)
+	transport := httputil.DebuggingRoundTripper(
+		http.DefaultTransport.(httputil.CancellableRoundTripper),
+		logger)
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf(
+			"could not get identitybindingtoken, status: %v", resp.StatusCode)
+		defer resp.Body.Close()
+		respBody, err2 := ioutil.ReadAll(resp.Body)
+		if err2 != nil {
+			fmt.Printf("Body: %v\n", respBody)
+		}
+		return
+	}
+
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	if err = json.Unmarshal(respBody, token); err != nil {
+		return
+	}
+	fmt.Printf("ItendityBindingToken: %v\n", token)
+	return
+}

--- a/main.go
+++ b/main.go
@@ -171,7 +171,10 @@ func handleMemoryProfileSignals() {
 
 func getConn(flags *flagStorage) (c gcs.Conn, err error) {
 	var tokenSrc oauth2.TokenSource
-	tokenSrc, err = auth.GetTokenSource(flags.KeyFile)
+	tokenSrc, err = auth.GetTokenSource(
+		flags.KeyFile,
+		flags.ExchangeToken,
+	)
 	if err != nil {
 		err = fmt.Errorf("GetTokenSource: %v", err)
 		return

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -86,8 +86,20 @@ func makeGcsfuseArgs(
 				"--"+strings.Replace(name, "_", "-", -1),
 			)
 
-			// Special case: support mount-like formatting for gcsfuse string flags.
-		case "dir_mode", "file_mode", "key_file", "temp_dir", "gid", "uid", "only_dir", "limit_ops_per_sec", "limit_bytes_per_sec", "stat_cache_ttl", "type_cache_ttl", "billing_project":
+		// Special case: support mount-like formatting for gcsfuse string flags.
+		case "dir_mode",
+			"file_mode",
+			"key_file",
+			"temp_dir",
+			"gid",
+			"uid",
+			"only_dir",
+			"limit_ops_per_sec",
+			"limit_bytes_per_sec",
+			"stat_cache_ttl",
+			"type_cache_ttl",
+			"exchange_token",
+			"billing_project":
 			args = append(
 				args,
 				"--"+strings.Replace(name, "_", "-", -1),
@@ -233,14 +245,14 @@ func run(args []string) (err error) {
 	cmd := exec.Command(gcsfusePath, gcsfuseArgs...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", path.Dir(fusermountPath)))
 
-        // Pass through the https_proxy/http_proxy environment variable,
+	// Pass through the https_proxy/http_proxy environment variable,
 	// in case the host requires a proxy server to reach the GCS endpoint.
 	// http_proxy has precedence over http_proxy, in case both are set
-        if p, ok := os.LookupEnv("https_proxy"); ok {
-                cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", p))
-        } else if p, ok := os.LookupEnv("http_proxy"); ok {
-                cmd.Env = append(cmd.Env, fmt.Sprintf("http_proxy=%s", p))
-        }
+	if p, ok := os.LookupEnv("https_proxy"); ok {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", p))
+	} else if p, ok := os.LookupEnv("http_proxy"); ok {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("http_proxy=%s", p))
+	}
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # cloud.google.com/go v0.56.0
+## explicit
 cloud.google.com/go
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/iam


### PR DESCRIPTION
Add a new flag `--k8s-token-file`, which provides a JWT for a Kubernetes ServiceAccount. Such token is then exchanged for GCP's IdentityBindingToken, which can authenticate the accesses to GCS APIs in gcsfuse.

This will enable gcsfuse to be deployed on GKE as a CSI driver using the pods' [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 