### PR TITLE
Fixing the Performance Drop in Random Reads - Implemented using Go Storage Client

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -64,6 +64,7 @@ func (bh *bucketHandle) NewReader(
 	}
 
 	// Returning NewRangeReader instance.
+	// "storage.Reader" is a io.ReadCloser, since it contains both Read() and Close() method.
 	return obj.NewRangeReader(ctx, start, length)
 }
 func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRequest) error {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -64,15 +64,12 @@ func (bh *bucketHandle) NewReader(
 	}
 
 	// Creating a NewRangeReader instance.
-	r, err := obj.NewRangeReader(ctx, start, length)
+	rc, err = obj.NewRangeReader(ctx, start, length)
 	if err != nil {
 		err = fmt.Errorf("error in creating a NewRangeReader instance: %v", err)
 		return
 	}
 
-	// Converting io.Reader to io.ReadCloser by adding a no-op closer method
-	// to match the return type interface.
-	rc = io.NopCloser(r)
 	return
 }
 func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRequest) error {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -44,7 +44,7 @@ func (bh *bucketHandle) Name() string {
 
 func (bh *bucketHandle) NewReader(
 	ctx context.Context,
-	req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
+	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
 	// Initialising the starting offset and the length to be read by the reader.
 	start := int64(0)
 	length := int64(-1)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -63,14 +63,8 @@ func (bh *bucketHandle) NewReader(
 		obj = obj.Generation(req.Generation)
 	}
 
-	// Creating a NewRangeReader instance.
-	rc, err = obj.NewRangeReader(ctx, start, length)
-	if err != nil {
-		err = fmt.Errorf("error in creating a NewRangeReader instance: %v", err)
-		return
-	}
-
-	return
+	// Returning NewRangeReader instance.
+	return obj.NewRangeReader(ctx, start, length)
 }
 func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRequest) error {
 	obj := b.bucket.Object(req.Name)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -63,8 +63,7 @@ func (bh *bucketHandle) NewReader(
 		obj = obj.Generation(req.Generation)
 	}
 
-	// Returning NewRangeReader instance.
-	// "storage.Reader" is a io.ReadCloser, since it contains both Read() and Close() method.
+	// NewRangeReader creates a "storage.Reader" object which is also io.ReadCloser since it contains both Read() and Close() methods present in io.ReadCloser interface.
 	return obj.NewRangeReader(ctx, start, length)
 }
 func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRequest) error {


### PR DESCRIPTION
Issue:

Because of NopCloser conversion  for converting Reader object to ReadCloser, we got less bandwidth and more latencies for random reads.
For 50mb File size
Bandwidth - 224 MiB/s
Latency - 12084.52 ms

Fixes:

After rechecking http_client [NewRangeReader](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/cloud.google.com/go/storage/http_client.go#L771) method we got  to know that the object is ReadCloser type only so we don't need extra conversion of NopCloser.
For 50mb File size
Bandwidth - 1184MiB/s
Latency - 2199.80ms

Reason:

This could be because of we are copying heavy object many times during conversion.
