### PR TITLE
retracting v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,3 +62,6 @@ require (
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+// Retracted un-release version
+retract v1.0.0


### PR DESCRIPTION
### Description
Retracting v1.0.0 before new release as mentioned [here](https://go.dev/blog/go116-module-changes#module-retraction)


### Link to the issue in case of a bug fix.
https://pkg.go.dev/github.com/googlecloudplatform/gcsfuse?tab=versions

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
