### PR TITLE
Fixing some issues encountered during KOKORO build for periodic experiments 

### DIFF
--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -464,20 +464,6 @@ def _parse_arguments(argv):
       required=False,
   )
   parser.add_argument(
-      '--config_id',
-      help='Configuration id of the experiment in the BigQuery tables',
-      action='store_true',
-      default=False,
-      required=False,
-  )
-  parser.add_argument(
-      '--start_time_build',
-      help='Time at which KOKORO triggered the build script.',
-      action='store_true',
-      default=False,
-      required=False,
-  )
-  parser.add_argument(
       '--command',
       help='Command to run the tests on.',
       action='store',


### PR DESCRIPTION
### Description
Fixing some issues encountered during KOKORO build for periodic experiments related to conflicting arguments. Removed the duplicated and conflicting arguments.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the build scripts from "periodic_experiments" folder using command "./build.sh" after commenting out the call to "run_load_test_and_fetch_metrics.sh" (only ran the list tests) and ensured that no arguments were conflicting with each other and all arguments were being parsed correctly.
2. Unit tests - NA
3. Integration tests - NA
