### PR TITLE
Fix seconds not available error

### DIFF
--- a/perfmetrics/scripts/vm_metrics/vm_metrics.py
+++ b/perfmetrics/scripts/vm_metrics/vm_metrics.py
@@ -145,8 +145,8 @@ def _create_metric_points_from_response(metrics_response, factor):
     for point in metric.points:
       value = _parse_metric_value_by_type(point.value, metric.value_type)
       metric_point = MetricPoint(value / factor,
-                                 point.interval.start_time.seconds,
-                                 point.interval.end_time.seconds)
+                                 point.interval.start_time.timestamp(),
+                                 point.interval.end_time.timestamp())
 
       metric_point_list.append(metric_point)
   metric_point_list.reverse()


### PR DESCRIPTION
seconds attribute is no longer available in
google.cloud.monitoring_v3.TimeInterval.start_time (google.protobuf.timestamp_pb2.Timestamp) in the latest version of protobuf (4.21.6). Using .timestamp() method to get time in seconds.