### PR TITLE
[Don't Review] Updating go version 1.20.3 to 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.20.3-alpine as builder
+FROM golang:1.20.4-alpine as builder
 
 RUN apk add git
 

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -6,8 +6,8 @@ echo "Installing git"
 sudo apt-get install git
 echo "Installing pip"
 sudo apt-get install pip -y
-echo "Installing go-lang 1.20.3"
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+echo "Installing go-lang 1.20.4"
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 echo "Installing fio"

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/setup.sh
+++ b/perfmetrics/scripts/ml_tests/setup.sh
@@ -4,7 +4,7 @@
 # >> source setup.sh
 
 # Go version to be installed.
-GO_VERSION=go1.19.7.linux-amd64.tar.gz
+GO_VERSION=go1.20.4.linux-amd64.tar.gz
 
 # This function will install the given module/dependency if it's not alredy 
 # installed.

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -5,7 +5,7 @@
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -22,8 +22,8 @@ pip install google-cloud
 pip install google-cloud-vision
 pip install google-api-python-client
 pip install prettytable
-echo Installing go-lang  1.20.3
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+echo Installing go-lang  1.20.4
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 echo Installing fio

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.20.3 as gcsfuse-package
+FROM golang:1.20.4 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.20.3 as builder
+FROM golang:1.20.4 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 


### PR DESCRIPTION
### Description
Updating go version 1.20.3 to 1.20.4

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
