### PR TITLE
Returning correct system error for un-implemented method

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1875,11 +1875,11 @@ func (fs *fileSystem) ReleaseFileHandle(
 func (fs *fileSystem) GetXattr(
 	ctx context.Context,
 	op *fuseops.GetXattrOp) (err error) {
-	return syscall.ENODATA
+	return syscall.ENOSYS
 }
 
 func (fs *fileSystem) ListXattr(
 	ctx context.Context,
 	op *fuseops.ListXattrOp) error {
-	return syscall.ENODATA
+	return syscall.ENOSYS
 }


### PR DESCRIPTION
### Description
Currently, we get many log-entries (if --debug_fs is enabled) containing GetXattr() while accessing any iNode. To avoid such entries, we need to return correct error response to the kernel. 

According to the linux-manual:
```
ENODATA
              The named attribute does not exist, or the process has no
              access to this attribute; see [xattr(7)](https://man7.org/linux/man-pages/man7/xattr.7.html).

              In POSIX.1-2001 (XSI STREAMS option), this error was
              described as "No message is available on the STREAM head
              read queue".
ENOSYS Function not implemented (POSIX.1-2001).
```

Currently, we were returning error as `ENODATA`, which says attribute doesn't exist and kernel requests to get the data in the further call again and again. Instead when we return error as `ENOSYS` which says function not implemented, and kernel doesn't request the same method further in future.

`debug_fs: GetXattr(1, security.capability): no data available`


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - checked the logs before and after the changes, before we get this call many times while accessing every iNode but after the change we get this call only once, irrespective of iNode.
2. Unit tests - NA
3. Integration tests - Automation