### PR TITLE
Use HTTPS to access packages.cloud.google.com

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -40,7 +40,7 @@ release codename.) Users of older releases should follow the instructions for
     key:
 
         export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
-        echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+        echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 2.  Update the list of packages available and install gcsfuse.


### PR DESCRIPTION
Using insecure HTTP for software updates unnecessarily opens a user up to interception / MitM attacks.