### PR TITLE
Created MinObject to store subset of object metadata and using that in fileInode

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -102,8 +102,6 @@ func NewFileInode(
 	localFileCache bool,
 	contentCache *contentcache.ContentCache,
 	mtimeClock timeutil.Clock) (f *FileInode) {
-	minObj := convertObjToMinObject(o)
-
 	// Set up the basic struct.
 	f = &FileInode{
 		bucket:         bucket,
@@ -113,7 +111,7 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
-		src:            minObj,
+		src:            convertObjToMinObject(o),
 	}
 
 	f.lc.Init(id)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/syncutil"
@@ -70,7 +71,7 @@ type FileInode struct {
 	// INVARIANT: src.Name == name.GcsObjectName()
 	//
 	// GUARDED_BY(mu)
-	src gcs.Object
+	src storage.MinObject
 
 	// The current content of this inode, or nil if the source object is still
 	// authoritative.
@@ -101,6 +102,8 @@ func NewFileInode(
 	localFileCache bool,
 	contentCache *contentcache.ContentCache,
 	mtimeClock timeutil.Clock) (f *FileInode) {
+	minObj := convertObjToMinObject(o)
+
 	// Set up the basic struct.
 	f = &FileInode{
 		bucket:         bucket,
@@ -110,7 +113,7 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
-		src:            *o,
+		src:            minObj,
 	}
 
 	f.lc.Init(id)
@@ -157,7 +160,7 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool) (o *g
 	// Stat the object in GCS. ForceFetchFromGcs ensures object is fetched from
 	// gcs and not cache.
 	req := &gcs.StatObjectRequest{
-		Name: f.name.GcsObjectName(),
+		Name:              f.name.GcsObjectName(),
 		ForceFetchFromGcs: forceFetchFromGcs,
 	}
 	o, err = f.bucket.StatObject(ctx, req)
@@ -275,7 +278,7 @@ func (f *FileInode) Name() Name {
 // record is guaranteed not to be modified, and users must not modify it.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) Source() *gcs.Object {
+func (f *FileInode) Source() *storage.MinObject {
 	// Make a copy, since we modify f.src.
 	o := f.src
 	return &o
@@ -482,7 +485,7 @@ func (f *FileInode) SetMtime(
 
 	o, err := f.bucket.UpdateObject(ctx, req)
 	if err == nil {
-		f.src = *o
+		f.src = convertObjToMinObject(o)
 		return
 	}
 
@@ -558,7 +561,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
-		f.src = *newObj
+		f.src = convertObjToMinObject(newObj)
 		f.content.Destroy()
 		f.content = nil
 	}
@@ -592,4 +595,15 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	}
 
 	return
+}
+
+func convertObjToMinObject(o *gcs.Object) (mo storage.MinObject) {
+	return storage.MinObject{
+		Name:           o.Name,
+		Size:           o.Size,
+		Generation:     o.Generation,
+		MetaGeneration: o.MetaGeneration,
+		Updated:        o.Updated,
+		Metadata:       o.Metadata,
+	}
 }

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -20,6 +20,7 @@ import (
 	"log"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/monitor/tags"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/jacobsa/gcloud/gcs"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -97,7 +98,7 @@ type RandomReader interface {
 	ReadAt(ctx context.Context, p []byte, offset int64) (n int, err error)
 
 	// Return the record for the object to which the reader is bound.
-	Object() (o *gcs.Object)
+	Object() (o *storage.MinObject)
 
 	// Clean up any resources associated with the reader, which must not be used
 	// again.
@@ -106,7 +107,7 @@ type RandomReader interface {
 
 // NewRandomReader create a random reader for the supplied object record that
 // reads using the given bucket.
-func NewRandomReader(o *gcs.Object, bucket gcs.Bucket, sequentialReadSizeMb int32) RandomReader {
+func NewRandomReader(o *storage.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32) RandomReader {
 	return &randomReader{
 		object:               o,
 		bucket:               bucket,
@@ -119,7 +120,7 @@ func NewRandomReader(o *gcs.Object, bucket gcs.Bucket, sequentialReadSizeMb int3
 }
 
 type randomReader struct {
-	object *gcs.Object
+	object *storage.MinObject
 	bucket gcs.Bucket
 
 	// If non-nil, an in-flight read request and a function for cancelling it.
@@ -256,7 +257,7 @@ func (rr *randomReader) ReadAt(
 	return
 }
 
-func (rr *randomReader) Object() (o *gcs.Object) {
+func (rr *randomReader) Object() (o *storage.MinObject) {
 	o = rr.object
 	return
 }

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -24,6 +24,7 @@ import (
 	"testing/iotest"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/jacobsa/gcloud/gcs"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/oglemock"
@@ -134,7 +135,7 @@ const sequentialReadSizeInMb = 10
 const sequentialReadSizeInBytes = sequentialReadSizeInMb * MB
 
 type RandomReaderTest struct {
-	object *gcs.Object
+	object *storage.MinObject
 	bucket gcs.MockBucket
 	rr     checkingRandomReader
 }
@@ -148,7 +149,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	t.rr.ctx = ti.Ctx
 
 	// Manufacture an object record.
-	t.object = &gcs.Object{
+	t.object = &storage.MinObject{
 		Name:       "foo",
 		Size:       17,
 		Generation: 1234,

--- a/internal/storage/object.go
+++ b/internal/storage/object.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2023 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/storage/object.go
+++ b/internal/storage/object.go
@@ -23,8 +23,7 @@ import (
 //
 // See here for more information about its fields:
 //
-//    https://cloud.google.com/storage/docs/json_api/v1/objects#resource
-//
+//	https://cloud.google.com/storage/docs/json_api/v1/objects#resource
 type MinObject struct {
 	Name           string
 	Size           uint64

--- a/internal/storage/object.go
+++ b/internal/storage/object.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"time"
+)
+
+// MinObject is a record representing subset of properties of a particular
+// generation object in GCS.
+//
+// See here for more information about its fields:
+//
+//    https://cloud.google.com/storage/docs/json_api/v1/objects#resource
+//
+type MinObject struct {
+	Name           string
+	Size           uint64
+	Generation     int64
+	MetaGeneration int64
+	Updated        time.Time
+	Metadata       map[string]string
+}


### PR DESCRIPTION
Right now we store entire object metadata in fileinode. But GCSFuse use few object properties. To avoid unnecessary memory usage by fileInode, made changes to store only min set of properties which are used by GCSFuse.