### PR TITLE
Fix list in garbage collection

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -221,8 +221,11 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 	// Iterating through all the objects in the bucket and one by one adding them to the list.
 	for {
 		var attrs *storage.ObjectAttrs
-		// itr.next returns all the objects present in the bucket. Hence adding a check to break after required number of objects are returned.
-		if len(list.Objects) == req.MaxResults {
+		// itr.next returns all the objects present in the bucket. Hence adding a
+		// check to break after required number of objects are returned.
+		// If req.MaxResults is 0, then wait till iterator is done. This is similar
+		// to https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/bucket.go#L164
+		if req.MaxResults != 0 && (len(list.Objects) == req.MaxResults) {
 			break
 		}
 		attrs, err = itr.Next()

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -417,19 +417,30 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
-	// We have 4 objects in the fakestorage.
-	fourObjWithoutMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
+	// Validate that ee have 4 objects in fakeserver
+	fourObjWithMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "",
 			Delimiter:                "",
 			IncludeTrailingDelimiter: true,
 			ContinuationToken:        "",
-			//MaxResults:               2, // Missing MaxResults
-			ProjectionVal: 0,
+			MaxResults:               100,
+			ProjectionVal:            0,
+		})
+	AssertEq(nil, err)
+	AssertEq(4, len(fourObjWithMaxResults.Objects))
+
+	fourObjWithoutMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			ProjectionVal:            0,
 		})
 
 	// Validate that all objects (4) are listed when MaxResults is not passed.
-	AssertEq(nil, err)
+	AssertEq(nil, err2)
 	AssertEq(4, len(fourObjWithoutMaxResults.Objects))
 	AssertEq(TestObjectRootFolderName, fourObjWithoutMaxResults.Objects[0].Name)
 	AssertEq(TestObjectSubRootFolderName, fourObjWithoutMaxResults.Objects[1].Name)
@@ -439,8 +450,20 @@ func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithZeroMaxResult() {
-	// We have 4 objects in fakeserver.
-	fourObjWithZeroMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
+	// Validate that ee have 4 objects in fakeserver
+	fourObj, err := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			MaxResults:               100,
+			ProjectionVal:            0,
+		})
+	AssertEq(nil, err)
+	AssertEq(4, len(fourObj.Objects))
+
+	fourObjWithZeroMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "",
 			Delimiter:                "",
@@ -452,7 +475,7 @@ func (t *BucketHandleTest) TestListObjectMethodWithZeroMaxResult() {
 
 	// Validate that all objects (4) are listed when MaxResults is 0. This has
 	// same behavior as not passing MaxResults in request.
-	AssertEq(nil, err)
+	AssertEq(nil, err2)
 	AssertEq(4, len(fourObjWithZeroMaxResults.Objects))
 	AssertEq(TestObjectRootFolderName, fourObjWithZeroMaxResults.Objects[0].Name)
 	AssertEq(TestObjectSubRootFolderName, fourObjWithZeroMaxResults.Objects[1].Name)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -417,18 +417,8 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
-	// We have 4 objects in fakeserver.
-	fourObjWithMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
-		&gcs.ListObjectsRequest{
-			Prefix:                   "",
-			Delimiter:                "",
-			IncludeTrailingDelimiter: true,
-			ContinuationToken:        "",
-			MaxResults:               100,
-			ProjectionVal:            0,
-		})
-
-	fourObjWithoutMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
+	// We have 4 objects in the fakestorage.
+	fourObjWithoutMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "",
 			Delimiter:                "",
@@ -438,18 +428,8 @@ func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
 			ProjectionVal: 0,
 		})
 
-	// Validate that 4 objects are listed when MaxResults = 100, because there
-	// are total of 4 objects in fakebucket.
-	AssertEq(nil, err)
-	AssertEq(4, len(fourObjWithMaxResults.Objects))
-	AssertEq(TestObjectRootFolderName, fourObjWithMaxResults.Objects[0].Name)
-	AssertEq(TestObjectSubRootFolderName, fourObjWithMaxResults.Objects[1].Name)
-	AssertEq(TestSubObjectName, fourObjWithMaxResults.Objects[2].Name)
-	AssertEq(TestObjectName, fourObjWithMaxResults.Objects[3].Name)
-	AssertEq(nil, fourObjWithMaxResults.CollapsedRuns)
-
 	// Validate that all objects (4) are listed when MaxResults is not passed.
