### PR TITLE
[Doc Update] Fixed gcsfuse --only-dir flag usage example.

### DIFF
--- a/docs/mounting.md
+++ b/docs/mounting.md
@@ -66,7 +66,7 @@ mkdir ```/path/to/mount/point```
 
 By default, Cloud Storage FUSE mounts the entire contents and directory structure within a bucket. To mount only a specific directory, pass the ```--only-dir``` option. For example, if ```my-bucket``` contains the path ```my-bucket/a/b``` to mount only a/b to my local directory ```/path/to/mount/point```:
 
-    gcsfuse --only-dir my-bucket a/b  /path/to/mount/point
+    gcsfuse --only-dir a/b my-bucket /path/to/mount/point
 
 # General filesystem mount options
 


### PR DESCRIPTION
This will be pull request template
### Description
[Doc Update] Fixed gcsfuse --only-dir flag usage example in mounting.md.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Manually tested mounting the bucket with the --only-dir flag.
2. Unit tests - NA
3. Integration tests - NA