### PR TITLE
Add copyright file

### DIFF
--- a/DEBIAN/changelog
+++ b/DEBIAN/changelog
@@ -1,0 +1,5 @@
+gcsfuse (1.0.0) stable; urgency=medium
+
+  * Package created with dpkg-deb --build
+
+ -- GCSFuse Eng Team <gcs-fuse-eng@google.com>  Thu, 13 Jul 2023 05:37:50 +0000

--- a/DEBIAN/changelog
+++ b/DEBIAN/changelog
@@ -2,4 +2,4 @@ gcsfuse (1.0.0) stable; urgency=medium
 
   * Package created with dpkg-deb --build
 
- -- GCSFuse Eng Team <gcs-fuse-eng@google.com>  Thu, 13 Jul 2023 05:37:50 +0000
+ -- GCSFuse Team <gcs-fuse-maintainers@google.com>  Thu, 13 Jul 2023 05:37:50 +0000

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,6 +1,6 @@
 Version: 1.0.0
 Source: gcsfuse
-Maintainer: GCSFuse Eng Team <gcs-fuse-eng@google.com>
+Maintainer: GCSFuse Team <gcs-fuse-maintainers@google.com>
 Homepage: https://github.com/GoogleCloudPlatform/gcsfuse
 Package: gcsfuse
 Architecture: amd64

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,0 +1,12 @@
+Version: 1.0.0
+Source: gcsfuse
+Maintainer: GCSFuse Eng Team <gcs-fuse-eng@google.com>
+Homepage: https://github.com/GoogleCloudPlatform/gcsfuse
+Package: gcsfuse
+Architecture: amd64
+Depends: libc6 (>= 2.3.2), fuse
+Description: User-space file system for Google Cloud Storage.
+ GCSFuse is a FUSE adapter that allows you to mount and access Cloud Storage
+ buckets as local file systems, so applications can read and write objects in
+ your bucket using standard file system semantics. Cloud Storage FUSE is an
+ open source product that's supported by Google.

--- a/DEBIAN/copyright
+++ b/DEBIAN/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: gcsfuse
-Upstream-Contact: gcs-fuse-eng@google.com
+Upstream-Contact: gcs-fuse-maintainers@google.com
 
 Files: *
 Copyright: Copyright 2020 Google Inc.

--- a/DEBIAN/copyright
+++ b/DEBIAN/copyright
@@ -1,0 +1,23 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: gcsfuse
+Upstream-Contact: gcs-fuse-eng@google.com
+
+Files: *
+Copyright: Copyright 2020 Google Inc.
+License: Apache-2.0
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the complete text of the Apache version 2.0 license
+ can be found in "/usr/share/common-licenses/Apache-2.0".

--- a/DEBIAN/gcsfuse-docs.docs
+++ b/DEBIAN/gcsfuse-docs.docs
@@ -1,0 +1,3 @@
+https://cloud.google.com/storage/docs/gcs-fuse
+https://github.com/GoogleCloudPlatform/gcsfuse#readme
+https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/docs

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -20,6 +20,7 @@
 FROM golang:1.20.4 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
+RUN apt update -qq && apt install -y binutils debhelper devscripts
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -31,34 +32,40 @@ ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
 RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
+ARG DEBEMAIL="gcs-fuse-dev@google.com"
+ARG DEBFULLNAME="GCSFuse Team"
+
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
-ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+#ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
 RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
 
-ARG GCSFUSE_BIN="/gcsfuse"
+ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_amd64"
+ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
 WORKDIR ${GOPATH}
 RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
+RUN mkdir -p ${GCSFUSE_BIN}/DEBIAN && cp $GOPATH/src/$GCSFUSE_REPO/DEBIAN/* ${GCSFUSE_BIN}/DEBIAN/
+RUN mkdir -p ${GCSFUSE_DOC}
+RUN mv ${GCSFUSE_BIN}/DEBIAN/copyright ${GCSFUSE_DOC} &&  \
+    mv ${GCSFUSE_BIN}/DEBIAN/changelog ${GCSFUSE_DOC} && \
+    mv ${GCSFUSE_BIN}/DEBIAN/gcsfuse-docs.docs ${GCSFUSE_DOC}
+RUN sed -i "1s/.*/gcsfuse (${GCSFUSE_VERSION}) stable; urgency=medium/" ${GCSFUSE_DOC}/changelog && \
+    sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control
+RUN gzip -9 -n ${GCSFUSE_DOC}/changelog
+RUN strip --strip-unneeded ${GCSFUSE_BIN}/usr/bin/gcsfuse && \
+    strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse
+RUN dpkg-deb --build ${GCSFUSE_BIN}
 
 ARG GCSFUSE_PKG="/packages"
 RUN mkdir -p ${GCSFUSE_PKG}
 WORKDIR ${GCSFUSE_PKG}
