### PR TITLE
Use RetryAlways policy in conjunction with custom ShouldRetry

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -90,16 +90,19 @@ func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh
 		return
 	}
 
+	// ShouldRetry function checks if an operation should be retried based on the
+	// response of operation (error.Code).
+	// RetryAlways causes all operations to be checked for retries using
+	// ShouldRetry function.
+	// Without RetryAlways, only those operations are checked for retries which
+	// are idempotent.
+	// https://github.com/googleapis/google-cloud-go/blob/main/storage/storage.go#L1953
 	sc.SetRetry(
 		storage.WithBackoff(gax.Backoff{
 			Max:        clientConfig.MaxRetryDuration,
 			Multiplier: clientConfig.RetryMultiplier,
 		}),
-		// RetryAlways causes all operations to be retried regardless of
-		// idempotency considerations.
 		storage.WithPolicy(storage.RetryAlways),
-		// Custom ShouldRetry function checks if operation should be retried on the
-		// basis of Response(error.Code).
 		storage.WithErrorFunc(storageutil.ShouldRetry))
 
 	sh = &storageClient{client: sc}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -90,13 +90,16 @@ func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh
 		return
 	}
 
-	// RetryAlways causes all operations to be retried when the service returns a transient error, regardless of
-	// idempotency considerations.
 	sc.SetRetry(
 		storage.WithBackoff(gax.Backoff{
 			Max:        clientConfig.MaxRetryDuration,
 			Multiplier: clientConfig.RetryMultiplier,
 		}),
+		// RetryAlways causes all operations to be retried regardless of
+		// idempotency considerations.
+		storage.WithPolicy(storage.RetryAlways),
+		// Custom ShouldRetry function checks if operation should be retried on the
+		// basis of Response(error.Code).
 		storage.WithErrorFunc(storageutil.ShouldRetry))
 
 	sh = &storageClient{client: sc}


### PR DESCRIPTION
Currently, the default WithPolicy is [RetryIdempotent](https://github.com/googleapis/google-cloud-go/blob/storage/v1.29.0/storage/storage.go#L1945) which only causes idempotent request to be retried in case of errors. Because of this, we recently observed failure in CopyObject operation(which is not idempotent) due to intermittent backend err(503) from GCS as retry was not performed.
With this change, we are shifting to RetryAlways policy which will try to retry for all requests regardless of idempotency considerations. 