### PR TITLE
Remove disable_http2 flag from mount command.

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -82,7 +82,6 @@ func makeGcsfuseArgs(
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs",
 			"foreground",
-			"disable_http2",
 			"experimental_local_file_cache",
 			"enable_storage_client_library",
 			"reuse_token_from_url",


### PR DESCRIPTION
This change should have been done as part of this change https://github.com/GoogleCloudPlatform/gcsfuse/pull/962 but was skipped mistakenly.

Testing:
Manual: NA
Unit Test: 
Ran all unit tests in gcsfuse.
Integration test: NA
