### PR TITLE
Making allbuckets and caching tests use struct level init and tear down

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -228,7 +228,7 @@ func (t *fsTest) TearDown() {
 	// for next test run.
 
 	// ReadDirPicky throws error incase of allbuckets_test. That is expected since
-	// we can list buckets when bucket-name is not specified during mount.
+	// we can't list buckets when bucket-name is not specified during mount.
 	// os.RemoveAll throws error incase of readonly mount.
 	// Ignoring any errors we get while deleting the mntDir contents.
 	entries, _ := fusetesting.ReadDirPicky(mntDir)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -208,7 +208,7 @@ func (t *fsTest) TearDownTestSuite() {
 	}
 
 	// Unlink the mount point.
-	if err = os.RemoveAll(mntDir); err != nil {
+	if err = os.Remove(mntDir); err != nil {
 		err = fmt.Errorf("Unlinking mount point: %w", err)
 		return
 	}
@@ -234,6 +234,7 @@ func (t *fsTest) TearDown() {
 	entries, _ := fusetesting.ReadDirPicky(mntDir)
 	for _, e := range entries {
 		os.RemoveAll(path.Join(mntDir, e.Name()))
+		os.Remove(path.Join(mntDir, e.Name()))
 	}
 }
 

--- a/internal/fs/implicit_dirs_test.go
+++ b/internal/fs/implicit_dirs_test.go
@@ -40,9 +40,6 @@ type ImplicitDirsTest struct {
 }
 
 func init() {
-	if os.Getenv("CI") != "" {
-		return
-	}
 	RegisterTestSuite(&ImplicitDirsTest{})
 }
 


### PR DESCRIPTION
Cleanup of unused variables in fs_test.go will be done after all tests are fixed.