### PR TITLE
ReadWrite integration tests fixes

### DIFF
--- a/tools/integration_tests/readwrite/readwrite_test.go
+++ b/tools/integration_tests/readwrite/readwrite_test.go
@@ -96,6 +96,13 @@ func unMount() error {
 }
 
 func clearKernelCache() error {
+	if _, err := os.Stat("/proc/sys/vm/drop_caches"); err != nil {
+		log.Printf("Kernel cache file not found: %v", err)
+		// No need to stop the test execution if cache file is not found. Further
+		// reads will be served from kernel cache.
+		return nil
+	}
+
 	// sudo permission is required to clear kernel page cache.
 	cmd := exec.Command("sudo", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches")
 	if err := cmd.Run(); err != nil {

--- a/tools/integration_tests/readwrite/readwrite_test.go
+++ b/tools/integration_tests/readwrite/readwrite_test.go
@@ -83,7 +83,7 @@ func mountGcsfuse() error {
 	return nil
 }
 
-func umount() error {
+func unMount() error {
 	fusermount, err := exec.LookPath("fusermount")
 	if err != nil {
 		return fmt.Errorf("cannot find fusermount: %w", err)
@@ -101,7 +101,7 @@ func clearKernelCache() error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clear kernel cache failed with error: %w", err)
 	}
-  return nil
+	return nil
 }
 
 func TestMain(m *testing.M) {
@@ -127,7 +127,7 @@ func TestMain(m *testing.M) {
 
 	// Delete all files from mntDir to delete files from gcs bucket.
 	os.RemoveAll(mntDir)
-	umount()
+	unMount()
 
 	os.Exit(ret)
 }

--- a/tools/integration_tests/readwrite/readwrite_test.go
+++ b/tools/integration_tests/readwrite/readwrite_test.go
@@ -83,16 +83,25 @@ func mountGcsfuse() error {
 	return nil
 }
 
-func umount(dir string) error {
-	umount, err := exec.LookPath("umount")
+func umount() error {
+	fusermount, err := exec.LookPath("fusermount")
 	if err != nil {
-		return fmt.Errorf("cannot find umount: %w", err)
+		return fmt.Errorf("cannot find fusermount: %w", err)
 	}
-	cmd := exec.Command(umount, mntDir)
+	cmd := exec.Command(fusermount, "-uz", mntDir)
 	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("umount error: %w", err)
+		return fmt.Errorf("fusermount error: %w", err)
 	}
 	return nil
+}
+
+func clearKernelCache() error {
+	// sudo permission is required to clear kernel page cache.
+	cmd := exec.Command("sudo", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("clear kernel cache failed with error: %w", err)
+	}
+  return nil
 }
 
 func TestMain(m *testing.M) {
@@ -116,7 +125,10 @@ func TestMain(m *testing.M) {
 	log.Printf("Test log: %s\n", logFile)
 	ret := m.Run()
 
-	umount(mntDir)
+	// Delete all files from mntDir to delete files from gcs bucket.
+	os.RemoveAll(mntDir)
+	umount()
+
 	os.Exit(ret)
 }
 
@@ -142,6 +154,10 @@ func TestReadAfterWrite(t *testing.T) {
 			t.Errorf("Close: %v", err)
 		}
 
+		// After write, data will be cached by kernel. So subsequent read will be
+		// served using cached data by kernel instead of calling gcsfuse.
+		// Clearing kernel cache to ensure that gcsfuse is invoked during read operation.
+		clearKernelCache()
 		tmpFile, err = os.Open(fileName)
 		if err != nil {
 			t.Errorf("Open %q: %v", fileName, err)


### PR DESCRIPTION
1. Using fusermount instead of umount since umount requires sudo permissions.
2. Clearing kernel page cache after write to ensure reads are made from gcsfuse
3. Deleting files from mount directory to ensure gcsbucket is not overloaded.