### PR TITLE
Setting MaxResults to 5000 and projection to noAcl in ListObjects call to fetch larger data set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
 	github.com/jacobsa/fuse v0.0.0-20220130133955-108387eec147
-	github.com/jacobsa/gcloud v0.0.0-20220218101620-8d1a66f33ec9
+	github.com/jacobsa/gcloud v0.0.0-20220411082628-5962fc71075a
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ github.com/jacobsa/gcloud v0.0.0-20211221120201-0d771bbe4dd5 h1:BHID6b7MWIkbwd89
 github.com/jacobsa/gcloud v0.0.0-20211221120201-0d771bbe4dd5/go.mod h1:3fF6sEraNZSToePaj5q+f9KSaMpuZcwccqAQmOKDv/k=
 github.com/jacobsa/gcloud v0.0.0-20220218101620-8d1a66f33ec9 h1:aB3IZPhzxvixiKrwalgFXy9X0/PF0PHZxwhhH7N8VWM=
 github.com/jacobsa/gcloud v0.0.0-20220218101620-8d1a66f33ec9/go.mod h1:nvUMlvvHkp6h7NFL7UuayN/8wmTp1pnVHxT3kfFQHDk=
+github.com/jacobsa/gcloud v0.0.0-20220411082628-5962fc71075a h1:M1P9HI/1MOZ+ooqBwURE3kTaqxmSfuOBBlURcRfwX60=
+github.com/jacobsa/gcloud v0.0.0-20220411082628-5962fc71075a/go.mod h1:nvUMlvvHkp6h7NFL7UuayN/8wmTp1pnVHxT3kfFQHDk=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -31,6 +31,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ListObjects call supports fetching upto 5000 results via maxResults param in
+// one call. By default 1000 results are returned if value is not set.
+// Defining a constant to set maxResults param.
+const MaxResultsForListObjectsCall = 5000
+
 // An inode representing a directory, with facilities for listing entries,
 // looking up children, and creating and deleting children. Must be locked for
 // any method additional to the Inode interface.
@@ -521,6 +526,7 @@ func (d *dirInode) readObjects(
 		IncludeTrailingDelimiter: true,
 		Prefix:                   d.Name().GcsObjectName(),
 		ContinuationToken:        tok,
+		MaxResults:               MaxResultsForListObjectsCall,
 	}
 
 	listing, err := d.bucket.ListObjects(ctx, req)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -31,8 +31,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ListObjects call supports fetching upto 5000 results via maxResults param in
-// one call. By default 1000 results are returned if value is not set.
+// ListObjects call supports fetching upto 5000 results when projection is noAcl
+// via maxResults param in one call. When projection is set to full, it returns
+// 2000 results max. In GcsFuse flows we will be setting projection as noAcl.
+// By default 1000 results are returned if maxResults is not set.
 // Defining a constant to set maxResults param.
 const MaxResultsForListObjectsCall = 5000
 
@@ -527,6 +529,9 @@ func (d *dirInode) readObjects(
 		Prefix:                   d.Name().GcsObjectName(),
 		ContinuationToken:        tok,
 		MaxResults:               MaxResultsForListObjectsCall,
+		// Setting Projection param to noAcl since fetching owner and acls are not
+		// required.
+		ProjectionVal: gcs.NoAcl,
 	}
 
 	listing, err := d.bucket.ListObjects(ctx, req)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -531,7 +531,7 @@ func (d *dirInode) readObjects(
 		MaxResults:               MaxResultsForListObjectsCall,
 		// Setting Projection param to noAcl since fetching owner and acls are not
 		// required.
-		ProjectionVal: gcs.NoAcl,
+		ProjectionVal:            gcs.NoAcl,
 	}
 
 	listing, err := d.bucket.ListObjects(ctx, req)

--- a/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
@@ -145,7 +145,7 @@ func (b *bucket) ListObjects(
 		httputil.EncodePathSegment(b.Name()))
 
 	query := make(url.Values)
-	query.Set("projection", "full")
+	query.Set("projection", req.ProjectionVal.String())
 
 	if req.Prefix != "" {
 		query.Set("prefix", req.Prefix)

--- a/vendor/github.com/jacobsa/gcloud/gcs/requests.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/requests.go
@@ -176,6 +176,25 @@ type StatObjectRequest struct {
 	Name string
 }
 
+type Projection int64
+
+const (
+	Full Projection = iota
+	NoAcl
+)
+
+// Returning the string values based on the values accepted by projection param.
+// https://cloud.google.com/storage/docs/json_api/v1/objects/list#parameters
+func (p Projection) String() string {
+	switch p {
+	case Full:
+		return "full"
+	case NoAcl:
+		return "noAcl"
+	}
+	return "full"
+}
+
 type ListObjectsRequest struct {
 	// List only objects whose names begin with this prefix.
 	Prefix string
@@ -220,6 +239,15 @@ type ListObjectsRequest struct {
 	// this number may actually be returned. If this is zero, a sensible default
 	// is used.
 	MaxResults int
+
+	// Set of properties to return. Acceptable values- full & noAcl.
+	//    1. full  - returns all properties
+	//    2. noAcl - omit owner, acl properties
+	//
+	// Currently projection value is hardcoded to full. To keep it aligned with
+	// the current flow, default value will be full and callers can override it
+	// using this param.
+	ProjectionVal Projection
 }
 
 // Listing contains a set of objects and delimter-based collapsed runs returned

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,7 @@ github.com/jacobsa/fuse/fuseutil
 github.com/jacobsa/fuse/internal/buffer
 github.com/jacobsa/fuse/internal/freelist
 github.com/jacobsa/fuse/internal/fusekernel
-# github.com/jacobsa/gcloud v0.0.0-20220218101620-8d1a66f33ec9
+# github.com/jacobsa/gcloud v0.0.0-20220411082628-5962fc71075a
 ## explicit
 github.com/jacobsa/gcloud/gcs
 github.com/jacobsa/gcloud/gcs/gcscaching


### PR DESCRIPTION
Right now we don't set the maxResults param in listObjects api. By default 1000 results are returned. ListObjects api supports fetching upto 5000 results. Hence utilising the maxResults param to fetch larger data set which will improve the directory listing.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/652