### PR TITLE
Use `storage.googleapis.com/storage/v1` by default for GCS requests

### DIFF
--- a/benchmarks/concurrent_read/readers/vendor.go
+++ b/benchmarks/concurrent_read/readers/vendor.go
@@ -35,7 +35,7 @@ func NewVendorClient(ctx context.Context, protocol string, connections int, buck
 	if err != nil {
 		return nil, err
 	}
-	endpoint, _ := url.Parse("https://www.googleapis.com:443")
+	endpoint, _ := url.Parse("https://storage.googleapis.com:443")
 	config := &gcs.ConnConfig{
 		Url:         endpoint,
 		TokenSource: tokenSrc,

--- a/flags.go
+++ b/flags.go
@@ -130,7 +130,7 @@ func newApp() (app *cli.App) {
 
 			cli.StringFlag{
 				Name:  "endpoint",
-				Value: "https://www.googleapis.com:443",
+				Value: "https://storage.googleapis.com:443",
 				Usage: "The endpoint to connect to.",
 			},
 

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func registerSIGINTHandler(mountPoint string) {
 
 func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 	var tokenSrc oauth2.TokenSource
-	if flags.Endpoint.Hostname() == "www.googleapis.com" {
+	if flags.Endpoint.Hostname() == "storage.googleapis.com" {
 		tokenSrc, err = auth.GetTokenSource(
 			context.Background(),
 			flags.KeyFile,


### PR DESCRIPTION
According to the [official storage endpoints documentation](https://cloud.google.com/storage/docs/request-endpoints):
| The www.googleapis.com endpoint is also supported for the JSON API, but storage.googleapis.com is the preferred endpoint for better performance and availability.

This change helps allowing/denying specific services based off host name in more restrictive environments.