### PR TITLE
Permission issue mounting a bucket in go client library

### DIFF
--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -17,7 +17,6 @@ package gcsx
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"time"
 
@@ -155,7 +154,7 @@ func setUpRateLimiting(
 // bucket as described in that package.
 func (bm *bucketManager) SetUpGcsBucket(ctx context.Context, name string) (b gcs.Bucket, err error) {
 	if bm.config.EnableStorageClientLibrary {
-		b, err = bm.storageHandle.BucketHandle(name)
+		b = bm.storageHandle.BucketHandle(name)
 		if err != nil {
 			return
 		}
@@ -245,9 +244,9 @@ func (bm *bucketManager) SetUpBucket(
 	// Check whether this bucket works, giving the user a warning early if there
 	// is some problem.
 	{
-		_, err := b.ListObjects(ctx, &gcs.ListObjectsRequest{MaxResults: 1})
+		_, err = b.ListObjects(ctx, &gcs.ListObjectsRequest{MaxResults: 1})
 		if err != nil {
-			fmt.Fprintln(os.Stdout, "WARNING, bucket doesn't appear to work: ", err)
+			return
 		}
 	}
 

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -155,9 +155,6 @@ func setUpRateLimiting(
 func (bm *bucketManager) SetUpGcsBucket(ctx context.Context, name string) (b gcs.Bucket, err error) {
 	if bm.config.EnableStorageClientLibrary {
 		b = bm.storageHandle.BucketHandle(name)
-		if err != nil {
-			return
-		}
 
 		if reqtrace.Enabled() {
 			b = gcs.GetWrappedWithReqtraceBucket(b)

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -32,12 +32,10 @@ var _ TearDownInterface = &BucketManagerTest{}
 func init() { RegisterTestSuite(&BucketManagerTest{}) }
 
 func (t *BucketManagerTest) SetUp(_ *TestInfo) {
-	var err error
 	t.fakeStorage = storage.NewFakeStorage()
 	t.storageHandle = t.fakeStorage.CreateStorageHandle()
-	t.bucket, err = t.storageHandle.BucketHandle(TestBucketName)
+	t.bucket = t.storageHandle.BucketHandle(TestBucketName)
 
-	AssertEq(nil, err)
 	AssertNe(nil, t.bucket)
 }
 

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -145,7 +145,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName)
 
-	ExpectNe(nil, bucket.Syncer)
 	// Error in iterating through objects: storage: bucket doesn't exist
 	ExpectNe(nil, err)
+	ExpectNe(nil, bucket.Syncer)
 }

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -145,7 +145,6 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName)
 
-	// Error in iterating through objects: storage: bucket doesn't exist
-	ExpectNe(nil, err)
+	ExpectEq("Error in iterating through objects: storage: bucket doesn't exist", err.Error())
 	ExpectNe(nil, bucket.Syncer)
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -55,12 +55,10 @@ var _ TearDownInterface = &BucketHandleTest{}
 func init() { RegisterTestSuite(&BucketHandleTest{}) }
 
 func (t *BucketHandleTest) SetUp(_ *TestInfo) {
-	var err error
 	t.fakeStorage = NewFakeStorage()
 	t.storageHandle = t.fakeStorage.CreateStorageHandle()
-	t.bucketHandle, err = t.storageHandle.BucketHandle(TestBucketName)
+	t.bucketHandle = t.storageHandle.BucketHandle(TestBucketName)
 
-	AssertEq(nil, err)
 	AssertNe(nil, t.bucketHandle)
 }
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -30,7 +30,7 @@ import (
 )
 
 type StorageHandle interface {
-	BucketHandle(bucketName string) (bh *bucketHandle, err error)
+	BucketHandle(bucketName string) (bh *bucketHandle)
 }
 
 type storageClient struct {
@@ -110,13 +110,9 @@ func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh
 	return
 }
 
-func (sh *storageClient) BucketHandle(bucketName string) (bh *bucketHandle, err error) {
+func (sh *storageClient) BucketHandle(bucketName string) (bh *bucketHandle) {
 	storageBucketHandle := sh.client.Bucket(bucketName)
-	obj, err := storageBucketHandle.Attrs(context.Background())
-	if err != nil {
-		return
-	}
 
-	bh = &bucketHandle{bucket: storageBucketHandle, bucketName: obj.Name}
+	bh = &bucketHandle{bucket: storageBucketHandle, bucketName: bucketName}
 	return
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -67,19 +67,17 @@ func (t *StorageHandleTest) invokeAndVerifyStorageHandle(sc StorageClientConfig)
 
 func (t *StorageHandleTest) TestBucketHandleWhenBucketExists() {
 	storageHandle := t.fakeStorage.CreateStorageHandle()
-	bucketHandle, err := storageHandle.BucketHandle(TestBucketName)
+	bucketHandle := storageHandle.BucketHandle(TestBucketName)
 
-	AssertEq(nil, err)
 	AssertNe(nil, bucketHandle)
 	AssertEq(TestBucketName, bucketHandle.bucketName)
 }
 
 func (t *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExist() {
 	storageHandle := t.fakeStorage.CreateStorageHandle()
-	bucketHandle, err := storageHandle.BucketHandle(invalidBucketName)
+	bucketHandle := storageHandle.BucketHandle(invalidBucketName)
 
-	AssertNe(nil, err)
-	AssertEq(nil, bucketHandle)
+	AssertEq(nil, bucketHandle.Bucket)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {


### PR DESCRIPTION
### Description
Before [Bucket Handle](https://github.com/GoogleCloudPlatform/gcsfuse/blob/ComponentCount_Not_Set/internal/storage/storage_handle.go#L109) method was making [bucket.Attrs](https://pkg.go.dev/cloud.google.com/go/storage#BucketHandle.Attrs) call which needs storage.object.get permission to check if the bucket does exist or not. I skip this call as we are already checking if the bucket exists [here](https://github.com/GoogleCloudPlatform/gcsfuse/blob/4859983c583c9f09f3edd26651c8de7f4e490439/internal/gcsx/bucket_manager.go#L248). Before this line only threw an error; I made it throw an error and closed mounting.

### Testing
Manual 
- Did sanity check(list, create, copy, delete operations)
-  What permissions does SA has - Storage Object Viewer
      - no storage.buckets.get permission
      - has storage.objects.get and storage.objects.list
      -  Output -Bucket mounted (read only operations are working)
          In case if bucket does not exist it is throwing error - Error in iterating through objects: storage: bucket doesn't exist
-  What permissions does SA has - Storage Admin
      - has storage.buckets.*  storage.objects.*
      - Output - Mounted Successfully. (all operations are working)
-  What permissions does SA has - Storage Legacy Bucket Reader
      - has storage.buckets.get, storage.objects.list 
      - Output -  Bucket mounted (read only operations are working)
-  What permissions does SA has - Storage Legacy Bucket Write
      - has storage.buckets.get 
      - Output - Bucket mounted (Write only operations are working)
-  What permissions does SA has - Storage Legacy Bucket Owner
      - Output - Bucket mounted (all operations are working)
-  What permissions does SA has - Storage Legacy Object Reader,  Storage Legacy Object Owner
     - no  storage.object.list permission
     - no storage.buckets.get
     - Output -We got this error - Error in iterating through objects: googleapi: Error 403: tulsishah@gcs-fuse-test.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist)., forbidden
mountWithArgs: mountWithConn: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: googleapi: Error 403: tulsishah@gcs-fuse-test.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist)., forbidden
    - In this case Jacobsa flow also throwing the same error.

Please refer this for [permissions ](https://cloud.google.com/storage/docs/access-control/iam-roles#legacy-roles)
       
Unit test - Added unit test for bucket does not exist in bucket_manager_test.go file
Integration test - N/A