### PR TITLE
List obj fix

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -276,7 +276,7 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 		}
 
 		// itr.next returns all the objects present in the bucket. Hence adding a
-		// check to break after required number of objects are returned.
+		// check to break after iterating over the current page.
 		// If req.MaxResults is 0, then wait till iterator is done. This is similar
 		// to https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/bucket.go#L164
 		if req.MaxResults != 0 && (pi.Remaining() == 0) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -250,6 +250,7 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 	pi.Token = req.ContinuationToken
 	var list gcs.Listing
 
+	var resultsCount int = 0
 	// Iterating through all the objects in the bucket and one by one adding them to the list.
 	for {
 		var attrs *storage.ObjectAttrs
@@ -257,7 +258,7 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 		// check to break after required number of objects are returned.
 		// If req.MaxResults is 0, then wait till iterator is done. This is similar
 		// to https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/bucket.go#L164
-		if req.MaxResults != 0 && (len(list.Objects) == req.MaxResults) {
+		if req.MaxResults != 0 && (resultsCount == req.MaxResults) {
 			break
 		}
 		attrs, err = itr.Next()
@@ -280,6 +281,7 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 			currObject := storageutil.ObjectAttrsToBucketObject(attrs)
 			list.Objects = append(list.Objects, currObject)
 		}
+		resultsCount++
 	}
 
 	list.ContinuationToken = itr.PageInfo().Token

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -276,7 +276,10 @@ func (b *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsRequ
 		}
 
 		// itr.next returns all the objects present in the bucket. Hence adding a
