### PR TITLE
Revert "Changing the description of log-file flag"

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -283,8 +283,8 @@ func newApp() (app *cli.App) {
 				Name:  "log-file",
 				Value: "",
 				Usage: "The file for storing logs that can be parsed by " +
-					"fluentd. When not provided, plain text logs are written to syslog " +
-					"and eventually redirected to /var/log/gcsfuse.log",
+					"fluentd. When not provided, plain text logs are printed to " +
+					"stdout.",
 			},
 
 			cli.StringFlag{


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcsfuse#971

We need to properly think about the support on docker container. Reverting it right now due to the below mentioned issues.

Issue link - https://github.com/GoogleCloudPlatform/gcsfuse/issues/976