### PR TITLE
GRPC Integration in GCSFuse

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -403,7 +403,6 @@ type flagStorage struct {
 	MaxConnsPerHost            int
 	MaxIdleConnsPerHost        int
 	EnableNonexistentTypeCache bool
-	EnableGRPC                 bool
 	GRPCConnPoolSize           int
 
 	// Monitoring & Logging

--- a/flags.go
+++ b/flags.go
@@ -276,8 +276,9 @@ func newApp() (app *cli.App) {
 			cli.IntFlag{
 				Name:  "grpc-conn-pool-size",
 				Value: 4,
-				Usage: "Number of gRPC channel. Normally, it's same as number of tcp connection, but in case of" +
-					"direct-path traffic it's hard to determine number of tcp-connections in one grpc channel.",
+				Usage: "Number of gRPC channel. For, direct-path traffic, it's hard to determine number of" +
+					" tcp-connections in one gRPC channel. For cloud-path traffic, number of tcp connection is" +
+					" equal to number of gRPC channel.",
 			},
 
 			/////////////////////////

--- a/flags.go
+++ b/flags.go
@@ -273,15 +273,11 @@ func newApp() (app *cli.App) {
 					" in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.",
 			},
 
-			cli.BoolFlag{
-				Name:  "enable-grpc",
-				Usage: "Once set, it connects to GCS via gRPC protocol.",
-			},
-
 			cli.IntFlag{
 				Name:  "grpc-conn-pool-size",
-				Value: 100,
-				Usage: "The size of grpc connection pool.",
+				Value: 4,
+				Usage: "Number of gRPC channel. Normally, it's same as number of tcp connection, but in case of" +
+					"direct-path traffic it's hard to determine number of tcp-connections in one grpc channel.",
 			},
 
 			/////////////////////////
@@ -549,7 +545,6 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		MaxConnsPerHost:            c.Int("max-conns-per-host"),
 		MaxIdleConnsPerHost:        c.Int("max-idle-conns-per-host"),
 		EnableNonexistentTypeCache: c.Bool("enable-nonexistent-type-cache"),
-		EnableGRPC:                 c.Bool("enable-grpc"),
 		GRPCConnPoolSize:           c.Int("grpc-conn-pool-size"),
 
 		// Monitoring & Logging

--- a/flags.go
+++ b/flags.go
@@ -273,6 +273,17 @@ func newApp() (app *cli.App) {
 					" in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.",
 			},
 
+			cli.BoolFlag{
+				Name:  "enable-grpc",
+				Usage: "Once set, it connects to GCS via gRPC protocol.",
+			},
+
+			cli.IntFlag{
+				Name:  "grpc-conn-pool-size",
+				Value: 100,
+				Usage: "The size of grpc connection pool.",
+			},
+
 			/////////////////////////
 			// Monitoring & Logging
 			/////////////////////////
@@ -396,6 +407,8 @@ type flagStorage struct {
 	MaxConnsPerHost            int
 	MaxIdleConnsPerHost        int
 	EnableNonexistentTypeCache bool
+	EnableGRPC                 bool
+	GRPCConnPoolSize           int
 
 	// Monitoring & Logging
 	StackdriverExportInterval time.Duration
@@ -536,6 +549,8 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		MaxConnsPerHost:            c.Int("max-conns-per-host"),
 		MaxIdleConnsPerHost:        c.Int("max-idle-conns-per-host"),
 		EnableNonexistentTypeCache: c.Bool("enable-nonexistent-type-cache"),
+		EnableGRPC:                 c.Bool("enable-grpc"),
+		GRPCConnPoolSize:           c.Int("grpc-conn-pool-size"),
 
 		// Monitoring & Logging
 		StackdriverExportInterval: c.Duration("stackdriver-export-interval"),

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect; indirectgo
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/googlecloudplatform/gcsfuse
 go 1.20
 
 require (
+	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/storage v1.31.0
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.11
@@ -25,20 +26,25 @@ require (
 	golang.org/x/net v0.10.0
 	golang.org/x/oauth2 v0.8.0
 	google.golang.org/api v0.126.0
+	google.golang.org/grpc v1.55.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/compute v1.19.3 // indirect
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.0 // indirect
 	cloud.google.com/go/monitoring v1.13.0 // indirect
 	cloud.google.com/go/pubsub v1.30.0 // indirect
 	cloud.google.com/go/trace v1.9.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.217 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
+	github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/envoyproxy/go-control-plane v0.11.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -63,7 +69,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
-	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMr
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -87,10 +89,14 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe h1:QQ3GSy+MqSHxm/d8nCtnAiZdYFd45cYZPs8vOOIYKfk=
+github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195 h1:58f1tJ1ra+zFINPlwLWvQsR9CzAKt2e+EWV2yX9oXQ4=
+github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -105,7 +111,11 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.11.0 h1:jtLewhRR2vMRNnq2ZZUoCjUlgut+Y0+sDDWPOfwOi1o=
+github.com/envoyproxy/go-control-plane v0.11.0/go.mod h1:VnHyVMpzcLvCFt9yUz1UnCwHLhwx1WguiVDV7pTG/tI=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/protoc-gen-validate v0.10.0 h1:oIfnZFdC0YhpNNEX+SuIqko4cqqVZeN9IGTrhZje83Y=
+github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -244,8 +254,10 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -697,6 +709,7 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -21,11 +21,12 @@ type ClientProtocol string
 const (
 	HTTP1 ClientProtocol = "http1"
 	HTTP2 ClientProtocol = "http2"
+	GRPC  ClientProtocol = "grpc"
 )
 
 func (cp ClientProtocol) IsValid() bool {
 	switch cp {
-	case HTTP1, HTTP2:
+	case HTTP1, HTTP2, GRPC:
 		return true
 	}
 	return false

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -296,7 +296,7 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 	obj := b.bucket.Object(req.Name)
 
 	if req.Generation != 0 {
-		obj = obj.Generation(req.Generation)
+		obj = obj.If(storage.Conditions{GenerationMatch: req.Generation})
 	}
 
 	if req.MetaGenerationPrecondition != nil {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -305,19 +305,25 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 
 	updateQuery := storage.ObjectAttrsToUpdate{}
 
+	var changed = false
+
 	if req.ContentType != nil {
+		//changed = true
 		updateQuery.ContentType = *req.ContentType
 	}
 
 	if req.ContentEncoding != nil {
+		//changed = true
 		updateQuery.ContentEncoding = *req.ContentEncoding
 	}
 
 	if req.ContentLanguage != nil {
+		//changed = true
 		updateQuery.ContentLanguage = *req.ContentLanguage
 	}
 
 	if req.CacheControl != nil {
+		//changed = true
 		updateQuery.CacheControl = *req.CacheControl
 	}
 
@@ -325,9 +331,16 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 		updateQuery.Metadata = make(map[string]string)
 		for key, element := range req.Metadata {
 			if element != nil {
+				changed = true
 				updateQuery.Metadata[key] = *element
 			}
 		}
+	}
+
+	if changed == false {
+		attrs, _ := obj.Attrs(ctx)
+		o = storageutil.ObjectAttrsToBucketObject(attrs)
+		return
 	}
 
 	attrs, err := obj.Update(ctx, updateQuery)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -296,7 +296,7 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 	obj := b.bucket.Object(req.Name)
 
 	if req.Generation != 0 {
-		obj = obj.If(storage.Conditions{GenerationMatch: req.Generation})
+		obj = obj.Generation(req.Generation)
 	}
 
 	if req.MetaGenerationPrecondition != nil {
@@ -305,25 +305,19 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 
 	updateQuery := storage.ObjectAttrsToUpdate{}
 
-	var changed = false
-
 	if req.ContentType != nil {
-		//changed = true
 		updateQuery.ContentType = *req.ContentType
 	}
 
 	if req.ContentEncoding != nil {
-		//changed = true
 		updateQuery.ContentEncoding = *req.ContentEncoding
 	}
 
 	if req.ContentLanguage != nil {
-		//changed = true
 		updateQuery.ContentLanguage = *req.ContentLanguage
 	}
 
 	if req.CacheControl != nil {
-		//changed = true
 		updateQuery.CacheControl = *req.CacheControl
 	}
 
@@ -331,16 +325,9 @@ func (b *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRe
 		updateQuery.Metadata = make(map[string]string)
 		for key, element := range req.Metadata {
 			if element != nil {
-				changed = true
 				updateQuery.Metadata[key] = *element
 			}
 		}
-	}
-
-	if changed == false {
-		attrs, _ := obj.Attrs(ctx)
-		o = storageutil.ObjectAttrsToBucketObject(attrs)
-		return
 	}
 
 	attrs, err := obj.Update(ctx, updateQuery)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -60,14 +60,24 @@ type StorageClientConfig struct {
 
 func createGRPCClientHandle(ctx context.Context, clientConfig StorageClientConfig) (sc *storage.Client, err error) {
 	if err := os.Setenv("STORAGE_USE_GRPC", "gRPC"); err != nil {
-		log.Fatalf("error setting enable grpc: %v", err)
+		log.Fatalf("error setting grpc env var: %v", err)
 	}
 
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		log.Fatalf("error setting direct path env var: %v", err)
 	}
 
-	return storage.NewClient(ctx, option.WithGRPCConnectionPool(clientConfig.GRPCConnPoolSize))
+	sc, err = storage.NewClient(ctx, option.WithGRPCConnectionPool(clientConfig.GRPCConnPoolSize))
+
+	if err := os.Unsetenv("STORAGE_USE_GRPC"); err != nil {
+		log.Fatalf("error while unsetting grpc env var: %v", err)
+	}
+
+	if err := os.Unsetenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS"); err != nil {
+		log.Fatalf("error while unsetting direct path env var: %v", err)
+	}
+
+	return
 }
 
 func createHTTPClientHandle(ctx context.Context, clientConfig StorageClientConfig) (sc *storage.Client, err error) {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -55,13 +55,10 @@ type StorageClientConfig struct {
 	MaxRetryDuration    time.Duration
 	RetryMultiplier     float64
 	UserAgent           string
-	EnableGRPC          bool
 	GRPCConnPoolSize    int
 }
 
 func createGRPCClientHandle(ctx context.Context, clientConfig StorageClientConfig) (sc *storage.Client, err error) {
-	os.Setenv("STORAGE_USE_GRPC", "gRPC")
-
 	if err := os.Setenv("STORAGE_USE_GRPC", "gRPC"); err != nil {
 		log.Fatalf("error setting enable grpc: %v", err)
 	}
@@ -112,9 +109,9 @@ func createHTTPClientHandle(ctx context.Context, clientConfig StorageClientConfi
 	return storage.NewClient(ctx, option.WithHTTPClient(httpClient))
 }
 
-// NewStorageHandle returns the handle of Go storage client containing
-// customized http client. We can configure the http client using the
-// storageClientConfig parameter.
+// NewStorageHandle returns the handle of Go storage client. It can be gRPC  or
+// HTTP client. We can customized the client by changing the storageClientConfig
+// parameter.
 func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh StorageHandle, err error) {
 	var sc *storage.Client
 	if clientConfig.ClientProtocol == mountpkg.GRPC {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -51,6 +52,8 @@ type StorageClientConfig struct {
 	MaxRetryDuration    time.Duration
 	RetryMultiplier     float64
 	UserAgent           string
+	EnableGRPC          bool
+	GRPCConnPoolSize    int
 }
 
 // NewStorageHandle returns the handle of Go storage client containing
@@ -91,8 +94,14 @@ func NewStorageHandle(ctx context.Context, clientConfig StorageClientConfig) (sh
 		wrapped:   httpClient.Transport,
 		UserAgent: clientConfig.UserAgent,
 	}
+
 	var sc *storage.Client
-	sc, err = storage.NewClient(ctx, option.WithHTTPClient(httpClient))
+	if clientConfig.EnableGRPC {
+		os.Setenv("STORAGE_USE_GRPC", "gRPC")
+		sc, err = storage.NewClient(ctx, option.WithGRPCConnectionPool(clientConfig.GRPCConnPoolSize))
+	} else {
+		sc, err = storage.NewClient(ctx, option.WithHTTPClient(httpClient))
+	}
 	if err != nil {
 		err = fmt.Errorf("go storage client creation failed: %w", err)
 		return

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -67,6 +67,24 @@ func (t *StorageHandleTest) invokeAndVerifyStorageHandle(sc StorageClientConfig)
 	AssertNe(nil, handleCreated)
 }
 
+func (t *StorageHandleTest) TestCreateGRPCClientHandle() {
+	sc := getDefaultStorageClientConfig()
+
+	handleCreated, err := createGRPCClientHandle(context.Background(), sc)
+
+	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
+}
+
+func (t *StorageHandleTest) TestCreateHTTPClientHandle() {
+	sc := getDefaultStorageClientConfig()
+
+	handleCreated, err := createHTTPClientHandle(context.Background(), sc)
+
+	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
+}
+
 func (t *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
 	storageHandle := t.fakeStorage.CreateStorageHandle()
 	bucketHandle := storageHandle.BucketHandle(TestBucketName, "")
@@ -106,6 +124,13 @@ func (t *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
 func (t *StorageHandleTest) TestNewStorageHandleHttp2Enabled() {
 	sc := getDefaultStorageClientConfig()
 	sc.ClientProtocol = mountpkg.HTTP2
+
+	t.invokeAndVerifyStorageHandle(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWithGRPCClientProtocol() {
+	sc := getDefaultStorageClientConfig()
+	sc.ClientProtocol = mountpkg.GRPC
 
 	t.invokeAndVerifyStorageHandle(sc)
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -17,12 +17,17 @@ package storageutil
 import (
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
 )
 
 func ShouldRetry(err error) (b bool) {
 	b = storage.ShouldRetry(err)
 	if b {
 		return
+	}
+
+	if ok && st.Code() == codes.ResourceExhausted {
+		return true
 	}
 
 	// HTTP 401 errors - Invalid Credentials
@@ -34,14 +39,6 @@ func ShouldRetry(err error) (b bool) {
 	// TODO: Please incorporate the correct fix post resolution of the above issue.
 	if typed, ok := err.(*googleapi.Error); ok {
 		if typed.Code == 401 {
-			b = true
-			return
-		}
-	}
-
-	// HTTP 429 errors (GCS uses these for rate limiting).
-	if typed, ok := err.(*googleapi.Error); ok {
-		if typed.Code == 429 {
 			b = true
 			return
 		}

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -38,5 +38,14 @@ func ShouldRetry(err error) (b bool) {
 			return
 		}
 	}
+
+	// HTTP 429 errors (GCS uses these for rate limiting).
+	if typed, ok := err.(*googleapi.Error); ok {
+		if typed.Code == 429 {
+			b = true
+			return
+		}
+	}
+
 	return
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -27,6 +27,8 @@ func ShouldRetry(err error) (b bool) {
 		return
 	}
 
+	// Actual fix (merged): https://github.com/googleapis/google-cloud-go/pull/8202
+	// TODO: Please remove this condition in the next go-client-library upgrade.
 	if st, ok := status.FromError(err); ok && st.Code() == codes.ResourceExhausted {
 		return true
 	}

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -18,6 +18,7 @@ import (
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func ShouldRetry(err error) (b bool) {
@@ -26,7 +27,7 @@ func ShouldRetry(err error) (b bool) {
 		return
 	}
 
-	if ok && st.Code() == codes.ResourceExhausted {
+	if st, ok := status.FromError(err); ok && st.Code() == codes.ResourceExhausted {
 		return true
 	}
 

--- a/main.go
+++ b/main.go
@@ -165,7 +165,6 @@ func createStorageHandle(flags *flagStorage) (storageHandle storage.StorageHandl
 		MaxRetryDuration:    flags.MaxRetryDuration,
 		RetryMultiplier:     flags.RetryMultiplier,
 		UserAgent:           getUserAgent(flags.AppName),
-		EnableGRPC:          flags.EnableGRPC,
 		GRPCConnPoolSize:    flags.GRPCConnPoolSize,
 	}
 

--- a/main.go
+++ b/main.go
@@ -165,6 +165,8 @@ func createStorageHandle(flags *flagStorage) (storageHandle storage.StorageHandl
 		MaxRetryDuration:    flags.MaxRetryDuration,
 		RetryMultiplier:     flags.RetryMultiplier,
 		UserAgent:           getUserAgent(flags.AppName),
+		EnableGRPC:          flags.EnableGRPC,
+		GRPCConnPoolSize:    flags.GRPCConnPoolSize,
 	}
 
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)


### PR DESCRIPTION
### Description
Adding support in gcsfuse to communicate with GCS via gRPC.

- Added new value for `client-protocol` flags to mount gcsfuse with gRPC protocol. you need to pass --client-protocol=grpc
- Added new flag `grcp-conn-pool-size` to control the number of channel used in gRPC protocol client.
- Added a new library "googledirectpath" which works as google-c2p resolver.
- Refactored current NewStorageClient method to create both http & grpc client based on the passed value for `--client-protocol`
- Added unit test for the newly added method in storage package.

[Testing in progress]
1. Unit test failed with google: default credential not found.
2. Facing issue in update object method: generation not supported.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Verified manually normal operations.
3. Unit tests - automation.
4. Integration tests - 
