### PR TITLE
Revert "Adding the logging info, since we are changing the default behavior"

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,10 +265,6 @@ func runCLIApp(c *cli.Context) (err error) {
 	}
 
 	if flags.Foreground {
-		if flags.LogFile == "" {
-			logger.Info("You haven't provided log-file hence logs will be redirected to syslog, please refer: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/logging.md")
-		}
-
 		err = logger.InitLogFile(flags.LogFile, flags.LogFormat)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcsfuse#973

We need to properly think about the support on docker container. Reverting it right now due to the below mentioned issues.

Issue link - https://github.com/GoogleCloudPlatform/gcsfuse/issues/976