### PR TITLE
gcsfuse content cache thread safety

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -118,11 +118,6 @@ func NewFileInode(
 	// Set up invariant checking.
 	f.mu = syncutil.NewInvariantMutex(f.checkInvariants)
 
-	if localFileCache {
-		// The gcs object is cached as local temp file
-		f.ensureContent(context.Background())
-	}
-
 	return
 }
 
@@ -566,4 +561,11 @@ func (f *FileInode) Truncate(
 	err = f.content.Truncate(size)
 
 	return
+}
+
+// Ensures cache content on read if content cache enabled
+func (f *FileInode) CacheEnsureContent(ctx context.Context) {
+	if f.localFileCache {
+		f.ensureContent(ctx)
+	}
 }


### PR DESCRIPTION
The changes move ensureContent from inode creation to the file read path so files are only cached during reads and not during file inode creation (which happens during directory listings etc.) to improve performance.

In order to support these changes, the content cache now needs to be thread safe as there are no synchronization primitives protecting against concurrent cache access.  (previously we had filesystem and inode locks as cache access occurred at the inode creation step, but such locks do not guard against concurrent cache access during reads)