### PR TITLE
Use the same steps to build gcsfuse in periodic test as used while releasing

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -35,9 +35,10 @@ git checkout master
 
 echo "Building and installing gcsfuse"
 # Build the gcsfuse package using the same commands used during release.
-sudo docker build ./tools/package_gcsfuse_docker/ -t gcsfuse:$commitId --build-arg GCSFUSE_VERSION=0.0.0 --build-arg BRANCH_NAME=$commitId
+GCSFUSE_VERSION=0.0.0
+sudo docker build ./tools/package_gcsfuse_docker/ -t gcsfuse:$commitId --build-arg GCSFUSE_VERSION=$GCSFUSE_VERSION --build-arg BRANCH_NAME=$commitId
 sudo docker run -v $HOME/release:/release gcsfuse:$commitId cp -r /packages /release/
-sudo dpkg -i $HOME/release/packages/gcsfuse_0.0.0_amd64.deb
+sudo dpkg -i $HOME/release/packages/gcsfuse_${GCSFUSE_VERSION}_amd64.deb
 
 # Mounting gcs bucket
 cd "./perfmetrics/scripts/"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -35,7 +35,7 @@ git checkout master
 
 echo "Building and installing gcsfuse"
 # Build the gcsfuse package using the same commands used during release.
-sudo docker build ./tools/package_gcsfuse_docker/ -t gcsfuse:$commitId --build-arg GCSFUSE_VERSION=v0.0.0 --build-arg BRANCH_NAME=$commitId
+sudo docker build ./tools/package_gcsfuse_docker/ -t gcsfuse:$commitId --build-arg GCSFUSE_VERSION=0.0.0 --build-arg BRANCH_NAME=$commitId
 sudo docker run -v $HOME/release:/release gcsfuse:$commitId cp -r /packages /release/
 sudo dpkg -i $HOME/release/packages/gcsfuse_0.0.0_amd64.deb
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -31,7 +31,10 @@ ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
 RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
-RUN git checkout "v${GCSFUSE_VERSION}"
+# Build Arg for building through a particular branch/commit. By default, it uses
+# the tag corresponding to passed GCSFUSE VERSION
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile


### PR DESCRIPTION
### Description
Use the same steps to build gcsfuse in periodic test as used while releasing. This can help us catch issues like beforehand: https://github.com/GoogleCloudPlatform/gcsfuse/pull/1094

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - (a) Tried building gcsfuse from release tag and with both release tag and branch/commit using package_gcsfuse_docker/Dockerfile. (b)  Tried running continuous_tests/gcp_ubuntu/build.sh. 
2. Unit tests - N/A
3. Integration tests - N/A