### PR TITLE
Correcting the flag used in PR_PERF_TEST script

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -21,7 +21,7 @@ sudo apt-get install fio -y
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo Mounting gcs bucket for master branch
 mkdir -p gcs
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --experimental-enable-storage-client-library=true"
+GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
 BUCKET_NAME=presubmit-perf-test
 MOUNT_POINT=gcs
 # The VM will itself exit if the gcsfuse mount fails.


### PR DESCRIPTION
### Description
Since we have renamed the flag from --experimental-enable-storage-client-library=true to "enable-storage-client-library" and by default it's true. Hence, removing this flag while mounting gcsfuse in the script.

### Testing
(1) Manual - NA
(2) Integration Test - NA
(3) Performance Test - NA