### PR TITLE
[execute-perf-test] Fixing kokoro tests which are failing with disk space error.

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -54,6 +54,8 @@ gcsfuse $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
 # Executing perf tests
 chmod +x run_load_test_and_fetch_metrics.sh
 ./run_load_test_and_fetch_metrics.sh
+sudo umount $MOUNT_POINT
+
 # Copying gcsfuse logs to bucket
 gsutil -m cp $LOG_FILE gs://periodic-perf-tests/fio-gcsfuse-logs/
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -62,6 +62,7 @@ go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
 # Running FIO test
 chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
 ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+sudo umount gcs
 
 echo showing results...
 python3 ./perfmetrics/scripts/presubmit/print_results.py


### PR DESCRIPTION
### Description
Kokoro will copy all files created during the test execution as artifacts unless they are deleted. Its copying all the files created by FIO as well. Hence doing umount to avoid copying the bucket contents as artifacts.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested the presubmit flow via kokoro. For continuous tests, manually tested the umount step on vm after mounting the gcsfuse 
2. Unit tests - NA
3. Integration tests - NA
