### PR TITLE
Disable repo_gpgcheck in yum install instructions

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -75,7 +75,7 @@ for [other distributions](#other-distributions) below.
         baseurl=https://packages.cloud.google.com/yum/repos/gcsfuse-el7-x86_64
         enabled=1
         gpgcheck=1
-        repo_gpgcheck=1
+        repo_gpgcheck=0
         gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
                https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
         EOF


### PR DESCRIPTION
repo_gpgcheck is buggy and nobody else uses it. We're following Red Hat et al. and disusing it too.