### PR TITLE
Add metageneration validation for cache files

### DIFF
--- a/internal/contentcache/contentcache_test.go
+++ b/internal/contentcache/contentcache_test.go
@@ -28,6 +28,7 @@ import (
 
 const testTempDir = "/tmp"
 const testGeneration = 10002022
+const testMetaGeneration = 1
 
 func TestValidateGeneration(t *testing.T) {
 	objectMetadata := contentcache.CacheFileObjectMetadata{
@@ -35,10 +36,10 @@ func TestValidateGeneration(t *testing.T) {
 		BucketName:          "foo",
 		ObjectName:          "baz",
 		Generation:          testGeneration,
-		MetaGeneration:      1,
+		MetaGeneration:      testMetaGeneration,
 	}
 	cacheObject := contentcache.CacheObject{CacheFileObjectMetadata: &objectMetadata}
-	ExpectTrue(cacheObject.ValidateGeneration(testGeneration))
+	ExpectTrue(cacheObject.ValidateGeneration(testGeneration, testMetaGeneration))
 }
 
 func TestReadWriteMetadataCheckpointFile(t *testing.T) {
@@ -51,7 +52,7 @@ func TestReadWriteMetadataCheckpointFile(t *testing.T) {
 		BucketName:          "foo",
 		ObjectName:          "baz",
 		Generation:          testGeneration,
-		MetaGeneration:      1,
+		MetaGeneration:      testMetaGeneration,
 	}
 	metadataFileName, err := contentCache.WriteMetadataCheckpointFile(objectMetadata.ObjectName, &objectMetadata)
 	AssertEq(err, nil)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -207,7 +207,7 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 		// Generation validation first occurs at inode creation/destruction
 		cacheObjectKey := &contentcache.CacheObjectKey{BucketName: f.bucket.Name(), ObjectName: f.name.objectName}
 		if cacheObject, exists := f.contentCache.Get(cacheObjectKey); exists {
-			if cacheObject.ValidateGeneration(f.src.Generation) {
+			if cacheObject.ValidateGeneration(f.src.Generation, f.src.MetaGeneration) {
 				f.content = cacheObject.CacheFile
 				return
 			}
@@ -220,7 +220,7 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 		}
 
 		// Insert object into content cache
-		tf, err := f.contentCache.AddOrReplace(cacheObjectKey, f.src.Generation, rc)
+		tf, err := f.contentCache.AddOrReplace(cacheObjectKey, f.src.Generation, f.src.MetaGeneration, rc)
 		if err != nil {
 			err = fmt.Errorf("AddOrReplace cache error: %w", err)
 			return err


### PR DESCRIPTION
Validate on metageneration (in addition to generation numbers) to verify consistency and update the unit tests to reflect this change.