### PR TITLE
Copying gcsfuse logs and fio output to gcs bucket via Kokoro

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -44,7 +44,7 @@ sudo dpkg -i $HOME/release/packages/gcsfuse_${GCSFUSE_VERSION}_amd64.deb
 cd "./perfmetrics/scripts/"
 echo "Mounting gcs bucket"
 mkdir -p gcs
-LOG_FILE=log-$(date '+%Y-%m-%d').txt
+LOG_FILE=${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs.txt
 GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --enable-storage-client-library --debug_fuse --debug_gcs --log-file $LOG_FILE --log-format \"text\" --stackdriver-export-interval=30s"
 BUCKET_NAME=periodic-perf-tests
 MOUNT_POINT=gcs
@@ -55,11 +55,6 @@ gcsfuse $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
 chmod +x run_load_test_and_fetch_metrics.sh
 ./run_load_test_and_fetch_metrics.sh
 
-# Copying gcsfuse logs to bucket
-gsutil -m cp $LOG_FILE gs://periodic-perf-tests/fio-gcsfuse-logs/
-
-# Deleting logs older than 10 days
-python3 utils/metrics_util.py gcs/fio-gcsfuse-logs/ 10
 sudo umount $MOUNT_POINT
 
 # ls_metrics test. This test does gcsfuse mount first and then do the testing.

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -1,2 +1,8 @@
+action {
+  define_artifacts {
+    regex: "gcsfuse-logs.txt"
+  }
+}
+
 build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh"
 

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -1,6 +1,8 @@
 action {
   define_artifacts {
     regex: "gcsfuse-logs.txt"
+    regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
+    strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }
 

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -3,10 +3,8 @@ set -e
 echo Print the time when FIO tests start
 date
 echo Running fio test..
-fio job_files/seq_rand_read_write.fio --lat_percentiles 1 --output-format=json --output='output.json'
-echo Logging fio results
-cp output.json gcs/fio-logs/output-$(date '+%Y-%m-%d').json
-python3 utils/metrics_util.py gcs/fio-logs/ 10
+fio job_files/seq_rand_read_write.fio --lat_percentiles 1 --output-format=json --output='fio-output.json'
+
 echo Installing requirements..
 pip install --require-hashes -r requirements.txt --user
 gsutil cp gs://periodic-perf-tests/creds.json gsheet
@@ -14,7 +12,7 @@ echo Fetching results..
 # Upload data to the gsheet only when it runs through kokoro.
 if [ "${KOKORO_JOB_TYPE}" != "RELEASE" ] && [ "${KOKORO_JOB_TYPE}" != "CONTINUOUS_INTEGRATION" ] && [ "${KOKORO_JOB_TYPE}" != "PRESUBMIT_GITHUB" ];
 then
-  python3 fetch_metrics.py output.json
+  python3 fetch_metrics.py fio-output.json
 else
-  python3 fetch_metrics.py output.json --upload
+  python3 fetch_metrics.py fio-output.json --upload
 fi


### PR DESCRIPTION
### Description
Today in CI script we manually copy the logs to gcs bucket. These logs doesn't get uploaded when there is a failure in script. Kokoro supports uploading artifacts to gcs bucket for both success and failure scenarios. Making changes to use the support provided.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Test manually by copying continuous integration script into presubmit script
2. Unit tests - NA
3. Integration tests - NA
