### PR TITLE
Fetch access tokens from a token url specified in flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -128,6 +128,13 @@ func newApp() (app *cli.App) {
 					"(default: none, Google application default credentials used)",
 			},
 
+			cli.StringFlag{
+				Name:  "auth-proxy",
+				Value: "",
+				Usage: "A URL for an authentication proxy that provides access " +
+					"tokens. Used when key-file is unset.",
+			},
+
 			cli.Float64Flag{
 				Name:  "limit-bytes-per-sec",
 				Value: -1,
@@ -262,6 +269,7 @@ type flagStorage struct {
 	// GCS
 	BillingProject                     string
 	KeyFile                            string
+	AuthProxy                          string
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
 
@@ -304,6 +312,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		// GCS,
 		BillingProject:                     c.String("billing-project"),
 		KeyFile:                            c.String("key-file"),
+		AuthProxy:                          c.String("auth-proxy"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 

--- a/flags.go
+++ b/flags.go
@@ -129,10 +129,9 @@ func newApp() (app *cli.App) {
 			},
 
 			cli.StringFlag{
-				Name:  "auth-proxy",
+				Name:  "token-url",
 				Value: "",
-				Usage: "A URL for an authentication proxy that provides access " +
-					"tokens. Used when key-file is unset.",
+				Usage: "An url for getting an access token when key-file is absent.",
 			},
 
 			cli.Float64Flag{
@@ -269,7 +268,7 @@ type flagStorage struct {
 	// GCS
 	BillingProject                     string
 	KeyFile                            string
-	AuthProxy                          string
+	TokenUrl                           string
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
 
@@ -312,7 +311,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		// GCS,
 		BillingProject:                     c.String("billing-project"),
 		KeyFile:                            c.String("key-file"),
-		AuthProxy:                          c.String("auth-proxy"),
+		TokenUrl:                           c.String("token-url"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,7 +55,7 @@ func newTokenSourceFromPath(
 func GetTokenSource(
 	ctx context.Context,
 	keyFile string,
-	authProxy string,
+	tokenUrl string,
 ) (tokenSrc oauth2.TokenSource, err error) {
 	// Create the oauth2 token source.
 	const scope = gcs.Scope_FullControl
@@ -64,8 +64,8 @@ func GetTokenSource(
 	if keyFile != "" {
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
-	} else if authProxy != "" {
-		tokenSrc = newProxyTokenSource(ctx, authProxy)
+	} else if tokenUrl != "" {
+		tokenSrc = newProxyTokenSource(ctx, tokenUrl)
 		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,6 +55,7 @@ func newTokenSourceFromPath(
 func GetTokenSource(
 	ctx context.Context,
 	keyFile string,
+	authProxy string,
 ) (tokenSrc oauth2.TokenSource, err error) {
 	// Create the oauth2 token source.
 	const scope = gcs.Scope_FullControl
@@ -63,6 +64,9 @@ func GetTokenSource(
 	if keyFile != "" {
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
+	} else if authProxy != "" {
+		tokenSrc = newProxyTokenSource(ctx, authProxy)
+		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)
 		method = "DefaultTokenSource"

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// newProxyTokenSource returns a TokenSource that calls an external
+// endpoint for authentication and access tokens.
+func newProxyTokenSource(
+	ctx context.Context,
+	endpoint string,
+) oauth2.TokenSource {
+	return proxyTokenSource{
+		ctx:      ctx,
+		endpoint: endpoint,
+		client:   &http.Client{},
+	}
+}
+
+type proxyTokenSource struct {
+	ctx      context.Context
+	endpoint string
+	client   *http.Client
+}
+
+func (ts proxyTokenSource) Token() (token *oauth2.Token, err error) {
+	resp, err := ts.client.Get(ts.endpoint)
+	if err != nil {
+		err = fmt.Errorf("proxyTokenSource cannot fetch token: %v", err)
+		return
+	}
+
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		err = fmt.Errorf("proxyTokenSource cannot load body: %v", err)
+		return
+	}
+
+	if c := resp.StatusCode; c < 200 || c >= 300 {
+		err = &oauth2.RetrieveError{
+			Response: resp,
+			Body:     body,
+		}
+		return
+	}
+
+	token = &oauth2.Token{}
+	err = json.Unmarshal(body, token)
+	if err != nil {
+		err = fmt.Errorf("proxyTokenSource cannot decode body: %v", err)
+		return
+	}
+
+	return
+}

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 	tokenSrc, err := auth.GetTokenSource(
 		context.Background(),
 		flags.KeyFile,
-		flags.AuthProxy,
+		flags.TokenUrl,
 	)
 	if err != nil {
 		err = fmt.Errorf("GetTokenSource: %v", err)

--- a/main.go
+++ b/main.go
@@ -170,7 +170,11 @@ func handleMemoryProfileSignals() {
 }
 
 func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
-	tokenSrc, err := auth.GetTokenSource(context.Background(), flags.KeyFile)
+	tokenSrc, err := auth.GetTokenSource(
+		context.Background(),
+		flags.KeyFile,
+		flags.AuthProxy,
+	)
 	if err != nil {
 		err = fmt.Errorf("GetTokenSource: %v", err)
 		return

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -91,6 +91,7 @@ func makeGcsfuseArgs(
 			"only_dir",
 			"billing_project",
 			"key_file",
+			"token_url",
 			"limit_bytes_per_sec",
 			"limit_ops_per_sec",
 			"max_retry_sleep",


### PR DESCRIPTION
Currently, there are 2 ways of authentication. 
1. Specify a `key-file`, and gcsfuse uses the key file to authenticate. 
2. Specify nothing, and gcsfuse uses the default method to authenticate. 

Now, we add the 3rd way: `--token-url`. With this option, gcsfuse will read the access token from this url. This basically delegates the authentication process to an external endpoint. 

In a typical case, the external endpoint will be a sidecar container in a Kubernetes pod, and gcsfuse will run in the main container. 