### PR TITLE
Changes to fetch statObject from gcs before syncing the file

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -522,7 +522,9 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// here will not have acl information even though there are acls present on
 	// the gcsObject.
 	// Hence, we are making an explicit gcs stat call to fetch the latest
-	// properties and using that when object is synced below.
+	// properties and using that when object is synced below. StatObject by
+	// default sets the projection to full, which fetches all the object
+	// properties.
 	latestGcsObj, isClobbered, err := f.GetLatestStatAndValidate(ctx, &f.src)
 
 	// Clobbered is treated as being unlinked. There's no reason to return an

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -371,9 +371,9 @@ func (f *FileInode) Attributes(
 
 	// If the object has been clobbered, we reflect that as the inode being
 	// unlinked.
-	o, clobbered, err := f.clobbered(ctx)
+	_, clobbered, err := f.clobbered(ctx)
 	if err != nil {
-		err = fmt.Errorf("objectName: %s is clobbered: %w", o.Name, err)
+		err = fmt.Errorf("clobbered: %w", err)
 		return
 	}
 


### PR DESCRIPTION
Object metadata is fetched in different flows like lookupInode, ListObject etc. Based on the flow either complete metadata or subset is fetched from gcs and stored in cache.  So cache will not have all the object metadata. Hence before syncing the file which recreates the file in gcs - we need to fetch the all the object properties and set those properties to the new file.