### PR TITLE
Fixing load-script related to process_id and thread_id

### DIFF
--- a/perfmetrics/scripts/load_tests/python/load_generator/load_generator.py
+++ b/perfmetrics/scripts/load_tests/python/load_generator/load_generator.py
@@ -236,7 +236,7 @@ class LoadGenerator:
     while cnt < num_executions_per_thread:
       for curr_task, curr_queue in zip(tasks, queues):
         start_time = time.time()
-        result = curr_task(thread_id, process_id)
+        result = curr_task(process_id, thread_id)
         end_time = time.time()
         curr_queue.put(
             TaskExecutionResult(

--- a/perfmetrics/scripts/load_tests/python/load_test.py
+++ b/perfmetrics/scripts/load_tests/python/load_test.py
@@ -119,7 +119,7 @@ def parse_args():
   parser.add_argument(
       '--start-delay',
       type=int,
-      default=10,
+      default=0,
       help='Time in seconds to wait before conducting load test on a task.')
   parser.add_argument(
       '--debug',
@@ -332,7 +332,7 @@ def main():
   logging.info('Starting load generation...')
   load_test_results = []
   for task_obj in filtered_task_objs:
-    logging.info('\nSleeping for: %s', args.start_delay)
+    logging.info('\nSleeping for: %s second', args.start_delay)
     time.sleep(args.start_delay)
 
     logging.info('\nRunning pre load test task for: %s', task_obj.task_name)

--- a/perfmetrics/scripts/load_tests/python/load_test.py
+++ b/perfmetrics/scripts/load_tests/python/load_test.py
@@ -119,7 +119,7 @@ def parse_args():
   parser.add_argument(
       '--start-delay',
       type=int,
-      default=0,
+      default=5,
       help='Time in seconds to wait before conducting load test on a task.')
   parser.add_argument(
       '--debug',
@@ -332,7 +332,7 @@ def main():
   logging.info('Starting load generation...')
   load_test_results = []
   for task_obj in filtered_task_objs:
-    logging.info('\nSleeping for: %s second', args.start_delay)
+    logging.info('\nSleeping for: %s seconds', args.start_delay)
     time.sleep(args.start_delay)
 
     logging.info('\nRunning pre load test task for: %s', task_obj.task_name)


### PR DESCRIPTION
### Description

- Due to wrong order of process_id and thread_id. We make the read call to the wrong file, which doesn't produce the load to the right file.
- Changing the sleep time default value to zero second.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - checked manually.
2. Unit tests - NA
3. Integration tests - NA