### PR TITLE
Update rate-limit docs to match default flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ your GCS spending on behalf of gcsfuse, you can do so:
     bandwidth from gcsfuse to GCS.
 
 All rate limiting is approximate, and is performed over an 8-hour window. By
-default, requests are limited to 5 per second. There is no limit applied to
-bandwidth by default.
+default, there are no limits applied.
 
 ## Upload procedure control
 


### PR DESCRIPTION
Thanks for an amazing tool! 

During some performance testing at NYT, I noticed that the README mentions a default 5 req/s GCS rate limit, but the [flags.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/flags.go#L166) looks like it sets `-1` by default.

This PR updates the README to indicate that both rate-limit and bandwidth are unlimited by default.