### PR TITLE
Checkout back to master branch in periodic tests to use latest CI test scripts

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -14,7 +14,8 @@ echo Installing fio
 sudo apt-get install fio -y
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
-# Get the latest commitId of yesterday in the log file
+# Get the latest commitId of yesterday in the log file. Build gcsfuse and run
+# integration tests using code upto that commit.
 commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 git checkout $commitId
 
@@ -27,6 +28,9 @@ sudo cp ~/temp/sbin/mount.gcsfuse /sbin
 
 # Executing integration tests
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test
+
+# Checkout back to master branch to use latest CI test scripts in master.
+git checkout master
 
 # Mounting gcs bucket
 cd "./perfmetrics/scripts/"


### PR DESCRIPTION
### Description
Small change to use the latest version CI test scripts (e.g. build.sh, run_load_test_and_fetch_metrics.sh) in master branch during periodic tests.

Before this change: The [build script](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh) checkout to yesterday's last commit and then run the complete tests while staying on that commit.
After this change: The [build script](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh) will checkout to yesterday's last commit, build gcsfuse, run integration tests, checkout back to master's last commit and run the complete tests using the gcsfuse built before checking out to latest commit.

This change should allow testing changes to CI test scripts quickly.

### Testing details
1. Manual: Ran the continuous test [script](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh) with this change.
3. Unit tests - N/A
4. Integration tests - N/A