### PR TITLE
Fix mount.gcsfuse options

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -86,16 +86,23 @@ func makeGcsfuseArgs(
 		// Special case: support mount-like formatting for gcsfuse string flags.
 		case "dir_mode",
 			"file_mode",
-			"key_file",
-			"temp_dir",
-			"gid",
 			"uid",
+			"gid",
 			"only_dir",
-			"limit_ops_per_sec",
+			"billing_project",
+			"key_file",
 			"limit_bytes_per_sec",
+			"limit_ops_per_sec",
+			"max_retry_sleep",
+			"stat_cache_capacity",
 			"stat_cache_ttl",
 			"type_cache_ttl",
-			"billing_project":
+			"local_file_cache",
+			"temp_dir",
+			"disable_http2",
+			"max_conns_per_host",
+			"monitoring_port",
+			"log_file":
 			args = append(args, "--"+strings.Replace(name, "_", "-", -1), value)
 
 		// Special case: support mount-like formatting for gcsfuse debug flags.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -81,25 +81,29 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs":
-			args = append(
-				args,
-				"--"+strings.Replace(name, "_", "-", -1),
-			)
+			args = append(args, "--"+strings.Replace(name, "_", "-", -1))
 
-			// Special case: support mount-like formatting for gcsfuse string flags.
-		case "dir_mode", "file_mode", "key_file", "temp_dir", "gid", "uid", "only_dir", "limit_ops_per_sec", "limit_bytes_per_sec", "stat_cache_ttl", "type_cache_ttl", "billing_project":
-			args = append(
-				args,
-				"--"+strings.Replace(name, "_", "-", -1),
-				value,
-			)
+		// Special case: support mount-like formatting for gcsfuse string flags.
+		case "dir_mode",
+			"file_mode",
+			"key_file",
+			"temp_dir",
+			"gid",
+			"uid",
+			"only_dir",
+			"limit_ops_per_sec",
+			"limit_bytes_per_sec",
+			"stat_cache_ttl",
+			"type_cache_ttl",
+			"billing_project":
+			args = append(args, "--"+strings.Replace(name, "_", "-", -1), value)
 
-			// Special case: support mount-like formatting for gcsfuse debug flags.
-		case "debug_fuse", "debug_gcs", "debug_http", "debug_invariants":
-			args = append(
-				args,
-				"--"+name,
-			)
+		// Special case: support mount-like formatting for gcsfuse debug flags.
+		case "debug_fuse",
+			"debug_gcs",
+			"debug_http",
+			"debug_invariants":
+			args = append(args, "--"+name)
 
 		// Pass through everything else.
 		default:
@@ -233,14 +237,14 @@ func run(args []string) (err error) {
 	cmd := exec.Command(gcsfusePath, gcsfuseArgs...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", path.Dir(fusermountPath)))
 
-        // Pass through the https_proxy/http_proxy environment variable,
+	// Pass through the https_proxy/http_proxy environment variable,
 	// in case the host requires a proxy server to reach the GCS endpoint.
 	// http_proxy has precedence over http_proxy, in case both are set
-        if p, ok := os.LookupEnv("https_proxy"); ok {
-                cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", p))
-        } else if p, ok := os.LookupEnv("http_proxy"); ok {
-                cmd.Env = append(cmd.Env, fmt.Sprintf("http_proxy=%s", p))
-        }
+	if p, ok := os.LookupEnv("https_proxy"); ok {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("https_proxy=%s", p))
+	} else if p, ok := os.LookupEnv("http_proxy"); ok {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("http_proxy=%s", p))
+	}
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
The tool `mount.gcsfuse` is provided to be used with `mount(8)`. Its options are different from gcsfuse. 

This PR syncs the options between the 2 executables. 