### PR TITLE
Disabling ls tests till the data is populated correctly

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -18,6 +18,7 @@ gcsfuse $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
 chmod +x run_load_test_and_fetch_metrics.sh
 ./run_load_test_and_fetch_metrics.sh
 # ls_metrics test
-cd "./ls_metrics"
-chmod +x run_ls_benchmark.sh
-./run_ls_benchmark.sh
+# commenting out ls tests till the data is populated correctly
+# cd "./ls_metrics"
+# chmod +x run_ls_benchmark.sh
+# ./run_ls_benchmark.sh


### PR DESCRIPTION
If ls tests doesn't find the required data, it will delete the data from the entire bucket and tries to recreate it. Offline population is conflicting with the ls tests triggered by kokoro and entire data is getting wiped off.