### PR TITLE
fix integration test

### DIFF
--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -42,6 +42,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strings"
 )
 
 // Build release binaries according to the supplied settings, setting up the
@@ -164,6 +165,9 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 		output, err = cmd.CombinedOutput()
 		if err != nil {
 			err = fmt.Errorf("%v: %w\nOutput:\n%s", cmd, err, output)
+			if strings.Contains(string(output), "flag provided but not defined: -C") {
+				err = fmt.Errorf("%v: %w\nOutput:\n%s\nPlease upgrade to go version 1.20 or higher", cmd, err, output)
+			}
 			return
 		}
 	}

--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -133,10 +133,10 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 		cmd := exec.Command(
 			"go",
 			"build",
-			"-o",
-			path.Join(dstDir, bin.outputPath),
 			"-C",
-			srcDir)
+			srcDir,
+			"-o",
+			path.Join(dstDir, bin.outputPath))
 
 		if path.Base(bin.outputPath) == "gcsfuse" {
 			cmd.Args = append(


### PR DESCRIPTION
### Description
while running integration tests with go version 1.21.x, we were seeing the following error: 
```
invalid value "$HOME/gcsfuse" for flag -C: -C flag must be first flag on command line
usage: go build [-o output] [build flags] [packages]
Run 'go help build' for details.
```
Fix: made -C the first flag on command line. These changes are compatible with go version 1.20.x and newer.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
