### PR TITLE
Fixes #728: Upgrade Go to 1.18.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   linux-tests:
     strategy:
       matrix:
-        go: [1.17.x]
+        go: [1.18.x]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.17.6-alpine as builder
+FROM golang:1.18.4-alpine as builder
 
 RUN apk add git
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.17.6 as builder
+FROM golang:1.18.4 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document fpm
 


### PR DESCRIPTION
Upgrade Go runtime to the latest version 1.18.4.