### PR TITLE
add unix socket support for token url

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -66,7 +66,7 @@ func GetTokenSource(
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
 	} else if tokenUrl != "" {
-		tokenSrc = newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
+		tokenSrc, err = newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)


### PR DESCRIPTION
In order to address the security concern where using a http endpoint for gcsfuse to retrieve token is not safe enough. If the token/auth server and the gcsfuse run on the same machine, using a unix socket for the communication is safer.

The code change is inspired by [[unixhttpc.go](https://gist.github.com/teknoraver/5ffacb8757330715bcbcc90e6d46ac74)](https://gist.github.com/teknoraver/5ffacb8757330715bcbcc90e6d46ac74)

The old way using http protocol and the new proposed unix protocol are all tested.  