### PR TITLE
Adding fsync=1 in performance test fio-job

### DIFF
--- a/perfmetrics/scripts/job_files/presubmit_perf_test.fio
+++ b/perfmetrics/scripts/job_files/presubmit_perf_test.fio
@@ -13,6 +13,7 @@ time_based=1
 nrfiles=1
 thread=1
 openfiles=1
+fsync=1
 group_reporting=1
 allrandrepeat=1
 filename_format=$jobname.$jobnum.$filenum


### PR DESCRIPTION
### Description
Run the perf_test script manually on the system. I have observed much fluctuation in perf_number of master branch vs current branch. Not sure, why exactly. 

Adding the fsync = 1 in the perf_fio_job so that we start comparing more realistic numbers.

### Testing
Manual - NA
Integration - NA
Performance - NA