-	AssertEq(nil, err2)
+	AssertEq(nil, err)
 	AssertEq(4, len(fourObjWithoutMaxResults.Objects))
 	AssertEq(TestObjectRootFolderName, fourObjWithoutMaxResults.Objects[0].Name)
 	AssertEq(TestObjectSubRootFolderName, fourObjWithoutMaxResults.Objects[1].Name)
@@ -460,17 +440,7 @@ func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
 
 func (t *BucketHandleTest) TestListObjectMethodWithZeroMaxResult() {
 	// We have 4 objects in fakeserver.
-	fourObj, err := t.bucketHandle.ListObjects(context.Background(),
-		&gcs.ListObjectsRequest{
-			Prefix:                   "",
-			Delimiter:                "",
-			IncludeTrailingDelimiter: true,
-			ContinuationToken:        "",
-			MaxResults:               100,
-			ProjectionVal:            0,
-		})
-
-	fourObjWithZeroMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
+	fourObjWithZeroMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "",
 			Delimiter:                "",
@@ -480,19 +450,9 @@ func (t *BucketHandleTest) TestListObjectMethodWithZeroMaxResult() {
 			ProjectionVal:            0,
 		})
 
-	// Validate that 4 objects are listed when MaxResults = 100, because there
-	// are total of 4 objects in fakebucket.
-	AssertEq(nil, err)
-	AssertEq(4, len(fourObj.Objects))
-	AssertEq(TestObjectRootFolderName, fourObj.Objects[0].Name)
-	AssertEq(TestObjectSubRootFolderName, fourObj.Objects[1].Name)
-	AssertEq(TestSubObjectName, fourObj.Objects[2].Name)
-	AssertEq(TestObjectName, fourObj.Objects[3].Name)
-	AssertEq(nil, fourObj.CollapsedRuns)
-
 	// Validate that all objects (4) are listed when MaxResults is 0. This has
 	// same behavior as not passing MaxResults in request.
-	AssertEq(nil, err2)
+	AssertEq(nil, err)
 	AssertEq(4, len(fourObjWithZeroMaxResults.Objects))
 	AssertEq(TestObjectRootFolderName, fourObjWithZeroMaxResults.Objects[0].Name)
 	AssertEq(TestObjectSubRootFolderName, fourObjWithZeroMaxResults.Objects[1].Name)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -399,6 +399,7 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 			ProjectionVal:            0,
 		})
 
+	// Validate that 4 objects are listed when MaxResults is passed 4.
 	AssertEq(nil, err)
 	AssertEq(4, len(fourObj.Objects))
 	AssertEq(TestObjectRootFolderName, fourObj.Objects[0].Name)
@@ -407,11 +408,97 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 	AssertEq(TestObjectName, fourObj.Objects[3].Name)
 	AssertEq(nil, fourObj.CollapsedRuns)
 
+	// Validate that 2 objects are listed when MaxResults is passed 2.
 	AssertEq(nil, err2)
 	AssertEq(2, len(twoObj.Objects))
 	AssertEq(TestObjectRootFolderName, twoObj.Objects[0].Name)
 	AssertEq(TestObjectSubRootFolderName, twoObj.Objects[1].Name)
 	AssertEq(nil, twoObj.CollapsedRuns)
