### PR TITLE
Set subtype to gcsfuse

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -130,6 +130,7 @@ be interacting with the file system.`)
 	status.Printf("Mounting file system %q...", fsName)
 	mountCfg := &fuse.MountConfig{
 		FSName:      fsName,
+		Subtype:     "gcsfuse",
 		VolumeName:  "gcsfuse",
 		Options:     flags.MountOptions,
 		ErrorLogger: logger.NewError("fuse: "),


### PR DESCRIPTION
This allows identifying mounts as "fuse.gcsfuse" instead of only
"fuse" on Linux.  This is useful for pjdfstest so it can exclude tests
that are not supported.  References #590.