### PR TITLE
Update protobuf version as suggested in dependabot alert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.29.0 // indirect
+	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f h1:X+tnaqoCcBgAwSTJtoYW6p0qKiuPyMfofEHEFUf2kdU=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20230425120156-b7182e0d0b51 h1:TqeYJCx5m/BvJQvoy4gQt/RdjG4p+C/qI0RVhhUZC0Q=
-github.com/jacobsa/fuse v0.0.0-20230425120156-b7182e0d0b51/go.mod h1:XUKuYy1M4vamyxQjW8/WZBTxyZ0NnUiq+kkA+WWOfeI=
 github.com/jacobsa/fuse v0.0.0-20230509090321-7263f3a2b474 h1:6z3Yj4PZKk3n18T2s7RYCa4uBCOpeLoQfDH/mUZTrVo=
 github.com/jacobsa/fuse v0.0.0-20230509090321-7263f3a2b474/go.mod h1:XUKuYy1M4vamyxQjW8/WZBTxyZ0NnUiq+kkA+WWOfeI=
 github.com/jacobsa/gcloud v0.0.0-20230425120041-5ed2958cdfee h1:1NvpBXX7CiuoK+SdLNMwelLB+2OkJLxhjllc0WgY8sE=
@@ -679,8 +677,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.29.0 h1:44S3JjaKmLEE4YIkjzexaP+NzZsudE3Zin5Njn/pYX0=
-google.golang.org/protobuf v1.29.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
+google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=


### PR DESCRIPTION
### Description
Update protobuf version as suggested in dependabot alert: https://github.com/GoogleCloudPlatform/gcsfuse/pull/1105/files


### Testing details
1. Manual - N/A
2. Unit tests - Automation
3. Integration tests - Automation

Results of perf tests (No perf regression):
Branch | File Size  |   Read BW    |  Write BW  | RandRead BW | RandWrite BW |
+--------+------------+--------------+------------+-------------+--------------+
| Master |  0.25MiB   | 398.16MiB/s  | 2.44MiB/s  |  30.4MiB/s  |  2.83MiB/s   |
|   PR   |  0.25MiB   |  396.0MiB/s  | 3.29MiB/s  |  28.74MiB/s |  2.77MiB/s   |
|        |            |              |            |             |              |
|        |            |              |            |             |              |
| Master | 48.828MiB  | 4496.73MiB/s | 79.3MiB/s  | 836.74MiB/s |  80.93MiB/s  |
|   PR   | 48.828MiB  | 4908.99MiB/s | 81.5MiB/s  | 966.65MiB/s |  80.2MiB/s   |
|        |            |              |            |             |              |
|        |            |              |            |             |              |
| Master | 976.562MiB | 4579.66MiB/s | 27.13MiB/s |  405.6MiB/s |  30.38MiB/s  |
|   PR   | 976.562MiB | 4579.55MiB/s | 23.76MiB/s | 455.17MiB/s |  26.7MiB/s 