### PR TITLE
Set symlink atime and ctime to mtime

### DIFF
--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -77,6 +77,8 @@ func NewSymlinkInode(
 			Uid:   attrs.Uid,
 			Gid:   attrs.Gid,
 			Mode:  attrs.Mode,
+			Atime: o.Updated,
+			Ctime: o.Updated,
 			Mtime: o.Updated,
 		},
 		target: o.Metadata[SymlinkMetadataKey],


### PR DESCRIPTION
This mimics the file logic and avoids nonsense values.  Found via
pjdfstests.