### PR TITLE
Remove unnecessary TODO

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+
 	//"runtime"
 	"syscall"
 	"testing"
@@ -160,9 +161,6 @@ func (t *GcsfuseTest) NonEmptyMountPoint() {
 
 	err = t.runGcsfuse(args)
 	ExpectThat(err, Error(HasSubstr("exit status 1")))
-	// TODO ezl the below string is not returned by cmd.CombinedOutput, we should make changes
-	// to detect it and passthrough this error
-	// ExpectThat(err, Error(HasSubstr("is not empty")))
 }
 */
 


### PR DESCRIPTION
Removes unnecessary TODO from broken integration test in CI.