### PR TITLE
Gcsfuse Release 0.41.9 | Updating the Installation Docs and Build Script

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -97,8 +97,8 @@ Ensure that dependencies are present:
 
 Download and install the latest release package:
 
-    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.41.8/gcsfuse-0.41.8-1.x86_64.rpm
-    sudo rpm --install -p gcsfuse-0.41.8-1.x86_64.rpm
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.41.9/gcsfuse-0.41.9-1.x86_64.rpm
+    sudo rpm --install -p gcsfuse-0.41.9-1.x86_64.rpm
 
 <a name="other-distributions"></a>
 
@@ -118,13 +118,13 @@ Ensure that dependencies are present:
 
 If you are on a distribution that uses `.rpm` files for package management:
 
-    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases#:~:text=gcsfuse%2D0.41.8%2D1.x86_64.rpm
-    sudo rpm --install -p gcsfuse-0.41.8-1.x86_64.rpm
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases#:~:text=gcsfuse%2D0.41.9%2D1.x86_64.rpm
+    sudo rpm --install -p gcsfuse-0.41.9-1.x86_64.rpm
 
 Or one that uses `.deb` files:
 
-    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.41.8/gcsfuse_0.41.8_amd64.deb
-    sudo dpkg --install gcsfuse_0.41.8_amd64.deb
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.41.9/gcsfuse_0.41.9_amd64.deb
+    sudo dpkg --install gcsfuse_0.41.9_amd64.deb
 
 On some systems it may be necessary to add the your user account to the `fuse`
 group in order to have permission to run `fusermount` (don't forget to log out

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 echo Installing fio
 sudo apt-get install fio -y
 echo Installing gcsfuse
-GCSFUSE_VERSION=0.41.8
+GCSFUSE_VERSION=0.41.9
 curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v$GCSFUSE_VERSION/gcsfuse_"$GCSFUSE_VERSION"_amd64.deb
 sudo dpkg --install gcsfuse_"$GCSFUSE_VERSION"_amd64.deb
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts"


### PR DESCRIPTION
>> Updating the installation docs for 0.41.9 release.
>> Updating the kokoro build script.

Tried on one of the machines, I was able to install the latest version (0.41.9).