+}
+
+func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {
+	// We have 4 objects in fakeserver.
+	fourObjWithMaxResults, err := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			MaxResults:               100,
+			ProjectionVal:            0,
+		})
+
+	fourObjWithoutMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			//MaxResults:               2, // Missing MaxResults
+			ProjectionVal: 0,
+		})
+
+	// Validate that 4 objects are listed when MaxResults = 100, because there
+	// are total of 4 objects in fakebucket.
+	AssertEq(nil, err)
+	AssertEq(4, len(fourObjWithMaxResults.Objects))
+	AssertEq(TestObjectRootFolderName, fourObjWithMaxResults.Objects[0].Name)
+	AssertEq(TestObjectSubRootFolderName, fourObjWithMaxResults.Objects[1].Name)
+	AssertEq(TestSubObjectName, fourObjWithMaxResults.Objects[2].Name)
+	AssertEq(TestObjectName, fourObjWithMaxResults.Objects[3].Name)
+	AssertEq(nil, fourObjWithMaxResults.CollapsedRuns)
+
+	// Validate that all objects (4) are listed when MaxResults is not passed.
+	AssertEq(nil, err2)
+	AssertEq(4, len(fourObjWithoutMaxResults.Objects))
+	AssertEq(TestObjectRootFolderName, fourObjWithoutMaxResults.Objects[0].Name)
+	AssertEq(TestObjectSubRootFolderName, fourObjWithoutMaxResults.Objects[1].Name)
+	AssertEq(TestSubObjectName, fourObjWithoutMaxResults.Objects[2].Name)
+	AssertEq(TestObjectName, fourObjWithoutMaxResults.Objects[3].Name)
+	AssertEq(nil, fourObjWithoutMaxResults.CollapsedRuns)
+}
+
+func (t *BucketHandleTest) TestListObjectMethodWithZeroMaxResult() {
+	// We have 4 objects in fakeserver.
+	fourObj, err := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			MaxResults:               100,
+			ProjectionVal:            0,
+		})
+
+	fourObjWithZeroMaxResults, err2 := t.bucketHandle.ListObjects(context.Background(),
+		&gcs.ListObjectsRequest{
+			Prefix:                   "",
+			Delimiter:                "",
+			IncludeTrailingDelimiter: true,
+			ContinuationToken:        "",
+			MaxResults:               0,
+			ProjectionVal:            0,
+		})
+
+	// Validate that 4 objects are listed when MaxResults = 100, because there
+	// are total of 4 objects in fakebucket.
+	AssertEq(nil, err)
+	AssertEq(4, len(fourObj.Objects))
+	AssertEq(TestObjectRootFolderName, fourObj.Objects[0].Name)
+	AssertEq(TestObjectSubRootFolderName, fourObj.Objects[1].Name)
+	AssertEq(TestSubObjectName, fourObj.Objects[2].Name)
+	AssertEq(TestObjectName, fourObj.Objects[3].Name)
+	AssertEq(nil, fourObj.CollapsedRuns)
+
+	// Validate that all objects (4) are listed when MaxResults is 0. This has
+	// same behavior as not passing MaxResults in request.
+	AssertEq(nil, err2)
+	AssertEq(4, len(fourObjWithZeroMaxResults.Objects))
+	AssertEq(TestObjectRootFolderName, fourObjWithZeroMaxResults.Objects[0].Name)
+	AssertEq(TestObjectSubRootFolderName, fourObjWithZeroMaxResults.Objects[1].Name)
+	AssertEq(TestSubObjectName, fourObjWithZeroMaxResults.Objects[2].Name)
+	AssertEq(TestObjectName, fourObjWithZeroMaxResults.Objects[3].Name)
+	AssertEq(nil, fourObjWithZeroMaxResults.CollapsedRuns)
 }
 
 // FakeGCSServer is not handling ContentType, ContentEncoding, ContentLanguage, CacheControl in updateflow


### PR DESCRIPTION
**Issue:** Before deleting the stale objects, garbage collector first list all the objects with configured prefix (.gcsfuse_temp/) and it is [not passing](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/gcsutil/list_prefix.go#L32) 'MaxResults' in [ListObjectsRequest](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/gcsx/garbage_collect.go#L41). And the ListObject method of Go storage client library [lists](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/storage/bucket_handle.go#L225) number of objects <= MaxResults which is 0 by default. So, no objects are listed.

**Fix** Modify the condition to list all objects when MaxResults is not passed (or when 0 is passed). This behaviour is similar to that in jacobsa/gcloud client librray (see [this condition](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/bucket.go#L164)). Note: This fix is in the ListObject method to return list objects when MaxResults is 0.

Testing
Manual:
1. Increased the garbage collection frequency to remove stale objects every 10 secs and created some objects manually that starts with configured prefix: It deleted the stale objects as expected.

Unit tests:
1. Added test cases for ListObject method in bucket_handle_test.go to test when MaxResults is missing or 0.
2. Ran all unit tests in gcsfuse.

Integration tests:
1. Ran integration tests present in tools/integration_tests/implicit-dirs


