### PR TITLE
Update gcloud version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ _testmain.go
 
 # Editors
 .idea/
+.vscode/
 
 # External folders
 vendor/

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
 	github.com/jacobsa/fuse v0.0.0-20230509090321-7263f3a2b474
-	github.com/jacobsa/gcloud v0.0.0-20230425120041-5ed2958cdfee
+	github.com/jacobsa/gcloud v0.0.0-20230803125757-3196d990d984
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/jacobsa/fuse v0.0.0-20230509090321-7263f3a2b474 h1:6z3Yj4PZKk3n18T2s7
 github.com/jacobsa/fuse v0.0.0-20230509090321-7263f3a2b474/go.mod h1:XUKuYy1M4vamyxQjW8/WZBTxyZ0NnUiq+kkA+WWOfeI=
 github.com/jacobsa/gcloud v0.0.0-20230425120041-5ed2958cdfee h1:1NvpBXX7CiuoK+SdLNMwelLB+2OkJLxhjllc0WgY8sE=
 github.com/jacobsa/gcloud v0.0.0-20230425120041-5ed2958cdfee/go.mod h1:CGkT80TfaoPTzQ8My+t2M7PnMDvkwAR36Qm8Mm8HytI=
+github.com/jacobsa/gcloud v0.0.0-20230803125757-3196d990d984 h1:kD9sX/8uHuPQI6OO/VKz/olbTXNkQ4vveSPNdS9AtHw=
+github.com/jacobsa/gcloud v0.0.0-20230803125757-3196d990d984/go.mod h1:CGkT80TfaoPTzQ8My+t2M7PnMDvkwAR36Qm8Mm8HytI=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=


### PR DESCRIPTION
### Description
Updates dependency to latest jacobsa/gcloud version. This is to account for https://github.com/jacobsa/gcloud/pull/34 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested by mounting a bucket, running ls command in different folders and checking file/object sizes etc.
2. Unit tests - NA
3. Integration tests - NA
