### PR TITLE
Profiling improvements

### DIFF
--- a/internal/perf/cpu.go
+++ b/internal/perf/cpu.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perf
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"syscall"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
+)
+
+
+func HandleCPUProfileSignals() {
+	profileOnce := func(duration time.Duration, path string) (err error) {
+		// Set up the file.
+		var f *os.File
+		f, err = os.Create(path)
+		if err != nil {
+			err = fmt.Errorf("Create: %w", err)
+			return
+		}
+
+		defer func() {
+			closeErr := f.Close()
+			if err == nil {
+				err = closeErr
+			}
+		}()
+
+		// Profile.
+		pprof.StartCPUProfile(f)
+		time.Sleep(duration)
+		pprof.StopCPUProfile()
+		return
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1)
+	for range c {
+		const path = "/tmp/cpu.pprof"
+		const duration = 10 * time.Second
+
+		logger.Infof("Writing %v CPU profile to %s...", duration, path)
+
+		err := profileOnce(duration, path)
+		if err == nil {
+			logger.Infof("Done writing CPU profile to %s.", path)
+		} else {
+			logger.Infof("Error writing CPU profile: %v", err)
+		}
+	}
+}

--- a/internal/perf/cpu.go
+++ b/internal/perf/cpu.go
@@ -53,7 +53,7 @@ func HandleCPUProfileSignals() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR1)
 	for range c {
-		const path = "/tmp/cpu.pprof"
+		path := fmt.Sprintf("/tmp/cpu-%d.pprof", time.Now().UnixNano())
 		const duration = 10 * time.Second
 
 		logger.Infof("Writing %v CPU profile to %s...", duration, path)

--- a/internal/perf/memory.go
+++ b/internal/perf/memory.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perf
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"runtime/pprof"
+	"syscall"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
+)
+
+
+func HandleMemoryProfileSignals() {
+	profileOnce := func(path string) (err error) {
+		// Trigger a garbage collection to get up to date information (cf.
+		// https://goo.gl/aXVQfL).
+		runtime.GC()
+
+		// Open the file.
+		var f *os.File
+		f, err = os.Create(path)
+		if err != nil {
+			err = fmt.Errorf("Create: %w", err)
+			return
+		}
+
+		defer func() {
+			closeErr := f.Close()
+			if err == nil {
+				err = closeErr
+			}
+		}()
+
+		// Dump to the file.
+		err = pprof.Lookup("heap").WriteTo(f, 0)
+		if err != nil {
+			err = fmt.Errorf("WriteTo: %w", err)
+			return
+		}
+
+		return
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR2)
+	for range c {
+		const path = "/tmp/mem.pprof"
+
+		err := profileOnce(path)
+		if err == nil {
+			logger.Infof("Wrote memory profile to %s.", path)
+		} else {
+			logger.Infof("Error writing memory profile: %v", err)
+		}
+	}
+}

--- a/internal/perf/memory.go
+++ b/internal/perf/memory.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"syscall"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 )
@@ -60,7 +61,7 @@ func HandleMemoryProfileSignals() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR2)
 	for range c {
-		const path = "/tmp/mem.pprof"
+		path := fmt.Sprintf("/tmp/mem-%d.pprof", time.Now().UnixNano())
 
 		err := profileOnce(path)
 		if err == nil {

--- a/internal/perf/memory.go
+++ b/internal/perf/memory.go
@@ -26,6 +26,11 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 )
 
+const (
+	KiB = 1024
+	MiB = 1024 * KiB
+)
+
 
 func HandleMemoryProfileSignals() {
 	profileOnce := func(path string) (err error) {
@@ -62,6 +67,10 @@ func HandleMemoryProfileSignals() {
 	signal.Notify(c, syscall.SIGUSR2)
 	for range c {
 		path := fmt.Sprintf("/tmp/mem-%d.pprof", time.Now().UnixNano())
+
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		logger.Infof("Heap allocation: %d MiB", m.Alloc / MiB)
 
 		err := profileOnce(path)
 		if err == nil {


### PR DESCRIPTION
1. Use timestamp in pprof files to avoid overwriting the same file.
2. Print the heap allocation right before memory profiling.
3. Move the code from main.go to its own package. 