### PR TITLE
Delete Directory integration tests

### DIFF
--- a/tools/integration_tests/operations/delete_dir_test.go
+++ b/tools/integration_tests/operations/delete_dir_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestDeleteEmptyExplicitDir(t *testing.T) {
 	dirPath := path.Join(setup.MntDir(), EmptyExplicitDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptyExplicitDirectoryForDeleteTest, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {

--- a/tools/integration_tests/operations/delete_dir_test.go
+++ b/tools/integration_tests/operations/delete_dir_test.go
@@ -1,0 +1,58 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for delete directory.
+package operations_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func TestDeleteEmptyExplicitDir(t *testing.T) {
+	dirPath := path.Join(setup.MntDir(), EmptyExplicitDirectoryForDeleteTest)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptyExplicitDirectoryForDeleteTest, dirPath, "", t)
+
+	err := os.RemoveAll(dirPath)
+	if err != nil {
+		t.Errorf("Error in deleting empty explicit directory.")
+	}
+
+	dir, err := os.Stat(dirPath)
+	if err == nil && dir.Name() == EmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
+		t.Errorf("Directory is not deleted.")
+	}
+}
+
+func TestDeleteNonEmptyExplicitDir(t *testing.T) {
+	dirPath := path.Join(setup.MntDir(), NonEmptyExplicitDirectoryForDeleteTest)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest, dirPath, PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest, t)
+
+	subDirPath := path.Join(dirPath, NonEmptyExplicitSubDirectoryForDeleteTest)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest, subDirPath, PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest, t)
+
+	err := os.RemoveAll(dirPath)
+	if err != nil {
+		t.Errorf("Error in deleting empty explicit directory.")
+	}
+
+	dir, err := os.Stat(dirPath)
+	if err == nil && dir.Name() == NonEmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
+		t.Errorf("Directory is not deleted.")
+	}
+}

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -60,7 +60,6 @@ const SecondFileInSecondSubDirectoryForListTest = "fileInSecondSubDirectoryForLi
 const EmptyExplicitDirectoryForDeleteTest = "emptyExplicitDirectoryForDeleteTest"
 const NonEmptyExplicitDirectoryForDeleteTest = "nonEmptyExplicitDirectoryForDeleteTest"
 const NonEmptyExplicitSubDirectoryForDeleteTest = "nonEmptyExplicitSubDirectoryForDeleteTest"
-const NumberOfFilesInEmptyExplicitDirectoryForDeleteTest = 0
 const NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest = 2
 const PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest = "filesInNonEmptyExplicitDirectoryForDeleteTest"
 const NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest = 1

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -57,6 +57,14 @@ const SecondSubDirectoryForListTest = "secondSubDirectoryForListTest"
 const PrefixFileInSecondSubDirectoryForListTest = "fileInSecondSubDirectoryForListTest"
 const FirstFileInSecondSubDirectoryForListTest = "fileInSecondSubDirectoryForListTest1"
 const SecondFileInSecondSubDirectoryForListTest = "fileInSecondSubDirectoryForListTest2"
+const EmptyExplicitDirectoryForDeleteTest = "emptyExplicitDirectoryForDeleteTest"
+const NonEmptyExplicitDirectoryForDeleteTest = "nonEmptyExplicitDirectoryForDeleteTest"
+const NonEmptyExplicitSubDirectoryForDeleteTest = "nonEmptyExplicitSubDirectoryForDeleteTest"
+const NumberOfFilesInEmptyExplicitDirectoryForDeleteTest = 0
+const NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest = 2
+const PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest = "filesInNonEmptyExplicitDirectoryForDeleteTest"
+const NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest = 1
+const PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest = "filesInNonEmptyExplicitSubDirectoryForDeleteTest"
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
1. Test delete empty explicit directory
2. Test delete non-empty explicit directory

Note: Test delete non-empty implicit directory test will add in implicit dir package.

### Testing details
1. Manual - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
2. Unit tests - NA
3. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
