### PR TITLE
Fixing: mount_gcsfuse not respecting bool values when passed to bool flags e.g. enable_storage_client_library

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -81,12 +81,15 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs",
-			"foreground",
 			"experimental_local_file_cache",
 			"enable_storage_client_library",
 			"reuse_token_from_url",
 			"enable_nonexistent_type_cache":
-			args = append(args, "--"+strings.Replace(name, "_", "-", -1))
+			if value == "" {
+				args = append(args, "--"+strings.Replace(name, "_", "-", -1))
+			} else {
+				args = append(args, "--"+strings.Replace(name, "_", "-", -1)+"="+value)
+			}
 
 		// Special case: support mount-like formatting for gcsfuse string flags.
 		case "dir_mode",
@@ -116,6 +119,7 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse debug flags.
 		case "debug_fuse",
+			"foreground",
 			"debug_fuse_errors",
 			"debug_fs",
 			"debug_gcs",

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -119,13 +119,13 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse debug flags.
 		case "debug_fuse",
-			"foreground",
 			"debug_fuse_errors",
 			"debug_fs",
 			"debug_gcs",
 			"debug_http",
 			"debug_invariants",
-			"debug_mutex":
+			"debug_mutex",
+			"foreground":
 			args = append(args, "--"+name)
 
 		// Pass through everything else.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -81,15 +81,15 @@ func makeGcsfuseArgs(
 
 		// Special case: support mount-like formatting for gcsfuse bool flags.
 		case "implicit_dirs",
+			"foreground",
 			"experimental_local_file_cache",
 			"enable_storage_client_library",
 			"reuse_token_from_url",
 			"enable_nonexistent_type_cache":
 			if value == "" {
-				args = append(args, "--"+strings.Replace(name, "_", "-", -1))
-			} else {
-				args = append(args, "--"+strings.Replace(name, "_", "-", -1)+"="+value)
+				value = "true"
 			}
+			args = append(args, "--"+strings.Replace(name, "_", "-", -1)+"="+value)
 
 		// Special case: support mount-like formatting for gcsfuse string flags.
 		case "dir_mode",
@@ -124,8 +124,7 @@ func makeGcsfuseArgs(
 			"debug_gcs",
 			"debug_http",
 			"debug_invariants",
-			"debug_mutex",
-			"foreground":
+			"debug_mutex":
 			args = append(args, "--"+name)
 
 		// Pass through everything else.


### PR DESCRIPTION
### Description 
Followed by this [issue](https://github.com/GoogleCloudPlatform/gcsfuse/issues/1014) 
Pass the value if explicitly define in flag, or pass it as  it is

### Testing
1. Manual - tested manually on VM
2. UnitTest - N/A
3. IntegrationTest - N/A