### PR TITLE
Made changes to export metrics for gcs read calls along with type

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -61,19 +61,19 @@ const random = "Random"
 // Initialize the metrics.
 func init() {
 	if err := view.Register(
-		      &view.View{
-									Name:        "gcsfuse_read_bytes",
-									Measure:     readBytes,
-									Description: "The number of bytes read from GCS",
-									Aggregation: view.Sum(),
-					},
-					&view.View{
-									Name:        "gcs_read_count",
-									Measure:     gcsReadCount,
-									Description: "Specifies the number of gcs reads made along with type- Sequential/Random",
-									Aggregation: view.Sum(),
-									TagKeys:     []tag.Key{tags.ReadType},
-					},
+		&view.View{
+			Name:        "gcsfuse_read_bytes",
+			Measure:     readBytes,
+			Description: "The number of bytes read from GCS",
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "gcs_read_count",
+			Measure:     gcsReadCount,
+			Description: "Specifies the number of gcs reads made along with type- Sequential/Random",
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{tags.ReadType},
+		},
 	); err != nil {
 		log.Fatalf("Failed to register the view: %v", err)
 	}

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -33,7 +33,7 @@ var (
 	// requests will be served from the downloaded data.
 	// This metric captures only the requests made to GCS, not the subsequent page calls.
 	gcsReadCount = stats.Int64("gcs/read_count", "Specifies the count of gcs reads made along with type", stats.UnitDimensionless)
-	downloadBytesCount = stats.Int64("gcs/download_bytes_count", "The number of bytes downloaded from GCS", stats.UnitBytes)
+	downloadBytesCount = stats.Int64("gcs/download_bytes_count", "Cumulative number of bytes downloaded from GCS along with read type", stats.UnitBytes)
 )
 
 // MB is 1 Megabyte. (Silly comment to make the lint warning go away)
@@ -400,5 +400,4 @@ func captureMetrics(ctx context.Context, readType string, requestedDataSize int6
 		// Error in recording gcsReadCount.
 		log.Fatalf("Cannot record downloadBytesCount %v", err)
 	}
-
 }

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -28,7 +28,6 @@ import (
 )
 
 var (
-	readBytes = stats.Int64("read_bytes", "The number of bytes read from GCS", "By")
 	// When a first read call is made by the user, we either fetch entire file or x number of bytes from GCS based on the request.
 	// Now depending on the pagesize multiple read calls will be issued by user to read the entire file. These
 	// requests will be served from the downloaded data.
@@ -61,12 +60,6 @@ const random = "Random"
 // Initialize the metrics.
 func init() {
 	if err := view.Register(
-		&view.View{
-			Name:        "gcsfuse_read_bytes",
-			Measure:     readBytes,
-			Description: "The number of bytes read from GCS",
-			Aggregation: view.Sum(),
-		},
 		&view.View{
 			Name:        "gcs_read_count",
 			Measure:     gcsReadCount,
@@ -249,7 +242,6 @@ func (rr *randomReader) ReadAt(
 		}
 	}
 
-	stats.Record(ctx, readBytes.M(int64(n)))
 	return
 }
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -32,7 +32,7 @@ var (
 	// Now depending on the pagesize multiple read calls will be issued by user to read the entire file. These
 	// requests will be served from the downloaded data.
 	// This metric captures only the requests made to GCS, not the subsequent page calls.
-	gcsReadCount = stats.Int64("gcs_reads", "Specifies the count of gcs reads made along with type", stats.UnitDimensionless)
+	gcsReadCount = stats.Int64("gcs/read_count", "Specifies the count of gcs reads made along with type", stats.UnitDimensionless)
 )
 
 // MB is 1 Megabyte. (Silly comment to make the lint warning go away)
@@ -61,7 +61,7 @@ const random = "Random"
 func init() {
 	if err := view.Register(
 		&view.View{
-			Name:        "gcs_read_count",
+			Name:        "gcs/read_count",
 			Measure:     gcsReadCount,
 			Description: "Specifies the number of gcs reads made along with type- Sequential/Random",
 			Aggregation: view.Sum(),

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -62,7 +62,7 @@ const random = "Random"
 func init() {
 	if err := view.Register(
 		      &view.View{
-						      Name:        "gcsfuse_read_bytes",
+									Name:        "gcsfuse_read_bytes",
 									Measure:     readBytes,
 									Description: "The number of bytes read from GCS",
 									Aggregation: view.Sum(),

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -32,8 +32,12 @@ var (
 	// Now depending on the pagesize multiple read calls will be issued by user to read the entire file. These
 	// requests will be served from the downloaded data.
 	// This metric captures only the requests made to GCS, not the subsequent page calls.
-	gcsReadCount = stats.Int64("gcs/read_count", "Specifies the count of gcs reads made along with type", stats.UnitDimensionless)
-	downloadBytesCount = stats.Int64("gcs/download_bytes_count", "Cumulative number of bytes downloaded from GCS along with read type", stats.UnitBytes)
+	gcsReadCount = stats.Int64("gcs/read_count",
+		"Specifies the count of gcs reads made along with type",
+		stats.UnitDimensionless)
+	downloadBytesCount = stats.Int64("gcs/download_bytes_count",
+		"Cumulative number of bytes downloaded from GCS along with read type",
+		stats.UnitBytes)
 )
 
 // MB is 1 Megabyte. (Silly comment to make the lint warning go away)

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -31,7 +31,6 @@ import (
 var (
 	// OpenCensus measures
 	readBytesCount = stats.Int64("gcs/read_bytes_count", "The number of bytes read from GCS objects.", stats.UnitBytes)
-	downloadBytesCount = stats.Int64("gcs/download_bytes_count", "The number of bytes downloaded from GCS", stats.UnitBytes)
 	readerCount    = stats.Int64("gcs/reader_count", "The number of GCS object readers opened or closed.", stats.UnitDimensionless)
 	requestCount   = stats.Int64("gcs/request_count", "The number of GCS requests processed.", stats.UnitDimensionless)
 	requestLatency = stats.Float64("gcs/request_latency", "The latency of a GCS request.", stats.UnitMilliseconds)
@@ -45,12 +44,6 @@ func init() {
 			Name:        "gcs/read_bytes_count",
 			Measure:     readBytesCount,
 			Description: "The cumulative number of bytes read from GCS objects.",
-			Aggregation: view.Sum(),
-		},
-		&view.View{
-			Name:        "gcs/download_bytes_count",
-			Measure:     downloadBytesCount,
-			Description: "The cumulative number of bytes downloaded from GCS.",
 			Aggregation: view.Sum(),
 		},
 		&view.View{
@@ -131,11 +124,6 @@ func (mb *monitoringBucket) NewReader(
 	}
 
 	recordRequest(ctx, "NewReader", startTime)
-
-	if req.Range != nil {
-		requestSize := req.Range.Limit - req.Range.Start
-		stats.Record(ctx, downloadBytesCount.M(int64(requestSize)))
-	}
 	return
 }
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -31,6 +31,7 @@ import (
 var (
 	// OpenCensus measures
 	readBytesCount = stats.Int64("gcs/read_bytes_count", "The number of bytes read from GCS objects.", stats.UnitBytes)
+	downloadBytesCount = stats.Int64("gcs/download_bytes_count", "The number of bytes downloaded from GCS", stats.UnitBytes)
 	readerCount    = stats.Int64("gcs/reader_count", "The number of GCS object readers opened or closed.", stats.UnitDimensionless)
 	requestCount   = stats.Int64("gcs/request_count", "The number of GCS requests processed.", stats.UnitDimensionless)
 	requestLatency = stats.Float64("gcs/request_latency", "The latency of a GCS request.", stats.UnitMilliseconds)
@@ -44,6 +45,12 @@ func init() {
 			Name:        "gcs/read_bytes_count",
 			Measure:     readBytesCount,
 			Description: "The cumulative number of bytes read from GCS objects.",
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "gcs/download_bytes_count",
+			Measure:     downloadBytesCount,
+			Description: "The cumulative number of bytes downloaded from GCS.",
 			Aggregation: view.Sum(),
 		},
 		&view.View{
@@ -124,6 +131,11 @@ func (mb *monitoringBucket) NewReader(
 	}
 
 	recordRequest(ctx, "NewReader", startTime)
+
+	if req.Range != nil {
+		requestSize := req.Range.Limit - req.Range.Start
+		stats.Record(ctx, downloadBytesCount.M(int64(requestSize)))
+	}
 	return
 }
 

--- a/internal/monitor/tags/tags.go
+++ b/internal/monitor/tags/tags.go
@@ -31,4 +31,7 @@ var (
 
 	// FSError annotates the file system failed operations with the error type
 	FSError = tag.MustNewKey("fs_error")
+
+	// ReadType annotates the read operation with the type - Sequential/Random
+	ReadType = tag.MustNewKey("read_type")
 )


### PR DESCRIPTION
1. Added two new metrics - gcs/read_count to capture number of read calls along with type, gcs/downloaded_bytes_count to capture amount of data downloading from gcs.
2. gcsfuse_read_bytes is same as gcs/read_bytes_count. Hence removed gcsfuse_read_bytes