### PR TITLE
Printing overall fio execution start and end time

### DIFF
--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -3,10 +3,9 @@ set -e
 echo Print the time when FIO tests start
 date
 echo Running fio test..
-
-echo "Overall fio start time:" `date +%s`
+echo "Overall fio start epoch time:" `date +%s`
 fio job_files/seq_rand_read_write.fio --lat_percentiles 1 --output-format=json --output='fio-output.json'
-echo "Overall fio end time:" `date +%s`
+echo "Overall fio end epoch time:" `date +%s`
 
 echo Installing requirements..
 pip install --require-hashes -r requirements.txt --user

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -3,7 +3,10 @@ set -e
 echo Print the time when FIO tests start
 date
 echo Running fio test..
+
+echo "Overall fio start time:" `date +%s`
 fio job_files/seq_rand_read_write.fio --lat_percentiles 1 --output-format=json --output='fio-output.json'
+echo "Overall fio end time:" `date +%s`
 
 echo Installing requirements..
 pip install --require-hashes -r requirements.txt --user


### PR DESCRIPTION
### Description
Logging the overall start and end time of fio jobs. This execution time will be source of truth and help in knowing that the calculated start and end time of the every job is correct or not.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - checked the echo command manually it print the time as epoch time.
2. Unit tests - NA
3. Integration tests - NA
