### PR TITLE
Refactor content cache to use wrapper structs

### DIFF
--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -25,14 +25,14 @@ import (
 	"log"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/jacobsa/timeutil"
 )
+
+const CACHE_FILE_PREFIX = "gcsfusecache"
 
 // CacheObjectKey uniquely identifies GCS objects by bucket name and object name
 type CacheObjectKey struct {
@@ -44,8 +44,50 @@ type CacheObjectKey struct {
 type ContentCache struct {
 	debug      *log.Logger
 	tempDir    string
-	fileMap    map[CacheObjectKey]gcsx.TempFile
+	fileMap    map[CacheObjectKey]*CacheObject
 	mtimeClock timeutil.Clock
+}
+
+// Metadata store struct
+type CacheFileObjectMetadata struct {
+	CacheFileNameOnDisk string
+	BucketName          string
+	ObjectName          string
+	Generation          int64
+	MetaGeneration      int64
+}
+
+type CacheObject struct {
+	MetadataFileName        string
+	CacheFileObjectMetadata *CacheFileObjectMetadata
+	CacheFile               gcsx.TempFile
+}
+
+func (c *CacheObject) ValidateGeneration(generation int64) bool {
+	if c.CacheFileObjectMetadata == nil {
+		return false
+	}
+	return c.CacheFileObjectMetadata.Generation == generation
+}
+
+func (c *ContentCache) WriteMetadataCheckpointFile(cacheFileName string, cacheFileObjectMetadata *CacheFileObjectMetadata) (metadataFileName string, err error) {
+	var file []byte
+	file, err = json.MarshalIndent(cacheFileObjectMetadata, "", " ")
+	if err != nil {
+		err = fmt.Errorf("json.MarshalIndent failed for object metadata: %w", err)
+		return
+	}
+	metadataFileName = fmt.Sprintf("%s.json", cacheFileName)
+	err = ioutil.WriteFile(metadataFileName, file, 0644)
+	if err != nil {
+		err = fmt.Errorf("WriteFile for JSON metadata: %w", err)
+		return
+	}
+	return
+}
+
+func (c *CacheObject) Destroy() {
+	// TODO ezl clean up
 }
 
 // RecoverFileFromCache recovers a file from the cache via metadata
@@ -57,10 +99,9 @@ func (c *ContentCache) RecoverFileFromCache(metadataFile fs.FileInfo) {
 	if !matchPattern(metadataFile.Name()) {
 		return
 	}
-	var metadata gcsx.TempFileObjectMetadata
+	var metadata CacheFileObjectMetadata
 	metadataAbsolutePath := path.Join(c.tempDir, metadataFile.Name())
 	contents, err := ioutil.ReadFile(metadataAbsolutePath)
-	// TODO ezl should we exec some sort of cleanup in the cache if there are errors
 	if err != nil {
 		c.debug.Printf("Skip metadata file %v due to read error: %s", metadataFile.Name(), err)
 		return
@@ -71,8 +112,7 @@ func (c *ContentCache) RecoverFileFromCache(metadataFile fs.FileInfo) {
 		return
 	}
 	cacheObjectKey := &CacheObjectKey{BucketName: metadata.BucketName, ObjectName: metadata.ObjectName}
-	// TODO ezl we should probably store the cached file name inside the cache file metadata instead of using the json file name
-	fileName := strings.TrimSuffix(metadataAbsolutePath, filepath.Ext(metadataFile.Name()))
+	fileName := metadata.CacheFileNameOnDisk
 	// TODO ezl linux fs limits single process to open max of 1024 file descriptors
 	// so this is not scalable
 	file, err := os.Open(fileName)
@@ -102,8 +142,7 @@ func (c *ContentCache) RecoverCache() error {
 
 // Helper function that matches the format of a gcsfuse file
 func matchPattern(fileName string) bool {
-	// TODO ezl: replace with constant defined in gcsx.TempFile
-	match, err := regexp.MatchString(fmt.Sprintf("%v[0-9]+[.]json", gcsx.CACHE_FILE_PREFIX), fileName)
+	match, err := regexp.MatchString(fmt.Sprintf("%v[0-9]+[.]json", CACHE_FILE_PREFIX), fileName)
 	if err != nil {
 		return false
 	}
@@ -115,7 +154,7 @@ func New(tempDir string, mtimeClock timeutil.Clock) *ContentCache {
 	return &ContentCache{
 		debug:      logger.NewDebug("content cache: "),
 		tempDir:    tempDir,
-		fileMap:    make(map[CacheObjectKey]gcsx.TempFile),
+		fileMap:    make(map[CacheObjectKey]*CacheObject),
 		mtimeClock: mtimeClock,
 	}
 }
@@ -127,27 +166,38 @@ func (c *ContentCache) NewTempFile(rc io.ReadCloser) (gcsx.TempFile, error) {
 }
 
 // AddOrReplace creates a new cache file or updates an existing cache file
-func (c *ContentCache) AddOrReplace(cacheObjectKey *CacheObjectKey, generation int64, rc io.ReadCloser) (gcsx.TempFile, error) {
+func (c *ContentCache) AddOrReplace(cacheObjectKey *CacheObjectKey, generation int64, rc io.ReadCloser) (*CacheObject, error) {
 	if cacheObject, exists := c.fileMap[*cacheObjectKey]; exists {
 		cacheObject.Destroy()
 	}
-	metadata := &gcsx.TempFileObjectMetadata{
-		BucketName: cacheObjectKey.BucketName,
-		ObjectName: cacheObjectKey.ObjectName,
-		Generation: generation,
-	}
-	file, err := c.NewCacheFile(rc, metadata)
+	file, err := c.NewCacheFile(rc)
 	if err != nil {
-		return nil, fmt.Errorf("Could not AddOrReplace cache file: %w", err)
+		return nil, fmt.Errorf("NewCacheFile: %w", err)
 	}
-	c.fileMap[*cacheObjectKey] = file
-	return file, err
+	metadata := &CacheFileObjectMetadata{
+		CacheFileNameOnDisk: file.Name(),
+		BucketName:          cacheObjectKey.BucketName,
+		ObjectName:          cacheObjectKey.ObjectName,
+		Generation:          generation,
+	}
+	var metadataFileName string
+	metadataFileName, err = c.WriteMetadataCheckpointFile(file.Name(), metadata)
+	if err != nil {
+		return nil, fmt.Errorf("WriteMetadataCheckpointFile: %w", err)
+	}
+	cacheObject := &CacheObject{
+		MetadataFileName:        metadataFileName,
+		CacheFileObjectMetadata: metadata,
+		CacheFile:               file,
+	}
+	c.fileMap[*cacheObjectKey] = cacheObject
+	return cacheObject, err
 }
 
 // Get retrieves a file from the cache given the GCS object name and bucket name
-func (c *ContentCache) Get(cacheObjectKey *CacheObjectKey) (gcsx.TempFile, bool) {
-	file, exists := c.fileMap[*cacheObjectKey]
-	return file, exists
+func (c *ContentCache) Get(cacheObjectKey *CacheObjectKey) (*CacheObject, bool) {
+	cacheObject, exists := c.fileMap[*cacheObjectKey]
+	return cacheObject, exists
 }
 
 // Remove removes and destroys the specfied cache file and metadata on disk
@@ -159,7 +209,6 @@ func (c *ContentCache) Remove(cacheObjectKey *CacheObjectKey) {
 }
 
 // NewCacheFile creates a cache file on the disk storing the object content
-// TODO ezl we should refactor reading/writing cache files and metadata to a different package
-func (c *ContentCache) NewCacheFile(rc io.ReadCloser, metadata *gcsx.TempFileObjectMetadata) (gcsx.TempFile, error) {
-	return gcsx.NewCacheFile(rc, metadata, c.tempDir, c.mtimeClock)
+func (c *ContentCache) NewCacheFile(rc io.ReadCloser) (gcsx.TempFile, error) {
+	return gcsx.NewCacheFile(rc, c.tempDir, c.mtimeClock)
 }

--- a/internal/contentcache/contentcache_test.go
+++ b/internal/contentcache/contentcache_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contentcache_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/contentcache"
+	"github.com/jacobsa/fuse/fsutil"
+	. "github.com/jacobsa/ogletest"
+	"github.com/jacobsa/timeutil"
+)
+
+const testTempDir = "/tmp"
+const testGeneration = 10002022
+
+func TestValidateGeneration(t *testing.T) {
+	objectMetadata := contentcache.CacheFileObjectMetadata{
+		CacheFileNameOnDisk: "foobar",
+		BucketName:          "foo",
+		ObjectName:          "baz",
+		Generation:          testGeneration,
+		MetaGeneration:      1,
+	}
+	cacheObject := contentcache.CacheObject{CacheFileObjectMetadata: &objectMetadata}
+	ExpectTrue(cacheObject.ValidateGeneration(testGeneration))
+}
+
+func TestReadWriteMetadataCheckpointFile(t *testing.T) {
+	mtimeClock := timeutil.RealClock()
+	contentCache := contentcache.New(testTempDir, mtimeClock)
+	f, err := fsutil.AnonymousFile(testTempDir)
+	AssertEq(err, nil)
+	objectMetadata := contentcache.CacheFileObjectMetadata{
+		CacheFileNameOnDisk: f.Name(),
+		BucketName:          "foo",
+		ObjectName:          "baz",
+		Generation:          testGeneration,
+		MetaGeneration:      1,
+	}
+	metadataFileName, err := contentCache.WriteMetadataCheckpointFile(objectMetadata.ObjectName, &objectMetadata)
+	AssertEq(err, nil)
+	newObjectMetadata := contentcache.CacheFileObjectMetadata{}
+	contents, err := ioutil.ReadFile(metadataFileName)
+	AssertEq(err, nil)
+	err = json.Unmarshal(contents, &newObjectMetadata)
+	AssertEq(err, nil)
+	// There is no struct equality support in ExpectEq
+	ExpectEq(objectMetadata.BucketName, newObjectMetadata.BucketName)
+	ExpectEq(objectMetadata.CacheFileNameOnDisk, newObjectMetadata.CacheFileNameOnDisk)
+	ExpectEq(objectMetadata.Generation, newObjectMetadata.Generation)
+	ExpectEq(objectMetadata.MetaGeneration, newObjectMetadata.MetaGeneration)
+	ExpectEq(objectMetadata.ObjectName, newObjectMetadata.ObjectName)
+	os.Remove(metadataFileName)
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -121,9 +121,6 @@ func NewFileSystem(
 
 	mtimeClock := timeutil.RealClock()
 
-	// TODO ezl Consider setting contentcache to nil when the local file cache is disabled
-	// This means we need to refactor and separate the local file cache logic away from
-	// temp files being used when users want to write/modify files in the filesystem
 	contentCache := contentcache.New(cfg.TempDir, mtimeClock)
 
 	if cfg.LocalFileCache {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -206,9 +206,9 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 		// Fetch content from the cache after validating generation numbers again
 		// Generation validation first occurs at inode creation/destruction
 		cacheObjectKey := &contentcache.CacheObjectKey{BucketName: f.bucket.Name(), ObjectName: f.name.objectName}
-		if file, exists := f.contentCache.Get(cacheObjectKey); exists {
-			if file.ValidateGeneration(f.src.Generation) {
-				f.content = file
+		if cacheObject, exists := f.contentCache.Get(cacheObjectKey); exists {
+			if cacheObject.ValidateGeneration(f.src.Generation) {
+				f.content = cacheObject.CacheFile
 				return
 			}
 		}
@@ -227,7 +227,7 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 		}
 
 		// Update state.
-		f.content = tf
+		f.content = tf.CacheFile
 	} else {
 		// Local filecache is not enabled
 		if f.content != nil {


### PR DESCRIPTION
Refactor content cache to support dynamic cache feature implementation.

To test, verify the read-only cache still works and that there is no change in behaviour.