### PR TITLE
Allow configuring non-Google endpoint

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -120,6 +121,12 @@ func newApp() (app *cli.App) {
 			/////////////////////////
 			// GCS
 			/////////////////////////
+
+			cli.StringFlag{
+				Name:  "endpoint",
+				Value: "https://www.googleapis.com:443",
+				Usage: "The endpoint to connect to.",
+			},
 
 			cli.StringFlag{
 				Name:  "billing-project",
@@ -285,6 +292,7 @@ type flagStorage struct {
 	RenameDirLimit int64
 
 	// GCS
+	Endpoint                           *url.URL
 	BillingProject                     string
 	KeyFile                            string
 	TokenUrl                           string
@@ -317,6 +325,11 @@ type flagStorage struct {
 // Add the flags accepted by run to the supplied flag set, returning the
 // variables into which the flags will parse.
 func populateFlags(c *cli.Context) (flags *flagStorage) {
+	endpoint, err := url.Parse(c.String("endpoint"))
+	if err != nil {
+		fmt.Printf("Could not parse endpoint")
+		return nil
+	}
 	flags = &flagStorage{
 		Foreground: c.Bool("foreground"),
 
@@ -331,6 +344,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		RenameDirLimit: int64(c.Int("rename-dir-limit")),
 
 		// GCS,
+		Endpoint:                           endpoint,
 		BillingProject:                     c.String("billing-project"),
 		KeyFile:                            c.String("key-file"),
 		TokenUrl:                           c.String("token-url"),

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.15.0
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
 	github.com/jacobsa/fuse v0.0.0-20210330112455-9677d0392291
-	github.com/jacobsa/gcloud v0.0.0-20210325123825-0cb59778cc89
+	github.com/jacobsa/gcloud v0.0.0-20210611094250-93436725bc18
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/jacobsa/gcloud v0.0.0-20210318100944-f73b85415adb h1:jIIP6QBXQdRbKwyv
 github.com/jacobsa/gcloud v0.0.0-20210318100944-f73b85415adb/go.mod h1:3fF6sEraNZSToePaj5q+f9KSaMpuZcwccqAQmOKDv/k=
 github.com/jacobsa/gcloud v0.0.0-20210325123825-0cb59778cc89 h1:29FVHRU9enfQBLFov7It4S38GsFLboAJ70MEY8ehypg=
 github.com/jacobsa/gcloud v0.0.0-20210325123825-0cb59778cc89/go.mod h1:3fF6sEraNZSToePaj5q+f9KSaMpuZcwccqAQmOKDv/k=
+github.com/jacobsa/gcloud v0.0.0-20210611094250-93436725bc18 h1:4grQXCnmoDLuCVjs6VW0Yh+k2mantFOKiGRh0Eu96FY=
+github.com/jacobsa/gcloud v0.0.0-20210611094250-93436725bc18/go.mod h1:3fF6sEraNZSToePaj5q+f9KSaMpuZcwccqAQmOKDv/k=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=

--- a/internal/gcsx/connection.go
+++ b/internal/gcsx/connection.go
@@ -38,6 +38,7 @@ func NewConnection(cfg *gcs.ConnConfig) (c *Connection, err error) {
 
 	gcs, err := storage.NewClient(
 		context.Background(),
+		option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", cfg.Url.String())),
 		option.WithTokenSource(cfg.TokenSource))
 	if err != nil {
 		err = fmt.Errorf("Cannot create GCS client: %w", err)

--- a/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
@@ -125,6 +125,7 @@ type Bucket interface {
 
 type bucket struct {
 	client         *http.Client
+	url            *url.URL
 	userAgent      string
 	name           string
 	billingProject string
@@ -139,7 +140,8 @@ func (b *bucket) ListObjects(
 	req *ListObjectsRequest) (listing *Listing, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/aVSAhT).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o",
+		"//%s/storage/v1/b/%s/o",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()))
 
 	query := make(url.Values)
@@ -166,8 +168,8 @@ func (b *bucket) ListObjects(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -211,7 +213,8 @@ func (b *bucket) StatObject(
 	req *StatObjectRequest) (o *Object, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/MoITmB).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -223,8 +226,8 @@ func (b *bucket) StatObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -276,7 +279,8 @@ func (b *bucket) DeleteObject(
 	req *DeleteObjectRequest) (err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/TRQJjZ).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -297,8 +301,8 @@ func (b *bucket) DeleteObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}
@@ -345,11 +349,13 @@ func (b *bucket) DeleteObject(
 
 func newBucket(
 	client *http.Client,
+	url *url.URL,
 	userAgent string,
 	name string,
 	billingProject string) Bucket {
 	return &bucket{
 		client:         client,
+		url:            url,
 		userAgent:      userAgent,
 		name:           name,
 		billingProject: billingProject,

--- a/vendor/github.com/jacobsa/gcloud/gcs/compose_objects.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/compose_objects.go
@@ -77,7 +77,8 @@ func (b *bucket) ComposeObjects(
 	objectSegment := httputil.EncodePathSegment(req.DstName)
 
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s/compose",
+		"//%s/storage/v1/b/%s/o/%s/compose",
+		b.url.Host,
 		bucketSegment,
 		objectSegment)
 
@@ -94,8 +95,8 @@ func (b *bucket) ComposeObjects(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/vendor/github.com/jacobsa/gcloud/gcs/copy_object.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/copy_object.go
@@ -42,7 +42,8 @@ func (b *bucket) CopyObject(
 
 	// Construct an appropriate URL (cf. https://goo.gl/A41CyJ).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s/copyTo/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s/copyTo/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.SrcName),
 		httputil.EncodePathSegment(b.Name()),
@@ -62,8 +63,8 @@ func (b *bucket) CopyObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/vendor/github.com/jacobsa/gcloud/gcs/create_object.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/create_object.go
@@ -66,7 +66,8 @@ func (b *bucket) startResumableUpload(
 	// 3986.
 	bucketSegment := httputil.EncodePathSegment(b.Name())
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/upload/storage/v1/b/%s/o",
+		"//%s/upload/storage/v1/b/%s/o",
+		b.url.Host,
 		bucketSegment)
 
 	query := make(url.Values)
@@ -84,8 +85,8 @@ func (b *bucket) startResumableUpload(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/vendor/github.com/jacobsa/gcloud/gcs/read.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/read.go
@@ -44,7 +44,8 @@ func (b *bucket) NewReader(
 	bucketSegment := httputil.EncodePathSegment(b.name)
 	objectSegment := httputil.EncodePathSegment(req.Name)
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/download/storage/v1/b/%s/o/%s",
+		"//%s/download/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		bucketSegment,
 		objectSegment)
 
@@ -60,8 +61,8 @@ func (b *bucket) NewReader(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/vendor/github.com/jacobsa/gcloud/gcs/update_object.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/update_object.go
@@ -86,7 +86,8 @@ func (b *bucket) UpdateObject(
 	req *UpdateObjectRequest) (o *Object, err error) {
 	// Construct an appropriate URL (cf. http://goo.gl/B46IDy).
 	opaque := fmt.Sprintf(
-		"//www.googleapis.com/storage/v1/b/%s/o/%s",
+		"//%s/storage/v1/b/%s/o/%s",
+		b.url.Host,
 		httputil.EncodePathSegment(b.Name()),
 		httputil.EncodePathSegment(req.Name))
 
@@ -104,8 +105,8 @@ func (b *bucket) UpdateObject(
 	}
 
 	url := &url.URL{
-		Scheme:   "https",
-		Host:     "www.googleapis.com",
+		Scheme:   b.url.Scheme,
+		Host:     b.url.Host,
 		Opaque:   opaque,
 		RawQuery: query.Encode(),
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/jacobsa/fuse/fuseutil
 github.com/jacobsa/fuse/internal/buffer
 github.com/jacobsa/fuse/internal/freelist
 github.com/jacobsa/fuse/internal/fusekernel
-# github.com/jacobsa/gcloud v0.0.0-20210325123825-0cb59778cc89
+# github.com/jacobsa/gcloud v0.0.0-20210611094250-93436725bc18
 ## explicit
 github.com/jacobsa/gcloud/gcs
 github.com/jacobsa/gcloud/gcs/gcscaching


### PR DESCRIPTION
This allows use of other implementations like fake-gcs-server.  Setting a
non-Google endpoint disables OAuth.