### PR TITLE
Adding delete file tests and refactor old tests

### DIFF
--- a/tools/integration_tests/operations/copy_file_test.go
+++ b/tools/integration_tests/operations/copy_file_test.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for copy file.
+package operations
+
+import (
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func TestCopyFile(t *testing.T) {
+	fileName := setup.CreateTempFile()
+
+	content, err := operations.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("Read: %v", err)
+	}
+
+	newFileName := fileName + "Copy"
+	if _, err := os.Stat(newFileName); err == nil {
+		t.Errorf("Copied file %s already present", newFileName)
+	}
+
+	err = operations.CopyFile(fileName, newFileName)
+	if err != nil {
+		t.Errorf("Error : %v", err)
+	}
+
+	// Check if the data in the copied file matches the original file,
+	// and the data in original file is unchanged.
+	setup.CompareFileContents(t, newFileName, string(content))
+	setup.CompareFileContents(t, fileName, string(content))
+}

--- a/tools/integration_tests/operations/delete_file_test.go
+++ b/tools/integration_tests/operations/delete_file_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for delete objects.
+
+package operations
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+const DirNameInTestBucket = "A"
+const FileNameInTestBucket = "A.txt"
+const FileNameInDirectoryTestBucket = "a.txt"
+
+func checkIfObjDeletionSucceeded(filePath string, t *testing.T) {
+	err := os.RemoveAll(filePath)
+
+	if err != nil {
+		t.Errorf("Objects deletion failed: %v", err)
+	}
+
+	file, err := os.Stat(filePath)
+	if err == nil && file.IsDir() == false {
+		t.Errorf("File is not deleted.")
+	}
+}
+
+func TestDeleteFileFromBucket(t *testing.T) {
+	filePath := path.Join(setup.MntDir(), FileNameInTestBucket)
+	_, err := os.Create(filePath)
+	if err != nil {
+		t.Errorf("Error in creating file: %v", err)
+	}
+
+	checkIfObjDeletionSucceeded(filePath, t)
+}
+
+func TestDeleteFileFromBucketDirectory(t *testing.T) {
+	dirPath := path.Join(setup.MntDir(), DirNameInTestBucket)
+	err := os.Mkdir(dirPath, setup.FilePermission_0600)
+	if err != nil {
+		t.Errorf("Error in creating directory: %v", err)
+	}
+
+	filePath := path.Join(dirPath, FileNameInDirectoryTestBucket)
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Errorf("Error in creating file: %v", err)
+	}
+
+	checkIfObjDeletionSucceeded(filePath, t)
+}

--- a/tools/integration_tests/operations/file_attributes_test.go
+++ b/tools/integration_tests/operations/file_attributes_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Provides integration tests for file operations.
+// Provides integration tests for file attributes.
 package operations_test
 
 import (
@@ -21,27 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
-
-func TestRenameFile(t *testing.T) {
-	fileName := setup.CreateTempFile()
-
-	content, err := operations.ReadFile(fileName)
-	if err != nil {
-		t.Errorf("Read: %v", err)
-	}
-
-	newFileName := fileName + "Rename"
-
-	err = operations.RenameFile(fileName, newFileName)
-	if err != nil {
-		t.Errorf("Error in file copying: %v", err)
-	}
-	// Check if the data in the file is the same after renaming.
-	setup.CompareFileContents(t, newFileName, string(content))
-}
 
 func TestFileAttributes(t *testing.T) {
 	preCreateTime := time.Now()
@@ -64,28 +45,4 @@ func TestFileAttributes(t *testing.T) {
 	if fStat.Size() != 14 {
 		t.Errorf("File size is not 14 bytes, found size: %d bytes", fStat.Size())
 	}
-}
-
-func TestCopyFile(t *testing.T) {
-	fileName := setup.CreateTempFile()
-
-	content, err := operations.ReadFile(fileName)
-	if err != nil {
-		t.Errorf("Read: %v", err)
-	}
-
-	newFileName := fileName + "Copy"
-	if _, err := os.Stat(newFileName); err == nil {
-		t.Errorf("Copied file %s already present", newFileName)
-	}
-
-	err = operations.CopyFile(fileName, newFileName)
-	if err != nil {
-		t.Errorf("Error : %v", err)
-	}
-
-	// Check if the data in the copied file matches the original file,
-	// and the data in original file is unchanged.
-	setup.CompareFileContents(t, newFileName, string(content))
-	setup.CompareFileContents(t, fileName, string(content))
 }

--- a/tools/integration_tests/operations/rename_file_test.go
+++ b/tools/integration_tests/operations/rename_file_test.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for rename file.
+package operations
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func TestRenameFile(t *testing.T) {
+	fileName := setup.CreateTempFile()
+
+	content, err := operations.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("Read: %v", err)
+	}
+
+	newFileName := fileName + "Rename"
+
+	err = operations.RenameFile(fileName, newFileName)
+	if err != nil {
+		t.Errorf("Error in file copying: %v", err)
+	}
+	// Check if the data in the file is the same after renaming.
+	setup.CompareFileContents(t, newFileName, string(content))
+}


### PR DESCRIPTION
### Description
Added Integration tests for delete file and refactor old tests for better readability from low level. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - All the integration tests are working fine for both the flags testBucket and mountedDirectoy.
2. Unit tests - N/A
3. Integration tests- All the integration tests are working fine together
