### PR TITLE
Compose object idempotency when dst object doesn't exist.

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -350,8 +350,8 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 	// Only set conditions on dstObj if there is at least one condition in
 	// dstObjConds. Otherwise, storage client library gives empty conditions error.
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1739
-	// Note: Requests are not idempotent in this case and only idempotent if
-	// GenerationMatch or DoesNotExist is set.
+	// Note: Requests are not idempotent when conditions are empty and only
+	// idempotent if GenerationMatch or DoesNotExist is set.
 	if dstObjConds != (storage.Conditions{}) {
 		dstObj = dstObj.If(dstObjConds)
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -338,8 +338,6 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 	// DstGenerationPrecondition or DoesNotExist should be set in dstObj
 	// preconditions to make requests Idempotent.
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/copy.go#L230
-	// When DstGenerationPrecondition is 0, set DoesNotExist as true.
-	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1710
 	if req.DstGenerationPrecondition != nil {
 		if *req.DstGenerationPrecondition == 0 {
 			dstObjConds.DoesNotExist = true
@@ -350,8 +348,6 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 	// Only set conditions on dstObj if there is at least one condition in
 	// dstObjConds. Otherwise, storage client library gives empty conditions error.
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1739
-	// Note: Requests are not idempotent when conditions are empty and only
-	// idempotent if GenerationMatch or DoesNotExist is set.
 	if dstObjConds != (storage.Conditions{}) {
 		dstObj = dstObj.If(dstObjConds)
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -348,7 +348,7 @@ func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjec
 	// Only set conditions on dstObj if there is at least one condition in
 	// dstObjConds. Otherwise, storage client library gives empty conditions error.
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1739
-	if dstObjConds != (storage.Conditions{}) {
+	if isStorageConditionsNotEmpty(dstObjConds) {
 		dstObj = dstObj.If(dstObjConds)
 	}
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -331,12 +331,29 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 func (b *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
 	dstObj := b.bucket.Object(req.DstName)
 
-	if req.DstGenerationPrecondition != nil && req.DstMetaGenerationPrecondition != nil {
-		dstObj = dstObj.If(storage.Conditions{GenerationMatch: *req.DstGenerationPrecondition, MetagenerationMatch: *req.DstMetaGenerationPrecondition})
-	} else if req.DstGenerationPrecondition != nil {
-		dstObj = dstObj.If(storage.Conditions{GenerationMatch: *req.DstGenerationPrecondition})
-	} else if req.DstMetaGenerationPrecondition != nil {
-		dstObj = dstObj.If(storage.Conditions{MetagenerationMatch: *req.DstMetaGenerationPrecondition})
+	dstObjConds := storage.Conditions{}
+	if req.DstMetaGenerationPrecondition != nil {
+		dstObjConds.MetagenerationMatch = *req.DstMetaGenerationPrecondition
+	}
+	// DstGenerationPrecondition or DoesNotExist should be set in dstObj
+	// preconditions to make requests Idempotent.
+	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/copy.go#L230
+	// When DstGenerationPrecondition is 0, set DoesNotExist as true.
+	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1710
+	if req.DstGenerationPrecondition != nil {
+		if *req.DstGenerationPrecondition == 0 {
+			dstObjConds.DoesNotExist = true
+		} else {
+			dstObjConds.GenerationMatch = *req.DstGenerationPrecondition
+		}
+	}
+	// Only set conditions on dstObj if there is at least one condition in
+	// dstObjConds. Otherwise, storage client library gives empty conditions error.
+	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/7ad451c6f2ead7992e030503e5b66c555b2ebf71/vendor/cloud.google.com/go/storage/storage.go#L1739
+	// Note: Requests are not idempotent in this case and only idempotent if
+	// GenerationMatch or DoesNotExist is set.
+	if dstObjConds != (storage.Conditions{}) {
+		dstObj = dstObj.If(dstObjConds)
 	}
 
 	// Converting the req.Sources list to a list of storage.ObjectHandle as expected by the Go Storage Client.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -879,8 +879,8 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 			StorageClass:       StorageClass,
 			Acl:                nil,
 		})
-
 	AssertEq(nil, err)
+
 	// Validation of srcObject1 to ensure that it is not effected.
 	srcBuffer1 := t.readObjectContent(context.Background(),
 		&gcs.ReadObjectRequest{
@@ -890,6 +890,8 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 				Limit: uint64(len(ContentInTestObject)),
 			},
 		})
+	ExpectEq(ContentInTestObject, srcBuffer1)
+
 	// Validation of srcObject2 to ensure that it is not effected.
 	srcBuffer2 := t.readObjectContent(context.Background(),
 		&gcs.ReadObjectRequest{
@@ -899,6 +901,8 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 				Limit: uint64(len(ContentInTestSubObject)),
 			},
 		})
+	ExpectEq(ContentInTestSubObject, srcBuffer2)
+
 	// Reading content of dstObject
 	dstBuffer := t.readObjectContent(context.Background(),
 		&gcs.ReadObjectRequest{

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -849,9 +849,9 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 	AssertNe(nil, srcObj2)
 
 	// Add DstGenerationPrecondition = 0 as the Destination object doesn't exist.
-	// Note: fakestorage doesn't respect precondition checks but still adding to
-	// make sure that it works when precondition checks are supported or we shift
-	// to different testing storage.
+	// Note: fake-gcs-server doesn't respect precondition checks but still adding
+	// to make sure that it works when precondition checks are supported or we
+	// shift to different testing storage.
 	var zeroPreCond int64 = 0
 	composedObj, err := t.bucketHandle.ComposeObjects(context.Background(),
 		&gcs.ComposeObjectsRequest{
@@ -953,9 +953,9 @@ func (t *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstObject() 
 		})
 	ExpectEq(ContentInTestSubObject, srcObj2Buffer)
 
-	// Note: fakestorage doesn't respect precondition checks but still adding to
-	// make sure that it works when precondition checks are supported or we shift
-	// to different testing storage.
+	// Note: fake-gcs-server doesn't respect precondition checks but still adding
+	// to make sure that it works when precondition checks are supported or we
+	// shift to different testing storage.
 	var preCond int64 = srcObj1.Generation
 	// Compose srcObj1 and srcObj2 back into srcObj1
 	composedObj, err := t.bucketHandle.ComposeObjects(context.Background(),


### PR DESCRIPTION
Description: Make ComposeObject method (when storage client library is enabled) idempotent when destination object doesn't exist. Currently, ComposeObject is called at the time of appending to file where dstObj = original object & srcObjects = [original object, temp object]. Hence, ComposeObject is always called with some GenerationPrecondition set. With these changes, ComposeObject will make idempotent requests even when dstObject doesn't exist and caller of ComposeObject sets 0 as GenerationPrecondition.

Testing:
Manual: 
1. Tried appending to a file of size 2mb and checked the debug_gcs logs. ComposeObject requests were successful.
2. Tried simulating retry of requests in 1# case by duplicating [this statement](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/cloud.google.com/go/storage/http_client.go#L711).
    - Application program doesn't fail.
    - GCS returns 404 error (StatusNotFound). This happens because one of the src object is dst obj also. So, in the duplicate request, src object is not found because it was changed in first request.

Unit tests:
1. Ran all the unit tests present in GCSFuse.
2. Added two unit tests for ComposeObject:
    - When destination object doesn't exist with 0 GenerationPrecondition (Note: fake-gcs-server doesn't respect the precondition checks).
    - When destination object is one of the source object. (which is close to what happens at the time of appending to file).

Integration tests:
1. Ran integration tests in tools/integration_tests/implicit-dirs