### PR TITLE
Adding rpm digest while creating rpm package

### DIFF
--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -66,6 +66,7 @@ RUN fpm \
     -C ${GCSFUSE_BIN} \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
+    --rpm-digest sha256 \
     --vendor "" \
     --url "https://$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."


### PR DESCRIPTION
### Description
Issue: Error "cpio: Digest mismatch" while installing gcsfuse on RHEL 8 in FIPS mode

```
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:gcsfuse-0.42.5-1                 ################################# [100%]
error: unpacking of archive failed on file /sbin/mount.gcsfuse;64a7afd5: cpio: Digest mismatch
error: gcsfuse-0.42.5-1.x86_64: install failed
```

Fix:
By default, per-file verification happens with MD5 digest, but in RHEL 8 (FIPS enabled) verification happens with sha256. Hence, this PR contains changes to build the rpm file with sha256 digest. This is also recommended.
Ref -  https://bugzilla.redhat.com/show_bug.cgi?id=1659053

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Basic sanity over all standard file-system operation.
2. Unit tests - Automation
3. Integration tests - Tested this commit on louhi pipeline. which covers integration test on all the supported OS. Tested rpm based OS version - **centos-7**, **centos-8**, **centos-9**, **rhel-7**, **rhel-8**, **rhel-9**.
