### PR TITLE
Adding the execution directory in the go build command

### DIFF
--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -136,7 +136,9 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 			"go",
 			"build",
 			"-o",
-			path.Join(dstDir, bin.outputPath))
+			path.Join(dstDir, bin.outputPath),
+			"-C",
+			srcDir)
 
 		if path.Base(bin.outputPath) == "gcsfuse" {
 			cmd.Args = append(


### PR DESCRIPTION
### Description
While building the gcsfuse using [this](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/package_gcsfuse_docker/Dockerfile) Dockerfile.
First we get the gcsfuse go module using `go get -d github.com/googlecloudplatform/gcsfuse` command, it fetches the data in the `$GO_PATH/src/github.com/googlecloudplatform/gcsfuse` directory. After that, build_gcsfuse package is installed using `go install github.com/googlecloudplatform/gcsfuse/tools/build_gcsfuse` command. And in the end, we execute `build_gcsfuse <src_dir> <output_dir> <version>` to build the gcsfuse binaries.

In the last step, internally it runs the `go build -o <binary_output_dir> github.com/googlecloudplatform/gcsfuse`, which eventually tries to get the latest dependency of gcsfuse and build it and leads to the failure due to some wrong dependency.

I made change in the `build_gcsfuse` package to execute `go build ...` command by going to the gcsfuse directory. In this case, it gets the `go.mod` file inside the `gcsfuse` module working directory and only fetches dependency of the version specified in the `go.mod` file.

What does `-C` flag mean in `go build` command?
**-C dir:** Change to dir before running the command. Any files named on the command line are interpreted after changing directories.



### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Tested to build `gcsfuse` package by building the Dockerfile. (package_gcsfuse_container and containerize_gcsfuse_container). Created a gcsfuse package and did basic functionality sanity on the build.
2. Unit tests
3. Integration tests