-RUN fpm \
-    -s dir \
-    -t deb \
-    -n gcsfuse \
-    -C ${GCSFUSE_BIN} \
-    -v ${GCSFUSE_VERSION} \
-    -d fuse \
-    --vendor "" \
-    --url "https://$GCSFUSE_REPO" \
-    --description "A user-space file system for Google Cloud Storage."
+RUN mv ${GCSFUSE_BIN}.deb .
 RUN fpm \
     -s dir \
     -t rpm \
@@ -66,7 +73,6 @@ RUN fpm \
     -C ${GCSFUSE_BIN} \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
-    --rpm-digest sha256 \
     --vendor "" \
     --url "https://$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
-#ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
 RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
@@ -50,16 +50,22 @@ RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
+
+# Creating structure for debian package as we are using 'dpkg-deb --build' to create debian package
 RUN mkdir -p ${GCSFUSE_BIN}/DEBIAN && cp $GOPATH/src/$GCSFUSE_REPO/DEBIAN/* ${GCSFUSE_BIN}/DEBIAN/
 RUN mkdir -p ${GCSFUSE_DOC}
 RUN mv ${GCSFUSE_BIN}/DEBIAN/copyright ${GCSFUSE_DOC} &&  \
     mv ${GCSFUSE_BIN}/DEBIAN/changelog ${GCSFUSE_DOC} && \
-    mv ${GCSFUSE_BIN}/DEBIAN/gcsfuse-docs.docs ${GCSFUSE_DOC}
+    mv ${GCSFUSE_BIN}/DEBIAN/gcsfuse-docs.docs ${GCSFUSE_DOC} \
+# Update gcsfuse version in changelog and control file
 RUN sed -i "1s/.*/gcsfuse (${GCSFUSE_VERSION}) stable; urgency=medium/" ${GCSFUSE_DOC}/changelog && \
-    sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control
+    sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control \
+# Compress changelog as required by lintian
 RUN gzip -9 -n ${GCSFUSE_DOC}/changelog
+# Strip unneeded from binaries as required by lintian
 RUN strip --strip-unneeded ${GCSFUSE_BIN}/usr/bin/gcsfuse && \
-    strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse
+    strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse \
+# Build the package
 RUN dpkg-deb --build ${GCSFUSE_BIN}
 
 ARG GCSFUSE_PKG="/packages"
@@ -73,6 +79,8 @@ RUN fpm \
     -C ${GCSFUSE_BIN} \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
+    --rpm-digest sha256 \
+    --license Apache-2.0 \
     --vendor "" \
     --url "https://$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -20,7 +20,6 @@
 FROM golang:1.20.4 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
-RUN apt update -qq && apt install -y binutils debhelper devscripts
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
@@ -32,7 +31,7 @@ ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
 RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
-ARG DEBEMAIL="gcs-fuse-dev@google.com"
+ARG DEBEMAIL="gcs-fuse-maintainers@google.com"
 ARG DEBFULLNAME="GCSFuse Team"
 
 # Build Arg for building through a particular branch/commit. By default, it uses
@@ -56,21 +55,21 @@ RUN mkdir -p ${GCSFUSE_BIN}/DEBIAN && cp $GOPATH/src/$GCSFUSE_REPO/DEBIAN/* ${GC
 RUN mkdir -p ${GCSFUSE_DOC}
 RUN mv ${GCSFUSE_BIN}/DEBIAN/copyright ${GCSFUSE_DOC} &&  \
     mv ${GCSFUSE_BIN}/DEBIAN/changelog ${GCSFUSE_DOC} && \
-    mv ${GCSFUSE_BIN}/DEBIAN/gcsfuse-docs.docs ${GCSFUSE_DOC} \
+    mv ${GCSFUSE_BIN}/DEBIAN/gcsfuse-docs.docs ${GCSFUSE_DOC}
 # Update gcsfuse version in changelog and control file
 RUN sed -i "1s/.*/gcsfuse (${GCSFUSE_VERSION}) stable; urgency=medium/" ${GCSFUSE_DOC}/changelog && \
-    sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control \
+    sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control
 # Compress changelog as required by lintian
 RUN gzip -9 -n ${GCSFUSE_DOC}/changelog
 # Strip unneeded from binaries as required by lintian
 RUN strip --strip-unneeded ${GCSFUSE_BIN}/usr/bin/gcsfuse && \
