### PR TITLE
GCSFuse mount fails when log-file flag is used without --foreground flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -401,19 +401,16 @@ func main() {
 	go perf.HandleCPUProfileSignals()
 	go perf.HandleMemoryProfileSignals()
 
-	err := resolvePathInCLIArguments([]string{"--log-file", "--key-file"}, os.Args, false)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	resolveErr := resolvePathInCLIArguments([]string{"--log-file", "--key-file"}, os.Args, false)
+	if resolveErr != nil {
+		fmt.Fprintln(os.Stderr, resolveErr)
 		os.Exit(1)
 	}
 
-	testArgs := os.Args
-	fmt.Println(testArgs)
-
 	// Run.
-	err1 := run()
+	err := run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err1)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestMains(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type MainTest struct {
+}
+
+func init() { RegisterTestSuite(&MainTest{}) }
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *MainTest) ResolvePathTest() {
+	currDir, err := os.Getwd()
+	if err != nil {
+		fmt.Errorf("current working directory: %w", err)
+	}
+
+	inputArgs0 := []string{"gcsfuse", "--log-file", "test.json", "--ht", "-x"}
+	resolvePathInCLIArguments(inputArgs0, true)
+	expected0 := []string{"gcsfuse",
+		"--log-file", fmt.Sprintf("%s/test.json", currDir), "--ht", "-x"}
+	ExpectTrue(reflect.DeepEqual(inputArgs0, expected0))
+
+	inputArgs1 := []string{"gcsfuse", "--log-file=test.json", "--foreground"}
+	resolvePathInCLIArguments(inputArgs1, true)
+	expected1 := []string{"gcsfuse",
+		fmt.Sprintf("--log-file=%s/test.json", currDir), "--foreground"}
+	ExpectTrue(reflect.DeepEqual(inputArgs1, expected1))
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Errorf("current working directory: %w", err)
+	}
+
+	inputArgs2 := []string{"gcsfuse", "--log-file=~/test.json", "--foreground"}
+	resolvePathInCLIArguments(inputArgs2, true)
+	expected2 := []string{"gcsfuse",
+		fmt.Sprintf("--log-file=%s/test.json", homeDir), "--foreground"}
+	fmt.Println(inputArgs2)
+	fmt.Println(expected2)
+	ExpectTrue(reflect.DeepEqual(inputArgs2, expected2))
+
+}

--- a/main_test.go
+++ b/main_test.go
@@ -45,13 +45,13 @@ func (t *MainTest) ResolvePathTest() {
 	}
 
 	inputArgs0 := []string{"gcsfuse", "--log-file", "test.json", "--ht", "-x"}
-	resolvePathInCLIArguments(inputArgs0, true)
+	resolvePathInCLIArguments([]string{"--log-file", "--key-file"}, inputArgs0, true)
 	expected0 := []string{"gcsfuse",
 		"--log-file", fmt.Sprintf("%s/test.json", currDir), "--ht", "-x"}
 	ExpectTrue(reflect.DeepEqual(inputArgs0, expected0))
 
 	inputArgs1 := []string{"gcsfuse", "--log-file=test.json", "--foreground"}
-	resolvePathInCLIArguments(inputArgs1, true)
+	resolvePathInCLIArguments([]string{"--log-file", "--key-file"}, inputArgs1, true)
 	expected1 := []string{"gcsfuse",
 		fmt.Sprintf("--log-file=%s/test.json", currDir), "--foreground"}
 	ExpectTrue(reflect.DeepEqual(inputArgs1, expected1))
@@ -61,12 +61,10 @@ func (t *MainTest) ResolvePathTest() {
 		fmt.Errorf("current working directory: %w", err)
 	}
 
