### PR TITLE
Modified CreateFile operation to create localFiles based on config flag

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 type WriteConfig struct {

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -7,3 +7,12 @@ type WriteConfig struct {
 type MountConfig struct {
 	WriteConfig `yaml:"write"`
 }
+
+func NewMountConfig() *MountConfig {
+	return &MountConfig{
+		WriteConfig{
+			// Making the default value as true to keep it inline with current behaviour.
+			CreateEmptyFile: true,
+		},
+	}
+}

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
-	mountConfig = &MountConfig{}
+	mountConfig = NewMountConfig()
 
 	if fileName == "" {
 		return

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -19,6 +19,7 @@ func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
 
 	AssertEq(nil, err)
 	AssertNe(nil, mountConfig)
+	AssertEq(true, mountConfig.CreateEmptyFile)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFile() {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -18,15 +18,19 @@ func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
 	mountConfig, err := ParseConfigFile("")
 
 	AssertEq(nil, err)
-	AssertNe(nil, mountConfig)
-	AssertEq(true, mountConfig.CreateEmptyFile)
+	validateDefaultConfig(mountConfig)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFile() {
 	mountConfig, err := ParseConfigFile("testdata/empty_file.yaml")
 
 	AssertEq(nil, err)
+	validateDefaultConfig(mountConfig)
+}
+
+func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertNe(nil, mountConfig)
+	AssertEq(true, mountConfig.CreateEmptyFile)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_NonExistingFile() {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -14,6 +14,11 @@ type YamlParserTest struct {
 
 func init() { RegisterTestSuite(&YamlParserTest{}) }
 
+func validateDefaultConfig(mountConfig *MountConfig) {
+	AssertNe(nil, mountConfig)
+	AssertEq(true, mountConfig.CreateEmptyFile)
+}
+
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
 	mountConfig, err := ParseConfigFile("")
 
@@ -26,11 +31,6 @@ func (t *YamlParserTest) TestReadConfigFile_EmptyFile() {
 
 	AssertEq(nil, err)
 	validateDefaultConfig(mountConfig)
-}
-
-func validateDefaultConfig(mountConfig *MountConfig) {
-	AssertNe(nil, mountConfig)
-	AssertEq(true, mountConfig.CreateEmptyFile)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_NonExistingFile() {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -530,7 +530,7 @@ func (fs *fileSystem) checkInvariantsForGenerationBackedInodes() {
 
 func (fs *fileSystem) checkInvariantsForInodes() {
 	// INVARIANT: For all keys k, fuseops.RootInodeID <= k < nextInodeID
-	for id, _ := range fs.inodes {
+	for id := range fs.inodes {
 		if id < fuseops.RootInodeID || id >= fs.nextInodeID {
 			panic(fmt.Sprintf("Illegal inode ID: %v", id))
 		}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
@@ -137,6 +138,7 @@ func (t *fsTest) SetUpTestSuite() {
 	}
 	t.serverCfg.RenameDirLimit = RenameDirLimit
 	t.serverCfg.SequentialReadSizeMb = SequentialReadSizeMb
+	t.serverCfg.MountConfig = config.NewMountConfig()
 
 	// Set up ownership.
 	t.serverCfg.Uid, t.serverCfg.Gid, err = perms.MyUserAndGroup()

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -176,6 +176,10 @@ func (d *baseDirInode) CreateChildFile(ctx context.Context, name string) (*Core,
 	return nil, fuse.ENOSYS
 }
 
+func (d *baseDirInode) CreateLocalChildFile(name string) (*Core, error) {
+	return nil, fuse.ENOSYS
+}
+
 func (d *baseDirInode) CloneToChildFile(ctx context.Context, name string, src *gcs.Object) (*Core, error) {
 	return nil, fuse.ENOSYS
 }

--- a/internal/fs/inode/core.go
+++ b/internal/fs/inode/core.go
@@ -58,7 +58,7 @@ func (c *Core) Type() Type {
 	switch {
 	case c == nil:
 		return UnknownType
-	case c.Object == nil:
+	case c.Object == nil && !c.Local:
 		return ImplicitDirType
 	case c.FullName.IsDir():
 		return ExplicitDirType
@@ -74,9 +74,6 @@ func (c *Core) Type() Type {
 func (c Core) SanityCheck() error {
 	if c.Object != nil && c.FullName.objectName != c.Object.Name {
 		return fmt.Errorf("inode name %q mismatches object name %q", c.FullName, c.Object.Name)
-	}
-	if c.Object != nil {
-		return nil
 	}
 
 	if c.Object == nil && !c.Local && !c.FullName.IsDir() {

--- a/internal/fs/inode/core.go
+++ b/internal/fs/inode/core.go
@@ -44,6 +44,9 @@ type Core struct {
 	// The GCS object in the bucket above that backs up the inode. Can be empty
 	// if the inode is the base directory or an implicit directory.
 	Object *gcs.Object
+
+	// Specifies a local object which is not yet synced to GCS.
+	Local bool
 }
 
 // Exists returns true iff the back object exists implicitly or explicitly.
@@ -72,8 +75,13 @@ func (c Core) SanityCheck() error {
 	if c.Object != nil && c.FullName.objectName != c.Object.Name {
 		return fmt.Errorf("inode name %q mismatches object name %q", c.FullName, c.Object.Name)
 	}
-	if c.Object == nil && !c.FullName.IsDir() {
+	if c.Object != nil {
+		return nil
+	}
+
+	if c.Object == nil && !c.Local && !c.FullName.IsDir() {
 		return fmt.Errorf("object missing for %q", c.FullName)
 	}
+
 	return nil
 }

--- a/internal/fs/inode/core_test.go
+++ b/internal/fs/inode/core_test.go
@@ -126,13 +126,6 @@ func (t *CoreTest) SanityCheck() {
 
 	c = &inode.Core{
 		Bucket:   &t.bucket,
-		FullName: inode.NewFileName(root, "bar"),
-		Object:   nil,
-	}
-	ExpectNe(nil, c.SanityCheck()) // missing object for file
-
-	c = &inode.Core{
-		Bucket:   &t.bucket,
 		FullName: inode.NewFileName(root, o.Name),
 		Object:   o,
 	}
@@ -144,4 +137,20 @@ func (t *CoreTest) SanityCheck() {
 		Object:   o,
 	}
 	ExpectNe(nil, c.SanityCheck()) // name mismatch
+
+	c = &inode.Core{
+		Bucket:   &t.bucket,
+		FullName: inode.NewFileName(root, "foo"),
+		Object:   nil,
+		Local:    true,
+	}
+	ExpectEq(nil, c.SanityCheck()) // object is nil for local fileInode.
+
+	c = &inode.Core{
+		Bucket:   &t.bucket,
+		FullName: inode.NewFileName(root, "foo"),
+		Object:   nil,
+		Local:    false,
+	}
+	ExpectNe(nil, c.SanityCheck()) // Missing object for non-local fileInode.
 }

--- a/internal/fs/inode/core_test.go
+++ b/internal/fs/inode/core_test.go
@@ -71,6 +71,18 @@ func (t *CoreTest) File() {
 	ExpectEq(inode.RegularFileType, c.Type())
 }
 
+func (t *CoreTest) LocalFile() {
+	name := inode.NewFileName(inode.NewRootName(t.bucket.Name()), "test")
+	c := &inode.Core{
+		Bucket:   &t.bucket,
+		FullName: name,
+		Object:   nil,
+		Local:    true,
+	}
+	ExpectTrue(c.Exists())
+	ExpectEq(inode.RegularFileType, c.Type())
+}
+
 func (t *CoreTest) ExplicitDir() {
 	o, err := gcsutil.CreateObject(t.ctx, t.bucket, "bar/", []byte(""))
 	AssertEq(nil, err)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -87,8 +87,8 @@ type DirInode interface {
 	// Return the full name of the child and the GCS object it backs up.
 	CreateChildFile(ctx context.Context, name string) (*Core, error)
 
-	// Create an empty child local file with the supplied (relative) name. Local
-	// file means the object is not created in GCS.
+	// Create an empty local child file with the supplied (relative) name. Local
+	// file means the object is not yet created in GCS.
 	CreateLocalChildFile(name string) (*Core, error)
 
 	// Like CreateChildFile, except clone the supplied source object instead of
@@ -670,12 +670,11 @@ func (d *dirInode) CreateChildFile(ctx context.Context, name string) (*Core, err
 func (d *dirInode) CreateLocalChildFile(name string) (*Core, error) {
 	fullName := NewFileName(d.Name(), name)
 
-	// TODO: check if its required.
-	d.cache.Insert(d.cacheClock.Now(), name, RegularFileType)
 	return &Core{
 		Bucket:   d.Bucket(),
 		FullName: fullName,
 		Object:   nil,
+		Local:    true,
 	}, nil
 }
 

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -87,6 +87,10 @@ type DirInode interface {
 	// Return the full name of the child and the GCS object it backs up.
 	CreateChildFile(ctx context.Context, name string) (*Core, error)
 
+	// Create an empty child local file with the supplied (relative) name. Local
+	// file means the object is not created in GCS.
+	CreateLocalChildFile(name string) (*Core, error)
+
 	// Like CreateChildFile, except clone the supplied source object instead of
 	// creating an empty object.
 	// Return the full name of the child and the GCS object it backs up.
@@ -660,6 +664,18 @@ func (d *dirInode) CreateChildFile(ctx context.Context, name string) (*Core, err
 		Bucket:   d.Bucket(),
 		FullName: fullName,
 		Object:   o,
+	}, nil
+}
+
+func (d *dirInode) CreateLocalChildFile(name string) (*Core, error) {
+	fullName := NewFileName(d.Name(), name)
+
+	// TODO: check if its required.
+	d.cache.Insert(d.cacheClock.Now(), name, RegularFileType)
+	return &Core{
+		Bucket:   d.Bucket(),
+		FullName: fullName,
+		Object:   nil,
 	}, nil
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1195,3 +1195,19 @@ func (t *DirTest) DeleteChildDir_ImplicitDirTrue() {
 	err := t.in.DeleteChildDir(t.ctx, name, true)
 	ExpectEq(nil, err)
 }
+
+func (t *DirTest) CreateLocalChildFile_ShouldnotCreateObjectInGCS() {
+	const name = "qux"
+
+	// Create the local file inode.
+	core, err := t.in.CreateLocalChildFile(name)
+
+	AssertEq(nil, err)
+	AssertEq(true, core.Local)
+	AssertEq(nil, core.Object)
+
+	// Object shouldn't get created in GCS.
+	result, err := t.in.LookUpChild(t.ctx, name)
+	AssertEq(nil, err)
+	AssertEq(nil, result)
+}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -68,7 +68,7 @@ type FileInode struct {
 
 	// The source object from which this inode derives.
 	//
-	// INVARIANT: src.Name == name.GcsObjectName()
+	// INVARIANT: for non local files,  src.Name == name.GcsObjectName()
 	//
 	// GUARDED_BY(mu)
 	src storage.MinObject
@@ -104,7 +104,8 @@ func NewFileInode(
 	bucket *gcsx.SyncerBucket,
 	localFileCache bool,
 	contentCache *contentcache.ContentCache,
-	mtimeClock timeutil.Clock) (f *FileInode) {
+	mtimeClock timeutil.Clock,
+	localFile bool) (f *FileInode) {
 	// Set up the basic struct.
 	f = &FileInode{
 		bucket:         bucket,
@@ -115,6 +116,7 @@ func NewFileInode(
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
 		src:            convertObjToMinObject(o),
+		local:          localFile,
 	}
 
 	f.lc.Init(id)
@@ -141,8 +143,8 @@ func (f *FileInode) checkInvariants() {
 		panic("Illegal file name: " + name.String())
 	}
 
-	// INVARIANT: src.Name == name
-	if f.src.Name != name.GcsObjectName() {
+	// INVARIANT: For non-local inodes, src.Name == name
+	if !f.IsLocal() && f.src.Name != name.GcsObjectName() {
 		panic(fmt.Sprintf(
 			"Name mismatch: %q vs. %q",
 			f.src.Name,
@@ -277,10 +279,6 @@ func (f *FileInode) Name() Name {
 
 func (f *FileInode) IsLocal() bool {
 	return f.local
-}
-
-func (f *FileInode) SetLocal(val bool) {
-	f.local = val
 }
 
 // Source returns a record for the GCS object from which this inode is branched. The

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jacobsa/syncutil"
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/contentcache"
@@ -65,6 +66,8 @@ var _ TearDownInterface = &FileTest{}
 func init() { RegisterTestSuite(&FileTest{}) }
 
 func (t *FileTest) SetUp(ti *TestInfo) {
+	// Enabling invariant check for all tests.
+	syncutil.EnableInvariantChecking()
 	t.ctx = ti.Ctx
 	t.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
 	t.bucket = gcsfake.NewFakeBucket(&t.clock, "some_bucket")
@@ -90,6 +93,9 @@ func (t *FileTest) TearDown() {
 }
 
 func (t *FileTest) createInode() {
+	t.createInodeWithLocalParam(false)
+}
+func (t *FileTest) createInodeWithLocalParam(local bool) {
 	if t.in != nil {
 		t.in.Unlock()
 	}
@@ -114,7 +120,8 @@ func (t *FileTest) createInode() {
 		&syncerBucket,
 		false, // localFileCache
 		contentcache.New("", &t.clock),
-		&t.clock)
+		&t.clock,
+		local)
 
 	t.in.Lock()
 }
@@ -681,4 +688,10 @@ func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
 	AssertEq(nil, err)
 	ExpectEq(newObj.Generation, o.Generation)
 	ExpectEq(newObj.MetaGeneration, o.MetaGeneration)
+}
+
+func (t *FileTest) TestCheckInvariants_ShouldNotThrowExceptionForLocalFiles() {
+	t.createInodeWithLocalParam(true)
+
+	AssertNe(nil, t.in)
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -690,7 +690,7 @@ func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
 	ExpectEq(newObj.MetaGeneration, o.MetaGeneration)
 }
 
-func (t *FileTest) TestCheckInvariants_ShouldNotThrowExceptionForLocalFiles() {
+func (t *FileTest) TestCheckInvariantsShouldNotThrowExceptionForLocalFiles() {
 	t.createInodeWithLocalParam(true)
 
 	AssertNe(nil, t.in)

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -29,6 +29,10 @@ const SymlinkMetadataKey = "gcsfuse_symlink_target"
 
 // IsSymlink Does the supplied object represent a symlink inode?
 func IsSymlink(o *gcs.Object) bool {
+	if o == nil {
+		return false
+	}
+
 	_, ok := o.Metadata[SymlinkMetadataKey]
 	return ok
 }

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode_test
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
+	"github.com/jacobsa/gcloud/gcs"
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestSymlink(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type SymlinkTest struct {
+}
+
+var _ SetUpInterface = &CoreTest{}
+var _ TearDownInterface = &CoreTest{}
+
+func init() { RegisterTestSuite(&SymlinkTest{}) }
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsPresent() {
+	metadata := map[string]string{
+		inode.SymlinkMetadataKey: "target",
+	}
+	o := gcs.Object{
+		Name:     "test",
+		Metadata: metadata,
+	}
+
+	AssertEq(true, inode.IsSymlink(&o))
+}
+
+func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsNotPresent() {
+	o := gcs.Object{
+		Name: "test",
+	}
+
+	AssertEq(false, inode.IsSymlink(&o))
+}
+
+func (t *SymlinkTest) TestIsSymLinkForNilObject() {
+	AssertEq(false, inode.IsSymlink(nil))
+}

--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -17,8 +17,10 @@ package wrappers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -94,6 +96,8 @@ func (em *errorMapping) handlePanic() {
 	// detect if panic occurred or not
 	a := recover()
 	if a != nil {
+		fmt.Printf("Error: %+v", errors.New(fmt.Sprintf("%v", a)))
+		fmt.Println(string(debug.Stack()))
 		em.logger.Fatal("Panic: ", a)
 	}
 }

--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -17,10 +17,8 @@ package wrappers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
-	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -96,8 +94,6 @@ func (em *errorMapping) handlePanic() {
 	// detect if panic occurred or not
 	a := recover()
 	if a != nil {
-		fmt.Printf("Error: %+v", errors.New(fmt.Sprintf("%v", a)))
-		fmt.Println(string(debug.Stack()))
 		em.logger.Fatal("Panic: ", a)
 	}
 }


### PR DESCRIPTION
### Modified createFile operation to create localFiles based on config flag. Other operations will be modified in different cls to keep the PRs simple.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually by enabling and disabling the flag. 
2. Unit tests - Added where ever applicable. We cannot add unit tests for fs.go since fs.go tests do real mounting using fake gcs bucket. For any file operation, multiple operations will be invoked by kernel like lookUpInode, CreateFile, writeFile etc. Without modifying all these operations we will not be able to write unit tests. Hence unit tests will be added in a seperate cl when all operations are modified in fs.go
3. Integration tests - Existing tests are running fine. New tests will be added after all operations are modified.
