### PR TITLE
copying crc by value instead of by-reference from attrs object

### DIFF
--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -48,6 +48,9 @@ func ObjectAttrsToBucketObject(attrs *storage.ObjectAttrs) *gcs.Object {
 	var md5 [md5.Size]byte
 	copy(md5[:], attrs.MD5)
 
+	// Making a local copy of crc to avoid keeping a reference to attrs instance.
+	crc := attrs.CRC32C
+
 	// Setting the parameters in Object and doing conversions as necessary.
 	return &gcs.Object{
 		Name:            attrs.Name,
@@ -58,7 +61,7 @@ func ObjectAttrsToBucketObject(attrs *storage.ObjectAttrs) *gcs.Object {
 		Size:            uint64(attrs.Size),
 		ContentEncoding: attrs.ContentEncoding,
 		MD5:             &md5,
-		CRC32C:          &attrs.CRC32C,
+		CRC32C:          &crc,
 		MediaLink:       attrs.MediaLink,
 		Metadata:        attrs.Metadata,
 		Generation:      attrs.Generation,

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -101,7 +101,7 @@ func (t objectAttrsTest) TestObjectAttrsToBucketObjectMethod() {
 	ExpectEq(object.ContentEncoding, attrs.ContentEncoding)
 	ExpectEq(len(object.MD5), len(&md5Expected))
 	ExpectEq(cap(object.MD5), cap(&md5Expected))
-	ExpectEq(object.CRC32C, &attrs.CRC32C)
+	ExpectEq(*object.CRC32C, attrs.CRC32C)
 	ExpectEq(object.MediaLink, attrs.MediaLink)
 	ExpectEq(object.Metadata, attrs.Metadata)
 	ExpectEq(object.Generation, attrs.Generation)


### PR DESCRIPTION
Crc returned from go-client library is copied by reference because of which entire attrs object returned by go-client library is not getting garbage collected. Fixing it to copy by value instead of reference