### PR TITLE
Create prefetch tool to cache gcs objects on disk

### DIFF
--- a/tools/prefetch_cache_gcsfuse/main.go
+++ b/tools/prefetch_cache_gcsfuse/main.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prefetches files into local disk cache from specified bucket
+//
+// Usage:
+//
+//     prefetch_cache_gcsfuse cache_dir bucket_name [prefix]
+//
+// This will prefetch the cache files from the specified bucket
+// with an optional file prefix to filter the GCS objects
+// and download them into the specified cache directory
+//
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+func run(args []string) (err error) {
+	// Extract arguments.
+	if len(args) < 2 || len(args) > 3 {
+		err = fmt.Errorf("Usage: %s cache_dir bucket_name [prefix]", os.Args[0])
+		return
+	}
+
+	cacheDir := args[0]
+	bucketName := args[1]
+	var prefix string
+
+	if len(args) > 2 {
+		prefix = args[2]
+	}
+
+	log.Printf("Using settings:")
+	log.Printf("  cacheDir:  %s", cacheDir)
+	log.Printf("  bucketName:  %s", bucketName)
+	log.Printf("  prefix:  %s", prefix)
+
+	// Try to preload persistent cache on disk using specified parameters
+	err = prefetchCache(cacheDir, bucketName, prefix)
+	if err != nil {
+		err = fmt.Errorf("prefetch_cache_gcsfuse: %w", err)
+	}
+
+	return
+}
+
+func main() {
+	log.SetFlags(log.Lmicroseconds)
+	flag.Parse()
+
+	err := run(flag.Args())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/tools/prefetch_cache_gcsfuse/prefetch.go
+++ b/tools/prefetch_cache_gcsfuse/prefetch.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
+	"google.golang.org/api/iterator"
+)
+
+// TODO ezl add this to be a configurable command line flag
+const NUM_WORKERS = 10
+
+func downloadFile(ctx context.Context, client *storage.Client, object *storage.ObjectAttrs, cacheDir string) (err error) {
+	log.Printf(fmt.Sprintf("downloading file %v from bucket %v into dir %v", object.Name, object.Bucket, cacheDir))
+
+	// TODO ezl store the file name inside the json metadata instead of stripping the metadata filename
+	metadata := &gcsx.TempFileObjectMetadata{
+		BucketName:     object.Bucket,
+		ObjectName:     object.Name,
+		Generation:     object.Generation,
+		MetaGeneration: object.Metageneration,
+	}
+
+	// TODO ezl refactor once we decouple content cache from gcsx
+	// Create a temporary cache file on disk
+	// TODO ezl concerns about partial download and cache file corruption
+	// We may want a way to verify the files are fully downloaded
+	// and either resuming the download or discarding and redownloading the file
+	// We may also want to do cleanup if files are created on disk but aren't populated in time
+	f, err := ioutil.TempFile(cacheDir, gcsx.CACHE_FILE_PREFIX)
+
+	if err != nil {
+		err = fmt.Errorf("ioutil.TempFile: %w", err)
+		return
+	}
+	defer f.Close()
+
+	rc, err := client.Bucket(object.Bucket).Object(object.Name).NewReader(ctx)
+
+	if err != nil {
+		return fmt.Errorf("Object(%q).NewReader: %w", object.Name, err)
+	}
+	defer rc.Close()
+
+	if _, err := io.Copy(f, rc); err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+
+	file, err := json.MarshalIndent(*metadata, "", " ")
+	err = ioutil.WriteFile(fmt.Sprintf("%s.json", f.Name()), file, 0644)
+	if err != nil {
+		err = fmt.Errorf("downloadFile failed to write metadata: %w", err)
+	}
+	return
+}
+
+func prefetchCache(cacheDir, bucketName, prefix string) (err error) {
+	start := time.Now()
+	filesAttempted := 0
+	var filesDownloaded int32
+	var wg sync.WaitGroup
+	var downloadTasks = make(chan *storage.ObjectAttrs)
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage.NewClient: %w", err)
+	}
+	defer client.Close()
+
+	// Should we set a higher timeout or let this be configurable by the user
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
+	defer cancel()
+
+	it := client.Bucket(bucketName).Objects(ctx, &storage.Query{
+		Prefix: prefix,
+	})
+
+	// Concurrently download files from specified gcs bucket with optional prefix
+
+	// Producer
+	go func() {
+		for {
+			attrs, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				log.Printf("Bucket(%q).Objects: %v", bucketName, err)
+				break
+			}
+			filesAttempted++
+			downloadTasks <- attrs
+		}
+		close(downloadTasks)
+	}()
+
+	// Consumers
+	for i := 0; i < NUM_WORKERS; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for attrs := range downloadTasks {
+				log.Printf("Worker %d: downloading file %v", i, attrs.Name)
+				err := downloadFile(ctx, client, attrs, cacheDir)
+				if err != nil {
+					log.Printf("prefetchCache: %v", err)
+				} else {
+					atomic.AddInt32(&filesDownloaded, 1)
+				}
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines downloading files to finish
+	wg.Wait()
+
+	elapsed := time.Since(start)
+	log.Printf("Prefetch cache took %s", elapsed)
+	log.Printf("Number of files downloaded successfully %v", filesDownloaded)
+	log.Printf("Number of files attempted to download %v", filesAttempted)
+
+	return
+}


### PR DESCRIPTION
Creates a catch prefetch tool to download files into local disk cache from specified bucket.  We use a typical single-producer multi-consumer concurrency pattern.

Usage:
`prefetch_cache_gcsfuse cache_dir bucket_name [prefix]`

To test, run the binary with the specified command line arguments.

Verify cache_dir is populated with files and metadata files.

Next try running gcsfuse specifying --local-file-cache flag with the value of the same cache_dir.  This will allow gcsfuse to use the cached files on disk.

The constant NUM_WORKERS specifies how many consumer workers to download files are created.

A higher NUM_WORKERS value creates more goroutines which can speed up downloads (up to a limit).

In the future, NUM_WORKERS can be a configurable command line flag exposed to the user.