### PR TITLE
Fix installing.md for updating Golang version.

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -171,7 +171,7 @@ In the future gcsfuse can be updated in the usual way for homebrew packages:
 Prerequisites:
 
 *   A working [Go][go] installation at least as new as [version
-    1.10][go-version]. See [Installing Go from source][go-setup].
+    1.13][go-version]. See [Installing Go from source][go-setup].
 *   Fuse. See the instructions for the binary release above.
 *   Git. This is probably available as `git` in your package manager.
 
@@ -184,5 +184,5 @@ This will fetch the gcsfuse sources to
 binary named `gcsfuse` to `$GOPATH/bin`.
 
 [go]: http://tip.golang.org/doc/install/source
-[go-version]: https://github.com/golang/go/releases/tag/go1.10
+[go-version]: https://github.com/golang/go/releases/tag/go1.13
 [go-setup]: http://golang.org/doc/code.html


### PR DESCRIPTION
## Summary
Updated prerequisites of Golang version to 1.13.

From these changes as below, Duration.Milliseconds method came into use. This method was added from go 1.13.
https://github.com/GoogleCloudPlatform/gcsfuse/commit/0bb4b043e144dcd02479fbb1488afed207478c9f#diff-d3ee08e42116032bd6394fd75495bfaa265bef1c6855762d568a7cff0342b1a3R84
https://github.com/GoogleCloudPlatform/gcsfuse/commit/3e07ccb961ef882bc11a885c61ed17af7df6c965#diff-2487b52744eeda784a0d378437ccf3830d88ddfeac76f1ef8fd5d1c419507396R104

https://github.com/golang/go/issues/28564
https://golang.org/pkg/time/#Duration.Milliseconds
 
So gcsfuse cannot be started less than go 1.13.


### The error I encountered.
Docker Image: `golang:1.12.13-alpine3.10` 
```
# github.com/googlecloudplatform/gcsfuse/internal/gcsx
src/github.com/googlecloudplatform/gcsfuse/internal/gcsx/monitoring_bucket.go:108:38: time.Since(start).Milliseconds undefined (type time.Duration has no field or method Milliseconds)
```