### PR TITLE
Removing condition in setup mounting 

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -1,7 +1,6 @@
 package setup
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -152,13 +151,10 @@ func MountGcsfuse(flags []string) error {
 		fmt.Println("Could not write cmd to logFile")
 	}
 
-	output, err := mountCmd.CombinedOutput()
+	_, err = mountCmd.CombinedOutput()
 	if err != nil {
 		log.Println(mountCmd.String())
 		return fmt.Errorf("cannot mount gcsfuse: %w\n", err)
-	}
-	if lines := bytes.Count(output, []byte{'\n'}); lines > 1 {
-		return fmt.Errorf("mount output: %q\n", output)
 	}
 	return nil
 }


### PR DESCRIPTION
This will be pull request template
### Description
Before if mounting output is throwing more then one line it was throwing an error.
but if I pass --key-file as parameter, in the first line it is fetching absolute path of key file and then throw success message.
but because of [this condition](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L160) it was failing before.

Remove the condition to fix the failure

### Link to the issue in case of a bug fix.

### Testing details
1. Manual
- All the integration tests are working fine for both the flags testBucket and mountedDirectoy.
- Tested for both foreground and background 
           - No permission from key file to mount the bucket (mounting is failing) 
           - Without key file and gcloud credentials
           - Panic  (mounting is failing) 
           - Crash during mounting
           - Normal error while mounting
3. Unit tests - N/A
4. Integration tests- All the integration tests are working fine together.