### PR TITLE
Adding the --foreground flag while mount gcsfuse using nohup in kokoro-automation

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/tf/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/tf/setup_scripts/setup_container.sh
@@ -19,7 +19,7 @@ cd -
 
 # Mount the bucket and run in background so that docker doesn't keep running after resnet_runner.py fails
 echo "Mounting the bucket"
-nohup gcsfuse/gcsfuse --implicit-dirs --experimental-enable-storage-client-library --debug_fuse --debug_gcs --max-conns-per-host 100 --disable-http2 --log-format "text" --log-file /home/logs/log.txt --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
+nohup gcsfuse/gcsfuse --foreground --implicit-dirs --experimental-enable-storage-client-library --debug_fuse --debug_gcs --max-conns-per-host 100 --disable-http2 --log-format "text" --log-file /home/logs/log.txt --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
 pip3 install --user tf-models-official==2.10.0

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -60,7 +60,7 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 echo "Running the pytorch dino model..."
 experiment=dino_experiment
 python3 -m torch.distributed.launch \
-  --nproc_per_node=2 dino/main_dino.py \
+  --nproc_per_node=8 dino/main_dino.py \
   --arch vit_small \
   --num_workers 20 \
   --data_path gcsfuse_data/imagenet/ILSVRC/Data/CLS-LOC/train/ \
@@ -68,7 +68,7 @@ python3 -m torch.distributed.launch \
   --norm_last_layer False \
   --use_fp16 False \
   --clip_grad 0 \
-  --epochs 40 \
+  --epochs 800 \
   --global_crops_scale 0.25 1.0 \
   --local_crops_number 10 \
   --local_crops_scale 0.05 0.25 \

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -17,7 +17,7 @@ cd -
 mkdir  run_artifacts/gcsfuse_logs
 
 echo "Mounting GCSFuse..."
-nohup /pytorch_dino/gcsfuse/gcsfuse --type-cache-ttl=1728000s \
+nohup /pytorch_dino/gcsfuse/gcsfuse --foreground --type-cache-ttl=1728000s \
         --stat-cache-ttl=1728000s \
         --stat-cache-capacity=1320000 \
         --stackdriver-export-interval=60s \
@@ -60,7 +60,7 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 echo "Running the pytorch dino model..."
 experiment=dino_experiment
 python3 -m torch.distributed.launch \
-  --nproc_per_node=8 dino/main_dino.py \
+  --nproc_per_node=2 dino/main_dino.py \
   --arch vit_small \
   --num_workers 20 \
   --data_path gcsfuse_data/imagenet/ILSVRC/Data/CLS-LOC/train/ \
@@ -68,7 +68,7 @@ python3 -m torch.distributed.launch \
   --norm_last_layer False \
   --use_fp16 False \
   --clip_grad 0 \
-  --epochs 800 \
+  --epochs 40 \
   --global_crops_scale 0.25 1.0 \
   --local_crops_number 10 \
   --local_crops_scale 0.05 0.25 \


### PR DESCRIPTION
>>  Adding the --foreground flag while mounting the gcsfuse in the pytorch/tf script. Since, we don't get the crash logs when we run the command with nohup and gcsfuse in background.