### PR TITLE
gzip integration tests

### DIFF
--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for gzip objects in gcsfuse mounts.
+package gzip_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip/helpers"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+const (
+	SeqReadSizeMb   = 1
+	TextContentSize = 10 * 1e6 * SeqReadSizeMb
+
+	TextContentWithContentEncodingWithNoTransformFilename    = "textContentWithContentEncodingWithNoTransform.txt"
+	TextContentWithContentEncodingWithoutNoTransformFilename = "textContentWithContentEncodingWithoutNoTransform.txt"
+
+	GzipContentWithoutContentEncodingFilename = "gzipContentWithoutContentEncoding.txt.gz"
+
+	GzipContentWithContentEncodingWithNoTransformFilename    = "gzipContentWithContentEncodingWithNoTransform.txt.gz"
+	GzipContentWithContentEncodingWithoutNoTransformFilename = "gzipContentWithContentEncodingWithoutNoTransform.txt.gz"
+
+	TestBucketPrefixPath = "gzip"
+)
+
+var (
+	gcsObjectsToBeDeletedEventually []string
+)
+
+func setup_testdata(m *testing.M) error {
+	fmds := []struct {
+		filename                    string
+		filesize                    int
+		keepCacheControlNoTransform bool // if true, no-transform is reset as ''
+		enableGzipEncodedContent    bool // if true, original file content is gzip-encoded
+		enableGzipContentEncoding   bool // if true, the content is uploaded as gsutil cp -Z i.e. with content-encoding: gzip header in GCS
+	}{
+		{
+			filename:                    TextContentWithContentEncodingWithNoTransformFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true,
+			enableGzipEncodedContent:    false,
+			enableGzipContentEncoding:   true,
+		},
+		{
+			filename:                    TextContentWithContentEncodingWithoutNoTransformFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: false,
+			enableGzipEncodedContent:    false,
+			enableGzipContentEncoding:   true,
+		},
+		{
+			filename:                    GzipContentWithoutContentEncodingFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true, // it's a don't care in this case
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   false,
+		}, {
+			filename:                    GzipContentWithContentEncodingWithNoTransformFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true,
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   true,
+		}, {
+			filename:                    GzipContentWithContentEncodingWithoutNoTransformFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: false,
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   true,
+		},
+	}
+
+	for _, fmd := range fmds {
+		var localFilePath string
+		localFilePath, err := helpers.CreateLocalTempFile(fmd.filesize, fmd.enableGzipEncodedContent)
+		if err != nil {
+			return err
+		}
+
+		defer os.Remove(localFilePath)
+
+		// upload to the test-bucket for testing
+		gcsObjectPath := path.Join(setup.TestBucket(), TestBucketPrefixPath, fmd.filename)
+
+		err = operations.UploadGcsObject(localFilePath, gcsObjectPath, fmd.enableGzipContentEncoding)
+		if err != nil {
+			return err
+		}
+
+		gcsObjectsToBeDeletedEventually = append(gcsObjectsToBeDeletedEventually, gcsObjectPath)
+
+		if !fmd.keepCacheControlNoTransform {
+			err = operations.ClearCacheControlOnGcsObject(gcsObjectPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func destroy_testdata(m *testing.M) error {
+	for _, gcsObjectPath := range gcsObjectsToBeDeletedEventually {
+		err := operations.DeleteGcsObject(gcsObjectPath)
+		if err != nil {
+			return fmt.Errorf("Failed to delete gcs object gs://%s", gcsObjectPath)
+		}
+	}
+
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	commonFlags := []string{"--sequential-read-size-mb=" + fmt.Sprint(SeqReadSizeMb), "--implicit-dirs"}
+	flags := [][]string{commonFlags}
+
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
+		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
+		os.Exit(1)
+	}
+
+	err := setup_testdata(m)
+	if err != nil {
+		fmt.Printf("Failed to setup test data: %v", err)
+		os.Exit(1)
+	}
+
+	defer func() {
+		err := destroy_testdata(m)
+		if err != nil {
+			fmt.Printf("Failed to destoy gzip test data: %v", err)
+		}
+	}()
+
+	// Run tests for mountedDirectory only if --mountedDirectory flag is set.
+	setup.RunTestsForMountedDirectoryFlag(m)
+
+	// Run tests for testBucket
+	setup.SetUpTestDirForTestBucketFlag()
+
+	successCode := static_mounting.RunTests(flags, m)
+
+	setup.RemoveBinFileCopiedForTesting()
+
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/gzip/helpers/helpers.go
+++ b/tools/integration_tests/gzip/helpers/helpers.go
@@ -121,7 +121,9 @@ func CreateLocalTempFile(contentSize int, gzipCompress bool) (string, error) {
 // Downloads given gzipped GCS object (with path without 'gs://') to local disk.
 // Fails if the object doesn't exist or permission to read object is not
 // available.
-// Uses go storage client library to download object.
+// Uses go storage client library to download object. Use of gsutil/gcloud is not
+// possible as they both always read back objects with content-encoding: gzip as
+// uncompressed/decompressed irrespective of any argument passed.
 func DownloadGzipGcsObjectAsCompressed(bucketName, objPathInBucket string) (string, error) {
 	gcsObjectPath := path.Join(setup.TestBucket(), objPathInBucket)
 	gcsObjectSize, err := operations.GetGcsObjectSize(gcsObjectPath)

--- a/tools/integration_tests/gzip/helpers/helpers.go
+++ b/tools/integration_tests/gzip/helpers/helpers.go
@@ -1,0 +1,177 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+const (
+	TempFileStrLine = "This is a test file"
+	TmpDirectory    = "/tmp"
+)
+
+// Creates a temporary file (name-collision-safe) in /tmp with given content size in bytes.
+// If gzipCompress is true, output file is a gzip-compressed file.
+// contentSize is the size of the uncompressed content. In case gzipCompress is true, the actual output file size will be
+// different from contentSize (typically gzip-compressed file size < contentSize).
+// Caller is responsible for deleting the created file when done using it.
+// Failure cases:
+// 1. contentSize <= 0
+// 2. os.CreateTemp() returned error or nil handle
+// 3. gzip.NewWriter() returned nil handle
+// 4. Failed to write the content to the created temp file
+func CreateLocalTempFile(contentSize int, gzipCompress bool) (string, error) {
+	// fail if contentSize <= 0
+	if contentSize <= 0 {
+		return "", fmt.Errorf("unsupported fileSize: %d", contentSize)
+	}
+
+	// Create text-content of given size.
+	// strings.builder is used as opposed to string appends
+	// as this is much more efficient when multiple concatenations
+	// are required.
+	var contentBuilder strings.Builder
+	const tempStr = TempFileStrLine + "\n"
+
+	for ; contentSize >= len(tempStr); contentSize -= len(tempStr) {
+		contentBuilder.WriteString(tempStr)
+	}
+
+	if contentSize > 0 {
+		contentBuilder.WriteString(tempStr[0:contentSize])
+	}
+
+	// reset contentSize
+	contentSize = contentBuilder.Len()
+
+	// create appropriate name template for temp file
+	filenameTemplate := "testfile-*.txt"
+	if gzipCompress {
+		filenameTemplate += ".gz"
+	}
+
+	// create a temp file
+	f, err := os.CreateTemp(TmpDirectory, filenameTemplate)
+	if err != nil {
+		return "", err
+	} else if f == nil {
+		return "", fmt.Errorf("nil file handle returned from os.CreateTemp")
+	}
+	defer operations.CloseFile(f)
+	filepath := f.Name()
+
+	content := contentBuilder.String()
+
+	if gzipCompress {
+		w := gzip.NewWriter(f)
+		if w == nil {
+			return "", fmt.Errorf("failed to open a gzip writer handle")
+		}
+		defer func() {
+			err := w.Close()
+			if err != nil {
+				fmt.Printf("Failed to close file %s: %v", filepath, err)
+			}
+		}()
+
+		// write the content created above as gzip
+		n, err := w.Write([]byte(content))
+		if err != nil {
+			return "", err
+		} else if n != contentSize {
+			return "", fmt.Errorf("failed to write to gzip file %s. Content-size: %d bytes, wrote = %d bytes", filepath, contentSize, n)
+		}
+	} else {
+		// write the content created above as text
+		n, err := f.WriteString(content)
+		if err != nil {
+			return "", err
+		} else if n != contentSize {
+			return "", fmt.Errorf("failed to write to text file %s. Content-size: %d bytes, wrote = %d bytes", filepath, contentSize, n)
+		}
+	}
+
+	return filepath, nil
+}
+
+// Downloads given gzipped GCS object (with path without 'gs://') to local disk.
+// Fails if the object doesn't exist or permission to read object is not
+// available.
+// Uses go storage client library to download object.
+func DownloadGzipGcsObjectAsCompressed(bucketName, objPathInBucket string) (string, error) {
+	gcsObjectPath := path.Join(setup.TestBucket(), objPathInBucket)
+	gcsObjectSize, err := operations.GetGcsObjectSize(gcsObjectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get size of gcs object %s: %w", gcsObjectPath, err)
+	}
+
+	tempfile, err := CreateLocalTempFile(1, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to create tempfile for downloading gcs object: %w", err)
+	}
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil || client == nil {
+		return "", fmt.Errorf("failed to create storage client: %w", err)
+	}
+	defer client.Close()
+
+	bktName := setup.TestBucket()
+	bkt := client.Bucket(bktName)
+	if bkt == nil {
+		return "", fmt.Errorf("failed to access bucket %s: %w", bktName, err)
+	}
+
+	obj := bkt.Object(objPathInBucket)
+	if obj == nil {
+		return "", fmt.Errorf("failed to access object %s from bucket %s: %w", objPathInBucket, bktName, err)
+	}
+
+	obj = obj.ReadCompressed(true)
+	if obj == nil {
+		return "", fmt.Errorf("failed to access object %s from bucket %s as compressed: %w", objPathInBucket, bktName, err)
+	}
+
+	r, err := obj.NewReader(ctx)
+	if r == nil || err != nil {
+		return "", fmt.Errorf("failed to read object %s from bucket %s: %w", objPathInBucket, bktName, err)
+	}
+	defer r.Close()
+
+	gcsObjectData, err := io.ReadAll(r)
+	if len(gcsObjectData) < gcsObjectSize || err != nil {
+		return "", fmt.Errorf("failed to read object %s from bucket %s (expected read-size: %d, actual read-size: %d): %w", objPathInBucket, bktName, gcsObjectSize, len(gcsObjectData), err)
+	}
+
+	err = os.WriteFile(tempfile, gcsObjectData, fs.FileMode(os.O_CREATE|os.O_WRONLY|os.O_TRUNC))
+	if err != nil || client == nil {
+		return "", fmt.Errorf("failed to write to tempfile %s: %w", tempfile, err)
+	}
+
+	return tempfile, nil
+}

--- a/tools/integration_tests/gzip/read_gzip_test.go
+++ b/tools/integration_tests/gzip/read_gzip_test.go
@@ -1,0 +1,149 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for gzip objects in gcsfuse mounts.
+package gzip_test
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip/helpers"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+// Verify that the passed file exists on the GCS test-bucket and in the mounted bucket
+// and its size in the mounted directory matches that of the GCS object. Also verify
+// that the passed file in the mounted bucket matches the corresponding
+// GCS object in content.
+// GCS object.
+func verifyFileSizeAndFullFileRead(t *testing.T, filename string) {
+	mountedFilePath := path.Join(setup.MntDir(), TestBucketPrefixPath, filename)
+	gcsObjectPath := path.Join(setup.TestBucket(), TestBucketPrefixPath, filename)
+	gcsObjectSize, err := operations.GetGcsObjectSize(gcsObjectPath)
+	if err != nil {
+		t.Fatalf("Failed to get size of gcs object %s: %v\n", gcsObjectPath, err)
+	}
+
+	fi, err := operations.StatFile(mountedFilePath)
+	if err != nil || fi == nil {
+		t.Fatalf("Failed to get stat info of mounted file %s: %v\n", mountedFilePath, err)
+	}
+
+	if (*fi).Size() != int64(gcsObjectSize) {
+		t.Fatalf("Size of file mounted through gcsfuse (%s, %d) doesn't match the size of the file on GCS (%s, %d)",
+			mountedFilePath, (*fi).Size(), gcsObjectPath, gcsObjectSize)
+	}
+
+	localCopy, err := helpers.DownloadGzipGcsObjectAsCompressed(setup.TestBucket(), path.Join(TestBucketPrefixPath, filename))
+	if err != nil {
+		t.Fatalf("failed to download gcs object (gs:/%s) to local-disk: %v", gcsObjectPath, err)
+	}
+
+	defer operations.RemoveFile(localCopy)
+
+	diff, err := operations.DiffFiles(localCopy, mountedFilePath)
+	if diff != 0 {
+		t.Fatalf("Tempfile (%s, download of GCS object %s) didn't match the Mounted local file (%s): %v", localCopy, gcsObjectPath, mountedFilePath, err)
+	}
+}
+
+// Verify that the passed file exists on the GCS test-bucket and in the mounted bucket
+// and its ranged read returns the same size as the requested read size.
+func verifyRangedRead(t *testing.T, filename string) {
+	mountedFilePath := path.Join(setup.MntDir(), TestBucketPrefixPath, filename)
+
+	gcsObjectPath := path.Join(setup.TestBucket(), TestBucketPrefixPath, filename)
+	gcsObjectSize, err := operations.GetGcsObjectSize(gcsObjectPath)
+	if err != nil {
+		t.Fatalf("Failed to get size of gcs object %s: %v\n", gcsObjectPath, err)
+	}
+
+	readSize := int64(gcsObjectSize / 10)
+	readOffset := int64(readSize / 10)
+	f, err := os.Open(mountedFilePath)
+	if err != nil || f == nil {
+		t.Fatalf("Failed to open local mounted file %s: %v", mountedFilePath, err)
+	}
+
+	localCopy, err := helpers.DownloadGzipGcsObjectAsCompressed(setup.TestBucket(), path.Join(TestBucketPrefixPath, filename))
+	if err != nil {
+		t.Fatalf("failed to download gcs object (gs:/%s) to local-disk: %v", gcsObjectPath, err)
+	}
+
+	defer operations.RemoveFile(localCopy)
+
+	for _, offsetMultiplier := range []int64{1, 3, 5, 7, 9} {
+		buf1, err := operations.ReadChunkFromFile(mountedFilePath, (readSize), offsetMultiplier*(readOffset))
+		if err != nil {
+			t.Fatalf("Failed to read mounted file %s: %v", mountedFilePath, err)
+		} else if buf1 == nil {
+			t.Fatalf("Failed to read mounted file %s: buffer returned as nul", mountedFilePath)
+		}
+
+		buf2, err := operations.ReadChunkFromFile(localCopy, (readSize), offsetMultiplier*(readOffset))
+		if err != nil {
+			t.Fatalf("Failed to read local file %s: %v", localCopy, err)
+		} else if buf2 == nil {
+			t.Fatalf("Failed to read local file %s: buffer returned as nul", localCopy)
+		}
+
+		if !bytes.Equal(buf1, buf2) {
+			t.Fatalf("Read buffer (of size %d from offset %d) of %s doesn't match that of %s", int64(readSize), offsetMultiplier*int64(readOffset), mountedFilePath, localCopy)
+		}
+	}
+}
+
+func TestGzipEncodedTextFileWithNoTransformSizeAndFullFileRead(t *testing.T) {
+	verifyFileSizeAndFullFileRead(t, TextContentWithContentEncodingWithNoTransformFilename)
+}
+
+func TestGzipEncodedTextFileWithNoTransformRangedRead(t *testing.T) {
+	verifyRangedRead(t, TextContentWithContentEncodingWithNoTransformFilename)
+}
+
+func TestGzipEncodedTextFileWithoutNoTransformSizeAndFullFileRead(t *testing.T) {
+	verifyFileSizeAndFullFileRead(t, TextContentWithContentEncodingWithoutNoTransformFilename)
+}
+
+func TestGzipEncodedTextFileWithoutNoTransformRangedRead(t *testing.T) {
+	verifyRangedRead(t, TextContentWithContentEncodingWithoutNoTransformFilename)
+}
+
+func TestGzipUnencodedGzipFileSizeAndFullFileRead(t *testing.T) {
+	verifyFileSizeAndFullFileRead(t, GzipContentWithoutContentEncodingFilename)
+}
+
+func TestGzipUnencodedGzipFileRangedRead(t *testing.T) {
+	verifyRangedRead(t, GzipContentWithoutContentEncodingFilename)
+}
+
+func TestGzipEncodedGzipFileWithNoTransformSizeAndFullFileRead(t *testing.T) {
+	verifyFileSizeAndFullFileRead(t, GzipContentWithContentEncodingWithNoTransformFilename)
+}
+
+func TestGzipEncodedGzipFileWithNoTransformRangedRead(t *testing.T) {
+	verifyRangedRead(t, GzipContentWithContentEncodingWithNoTransformFilename)
+}
+
+func TestGzipEncodedGzipFileWithoutNoTransformSizeAndFullFileRead(t *testing.T) {
+	verifyFileSizeAndFullFileRead(t, GzipContentWithContentEncodingWithoutNoTransformFilename)
+}
+
+func TestGzipEncodedGzipFileWithoutNoTransformRangedRead(t *testing.T) {
+	verifyRangedRead(t, GzipContentWithContentEncodingWithoutNoTransformFilename)
+}

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -272,3 +272,7 @@ sudo umount $MOUNT_DIR
 gcsfuse --implicit-dirs --enable-storage-client-library=false $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/write_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
+
+gcsfuse --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/gzip/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR


### PR DESCRIPTION
### Description
This adds read-flow integration tests for the gzip read-compressed changes added in previous PR https://github.com/GoogleCloudPlatform/gcsfuse/pull/1255 .

Tests added (2*5 = 10 tests)
* Two types of operations each
  * List, Stat and full-file read
* On five types of objects each
  * Object with text content, uploaded with gzip compression with content-encoding: gzip, and cache-control: no-transform
  * Object with text content, uploaded with gzip compression with content-encoding: gzip, and cache-control: ''
  * Object with gzip content, uploaded with content-encoding: ''
  * Object with gzip content, uploaded with gzip compression (i.e. doubly compressed) with content-encoding: gzip, and cache-control: no-transform
  * Object with gzip content, uploaded with gzip compression (i.e. doubly compressed) with content-encoding: gzip, and cache-control: ''

This change is dependent on https://github.com/GoogleCloudPlatform/gcsfuse/pull/1255 .

Write-flow tests are added in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1262. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
2. Unit tests - NA
3. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
