### PR TITLE
Fix contentcache error handling

### DIFF
--- a/internal/contentcache/contentcache.go
+++ b/internal/contentcache/contentcache.go
@@ -148,7 +148,6 @@ func (c *ContentCache) recoverFileFromCache(metadataFile fs.FileInfo) {
 }
 
 // RecoverCache recovers the cache with existing persisted files when gcsfuse starts
-//
 // RecoverCache should not be called concurrently
 func (c *ContentCache) RecoverCache() error {
 	if c.tempDir == "" {
@@ -202,12 +201,9 @@ func (c *ContentCache) AddOrReplace(cacheObjectKey *CacheObjectKey, generation i
 	// Create a temporary cache file on disk
 	f, err := ioutil.TempFile(c.tempDir, CacheFilePrefix)
 	if err != nil {
-		err = fmt.Errorf("TempFile: %w", err)
+		return nil, fmt.Errorf("TempFile: %w", err)
 	}
-	file, err := c.NewCacheFile(rc, f)
-	if err != nil {
-		return nil, fmt.Errorf("NewCacheFile: %w", err)
-	}
+	file := c.NewCacheFile(rc, f)
 	metadata := &CacheFileObjectMetadata{
 		CacheFileNameOnDisk: file.Name(),
 		BucketName:          cacheObjectKey.BucketName,
@@ -249,8 +245,8 @@ func (c *ContentCache) Remove(cacheObjectKey *CacheObjectKey) {
 	}
 }
 
-// NewCacheFile creates a cache file on the disk storing the object content
-func (c *ContentCache) NewCacheFile(rc io.ReadCloser, f *os.File) (gcsx.TempFile, error) {
+// NewCacheFile returns a cache tempfile wrapper around the source reader and file
+func (c *ContentCache) NewCacheFile(rc io.ReadCloser, f *os.File) gcsx.TempFile {
 	return gcsx.NewCacheFile(rc, f, c.tempDir, c.mtimeClock)
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -210,7 +210,7 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 
 		rc, err := f.openReader(ctx)
 		if err != nil {
-			fmt.Errorf("open reader error: %w", err)
+			err = fmt.Errorf("openReader Error: %w", err)
 			return err
 		}
 
@@ -231,7 +231,7 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 
 		rc, err := f.openReader(ctx)
 		if err != nil {
-			fmt.Errorf("Open Reader Error: %w", err)
+			err = fmt.Errorf("openReader Error: %w", err)
 			return err
 		}
 

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -100,14 +100,14 @@ func NewTempFile(
 	return
 }
 
-// NewCacheFile creates a temp file whose initial contents are given by the
-// supplied reader. dir is a directory on whose file system the file will live,
+// NewCacheFile creates a wrapper temp file whose initial contents are given by the
+// supplied source. dir is a directory on whose file system the file will live,
 // or the system default temporary location if empty.
 func NewCacheFile(
 	source io.ReadCloser,
 	f *os.File,
 	dir string,
-	clock timeutil.Clock) (tf TempFile, err error) {
+	clock timeutil.Clock) (tf TempFile) {
 
 	tf = &tempFile{
 		source:         source,


### PR DESCRIPTION
Address #645 as quickfix for error handling.

Long term we would like to open files in our cache with os.Open only when necessary (on demand).