### PR TITLE
Fix authentication failure with key-file specified but not used

### DIFF
--- a/internal/gcsx/connection.go
+++ b/internal/gcsx/connection.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsx
+
+import (
+	"fmt"
+
+	"cloud.google.com/go/storage"
+	"github.com/jacobsa/gcloud/gcs"
+	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+type Connection struct {
+	wrapped gcs.Conn
+	gcs     *storage.Client
+}
+
+func NewConnection(cfg *gcs.ConnConfig) (c *Connection, err error) {
+	wrapped, err := gcs.NewConn(cfg)
+	if err != nil {
+		err = fmt.Errorf("Cannot create Conn: %v", err)
+		return
+	}
+
+	gcs, err := storage.NewClient(
+		context.Background(),
+		option.WithTokenSource(cfg.TokenSource))
+	if err != nil {
+		err = fmt.Errorf("Cannot create GCS client: %v", err)
+		return
+	}
+
+	c = &Connection{
+		wrapped: wrapped,
+		gcs:     gcs,
+	}
+	return
+}
+
+func (c *Connection) OpenBucket(
+	ctx context.Context,
+	options *gcs.OpenBucketOptions) (b gcs.Bucket, err error) {
+	b, err = c.wrapped.OpenBucket(ctx, options)
+	return
+}
+
+func (c *Connection) ListBuckets(
+	ctx context.Context,
+	projectId string) (names []string, err error) {
+	it := c.gcs.Buckets(ctx, projectId)
+	for {
+		bucket, nextErr := it.Next()
+		switch nextErr {
+		case nil:
+			names = append(names, bucket.Name)
+		case iterator.Done:
+			return
+		default:
+			err = nextErr
+			return
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/internal/auth"
 	"github.com/googlecloudplatform/gcsfuse/internal/canned"
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/internal/logfile"
 	"github.com/jacobsa/daemonize"
 	"github.com/jacobsa/fuse"
@@ -168,7 +169,7 @@ func handleMemoryProfileSignals() {
 	}
 }
 
-func getConn(flags *flagStorage) (c gcs.Conn, err error) {
+func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 	tokenSrc, err := auth.GetTokenSource(context.Background(), flags.KeyFile)
 	if err != nil {
 		err = fmt.Errorf("GetTokenSource: %v", err)
@@ -205,7 +206,7 @@ func getConn(flags *flagStorage) (c gcs.Conn, err error) {
 		cfg.GCSDebugLogger = log.New(os.Stdout, "gcs: ", log.Flags())
 	}
 
-	return gcs.NewConn(cfg)
+	return gcsx.NewConnection(cfg)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -227,7 +228,7 @@ func mountWithArgs(
 	//
 	// Special case: if we're mounting the fake bucket, we don't need an actual
 	// connection.
-	var conn gcs.Conn
+	var conn *gcsx.Connection
 	if bucketName != canned.FakeBucketName {
 		mountStatus.Println("Opening GCS connection...")
 

--- a/mount.go
+++ b/mount.go
@@ -26,7 +26,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/perms"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fsutil"
-	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/timeutil"
 )
 
@@ -37,7 +36,7 @@ func mountWithConn(
 	bucketName string,
 	mountPoint string,
 	flags *flagStorage,
-	conn gcs.Conn,
+	conn *gcsx.Connection,
 	status *log.Logger) (mfs *fuse.MountedFileSystem, err error) {
 	// Sanity check: make sure the temporary directory exists and is writable
 	// currently. This gives a better user experience than harder to debug EIO


### PR DESCRIPTION
Fix #471 where the `storage.NewClient` did not get the `TokenSource` backed by the key-file. 