### PR TITLE
Adding foreground flag to work with mount command

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -81,6 +81,7 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs",
+			"foreground",
 			"disable_http2",
 			"experimental_local_file_cache",
 			"experimental_enable_storage_client_library",


### PR DESCRIPTION
'foreground' option is not added for mount command. I tried using foreground with mount command and it is working. Command used: `mount -t gcsfuse ayushsethi-working-dirs ./gg -o "key_file=key.json,client_protocol=http1,debug_gcs,debug_http,foreground"`