### PR TITLE
Update CI timeout to 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         go: [1.17.x]
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
If tests in CI are hanging, timeout will trigger earlier.