### PR TITLE
Changing the description of log-file flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -283,8 +283,8 @@ func newApp() (app *cli.App) {
 				Name:  "log-file",
 				Value: "",
 				Usage: "The file for storing logs that can be parsed by " +
-					"fluentd. When not provided, plain text logs are printed to " +
-					"stdout.",
+					"fluentd. When not provided, plain text logs are written to syslog " +
+					"and eventually redirected to /var/log/gcsfuse.log",
 			},
 
 			cli.StringFlag{


### PR DESCRIPTION
### Description
Changing the description of log-file flag, for default we started writing the logs to /var/log/gcsfuse.log.

### Testing
1. Manual - NA
2. Integration Test - NA
3. Unit Test - NA