### PR TITLE
Fixing the build failure using go get command

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -54,6 +54,6 @@ To install Cloud Storage FUSE by building the binaries from source, follow the i
 3. Make sure you have the Git command-line tool installed. This is probably available as ```git``` in your package manager.
 4. To install or update Cloud Storage FUSE, run the following command
 
-       GO111MODULE=auto go get -u github.com/googlecloudplatform/gcsfuse
+       GO111MODULE=auto go get -d -u github.com/googlecloudplatform/gcsfuse
 
 This will fetch the latest Cloud Storage FUSE sources to ```$GOPATH/src/github.com/googlecloudplatform/gcsfuse```, build the sources, and then install a binary named gcsfuse to ```$GOPATH/bin```.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -55,8 +55,17 @@ go install github.com/googlecloudplatform/gcsfuse@master
 ```
 
 ### Method 2: By cloning the git repo
-1. Clone the repo using - `git clone https://github.com/GoogleCloudPlatform/gcsfuse.git`
-2. Change to repo directory - `cd gcsfuse`
-3. Install gcsfuse - `go install .`
+1. Clone the repo using:
+```
+git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
+```
+2. Change to repo directory:
+```
+cd gcsfuse
+```
+3. Install gcsfuse:
+```
+go install .
+```
 
-**Note:** In the both cases, a binary named `gcsfuse` will be installed to `$GOPATH/bin`.
+**Note:** In both cases, a binary named `gcsfuse` will be installed to `$GOPATH/bin`.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -45,15 +45,18 @@ To install Cloud Storage FUSE for CentOS or Red Hat, follow the instructions bel
 
    Be sure to answer "yes" to any questions about adding the GPG signing key.
 
-# Install gcsfuse by building the latest source code:
-Make sure you have a working Go installation, follow [this](https://go.dev/doc/install) to install go.
+## Install gcsfuse by building the latest source code:
+Make sure you have `fuse`, `git` and `go` (the newest version specified in [go.mod](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/go.mod)) installed on the system.
 
-## Method 1 by cloning the git repo:
+### Method 1: Using the go install command directly
+Install gcsfuse directly using the below command:
+```
+go install github.com/googlecloudplatform/gcsfuse@master
+```
+
+### Method 2: By cloning the git repo
 1. Clone the repo using - `git clone https://github.com/GoogleCloudPlatform/gcsfuse.git`
 2. Change to repo directory - `cd gcsfuse`
 3. Install gcsfuse - `go install .`
-
-## Method 2 using the go install command directly:
-Install gcsfuse directly - `go install github.com/googlecloudplatform/gcsfuse@master`
 
 **Note:** In the both cases, a binary named `gcsfuse` will be installed to `$GOPATH/bin`.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -45,15 +45,15 @@ To install Cloud Storage FUSE for CentOS or Red Hat, follow the instructions bel
 
    Be sure to answer "yes" to any questions about adding the GPG signing key.
 
-# Install by building the binaries from source
+# Install gcsfuse by building the latest source code:
+Make sure you have a working Go installation, follow [this](https://go.dev/doc/install) to install go.
 
-To install Cloud Storage FUSE by building the binaries from source, follow the instructions below:
+## Method 1 by cloning the git repo:
+1. Clone the repo using - `git clone https://github.com/GoogleCloudPlatform/gcsfuse.git`
+2. Change to repo directory - `cd gcsfuse`
+3. Install gcsfuse - `go install .`
 
-1. Make sure you have a working Go installation, the newest version specified in [go.mod](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/go.mod). See Installing Go from source.
-2. [Fuse](https://github.com/libfuse/libfuse). See the instructions for the binary release above.
-3. Make sure you have the Git command-line tool installed. This is probably available as ```git``` in your package manager.
-4. To install or update Cloud Storage FUSE, run the following command
+## Method 2 using the go install command directly:
+Install gcsfuse directly - `go install github.com/googlecloudplatform/gcsfuse@master`
 
-       GO111MODULE=auto go get -d -u github.com/googlecloudplatform/gcsfuse
-
-This will fetch the latest Cloud Storage FUSE sources to ```$GOPATH/src/github.com/googlecloudplatform/gcsfuse```, build the sources, and then install a binary named gcsfuse to ```$GOPATH/bin```.
+**Note:** In the both cases, a binary named `gcsfuse` will be installed to `$GOPATH/bin`.

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -45,7 +45,7 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
 ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
-RUN go get ${GCSFUSE_REPO}
+RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
 # Branch name for building through a particular branch.

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -28,7 +28,7 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
 ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
-RUN go get ${GCSFUSE_REPO}
+RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
 RUN git checkout "v${GCSFUSE_VERSION}"


### PR DESCRIPTION
### Description
Due to the recent changes of removing the vendoring file in git, `go get github.com/GoogleCloudPlatform/gcsfuse` started building and installing by fetching the latest dependencies.

Go fetch module dependency on the basis of this environment variable `GO111MODULE=on`
1. `ON` - Always tries to find go.mod file in the current directory and any parent directory and fetches the dependency according to the `go.mod` file.
2. `OFF` - In this mode go fetch the latest code as a module dependency.
3. `AUTO`- So, if `go.mod` file exist in current or parent directory this is treated as `on` other wise `off`.

Note: `go get` command doesn't build or install module in module aware mode (`GO111MODULE=on`), otherwise we need to explicitly add `-d` flag to bypass building and installation of the module provided as an argument.  See - [here](https://go.dev/doc/go-get-install-deprecation)

Now in our case, we fetch the dependency using `go get` command which runs in `GO111MODULE=auto` (eventually `off` due to absence of the go.mod file in GOPATH). So, it fetches the latest dependent modules of gcsfuse, which leads to failure due to the API change in urfave.CLI. See the issue [here](https://github.com/GoogleCloudPlatform/gcsfuse/issues/1090).

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Tested - It takes around 30sec to 1 min to fetch the dependencies, so a little bit delay in building the Dockerfile. Initially, build was happening directly with the dependency in the vendor file.
5. Unit tests
6. Integration tests