### PR TITLE
Fixing Hang Issue in KeyFile Integration Test

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -185,7 +185,7 @@ func (t *GcsfuseTest) KeyFile() {
 	const nonexistent = "/tmp/foobarbazdoesntexist"
 
 	// Specify a non-existent key file in two different ways.
-	// We pass --max-retry-sleep 0, just to limit number of retry to 1 with no wait time
+	// We pass --max-retry-sleep 0, just to limit the number of retry to 0 with no wait time
 	testCases := []struct {
 		extraArgs []string
 		env       []string

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -185,6 +185,7 @@ func (t *GcsfuseTest) KeyFile() {
 	const nonexistent = "/tmp/foobarbazdoesntexist"
 
 	// Specify a non-existent key file in two different ways.
+	// We pass --max-retry-sleep 0, just to limit number of retry to 1 with no wait time
 	testCases := []struct {
 		extraArgs []string
 		env       []string

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-
 	//"runtime"
 	"syscall"
 	"testing"
@@ -182,8 +181,6 @@ func (t *GcsfuseTest) MountPointIsAFile() {
 	ExpectThat(err, Error(HasSubstr("is not a directory")))
 }
 
-// TODO: hangs
-/*
 func (t *GcsfuseTest) KeyFile() {
 	const nonexistent = "/tmp/foobarbazdoesntexist"
 
@@ -194,12 +191,13 @@ func (t *GcsfuseTest) KeyFile() {
 	}{
 		// Via flag
 		0: {
-			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent)},
+			extraArgs: []string{fmt.Sprintf("--key-file=%s", nonexistent), "--max-retry-sleep=0"},
 		},
 
 		// Via the environment
 		1: {
-			env: []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
+			env:       []string{fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", nonexistent)},
+			extraArgs: []string{"--max-retry-sleep=0"},
 		},
 	}
 
@@ -218,7 +216,6 @@ func (t *GcsfuseTest) KeyFile() {
 		ExpectThat(string(output), HasSubstr("no such file"), "case %d", i)
 	}
 }
-*/
 
 func (t *GcsfuseTest) CannedContents() {
 	var err error


### PR DESCRIPTION
**Issue:** By default when we pass wrong key-file it retries several time and returns the response after ~200 secs. We have two test-cases in that particular test (KeyFile), so it returns the response after ~400 secs, which feels like the hang in the integration test.

**Fix:**    By setting the --max-retry-sleep to 0, we only try to connect to the server once which also removes the concept of wait time and we are able to complete the test in 4-5 secs.