### PR TITLE
Fixing the delay between first two jobs

### DIFF
--- a/perfmetrics/scripts/job_files/seq_rand_read_write.fio
+++ b/perfmetrics/scripts/job_files/seq_rand_read_write.fio
@@ -28,7 +28,7 @@ numjobs=40
 
 [2_thread]
 stonewall
-startdelay=190
+startdelay=310
 bs=16k
 directory=gcs/256kb
 filesize=256k
@@ -37,14 +37,14 @@ numjobs=40
 
 [3_thread]
 stonewall
-startdelay=380
+startdelay=500
 directory=gcs/3mb
 filesize=3M
 numjobs=40
 
 [4_thread]
 stonewall
-startdelay=570
+startdelay=690
 directory=gcs/3mb
 filesize=3M
 rw=write
@@ -52,14 +52,14 @@ numjobs=40
 
 [5_thread]
 stonewall
-startdelay=760
+startdelay=880
 directory=gcs/5mb
 filesize=5M
 numjobs=40
 
 [6_thread]
 stonewall
-startdelay=950
+startdelay=1070
 directory=gcs/5mb
 filesize=5M
 rw=write
@@ -67,14 +67,14 @@ numjobs=40
 
 [7_thread]
 stonewall
-startdelay=1140
+startdelay=1260
 directory=gcs/50mb
 filesize=50M
 numjobs=40
 
 [8_thread]
 stonewall
-startdelay=1330
+startdelay=1450
 directory=gcs/50mb
 filesize=50M
 rw=write
@@ -82,7 +82,7 @@ numjobs=40
 
 [9_thread]
 stonewall
-startdelay=1520
+startdelay=1640
 bs=16k
 directory=gcs/256kb
 filesize=256k
@@ -91,7 +91,7 @@ numjobs=40
 
 [10_thread]
 stonewall
-startdelay=1710
+startdelay=1830
 bs=16k
 directory=gcs/256kb
 filesize=256k
@@ -100,7 +100,7 @@ numjobs=40
 
 [11_thread]
 stonewall
-startdelay=1900
+startdelay=2020
 directory=gcs/3mb
 filesize=3M
 rw=randread
@@ -108,7 +108,7 @@ numjobs=40
 
 [12_thread]
 stonewall
-startdelay=2090
+startdelay=2210
 directory=gcs/3mb
 filesize=3M
 rw=randwrite
@@ -116,7 +116,7 @@ numjobs=40
 
 [13_thread]
 stonewall
-startdelay=2280
+startdelay=2400
 directory=gcs/5mb
 filesize=5M
 rw=randread
@@ -124,7 +124,7 @@ numjobs=40
 
 [14_thread]
 stonewall
-startdelay=2470
+startdelay=2590
 directory=gcs/5mb
 filesize=5M
 rw=randwrite
@@ -132,7 +132,7 @@ numjobs=40
 
 [15_thread]
 stonewall
-startdelay=2660
+startdelay=2780
 directory=gcs/50mb
 filesize=50M
 rw=randread
@@ -140,7 +140,7 @@ numjobs=40
 
 [16_thread]
 stonewall
-startdelay=2850
+startdelay=2970
 directory=gcs/50mb
 filesize=50M
 rw=randwrite


### PR DESCRIPTION
Currently the delay between first two jobs is 0 and for others it is 2mins. fio_metrics.py uses global start delay(2m) to compute the start and end time of each job.  https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/fio/fio_metrics.py#L240

Because of this the start and end times of first job are computed wrong and goes to the time where the test hasn't even started. 
end_time_of_first_job = start_time_of_2nd_job - delay.
Delay used in above formula is 2mins (global_delay) whereas actual delay is 0secs.

Hence vm_metrics returns no metrics found for given interval.
