### PR TITLE
gzip write-flow integration tests

### DIFF
--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -40,6 +40,14 @@ const (
 	GzipContentWithContentEncodingWithNoTransformFilename    = "gzipContentWithContentEncodingWithNoTransform.txt.gz"
 	GzipContentWithContentEncodingWithoutNoTransformFilename = "gzipContentWithContentEncodingWithoutNoTransform.txt.gz"
 
+	TextContentWithContentEncodingWithNoTransformToOverwrite    = "TextContentWithContentEncodingWithNoTransformToOverwrite.txt"
+	TextContentWithContentEncodingWithoutNoTransformToOverwrite = "TextContentWithContentEncodingWithoutNoTransformToOverwrite.txt"
+
+	GzipContentWithoutContentEncodingToOverwrite = "GzipContentWithoutContentEncodingToOverwrite.txt.gz"
+
+	GzipContentWithContentEncodingWithNoTransformToOverwrite    = "GzipContentWithContentEncodingWithNoTransformToOverwrite.txt.gz"
+	GzipContentWithContentEncodingWithoutNoTransformToOverwrite = "GzipContentWithContentEncodingWithoutNoTransformToOverwrite.txt.gz"
+
 	TestBucketPrefixPath = "gzip"
 )
 
@@ -83,6 +91,39 @@ func setup_testdata(m *testing.M) error {
 			enableGzipContentEncoding:   true,
 		}, {
 			filename:                    GzipContentWithContentEncodingWithoutNoTransformFilename,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: false,
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   true,
+		},
+		{
+			filename:                    TextContentWithContentEncodingWithNoTransformToOverwrite,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true,
+			enableGzipEncodedContent:    false,
+			enableGzipContentEncoding:   true,
+		},
+		{
+			filename:                    TextContentWithContentEncodingWithoutNoTransformToOverwrite,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: false,
+			enableGzipEncodedContent:    false,
+			enableGzipContentEncoding:   true,
+		},
+		{
+			filename:                    GzipContentWithoutContentEncodingToOverwrite,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true, // it's a don't care in this case
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   false,
+		}, {
+			filename:                    GzipContentWithContentEncodingWithNoTransformToOverwrite,
+			filesize:                    TextContentSize,
+			keepCacheControlNoTransform: true,
+			enableGzipEncodedContent:    true,
+			enableGzipContentEncoding:   true,
+		}, {
+			filename:                    GzipContentWithContentEncodingWithoutNoTransformToOverwrite,
 			filesize:                    TextContentSize,
 			keepCacheControlNoTransform: false,
 			enableGzipEncodedContent:    true,

--- a/tools/integration_tests/gzip/write_gzip_test.go
+++ b/tools/integration_tests/gzip/write_gzip_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for gzip objects in gcsfuse mounts.
+package gzip_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip/helpers"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+// Size of the overwritten content created in bytes.
+const OverwittenFileSize = 1000
+
+// Verify that the passed file exists on the GCS test-bucket and in the mounted bucket
+// and its size in the mounted directory matches that of the GCS object. Also verify
+// that the passed file in the mounted bucket matches the corresponding
+// GCS object in content.
+// GCS object.
+func verifyFullFileOverwrite(t *testing.T, filename string) {
+	mountedFilePath := path.Join(setup.MntDir(), TestBucketPrefixPath, filename)
+	gcsObjectPath := path.Join(setup.TestBucket(), TestBucketPrefixPath, filename)
+	gcsObjectSize, err := operations.GetGcsObjectSize(gcsObjectPath)
+	if err != nil {
+		t.Fatalf("Failed to get size of gcs object %s: %v\n", gcsObjectPath, err)
+	}
+
+	fi, err := operations.StatFile(mountedFilePath)
+	if err != nil || fi == nil {
+		t.Fatalf("Failed to get stat info of mounted file %s: %v\n", mountedFilePath, err)
+	}
+
+	if (*fi).Size() != int64(gcsObjectSize) {
+		t.Fatalf("Size of file mounted through gcsfuse (%s, %d) doesn't match the size of the file on GCS (%s, %d)",
+			mountedFilePath, (*fi).Size(), gcsObjectPath, gcsObjectSize)
+	}
+
+	// No need to worry about gzipping the overwritten data, because it's
+	// expensive to invoke a gzip-writer and unnecessary in this case.
+	// All we are interested in testing is that the content of the overwritten
+	// gzip file matches in size with that of the source file that was used to
+	// overwrite it.
+	tempfile, err := helpers.CreateLocalTempFile(OverwittenFileSize, false)
+	if err != nil {
+		t.Fatalf("Failed to create local temp file for overwriting existing gzip object: %v", err)
+	}
+	defer operations.RemoveFile(tempfile)
+
+	err = operations.CopyFileAllowOverwrite(tempfile, mountedFilePath)
+	if err != nil {
+		t.Fatalf("Failed to copy/overwrite temp file %s to existing gzip object/file %s: %v", tempfile, mountedFilePath, err)
+	}
+
+	gcsObjectSize, err = operations.GetGcsObjectSize(gcsObjectPath)
+	if err != nil {
+		t.Fatalf("Failed to get size of gcs object %s: %v\n", gcsObjectPath, err)
+	}
+
+	if gcsObjectSize != OverwittenFileSize {
+		t.Fatalf("Size of overwritten gcs object (%s, %d) doesn't match that of the expected overwrite size (%s, %d)", gcsObjectPath, gcsObjectSize, tempfile, OverwittenFileSize)
+	}
+}
+
+func TestGzipEncodedTextFileWithNoTransformFullFileOverwrite(t *testing.T) {
+	verifyFullFileOverwrite(t, TextContentWithContentEncodingWithNoTransformToOverwrite)
+}
+
+func TestGzipEncodedTextFileWithoutNoTransformFullFileOverwrite(t *testing.T) {
+	verifyFullFileOverwrite(t, TextContentWithContentEncodingWithoutNoTransformToOverwrite)
+}
+
+func TestGzipUnencodedGzipFileFullFileOverwrite(t *testing.T) {
+	verifyFullFileOverwrite(t, GzipContentWithoutContentEncodingToOverwrite)
+}
+
+func TestGzipEncodedGzipFileWithNoTransformFullFileOverwrite(t *testing.T) {
+	verifyFullFileOverwrite(t, GzipContentWithContentEncodingWithNoTransformToOverwrite)
+}
+
+func TestGzipEncodedGzipFileWithoutNoTransformFullFileOverwrite(t *testing.T) {
+	verifyFullFileOverwrite(t, GzipContentWithContentEncodingWithoutNoTransformToOverwrite)
+}

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -273,6 +273,7 @@ gcsfuse --implicit-dirs --enable-storage-client-library=false $TEST_BUCKET_NAME 
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/write_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
 
+# Run integration tests from gzip package/directory with static mounting
 gcsfuse --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/gzip/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -29,36 +29,53 @@ import (
 	"syscall"
 )
 
-func CopyFile(srcFileName string, newFileName string) (err error) {
-	if _, err = os.Stat(newFileName); err == nil {
-		err = fmt.Errorf("Copied file %s already present", newFileName)
-		return
+func copyFile(srcFileName, dstFileName string, allowOverwrite bool) (err error) {
+	if !allowOverwrite {
+		if _, err = os.Stat(dstFileName); err == nil {
+			err = fmt.Errorf("destination file %s already present", dstFileName)
+			return
+		}
 	}
 
 	source, err := os.OpenFile(srcFileName, syscall.O_DIRECT, FilePermission_0600)
 	if err != nil {
-		err = fmt.Errorf("File %s opening error: %v", srcFileName, err)
+		err = fmt.Errorf("file %s opening error: %v", srcFileName, err)
 		return
 	}
 
 	// Closing file at the end.
 	defer CloseFile(source)
 
-	destination, err := os.OpenFile(newFileName, os.O_WRONLY|os.O_CREATE|syscall.O_DIRECT, FilePermission_0600)
+	var destination *os.File
+	if allowOverwrite {
+		destination, err = os.OpenFile(dstFileName, os.O_WRONLY|os.O_CREATE|syscall.O_DIRECT|os.O_TRUNC, FilePermission_0600)
+	} else {
+		destination, err = os.OpenFile(dstFileName, os.O_WRONLY|os.O_CREATE|syscall.O_DIRECT, FilePermission_0600)
+	}
+
 	if err != nil {
-		err = fmt.Errorf("Copied file creation error: %v", err)
+		err = fmt.Errorf("copied file creation error: %v", err)
 		return
 	}
+
 	// Closing file at the end.
 	defer CloseFile(destination)
 
 	// File copying with io.Copy() utility.
 	_, err = io.Copy(destination, source)
 	if err != nil {
-		err = fmt.Errorf("Error in file copying: %v", err)
+		err = fmt.Errorf("error in file copying: %v", err)
 		return
 	}
 	return
+}
+
+func CopyFile(srcFileName, newFileName string) (err error) {
+	return copyFile(srcFileName, newFileName, false)
+}
+
+func CopyFileAllowOverwrite(srcFileName, newFileName string) (err error) {
+	return copyFile(srcFileName, newFileName, true)
 }
 
 func ReadFile(filePath string) (content []byte, err error) {
@@ -293,10 +310,11 @@ func StatFile(file string) (*fs.FileInfo, error) {
 
 // Finds if two local files have identical content (equivalnt to binary diff).
 // Needs (a) both files to exist, (b)read permission on both the files, (c) both
-// inputs to be proper files, symlinks/directories not supported.
+// inputs to be proper files, i.e. directories not supported.
 // Compares file names first. If different, compares sizes next.
-// If sizes match, then compares hashes of both the files.
-// Not a good idea for very large files as it loads both the files in the memory completely.
+// If sizes match, then compares the contents of both the files.
+// Not a good idea for very large files as it loads both the files' contents in
+// the memory completely.
 // Returns 0 if no error and files match.
 // Returns 1 if files don't match and captures reason for mismatch in err.
 // Returns 2 if any error.
@@ -363,7 +381,9 @@ func executeToolCommandf(tool string, format string, args ...any) ([]byte, error
 	return stdout.Bytes(), nil
 }
 
-// Executes any given gcloud command with given args
+// Executes any given gcloud command with given args.
+// Using `gcloud alpha` instead of `gcloud` as the latter isn't supported
+// on some VMs e.e. kokoro VMs and rhel/centos VMs etc.
 func ExecuteGcloudCommandf(format string, args ...any) ([]byte, error) {
 	return executeToolCommandf("gcloud alpha", format, args...)
 }


### PR DESCRIPTION
### Description
It adds write-flow integration tests (on top of the read-flow tests added in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1256) for GCSfuse-mounted objects with content-encoding gzip. 
These tests replace an existing gzip object in a mounted bucket, then verify the size of the re-uploaded GCS object.


Tests added (1*5 = 5 tests)
* One type of operation
  * Overwrite
* On five types of objects each
  * Object with text content, uploaded with gzip compression with content-encoding: gzip, and cache-control: no-transform
  * Object with text content, uploaded with gzip compression with content-encoding: gzip, and cache-control: ''
  * Object with gzip content, uploaded with content-encoding: ''
  * Object with gzip content, uploaded with gzip compression (i.e. doubly compressed) with content-encoding: gzip, and cache-control: no-transform
  * Object with gzip content, uploaded with gzip compression (i.e. doubly compressed) with content-encoding: gzip, and cache-control: ''

This also adds a necessary CopyFileAllowOverwrite alternative utility to the existing CopyFile utility(which doesn't allow file overwrite) in tools/integration_tests/util/operations/file_operations.go .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
2. Unit tests - NA
3. Integration tests - Run all the tests for testbucket and mountedDirectory flags.(status:SUCCESS)
