### PR TITLE
Adding condition when project team is nil in ObjectAttr conversion

### DIFF
--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -24,31 +24,45 @@ import (
 )
 
 func convertObjectAccessControlToACLRule(obj *storagev1.ObjectAccessControl) storage.ACLRule {
-	return storage.ACLRule{
+	aclObj := storage.ACLRule{
 		Entity:   storage.ACLEntity(obj.Entity),
 		EntityID: obj.EntityId,
 		Role:     storage.ACLRole(obj.Role),
 		Domain:   obj.Domain,
 		Email:    obj.Email,
-		ProjectTeam: &storage.ProjectTeam{
+	}
+
+	if obj.ProjectTeam != nil {
+		aclObj.ProjectTeam = &storage.ProjectTeam{
 			ProjectNumber: obj.ProjectTeam.ProjectNumber,
 			Team:          obj.ProjectTeam.Team,
-		},
+		}
+	} else {
+		aclObj.ProjectTeam = nil
 	}
+
+	return aclObj
 }
 
 func convertACLRuleToObjectAccessControl(element storage.ACLRule) *storagev1.ObjectAccessControl {
-	return &storagev1.ObjectAccessControl{
+	obj := &storagev1.ObjectAccessControl{
 		Entity:   string(element.Entity),
 		EntityId: element.EntityID,
 		Role:     string(element.Role),
 		Domain:   element.Domain,
 		Email:    element.Email,
-		ProjectTeam: &storagev1.ObjectAccessControlProjectTeam{
+	}
+
+	if element.ProjectTeam != nil {
+		obj.ProjectTeam = &storagev1.ObjectAccessControlProjectTeam{
 			ProjectNumber: element.ProjectTeam.ProjectNumber,
 			Team:          element.ProjectTeam.Team,
-		},
+		}
+	} else {
+		obj.ProjectTeam = nil
 	}
+
+	return obj
 }
 
 func ObjectAttrsToBucketObject(attrs *storage.ObjectAttrs) *gcs.Object {

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -37,8 +37,6 @@ func convertObjectAccessControlToACLRule(obj *storagev1.ObjectAccessControl) sto
 			ProjectNumber: obj.ProjectTeam.ProjectNumber,
 			Team:          obj.ProjectTeam.Team,
 		}
-	} else {
-		aclObj.ProjectTeam = nil
 	}
 
 	return aclObj
@@ -58,8 +56,6 @@ func convertACLRuleToObjectAccessControl(element storage.ACLRule) *storagev1.Obj
 			ProjectNumber: element.ProjectTeam.ProjectNumber,
 			Team:          element.ProjectTeam.Team,
 		}
-	} else {
-		obj.ProjectTeam = nil
 	}
 
 	return obj

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -60,6 +60,16 @@ func (t objectAttrsTest) TestConvertACLRuleToObjectAccessControlMethod() {
 	ExpectEq(objectAccessControl.ProjectTeam.Team, attrs.ProjectTeam.Team)
 }
 
+func (t objectAttrsTest) TestConvertACLRuleToObjectAccessControlMethodWhenProjectTeamEqualsNil() {
+	var attrs = storage.ACLRule{
+		ProjectTeam: nil,
+	}
+
+	objectAccessControl := convertACLRuleToObjectAccessControl(attrs)
+
+	ExpectEq(nil, objectAccessControl.ProjectTeam)
+}
+
 func (t objectAttrsTest) TestObjectAttrsToBucketObjectMethod() {
 	var attrMd5 []byte
 	timeAttr := time.Now()
@@ -153,6 +163,16 @@ func (t objectAttrsTest) TestConvertObjectAccessControlToACLRuleMethod() {
 	ExpectEq(aclRule.Email, objectAccessControl.Email)
 	ExpectEq(aclRule.ProjectTeam.ProjectNumber, objectAccessControl.ProjectTeam.ProjectNumber)
 	ExpectEq(aclRule.ProjectTeam.Team, objectAccessControl.ProjectTeam.Team)
+}
+
+func (t objectAttrsTest) TestConvertObjectAccessControlToACLRuleMethodWhenProjectTeamEqualsNil() {
+	objectAccessControl := &storagev1.ObjectAccessControl{
+		ProjectTeam: nil,
+	}
+
+	aclRule := convertObjectAccessControlToACLRule(objectAccessControl)
+
+	ExpectEq(nil, aclRule.ProjectTeam)
 }
 
 func (t objectAttrsTest) TestSetAttrsInWriterMethod() {


### PR DESCRIPTION
### Description
Throwing nil pointer exception when the project team was nil. 
### Testing
- Manual
     - Did sanity check(list, create, copy, delete operations)
     - Project team is nil(in User), it will set Project Team nil in Object (see Unit test)
     - If Access = Uniform: No object-level ACLs enabled - ACL=nil 
     - If Access = Fine-grained: Object-level ACLs enabled - It has 4 ACLs (3 Project Related and 1 User) - for the first three project team will not equal to nil so that It will set, and for the fourth(User) ProjectTeam will be nil so It will set nil.
- Unit-test -
     - Created unit test when the project team was nil
- Integration-test - N/A
