### PR TITLE
Kokoro perf test fix - Integration tests

### DIFF
--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -49,5 +49,7 @@ func TestMain(m *testing.M) {
 
 	successCode := static_mounting.RunTests(flags, m)
 
+	setup.RemoveBinFileCopiedForTesting()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -118,5 +118,7 @@ func TestMain(m *testing.M) {
 		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
 	}
 
+	setup.RemoveBinFileCopiedForTesting()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -21,9 +21,6 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/creds_tests"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/persistent_mounting"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
@@ -103,20 +100,20 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucketFlag()
 
-	successCode := static_mounting.RunTests(flags, m)
+	//successCode := static_mounting.RunTests(flags, m)
+	//
+	//if successCode == 0 {
+	//	successCode = only_dir_mounting.RunTests(flags, m)
+	//}
+	//
+	//if successCode == 0 {
+	//	successCode = persistent_mounting.RunTests(flags, m)
+	//}
 
-	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flags, m)
-	}
-
-	if successCode == 0 {
-		// Test for admin permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
-	}
+	//if successCode == 0 {
+	// Test for admin permission on test bucket.
+	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
+	//}
 
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/creds_tests"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/persistent_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
@@ -100,20 +103,20 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucketFlag()
 
-	//successCode := static_mounting.RunTests(flags, m)
-	//
-	//if successCode == 0 {
-	//	successCode = only_dir_mounting.RunTests(flags, m)
-	//}
-	//
-	//if successCode == 0 {
-	//	successCode = persistent_mounting.RunTests(flags, m)
-	//}
+	successCode := static_mounting.RunTests(flags, m)
 
-	//if successCode == 0 {
-	// Test for admin permission on test bucket.
-	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
-	//}
+	if successCode == 0 {
+		successCode = only_dir_mounting.RunTests(flags, m)
+	}
+
+	if successCode == 0 {
+		successCode = persistent_mounting.RunTests(flags, m)
+	}
+
+	if successCode == 0 {
+		// Test for admin permission on test bucket.
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
+	}
 
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -93,5 +93,7 @@ func TestMain(m *testing.M) {
 	// Delete objects from bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", setup.TestBucket())
 
+	setup.RemoveBinFileCopiedForTesting()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -64,5 +64,7 @@ func TestMain(m *testing.M) {
 		successCode = persistent_mounting.RunTests(flags, m)
 	}
 
+	setup.RemoveBinFileCopiedForTesting()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -56,6 +56,9 @@ func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]
 	// Provide permission to service account for testing.
 	setPermission(permission, serviceAccount)
 
+	// Revoke the permission and delete creds and service account after testing.
+	defer setup.RunScriptForTestData("../util/creds_tests/testdata/revoke_permission_and_delete_service_account_and_creds.sh", serviceAccount, key_file_path)
+
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
 	// https://github.com/golang/oauth2/blob/master/google/default.go#L160

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -56,9 +56,6 @@ func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]
 	// Provide permission to service account for testing.
 	setPermission(permission, serviceAccount)
 