-		// check to break after iterating over the current page.
+		// check to break after iterating over the current page. pi.Remaining()
+		// function returns number of items (items + prefixes) remaining in current
+		// page to be iterated by iterator (itr). The func returns (number of items in current page - 1)
+		// after first itr.Next() call and becomes 0 when iteration is done.
 		// If req.MaxResults is 0, then wait till iterator is done. This is similar
 		// to https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/github.com/jacobsa/gcloud/gcs/bucket.go#L164
 		if req.MaxResults != 0 && (pi.Remaining() == 0) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -44,8 +44,8 @@ func (bh *bucketHandle) Name() string {
 }
 
 func (bh *bucketHandle) NewReader(
-		ctx context.Context,
-		req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
+	ctx context.Context,
+	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
 	// Initialising the starting offset and the length to be read by the reader.
 	start := int64(0)
 	length := int64(-1)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -473,7 +473,7 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 	AssertEq(TestObjectName, fourObj.Objects[3].Name)
 	AssertEq(nil, fourObj.CollapsedRuns)
 
-	// Note: Thw behavior is different in real GCS storage JSON API. In real API,
+	// Note: The behavior is different in real GCS storage JSON API. In real API,
 	// only 1 object and 1 collapsedRuns would have been returned if
 	// IncludeTrailingDelimiter = false and 2 objects and 1 collapsedRuns if
 	// IncludeTrailingDelimiter = true.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -477,6 +477,8 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 	// only 1 object and 1 collapsedRuns would have been returned if
 	// IncludeTrailingDelimiter = false and 2 objects and 1 collapsedRuns if
 	// IncludeTrailingDelimiter = true.
+	// This is because fake storage doesn't support pagination and hence maxResults
+	// has no affect.
 	AssertEq(nil, err2)
 	AssertEq(2, len(twoObj.Objects))
 	AssertEq(TestObjectRootFolderName, twoObj.Objects[0].Name)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -365,8 +365,6 @@ func (t *BucketHandleTest) TestGetProjectValueWhenGcloudProjectionIsDefault() {
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithPrefixObjectExist() {
-	// Note: ContinuationToken doesn't work with fake storage and hence we can't
-	// add unit tests to test its functionality.
 	obj, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "gcsfuse/",
@@ -450,7 +448,7 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 		&gcs.ListObjectsRequest{
 			Prefix:                   "",
 			Delimiter:                "",
-			IncludeTrailingDelimiter: true,
+			IncludeTrailingDelimiter: false,
 			ContinuationToken:        "",
 			MaxResults:               4,
 			ProjectionVal:            0,
@@ -458,9 +456,9 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 
 	twoObj, err2 := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
-			Prefix:                   "",
-			Delimiter:                "",
-			IncludeTrailingDelimiter: true,
+			Prefix:                   "gcsfuse/",
+			Delimiter:                "/",
+			IncludeTrailingDelimiter: false,
 			ContinuationToken:        "",
 			MaxResults:               2,
 			ProjectionVal:            0,
@@ -475,12 +473,15 @@ func (t *BucketHandleTest) TestListObjectMethodForMaxResult() {
 	AssertEq(TestObjectName, fourObj.Objects[3].Name)
 	AssertEq(nil, fourObj.CollapsedRuns)
 
-	// Validate that 2 objects are listed when MaxResults is passed 2.
+	// Note: Thw behavior is different in real GCS storage JSON API. In real API,
+	// only 1 object and 1 collapsedRuns would have been returned if
+	// IncludeTrailingDelimiter = false and 2 objects and 1 collapsedRuns if
+	// IncludeTrailingDelimiter = true.
 	AssertEq(nil, err2)
 	AssertEq(2, len(twoObj.Objects))
 	AssertEq(TestObjectRootFolderName, twoObj.Objects[0].Name)
-	AssertEq(TestObjectSubRootFolderName, twoObj.Objects[1].Name)
-	AssertEq(nil, twoObj.CollapsedRuns)
+	AssertEq(TestObjectName, twoObj.Objects[1].Name)
+	AssertEq(1, len(twoObj.CollapsedRuns))
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithMissingMaxResult() {

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -365,6 +365,8 @@ func (t *BucketHandleTest) TestGetProjectValueWhenGcloudProjectionIsDefault() {
 }
 
 func (t *BucketHandleTest) TestListObjectMethodWithPrefixObjectExist() {
+	// Note: ContinuationToken doesn't work with fake storage and hence we can't
+	// test its functionality.
 	obj, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "gcsfuse/",

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -366,7 +366,7 @@ func (t *BucketHandleTest) TestGetProjectValueWhenGcloudProjectionIsDefault() {
 
 func (t *BucketHandleTest) TestListObjectMethodWithPrefixObjectExist() {
 	// Note: ContinuationToken doesn't work with fake storage and hence we can't
-	// test its functionality.
+	// add unit tests to test its functionality.
 	obj, err := t.bucketHandle.ListObjects(context.Background(),
 		&gcs.ListObjectsRequest{
 			Prefix:                   "gcsfuse/",


### PR DESCRIPTION
### Description
Fix bug in list object method due to which some files are not listed if number of files in a directory are more than 5000 and contains one or more nested directory.

#### More details:

- The listing of objects (includes both files and directories as directories are also object in GCS) happens one by one using the next function of [this](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/storage/bucket_handle.go#L263) iterator. 
- The next function returns object, next page token and other attributes. E.g. if the listing is happening for 1st page, then the next function returns page token of 2nd page. 

Before fix: 
- This [for](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/storage/bucket_handle.go#L254) loop runs until the number of files [are not equal](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/storage/bucket_handle.go#L260) to MaxResults (5000) which is problematic. E.g. if we are listing for 1st page which consists of 5000 objects including 4000 files and 1000 directories, then this for loop will [not stop](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/storage/bucket_handle.go#L278) after listing 4000 files and 1000 directories but will go on till it lists 5000 files, which will go into 2nd page. Now assume 2nd page consists of 5000 files and 0 directories.  At the end of listing 5000 files (4000 from 1st page and 1000 from 2nd page), the next page token will be of 3rd page. So the next ListObject method call from downstream methods will start from 3rd page and hence skipping 4000 files from 2nd page.

After fix: 
- This for loop will run until all the objects in requested page are fetched using (itr.Next() method). So, taking the same example as before, the first call to ListObject will list objects only from 1st page and return token of 2nd page. Hence will not miss 4000 files/objects of 2nd page.


### Link to the issue in case of a bug fix.
This bug was identified in this issue: https://github.com/GoogleCloudPlatform/gcsfuse/issues/1054

### Testing details
1. Manual
   a. Verified that correct number of files are listed for the exact issue specified by customer: This bug was identified in this issue: https://github.com/GoogleCloudPlatform/gcsfuse/issues/1054
   b. Reproduced the issue for lesser number of files i.e. 5500 and verified the fix against that many files as well.
   c. Also ran [listing benchmarks](https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/perfmetrics/scripts/ls_metrics) and got similar performance.
3. Unit tests
   a. Can't add unit test for testing this functionality specifically because the fake storage doesn't support ContinuationToken.
5. Integration tests