### PR TITLE
Print starttime and endtime for kokoro failure

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -16,7 +16,7 @@ sudo apt-get install fio -y
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 # Get the latest commitId of yesterday in the log file
 commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
-git checkout $commitId
+#git checkout $commitId
 
 echo Building and installing gcsfuse
 go install ./tools/build_gcsfuse

--- a/perfmetrics/scripts/fetch_metrics.py
+++ b/perfmetrics/scripts/fetch_metrics.py
@@ -38,6 +38,11 @@ if __name__ == '__main__':
   for ind, job in enumerate(temp):
     start_time_sec = job[fio_metrics.consts.START_TIME]
     end_time_sec = job[fio_metrics.consts.END_TIME]
+
+    # Print start and end time of jobs
+    print("Start time: ",start_time_sec)
+    print("End time: ",end_time_sec)
+
     rw = job[fio_metrics.consts.PARAMS][fio_metrics.consts.RW]
     print(f'Getting VM metrics for job at index {ind+1}...')
     metrics_data = vm_metrics_obj.fetch_metrics(start_time_sec, end_time_sec, INSTANCE, PERIOD_SEC, rw)

--- a/perfmetrics/scripts/fio/fio_metrics.py
+++ b/perfmetrics/scripts/fio/fio_metrics.py
@@ -363,6 +363,11 @@ class FioMetrics:
 
     job_params = self._get_job_params(fio_out)
     start_end_times = self._get_start_end_times(fio_out, job_params)
+
+    # Print start and end time of jobs
+    for time in start_end_times :
+      print(time)
+
     all_jobs = []
     # Get the required metrics for every job
     for i, job in enumerate(fio_out[consts.JOBS]):

--- a/perfmetrics/scripts/fio/fio_metrics.py
+++ b/perfmetrics/scripts/fio/fio_metrics.py
@@ -363,7 +363,6 @@ class FioMetrics:
 
     job_params = self._get_job_params(fio_out)
     start_end_times = self._get_start_end_times(fio_out, job_params)
-
     all_jobs = []
     # Get the required metrics for every job
     for i, job in enumerate(fio_out[consts.JOBS]):

--- a/perfmetrics/scripts/fio/fio_metrics.py
+++ b/perfmetrics/scripts/fio/fio_metrics.py
@@ -364,10 +364,6 @@ class FioMetrics:
     job_params = self._get_job_params(fio_out)
     start_end_times = self._get_start_end_times(fio_out, job_params)
 
-    # Print start and end time of jobs
-    for time in start_end_times :
-      print(time)
-
     all_jobs = []
     # Get the required metrics for every job
     for i, job in enumerate(fio_out[consts.JOBS]):

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+echo Print the time when FIO tests start
+date
 echo Running fio test..
 fio job_files/seq_rand_read_write.fio --lat_percentiles 1 --output-format=json --output='output.json'
 echo Logging fio results


### PR DESCRIPTION
Logging time when fio test starts.
Logging start time and end time  for each job in fio. 
Blocked checkout through commit ID
Uses master branch script only