### PR TITLE
Adding custom retry mechanism in Go Storage Client

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
@@ -98,7 +99,7 @@ func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh
 			Max:        clientConfig.MaxRetryDuration,
 			Multiplier: clientConfig.RetryMultiplier,
 		}),
-		storage.WithPolicy(storage.RetryAlways))
+		storage.WithErrorFunc(storageutil.ShouldRetry))
 
 	sh = &storageClient{client: sc}
 	return

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -1,0 +1,78 @@
+package storageutil
+
+import (
+	"io"
+	"net"
+	"net/url"
+
+	"google.golang.org/api/googleapi"
+)
+
+func ShouldRetry(err error) (b bool) {
+	// HTTP 50x errors.
+	if typed, ok := err.(*googleapi.Error); ok {
+		if typed.Code >= 500 && typed.Code < 600 {
+			b = true
+			return
+		}
+	}
+
+	// HTTP 429 errors (GCS uses these for rate limiting).
+	if typed, ok := err.(*googleapi.Error); ok {
+		if typed.Code == 429 {
+			b = true
+			return
+		}
+	}
+
+	// HTTP 401 errors - Invalid Credentials
+	// This is a work-around to fix the rare issue, we get while executing the
+	// long ml-based test on gcsfuse. The better fix would be to expire the
+	// cached token a little earlier which is used to access the GCS resources
+	// through API.
+
+	// TODO: please replace this implementation with the correction one after the
+	// resolution of this issue: https://github.com/golang/oauth2/issues/623
+	if typed, ok := err.(*googleapi.Error); ok {
+		if typed.Code == 401 {
+			b = true
+			return
+		}
+	}
+
+	// Network errors, which tend to show up transiently when doing lots of
+	// operations in parallel. For example:
+	//
+	//     dial tcp 74.125.203.95:443: too many open files
+	//
+	if _, ok := err.(*net.OpError); ok {
+		b = true
+		return
+	}
+
+	// The HTTP package returns ErrUnexpectedEOF in several places. This seems to
+	// come up when the server terminates the connection in the middle of an
+	// object read.
+	if err == io.ErrUnexpectedEOF {
+		b = true
+		return
+	}
+
+	// The HTTP library also appears to leak EOF errors from... somewhere in its
+	// guts as URL errors sometimes.
+	if urlErr, ok := err.(*url.Error); ok {
+		if urlErr.Err == io.EOF {
+			b = true
+			return
+		}
+	}
+
+	// Sometimes the HTTP package helpfully encapsulates the real error in a URL
+	// error.
+	if urlErr, ok := err.(*url.Error); ok {
+		b = ShouldRetry(urlErr.Err)
+		return
+	}
+
+	return
+}

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -1,78 +1,28 @@
 package storageutil
 
 import (
-	"io"
-	"net"
-	"net/url"
-
+	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
 )
 
 func ShouldRetry(err error) (b bool) {
-	// HTTP 50x errors.
-	if typed, ok := err.(*googleapi.Error); ok {
-		if typed.Code >= 500 && typed.Code < 600 {
-			b = true
-			return
-		}
-	}
-
-	// HTTP 429 errors (GCS uses these for rate limiting).
-	if typed, ok := err.(*googleapi.Error); ok {
-		if typed.Code == 429 {
-			b = true
-			return
-		}
+	b = storage.ShouldRetry(err)
+	if b {
+		return
 	}
 
 	// HTTP 401 errors - Invalid Credentials
-	// This is a work-around to fix the rare issue, we get while executing the
-	// long ml-based test on gcsfuse. The better fix would be to expire the
-	// cached token a little earlier which is used to access the GCS resources
-	// through API.
-
-	// TODO: please replace this implementation with the correction one after the
-	// resolution of this issue: https://github.com/golang/oauth2/issues/623
+	// This is a work-around to fix the corner case where GCSFuse checks the token
+	// as valid but GCS says invalid. This might be due to client-server timer
+	// issues. Actual fix will be refresh the token earlier than 1 hr.
+	// Changes will be done post resolution of the below issue:
+	// https://github.com/golang/oauth2/issues/623
+	// TODO: Please incorporate the correct fix post resolution of the above issue.
 	if typed, ok := err.(*googleapi.Error); ok {
 		if typed.Code == 401 {
 			b = true
 			return
 		}
 	}
-
-	// Network errors, which tend to show up transiently when doing lots of
-	// operations in parallel. For example:
-	//
-	//     dial tcp 74.125.203.95:443: too many open files
-	//
-	if _, ok := err.(*net.OpError); ok {
-		b = true
-		return
-	}
-
-	// The HTTP package returns ErrUnexpectedEOF in several places. This seems to
-	// come up when the server terminates the connection in the middle of an
-	// object read.
-	if err == io.ErrUnexpectedEOF {
-		b = true
-		return
-	}
-
-	// The HTTP library also appears to leak EOF errors from... somewhere in its
-	// guts as URL errors sometimes.
-	if urlErr, ok := err.(*url.Error); ok {
-		if urlErr.Err == io.EOF {
-			b = true
-			return
-		}
-	}
-
-	// Sometimes the HTTP package helpfully encapsulates the real error in a URL
-	// error.
-	if urlErr, ok := err.(*url.Error); ok {
-		b = ShouldRetry(urlErr.Err)
-		return
-	}
-
 	return
 }

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -39,7 +39,7 @@ func (t customRetryTest) ShouldRetryReturnsTrueWithGoogleApiError() {
 	ExpectEq(ShouldRetry(&err429), true)
 }
 
-func (t customRetryTest) ShouldRetryReturnsFalseWithGoogleApiError() {
+func (t customRetryTest) ShouldRetryReturnsFalseWithGoogleApiError400() {
 	// 400 - bad request
 	var err400 = googleapi.Error{
 		Code: 400,

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -1,0 +1,74 @@
+package storageutil
+
+import (
+	"io"
+	"net"
+	"net/url"
+	"testing"
+
+	. "github.com/jacobsa/ogletest"
+	"google.golang.org/api/googleapi"
+)
+
+func TestCustomRetry(t *testing.T) { RunTests(t) }
+
+type customRetryTest struct {
+}
+
+func init() { RegisterTestSuite(&customRetryTest{}) }
+
+func (t customRetryTest) TestGoogleAPIErrorRetry() {
+	// 401
+	var err401 = googleapi.Error{
+		Code: 401,
+		Body: "Invalid Credential",
+	}
+	// 50x error
+	var err502 = googleapi.Error{
+		Code: 502,
+	}
+	// 429 - rate limiting error
+	var err429 = googleapi.Error{
+		Code: 429,
+		Body: "API rate limit exceeded",
+	}
+	// 400 - bad request
+	var err400 = googleapi.Error{
+		Code: 400,
+	}
+
+	ExpectEq(ShouldRetry(&err401), true)
+	ExpectEq(ShouldRetry(&err502), true)
+	ExpectEq(ShouldRetry(&err429), true)
+	ExpectEq(ShouldRetry(&err400), false)
+}
+
+func (t customRetryTest) TestUnexpectedEOFErrorRetry() {
+	ExpectEq(ShouldRetry(io.ErrUnexpectedEOF), true)
+}
+
+func (t customRetryTest) TestNetworkErrorRetry() {
+	ExpectEq(ShouldRetry(&net.OpError{}), true)
+}
+
+func (t customRetryTest) TestURLErrorRetry() {
+	var urlErr401 = url.Error{
+		Err: &googleapi.Error{
+			Code: 401,
+			Body: "Invalid Credential",
+		},
+	}
+	var urlErr400 = url.Error{
+		Err: &googleapi.Error{
+			Code: 400,
+			Body: "Bad Request",
+		},
+	}
+	var urlEOF = url.Error{
+		Err: io.EOF,
+	}
+
+	ExpectEq(ShouldRetry(&urlErr400), false)
+	ExpectEq(ShouldRetry(&urlErr401), true)
+	ExpectEq(ShouldRetry(&urlEOF), true)
+}


### PR DESCRIPTION
>> Added support for custom error retry in go-client workflow.
>> Adding 401 as a retryable error - specially this 401 retryable error will be reverted after the resolution of the issue: https://github.com/golang/oauth2/issues/623

