### PR TITLE
Make CI green and update TravisCI go versions with supported only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@
 language: go
 
 go:
-  - "1.10"
-  - "1.11"
-  - "1.12"
-  - "1.13"
   - "1.14"
-  - "1.15.2"
+  - "1.15"
+  - "1.16"
   - stable
 
 # Use the virtualized Trusty beta Travis is running in order to get support for

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -147,29 +147,29 @@ func (tf *tempFile) CheckInvariants() {
 	// Restore the seek position after using Stat below.
 	pos, err := tf.Seek(0, 1)
 	if err != nil {
-		panic(fmt.Sprintf("Seek: %w", err))
+		panic(fmt.Errorf("Seek: %w", err))
 	}
 
 	defer func() {
 		_, err := tf.Seek(pos, 0)
 		if err != nil {
-			panic(fmt.Sprintf("Seek: %w", err))
+			panic(fmt.Errorf("Seek: %w", err))
 		}
 	}()
 
 	// INVARIANT: Stat().DirtyThreshold <= Stat().Size
 	sr, err := tf.Stat()
 	if err != nil {
-		panic(fmt.Sprintf("Stat: %w", err))
+		panic(fmt.Errorf("Stat: %w", err))
 	}
 
 	if !(sr.DirtyThreshold <= sr.Size) {
-		panic(fmt.Sprintf("Mismatch: %d vs. %d", sr.DirtyThreshold, sr.Size))
+		panic(fmt.Errorf("Mismatch: %d vs. %d", sr.DirtyThreshold, sr.Size))
 	}
 
 	// INVARIANT: mtime == nil => Stat().DirtyThreshold == Stat().Size
 	if tf.mtime == nil && sr.DirtyThreshold != sr.Size {
-		panic(fmt.Sprintf("Mismatch: %d vs. %d", sr.DirtyThreshold, sr.Size))
+		panic(fmt.Errorf("Mismatch: %d vs. %d", sr.DirtyThreshold, sr.Size))
 	}
 }
 

--- a/tools/integration_tests/main_test.go
+++ b/tools/integration_tests/main_test.go
@@ -43,21 +43,21 @@ func TestMain(m *testing.M) {
 	if runtime.GOOS == "linux" {
 		gFusermountPath, err = exec.LookPath("fusermount")
 		if err != nil {
-			log.Fatalf("LookPath(fusermount): %w", err)
+			log.Fatalf("LookPath(fusermount): %p", err)
 		}
 	}
 
 	// Set up a directory into which we will build.
 	gBuildDir, err = ioutil.TempDir("", "gcsfuse_integration_tests")
 	if err != nil {
-		log.Fatalf("TempDir: %w", err)
+		log.Fatalf("TempDir: %p", err)
 		return
 	}
 
 	// Build into that directory.
 	err = buildGcsfuse(gBuildDir)
 	if err != nil {
-		log.Fatalf("buildGcsfuse: %w", err)
+		log.Fatalf("buildGcsfuse: %p", err)
 		return
 	}
 


### PR DESCRIPTION
- Fix minor issues in the failed test
-  Use only modern (supported) go versions in TravisCI