### PR TITLE
Creating a text/json writer wrapping over standard output logging writer

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -170,10 +170,10 @@ func (f *loggerFactory) writer(level string) io.Writer {
 
 	switch level {
 	case "NOTICE":
-		return daemonize.StatusWriter
+		return f.createJsonOrTextWriter(level, daemonize.StatusWriter)
 	case "ERROR":
-		return os.Stderr
+		return f.createJsonOrTextWriter(level, os.Stderr)
 	default:
-		return os.Stdout
+		return f.createJsonOrTextWriter(level, os.Stdout)
 	}
 }


### PR DESCRIPTION
### Description
GCSFuse doesn't writer time-stamp information while logging via os.Stdout/err writer. Added a wrapper over these writer to write all these information.

Command executed:
`gcsfuse --debug_fuse --debug_fs --foreground <bucket_name> <mount_dir>`

Before:
```text
Creating a new server...
Set up root directory for bucket princer-working-dirs
Mounting file system "princer-working-dirs"...
Error while mounting gcsfuse: mountWithConn: Mount: stat /usr/local/google/home/princer/Documents/code/gcsfuse/mnt: no such file or directory
mountWithArgs: mountWithConn: Mount: stat /usr/local/google/home/princer/Documents/code/gcsfuse/mnt: no such file or directory

```

After:

```text
I0411 15:33:59.567735 Opening GCS connection...
I0411 15:33:59.567950 Creating a mount at "/usr/local/google/home/princer/Documents/code/gcsfuse/mnt"
I0411 15:33:59.568341 Creating a new server...
I0411 15:33:59.568355 Set up root directory for bucket princer-working-dirs
I0411 15:34:00.900929 Mounting file system "princer-working-dirs"...
I0411 15:34:00.901060 Error while mounting gcsfuse: mountWithConn: Mount: stat /usr/local/google/home/princer/Documents/code/gcsfuse/mnt: no such file or directory
mountWithArgs: mountWithConn: Mount: stat /usr/local/google/home/princer/Documents/code/gcsfuse/mnt: no such file or directory

```
### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Manually tested.
2. Unit tests - Automation.
3. Integration tests - Automation.