### PR TITLE
Allow creation of temp cache files and metadata files

### DIFF
--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -51,8 +51,7 @@ func (c *ContentCache) NewTempFile(rc io.ReadCloser) (gcsx.TempFile, error) {
 	return gcsx.NewTempFile(rc, c.tempDir, c.mtimeClock)
 }
 
-// NewTempFile returns a handle for a temporary file on the disk. The caller
-// must call Destroy on the TempFile before releasing it.
+// NewCacheFile returns a handle for a cache file on the disk.
 func (c *ContentCache) NewCacheFile(rc io.ReadCloser, metadata *gcsx.TempFileObjectMetadata) (gcsx.TempFile, error) {
 	return gcsx.NewCacheFile(rc, metadata, c.tempDir, c.mtimeClock)
 }

--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -50,3 +50,9 @@ func New(tempDir string, mtimeClock timeutil.Clock) *ContentCache {
 func (c *ContentCache) NewTempFile(rc io.ReadCloser) (gcsx.TempFile, error) {
 	return gcsx.NewTempFile(rc, c.tempDir, c.mtimeClock)
 }
+
+// NewTempFile returns a handle for a temporary file on the disk. The caller
+// must call Destroy on the TempFile before releasing it.
+func (c *ContentCache) NewCacheFile(rc io.ReadCloser, metadata *gcsx.TempFileObjectMetadata) (gcsx.TempFile, error) {
+	return gcsx.NewCacheFile(rc, metadata, c.tempDir, c.mtimeClock)
+}

--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -51,7 +51,8 @@ func (c *ContentCache) NewTempFile(rc io.ReadCloser) (gcsx.TempFile, error) {
 	return gcsx.NewTempFile(rc, c.tempDir, c.mtimeClock)
 }
 
-// NewCacheFile returns a handle for a cache file on the disk.
+// NewCacheFile creates a cache file on the disk storing the object content
+// TODO ezl we should refactor reading/writing cache files and metadata to a different package
 func (c *ContentCache) NewCacheFile(rc io.ReadCloser, metadata *gcsx.TempFileObjectMetadata) (gcsx.TempFile, error) {
 	return gcsx.NewCacheFile(rc, metadata, c.tempDir, c.mtimeClock)
 }

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -116,6 +116,7 @@ func NewTempFile(
 // NewCacheFile creates a temp file whose initial contents are given by the
 // supplied reader. dir is a directory on whose file system the file will live,
 // or the system default temporary location if empty.
+// TODO ezl we should refactor reading/writing cache files and metadata to a different package
 func NewCacheFile(
 	source io.ReadCloser,
 	tempFileObjectMetadata *TempFileObjectMetadata,


### PR DESCRIPTION
Add way to persist temp cache files and metadata files on disk.

One concern I have is whether we want to store a pointer to the file on disk or if storing the struct in memory is enough.  The metadata on disk is only used to allow gcsfuse to hotload the cache on startup and isn't used any other time.

Testing:

Run go test ./....  and unit tests should pass. There should be no impacting changes on unit tests.