-    strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse \
-# Build the package
-RUN dpkg-deb --build ${GCSFUSE_BIN}
+    strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse
 
 ARG GCSFUSE_PKG="/packages"
 RUN mkdir -p ${GCSFUSE_PKG}
 WORKDIR ${GCSFUSE_PKG}
+# Build the package
+RUN dpkg-deb --build ${GCSFUSE_BIN}
 RUN mv ${GCSFUSE_BIN}.deb .
 RUN fpm \
     -s dir \


### PR DESCRIPTION
### Description
Included copyright file in deb package.

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/290

### Testing details
1. Manual - Copyright file present in /usr/share/doc/gcsfuse post installation
```
ashmeen_google_com@ashmeen-bookworm:/usr/share/doc/gcsfuse$ ls
changelog.gz  copyright  gcsfuse-docs.docs
```
Added license flag to rpm package
```
ashmeen@ashmeen:~/gcsfuse/release/v1.0.2/packages$ rpm -qid gcsfuse-1.0.2-1.x86_64.rpm
Name        : gcsfuse
Version     : 1.0.2
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : default
Size        : 22491743
License     : Apache-2.0
Signature   : (none)
Source RPM  : gcsfuse-1.0.2-1.src.rpm
Build Date  : Mon 17 Jul 2023 06:27:21 AM UTC
Build Host  : 47c73e7d027e
Relocations : / 
Packager    : GCSFuse Team <gcs-fuse-dev@google.com>
URL         : https://github.com/googlecloudplatform/gcsfuse/
Summary     : A user-space file system for Google Cloud Storage.
Description :
A user-space file system for Google Cloud Storage.
/usr/share/doc/gcsfuse/changelog.gz
/usr/share/doc/gcsfuse/copyright
/usr/share/doc/gcsfuse/gcsfuse-docs.docs
```
verified that installation of rpm package adds copyright file at /usr/share/doc/gcsfuse
```
[starterscriptuser@release-test-rhel-8 gcsfuse]$ ls
changelog.gz  copyright  gcsfuse-docs.docs
```

2. Unit tests - NA
3. Lintian fixes -
On old deb package
```
ashmeen@ashmeen:~/gcsfuse/release$ lintian v1.0.0/gcsfuse_1.0.0_amd64.deb 
E: gcsfuse: extended-description-is-empty
E: gcsfuse: malformed-contact Maintainer <@8c10b0688c04>
E: gcsfuse: missing-dependency-on-libc needed by usr/bin/gcsfuse
E: gcsfuse: no-copyright-file
E: gcsfuse: statically-linked-binary [sbin/mount.gcsfuse]
E: gcsfuse: unstripped-binary-or-object [sbin/mount.gcsfuse]
E: gcsfuse: unstripped-binary-or-object [usr/bin/gcsfuse]
W: gcsfuse: description-synopsis-starts-with-article
W: gcsfuse: hardening-no-pie [usr/bin/gcsfuse]
W: gcsfuse: hardening-no-relro [usr/bin/gcsfuse]
W: gcsfuse: no-manual-page [sbin/mount.fuse.gcsfuse]
W: gcsfuse: no-manual-page [sbin/mount.gcsfuse]
W: gcsfuse: no-manual-page [usr/bin/gcsfuse]
W: gcsfuse: package-contains-timestamped-gzip 2023-06-26T06:56:58 [usr/share/doc/gcsfuse/changelog.gz]
W: gcsfuse: syntax-error-in-debian-changelog "not a Debian changelog" [usr/share/doc/gcsfuse/changelog.gz:1]
W: gcsfuse: unknown-field License
W: gcsfuse: unknown-section default
```
On new deb package
```
ashmeen@ashmeen:~/gcsfuse/release$ lintian v1.0.2/gcsfuse_1.0.2_amd64.deb 
E: gcsfuse: statically-linked-binary [sbin/mount.gcsfuse]
W: gcsfuse: hardening-no-pie [usr/bin/gcsfuse]
W: gcsfuse: hardening-no-relro [usr/bin/gcsfuse]
W: gcsfuse: no-manual-page [sbin/mount.fuse.gcsfuse]
W: gcsfuse: no-manual-page [sbin/mount.gcsfuse]
W: gcsfuse: no-manual-page [usr/bin/gcsfuse]
W: gcsfuse: recommended-field gcsfuse_1.0.2_amd64.deb Priority
W: gcsfuse: recommended-field gcsfuse_1.0.2_amd64.deb Section
```
4. Integration tests - Ran successfully on debian vm
