### PR TITLE
Gcsfuse dynamic writethrough cache support

### DIFF
--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -130,6 +130,28 @@ func NewCacheFile(
 	return
 }
 
+func RecoverCacheFile(
+	source *os.File,
+	dir string,
+	clock timeutil.Clock) (tf TempFile, err error) {
+
+	stat, err := source.Stat()
+
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve file stat: %w", err)
+	}
+
+	tf = &tempFile{
+		source:         source,
+		state:          fileComplete,
+		clock:          clock,
+		f:              source,
+		dirtyThreshold: stat.Size(),
+	}
+
+	return
+}
+
 type fileState string
 
 const (


### PR DESCRIPTION
Properly recover files from disk after prefetching, evict/cleanup stale cache files and handle both read/write to our cache. 

Dynamic cache support for the writethrough content cache should now be working.

**Known Issue:**
Currently, if files are generated in the virtual filesystem (for example swap files), these will be left in the cache as garbage files with no cleanup.  Work needs to be done to investigate how best to clean these up.

Depends on #624 
