### PR TITLE
Do not allow renaming into a non-empty directory

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1501,14 +1501,20 @@ func (fs *fileSystem) renameDir(
 	}
 	pendingInodes = append(pendingInodes, oldDir)
 
-	// Fetch all the descendants of the directory recuirsively
+	// Fetch all the descendants of the old directory recursively
 	descendants, err := oldDir.ReadDescendants(ctx, int(fs.renameDirLimit+1))
 	if len(descendants) > int(fs.renameDirLimit) {
 		return fmt.Errorf("too many objects to be renamed: %w", syscall.EMFILE)
 	}
 
-	// Create the backing object of the new directory.
 	newParent.Lock()
+	// Fetch a single descendant of the new parent
+	if newParentDescendents, err := newParent.ReadDescendants(ctx, 1); err == nil && len(newParentDescendents) > 0 {
+		newParent.Unlock()
+		return fuse.ENOTEMPTY
+	}
+
+	// Create the backing object of the new directory.
 	_, err = newParent.CreateChildDir(ctx, newName)
 	newParent.Unlock()
 	if err != nil {


### PR DESCRIPTION
This allows pjdfstest rename/20.t to pass.  References
GoogleCloudPlatform/gcsfuse#590.