### PR TITLE
Adding logs to print all the fio job timing

### DIFF
--- a/perfmetrics/scripts/fetch_metrics.py
+++ b/perfmetrics/scripts/fetch_metrics.py
@@ -63,6 +63,17 @@ if __name__ == '__main__':
   # waiting for 360 secs instead of 240 secs
   time.sleep(360)
 
+  # Print the start and end time of all the fio-jobs
+  # This is just make sure, the total run time of fio jobs are constant over
+  # different execution.
+  for ind, job in enumerate(temp):
+    start_time_sec = job[fio_metrics.consts.START_TIME]
+    end_time_sec = job[fio_metrics.consts.END_TIME]
+
+    # Print start and end time of jobs
+    print("Start time: ", start_time_sec)
+    print("End time: ", end_time_sec)
+
   vm_metrics_obj = vm_metrics.VmMetrics()
   vm_metrics_data = []
   # Getting VM metrics for every job

--- a/perfmetrics/scripts/fetch_metrics.py
+++ b/perfmetrics/scripts/fetch_metrics.py
@@ -70,6 +70,8 @@ if __name__ == '__main__':
     start_time_sec = job[fio_metrics.consts.START_TIME]
     end_time_sec = job[fio_metrics.consts.END_TIME]
 
+    print(f'Start and end time for job {ind + 1}...')
+
     # Print start and end time of jobs
     print("Start time: ", start_time_sec)
     print("End time: ", end_time_sec)


### PR DESCRIPTION
### Description
Printing the start and end time of all the fio jobs during the daily kokoro test. This will help to ensure the total run time of fio job is constant. If that is the case, then we have to figure out for the shift, for which we can reach to open-centsos team.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
