### PR TITLE
Creds test error fixing Integration tests

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -21,9 +21,6 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/creds_tests"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/persistent_mounting"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
@@ -103,20 +100,20 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucketFlag()
 
-	successCode := static_mounting.RunTests(flags, m)
+	//successCode := static_mounting.RunTests(flags, m)
+	//
+	//if successCode == 0 {
+	//	successCode = only_dir_mounting.RunTests(flags, m)
+	//}
+	//
+	//if successCode == 0 {
+	//	successCode = persistent_mounting.RunTests(flags, m)
+	//}
 
-	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flags, m)
-	}
-
-	if successCode == 0 {
-		// Test for admin permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
-	}
+	//if successCode == 0 {
+	// Test for admin permission on test bucket.
+	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
+	//}
 
 	setup.RemoveBinFileCopiedForTesting()
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/creds_tests"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/persistent_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
@@ -100,20 +103,20 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucketFlag()
 
-	//successCode := static_mounting.RunTests(flags, m)
-	//
-	//if successCode == 0 {
-	//	successCode = only_dir_mounting.RunTests(flags, m)
-	//}
-	//
-	//if successCode == 0 {
-	//	successCode = persistent_mounting.RunTests(flags, m)
-	//}
+	successCode := static_mounting.RunTests(flags, m)
 
-	//if successCode == 0 {
-	// Test for admin permission on test bucket.
-	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
-	//}
+	if successCode == 0 {
+		successCode = only_dir_mounting.RunTests(flags, m)
+	}
+
+	if successCode == 0 {
+		successCode = persistent_mounting.RunTests(flags, m)
+	}
+
+	if successCode == 0 {
+		// Test for admin permission on test bucket.
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
+	}
 
 	setup.RemoveBinFileCopiedForTesting()
 

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -56,7 +56,7 @@ func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]
 	// Provide permission to service account for testing.
 	setPermission(permission, serviceAccount)
 
-	// Revoke the permission and delete creds and service account after testing.
+	// Revoke the permission and delete creds after testing.
 	defer setup.RunScriptForTestData("../util/creds_tests/testdata/revoke_permission_and_creds.sh", serviceAccount, key_file_path)
 
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -57,7 +57,7 @@ func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]
 	setPermission(permission, serviceAccount)
 
 	// Revoke the permission and delete creds and service account after testing.
-	defer setup.RunScriptForTestData("../util/creds_tests/testdata/revoke_permission_and_delete_service_account_and_creds.sh", serviceAccount, key_file_path)
+	defer setup.RunScriptForTestData("../util/creds_tests/testdata/revoke_permission_and_creds.sh", serviceAccount, key_file_path)
 
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -46,7 +46,7 @@ func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]
 	serviceAccount := NameOfServiceAccount + "@" + id + ".iam.gserviceaccount.com"
 
 	// Create service account
-	setup.RunScriptForTestData("../util/creds_tests/testdata/create_service_account.sh", NameOfServiceAccount, serviceAccount)
+	setup.RunScriptForTestData("../util/creds_tests/testdata/create_service_account.sh", NameOfServiceAccount)
 
 	key_file_path := path.Join(os.Getenv("HOME"), "creds.json")
 

--- a/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
@@ -14,4 +14,4 @@
 
 KEY_FILE_PATH=$1
 SERVICE_ACCOUNT=$2
-gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT
+gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT &>> key_id.txt

--- a/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
@@ -14,4 +14,4 @@
 
 KEY_FILE_PATH=$1
 SERVICE_ACCOUNT=$2
-gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT &>> ~/key_id.txt
+gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT 2>&1 | tee ~/key_id.txt

--- a/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_key_file.sh
@@ -14,4 +14,4 @@
 
 KEY_FILE_PATH=$1
 SERVICE_ACCOUNT=$2
-gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT &>> key_id.txt
+gcloud iam service-accounts keys create $KEY_FILE_PATH --iam-account=$SERVICE_ACCOUNT &>> ~/key_id.txt

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set +e
 SERVICE_ACCOUNT=$1
 SERVICE_ACCOUNT_ID=$2
-# Create service account if already exist.
 gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT"
+if [ $? -eq 1 ]; then
+  echo "Service account exist."
+fi

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -15,11 +15,13 @@
 
 SERVICE_ACCOUNT=$1
 
-gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> output.txt
+gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> ~/output.txt
 if [ $? -eq 1 ]; then
   if grep "already exists within project" output.txt; then
     echo "Service account exist."
+    rm ~/output.txt
   else
+    rm ~/output.txt
     exit 1
   fi
 fi

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -14,6 +14,7 @@
 # Create service account if does not exist.
 
 SERVICE_ACCOUNT=$1
+
 gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> output.txt
 if [ $? -eq 1 ]; then
   if grep "already exists within project" output.txt; then

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -14,7 +14,6 @@
 # Create service account if does not exist.
 
 SERVICE_ACCOUNT=$1
-SERVICE_ACCOUNT_ID=$2
 gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> output.txt
 if [ $? -eq 1 ]; then
   if grep "already exists within project" output.txt; then

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Create service account if does not exist.
 
 SERVICE_ACCOUNT=$1
 SERVICE_ACCOUNT_ID=$2

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -15,13 +15,11 @@
 
 SERVICE_ACCOUNT=$1
 
-gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> ~/output.txt
-if [ $? -eq 1 ]; then
-  if grep "already exists within project" output.txt; then
-    echo "Service account exist."
-    rm ~/output.txt
-  else
-    rm ~/output.txt
-    exit 1
-  fi
+gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" 2>&1 | tee ~/output.txt
+if grep "already exists within project" ~/output.txt; then
+  echo "Service account exist."
+  rm ~/output.txt
+else
+  rm ~/output.txt
+  exit 1
 fi

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set +e
 SERVICE_ACCOUNT=$1
 SERVICE_ACCOUNT_ID=$2
-# Delete service account if already exist.
+# Create service account if already exist.
 gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT"

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -15,8 +15,4 @@
 SERVICE_ACCOUNT=$1
 SERVICE_ACCOUNT_ID=$2
 # Delete service account if already exist.
-gcloud iam service-accounts delete $SERVICE_ACCOUNT_ID
-if [ $? -eq 1 ]; then
-  echo "Service account does not exist."
-fi
 gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT"

--- a/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/create_service_account.sh
@@ -14,7 +14,11 @@
 
 SERVICE_ACCOUNT=$1
 SERVICE_ACCOUNT_ID=$2
-gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT"
+gcloud iam service-accounts create $SERVICE_ACCOUNT --description="$SERVICE_ACCOUNT" --display-name="$SERVICE_ACCOUNT" &>> output.txt
 if [ $? -eq 1 ]; then
-  echo "Service account exist."
+  if grep "already exists within project" output.txt; then
+    echo "Service account exist."
+  else
+    exit 1
+  fi
 fi

--- a/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
@@ -15,6 +15,16 @@
 # Delete service account after testing
 SERVICE_ACCOUNT=$1
 KEY_FILE=$2
+
 gcloud auth revoke $SERVICE_ACCOUNT
-gcloud iam service-accounts delete $SERVICE_ACCOUNT
+# Crete key file output
+# e.g. created key [key_id] of type [json] as [key_file_path] for [service_account]
+# capturing third word from the file to get key-id
+
+# capture [KEY_ID]
+KEY_ID=$(cat key_id.txt | cut -d " " -f 3)
+# capture KEY_ID
+KEY_ID=${KEY_ID:1:40}
+
+gcloud iam service-accounts keys delete $KEY_ID --iam-account=$SERVICE_ACCOUNT
 rm $KEY_FILE

--- a/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
@@ -18,9 +18,12 @@ KEY_FILE=$2
 
 gcloud auth revoke $SERVICE_ACCOUNT
 # Crete key file output
-# e.g. created key [key_id] of type [json] as [key_file_path] for [service_account]
-# capturing third word from the file to get key-id
-# e.g. capture [KEY_ID]
+# e.g. Created key [KEY_ID] of type [json] as [key_file_path] for [service_account]
+# Capturing third word from the file to get key-id
+# e.g. Capture [KEY_ID]
+if [ ! -f "~/key_id.txt" ]; then
+    echo "file does not exist"
+fi
 KEY_ID=$(cat ~/key_id.txt | cut -d " " -f 3)
 # removing braces
 # e.g. capture KEY_ID

--- a/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
@@ -21,10 +21,11 @@ gcloud auth revoke $SERVICE_ACCOUNT
 # e.g. created key [key_id] of type [json] as [key_file_path] for [service_account]
 # capturing third word from the file to get key-id
 # e.g. capture [KEY_ID]
-KEY_ID=$(cat key_id.txt | cut -d " " -f 3)
+KEY_ID=$(cat ~/key_id.txt | cut -d " " -f 3)
 # removing braces
 # e.g. capture KEY_ID
 KEY_ID=${KEY_ID:1:40}
 
 gcloud iam service-accounts keys delete $KEY_ID --iam-account=$SERVICE_ACCOUNT
+rm ~/key_id.txt
 rm $KEY_FILE

--- a/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
+++ b/tools/integration_tests/util/creds_tests/testdata/revoke_permission_and_creds.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Delete service account after testing
+# Delete key file after testing
 SERVICE_ACCOUNT=$1
 KEY_FILE=$2
 
@@ -20,10 +20,10 @@ gcloud auth revoke $SERVICE_ACCOUNT
 # Crete key file output
 # e.g. created key [key_id] of type [json] as [key_file_path] for [service_account]
 # capturing third word from the file to get key-id
-
-# capture [KEY_ID]
+# e.g. capture [KEY_ID]
 KEY_ID=$(cat key_id.txt | cut -d " " -f 3)
-# capture KEY_ID
+# removing braces
+# e.g. capture KEY_ID
 KEY_ID=${KEY_ID:1:40}
 
 gcloud iam service-accounts keys delete $KEY_ID --iam-account=$SERVICE_ACCOUNT


### PR DESCRIPTION
### Description
As we are hardcoded [service account name](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/creds_tests/creds.go#L31), when two VMs belongs to the same projects tries to run the tests at a time it is failing due to service account creation and deletion inconsistency. 

Made changes to create a service account and ignore the error if "already exist." 

The flow is.
1. Create service account will create service account name creds-test-gcsfuse in the project. If the service account already exist it will use existing one only.
2. create_key_file script will create credentials in that service account for testing.
3. revoke_and_delete_creds will revoke permission and delete the crede which we have created in create_key_file script.

here we are not deleting service account at any place, but accidentally if anyone deleted or we want to run the tests in different project, it will create the service account with given name. as we are not deleting service account, it can be possible that creation of credentials may exceeded greater than limit(10). which can fail the tests. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Run all the tests for testbucket( Parallal on two VMs belongs to same project)  and mountedDirectory flags.(status:SUCCESS)
11. Unit tests - NA
12. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
