### PR TITLE
Support experimental_enable_storage_client_library flag in mount command

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -83,6 +83,7 @@ func makeGcsfuseArgs(
 		case "implicit_dirs",
 			"disable_http2",
 			"experimental_local_file_cache",
+			"experimental_enable_storage_client_library",
 			"reuse_token_from_url":
 			args = append(args, "--"+strings.Replace(name, "_", "-", -1))
 


### PR DESCRIPTION
This change was identified in https://github.com/GoogleCloudPlatform/gcsfuse/issues/891#issuecomment-1397905072