### PR TITLE
Making createObject idempotent

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1582,7 +1582,7 @@ func (fs *fileSystem) renameDir(
 	newParent.Unlock()
 	if err != nil {
 		var preconditionErr *gcs.PreconditionError
-		if errors.As(err, &preconditionErr) && strings.Contains(preconditionErr.Error(), "object exists") {
+		if errors.As(err, &preconditionErr) {
 			// This means the new directory already exists, which is OK if
 			// it is empty (checked below).
 		} else {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -375,8 +375,5 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 }
 
 func isStorageConditionsNotEmpty(conditions storage.Conditions) bool {
-	if conditions != (storage.Conditions{}) {
-		return true
-	}
-	return false
+	return conditions != (storage.Conditions{})
 }

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -112,12 +112,24 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// MetaGenerationPrecondition - If non-nil, the object will be created/overwritten
 	// only if the current metaGeneration for the object name is equal to the given value.
 	// Zero means the object does not exist.
-	if req.GenerationPrecondition != nil && *req.GenerationPrecondition != 0 && req.MetaGenerationPrecondition != nil && *req.MetaGenerationPrecondition != 0 {
-		obj = obj.If(storage.Conditions{GenerationMatch: *req.GenerationPrecondition, MetagenerationMatch: *req.MetaGenerationPrecondition})
-	} else if req.GenerationPrecondition != nil && *req.GenerationPrecondition != 0 {
-		obj = obj.If(storage.Conditions{GenerationMatch: *req.GenerationPrecondition})
-	} else if req.MetaGenerationPrecondition != nil && *req.MetaGenerationPrecondition != 0 {
-		obj = obj.If(storage.Conditions{MetagenerationMatch: *req.MetaGenerationPrecondition})
+	preconditions := storage.Conditions{}
+
+	if req.GenerationPrecondition != nil {
+		if *req.GenerationPrecondition == 0 {
+			preconditions.DoesNotExist = true
+		} else {
+			preconditions.GenerationMatch = *req.GenerationPrecondition
+		}
+	}
+
+	if req.MetaGenerationPrecondition != nil && *req.MetaGenerationPrecondition != 0 {
+		preconditions.MetagenerationMatch = *req.MetaGenerationPrecondition
+	}
+
+	// Setting up the conditions on the object if it's not empty i.e, atleast
+	// if one of the condition is set.
+	if isStorageConditionsNotEmpty(preconditions) {
+		obj = obj.If(preconditions)
 	}
 
 	// Creating a NewWriter with requested attributes, using Go Storage Client.
@@ -360,4 +372,11 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 	o = storageutil.ObjectAttrsToBucketObject(attrs)
 
 	return
+}
+
+func isStorageConditionsNotEmpty(conditions storage.Conditions) bool {
+	if conditions != (storage.Conditions{}) {
+		return true
+	}
+	return false
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -265,6 +265,47 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithValidObject() {
 	AssertEq(nil, err)
 }
 
+func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZero() {
+	content := "Creating a new object"
+	var generation int64 = 0
+	obj, err := t.bucketHandle.CreateObject(context.Background(),
+		&gcs.CreateObjectRequest{
+			Name:                   "test_object",
+			Contents:               strings.NewReader(content),
+			GenerationPrecondition: &generation,
+		})
+
+	AssertEq(obj.Name, "test_object")
+	AssertEq(obj.Size, len(content))
+	AssertEq(nil, err)
+}
+
+func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZeroWhenObjectAlreadyExists() {
+	content := "Creating a new object"
+	var generation int64 = 0
+	var precondition *gcs.PreconditionError
+	obj, err := t.bucketHandle.CreateObject(context.Background(),
+		&gcs.CreateObjectRequest{
+			Name:                   "test_object",
+			Contents:               strings.NewReader(content),
+			GenerationPrecondition: &generation,
+		})
+
+	AssertEq(obj.Name, "test_object")
+	AssertEq(obj.Size, len(content))
+	AssertEq(nil, err)
+
+	obj, err = t.bucketHandle.CreateObject(context.Background(),
+		&gcs.CreateObjectRequest{
+			Name:                   "test_object",
+			Contents:               strings.NewReader(content),
+			GenerationPrecondition: &generation,
+		})
+
+	AssertEq(nil, obj)
+	AssertTrue(errors.As(err, &precondition))
+}
+
 func (t *BucketHandleTest) TestCreateObjectMethodWhenGivenGenerationObjectNotExist() {
 	var precondition *gcs.PreconditionError
 	content := "Creating a new object"
@@ -766,4 +807,25 @@ func (t *BucketHandleTest) TestNameMethod() {
 	name := t.bucketHandle.Name()
 
 	AssertEq(TestBucketName, name)
+}
+
+func (t *BucketHandleTest) TestIsStorageConditionsNotEmptyWithEmptyConditions() {
+	AssertFalse(isStorageConditionsNotEmpty(storage.Conditions{}))
+}
+
+func (t *BucketHandleTest) TestIsStorageConditionsNotEmptyWithNonEmptyConditions() {
+	// GenerationMatch is set.
+	AssertTrue(isStorageConditionsNotEmpty(storage.Conditions{GenerationMatch: 123}))
+
+	// GenerationNotMatch is set.
+	AssertTrue(isStorageConditionsNotEmpty(storage.Conditions{GenerationNotMatch: 123}))
+
+	// MetagenerationMatch is set.
+	AssertTrue(isStorageConditionsNotEmpty(storage.Conditions{MetagenerationMatch: 123}))
+
+	// MetagenerationNotMatch is set.
+	AssertTrue(isStorageConditionsNotEmpty(storage.Conditions{MetagenerationNotMatch: 123}))
+
+	// DoesNotExist is set.
+	AssertTrue(isStorageConditionsNotEmpty(storage.Conditions{DoesNotExist: true}))
 }


### PR DESCRIPTION
1. Rightnow CreateObject is not idempotent because when generation is zero in the request, generation is not set in the call to GCS. To make it idempotent, we need to set storage.conditions.DoesNotExist = true when generation is zero.
Generation is zero means create the object only when object doesn't exist.
2. In the rename flow, when the destination directory already exists, precondition error is ignored. But rightn ow it also checks if the error has string **object exists** which is not returned by gcs. Hence removing it.

Testing:
Unit Tests: Added
Integration Tests: N/A
Manual Testing: Done for all scenarios where CreateObject is called using linux commands. Retry is simulated by calling CreateObject twice. Also added some custom log statements to log what is happening - whether the call is successful or failed

- CreateFile/MkNode method -> These are used to create a file if the file doesn't exist. Working as intended. If the file already exists, getting preconditions not met error.
- CreateSymlink -> Same as createFile. Failed if the object already exists. Passed otherwise
- MkDir -> Failed if the directory already exists. Passed otherwise
- RenameDir -> Checks if the destination directory already exists. If the directory already exists, it will ignore the error and move on. Verified for both destination directory exists and not exists.
- FullObjectCreator -> Used to overwrite the entire object when an edit is done. Validates if the generation matches. Verified that its returning success when generation matches and precondition failure when generation does not match. Overall edit will succeed since precondition error is ignored.
- AppendObjectCreator -> In the append flow, creates a temp object with the appended content with generation zero. Validated when object exists and not exists. Overall edit will succeed since precondition error is ignored.
