### PR TITLE
Add cache and metadata support for on disk cache

### DIFF
--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -22,18 +22,32 @@ import (
 	"github.com/jacobsa/timeutil"
 )
 
+// CacheObjectKey contains
+type CacheObjectKey struct {
+	BucketName string
+	ObjectName string
+}
+
 // ContentCache is a directory on local disk to store the object content.
 type ContentCache struct {
-	tempDir    string
-	mtimeClock timeutil.Clock
+	tempDir        string
+	localFileCache bool
+	fileMap        map[CacheObjectKey]gcsx.TempFile
+	mtimeClock     timeutil.Clock
 }
 
 // New creates a ContentCache.
 func New(tempDir string, mtimeClock timeutil.Clock) *ContentCache {
 	return &ContentCache{
 		tempDir:    tempDir,
+		fileMap:    make(map[CacheObjectKey]gcsx.TempFile),
 		mtimeClock: mtimeClock,
 	}
+}
+
+// Populates the ContentCache with files on disk
+func (c *ContentCache) PopulateCache() {
+
 }
 
 // NewTempFile returns a handle for a temporary file on the disk. The caller

--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jacobsa/timeutil"
 )
 
-// CacheObjectKey contains
+// CacheObjectKey uniquely identifies GCS objects by bucket name and object name
 type CacheObjectKey struct {
 	BucketName string
 	ObjectName string
@@ -43,11 +43,6 @@ func New(tempDir string, mtimeClock timeutil.Clock) *ContentCache {
 		fileMap:    make(map[CacheObjectKey]gcsx.TempFile),
 		mtimeClock: mtimeClock,
 	}
-}
-
-// Populates the ContentCache with files on disk
-func (c *ContentCache) PopulateCache() {
-
 }
 
 // NewTempFile returns a handle for a temporary file on the disk. The caller

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -47,7 +47,7 @@ type TempFile interface {
 	// until another method that modifies the file is called.
 	SetMtime(mtime time.Time)
 
-	// Validate the metadata generation
+	// Validate the generation number of the file
 	ValidateGeneration(generation int64) bool
 
 	// Throw away the resources used by the temporary file. The object must not
@@ -75,7 +75,7 @@ type StatResult struct {
 }
 
 // Metadata store struct
-type Metadata struct {
+type TempFileObjectMetadata struct {
 	BucketName     string
 	ObjectName     string
 	Generation     int64
@@ -135,7 +135,7 @@ type tempFile struct {
 	f *os.File
 
 	// Metadata for the temp file
-	metadata *Metadata
+	tempFileObjectMetadata *TempFileObjectMetadata
 
 	// The lowest byte index that has been modified from the initial contents.
 	//
@@ -279,7 +279,10 @@ func (tf *tempFile) SetMtime(mtime time.Time) {
 }
 
 func (tf *tempFile) ValidateGeneration(generation int64) bool {
-	return tf.metadata.Generation == generation
+	if tf.tempFileObjectMetadata == nil {
+		return false
+	}
+	return tf.tempFileObjectMetadata.Generation == generation
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -47,6 +47,9 @@ type TempFile interface {
 	// until another method that modifies the file is called.
 	SetMtime(mtime time.Time)
 
+	// Validate the metadata generation
+	ValidateGeneration(generation int64) bool
+
 	// Throw away the resources used by the temporary file. The object must not
 	// be used again.
 	Destroy()
@@ -69,6 +72,14 @@ type StatResult struct {
 	// If neither of those things has ever happened, it is nil. This implies that
 	// DirtyThreshold == Size.
 	Mtime *time.Time
+}
+
+// Metadata store struct
+type Metadata struct {
+	BucketName     string
+	ObjectName     string
+	Generation     int64
+	MetaGeneration int64
 }
 
 // NewTempFile creates a temp file whose initial contents are given by the
@@ -122,6 +133,9 @@ type tempFile struct {
 
 	// A file containing our current contents.
 	f *os.File
+
+	// Metadata for the temp file
+	metadata *Metadata
 
 	// The lowest byte index that has been modified from the initial contents.
 	//
@@ -262,6 +276,10 @@ func (tf *tempFile) Truncate(n int64) error {
 
 func (tf *tempFile) SetMtime(mtime time.Time) {
 	tf.mtime = &mtime
+}
+
+func (tf *tempFile) ValidateGeneration(generation int64) bool {
+	return tf.metadata.Generation == generation
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We add metadata and file support in memory for the cache.  We add the in memory map in contentcache.go and create supporting structs and modifications to support metadata in gcsx.TempFile.

This change should not impact or break any unit tests: run go test ./... in the gcsfuse directory and all tests should continue to pass.