-	// Revoke the permission and delete creds and service account after testing.
-	defer setup.RunScriptForTestData("../util/creds_tests/testdata/revoke_permission_and_delete_service_account_and_creds.sh", serviceAccount, key_file_path)
-
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
 	// https://github.com/golang/oauth2/blob/master/google/default.go#L160

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -31,6 +31,7 @@ const FilePermission_0777 = 0777
 func CopyDir(srcDirPath string, destDirPath string) (err error) {
 	cmd := exec.Command("cp", "--recursive", srcDirPath, destDirPath)
 
+	log.Print(srcDirPath, destDirPath)
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("Copying dir operation is failed: %v", err)

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -29,9 +29,8 @@ const FilePermission_0600 = 0600
 const FilePermission_0777 = 0777
 
 func CopyDir(srcDirPath string, destDirPath string) (err error) {
-	cmd := exec.Command("cp", "--recursive", srcDirPath, destDirPath)
+	cmd := exec.Command("sudo", "cp", "--recursive", srcDirPath, destDirPath)
 
-	log.Print(srcDirPath, destDirPath)
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("Copying dir operation is failed: %v", err)

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -29,6 +29,16 @@ const FilePermission_0600 = 0600
 const FilePermission_0777 = 0777
 
 func CopyDir(srcDirPath string, destDirPath string) (err error) {
+	cmd := exec.Command("cp", "--recursive", srcDirPath, destDirPath)
+
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("Copying dir operation is failed: %v", err)
+	}
+	return
+}
+
+func CopyDirWithRootPermission(srcDirPath string, destDirPath string) (err error) {
 	cmd := exec.Command("sudo", "cp", "--recursive", srcDirPath, destDirPath)
 
 	err = cmd.Run()

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -28,9 +28,7 @@ import (
 const FilePermission_0600 = 0600
 const FilePermission_0777 = 0777
 
-func CopyDir(srcDirPath string, destDirPath string) (err error) {
-	cmd := exec.Command("cp", "--recursive", srcDirPath, destDirPath)
-
+func executeCommandForCopyOperation(cmd *exec.Cmd) (err error) {
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("Copying dir operation is failed: %v", err)
@@ -38,11 +36,11 @@ func CopyDir(srcDirPath string, destDirPath string) (err error) {
 	return
 }
 
-func executeCommandForCopyOperation(cmd *exec.Cmd) (err error) {
-	err = cmd.Run()
-	if err != nil {
-		err = fmt.Errorf("Copying dir operation is failed: %v", err)
-	}
+func CopyDir(srcDirPath string, destDirPath string) (err error) {
+	cmd := exec.Command("cp", "--recursive", srcDirPath, destDirPath)
+
+	err = executeCommandForCopyOperation(cmd)
+
 	return
 }
 
@@ -57,8 +55,10 @@ func CopyDirWithRootPermission(srcDirPath string, destDirPath string) (err error
 func MoveDir(srcDirPath string, destDirPath string) (err error) {
 	cmd := exec.Command("mv", srcDirPath, destDirPath)
 
-	err = executeCommandForCopyOperation(cmd)
-
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("Moving dir operation is failed: %v", err)
+	}
 	return
 }
 

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -38,9 +38,7 @@ func CopyDir(srcDirPath string, destDirPath string) (err error) {
 	return
 }
 
-func CopyDirWithRootPermission(srcDirPath string, destDirPath string) (err error) {
-	cmd := exec.Command("sudo", "cp", "--recursive", srcDirPath, destDirPath)
-
+func executeCommandForCopyOperation(cmd *exec.Cmd) (err error) {
 	err = cmd.Run()
 	if err != nil {
 		err = fmt.Errorf("Copying dir operation is failed: %v", err)
@@ -48,13 +46,19 @@ func CopyDirWithRootPermission(srcDirPath string, destDirPath string) (err error
 	return
 }
 
+func CopyDirWithRootPermission(srcDirPath string, destDirPath string) (err error) {
+	cmd := exec.Command("sudo", "cp", "--recursive", srcDirPath, destDirPath)
+
+	err = executeCommandForCopyOperation(cmd)
+
+	return
+}
+
 func MoveDir(srcDirPath string, destDirPath string) (err error) {
 	cmd := exec.Command("mv", srcDirPath, destDirPath)
 
-	err = cmd.Run()
-	if err != nil {
-		err = fmt.Errorf("Moving dir operation is failed: %v", err)
-	}
+	err = executeCommandForCopyOperation(cmd)
+
 	return
 }
 

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -63,6 +63,8 @@ func RunTestsForImplicitDirAndExplicitDir(flags [][]string, m *testing.M) {
 		successCode = persistent_mounting.RunTests(flags, m)
 	}
 
+	setup.RemoveBinFileCopiedForTesting()
+
 	os.Exit(successCode)
 }
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -175,7 +175,8 @@ func SetUpTestDir() error {
 // Removing bin file after testing.
 func RemoveBinFileCopiedForTesting() {
 	if !TestInstalledPackage() {
-		err := os.Remove("/usr/local/bin/gcsfuse")
+		cmd := exec.Command("sudo", "rm", "/usr/local/bin/gcsfuse")
+		err := cmd.Run()
 		if err != nil {
 			log.Printf("Error in removing file:%v", err)
 		}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -148,6 +148,11 @@ func SetUpTestDir() error {
 		}
 		binFile = path.Join(TestDir(), "bin/gcsfuse")
 		sbinFile = path.Join(TestDir(), "sbin/mount.gcsfuse")
+
+		err := operations.CopyDir(binFile, "/usr/local/bin")
+		if err != nil {
+			log.Printf("Error in copying bin file:%v", err)
+		}
 	} else {
 		// when testInstalledPackage flag is set, gcsfuse is preinstalled on the
 		// machine. Hence, here we are overwriting binFile to gcsfuse.

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -149,6 +149,9 @@ func SetUpTestDir() error {
 		binFile = path.Join(TestDir(), "bin/gcsfuse")
 		sbinFile = path.Join(TestDir(), "sbin/mount.gcsfuse")
 
+		// mount.gcsfuse will find gcsfuse executable in mentioned locations.
+		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
+		// Copying the executable to /usr/local/bin
 		err := operations.CopyDir(binFile, "/usr/local/bin")
 		if err != nil {
 			log.Printf("Error in copying bin file:%v", err)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -152,7 +152,7 @@ func SetUpTestDir() error {
 		// mount.gcsfuse will find gcsfuse executable in mentioned locations.
 		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
 		// Copying the executable to /usr/local/bin
-		err := operations.CopyDir(binFile, "/usr/local/bin")
+		err := operations.CopyDirWithRootPermission(binFile, "/usr/local/bin")
 		if err != nil {
 			log.Printf("Error in copying bin file:%v", err)
 		}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -172,6 +172,16 @@ func SetUpTestDir() error {
 	return nil
 }
 
+// Removing bin file after testing.
+func RemoveBinFileCopiedForTesting() {
+	if !TestInstalledPackage() {
+		err := os.Remove("/usr/local/bin/gcsfuse")
+		if err != nil {
+			log.Printf("Error in removing file:%v", err)
+		}
+	}
+}
+
 func UnMount() error {
 	fusermount, err := exec.LookPath("fusermount")
 	if err != nil {


### PR DESCRIPTION
### Description
mount.gcsfuse was searching gcsfuse executables in the mentioned [places](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59). As gcsfuse was not installed in the machine where we are doing perf tests, it was failing.
Solution: Copied executables in /usr/local/bin dir 

It can run only with sudo permission so added function to copy with sudo permission.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
11. Unit tests - NA
12. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