-	inputArgs2 := []string{"gcsfuse", "--log-file=~/test.json", "--foreground"}
-	resolvePathInCLIArguments(inputArgs2, true)
+	inputArgs2 := []string{"gcsfuse", "--log-file=test.txt", "--key-file=~/test.json", "--foreground"}
+	resolvePathInCLIArguments([]string{"--log-file", "--key-file"}, inputArgs2, true)
 	expected2 := []string{"gcsfuse",
-		fmt.Sprintf("--log-file=%s/test.json", homeDir), "--foreground"}
-	fmt.Println(inputArgs2)
-	fmt.Println(expected2)
+		fmt.Sprintf("--log-file=%s/test.txt", currDir),
+		fmt.Sprintf("--key-file=%s/test.json", homeDir), "--foreground"}
 	ExpectTrue(reflect.DeepEqual(inputArgs2, expected2))
-
 }

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-
 	//"runtime"
 	"syscall"
 	"testing"
@@ -182,8 +181,6 @@ func (t *GcsfuseTest) MountPointIsAFile() {
 	ExpectThat(err, Error(HasSubstr("is not a directory")))
 }
 
-// TODO: hangs
-/*
 func (t *GcsfuseTest) KeyFile() {
 	const nonexistent = "/tmp/foobarbazdoesntexist"
 
@@ -194,12 +191,13 @@ func (t *GcsfuseTest) KeyFile() {
 	}{
 		// Via flag
 		0: {
-			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent)},
+			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent), "--max-retry-sleep=0"},
 		},
 
 		// Via the environment
 		1: {
-			env: []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
+			env:       []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
+			extraArgs: []string{"--max-retry-sleep=0"},
 		},
 	}
 
@@ -209,7 +207,8 @@ func (t *GcsfuseTest) KeyFile() {
 		args = append(args, "some-non-canned-bucket-name", t.dir)
 
 		cmd := t.gcsfuseCommand(args, tc.env)
-
+		fmt.Println(cmd)
+		//fmt.Println(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
 		output, err := cmd.CombinedOutput()
 		util.Unmount(t.dir)
 
@@ -218,7 +217,6 @@ func (t *GcsfuseTest) KeyFile() {
 		ExpectThat(string(output), HasSubstr("no such file"), "case %d", i)
 	}
 }
-*/
 
 func (t *GcsfuseTest) CannedContents() {
 	var err error

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+
 	//"runtime"
 	"syscall"
 	"testing"
@@ -181,6 +182,8 @@ func (t *GcsfuseTest) MountPointIsAFile() {
 	ExpectThat(err, Error(HasSubstr("is not a directory")))
 }
 
+// TODO: hangs
+/*
 func (t *GcsfuseTest) KeyFile() {
 	const nonexistent = "/tmp/foobarbazdoesntexist"
 
@@ -191,13 +194,12 @@ func (t *GcsfuseTest) KeyFile() {
 	}{
 		// Via flag
 		0: {
-			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent), "--max-retry-sleep=0"},
+			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent)},
 		},
 
 		// Via the environment
 		1: {
-			env:       []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
-			extraArgs: []string{"--max-retry-sleep=0"},
+			env: []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
 		},
 	}
 
@@ -216,6 +218,7 @@ func (t *GcsfuseTest) KeyFile() {
 		ExpectThat(string(output), HasSubstr("no such file"), "case %d", i)
 	}
 }
+*/
 
 func (t *GcsfuseTest) CannedContents() {
 	var err error

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -207,8 +207,7 @@ func (t *GcsfuseTest) KeyFile() {
 		args = append(args, "some-non-canned-bucket-name", t.dir)
 
 		cmd := t.gcsfuseCommand(args, tc.env)
-		fmt.Println(cmd)
-		//fmt.Println(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+
 		output, err := cmd.CombinedOutput()
 		util.Unmount(t.dir)
 


### PR DESCRIPTION
1. Fix for hang integration test.
2. Fixing the issue when mounting fails when we provide relative path for --log-file flag in absence of --foreground flag.
3. Added the unit test for main.go file.

Todo:
>> Need to generalize this for any types of keyword. 
