### PR TITLE
Making required variables as global.

### DIFF
--- a/internal/fs/all_buckets_test.go
+++ b/internal/fs/all_buckets_test.go
@@ -41,7 +41,7 @@ func init() {
 
 func (t *AllBucketsTest) SetUpTestSuite() {
 	mtimeClock = timeutil.RealClock()
-	t.buckets = map[string]gcs.Bucket{
+	buckets = map[string]gcs.Bucket{
 		"bucket-0": gcsfake.NewFakeBucket(mtimeClock, "bucket-0"),
 		"bucket-1": gcsfake.NewFakeBucket(mtimeClock, "bucket-1"),
 		"bucket-2": gcsfake.NewFakeBucket(mtimeClock, "bucket-2"),

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -404,7 +404,7 @@ func (t *CachingWithImplicitDirsTest) SymlinksAreTypeCached() {
 
 	// Create a directory object out of band, so the root inode doesn't notice.
 	_, err = gcsutil.CreateObject(
-		t.ctx,
+		ctx,
 		uncachedBucket,
 		"foo/",
 		[]byte(""))

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -284,7 +284,8 @@ func (t *ForeignModsTest) UnreachableObjects() {
 	// These unreachable objects (test/0, test/1, bar/0) start showing up in
 	// other tests as soon as directory with similar name is created. Hence
 	// cleaning them.
-	gcsutil.DeleteAllObjects(ctx, bucket)
+	err = gcsutil.DeleteAllObjects(ctx, bucket)
+	AssertEq(nil, err)
 }
 
 func (t *ForeignModsTest) FileAndDirectoryWithConflictingName() {

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -280,6 +280,11 @@ func (t *ForeignModsTest) UnreachableObjects() {
 	// Statting the other name shouldn't work at all.
 	_, err = os.Stat(path.Join(mntDir, "bar"))
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+
+	// These unreachable objects (test/0, test/1, bar/0) start showing up in
+	// other tests as soon as directory with similar name is created. Hence
+	// cleaning them.
+	gcsutil.DeleteAllObjects(ctx, bucket)
 }
 
 func (t *ForeignModsTest) FileAndDirectoryWithConflictingName() {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -201,8 +201,7 @@ func (t *fsTest) TearDownTestSuite() {
 		return
 	}
 
-	// Setting nil ensures bucket/buckets variable are clean for next test suite
-	// run.
+	// Cleaning of bucket/buckets variable to be clean for next test suite run.
 	buckets = nil
 	bucket = nil
 }

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -201,7 +201,8 @@ func (t *fsTest) TearDownTestSuite() {
 		return
 	}
 
-	// Cleaning of bucket/buckets variable to be clean for next test suite run.
+	// Setting nil ensures bucket/buckets variable are clean for next test suite
+	// run.
 	buckets = nil
 	bucket = nil
 }

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -201,7 +201,8 @@ func (t *fsTest) TearDownTestSuite() {
 		return
 	}
 
-	// Cleaning of bucket/buckets variable to be clean for next test suite run.
+	// Setting nil ensures bucket/buckets variables are clean for next test suite
+	// run.
 	buckets = nil
 	bucket = nil
 }


### PR DESCRIPTION
These variables are required by every test method but are not persisted in fstest struct since new instance of fsTest will be passed for every test method. https://pkg.go.dev/github.com/jacobsa/ogletest#SetUpTestSuiteInterface
Hence making them global.