### PR TITLE
Fixed end_date in SeptRelease config

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -10,7 +10,7 @@
       "config_name": "SeptRelease",
       "gcsfuse_flags": "--implicit-dirs --debug_fuse --debug_gcs",
       "branch": "sept_release",
-      "end_date": "2023-09-30"
+      "end_date": "2023-09-30 05:30:00+00:00"
     },
     {
       "config_name": "EnabledStorageClientLibraryProtocolHTTP2",


### PR DESCRIPTION
### Description
Added time to the end_date of "SeptRelease" config to fix failing KOKORO build.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
