### PR TITLE
Removing --disable-http2 flag and adding --client-protocol flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -243,17 +243,18 @@ func newApp() (app *cli.App) {
 					"copies. (default: system default, likely /tmp)",
 			},
 
-			cli.BoolFlag{
-				Name: "disable-http2",
-				Usage: "Once set, the protocol used for communicating with " +
-					"GCS backend would be HTTP/1.1, instead of the default HTTP/2.",
+			cli.StringFlag{
+				Name:  "client-protocol",
+				Value: string(mountpkg.HTTP1),
+				Usage: "The protocol used for communicating with GCS backend. " +
+					"Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2).",
 			},
 
 			cli.IntFlag{
 				Name:  "max-conns-per-host",
 				Value: 100,
 				Usage: "The max number of TCP connections allowed per server. " +
-					"This is effective when --disable-http2 is set.",
+					"This is effective when --client-protocol is set as 'http1'.",
 			},
 
 			cli.IntFlag{
@@ -381,7 +382,7 @@ type flagStorage struct {
 	RetryMultiplier     float64
 	LocalFileCache      bool
 	TempDir             string
-	DisableHTTP2        bool
+	ClientProtocol      mountpkg.ClientProtocol
 	MaxConnsPerHost     int
 	MaxIdleConnsPerHost int
 
@@ -478,6 +479,8 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		fmt.Printf("Could not parse endpoint")
 		return
 	}
+	clientProtocolString := strings.ToLower(c.String("client-protocol"))
+	clientProtocol := mountpkg.ClientProtocol(clientProtocolString)
 	flags = &flagStorage{
 		AppName:    c.String("app-name"),
 		Foreground: c.Bool("foreground"),
@@ -511,7 +514,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		RetryMultiplier:     c.Float64("retry-multiplier"),
 		LocalFileCache:      c.Bool("experimental-local-file-cache"),
 		TempDir:             c.String("temp-dir"),
-		DisableHTTP2:        c.Bool("disable-http2"),
+		ClientProtocol:      clientProtocol,
 		MaxConnsPerHost:     c.Int("max-conns-per-host"),
 		MaxIdleConnsPerHost: c.Int("max-idle-conns-per-host"),
 
@@ -547,8 +550,12 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 func validateFlags(flags *flagStorage) (err error) {
 	if flags.SequentialReadSizeMb < 1 || flags.SequentialReadSizeMb > maxSequentialReadSizeMb {
 		err = fmt.Errorf("SequentialReadSizeMb should be less than %d", maxSequentialReadSizeMb)
+		return
 	}
 
+	if !flags.ClientProtocol.IsValid() {
+		err = fmt.Errorf("client protocol: %s is not valid", flags.ClientProtocol)
+	}
 	return
 }
 

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -12,13 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Helper functions for dealing with mount(8)-style flags.
 package mount
 
 import "strings"
 
-// Parse an option string in the format accepted by mount(8) and generated for
-// its external mount helpers.
+type ClientProtocol string
+
+const (
+	HTTP1 ClientProtocol = "http1"
+	HTTP2 ClientProtocol = "http2"
+)
+
+func (cp ClientProtocol) IsValid() bool {
+	switch cp {
+	case HTTP1, HTTP2:
+		return true
+	}
+	return false
+}
+
+// ParseOptions parse an option string in the format accepted by mount(8) and
+// generated for its external mount helpers.
 //
 // It is assumed that option name and values do not contain commas, and that
 // the first equals sign in an option is the name/value separator. There is no
@@ -26,14 +40,13 @@ import "strings"
 //
 // For example, if the input is
 //
-//     user,foo=bar=baz,qux
+//	user,foo=bar=baz,qux
 //
 // then the following will be inserted into the map.
 //
-//     "user": "",
-//     "foo": "bar=baz",
-//     "qux": "",
-//
+//	"user": "",
+//	"foo": "bar=baz",
+//	"qux": "",
 func ParseOptions(m map[string]string, s string) {
 	// NOTE(jacobsa): The man pages don't define how escaping works, and as far
 	// as I can tell there is no way to properly escape or quote a comma in the

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/gax-go/v2"
+	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -37,7 +38,7 @@ type storageClient struct {
 }
 
 type StorageClientConfig struct {
-	DisableHTTP2        bool
+	ClientProtocol      mountpkg.ClientProtocol
 	MaxConnsPerHost     int
 	MaxIdleConnsPerHost int
 	TokenSrc            oauth2.TokenSource
@@ -51,8 +52,8 @@ type StorageClientConfig struct {
 // storageClientConfig parameter.
 func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh StorageHandle, err error) {
 	var transport *http.Transport
-	// Disabling the http2 makes the client more performant.
-	if clientConfig.DisableHTTP2 {
+	// Using http1 makes the client more performant.
+	if clientConfig.ClientProtocol == mountpkg.HTTP1 {
 		transport = &http.Transport{
 			MaxConnsPerHost:     clientConfig.MaxConnsPerHost,
 			MaxIdleConnsPerHost: clientConfig.MaxIdleConnsPerHost,

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	. "github.com/jacobsa/ogletest"
 	"golang.org/x/oauth2"
 )
@@ -27,7 +28,7 @@ const invalidBucketName string = "will-not-be-present-in-fake-server"
 
 func getDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 	return StorageClientConfig{
-		DisableHTTP2:        true,
+		ClientProtocol:      mountpkg.HTTP1,
 		MaxConnsPerHost:     10,
 		MaxIdleConnsPerHost: 100,
 		TokenSrc:            oauth2.StaticTokenSource(&oauth2.Token{}),
@@ -82,14 +83,14 @@ func (t *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExist() {
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
-	sc := getDefaultStorageClientConfig() // by default http2 disabled
+	sc := getDefaultStorageClientConfig() // by default http1 enabled
 
 	t.invokeAndVerifyStorageHandle(sc)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleHttp2Enabled() {
 	sc := getDefaultStorageClientConfig()
-	sc.DisableHTTP2 = false
+	sc.ClientProtocol = mountpkg.HTTP2
 
 	t.invokeAndVerifyStorageHandle(sc)
 }

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/monitor"
+	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/internal/perf"
 	"github.com/jacobsa/daemonize"
 	"github.com/jacobsa/fuse"
@@ -108,7 +109,7 @@ func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 	// does not create new TCP connections even when the idle connections
 	// run out. To specify multiple connections per host, HTTP/2 is disabled
 	// on purpose.
-	if flags.DisableHTTP2 {
+	if flags.ClientProtocol == mountpkg.HTTP1 {
 		cfg.Transport = &http.Transport{
 			MaxConnsPerHost: flags.MaxConnsPerHost,
 			// This disables HTTP/2 in the transport.
@@ -147,7 +148,7 @@ func createStorageHandle(flags *flagStorage) (storageHandle storage.StorageHandl
 	}
 
 	storageClientConfig := storage.StorageClientConfig{
-		DisableHTTP2:        flags.DisableHTTP2,
+		ClientProtocol:      flags.ClientProtocol,
 		MaxConnsPerHost:     flags.MaxConnsPerHost,
 		MaxIdleConnsPerHost: flags.MaxIdleConnsPerHost,
 		TokenSrc:            tokenSrc,

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -31,7 +32,7 @@ func (t *MainTest) TestCreateStorageHandleEnableStorageClientLibraryIsTrue() {
 
 func (t *MainTest) TestCreateStorageHandle() {
 	flags := &flagStorage{
-		DisableHTTP2:        false,
+		ClientProtocol:      mountpkg.HTTP1,
 		MaxConnsPerHost:     5,
 		MaxIdleConnsPerHost: 100,
 		MaxRetryDuration:    7,

--- a/perfmetrics/scripts/compare_fuse_types_using_fio.py
+++ b/perfmetrics/scripts/compare_fuse_types_using_fio.py
@@ -14,7 +14,7 @@ python3 compare_fuse_types_using_fio.py -- --fuse_type_1=<value1> --fuse_type_1_
 3) --flags_1=<flags1> & --flags_2=<flags2>
 -> Provide  the flags for mounting bucket using specific provided fuse based filesystem.
 -> Since there might be more than one flags, provided all of them inside single quotes.
--> Example for GCSFuse flags: --flags_1='--implicit-dirs --max-conns-per-host 100 --disable-http2'
+-> Example for GCSFuse flags: --flags_1='--implicit-dirs --max-conns-per-host 100'
 4) --jobfile_path=<jobfile_path>
 -> Job file path for the FIO load test.
 5) --gcs_bucket=<gcs_bucket>
@@ -33,7 +33,7 @@ from fio import fio_metrics
 from absl import app
 
 GCSFUSE_REPO = 'https://github.com/GoogleCloudPlatform/gcsfuse'
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --disable-http2"
+GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
 
 
 def _install_gcsfuse(version, gcs_bucket, gcsfuse_flags) -> None:

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -30,7 +30,7 @@ cd "./perfmetrics/scripts/"
 echo Mounting gcs bucket
 mkdir -p gcs
 LOG_FILE=log-$(date '+%Y-%m-%d').txt
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --experimental-enable-storage-client-library=true --disable-http2 --debug_fuse --debug_gcs --log-file $LOG_FILE --log-format \"text\" --stackdriver-export-interval=30s"
+GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --experimental-enable-storage-client-library=true --debug_fuse --debug_gcs --log-file $LOG_FILE --log-format \"text\" --stackdriver-export-interval=30s"
 BUCKET_NAME=gcs-fuse-dashboard-fio
 MOUNT_POINT=gcs
 # The VM will itself exit if the gcsfuse mount fails.

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -375,7 +375,7 @@ def _mount_gcs_bucket(bucket_name) -> str:
   subprocess.call('mkdir {}'.format(gcs_bucket), shell=True)
 
   exit_code = subprocess.call(
-      'gcsfuse --implicit-dirs --disable-http2 --max-conns-per-host 100 {} {}'.format(
+      'gcsfuse --implicit-dirs --max-conns-per-host 100 {} {}'.format(
           bucket_name, gcs_bucket), shell=True)
   if exit_code != 0:
     log.error('Cannot mount the GCS bucket due to exit code %s.\n', exit_code)

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
@@ -582,7 +582,7 @@ class ListingBenchmarkTest(unittest.TestCase):
     self.assertEqual(mock_subprocess_call.call_count, 2)
     self.assertEqual(mock_subprocess_call.call_args_list, [
         call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs --disable-http2 --max-conns-per-host 100 fake_bucket fake_bucket', shell=True)
+        call('gcsfuse --implicit-dirs --max-conns-per-host 100 fake_bucket fake_bucket', shell=True)
     ])
 
   @patch('listing_benchmark.subprocess.call', return_value=1)
@@ -591,7 +591,7 @@ class ListingBenchmarkTest(unittest.TestCase):
     self.assertEqual(mock_subprocess_call.call_count, 3)
     self.assertEqual(mock_subprocess_call.call_args_list, [
         call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs --disable-http2 --max-conns-per-host 100 fake_bucket fake_bucket', shell=True),
+        call('gcsfuse --implicit-dirs --max-conns-per-host 100 fake_bucket fake_bucket', shell=True),
         call('bash', shell=True)
     ])
 

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -22,7 +22,6 @@ nohup /pytorch_dino/gcsfuse/gcsfuse --foreground --type-cache-ttl=1728000s \
         --stat-cache-capacity=1320000 \
         --stackdriver-export-interval=60s \
         --implicit-dirs \
-        --disable-http2 \
         --experimental-enable-storage-client-library \
         --max-conns-per-host=100 \
         --debug_fs \

--- a/perfmetrics/scripts/ml_tests/run_image_recognition_models.py
+++ b/perfmetrics/scripts/ml_tests/run_image_recognition_models.py
@@ -78,7 +78,7 @@ def _mount_gcsbucket(gcs_bucket, data_directory_name) -> None:
     data_directory_name(str): Destination for mounting the gcs_bucket.
   """
   os.system(f'''mkdir {data_directory_name}
-            gcsfuse --implicit-dirs --stat-cache-capacity 1000000 --disable-http2 --max-conns-per-host 100 --stackdriver-export-interval=60s {gcs_bucket} {data_directory_name}
+            gcsfuse --implicit-dirs --stat-cache-capacity 1000000 --max-conns-per-host 100 --stackdriver-export-interval=60s {gcs_bucket} {data_directory_name}
             ''')
 
 
@@ -105,7 +105,7 @@ def _run_from_source(gcs_bucket, data_directory_name) -> None:
   os.system(f'''mkdir {data_directory_name}
             git clone {GITHUB_REPO}
             cd gcsfuse
-            go run . --implicit-dirs --stat-cache-capacity 1000000 --disable-http2 --max-conns-per-host 100 --stackdriver-export-interval=60s {gcs_bucket} ../{data_directory_name}
+            go run . --implicit-dirs --stat-cache-capacity 1000000 --max-conns-per-host 100 --stackdriver-export-interval=60s {gcs_bucket} ../{data_directory_name}
             cd ..
             ''')
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -19,7 +19,7 @@ cd -
 
 # Mount the bucket and run in background so that docker doesn't keep running after resnet_runner.py fails
 echo "Mounting the bucket"
-nohup gcsfuse/gcsfuse --foreground --implicit-dirs --experimental-enable-storage-client-library --debug_fs --debug_gcs --max-conns-per-host 100 --disable-http2 --log-format "text" --log-file /home/logs/log.txt --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
+nohup gcsfuse/gcsfuse --foreground --implicit-dirs --experimental-enable-storage-client-library --debug_fs --debug_gcs --max-conns-per-host 100 --log-format "text" --log-file /home/logs/log.txt --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
 pip3 install --user tf-models-official==2.10.0

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -21,7 +21,7 @@ sudo apt-get install fio -y
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo Mounting gcs bucket for master branch
 mkdir -p gcs
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --experimental-enable-storage-client-library=true --disable-http2"
+GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --experimental-enable-storage-client-library=true"
 BUCKET_NAME=presubmit-perf-test
 MOUNT_POINT=gcs
 # The VM will itself exit if the gcsfuse mount fails.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -81,7 +81,6 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs",
-			"disable_http2",
 			"experimental_local_file_cache",
 			"experimental_enable_storage_client_library",
 			"reuse_token_from_url":
@@ -95,6 +94,7 @@ func makeGcsfuseArgs(
 			"app_name",
 			"only_dir",
 			"billing_project",
+			"client_protocol",
 			"key_file",
 			"token_url",
 			"limit_bytes_per_sec",


### PR DESCRIPTION
This PR includes code changes. I will raise another PR for documentation changes.
Testing details:
1. Manual: 
   - Check client-protocol flag's description and default value using `gcsfuse --help` command.
   - Tried mounting and reading and writing a file with combinations - (http1, jacobsa/gcloud), (http2, jacobsa/gcloud), (http1, Go storage library),  (http2, Go storage library).
   - Build gcsfuse using tools/build_gcsfuse.
   - Mount gcsfuse with http1, http2 protocol using mount command: `mount -t gcsfuse ayushsethi-working-dirs ./gg -o "key_file=key.json,client_protocol=http1,debug_gcs,debug_http,log_file=gg.l"`
   - Tried passing invalid `client-protocol` (http4) and got the expected error.
3. Unit tests:
   - Added unit test case in flags_test.go to test that the input string value for --client-protocol flag is parsed correctly.
   - Added unit test case in flags_test.go to validate the input string values for --client-protocol flag.
   - Made modifications in storage_handle_test.go and main_test.go and ran these tests files manually.
   - CI tests are also passing.
4. Integration tests:
    - Manually ran integration tests in https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/tools/integration_tests/implicitdir. Command used: `GODEBUG=asyncpreemptoff=1 go test -v --testbucket=temp-0011001100-bucket`
5. Perf tests:
    - Read: file size=5mb, client-protocol=http1, go storage client library. 
       - Command used: `gcsfuse --implicit-dirs --max-conns-per-host 100 --client-protocol http1 --only-dir fio_load --key-file ~/key.json ayushsethi-working-dirs gcs`
       - BW: 4143MiB/sec.
     - Read: file size=5mb, go storage client library. (default client protocol)
        - Command used: `gcsfuse --implicit-dirs --max-conns-per-host 100 --only-dir fio_load --key-file ~/key.json ayushsethi-working-dirs gcs`
        - BW: 4033 MiB/sec.
     - Read: file size=5mb, client-protocol=http2, go storage client library
        - Command used: `gcsfuse --implicit-dirs --max-conns-per-host 100 --client-protocol http2 --only-dir fio_load --key-file ~/key.json ayushsethi-working-dirs gcs`
        - BW: 227 MiB/sec.
    