### PR TITLE
Kokoro automation - Log rotation using logrotate

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
@@ -22,6 +22,7 @@ sudo docker run --runtime=nvidia --name=pytorch_automation_container --privilege
 echo "Creating logrotate configuration..."
 cat << EOF | tee ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log {
+  su root adm
   rotate 10
   size 5G
   missingok
@@ -32,6 +33,9 @@ ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log {
   copytruncate
 }
 EOF
+
+# Set the correct access permission to the config file.
+chmod 0644 ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 
 # Make sure logrotate installed on the system.
 if test -x /usr/sbin/logrotate ; then

--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
@@ -36,6 +36,7 @@ EOF
 
 # Set the correct access permission to the config file.
 chmod 0644 ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
+chown root ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 
 # Make sure logrotate installed on the system.
 if test -x /usr/sbin/logrotate ; then

--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
@@ -13,15 +13,15 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo "Building docker image containing all pytorch libraries..."
 sudo docker build . -f perfmetrics/scripts/ml_tests/pytorch/dino/Dockerfile --tag pytorch-gcsfuse
 
-mkdir container_artifacts
+mkdir -p container_artifacts
 
 echo "Running the docker image build in the previous step..."
 sudo docker run --runtime=nvidia --name=pytorch_automation_container --privileged -d -v ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts:/pytorch_dino/run_artifacts:rw,rshared \
 --shm-size=128g pytorch-gcsfuse:latest
 
 # Setup the log_rotation.
-chmod +x ./ml_tests/setup_log_rotation.sh
-sudo ./ml_tests/setup_log_rotation.sh ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log
+chmod +x ./perfmetrics/scripts/ml_tests/setup_log_rotation.sh
+sudo ./perfmetrics/scripts/ml_tests/setup_log_rotation.sh ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log
 
 # Wait for the script completion as well as logs output.
 sudo docker logs -f pytorch_automation_container

--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
@@ -20,8 +20,8 @@ sudo docker run --runtime=nvidia --name=pytorch_automation_container --privilege
 --shm-size=128g pytorch-gcsfuse:latest
 
 # Setup the log_rotation.
-chmod +x ./perfmetrics/scripts/ml_tests/setup_log_rotation.sh
-sudo ./perfmetrics/scripts/ml_tests/setup_log_rotation.sh ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log
+chmod +x perfmetrics/scripts/ml_tests/setup_log_rotation.sh
+source perfmetrics/scripts/ml_tests/setup_log_rotation.sh ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log
 
 # Wait for the script completion as well as logs output.
 sudo docker logs -f pytorch_automation_container

--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh
@@ -19,8 +19,30 @@ echo "Running the docker image build in the previous step..."
 sudo docker run --runtime=nvidia --name=pytorch_automation_container --privileged -d -v ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts:/pytorch_dino/run_artifacts:rw,rshared \
 --shm-size=128g pytorch-gcsfuse:latest
 
-echo "Setting up cron job to delete the gcsfuse_logs."
-echo "0 */1 * * * cd ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse && sudo sh ./perfmetrics/scripts/ml_tests/smart_log_deleter.sh container_artifacts/gcsfuse_logs/" | crontab -
+echo "Creating logrotate configuration..."
+cat << EOF | tee ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
+${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/container_artifacts/gcsfuse.log {
+  rotate 10
+  size 5G
+  missingok
+  notifempty
+  compress
+  dateext
+  dateformat -%Y%m%d-%s
+  copytruncate
+}
+EOF
+
+# Make sure logrotate installed on the system.
+if test -x /usr/sbin/logrotate ; then
+  echo "Logrotate already installed on the system."
+else
+  echo "Installing logrotate on the system..."
+  sudo apt-get install logrotate
+fi
+
+echo "Setting up cron job to rotate the gcsfuse_logs."
+echo "0 */1 * * * /usr/sbin/logrotate ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf --state ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate_status" | crontab -
 
 # Wait for the script completion as well as logs output.
 sudo docker logs -f pytorch_automation_container

--- a/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/continuous.cfg
@@ -1,7 +1,7 @@
 build_file: "gcsfuse/perfmetrics/scripts/continuous_test/ml_tests/pytorch/dino/build.sh"
 
-# Setting the 16 days (23040 mins) timeout for kokoro-jobs.
-timeout_mins: 23040
+# Setting the 8 days (11520 mins) timeout for kokoro-jobs.
+timeout_mins: 11520
 
 
 # Post the gcsfuse logs as an artifact to GCSBucket

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -8,7 +8,6 @@ export PATH=$PATH:/usr/local/go/bin
 # Hence, we need to setup the job to delete the logs file if not required.
 git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse
-git checkout automation_log_rotation
 go build .
 cd -
 

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -8,6 +8,7 @@ export PATH=$PATH:/usr/local/go/bin
 # Hence, we need to setup the job to delete the logs file if not required.
 git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse
+git checkout automation_log_rotation
 go build .
 cd -
 

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -4,12 +4,10 @@ wget -O go_tar.tar.gz https://go.dev/dl/go1.19.5.linux-amd64.tar.gz
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 
-# Todo: please update the branch, when log-rotation changes are merged.
 # Log-rotation branch will create the logs.txt file after every 6 hours.
 # Hence, we need to setup the job to delete the logs file if not required.
 git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse
-git checkout log_rotation
 go build .
 cd -
 
@@ -26,7 +24,7 @@ nohup /pytorch_dino/gcsfuse/gcsfuse --foreground --type-cache-ttl=1728000s \
         --max-conns-per-host=100 \
         --debug_fs \
         --debug_gcs \
-        --log-file run_artifacts/gcsfuse_logs/logs.txt \
+        --log-file run_artifacts/gcsfuse.log \
         --log-format text \
        gcsfuse-ml-data gcsfuse_data > "run_artifacts/gcsfuse.out" 2> "run_artifacts/gcsfuse.err" &
 

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -21,7 +21,6 @@ nohup /pytorch_dino/gcsfuse/gcsfuse --foreground --type-cache-ttl=1728000s \
         --stat-cache-capacity=1320000 \
         --stackdriver-export-interval=60s \
         --implicit-dirs \
-        --experimental-enable-storage-client-library \
         --max-conns-per-host=100 \
         --debug_fs \
         --debug_gcs \

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -64,7 +64,7 @@ python3 -m torch.distributed.launch \
   --norm_last_layer False \
   --use_fp16 False \
   --clip_grad 0 \
-  --epochs 200 \
+  --epochs 100 \
   --global_crops_scale 0.25 1.0 \
   --local_crops_number 10 \
   --local_crops_scale 0.05 0.25 \

--- a/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
+++ b/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
@@ -8,8 +8,8 @@ echo "Creating logrotate configuration..."
 cat << EOF | sudo tee ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 ${log_file} {
   su root adm
-  rotate 10
-  size 5G
+  rotate 3
+  size 1G
   missingok
   notifempty
   compress

--- a/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
+++ b/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Add a shell script which will be run hourly, which eventually executes the
+# command to rotate the logs according to config present in /etc/logrotate.hourly.d
+cat << EOF | tee /etc/cron.hourly/gcsfuse_logrotate
+#!/bin/bash
+test -x /usr/sbin/logrotate || exit 0
+/usr/sbin/logrotate ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf --state ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate_status"
+EOF
+
+# Make sure, we have hourly logrotate setup inplace correctly.
+if [ $? -eq 0 ]; then
+        echo "Hourly cron setup for logrotate completed successfully"
+else
+        echo "Please install linux package - cron"
+        exit 1
+fi
+
+chmod 775 /etc/cron.hourly/gcsfuse-logrotate

--- a/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
+++ b/perfmetrics/scripts/ml_tests/setup_log_rotation.sh
@@ -5,7 +5,7 @@
 
 log_file=$1
 echo "Creating logrotate configuration..."
-cat << EOF | tee ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
+cat << EOF | sudo tee ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 ${log_file} {
   su root adm
   rotate 10
@@ -20,8 +20,8 @@ ${log_file} {
 EOF
 
 # Set the correct access permission to the config file.
-chmod 0644 ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
-chown root ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
+sudo chmod 0644 ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
+sudo chown root ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf
 
 # Make sure logrotate installed on the system.
 if test -x /usr/sbin/logrotate ; then
@@ -33,10 +33,10 @@ fi
 
 # Add a shell script which will be run hourly, which eventually executes the
 # command to rotate the logs according to config present in /etc/logrotate.hourly.d
-cat << EOF | tee /etc/cron.hourly/gcsfuse_logrotate
+cat << EOF | sudo tee /etc/cron.hourly/gcsfuse_logrotate
 #!/bin/bash
 test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf --state ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate_status"
+/usr/sbin/logrotate ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate.conf --state ${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/gcsfuse_logrotate_status
 EOF
 
 # Make sure, we have hourly logrotate setup inplace correctly.
@@ -47,7 +47,7 @@ else
         exit 1
 fi
 
-chmod 775 /etc/cron.hourly/gcsfuse-logrotate
+sudo chmod 775 /etc/cron.hourly/gcsfuse_logrotate
 
 # Restart the cron service
 sudo service cron restart


### PR DESCRIPTION
### Description
1. We were using a workaround branch to support log-rotation for kokoro-automation. Now, we will use logrotate package to support log-rotation for kokoro-automation.

Current change requires only for dino model.  I'll create a separate PR for tf-automation.

2. Also, changing the kokoro-job time to 7 days instead of 16 days.

### Testing
1. Manual - Tested on the fresh machine, it's working fine.
2. Integration - NA
3. Unit - NA