### PR TITLE
Move the temp file destruction from syncer to inode

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -505,6 +505,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil {
 		f.src = *newObj
+		f.content.Destroy()
 		f.content = nil
 	}
 

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -37,9 +37,6 @@ type Syncer interface {
 	//
 	// *   Otherwise, write out a new generation in the bucket (failing with
 	//     *gcs.PreconditionError if the source generation is no longer current).
-	//
-	// In the second case, the TempFile is destroyed. Otherwise, including when
-	// this function fails, it is guaranteed to still be valid.
 	SyncObject(
 		ctx context.Context,
 		srcObject *gcs.Object,
@@ -218,9 +215,6 @@ func (os *syncer) SyncObject(
 		err = fmt.Errorf("Create: %w", err)
 		return
 	}
-
-	// Destroy the temp file.
-	content.Destroy()
 
 	return
 }


### PR DESCRIPTION
Each file inode keeps a temp file containing written data. The temp file
should be destroyed when the content is synced (uploaded), and other
conditions of the file inodes are met (such as local file cache
configs).

Before this change, the temp file destruction is triggered by the syncer
in the client library gcsx, regardless of the file inode conditions.

This change, however, moves the destruction out of the syncer to the file
inode, making it simplier to couple the destruction with the rest of the
inode instead.

Test:
```
go test ./...
```