### PR TITLE
Asynchronously fetch data in background to serve next page calls

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1696,8 +1696,8 @@ func (fs *fileSystem) ReadDir(
 	dh := fs.handles[op.Handle].(*dirHandle)
 	fs.mu.Unlock()
 
-	dh.Mu.Lock()
-	defer dh.Mu.Unlock()
+	//dh.Mu.Lock()
+	//defer dh.Mu.Unlock()
 
 	// Serve the request.
 	if err := dh.ReadDir(ctx, op); err != nil {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -43,6 +43,7 @@ func (bh *bucketHandle) Name() string {
 	return bh.bucketName
 }
 
+
 func (bh *bucketHandle) NewReader(
 	ctx context.Context,
 	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {


### PR DESCRIPTION
### Description
As kernel requests for the first page,start a goroutine to fetch data from GCSFuse. The calling goroutine is blocked until the page is ready.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
