### PR TITLE
Set up Go Storage Client as a parameter of bucket struct in jacobsa library.

### DIFF
--- a/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
@@ -126,7 +126,7 @@ type Bucket interface {
 
 type bucket struct {
 	client         *http.Client
-	sclClient      *storage.Client //Go Storage Library Client.
+	storageClient  *storage.Client //Go Storage Library Client.
 	url            *url.URL
 	userAgent      string
 	name           string
@@ -359,18 +359,18 @@ func newBucket(
 	name string,
 	billingProject string) Bucket {
 
-	// Creating client through GSCL for the sclClient parameter of bucket.
-	var sclClient *storage.Client = nil
-	sclClient, err := storage.NewClient(ctx)
+	// Creating client through Go Storage Client Library for the storageClient parameter of bucket.
+	var storageClient *storage.Client = nil
+	storageClient, err := storage.NewClient(ctx)
 	if err != nil {
-		err = fmt.Errorf("Error in creating the client through GSCL: %v", err)
+		err = fmt.Errorf("Error in creating the client through Go Storage Library: %v", err)
 	} else {
-		fmt.Println("GSCL Client Created")
+		fmt.Println("Go Storage Client Created")
 	}
 
 	return &bucket{
 		client:         client,
-		sclClient:      sclClient,
+		storageClient:  storageClient,
 		url:            url,
 		userAgent:      userAgent,
 		name:           name,

--- a/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
@@ -364,8 +364,6 @@ func newBucket(
 	storageClient, err := storage.NewClient(ctx)
 	if err != nil {
 		err = fmt.Errorf("Error in creating the client through Go Storage Library: %v", err)
-	} else {
-		fmt.Println("Go Storage Client Created")
 	}
 
 	return &bucket{

--- a/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/bucket.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"cloud.google.com/go/storage"
 	"github.com/jacobsa/gcloud/httputil"
 	"golang.org/x/net/context"
 	"google.golang.org/api/googleapi"
@@ -125,6 +126,7 @@ type Bucket interface {
 
 type bucket struct {
 	client         *http.Client
+	sclClient      *storage.Client //Go Storage Library Client.
 	url            *url.URL
 	userAgent      string
 	name           string
@@ -350,13 +352,25 @@ func (b *bucket) DeleteObject(
 }
 
 func newBucket(
+	ctx context.Context,
 	client *http.Client,
 	url *url.URL,
 	userAgent string,
 	name string,
 	billingProject string) Bucket {
+
+	// Creating client through GSCL for the sclClient parameter of bucket.
+	var sclClient *storage.Client = nil
+	sclClient, err := storage.NewClient(ctx)
+	if err != nil {
+		err = fmt.Errorf("Error in creating the client through GSCL: %v", err)
+	} else {
+		fmt.Println("GSCL Client Created")
+	}
+
 	return &bucket{
 		client:         client,
+		sclClient:      sclClient,
 		url:            url,
 		userAgent:      userAgent,
 		name:           name,

--- a/vendor/github.com/jacobsa/gcloud/gcs/conn.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/conn.go
@@ -157,7 +157,7 @@ type conn struct {
 func (c *conn) OpenBucket(
 	ctx context.Context,
 	options *OpenBucketOptions) (b Bucket, err error) {
-	b = newBucket(c.client, c.url, c.userAgent, options.Name, options.BillingProject)
+	b = newBucket(ctx, c.client, c.url, c.userAgent, options.Name, options.BillingProject)
 
 	// Enable retry loops if requested.
 	if c.maxBackoffSleep > 0 {

--- a/vendor/github.com/jacobsa/gcloud/gcs/read.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/read.go
@@ -23,14 +23,10 @@ import (
 	"net/url"
 	"strings"
 
+	"cloud.google.com/go/storage"
 	"github.com/jacobsa/gcloud/httputil"
 	"golang.org/x/net/context"
 	"google.golang.org/api/googleapi"
-	"cloud.google.com/go/storage"
-)
-
-var (
-	sclClient *storage.Client = nil // Client for the Go Storage Client Library.
 )
 
 func (b *bucket) NewReader(
@@ -49,12 +45,12 @@ func (b *bucket) NewReader(
 
 	// Switching to Go Storage Client Library.
 	if true {
-                rc, err = NewReaderSCL(ctx, req, b.name)
-                if err != nil {
-                        err = fmt.Errorf("Error in creating client through NewReaderSCL")
-                }
-                return
-        }
+		rc, err = NewReaderSCL(ctx, req, b.name, b.sclClient)
+		if err != nil {
+			err = fmt.Errorf("Error in creating client through NewReaderSCL")
+		}
+		return
+	}
 
 	bucketSegment := httputil.EncodePathSegment(b.name)
 	objectSegment := httputil.EncodePathSegment(req.Name)
@@ -153,36 +149,31 @@ func (b *bucket) NewReader(
 	return
 }
 
-
 // Custom function made to create a new reader using Storage Client Library.
 func NewReaderSCL(
-        ctx context.Context,
-        req *ReadObjectRequest, bucketName string) (rc io.ReadCloser, err error){
-	// Create a client if there is not one already created.
-        if sclClient == nil {
-		sclClient, err = storage.NewClient(ctx)
-		if err != nil {
-			err = fmt.Errorf("Error in creating the client: %v", err)
-			return
-		}
-		fmt.Println("Client Created")
+	ctx context.Context,
+	req *ReadObjectRequest, bucketName string, sclClient *storage.Client) (rc io.ReadCloser, err error) {
+	// If client is "nil", it means that there was some problem in initializing client in newBucket function of bucket.go file.
+	if sclClient == nil {
+		err = fmt.Errorf("Error in creating client through GSCL: %v", err)
+		return
 	}
 
 	// Initialising the starting offset and the length to be read by the reader.
-        start := int64((*req.Range).Start)
-        end := int64((*req.Range).Limit)
-        length := int64(end - start)
+	start := int64((*req.Range).Start)
+	end := int64((*req.Range).Limit)
+	length := int64(end - start)
 
 	// Creating a NewRangeReader instance.
-        r, err := sclClient.Bucket(bucketName).Object(req.Name).NewRangeReader(ctx, start, length)
-        if err != nil {
+	r, err := sclClient.Bucket(bucketName).Object(req.Name).NewRangeReader(ctx, start, length)
+	if err != nil {
 		err = fmt.Errorf("Error in creating a NewRangeReader instance: %v", err)
-                return
-        }
+		return
+	}
 
-        rc = io.NopCloser(r) // Converting io.Reader to io.ReadCloser.
+	rc = io.NopCloser(r) // Converting io.Reader to io.ReadCloser.
 
-        return
+	return
 }
 
 // Given a [start, limit) range, create an HTTP 1.1 Range header which ensures

--- a/vendor/github.com/jacobsa/gcloud/gcs/read.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/read.go
@@ -45,7 +45,7 @@ func (b *bucket) NewReader(
 
 	// Switching to Go Storage Client Library.
 	if true {
-		rc, err = NewReaderSCL(ctx, req, b.name, b.sclClient)
+		rc, err = NewReaderSCL(ctx, req, b.name, b.storageClient)
 		if err != nil {
 			err = fmt.Errorf("Error in creating client through NewReaderSCL")
 		}
@@ -152,10 +152,10 @@ func (b *bucket) NewReader(
 // Custom function made to create a new reader using Storage Client Library.
 func NewReaderSCL(
 	ctx context.Context,
-	req *ReadObjectRequest, bucketName string, sclClient *storage.Client) (rc io.ReadCloser, err error) {
+	req *ReadObjectRequest, bucketName string, storageClient *storage.Client) (rc io.ReadCloser, err error) {
 	// If client is "nil", it means that there was some problem in initializing client in newBucket function of bucket.go file.
-	if sclClient == nil {
-		err = fmt.Errorf("Error in creating client through GSCL: %v", err)
+	if storageClient == nil {
+		err = fmt.Errorf("Error in creating client through Go Storage Library: %v", err)
 		return
 	}
 
@@ -165,7 +165,7 @@ func NewReaderSCL(
 	length := int64(end - start)
 
 	// Creating a NewRangeReader instance.
-	r, err := sclClient.Bucket(bucketName).Object(req.Name).NewRangeReader(ctx, start, length)
+	r, err := storageClient.Bucket(bucketName).Object(req.Name).NewRangeReader(ctx, start, length)
 	if err != nil {
 		err = fmt.Errorf("Error in creating a NewRangeReader instance: %v", err)
 		return

--- a/vendor/github.com/jacobsa/gcloud/gcs/read_test.go
+++ b/vendor/github.com/jacobsa/gcloud/gcs/read_test.go
@@ -1,6 +1,7 @@
 package gcs
 
 import (
+	"cloud.google.com/go/storage"
 	"github.com/jacobsa/gcloud/gcs"
 	. "github.com/jacobsa/ogletest"
 	"golang.org/x/net/context"
@@ -14,6 +15,7 @@ func TestRead(t *testing.T) { RunTests(t) }
 type ReadTest struct {
 	ctx        context.Context
 	bucketName string
+	client     *storage.Client
 }
 
 var _ SetUpInterface = &ReadTest{}
@@ -21,10 +23,12 @@ var _ SetUpInterface = &ReadTest{}
 func init() { RegisterTestSuite(&ReadTest{}) }
 
 func (t *ReadTest) SetUp(ti *TestInfo) {
-
+	var err error
 	t.ctx = ti.Ctx
 
 	t.bucketName = "testing-gcsfuse" // Testing on my personal bucket.
+	t.client, err = storage.NewClient(t.ctx)
+	AssertEq(nil, err)
 }
 
 // Offset equals 0 and Length equals 0. In this case printed string should be empty.
@@ -42,7 +46,7 @@ func (t *ReadTest) OffsetZeroLengthZero() {
 			Limit: uint64(end),
 		},
 	}
-	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName) // NewRangeReader of Go Storage Client Library is used to create reader.
+	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName, t.client) // NewRangeReader of Go Storage Client Library is used to create reader.
 	AssertEq(nil, err)
 
 	buf := new(strings.Builder)
@@ -66,7 +70,7 @@ func (t *ReadTest) OffsetZeroLengthNonZero() {
 			Limit: uint64(end),
 		},
 	}
-	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName)
+	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName, t.client)
 	AssertEq(nil, err)
 
 	buf := new(strings.Builder)
@@ -90,7 +94,7 @@ func (t *ReadTest) OffsetNonZeroLengthZero() {
 			Limit: uint64(end),
 		},
 	}
-	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName)
+	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName, t.client)
 	AssertEq(nil, err)
 
 	buf := new(strings.Builder)
@@ -114,7 +118,7 @@ func (t *ReadTest) OffsetNonZeroLengthNonZero() {
 			Limit: uint64(end),
 		},
 	}
-	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName)
+	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName, t.client)
 	AssertEq(nil, err)
 
 	buf := new(strings.Builder)
@@ -138,7 +142,7 @@ func (t *ReadTest) LengthGreaterThanFileLength() {
 			Limit: uint64(end),
 		},
 	}
-	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName)
+	rc, err := gcs.NewReaderSCL(t.ctx, req, t.bucketName, t.client)
 	AssertEq(nil, err)
 
 	buf := new(strings.Builder)


### PR DESCRIPTION
Moved Go Storage Client declaration from NewReaderSCL method in read.go to newBucket method in bucket.go.
The earlier declaration in NewReaderSCL method was not thread protected i.e. multiple clients can be formed from different threads whereas we want a single client for all threads.
Moved to newBucket method because it is only called once after starting gcsfuse irrespective of different threads. Also if passed as a argument to bucket, the same client can be used by read, write, get methods without creating different clients for different methods.