### PR TITLE
GCSFuse code change to write the logs to syslog files

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -15,7 +15,6 @@
 package logger
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"log/syslog"
@@ -65,7 +64,7 @@ func InitLogFile(filename string, format string) error {
 			// debug messages.
 			sysWriter, err = syslog.New(syslog.LOG_LOCAL7|syslog.LOG_DEBUG, ProgrammeName)
 			if err != nil {
-				fmt.Printf("error while creating syswriter: %w", err)
+				Infof("error while creating sys writer: %w", err)
 				sysWriter = nil
 			}
 		} else {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -15,12 +15,20 @@
 package logger
 
 import (
+	"fmt"
 	"io"
 	"log"
+	"log/syslog"
 	"os"
 
 	"github.com/jacobsa/daemonize"
 )
+
+// Syslog file contains logs from all different programmes running on the VM.
+// ProgrammeName is prefixed to all the logs written to syslog. This constant is
+// used to filter the logs from syslog and write it to respective log files -
+// gcsfuse.log in case of GCSFuse.
+const ProgrammeName string = "gcsfuse"
 
 var (
 	defaultLoggerFactory *loggerFactory
@@ -29,20 +37,39 @@ var (
 
 // InitLogFile initializes the logger factory to create loggers that print to
 // a log file.
+// In case of empty file, it starts writing the log to syslog file, which
+// is eventually filtered and redirected to a fixed location using syslog
+// config.
 func InitLogFile(filename string, format string) error {
-	f, err := os.OpenFile(
-		filename,
-		os.O_WRONLY|os.O_CREATE|os.O_APPEND,
-		0644,
-	)
-	if err != nil {
-		return err
+	var f *os.File
+	var sysWriter *syslog.Writer
+	var err error
+	if filename != "" {
+		f, err = os.OpenFile(
+			filename,
+			os.O_WRONLY|os.O_CREATE|os.O_APPEND,
+			0644,
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Priority consist of facility and severity, here facility to specify the
+		// type of system that is logging the message to syslog and severity is log-level.
+		// User applications are allowed to take facility value between LOG_LOCAL0
+		// to LOG_LOCAL7. We are using LOG_LOCAL7 as facility and LOG_DEBUG to write
+		// debug messages.
+		sysWriter, err = syslog.New(syslog.LOG_LOCAL7|syslog.LOG_DEBUG, ProgrammeName)
+		if err != nil {
+			return fmt.Errorf("error while creating syswriter: %w", err)
+		}
 	}
 
 	defaultLoggerFactory = &loggerFactory{
-		file:   f,
-		flag:   0,
-		format: format,
+		file:      f,
+		sysWriter: sysWriter,
+		flag:      0,
+		format:    format,
 	}
 	defaultInfoLogger = NewInfo("")
 
@@ -103,29 +130,37 @@ func Info(v ...interface{}) {
 
 type loggerFactory struct {
 	// If nil, log to stdout or stderr. Otherwise, log to this file.
-	file   *os.File
-	flag   int
-	format string
+	file      *os.File
+	sysWriter *syslog.Writer
+	flag      int
+	format    string
 }
 
 func (f *loggerFactory) newLogger(level, prefix string) *log.Logger {
 	return log.New(f.writer(level), prefix, f.flag)
 }
 
+func (f *loggerFactory) createJsonOrTextWriter(level string, writer io.Writer) io.Writer {
+	if f.format == "json" {
+		return &jsonWriter{
+			w:     writer,
+			level: level,
+		}
+	}
+
+	return &textWriter{
+		w:     writer,
+		level: level,
+	}
+}
+
 func (f *loggerFactory) writer(level string) io.Writer {
 	if f.file != nil {
-		switch f.format {
-		case "json":
-			return &jsonWriter{
-				w:     f.file,
-				level: level,
-			}
-		case "text":
-			return &textWriter{
-				w:     f.file,
-				level: level,
-			}
-		}
+		return f.createJsonOrTextWriter(level, f.file)
+	}
+
+	if f.sysWriter != nil {
+		return f.createJsonOrTextWriter(level, f.sysWriter)
 	}
 
 	switch level {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -64,7 +64,7 @@ func InitLogFile(filename string, format string) error {
 			// debug messages.
 			sysWriter, err = syslog.New(syslog.LOG_LOCAL7|syslog.LOG_DEBUG, ProgrammeName)
 			if err != nil {
-				Infof("error while creating sys writer: %w", err)
+				Infof("error while creating sys writer: %v", err)
 				sysWriter = nil
 			}
 		} else {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -28,7 +28,7 @@ import (
 // used to filter the logs from syslog and write it to respective log files -
 // gcsfuse.log in case of GCSFuse.
 const ProgrammeName string = "gcsfuse"
-const GCSFuseAsBackground string = "GCSFUSE_AS_BACKGROUND"
+const GCSFuseInBackgroundMode string = "GCSFUSE_IN_BACKGROUND_MODE"
 
 var (
 	defaultLoggerFactory *loggerFactory
@@ -56,19 +56,17 @@ func InitLogFile(filename string, format string) error {
 			return err
 		}
 	} else {
-		if _, ok := os.LookupEnv(GCSFuseAsBackground); ok {
+		if _, ok := os.LookupEnv(GCSFuseInBackgroundMode); ok {
 			// Priority consist of facility and severity, here facility to specify the
 			// type of system that is logging the message to syslog and severity is log-level.
 			// User applications are allowed to take facility value between LOG_LOCAL0
 			// to LOG_LOCAL7. We are using LOG_LOCAL7 as facility and LOG_DEBUG to write
 			// debug messages.
-			sysWriter, err = syslog.New(syslog.LOG_LOCAL7|syslog.LOG_DEBUG, ProgrammeName)
-			if err != nil {
-				Infof("error while creating sys writer: %v", err)
-				sysWriter = nil
-			}
-		} else {
-			sysWriter = nil
+
+			// Suppressing the error while creating the syslog, although logger will
+			// be initialised with stdout/err, log will be printed anywhere. Because,
+			// in this case gcsfuse will be running as daemon.
+			sysWriter, _ = syslog.New(syslog.LOG_LOCAL7|syslog.LOG_DEBUG, ProgrammeName)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -350,7 +350,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		// This environment variable will be helpful to distinguish b/w the main
 		// process and daemon process. If this environment variable set that means
 		// programme is running as daemon process.
-		env = append(env, fmt.Sprintf("%s=true", logger.GCSFuseAsBackground))
+		env = append(env, fmt.Sprintf("%s=true", logger.GCSFuseInBackgroundMode))
 
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)

--- a/main.go
+++ b/main.go
@@ -264,7 +264,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		return fmt.Errorf("parsing flags failed: %w", err)
 	}
 
-	if flags.Foreground && flags.LogFile != "" {
+	if flags.Foreground {
 		err = logger.InitLogFile(flags.LogFile, flags.LogFormat)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)

--- a/main.go
+++ b/main.go
@@ -347,6 +347,11 @@ func runCLIApp(c *cli.Context) (err error) {
 			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
 		}
 
+		// This environment variable will be helpful to distinguish b/w the main
+		// process and daemon process. If this environment variable set that means
+		// programme is running as daemon process.
+		env = append(env, fmt.Sprintf("%s=true", logger.GCSFuseAsBackground))
+
 		// Run.
 		err = daemonize.Run(path, args, env, os.Stdout)
 		if err != nil {


### PR DESCRIPTION
### Description
1. Reverts GoogleCloudPlatform/gcsfuse#977
2. Modified log behavior - If user passes --log-file in case all the logs will be written to given log file. Otherwise in background mode gcsfuse will write the log to syslog and in foreground mode logs will be printed to console as stdout/err.

### Testing
1. Manual - Checked all the four behaviors manually.
2. Integration Test - NA
3. Unit Test - NA