### PR TITLE
Flag changes to have ErrorLogger as optional

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -255,16 +255,16 @@ func newApp() (app *cli.App) {
 				Usage: "The format of the log file: 'text' or 'json'.",
 			},
 
+			/////////////////////////
+			// Debugging
+			/////////////////////////
+
 			cli.BoolTFlag{
-				Name: "log-fuse-errors",
+				Name: "debug_fuse_errors",
 				Usage: "If false, fuse errors will not be logged to the " +
 					"console (in case of --foreground) or the log-file " +
 					"(if specified",
 			},
-
-			/////////////////////////
-			// Debugging
-			/////////////////////////
 
 			cli.BoolFlag{
 				Name:  "debug_fuse",
@@ -338,7 +338,7 @@ type flagStorage struct {
 	OtelCollectorAddress      string
 	LogFile                   string
 	LogFormat                 string
-	LogFuseErrors             bool
+	DebugFuseErrors           bool
 
 	// Debugging
 	DebugFuse       bool
@@ -394,9 +394,9 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		OtelCollectorAddress:      c.String("experimental-opentelemetry-collector-address"),
 		LogFile:                   c.String("log-file"),
 		LogFormat:                 c.String("log-format"),
-		LogFuseErrors:             c.BoolT("log-fuse-errors"),
 
 		// Debugging,
+		DebugFuseErrors: c.BoolT("debug_fuse_errors"),
 		DebugFuse:       c.Bool("debug_fuse"),
 		DebugGCS:        c.Bool("debug_gcs"),
 		DebugFS:         c.Bool("debug_fs"),

--- a/flags.go
+++ b/flags.go
@@ -255,6 +255,13 @@ func newApp() (app *cli.App) {
 				Usage: "The format of the log file: 'text' or 'json'.",
 			},
 
+			cli.BoolTFlag{
+				Name: "log-fuse-errors",
+				Usage: "If false, fuse errors will not be logged to the " +
+					"console (in case of --foreground) or the log-file " +
+					"(if specified",
+			},
+
 			/////////////////////////
 			// Debugging
 			/////////////////////////
@@ -331,6 +338,7 @@ type flagStorage struct {
 	OtelCollectorAddress      string
 	LogFile                   string
 	LogFormat                 string
+	LogFuseErrors             bool
 
 	// Debugging
 	DebugFuse       bool
@@ -386,6 +394,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		OtelCollectorAddress:      c.String("experimental-opentelemetry-collector-address"),
 		LogFile:                   c.String("log-file"),
 		LogFormat:                 c.String("log-format"),
+		LogFuseErrors:             c.BoolT("log-fuse-errors"),
 
 		// Debugging,
 		DebugFuse:       c.Bool("debug_fuse"),

--- a/flags_test.go
+++ b/flags_test.go
@@ -81,6 +81,9 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq(time.Minute, f.TypeCacheTTL)
 	ExpectEq("", f.TempDir)
 
+	// Logging
+	ExpectTrue(f.LogFuseErrors)
+
 	// Debugging
 	ExpectFalse(f.DebugFuse)
 	ExpectFalse(f.DebugGCS)
@@ -91,6 +94,7 @@ func (t *FlagsTest) Defaults() {
 func (t *FlagsTest) Bools() {
 	names := []string{
 		"implicit-dirs",
+		"log-fuse-errors",
 		"debug_fuse",
 		"debug_gcs",
 		"debug_http",
@@ -108,6 +112,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
+	ExpectTrue(f.LogFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)
 	ExpectTrue(f.DebugHTTP)
@@ -121,6 +126,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectFalse(f.ImplicitDirs)
+	ExpectFalse(f.LogFuseErrors)
 	ExpectFalse(f.DebugFuse)
 	ExpectFalse(f.DebugGCS)
 	ExpectFalse(f.DebugHTTP)
@@ -134,6 +140,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
+	ExpectTrue(f.LogFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)
 	ExpectTrue(f.DebugHTTP)

--- a/flags_test.go
+++ b/flags_test.go
@@ -82,7 +82,7 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq("", f.TempDir)
 
 	// Logging
-	ExpectTrue(f.LogFuseErrors)
+	ExpectTrue(f.DebugFuseErrors)
 
 	// Debugging
 	ExpectFalse(f.DebugFuse)
@@ -94,7 +94,7 @@ func (t *FlagsTest) Defaults() {
 func (t *FlagsTest) Bools() {
 	names := []string{
 		"implicit-dirs",
-		"log-fuse-errors",
+		"debug_fuse_errors",
 		"debug_fuse",
 		"debug_gcs",
 		"debug_http",
@@ -112,7 +112,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
-	ExpectTrue(f.LogFuseErrors)
+	ExpectTrue(f.DebugFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)
 	ExpectTrue(f.DebugHTTP)
@@ -126,7 +126,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectFalse(f.ImplicitDirs)
-	ExpectFalse(f.LogFuseErrors)
+	ExpectFalse(f.DebugFuseErrors)
 	ExpectFalse(f.DebugFuse)
 	ExpectFalse(f.DebugGCS)
 	ExpectFalse(f.DebugHTTP)
@@ -140,7 +140,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
-	ExpectTrue(f.LogFuseErrors)
+	ExpectTrue(f.DebugFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)
 	ExpectTrue(f.DebugHTTP)

--- a/mount.go
+++ b/mount.go
@@ -122,18 +122,21 @@ be interacting with the file system.`)
 
 	fsName := bucketName
 	if bucketName == "" || bucketName == "_" {
-		// mouting all the buckets at once
+		// mounting all the buckets at once
 		fsName = "gcsfuse"
 	}
 
 	// Mount the file system.
 	status.Printf("Mounting file system %q...", fsName)
 	mountCfg := &fuse.MountConfig{
-		FSName:      fsName,
-		Subtype:     "gcsfuse",
-		VolumeName:  "gcsfuse",
-		Options:     flags.MountOptions,
-		ErrorLogger: logger.NewError("fuse: "),
+		FSName:     fsName,
+		Subtype:    "gcsfuse",
+		VolumeName: "gcsfuse",
+		Options:    flags.MountOptions,
+	}
+
+	if flags.LogFuseErrors {
+		mountCfg.ErrorLogger = logger.NewError("fuse: ")
 	}
 
 	if flags.DebugFuse {

--- a/mount.go
+++ b/mount.go
@@ -135,7 +135,7 @@ be interacting with the file system.`)
 		Options:    flags.MountOptions,
 	}
 
-	if flags.LogFuseErrors {
+	if flags.DebugFuseErrors {
 		mountCfg.ErrorLogger = logger.NewError("fuse: ")
 	}
 


### PR DESCRIPTION
PR adds the --log-fuse-errors as a default true flag which can be optionally set to false in case a user wants to ignore the error logs from fuse.  Attached a screenshot which confirms that the fuse: messages disappear only when the flag is explicitly set to false.

![image](https://user-images.githubusercontent.com/1674877/183374565-2b1c4e13-843c-49b4-9abf-75ce0936b88f.png)
