### PR TITLE
Fixing Integration Test Regression - Produced due to Syslog Changes

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-
 	//"runtime"
 	"syscall"
 	"testing"
@@ -475,8 +474,10 @@ func (t *GcsfuseTest) RelativeMountPoint() {
 
 func (t *GcsfuseTest) ForegroundMode() {
 	// Start gcsfuse, writing stderr to a pipe.
+	// Here --log-file=/proc/self/fd/2 represents stderr
 	cmd := t.gcsfuseCommand([]string{
 		"--foreground",
+		"--log-file=/proc/self/fd/2",
 		canned.FakeBucketName,
 		t.dir,
 	},


### PR DESCRIPTION
Fixing the regression in integration test - came with syslog changes.

Reason:
In this particular test, it tries to read the log from stderr. As a part of syslog changes, we start writing the logs to syslog by default if --log-file key is no specified. Since, after the syslog changes, we don't write to stderr and test try to get from stderr and wait for long time and eventually cancelled due to time-out.