### PR TITLE
Added timeout to golangci-lint as it is fails with timeout error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@032fa5c5e48499f06cf9d32c02149bfac1284239
       with:
-        args: -E=goimports
+        args: -E=goimports --timeout 2m0s
         only-new-issues: true
 


### PR DESCRIPTION
This will be pull request template
### CI-lint test has been failing frequently with the timeout error. I increased the timeout to 2 minutes.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual: NA
2. Unit tests: NA
3. Integration tests: NA