### PR TITLE
Handling the order of lock for implicit dir node in lookupinode flow

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -649,6 +649,9 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 			if !ok {
 				in = fs.mintInode(ic)
 				fs.implicitDirInodes[in.Name()] = in.(inode.DirInode)
+				// Since we are creating inode here, there is no chance that something else
+				// is holding the lock for inode. Hence its safe to take lock on inode 
+				// without releasing fs.mu.lock.
 				in.Lock()
 				return
 			}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -642,7 +642,8 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 		}
 
 		var ok bool
-		for {
+		var maxTriesToCreateInode = 3
+		for n := 0; n < maxTriesToCreateInode; n++ {
 			in, ok = fs.implicitDirInodes[ic.FullName]
 			// If we don't have an entry, create one.
 			if !ok {
@@ -668,6 +669,8 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 
 			return
 		}
+
+		return
 	}
 
 	oGen := inode.Generation{

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -650,7 +650,7 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 				in = fs.mintInode(ic)
 				fs.implicitDirInodes[in.Name()] = in.(inode.DirInode)
 				// Since we are creating inode here, there is no chance that something else
-				// is holding the lock for inode. Hence its safe to take lock on inode 
+				// is holding the lock for inode. Hence its safe to take lock on inode
 				// without releasing fs.mu.lock.
 				in.Lock()
 				return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -673,6 +673,10 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 			return
 		}
 
+		// Incase we exhausted the number of tries to createInode, we will return
+		// nil object. Returning nil is handled by callers to throw appropriate
+		// errors back to kernel.
+		in = nil
 		return
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -642,15 +642,32 @@ func (fs *fileSystem) lookUpOrCreateInodeIfNotStale(ic inode.Core) (in inode.Ino
 		}
 
 		var ok bool
-		in, ok = fs.implicitDirInodes[ic.FullName]
-		// If we don't have an entry, create one.
-		if !ok {
-			in = fs.mintInode(ic)
-			fs.implicitDirInodes[in.Name()] = in.(inode.DirInode)
-		}
+		for {
+			in, ok = fs.implicitDirInodes[ic.FullName]
+			// If we don't have an entry, create one.
+			if !ok {
+				in = fs.mintInode(ic)
+				fs.implicitDirInodes[in.Name()] = in.(inode.DirInode)
+				in.Lock()
+				return
+			}
 
-		in.Lock()
-		return
+			// If the inode already exists, we need to follow the lock ordering rules
+			// to get the lock. First get inode lock and then fs lock.
+			fs.mu.Unlock()
+			in.Lock()
+			fs.mu.Lock()
+
+			// Check if inode is still valid by the time we got the lock. If not,
+			// its means inode is in the process of getting destroyed. Try creating it
+			// again.
+			if fs.implicitDirInodes[ic.FullName] != in {
+				in.Unlock()
+				continue
+			}
+
+			return
+		}
 	}
 
 	oGen := inode.Generation{
@@ -872,16 +889,16 @@ func (fs *fileSystem) unlockAndDecrementLookupCount(in inode.Inode, N uint64) {
 //
 // Typical usage:
 //
-//     func (fs *fileSystem) doFoo() (err error) {
-//       in, err := fs.lookUpOrCreateInodeIfNotStale(...)
-//       if err != nil {
-//         return
-//       }
+//	func (fs *fileSystem) doFoo() (err error) {
+//	  in, err := fs.lookUpOrCreateInodeIfNotStale(...)
+//	  if err != nil {
+//	    return
+//	  }
 //
-//       defer fs.unlockAndMaybeDisposeOfInode(in, &err)
+//	  defer fs.unlockAndMaybeDisposeOfInode(in, &err)
 //
-//       ...
-//     }
+//	  ...
+//	}
 //
 // LOCKS_REQUIRED(in)
 // LOCKS_EXCLUDED(fs.mu)


### PR DESCRIPTION
We need to follow this order for fetching locks -> inode and then filesystem level lock. Incase of implicitDir flow, we are fetching taking fs lock and then inode lock which is conflicting with other flow in the code that follows locking order. This conflict is creating deadlocks.

This PR fixes the deadlock by following the lock order in case of implicit dir flow.