### PR TITLE
Updating the description for --debug_http flag

### DIFF
--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -188,16 +188,3 @@ Type ```gcsfuse --help``` to see the full list:
 |--enable-storage-client-library|If true, will use go storage client library otherwise jacobsa/gcloud|
 |--help, -h|Show help|
 |--version, -v|Print version|
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -182,12 +182,13 @@ Type ```gcsfuse --help``` to see the full list:
 |--debug_fuse|Enable fuse-related debugging output.|
 |--debug_fs|Enable file system debugging output.|
 |--debug_gcs|Print GCS request and timing information.|
-|--debug_http|Dump HTTP requests and responses to/from GCS.|
+|--debug_http| Dump HTTP requests and responses to/from GCS, doesn't work when --enable-storage-client-library flag is true.|
 |--debug_invariants|Panic when internal invariants are violated.|
 |--debug_mutex|Print debug messages when a mutex is held too long.|
 |--enable-storage-client-library|If true, will use go storage client library otherwise jacobsa/gcloud|
 |--help, -h|Show help|
 |--version, -v|Print version|
+
 
 
 

--- a/flags.go
+++ b/flags.go
@@ -317,8 +317,9 @@ func newApp() (app *cli.App) {
 			},
 
 			cli.BoolFlag{
-				Name:  "debug_http",
-				Usage: "Dump HTTP requests and responses to/from GCS.",
+				Name: "debug_http",
+				Usage: "Dump HTTP requests and responses to/from GCS, " +
+					"doesn't work when enable-storage-client-library flag is true",
 			},
 
 			cli.BoolFlag{

--- a/flags.go
+++ b/flags.go
@@ -319,7 +319,7 @@ func newApp() (app *cli.App) {
 			cli.BoolFlag{
 				Name: "debug_http",
 				Usage: "Dump HTTP requests and responses to/from GCS, " +
-					"doesn't work when enable-storage-client-library flag is true",
+					"doesn't work when enable-storage-client-library flag is true.",
 			},
 
 			cli.BoolFlag{


### PR DESCRIPTION
### Description
`--debug_http` flag doesn't work for storage-client-library, updating the description. It is supported only for jacobsa/gcloud client.

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1049

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA