### PR TITLE
Fixing the Log-file Relative Path Bug using Environment Variable

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -381,15 +381,12 @@ func getResolvedPath(filePath string) (resolvedPath string, err error) {
 func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) {
 	flagValue := c.String(flagKey)
 	resolvedPath, err := getResolvedPath(flagValue)
-	if err != nil {
+	if flagValue == resolvedPath || err != nil {
 		return
 	}
 	c.Set(flagKey, resolvedPath)
-
-	if flagValue != resolvedPath {
-		logger.Infof("Value of [%s] resolved from [%s] to [%s]\n",
-			flagKey, flagValue, resolvedPath)
-	}
+	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n",
+		flagKey, flagValue, resolvedPath)
 
 	return
 }

--- a/flags.go
+++ b/flags.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	"github.com/urfave/cli"
 )
@@ -384,7 +385,8 @@ func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) 
 		return fmt.Errorf("While resolving path: [%w]", err)
 	}
 	c.Set(flagKey, resolvedPath)
-
+	logger.Infof(fmt.Sprintf("Value of [%s] resolved from [%s] to [%s]\n",
+		flagKey, flagValue, resolvedPath))
 	return
 }
 

--- a/flags.go
+++ b/flags.go
@@ -347,18 +347,18 @@ type flagStorage struct {
 
 const GCSFUSE_PARENT_PROCESS_DIR = "gcsfuse-parent-process-dir"
 
-// (1) returns the same filepath in case of absolute path or empty filename.
-// (2) for relative path with . && .. or nothing, it resolves smartly the path
+// 1. Returns the same filepath in case of absolute path or empty filename.
+// 2. For relative path with . or .. or nothing, it resolves smartly the path
 // in case of child proces it resolves with respect to GCSFUSE_PARENT_PROCESS_DIR
 // otherwise with respect to the current working dir.
-// (3) for relative path starting with ~, it resolves with respect to home dir.
+// 3. For relative path starting with ~, it resolves with respect to home dir.
 func getResolvedPath(filePath string) (resolvedPath string, err error) {
 	if filePath == "" || path.IsAbs(filePath) {
 		resolvedPath = filePath
 		return
 	}
 
-	// relative path starting with tilda (~)
+	// Relative path starting with tilda (~)
 	if strings.HasPrefix(filePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -367,7 +367,7 @@ func getResolvedPath(filePath string) (resolvedPath string, err error) {
 		return filepath.Join(homeDir, filePath[2:]), err
 	}
 
-	// means - relative path starting with ., .. or nothing.
+	// Means - relative path starting with ., .. or nothing.
 	gcsfuseParentProcessDir, _ := os.LookupEnv(GCSFUSE_PARENT_PROCESS_DIR)
 	gcsfuseParentProcessDir = strings.TrimSpace(gcsfuseParentProcessDir)
 	if gcsfuseParentProcessDir == "" {
@@ -382,16 +382,16 @@ func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) 
 	flagValue := c.String(flagKey)
 	resolvedPath, err := getResolvedPath(flagValue)
 	if err != nil {
-		return fmt.Errorf("While resolving path: [%w]", err)
+		return
 	}
 	c.Set(flagKey, resolvedPath)
-	logger.Infof(fmt.Sprintf("Value of [%s] resolved from [%s] to [%s]\n",
-		flagKey, flagValue, resolvedPath))
+	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n",
+		flagKey, flagValue, resolvedPath)
 	return
 }
 
 // For parent process: it only resolves the path with respect to home folder.
-// For child process (when --foreground flag is disabled) - it resolves
+// For child process (when --foreground flag is disabled): it resolves
 // the path relative to both current directory and home directory
 func resolvePathForTheRequiredFlagInContext(c *cli.Context) (err error) {
 	err = resolvePathForTheFlagInContext("log-file", c)

--- a/flags.go
+++ b/flags.go
@@ -362,7 +362,7 @@ func getResolvedPath(filePath string) (resolvedPath string, err error) {
 	if strings.HasPrefix(filePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("Fetch home dir: [%w]", homeDir)
+			return "", fmt.Errorf("Fetch home dir: [%w]", err)
 		}
 		return filepath.Join(homeDir, filePath[2:]), err
 	}

--- a/flags.go
+++ b/flags.go
@@ -354,11 +354,11 @@ const GCSFUSE_PARENT_PROCESS_DIR = "gcsfuse-parent-process-dir"
 func getResolvedPath(filePath string) (resolvedPath string, err error) {
 	if filePath == "" || path.IsAbs(filePath) {
 		resolvedPath = filePath
-		return resolvedPath, err
+		return
 	}
 
 	// relative path starting with tilda (~)
-	if strings.HasPrefix(filePath, "~") {
+	if strings.HasPrefix(filePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("Fetch home dir: [%w]", homeDir)
@@ -368,6 +368,7 @@ func getResolvedPath(filePath string) (resolvedPath string, err error) {
 
 	// means - relative path starting with ., .. or nothing.
 	gcsfuseParentProcessDir, _ := os.LookupEnv(GCSFUSE_PARENT_PROCESS_DIR)
+	gcsfuseParentProcessDir = strings.TrimSpace(gcsfuseParentProcessDir)
 	if gcsfuseParentProcessDir == "" {
 		return filepath.Abs(filePath)
 	} else {
@@ -384,10 +385,9 @@ func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) 
 	}
 	c.Set(flagKey, resolvedPath)
 
-	return err
+	return
 }
 
-// It smartly resolves the path of the required flag.
 // For parent process: it only resolves the path with respect to home folder.
 // For child process (when --foreground flag is disabled) - it resolves
 // the path relative to both current directory and home directory

--- a/flags.go
+++ b/flags.go
@@ -112,7 +112,7 @@ func newApp() (app *cli.App) {
 			cli.BoolFlag{
 				Name: "implicit-dirs",
 				Usage: "Implicitly define directories based on content. See " +
-						"docs/semantics.md",
+					"docs/semantics.md",
 			},
 
 			cli.StringFlag{
@@ -124,7 +124,7 @@ func newApp() (app *cli.App) {
 				Name:  "rename-dir-limit",
 				Value: 0,
 				Usage: "Allow rename a directory containing fewer descendants " +
-						"than this limit.",
+					"than this limit.",
 			},
 
 			/////////////////////////
@@ -141,14 +141,14 @@ func newApp() (app *cli.App) {
 				Name:  "billing-project",
 				Value: "",
 				Usage: "Project to use for billing when accessing requester pays buckets. " +
-						"(default: none)",
+					"(default: none)",
 			},
 
 			cli.StringFlag{
 				Name:  "key-file",
 				Value: "",
 				Usage: "Absolute path to JSON key file for use with GCS. " +
-						"(default: none, Google application default credentials used)",
+					"(default: none, Google application default credentials used)",
 			},
 
 			cli.StringFlag{
@@ -161,14 +161,14 @@ func newApp() (app *cli.App) {
 				Name:  "limit-bytes-per-sec",
 				Value: -1,
 				Usage: "Bandwidth limit for reading data, measured over a 30-second " +
-						"window. (use -1 for no limit)",
+					"window. (use -1 for no limit)",
 			},
 
 			cli.Float64Flag{
 				Name:  "limit-ops-per-sec",
 				Value: -1,
 				Usage: "Operations per second limit, measured over a 30-second window " +
-						"(use -1 for no limit)",
+					"(use -1 for no limit)",
 			},
 
 			/////////////////////////
@@ -179,9 +179,9 @@ func newApp() (app *cli.App) {
 				Name:  "max-retry-sleep",
 				Value: time.Minute,
 				Usage: "The maximum duration allowed to sleep in a retry loop with " +
-						"exponential backoff for failed requests to GCS backend. Once the " +
-						"backoff duration exceeds this limit, the retry stops. The default " +
-						"is 1 minute. A value of 0 disables retries.",
+					"exponential backoff for failed requests to GCS backend. Once the " +
+					"backoff duration exceeds this limit, the retry stops. The default " +
+					"is 1 minute. A value of 0 disables retries.",
 			},
 
 			cli.IntFlag{
@@ -200,7 +200,7 @@ func newApp() (app *cli.App) {
 				Name:  "type-cache-ttl",
 				Value: time.Minute,
 				Usage: "How long to cache name -> file/dir mappings in directory " +
-						"inodes.",
+					"inodes.",
 			},
 
 			cli.BoolFlag{
@@ -212,20 +212,20 @@ func newApp() (app *cli.App) {
 				Name:  "temp-dir",
 				Value: "",
 				Usage: "Absolute path to temporary directory for local GCS object " +
-						"copies. (default: system default, likely /tmp)",
+					"copies. (default: system default, likely /tmp)",
 			},
 
 			cli.BoolFlag{
 				Name: "disable-http2",
 				Usage: "Once set, the protocol used for communicating with " +
-						"GCS backend would be HTTP/1.1, instead of the default HTTP/2.",
+					"GCS backend would be HTTP/1.1, instead of the default HTTP/2.",
 			},
 
 			cli.IntFlag{
 				Name:  "max-conns-per-host",
 				Value: 10,
 				Usage: "The max number of TCP connections allowed per server. " +
-						"This is effective when --disable-http2 is set.",
+					"This is effective when --disable-http2 is set.",
 			},
 
 			/////////////////////////
@@ -248,8 +248,8 @@ func newApp() (app *cli.App) {
 				Name:  "log-file",
 				Value: "",
 				Usage: "The file for storing logs that can be parsed by " +
-						"fluentd. When not provided, plain text logs are printed to " +
-						"stdout.",
+					"fluentd. When not provided, plain text logs are printed to " +
+					"stdout.",
 			},
 
 			cli.StringFlag{

--- a/flags.go
+++ b/flags.go
@@ -351,7 +351,7 @@ const GCSFUSE_PARENT_PROCESS_DIR = "gcsfuse-parent-process-dir"
 // 2. For child process, it resolves relative path like, ./test.txt, test.txt
 // ../test.txt etc, with respect to GCSFUSE_PARENT_PROCESS_DIR
 // because we execute the child process from different directory and input
-// files are provided with respect the GCSFUSE_PARENT_PROCESS_DIR.
+// files are provided with respect to GCSFUSE_PARENT_PROCESS_DIR.
 // 3. For relative path starting with ~, it resolves with respect to home dir.
 func getResolvedPath(filePath string) (resolvedPath string, err error) {
 	if filePath == "" || path.IsAbs(filePath) {

--- a/flags.go
+++ b/flags.go
@@ -363,7 +363,7 @@ func getResolvedPath(filePath string) (resolvedPath string, err error) {
 	if strings.HasPrefix(filePath, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("Fetch home dir: [%w]", err)
+			return "", fmt.Errorf("fetch home dir: %w", err)
 		}
 		return filepath.Join(homeDir, filePath[2:]), err
 	}

--- a/flags.go
+++ b/flags.go
@@ -385,8 +385,12 @@ func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) 
 		return
 	}
 	c.Set(flagKey, resolvedPath)
-	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n",
-		flagKey, flagValue, resolvedPath)
+
+	if flagValue != resolvedPath {
+		logger.Infof("Value of [%s] resolved from [%s] to [%s]\n",
+			flagKey, flagValue, resolvedPath)
+	}
+
 	return
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -323,10 +323,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndAbsoluteFilePath() {
 
 func (t *FlagsTest) TestResolvePathForTheFlagInContext() {
 	app := newApp()
-
 	currentWorkingDir, err := os.Getwd()
 	AssertEq(nil, err)
-
 	app.Action = func(appCtx *cli.Context) {
 		resolvePathForTheFlagInContext("log-file", appCtx)
 		resolvePathForTheFlagInContext("key-file", appCtx)
@@ -336,21 +334,19 @@ func (t *FlagsTest) TestResolvePathForTheFlagInContext() {
 		ExpectEq(filepath.Join(currentWorkingDir, "test.txt"),
 			appCtx.String("key-file"))
 	}
-
 	// Simulate argv.
 	fullArgs := []string{"some_app", "--log-file=test.txt",
 		"--key-file=test.txt"}
 
 	err = app.Run(fullArgs)
+
 	AssertEq(nil, err)
 }
 
 func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 	app := newApp()
-
 	currentWorkingDir, err := os.Getwd()
 	AssertEq(nil, err)
-
 	app.Action = func(appCtx *cli.Context) {
 		resolvePathForTheFlagsInContext(appCtx)
 
@@ -359,11 +355,11 @@ func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 		ExpectEq(filepath.Join(currentWorkingDir, "test.txt"),
 			appCtx.String("key-file"))
 	}
-
 	// Simulate argv.
 	fullArgs := []string{"some_app", "--log-file=test.txt",
 		"--key-file=test.txt"}
 
 	err = app.Run(fullArgs)
+
 	AssertEq(nil, err)
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -239,7 +239,7 @@ func (t *FlagsTest) ResolvePathInParentProcess() {
 func (t *FlagsTest) ResolvePathInChildProcess() {
 	args := []string{
 		"--log-file=test.txt",
-		"--key-file=test.json",
+		"--key-file=~/test.json",
 	}
 
 	const gcsFuseParentProcessDir = "/var/generic/google"
@@ -248,8 +248,11 @@ func (t *FlagsTest) ResolvePathInChildProcess() {
 	os.Setenv(GCSFUSE_PARENT_PROCESS_DIR, gcsFuseParentProcessDir)
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
+	homeDir, err := os.UserHomeDir()
+	AssertEq(nil, err)
+
 	f := parseArgs(args)
 
 	ExpectEq(filepath.Join(gcsFuseParentProcessDir, "test.txt"), f.LogFile)
-	ExpectEq(filepath.Join(gcsFuseParentProcessDir, "test.json"), f.KeyFile)
+	ExpectEq(filepath.Join(homeDir, "test.json"), f.KeyFile)
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+const gcsFuseParentProcessDir = "/var/generic/google"
+
 func TestFlags(t *testing.T) { RunTests(t) }
 
 ////////////////////////////////////////////////////////////////////////
@@ -217,8 +219,8 @@ func (t *FlagsTest) Maps() {
 
 func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithTilda() {
 	resolvedPath, err := getResolvedPath("~/test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	homeDir, err := os.UserHomeDir()
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(homeDir, "test.txt"), resolvedPath)
@@ -226,8 +228,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithTilda(
 
 func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithDot() {
 	resolvedPath, err := getResolvedPath("./test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	currentWorkingDir, err := os.Getwd()
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(currentWorkingDir, "./test.txt"), resolvedPath)
@@ -235,8 +237,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithDot() 
 
 func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithDoubleDot() {
 	resolvedPath, err := getResolvedPath("../test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	currentWorkingDir, err := os.Getwd()
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(currentWorkingDir, "../test.txt"), resolvedPath)
@@ -244,8 +246,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndFilePathStartsWithDouble
 
 func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndRelativePath() {
 	resolvedPath, err := getResolvedPath("test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	currentWorkingDir, err := os.Getwd()
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(currentWorkingDir, "test.txt"), resolvedPath)
@@ -253,19 +255,17 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndRelativePath() {
 
 func (t *FlagsTest) ResolveWhenParentProcDirEnvNotSetAndAbsoluteFilePath() {
 	resolvedPath, err := getResolvedPath("/var/dir/test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq("/var/dir/test.txt", resolvedPath)
 }
 
 func (t *FlagsTest) ResolveEmptyFilePath() {
 	resolvedPath, err := getResolvedPath("")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq("", resolvedPath)
 }
-
-const gcsFuseParentProcessDir = "/var/generic/google"
 
 // Below all tests when GCSFUSE_PARENT_PROCESS_DIR env variable is set.
 // By setting this environment variable, resolve will work for child process.
@@ -274,8 +274,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndFilePathStartsWithTilda() {
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
 	resolvedPath, err := getResolvedPath("~/test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	homeDir, err := os.UserHomeDir()
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(homeDir, "test.txt"), resolvedPath)
@@ -286,8 +286,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndFilePathStartsWithDot() {
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
 	resolvedPath, err := getResolvedPath("./test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq(filepath.Join(gcsFuseParentProcessDir, "./test.txt"), resolvedPath)
 }
 
@@ -296,8 +296,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndFilePathStartsWithDoubleDot
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
 	resolvedPath, err := getResolvedPath("../test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq(filepath.Join(gcsFuseParentProcessDir, "../test.txt"), resolvedPath)
 }
 
@@ -306,8 +306,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndRelativePath() {
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
 	resolvedPath, err := getResolvedPath("test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq(filepath.Join(gcsFuseParentProcessDir, "test.txt"), resolvedPath)
 }
 
@@ -316,8 +316,8 @@ func (t *FlagsTest) ResolveWhenParentProcDirEnvSetAndAbsoluteFilePath() {
 	defer os.Unsetenv(GCSFUSE_PARENT_PROCESS_DIR)
 
 	resolvedPath, err := getResolvedPath("/var/dir/test.txt")
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	ExpectEq("/var/dir/test.txt", resolvedPath)
 }
 

--- a/main.go
+++ b/main.go
@@ -16,8 +16,7 @@
 //
 // Usage:
 //
-//     gcsfuse [flags] bucket mount_point
-//
+//	gcsfuse [flags] bucket mount_point
 package main
 
 import (
@@ -29,6 +28,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -212,7 +212,7 @@ func populateArgs(c *cli.Context) (
 	// Canonicalize the mount point, making it absolute. This is important when
 	// daemonizing below, since the daemon will change its working directory
 	// before running this code again.
-	mountPoint, err = filepath.Abs(mountPoint)
+	mountPoint, err = getResolvedPath(mountPoint)
 	if err != nil {
 		err = fmt.Errorf("canonicalizing mount point: %w", err)
 		return
@@ -220,7 +220,55 @@ func populateArgs(c *cli.Context) (
 	return
 }
 
+func getResolvedPath(filePath string) (resolvedPath string, err error) {
+	if path.IsAbs(filePath) {
+		return filePath, nil
+	}
+
+	if strings.HasPrefix(filePath, "~/") {
+		homeDir, err1 := os.UserHomeDir()
+		if err1 != nil {
+			return "", fmt.Errorf("get home dir: %w", err1)
+		}
+		return filepath.Join(homeDir, filePath[2:]), nil
+	} else {
+		return filepath.Abs(filePath)
+	}
+}
+
+func resolveRelativePath(c *cli.Context) (err error) {
+	parentProcessExecutionDir, ok := os.LookupEnv("parent_process_execution_dir")
+	if !ok { // Don't do anything, directory is not set
+		return nil
+	}
+	//var parentProcessExecutionDir string
+	logFile := c.String("log-file")
+
+	if logFile == "" || path.IsAbs(logFile) {
+		return nil
+	} else if strings.HasPrefix(logFile, "~") {
+		var resolvedPath string
+		resolvedPath, err = getResolvedPath(logFile)
+		if err != nil {
+			return fmt.Errorf("while resolving path: %w", err)
+		}
+		c.Set("log-file", resolvedPath)
+	} else { // relative to parent process's execution directory
+		err = c.Set("log-file", filepath.Join(parentProcessExecutionDir, logFile))
+		if err != nil {
+			return fmt.Errorf("while setting value in context: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func runCLIApp(c *cli.Context) (err error) {
+	err = resolveRelativePath(c)
+	if err != nil {
+		return fmt.Errorf("Resolving path: %w", err)
+	}
+
 	flags := populateFlags(c)
 
 	if flags.Foreground && flags.LogFile != "" {
@@ -291,6 +339,25 @@ func runCLIApp(c *cli.Context) (err error) {
 				os.Stdout,
 				"Added environment no_proxy: %s\n",
 				p)
+		}
+
+		// Pass the parent process working directory to child process via
+		// environment variable. This variable will be used to resolve relative paths.
+		var parentProcessExecutionDir string
+		parentProcessExecutionDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("Getting current working dir: %w", err)
+		}
+		env = append(env, fmt.Sprintf("parent_process_execution_dir=%s", parentProcessExecutionDir))
+
+		if strings.HasPrefix(flags.LogFile, "~") {
+			// pass home directory, it is not set for sub-process
+			var homeDir string
+			homeDir, err = os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("while retrieving home dir: %w", err)
+			}
+			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
 		}
 
 		// Run.

--- a/main.go
+++ b/main.go
@@ -298,16 +298,13 @@ func runCLIApp(c *cli.Context) (err error) {
 
 		// Pass the parent process working directory to child process via
 		// environment variable. This variable will be used to resolve relative paths.
-		var parentProcessExecutionDir string
-		parentProcessExecutionDir, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("Getting current working dir: %w", err)
+		if parentProcessExecutionDir, err := os.Getwd(); err == nil {
+			env = append(env, fmt.Sprintf("%s=%s", GCSFUSE_PARENT_PROCESS_DIR, parentProcessExecutionDir))
 		}
-		env = append(env, fmt.Sprintf("%s=%s", PARENT_PROCESS_EXECUTION_DIR_KEY, parentProcessExecutionDir))
 
-		// no need to handle error, here resolvePath method will take care of this.
-		homeDir, _ := os.UserHomeDir()
-		env = append(env, fmt.Sprintf("HOME=%s", homeDir))
+		if homeDir, _ := os.UserHomeDir(); err == nil {
+			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
+		}
 
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -220,7 +219,7 @@ func populateArgs(c *cli.Context) (
 }
 
 func runCLIApp(c *cli.Context) (err error) {
-	err = resolvePathInSubprocessForTheRequiredFlag(c)
+	err = resolvePathForTheRequiredFlagInContext(c)
 	if err != nil {
 		return fmt.Errorf("Resolving path: %w", err)
 	}
@@ -306,15 +305,9 @@ func runCLIApp(c *cli.Context) (err error) {
 		}
 		env = append(env, fmt.Sprintf("%s=%s", PARENT_PROCESS_EXECUTION_DIR_KEY, parentProcessExecutionDir))
 
-		if strings.HasPrefix(flags.LogFile, "~") || strings.HasPrefix(flags.KeyFile, "~") {
-			// pass home directory, it is not set for sub-process
-			var homeDir string
-			homeDir, err = os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("while retrieving home dir: %w", err)
-			}
-			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
-		}
+		// no need to handle error, here resolvePath method will take care of this.
+		homeDir, _ := os.UserHomeDir()
+		env = append(env, fmt.Sprintf("HOME=%s", homeDir))
 
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func populateArgs(c *cli.Context) (
 }
 
 func runCLIApp(c *cli.Context) (err error) {
-	err = resolvePathForTheRequiredFlagInContext(c)
+	err = resolvePathForTheFlagsInContext(c)
 	if err != nil {
 		return fmt.Errorf("Resolving path: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -299,9 +299,12 @@ func runCLIApp(c *cli.Context) (err error) {
 		// Pass the parent process working directory to child process via
 		// environment variable. This variable will be used to resolve relative paths.
 		if parentProcessExecutionDir, err := os.Getwd(); err == nil {
-			env = append(env, fmt.Sprintf("%s=%s", GCSFUSE_PARENT_PROCESS_DIR, parentProcessExecutionDir))
+			env = append(env, fmt.Sprintf("%s=%s", GCSFUSE_PARENT_PROCESS_DIR,
+				parentProcessExecutionDir))
 		}
 
+		// Here, parent process doesn't pass the $HOME to child process implicitly,
+		// hence we need to pass it explicitly.
 		if homeDir, _ := os.UserHomeDir(); err == nil {
 			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
 		}

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	//"runtime"
 	"syscall"
 	"testing"
@@ -80,10 +81,10 @@ func (t *GcsfuseTest) gcsfuseCommand(args []string, env []string) (cmd *exec.Cmd
 	return
 }
 
-// Call gcsfuse with the supplied args, waiting for it to exit. Return nil only
-// if it exits successfully.
-func (t *GcsfuseTest) runGcsfuse(args []string) (err error) {
-	cmd := t.gcsfuseCommand(args, nil)
+// Call gcsfuse with the supplied args and environment variable,
+// waiting for it to exit. Return nil only if it exits successfully.
+func (t *GcsfuseTest) runGcsfuseWithEnv(args []string, env []string) (err error) {
+	cmd := t.gcsfuseCommand(args, env)
 
 	// Run.
 	output, err := cmd.CombinedOutput()
@@ -93,6 +94,12 @@ func (t *GcsfuseTest) runGcsfuse(args []string) (err error) {
 	}
 
 	return
+}
+
+// Call gcsfuse with the supplied args, waiting for it to exit. Return nil only
+// if it exits successfully.
+func (t *GcsfuseTest) runGcsfuse(args []string) (err error) {
+	return t.runGcsfuseWithEnv(args, nil)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -549,5 +556,56 @@ func (t *GcsfuseTest) HelpFlags() {
 		cmd := t.gcsfuseCommand(tc.args, nil)
 		output, err := cmd.CombinedOutput()
 		ExpectEq(nil, err, "case %d\nOutput:\n%s", i, output)
+	}
+}
+
+func (t *GcsfuseTest) RelativeLogFilePath() {
+
+	var err error
+	var homeDir string
+
+	// create a temp file in current working directory
+	currentDirTestFile := filepath.Join(t.dir, "test.txt")
+	_, err = os.Create(currentDirTestFile)
+	AssertEq(nil, err)
+	defer os.Remove(currentDirTestFile)
+
+	//create a temp log file in home directory
+	homeDir, err = os.UserHomeDir()
+	AssertEq(nil, err)
+
+	homeTestFile := filepath.Join(homeDir, "test_home.json")
+	_, err = os.Create(homeTestFile)
+	defer os.Remove(homeTestFile)
+
+	// Specify log file in different way.
+	testCases := []struct {
+		extraArgs []string
+		env       []string
+	}{
+		// without --foreground flag, relative path
+		0: {
+			extraArgs: []string{"--log-file", "test.txt"},
+		},
+
+		// without --foreground flag, relative with ./
+		1: {
+			extraArgs: []string{"--log-file", "./test.txt"},
+		},
+
+		// without --foreground flag, path with tilda
+		2: {
+			extraArgs: []string{"--log-file", "~/test_home.json"},
+			env:       []string{fmt.Sprintf("HOME=%s", homeDir)},
+		},
+	}
+
+	for _, tc := range testCases {
+		args := tc.extraArgs
+		args = append(args, canned.FakeBucketName, t.dir)
+
+		err := t.runGcsfuseWithEnv(args, tc.env)
+		util.Unmount(t.dir)
+		ExpectEq(nil, err)
 	}
 }

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -560,18 +560,14 @@ func (t *GcsfuseTest) HelpFlags() {
 }
 
 func (t *GcsfuseTest) RelativeLogFilePath() {
-
-	var err error
-	var homeDir string
-
-	// create a temp file in current working directory
+	// Create a temp file in current working directory
 	currentDirTestFile := filepath.Join(t.dir, "test.txt")
-	_, err = os.Create(currentDirTestFile)
+	_, err := os.Create(currentDirTestFile)
 	AssertEq(nil, err)
 	defer os.Remove(currentDirTestFile)
 
-	//create a temp log file in home directory
-	homeDir, err = os.UserHomeDir()
+	// Create a temp log file in home directory
+	homeDir, err := os.UserHomeDir()
 	AssertEq(nil, err)
 
 	homeTestFile := filepath.Join(homeDir, "test_home.json")
@@ -583,20 +579,39 @@ func (t *GcsfuseTest) RelativeLogFilePath() {
 		extraArgs []string
 		env       []string
 	}{
-		// without --foreground flag, relative path
+		// Without --foreground flag, relative path
 		0: {
 			extraArgs: []string{"--log-file", "test.txt"},
 		},
 
-		// without --foreground flag, relative with ./
+		// Without --foreground flag, relative with ./
 		1: {
 			extraArgs: []string{"--log-file", "./test.txt"},
 		},
 
-		// without --foreground flag, path with tilda
+		// Without --foreground flag, path with tilda
 		2: {
 			extraArgs: []string{"--log-file", "~/test_home.json"},
 			env:       []string{fmt.Sprintf("HOME=%s", homeDir)},
+		},
+
+		// Without --foreground flag, key-file relative path
+		3: {
+			extraArgs: []string{"--log-file", "test.txt"},
+		},
+
+		// Without --foreground flag, both key-file and log-file
+		4: {
+			extraArgs: []string{"--key-file", "~/test_home.json",
+				"--log-file", "test.txt"},
+			env: []string{fmt.Sprintf("HOME=%s", homeDir)},
+		},
+
+		// Without --foreground flag, both key-file and log-file
+		5: {
+			extraArgs: []string{"--key-file", "./test.txt",
+				"--log-file", "~/test_home.json"},
+			env: []string{fmt.Sprintf("HOME=%s", homeDir)},
 		},
 	}
 

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -562,10 +562,10 @@ func (t *GcsfuseTest) HelpFlags() {
 const TEST_RELATIVE_FILE_NAME = "test.txt"
 const TEST_HOME_RELATIVE_FILE_NAME = "test_home.json"
 
-func (t *GcsfuseTest) createTestFilesForRelativePathTesting() (
+func createTestFilesForRelativePathTesting(curWorkingDir string) (
 	curDirTestFile string, homeDirTestFile string) {
 
-	curDirTestFile = filepath.Join(t.dir, TEST_RELATIVE_FILE_NAME)
+	curDirTestFile = filepath.Join(curWorkingDir, TEST_RELATIVE_FILE_NAME)
 	_, err := os.Create(curDirTestFile)
 	AssertEq(nil, err)
 
@@ -579,8 +579,8 @@ func (t *GcsfuseTest) createTestFilesForRelativePathTesting() (
 	return
 }
 
-func (t *GcsfuseTest) RelativeLogFilePath() {
-	curDirTestFile, homeDirTestFile := t.createTestFilesForRelativePathTesting()
+func (t *GcsfuseTest) LogFilePath() {
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 
@@ -592,22 +592,27 @@ func (t *GcsfuseTest) RelativeLogFilePath() {
 		extraArgs []string
 		env       []string
 	}{
-		// relative path
+		// Relative path
 		0: {
 			extraArgs: []string{"--log-file", TEST_RELATIVE_FILE_NAME},
 		},
 
-		// relative with ./
+		// Relative with ./
 		1: {
 			extraArgs: []string{"--log-file",
 				fmt.Sprintf("./%s", TEST_RELATIVE_FILE_NAME)},
 		},
 
-		// path with tilda
+		// Path with tilda
 		2: {
 			extraArgs: []string{"--log-file",
 				fmt.Sprintf("~/%s", TEST_HOME_RELATIVE_FILE_NAME)},
 			env: []string{fmt.Sprintf("HOME=%s", homeDir)},
+		},
+
+		// Absolute path
+		3: {
+			extraArgs: []string{"--log-file", curDirTestFile},
 		},
 	}
 
@@ -621,8 +626,8 @@ func (t *GcsfuseTest) RelativeLogFilePath() {
 	}
 }
 
-func (t *GcsfuseTest) RelativeKeyFilePath() {
-	curDirTestFile, homeDirTestFile := t.createTestFilesForRelativePathTesting()
+func (t *GcsfuseTest) KeyFilePath() {
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 
@@ -651,6 +656,11 @@ func (t *GcsfuseTest) RelativeKeyFilePath() {
 				fmt.Sprintf("~/%s", TEST_HOME_RELATIVE_FILE_NAME)},
 			env: []string{fmt.Sprintf("HOME=%s", homeDir)},
 		},
+
+		// Absolute path
+		3: {
+			extraArgs: []string{"--key-file", curDirTestFile},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -663,8 +673,8 @@ func (t *GcsfuseTest) RelativeKeyFilePath() {
 	}
 }
 
-func (t *GcsfuseTest) RelativeBothLogAndKeyFilePath() {
-	curDirTestFile, homeDirTestFile := t.createTestFilesForRelativePathTesting()
+func (t *GcsfuseTest) BothLogAndKeyFilePath() {
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 
@@ -697,6 +707,12 @@ func (t *GcsfuseTest) RelativeBothLogAndKeyFilePath() {
 				"--log-file",
 				fmt.Sprintf("~/%s", TEST_HOME_RELATIVE_FILE_NAME)},
 			env: []string{fmt.Sprintf("HOME=%s", homeDir)},
+		},
+
+		// Absolute path
+		3: {
+			extraArgs: []string{"--log-file", curDirTestFile,
+				"--key-file", curDirTestFile},
 		},
 	}
 


### PR DESCRIPTION
>> log-file flagKey path tested.
>> key-file flagKey path not tested. Maybe we can disable it for now, by seeing the scope of the bug.