### PR TITLE
Enabling the ls_metrics tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -18,7 +18,6 @@ gcsfuse $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
 chmod +x run_load_test_and_fetch_metrics.sh
 ./run_load_test_and_fetch_metrics.sh
 # ls_metrics test
-# commenting out ls tests till the data is populated correctly
-# cd "./ls_metrics"
-# chmod +x run_ls_benchmark.sh
-# ./run_ls_benchmark.sh
+cd "./ls_metrics"
+chmod +x run_ls_benchmark.sh
+./run_ls_benchmark.sh


### PR DESCRIPTION
Generated the required data in gcsbucket. Enabling the ls_metrics