### PR TITLE
Fixing Integration Test Related to Relative Log/Key File Path

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+
 	//"runtime"
 	"syscall"
 	"testing"
@@ -562,11 +563,13 @@ func (t *GcsfuseTest) HelpFlags() {
 const TEST_RELATIVE_FILE_NAME = "test.txt"
 const TEST_HOME_RELATIVE_FILE_NAME = "test_home.json"
 
-func createTestFilesForRelativePathTesting(curWorkingDir string) (
+func createTestFilesForRelativePathTesting() (
 	curDirTestFile string, homeDirTestFile string) {
 
+	curWorkingDir, err := os.Getwd()
+	AssertEq(nil, err)
 	curDirTestFile = filepath.Join(curWorkingDir, TEST_RELATIVE_FILE_NAME)
-	_, err := os.Create(curDirTestFile)
+	_, err = os.Create(curDirTestFile)
 	AssertEq(nil, err)
 
 	homeDir, err := os.UserHomeDir()
@@ -580,7 +583,7 @@ func createTestFilesForRelativePathTesting(curWorkingDir string) (
 }
 
 func (t *GcsfuseTest) LogFilePath() {
-	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting()
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 
@@ -627,7 +630,7 @@ func (t *GcsfuseTest) LogFilePath() {
 }
 
 func (t *GcsfuseTest) KeyFilePath() {
-	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting()
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 
@@ -674,7 +677,7 @@ func (t *GcsfuseTest) KeyFilePath() {
 }
 
 func (t *GcsfuseTest) BothLogAndKeyFilePath() {
-	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting(t.dir)
+	curDirTestFile, homeDirTestFile := createTestFilesForRelativePathTesting()
 	defer os.Remove(curDirTestFile)
 	defer os.Remove(homeDirTestFile)
 


### PR DESCRIPTION
>> Issue: whenever we run the test related to relative log/key file path. One new test.txt file gets created in the working directory.

>> Fix: We were passing different working directory while creating the absolute path for given relative path. Now, I made changes to get the current working directory from os.Getwd()


Question: Why the behavior is different for desktop machine and GCP machine?
>> For desktop, finally mounting happens with **fusermount3** package binary and for GCP vm, it is done using **fusermount**.   Both are different package binary, if we want the same behavior, we need to install **fusermount3** on the GCP_vm. So, fusermount3 looks updated version and it mounts the non-empty directory too, which is not the case for fusermout.