### PR TITLE
Add flag to have ability to not cache Token from token-url

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -158,6 +158,11 @@ func newApp() (app *cli.App) {
 				Usage: "An url for getting an access token when key-file is absent.",
 			},
 
+			cli.BoolTFlag{
+				Name:  "reuse-token-from-url",
+				Usage: "If false, the token acquired from token-url is not reused.",
+			},
+
 			cli.Float64Flag{
 				Name:  "limit-bytes-per-sec",
 				Value: -1,
@@ -324,6 +329,7 @@ type flagStorage struct {
 	BillingProject                     string
 	KeyFile                            string
 	TokenUrl                           string
+	ReuseTokenFromUrl                  bool
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
 
@@ -446,6 +452,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage) {
 		BillingProject:                     c.String("billing-project"),
 		KeyFile:                            c.String("key-file"),
 		TokenUrl:                           c.String("token-url"),
+		ReuseTokenFromUrl:                  c.BoolT("reuse-token-from-url"),
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -77,6 +77,7 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq("", f.KeyFile)
 	ExpectEq(-1, f.EgressBandwidthLimitBytesPerSecond)
 	ExpectEq(-1, f.OpRateLimitHz)
+	ExpectTrue(f.ReuseTokenFromUrl)
 
 	// Tuning
 	ExpectEq(4096, f.StatCacheCapacity)
@@ -97,6 +98,7 @@ func (t *FlagsTest) Defaults() {
 func (t *FlagsTest) Bools() {
 	names := []string{
 		"implicit-dirs",
+		"reuse-token-from-url",
 		"debug_fuse_errors",
 		"debug_fuse",
 		"debug_gcs",
@@ -115,6 +117,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
+	ExpectTrue(f.ReuseTokenFromUrl)
 	ExpectTrue(f.DebugFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)
@@ -129,6 +132,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectFalse(f.ImplicitDirs)
+	ExpectFalse(f.ReuseTokenFromUrl)
 	ExpectFalse(f.DebugFuseErrors)
 	ExpectFalse(f.DebugFuse)
 	ExpectFalse(f.DebugGCS)
@@ -143,6 +147,7 @@ func (t *FlagsTest) Bools() {
 
 	f = parseArgs(args)
 	ExpectTrue(f.ImplicitDirs)
+	ExpectTrue(f.ReuseTokenFromUrl)
 	ExpectTrue(f.DebugFuseErrors)
 	ExpectTrue(f.DebugFuse)
 	ExpectTrue(f.DebugGCS)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -56,6 +56,7 @@ func GetTokenSource(
 	ctx context.Context,
 	keyFile string,
 	tokenUrl string,
+	reuseTokenFromUrl bool,
 ) (tokenSrc oauth2.TokenSource, err error) {
 	// Create the oauth2 token source.
 	const scope = gcs.Scope_FullControl
@@ -65,7 +66,7 @@ func GetTokenSource(
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
 	} else if tokenUrl != "" {
-		tokenSrc = newProxyTokenSource(ctx, tokenUrl)
+		tokenSrc = newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -30,13 +30,17 @@ import (
 func newProxyTokenSource(
 	ctx context.Context,
 	endpoint string,
+	reuseTokenFromUrl bool,
 ) oauth2.TokenSource {
 	ts := proxyTokenSource{
 		ctx:      ctx,
 		endpoint: endpoint,
 		client:   &http.Client{},
 	}
-	return oauth2.ReuseTokenSource(nil, ts)
+	if reuseTokenFromUrl {
+		return oauth2.ReuseTokenSource(nil, ts)
+	}
+	return ts
 }
 
 type proxyTokenSource struct {

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 			context.Background(),
 			flags.KeyFile,
 			flags.TokenUrl,
+			flags.ReuseTokenFromUrl,
 		)
 		if err != nil {
 			err = fmt.Errorf("GetTokenSource: %w", err)


### PR DESCRIPTION
This is essentially adding a flag against the https://github.com/GoogleCloudPlatform/gcsfuse/commit/cf6bfbb27cc1365201f47d1fb8a4fafc92fbd485 change where a user should have an option to call for a new token for each request which will be done by the ProxyTokenSource