### PR TITLE
Fixing some issues encountered during KOKORO build for periodic experiments

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/build.sh
@@ -59,7 +59,7 @@ CONFIG_ID=$(eval "python3 -m bigquery.get_experiments_config --gcsfuse_flags '$G
 START_TIME_BUILD=$(date +%s)
 
 UPLOAD_FLAGS=""
-if [ "${KOKORO_JOB_TYPE}" == "RELEASE" ] || [ "${KOKORO_JOB_TYPE}" == "CONTINUOUS_INTEGRATION" ] || [ "${KOKORO_JOB_TYPE}" == "PRESUBMIT_GITHUB" ];
+if [ "${KOKORO_JOB_TYPE}" == "RELEASE" ] || [ "${KOKORO_JOB_TYPE}" == "CONTINUOUS_INTEGRATION" ] || [ "${KOKORO_JOB_TYPE}" == "PRESUBMIT_GITHUB" ] || [ "${KOKORO_JOB_TYPE}" == "SUB_JOB" ];
 then
   UPLOAD_FLAGS="--upload_gs --upload_bq --config_id $CONFIG_ID --start_time_build $START_TIME_BUILD"
 fi

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -446,7 +446,7 @@ def _parse_arguments(argv):
       help='Number of samples to collect of each test.',
       action='store',
       nargs=1,
-      default=[300],
+      default=[30],
       required=False,
   )
   parser.add_argument(

--- a/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
+++ b/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
@@ -14,4 +14,4 @@ UPLOAD_FLAGS=$2
 echo Running script..
 # TODO (ruchikasharmaa): Changed name of bucket in config.json file to 'list-benchmark-test1' for running periodic experiments.
 #  The bucket is in gcs-fuse-test project. Before merging to master, we need to resolve the conflicts.
-python3 listing_benchmark.py config.json --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 300 --message "Testing CT setup."
+python3 listing_benchmark.py config.json --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 30 --message "Testing CT setup."


### PR DESCRIPTION
### Description
Fixing some issues related to timeout and problem in uploading metrics to BigQuery during KOKORO build. Added new KOKORO_JOB_TYPE, SUB_JOB and reduced sample size to 30 for listing tests

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the build scripts from "periodic_experiments" folder using command "./build.sh" after commenting out the call to "run_load_test_and_fetch_metrics.sh" and setting EXPERIMENT_NUMBER to "1" and KOKORO_JOB_TYPE to "SUB_JOB". Observed the time taken for listing experiments to run, it was 18 mins and 34 seconds, which was under acceptable range.
2. Unit tests - NA
3. Integration tests - NA
