### PR TITLE
Changing the number of epoch based on previous run

### DIFF
--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -74,7 +74,7 @@ gsutil cp start_time.txt $ARTIFACTS_BUCKET_PATH/
     --norm_last_layer False \
     --use_fp16 False \
     --clip_grad 0 \
-    --epochs 100 \
+    --epochs 80 \
     --global_crops_scale 0.25 1.0 \
     --local_crops_number 10 \
     --local_crops_scale 0.05 0.25 \

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/resnet_runner.py
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/resnet_runner.py
@@ -111,5 +111,5 @@ model, eval_logs = tfm.core.train_lib.run_experiment(
     params=exp_config,
     model_dir=model_dir,
     run_post_eval=True,
-    epochs=1000,
+    epochs=675,
     clear_kernel_cache=True)


### PR DESCRIPTION
### Description
**Changing the number of epochs:**
**Pytorch** - from 100 to 80 - since initial number took more than 7 days. Expectation is to run the test for 7 days, hence reducing the number of epochs.
**TF** - 675 - from 1000 to 675 - since initial number took more than 7 days. Expectation is to run the test for 7 days, hence reducing the number of epochs.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
