### PR TITLE
minor change to test script

### DIFF
--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -30,7 +30,7 @@ then
     echo 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main' | sudo tee -a /etc/apt/sources.list.d/artifact-registry.list
     sudo apt update
     sudo apt install apt-transport-artifact-registry
-    echo 'deb ar+https://us-apt.pkg.dev/projects/gcs-fuse-prod $(lsb_release -cs) main' | sudo tee -a /etc/apt/sources.list.d/artifact-registry.list
+    echo "deb ar+https://us-apt.pkg.dev/projects/gcs-fuse-prod gcsfuse-$(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/artifact-registry.list
     sudo apt update
 
     # Install released gcsfuse version


### PR DESCRIPTION
### Description
To install from artifact registry, we need to write "deb ar+https://us-apt.pkg.dev/projects/gcs-fuse-prod gcsfuse-$(lsb_release -cs) main" to `/etc/apt/sources.list.d/artifact-registry.list` file.

`gcsfuse-` was missing in this command.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested the changes manually by running on a VM
2. Unit tests - NA
3. Integration tests - NA
