### PR TITLE
Changing user agent to differentiat jacobsa and go storage client

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,12 +81,12 @@ func registerSIGINTHandler(mountPoint string) {
 func getUserAgent(appName string, clientName string) string {
 	gcsfuseMetadataImageType := os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")
 	if len(gcsfuseMetadataImageType) > 0 {
-		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s) client-%s", getVersion(), appName, gcsfuseMetadataImageType, clientName)
+		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s) client:%s", getVersion(), appName, gcsfuseMetadataImageType, clientName)
 		return strings.Join(strings.Fields(userAgent), " ")
 	} else if len(appName) > 0 {
-		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s) client-%s", getVersion(), appName, clientName)
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s) client:%s", getVersion(), appName, clientName)
 	} else {
-		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), clientName)
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client:%s", getVersion(), clientName)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ import (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-const JacobsaClient = "Jacobsa"
-const GoStorageClient = "GoStorage"
+const JacobsaClient = "jacobsa"
+const GoStorageClient = "go-storage"
 
 func registerSIGINTHandler(mountPoint string) {
 	// Register for SIGINT.

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ import (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
+const JacobsaClient = "Jacobsa"
+const GoStorageClient = "GoStorage"
+
 func registerSIGINTHandler(mountPoint string) {
 	// Register for SIGINT.
 	signalChan := make(chan os.Signal, 1)
@@ -75,15 +78,15 @@ func registerSIGINTHandler(mountPoint string) {
 	}()
 }
 
-func getUserAgent(appName string) string {
+func getUserAgent(appName string, clientName string) string {
 	gcsfuseMetadataImageType := os.Getenv("GCSFUSE_METADATA_IMAGE_TYPE")
 	if len(gcsfuseMetadataImageType) > 0 {
-		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s)", getVersion(), appName, gcsfuseMetadataImageType)
+		userAgent := fmt.Sprintf("gcsfuse/%s %s (GPN:gcsfuse-%s) client-%s", getVersion(), appName, gcsfuseMetadataImageType, clientName)
 		return strings.Join(strings.Fields(userAgent), " ")
 	} else if len(appName) > 0 {
-		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s)", getVersion(), appName)
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-%s) client-%s", getVersion(), appName, clientName)
 	} else {
-		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse)", getVersion())
+		return fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), clientName)
 	}
 }
 
@@ -109,7 +112,7 @@ func getConn(flags *flagStorage) (c *gcsx.Connection, err error) {
 	cfg := &gcs.ConnConfig{
 		Url:             flags.Endpoint,
 		TokenSource:     tokenSrc,
-		UserAgent:       getUserAgent(flags.AppName),
+		UserAgent:       getUserAgent(flags.AppName, JacobsaClient),
 		MaxBackoffSleep: flags.MaxRetrySleep,
 	}
 
@@ -163,7 +166,7 @@ func createStorageHandle(flags *flagStorage) (storageHandle storage.StorageHandl
 		HttpClientTimeout:   flags.HttpClientTimeout,
 		MaxRetryDuration:    flags.MaxRetryDuration,
 		RetryMultiplier:     flags.RetryMultiplier,
-		UserAgent:           getUserAgent(flags.AppName),
+		UserAgent:           getUserAgent(flags.AppName, GoStorageClient),
 	}
 
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)

--- a/main_test.go
+++ b/main_test.go
@@ -56,28 +56,28 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
 
 	userAgent := getUserAgent("AppName", ClientName)
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) client-%s", getVersion(), ClientName))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) client:%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
 	userAgent := getUserAgent("AppName", ClientName)
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) client-%s", getVersion(), ClientName))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) client:%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAreNotSet() {
 	userAgent := getUserAgent("", ClientName)
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), ClientName))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client:%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAndClientNameAreNotSet() {
 	userAgent := getUserAgent("", "")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), ""))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client:%s", getVersion(), ""))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
@@ -87,7 +87,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSe
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
 
 	userAgent := getUserAgent("", ClientName)
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) client-%s", getVersion(), ClientName))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) client:%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,8 @@ func Test_Main(t *testing.T) { RunTests(t) }
 type MainTest struct {
 }
 
+const ClientName = "client"
+
 func init() { RegisterTestSuite(&MainTest{}) }
 
 func (t *MainTest) TestCreateStorageHandleEnableStorageClientLibraryIsTrue() {
@@ -53,32 +55,38 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 	os.Setenv("GCSFUSE_METADATA_IMAGE_TYPE", "DLVM")
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
 
-	userAgent := getUserAgent("AppName")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM)", getVersion()))
+	userAgent := getUserAgent("AppName", ClientName)
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) client-%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
-	userAgent := getUserAgent("AppName")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName)", getVersion()))
+	userAgent := getUserAgent("AppName", ClientName)
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) client-%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAreNotSet() {
-	userAgent := getUserAgent("")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse)", getVersion()))
+	userAgent := getUserAgent("", ClientName)
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
 
+func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAndClientNameAreNotSet() {
+	userAgent := getUserAgent("", "")
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse) client-%s", getVersion(), ""))
+
+	ExpectEq(expectedUserAgent, userAgent)
+}
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSet() {
 	os.Setenv("GCSFUSE_METADATA_IMAGE_TYPE", "DLVM")
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")
 
-	userAgent := getUserAgent("")
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM)", getVersion()))
+	userAgent := getUserAgent("", ClientName)
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) client-%s", getVersion(), ClientName))
 
 	ExpectEq(expectedUserAgent, userAgent)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -81,6 +81,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarAndAppNameAndClien
 
 	ExpectEq(expectedUserAgent, userAgent)
 }
+
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSet() {
 	os.Setenv("GCSFUSE_METADATA_IMAGE_TYPE", "DLVM")
 	defer os.Unsetenv("GCSFUSE_METADATA_IMAGE_TYPE")


### PR DESCRIPTION
### Description
Added client name to differentiate Jacobsa and go storage client users.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually check UserAgent in both the scenarios.
2. Unit tests - Added
3. Integration tests - NA
