### PR TITLE
Add "(GPN: gcsfuse-<client-identifier>)" to useragent

### DIFF
--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -36,7 +36,7 @@ func getDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		HttpClientTimeout:   800 * time.Millisecond,
 		MaxRetryDuration:    30 * time.Second,
 		RetryMultiplier:     2,
-		UserAgent:           "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df)",
+		UserAgent:           "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) (GCP:gcsfuse)",
 	}
 }
 
@@ -113,13 +113,6 @@ func (t *StorageHandleTest) TestNewStorageHandleHttp2Enabled() {
 func (t *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHost() {
 	sc := getDefaultStorageClientConfig()
 	sc.MaxConnsPerHost = 0
-
-	t.invokeAndVerifyStorageHandle(sc)
-}
-
-func (t *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSet() {
-	sc := getDefaultStorageClientConfig()
-	sc.UserAgent = "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df)"
 
 	t.invokeAndVerifyStorageHandle(sc)
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -116,3 +116,10 @@ func (t *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHost() {
 
 	t.invokeAndVerifyStorageHandle(sc)
 }
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSet() {
+	sc := getDefaultStorageClientConfig()
+	sc.UserAgent = "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) appName (GPN:Gcsfuse-DLC)"
+
+	t.invokeAndVerifyStorageHandle(sc)
+}

--- a/main.go
+++ b/main.go
@@ -76,7 +76,14 @@ func registerSIGINTHandler(mountPoint string) {
 }
 
 func getUserAgent(appName string) string {
-	return strings.TrimSpace(fmt.Sprintf("gcsfuse/%s %s %s", getVersion(), appName, os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")))
+	if len(os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")) > 0 {
+		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s)", getVersion(), appName, os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE"))
+		return strings.Join(strings.Fields(userAgent), " ")
+	} else if len(appName) > 0 {
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s)", getVersion(), appName)
+	} else {
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse)", getVersion())
+	}
 }
 
 func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {

--- a/main.go
+++ b/main.go
@@ -76,8 +76,9 @@ func registerSIGINTHandler(mountPoint string) {
 }
 
 func getUserAgent(appName string) string {
-	if len(os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")) > 0 {
-		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s)", getVersion(), appName, os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE"))
+	gcsfuseMetadataImageType := os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")
+	if len(gcsfuseMetadataImageType) > 0 {
+		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s)", getVersion(), appName, gcsfuseMetadataImageType)
 		return strings.Join(strings.Fields(userAgent), " ")
 	} else if len(appName) > 0 {
 		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s)", getVersion(), appName)

--- a/main_test.go
+++ b/main_test.go
@@ -54,14 +54,31 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
 
 	userAgent := getUserAgent("AppName")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s %s %s", getVersion(), "AppName", os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM)", getVersion()))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
 	userAgent := getUserAgent("AppName")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s %s", getVersion(), "AppName"))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName)", getVersion()))
+
+	ExpectEq(expectedUserAgent, userAgent)
+}
+
+func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAreNotSet() {
+	userAgent := getUserAgent("")
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse)", getVersion()))
+
+	ExpectEq(expectedUserAgent, userAgent)
+}
+
+func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSet() {
+	os.Setenv("GCSFUSE_METADATA_IMAGE_TYPE", "DLVM")
+	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
+
+	userAgent := getUserAgent("")
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM)", getVersion()))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }


### PR DESCRIPTION
### Description
Added GPN:gcsfuse-<client-identifier> to user agent.
Removed redundant client identifier(appname or metadata image type env variable) from user agent if it has been appended to GPN.

Possible Scenarios and changes:
1. When both GCSFUSE_METADATA_IMAGE_TYPE  environment variable and app-name flag are set
      - `GCSFUSE_METADATA_IMAGE_TYPE=DLC` `app-name=myapp`
      - Old UserAgent = `gcsfuse/0.42.3 (Go version go1.19.5) myapp DLC,gzip(gfe)`
      - New UserAgent =`gcsfuse/0.42.3 (Go version go1.19.5) myapp (GPN:gcsfuse-DLC),gzip(gfe)`
2.  When both GCSFUSE_METADATA_IMAGE_TYPE  environment variable and app-name flag are unset
      - `GCSFUSE_METADATA_IMAGE_TYPE=""` `app-name=""`
      - Old UserAgent = `gcsfuse/0.42.3 (Go version go1.19.5),gzip(gfe)`
      - New UserAgent =`gcsfuse/0.42.3 (Go version go1.19.5) (GPN:gcsfuse),gzip(gfe)`
3. When GCSFUSE_METADATA_IMAGE_TYPE is set and app-name is unset
      - `GCSFUSE_METADATA_IMAGE_TYPE=DLC` `app-name=""`
      - Old UserAgent = `gcsfuse/0.42.3 (Go version go1.19.5) DLC,gzip(gfe)`
      - New UserAgent =`gcsfuse/0.42.3 (Go version go1.19.5) (GPN:gcsfuse-DLC),gzip(gfe)`
4. When GCSFUSE_METADATA_IMAGE_TYPE is unset and app-name is set
      - `GCSFUSE_METADATA_IMAGE_TYPE=""` `app-name=myapp`
      - Old UserAgent = `gcsfuse/0.42.3 (Go version go1.19.5) myapp,gzip(gfe)`
      - New UserAgent =`gcsfuse/0.42.3 (Go version go1.19.5) (GPN:gcsfuse-myapp),gzip(gfe)`


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Manually verified that the user agent has GPN appended
7. Unit tests - added
8. Integration tests - NA