### PR TITLE
Revert "GCSFuse code change to write the logs to syslog files"

### DIFF
--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		return fmt.Errorf("parsing flags failed: %w", err)
 	}
 
-	if flags.Foreground {
+	if flags.Foreground && flags.LogFile != "" {
 		err = logger.InitLogFile(flags.LogFile, flags.LogFormat)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcsfuse#949

We need to properly think about the support on docker container. Reverting it right now due to the below mentioned issues.

Issue link - https://github.com/GoogleCloudPlatform/gcsfuse/issues/976