### PR TITLE
Patch 1

### DIFF
--- a/perfmetrics/scripts/ml_tests/fashion_items_image_recognition_model/requirements.txt
+++ b/perfmetrics/scripts/ml_tests/fashion_items_image_recognition_model/requirements.txt
@@ -2,7 +2,7 @@ matplotlib==3.5.1
 numpy==1.23.0
 pandas==1.3.5
 Pillow==9.3.0
-torch==1.12.0
+torch==1.13.1
 torchvision==0.13.0
 keras==2.9.0
 Keras-Preprocessing==1.1.2

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -14,13 +14,13 @@
 
 # Build image with gcsfuse installed:
 # (a) distroless image
-#   > docker build ./ --target distroless -t gcsfuse-distroless:v{GCSFUSE_VERSION} --build-arg GCSFUSE_VERSION={GCSFUSE_VERSION}
+#   > docker build ./ --target distroless -t gcsfuse-distroless:v{GCSFUSE_VERSION} --build-arg GCSFUSE_VERSION={GCSFUSE_VERSION} --build-arg GCSFUSE_COMMIT_HASH
 #   E.g
-#   > docker build ./ --target distroless -t gcsfuse-distroless:v0.41.7 --build-arg GCSFUSE_VERSION=0.41.7
+#   > docker build ./ --target distroless -t gcsfuse-distroless:v0.41.7 --build-arg GCSFUSE_VERSION=0.41.7 --build-arg GCSFUSE_COMMIT_HASH
 # (b) Ubuntu/debian image
-#   > docker build . -t gcsfuse-{OS_NAME}:v{GCSFUSE_VERSION} --build-arg GCSFUSE_VERSION={GCSFUSE_VERSION} --build-arg OS_NAME={OS_NAME} --build-arg OS_VERSION={OS_VERSION}
+#   > docker build . -t gcsfuse-{OS_NAME}:v{GCSFUSE_VERSION} --build-arg GCSFUSE_VERSION={GCSFUSE_VERSION} --build-arg GCSFUSE_COMMIT_HASH --build-arg OS_NAME={OS_NAME} --build-arg OS_VERSION={OS_VERSION}
 #   E.g.
-#   > docker build . -t gcsfuse-ubuntu:v0.41.7 --build-arg GCSFUSE_VERSION=0.41.7 --build-arg OS_NAME=ubuntu --build-arg OS_VERSION=22.04
+#   > docker build . -t gcsfuse-ubuntu:v0.41.7 --build-arg GCSFUSE_VERSION=0.41.7 --build-arg GCSFUSE_COMMIT_HASH --build-arg OS_NAME=ubuntu --build-arg OS_VERSION=22.04
 
 # Mount bucket to /mnt/gcs on host (/gcs in container):
 # (a) using distroless image
@@ -43,6 +43,7 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
+ARG GCSFUSE_COMMIT_HASH
 ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
 ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
 RUN go get ${GCSFUSE_REPO}
@@ -50,7 +51,7 @@ RUN go get ${GCSFUSE_REPO}
 WORKDIR ${GCSFUSE_PATH}
 # Branch name for building through a particular branch.
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+RUN git checkout "${GCSFUSE_COMMIT_HASH}"
 
 ARG GCSFUSE_BIN="/gcsfuse"
 WORKDIR ${GOPATH}

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build an image with gcsfuse packages:
-#   > docker build . -t gcsfuse-release --build-arg GCSFUSE_VERSION=0.39.2
+#   > docker build . -t gcsfuse-release --build-arg GCSFUSE_VERSION=0.39.2 --build-arg GCSFUSE_COMMIT_HASH
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
@@ -26,12 +26,13 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
+ARG GCSFUSE_COMMIT_HASH
 ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
 ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
 RUN go get ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
-RUN git checkout "v${GCSFUSE_VERSION}"
+RUN git checkout "${GCSFUSE_COMMIT_HASH}"
 
 ARG GCSFUSE_BIN="/gcsfuse"
 WORKDIR ${GOPATH}


### PR DESCRIPTION
Added GCSFUSE_COMMIT_HASH environment variable and changed dockerfiles to checkout to commit hash instead of tag 
The same script can still be used for earlier functionality by entering the GCSFUSE_COMMIT_HASH equal to vRELEASE_VERSION