### PR TITLE
Fixing open file issue

### DIFF
--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -76,7 +76,7 @@ func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string,
 		}
 
 		// Closing file at the end.
-		defer CloseFile(file)
+		CloseFile(file)
 	}
 }
 


### PR DESCRIPTION
### Description
Removing defer as not working properly in for loop.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
Tested on centos-7 (Throwing error previously, working fine now)
Tested on Ubuntu
11. Unit tests - NA
12. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
