### PR TITLE
Changing log-level notice to info while mounting

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,8 +194,7 @@ func mountWithArgs(
 			conn, err = getConnWithRetry(flags)
 		}
 		if err != nil {
-			mountStatus.Printf("Failed to open connection: %v\n", err)
-			err = fmt.Errorf("getConnWithRetry: %w", err)
+			err = fmt.Errorf("failed to open connection - getConnWithRetry: %w", err)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -370,7 +370,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	// daemonize gives us and telling it about the outcome.
 	var mfs *fuse.MountedFileSystem
 	{
-		mountStatus := logger.NewNotice("")
+		mountStatus := logger.NewInfo("")
 		mfs, err = mountWithArgs(bucketName, mountPoint, flags, mountStatus)
 
 		if err == nil {

--- a/main.go
+++ b/main.go
@@ -376,6 +376,9 @@ func runCLIApp(c *cli.Context) (err error) {
 			mountStatus.Println("File system has been successfully mounted.")
 			daemonize.SignalOutcome(nil)
 		} else {
+			// Printing via mountStatus will have duplicate logs on the console while
+			// mounting gcsfuse in foreground mode. But this is important to avoid
+			// losing error logs when run in the background mode.
 			mountStatus.Printf("Error while mounting gcsfuse: %v\n", err)
 			err = fmt.Errorf("mountWithArgs: %w", err)
 			daemonize.SignalOutcome(err)

--- a/main.go
+++ b/main.go
@@ -376,6 +376,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			mountStatus.Println("File system has been successfully mounted.")
 			daemonize.SignalOutcome(nil)
 		} else {
+			mountStatus.Printf("Error while mounting gcsfuse: %v\n", err)
 			err = fmt.Errorf("mountWithArgs: %w", err)
 			daemonize.SignalOutcome(err)
 			return


### PR DESCRIPTION
### Description
Changing the log-level from NewNotice to NewInfo while mounting the gcsfuse.

NewNotice is used to write the mount status using daemonize.StatusWriter - useful in case we run the gcsfuse in background mode. 
But StatusWriter isinitialized with os.stderr hence all the information from the daemon process is written as stderr. 

Ideally, we should print the error only in case of error while mounting the gcsfuse.

```text
2023/03/14 12:58:20.430060 Value of [log-file] resolved from [gcsfuse.log] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.log]
2023/03/14 12:58:20.430140 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
2023/03/14 12:58:20.454958 Value of [log-file] resolved from [gcsfuse.log] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.log]
```

The above logs get printed every time because of default logger - initialized with std::out and it runs inside main process.

### Existing Behavior vs New Behavior
1. One log-entry will be added to the log-file in case of error. Other than that, there will not be any change in the logging behavior when log-file is specified.
2. When log-file is not specified:
(a) In foreground mode - In case of error while mounting - we get the error log twice on the console.
(b) In background mode - all the mount-status info logs will go to syslog if configured otherwise lost. Also, in case of error while mounting one extra log-entry of error log will be added to syslog file.

There will not be any impact on error logs while mounting.


### Logs with the new change
#### Failure case:
1. In foreground mode without log-file
```text
Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
Opening GCS connection...
Creating a mount at "/usr/local/google/home/princer/Downloads/mnt"
Creating a new server...
Set up root directory for bucket princer-working-dirs
gcs: Req              0x0: <- ListObjects("")
gcs: Req              0x0: -> ListObjects("") (1.232616148s): OK
Mounting file system "princer-working-dirs"...
/usr/bin/fusermount3: failed to access mountpoint /usr/local/google/home/princer/Downloads/mnt: Permission denied
Error while mounting gcsfuse: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1
mountWithArgs: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1
```

2. In foreground mode without log-file
```text
console: 
2023/03/14 16:27:12.544602 Value of [log-file] resolved from [gcsfuse.logs] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.logs]
/usr/bin/fusermount3: failed to access mountpoint /usr/local/google/home/princer/Downloads/mnt: Permission denied
mountWithArgs: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1


File:
I0314 16:27:12.544824 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
I0314 16:27:12.544924 Opening GCS connection...
I0314 16:27:12.545847 Creating a mount at "/usr/local/google/home/princer/Downloads/mnt"
I0314 16:27:12.547002 Creating a new server...
I0314 16:27:12.547063 Set up root directory for bucket princer-working-dirs
D0314 16:27:12.547113 gcs: Req              0x0: <- ListObjects("")
D0314 16:27:13.811478 gcs: Req              0x0: -> ListObjects("") (1.264322121s): OK
I0314 16:27:13.811606 Mounting file system "princer-working-dirs"...
I0314 16:27:13.815992 Error while mounting gcsfuse: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1
```

3. In background with log-file
```text
console:
2023/03/14 16:28:16.639506 Value of [log-file] resolved from [gcsfuse.logs] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.logs]
2023/03/14 16:28:16.639606 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1

logfile:
I0314 16:28:16.661399 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
I0314 16:28:16.661453 Opening GCS connection...
I0314 16:28:16.661883 Creating a mount at "/usr/local/google/home/princer/Downloads/mnt"
I0314 16:28:16.662604 Creating a new server...
I0314 16:28:16.662639 Set up root directory for bucket princer-working-dirs
D0314 16:28:16.662672 gcs: Req              0x0: <- ListObjects("")
D0314 16:28:17.858348 gcs: Req              0x0: -> ListObjects("") (1.19566018s): OK
I0314 16:28:17.858483 Mounting file system "princer-working-dirs"...
I0314 16:28:17.862571 Error while mounting gcsfuse: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1

```
4. In background mode without log-file
```
console:
2023/03/14 16:30:20.750795 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1

syslog-file:
2023-03-14T16:33:45.591993+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app \"\" using mount point: /usr/local/google/home/princer/Downloads/mnt\n","timestampSeconds":1678791825,"timestampNanos":591203874}
2023-03-14T16:33:45.592311+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Opening GCS connection...\n","timestampSeconds":1678791825,"timestampNanos":591341072}
2023-03-14T16:33:45.592458+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a mount at \"/usr/local/google/home/princer/Downloads/mnt\"\n","timestampSeconds":1678791825,"timestampNanos":591802233}
2023-03-14T16:33:45.592688+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a new server...\n","timestampSeconds":1678791825,"timestampNanos":592608659}
2023-03-14T16:33:45.592814+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Set up root directory for bucket princer-working-dirs\n","timestampSeconds":1678791825,"timestampNanos":592668657}
2023-03-14T16:33:45.592976+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: \u003c- ListObjects(\"\")\n","timestampSeconds":1678791825,"timestampNanos":592703226}
2023-03-14T16:33:46.359203+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: -\u003e ListObjects(\"\") (766.277304ms): OK\n","timestampSeconds":1678791826,"timestampNanos":358996179}
2023-03-14T16:33:46.359587+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Mounting file system \"princer-working-dirs\"...\n","timestampSeconds":1678791826,"timestampNanos":359097667}
2023-03-14T16:33:46.363256+05:30 33princer.hyd.corp.google.com gcsfuse[3763313]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Error while mounting gcsfuse: mountWithConn: Mount: mount: running /usr/bin/fusermount3: exit status 1\n","timestampSeconds":1678791826,"timestampNanos":363123341}
```

#### Success case:
1. In foreground mode without log-file
```text
Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt
Opening GCS connection...
Creating a mount at "/usr/local/google/home/princer/Downloads/mnt"
Creating a new server...
Set up root directory for bucket princer-working-dirs
gcs: Req              0x0: <- ListObjects("")
gcs: Req              0x0: -> ListObjects("") (1.408207472s): OK
Mounting file system "princer-working-dirs"...
File system has been successfully mounted.
gcs: Req              0x2: <- StatObject(".Trash")
```

2. In foreground mode with log-file
```text
console: 2023/03/14 16:37:39.161305 Value of [log-file] resolved from [gcsfuse.log] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.log]

file:

{"name":"root","levelname":"INFO","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app \"\" using mount point: /usr/local/google/home/princer/Downloads/mnt\n","timestampSeconds":1678792059,"timestampNanos":161557682}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Opening GCS connection...\n","timestampSeconds":1678792059,"timestampNanos":161666346}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a mount at \"/usr/local/google/home/princer/Downloads/mnt\"\n","timestampSeconds":1678792059,"timestampNanos":162382999}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a new server...\n","timestampSeconds":1678792059,"timestampNanos":163529466}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Set up root directory for bucket princer-working-dirs\n","timestampSeconds":1678792059,"timestampNanos":163575024}
{"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: \u003c- ListObjects(\"\")\n","timestampSeconds":1678792059,"timestampNanos":163604254}
{"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: -\u003e ListObjects(\"\") (655.566624ms): OK\n","timestampSeconds":1678792059,"timestampNanos":819185303}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Mounting file system \"princer-working-dirs\"...\n","timestampSeconds":1678792059,"timestampNanos":819330790}
{"name":"root","levelname":"INFO","severity":"INFO","message":"File system has been successfully mounted.\n","timestampSeconds":1678792059,"timestampNanos":824592874}
{"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x1: \u003c- StatObject(\".Trash\")\n","timestampSeconds":1678792059,"timestampNanos":829114420}
```

3. In background with log-file
```text
console:
2023/03/14 16:39:56.285095 Value of [log-file] resolved from [gcsfuse.log] to [/usr/local/google/home/princer/Documents/code/gcsfuse_release/gcsfuse/gcsfuse.log]
2023/03/14 16:39:56.285163 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt

file:
{"name":"root","levelname":"INFO","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app \"\" using mount point: /usr/local/google/home/princer/Downloads/mnt\n","timestampSeconds":1678792059,"timestampNanos":161557682}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Opening GCS connection...\n","timestampSeconds":1678792059,"timestampNanos":161666346}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a mount at \"/usr/local/google/home/princer/Downloads/mnt\"\n","timestampSeconds":1678792059,"timestampNanos":162382999}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a new server...\n","timestampSeconds":1678792059,"timestampNanos":163529466}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Set up root directory for bucket princer-working-dirs\n","timestampSeconds":1678792059,"timestampNanos":163575024}
{"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: \u003c- ListObjects(\"\")\n","timestampSeconds":1678792059,"timestampNanos":163604254}
{"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: -\u003e ListObjects(\"\") (655.566624ms): OK\n","timestampSeconds":1678792059,"timestampNanos":819185303}
{"name":"root","levelname":"INFO","severity":"INFO","message":"Mounting file system \"princer-working-dirs\"...\n","timestampSeconds":1678792059,"timestampNanos":819330790}
{"name":"root","levelname":"INFO","severity":"INFO","message":"File system has been successfully mounted.\n","timestampSeconds":1678792059,"timestampNanos":824592874}
```

4. In background mode without log-file
```text
console:
2023/03/14 16:41:16.919020 Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app "" using mount point: /usr/local/google/home/princer/Downloads/mnt

file:
2023-03-14T16:41:16.939235+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.20-20221229-RC00 cl/498461153 +db36eca33c) for app \"\" using mount point: /usr/local/google/home/princer/Downloads/mnt\n","timestampSeconds":1678792276,"timestampNanos":938408271}
2023-03-14T16:41:16.939692+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Opening GCS connection...\n","timestampSeconds":1678792276,"timestampNanos":938533134}
2023-03-14T16:41:16.940547+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a mount at \"/usr/local/google/home/princer/Downloads/mnt\"\n","timestampSeconds":1678792276,"timestampNanos":939013754}
2023-03-14T16:41:16.940770+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Creating a new server...\n","timestampSeconds":1678792276,"timestampNanos":939761926}
2023-03-14T16:41:16.940965+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Set up root directory for bucket princer-working-dirs\n","timestampSeconds":1678792276,"timestampNanos":939803655}
2023-03-14T16:41:16.941128+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: \u003c- ListObjects(\"\")\n","timestampSeconds":1678792276,"timestampNanos":939826659}
2023-03-14T16:41:18.436215+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"DEBUG","severity":"DEBUG","message":"gcs: Req              0x0: -\u003e ListObjects(\"\") (1.49546617s): OK\n","timestampSeconds":1678792278,"timestampNanos":435313608}
2023-03-14T16:41:18.437256+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"Mounting file system \"princer-working-dirs\"...\n","timestampSeconds":1678792278,"timestampNanos":435441755}
2023-03-14T16:41:18.442546+05:30 33princer.hyd.corp.google.com gcsfuse[3766260]: {"name":"root","levelname":"INFO","severity":"INFO","message":"File system has been successfully mounted.\n","timestampSeconds":1678792278,"timestampNanos":442358394}
```





### Test
#### Manually:
1. When custom file is passed - all the mounting related status is written to provided log-file, only error part is printed to console.

6. When custom file is not passed:
    (a) In background mode: all the mounting related status is written to syslog (/var/log/gcsfuse.log), only error part is printed to console.
    (b) In foreground mode: all the mounting related status is written to console including the error message if it comes.


#### Integration Test - Automation
#### Unit Test - Automation

