### PR TITLE
replace with gcloud auth application-default login

### DIFF
--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -14,6 +14,7 @@ access to buckets owned by the same project as the VM.
 When testing, especially on a developer machine, credentials can also be
 configured using the [gcloud tool][]:
 
+    gcloud auth application-default login
     gcloud auth login
 
 Alternatively, you can set the `GOOGLE_APPLICATION_CREDENTIALS` environment


### PR DESCRIPTION
I had to execute `gcloud auth application-default login` per https://github.com/GoogleCloudPlatform/gcsfuse/issues/320#issuecomment-698284734 to use the right credentials. Otherwise, I receive the following error after executing gcloud auth login:

`daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithConn: fs.NewServer: SetUpBucket: OpenBucket: Bad credentials for bucket "bucket******_hil". Check the bucket name and your credentials.
`