### PR TITLE
Modified Sync, forgetInode  operations to handle localFiles

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -26,7 +26,7 @@ func NewMountConfig() *MountConfig {
 	return &MountConfig{
 		WriteConfig{
 			// Making the default value as true to keep it inline with current behaviour.
-			CreateEmptyFile: false,
+			CreateEmptyFile: true,
 		},
 	}
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -26,7 +26,7 @@ func NewMountConfig() *MountConfig {
 	return &MountConfig{
 		WriteConfig{
 			// Making the default value as true to keep it inline with current behaviour.
-			CreateEmptyFile: true,
+			CreateEmptyFile: false,
 		},
 	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -908,7 +908,7 @@ func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName stri
 	fileName := inode.NewFileName(parent.Name(), childName)
 	// Lock is required to ensure that localFileInode is not updated/deleted in the meantime.
 	fs.mu.Lock()
-	child, _ = fs.localFileInodes[fileName]
+	child = fs.localFileInodes[fileName]
 	fs.mu.Unlock()
 
 	return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -908,12 +908,8 @@ func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName stri
 	fileName := inode.NewFileName(parent.Name(), childName)
 	// Lock is required to ensure that localFileInode is not updated/deleted in the meantime.
 	fs.mu.Lock()
-	child, ok := fs.localFileInodes[fileName]
+	child, _ = fs.localFileInodes[fileName]
 	fs.mu.Unlock()
-
-	if ok {
-		return
-	}
 
 	return
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -846,15 +846,6 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 	ctx context.Context,
 	parent inode.DirInode,
 	childName string) (child inode.Inode, err error) {
-	// First check if the requested child is a localFileInode.
-	child = fs.lookUpLocalFileInode(parent, childName)
-	if child != nil {
-		return
-	}
-
-	// If the requested child is not a localFileInode, continue with the existing
-	// flow of checking GCS for file/directory.
-
 	// Set up a function that will find a lookup result for the child with the
 	// given name. Expects no locks to be held.
 	getLookupResult := func() (*inode.Core, error) {
@@ -887,57 +878,6 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 	}
 
 	err = fmt.Errorf("cannot find %q in %q with %v tries", childName, parent.Name(), maxTries)
-	return
-}
-
-// Look up the localFileInodes to check if a file with given name exists.
-// Return inode if it exists, else return nil.
-// LOCKS_EXCLUDED(fs.mu)
-// LOCKS_EXCLUDED(parent)
-// UNLOCK_FUNCTION(fs.mu)
-// LOCK_FUNCTION(child)
-func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName string) (child inode.Inode) {
-	defer func() {
-		if child != nil {
-			child.IncrementLookupCount()
-		}
-		fs.mu.Unlock()
-	}()
-
-	fileName := inode.NewFileName(parent.Name(), childName)
-
-	fs.mu.Lock()
-	var maxTriesToLookupInode = 3
-	for n := 0; n < maxTriesToLookupInode; n++ {
-		child = fs.localFileInodes[fileName]
-
-		if child == nil {
-			return
-		}
-
-		// If the inode already exists, we need to follow the lock ordering rules
-		// to get the lock. First get inode lock and then fs lock.
-		fs.mu.Unlock()
-		child.Lock()
-		// Filesystem lock will be held till we increment lookUpCount to avoid
-		// deletion of inode from fs.inodes/fs.localFileInodes map by other flows.
-		fs.mu.Lock()
-		// Once we get fs lock, validate if the inode is still valid. If not
-		// try to fetch it again. Eg: If the inode is deleted by other thread after
-		// we fetched it from fs.localFileInodes map, then any call to perform
-		// inode operation will crash GCSFuse since the inode is not valid. Hence
-		// it is important to acquire lock and increment lookUpCount before letting
-		// other threads modify it.
-		if fs.localFileInodes[fileName] != child {
-			child.Unlock()
-			continue
-		}
-
-		return
-	}
-
-	// In case we exhausted the retries, return nil object.
-	child = nil
 	return
 }
 
@@ -1431,10 +1371,6 @@ func (fs *fileSystem) createFile(
 	return
 }
 
-// Creates localFileInode with the given name under the parent inode.
-// LOCKS_EXCLUDED(fs.mu)
-// UNLOCK_FUNCTION(fs.mu)
-// LOCK_FUNCTION(in)
 func (fs *fileSystem) createLocalFile(
 	parentID fuseops.InodeID,
 	name string) (child inode.Inode, err error) {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -174,6 +174,7 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool) (o *g
 	if errors.As(err, &notFoundErr) {
 		err = nil
 		if f.IsLocal() {
+			// For localFile, it is expected that object doesn't exist in GCS.
 			return
 		}
 
@@ -582,6 +583,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
 		f.src = convertObjToMinObject(newObj)
+		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false
 		}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -385,7 +385,9 @@ func (f *FileInode) Attributes(
 	attrs.Atime = attrs.Mtime
 	attrs.Ctime = attrs.Mtime
 
-	// Avoid clobbered check and return the attributes for local files.
+	// Clobbered check makes a stat call to GCS. Avoiding stat calls to GCS for
+	// local files when fetching attributes. Any validations will be done during
+	// sync call.
 	if f.IsLocal() {
 		return
 	}

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -390,7 +390,9 @@ func (t *FileTest) WriteThenSync() {
 func (t *FileTest) WriteToLocalFileThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
+	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
+	// Create a temp file for the local inode created above.
 	err = t.in.CreateEmptyTempFile()
 	AssertEq(nil, err)
 	// Write some content to temp file.
@@ -430,7 +432,9 @@ func (t *FileTest) WriteToLocalFileThenSync() {
 func (t *FileTest) SyncEmptyLocalFile() {
 	var attrs fuseops.InodeAttributes
 	var err error
+	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
+	// Create a temp file for the local inode created above.
 	err = t.in.CreateEmptyTempFile()
 	AssertEq(nil, err)
 

--- a/internal/gcsx/append_object_creator.go
+++ b/internal/gcsx/append_object_creator.go
@@ -78,9 +78,12 @@ func (oc *appendObjectCreator) chooseName() (name string, err error) {
 	return
 }
 
+// ObjectName param is present here for consistency between fullObjectCreator
+// and appendObjectCreator. ObjectName is not used in append flow since
+// srcObject.Name gives the objectName.
 func (oc *appendObjectCreator) Create(
 	ctx context.Context,
-	fileName string,
+	objectName string,
 	srcObject *gcs.Object,
 	mtime *time.Time,
 	r io.Reader) (o *gcs.Object, err error) {

--- a/internal/gcsx/append_object_creator.go
+++ b/internal/gcsx/append_object_creator.go
@@ -80,8 +80,9 @@ func (oc *appendObjectCreator) chooseName() (name string, err error) {
 
 func (oc *appendObjectCreator) Create(
 	ctx context.Context,
+	fileName string,
 	srcObject *gcs.Object,
-	mtime time.Time,
+	mtime *time.Time,
 	r io.Reader) (o *gcs.Object, err error) {
 	// Choose a name for a temporary object.
 	tmpName, err := oc.chooseName()
@@ -125,7 +126,9 @@ func (oc *appendObjectCreator) Create(
 		MetadataMap[key] = value
 	}
 
-	MetadataMap[MtimeMetadataKey] = mtime.Format(time.RFC3339Nano)
+	if mtime != nil {
+		MetadataMap[MtimeMetadataKey] = mtime.UTC().Format(time.RFC3339Nano)
+	}
 
 	// Compose the old contents plus the new over the old.
 	o, err = oc.bucket.ComposeObjects(

--- a/internal/gcsx/append_object_creator_test.go
+++ b/internal/gcsx/append_object_creator_test.go
@@ -155,7 +155,7 @@ func (t *AppendObjectCreatorTest) CallsComposeObjects() {
 	t.srcObject.Name = "foo"
 	t.srcObject.Generation = 17
 	t.srcObject.MetaGeneration = 23
-	t.mtime = time.Now().Add(123 * time.Second).UTC()
+	t.mtime = time.Now().Add(123 * time.Second)
 
 	// CreateObject
 	tmpObject := &gcs.Object{
@@ -188,7 +188,7 @@ func (t *AppendObjectCreatorTest) CallsComposeObjects() {
 		Pointee(Equals(t.srcObject.MetaGeneration)))
 
 	ExpectEq(1, len(req.Metadata))
-	ExpectEq(t.mtime.Format(time.RFC3339Nano), req.Metadata["gcsfuse_mtime"])
+	ExpectEq(t.mtime.UTC().Format(time.RFC3339Nano), req.Metadata["gcsfuse_mtime"])
 
 	AssertEq(2, len(req.Sources))
 	var src gcs.ComposeSource
@@ -216,7 +216,7 @@ func (t *AppendObjectCreatorTest) CallsComposeObjectsWithObjectProperties() {
 	t.srcObject.Metadata = map[string]string{
 		"test_key": "test_value",
 	}
-	t.mtime = time.Now().Add(123 * time.Second).UTC()
+	t.mtime = time.Now().Add(123 * time.Second)
 
 	// CreateObject
 	tmpObject := &gcs.Object{
@@ -255,7 +255,7 @@ func (t *AppendObjectCreatorTest) CallsComposeObjectsWithObjectProperties() {
 	ExpectEq(t.srcObject.EventBasedHold, req.EventBasedHold)
 
 	ExpectEq(2, len(req.Metadata))
-	ExpectEq(t.mtime.Format(time.RFC3339Nano), req.Metadata["gcsfuse_mtime"])
+	ExpectEq(t.mtime.UTC().Format(time.RFC3339Nano), req.Metadata["gcsfuse_mtime"])
 	ExpectEq("test_value", req.Metadata["test_key"])
 
 	AssertEq(2, len(req.Sources))

--- a/internal/gcsx/append_object_creator_test.go
+++ b/internal/gcsx/append_object_creator_test.go
@@ -89,8 +89,9 @@ func (t *AppendObjectCreatorTest) SetUp(ti *TestInfo) {
 func (t *AppendObjectCreatorTest) call() (o *gcs.Object, err error) {
 	o, err = t.creator.Create(
 		t.ctx,
+		t.srcObject.Name,
 		&t.srcObject,
-		t.mtime,
+		&t.mtime,
 		strings.NewReader(t.srcContents))
 
 	return
@@ -209,10 +210,10 @@ func (t *AppendObjectCreatorTest) CallsComposeObjectsWithObjectProperties() {
 	t.srcObject.ContentDisposition = "inline"
 	t.srcObject.ContentEncoding = "gzip"
 	t.srcObject.ContentType = "text/plain"
-	t.srcObject.CustomTime  = "2022-04-02T00:30:00Z"
+	t.srcObject.CustomTime = "2022-04-02T00:30:00Z"
 	t.srcObject.EventBasedHold = true
 	t.srcObject.StorageClass = "STANDARD"
-	t.srcObject.Metadata = map[string]string {
+	t.srcObject.Metadata = map[string]string{
 		"test_key": "test_value",
 	}
 	t.mtime = time.Now().Add(123 * time.Second).UTC()

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -95,6 +95,7 @@ func (oc *fullObjectCreator) Create(
 		}
 	}
 
+	// Any existing mtime value will be overwritten with new value.
 	if mtime != nil {
 		MetadataMap[MtimeMetadataKey] = mtime.UTC().Format(time.RFC3339Nano)
 	}
@@ -193,6 +194,8 @@ func (os *syncer) SyncObject(
 	}
 
 	if srcObject == nil {
+		// Content.Stat() seeks the current position to end of file. Seek it back
+		// to beginning of the file.
 		_, err = content.Seek(0, 0)
 		if err != nil {
 			err = fmt.Errorf("error in seeking: %w", err)
@@ -225,9 +228,6 @@ func (os *syncer) SyncObject(
 		err = fmt.Errorf("Wacky stat result: %#v", sr)
 		return
 	}
-
-	fmt.Println("mtime")
-	fmt.Println(sr.Mtime)
 
 	// Otherwise, we need to create a new generation. If the source object is
 	// long enough, hasn't been dirtied, and has a low enough component count,

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -213,7 +213,7 @@ func (t *FullObjectCreatorTest) validateEmptyProperties(req *gcs.CreateObjectReq
 	AssertEq("", req.CustomTime)
 	AssertEq(false, req.EventBasedHold)
 	AssertEq("", req.StorageClass)
-	// Validate the objecct contents.
+	// Validate the object contents.
 	b, err := ioutil.ReadAll(req.Contents)
 	AssertEq(nil, err)
 	ExpectEq(t.srcContents, string(b))

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -64,8 +64,9 @@ func (t *FullObjectCreatorTest) SetUp(ti *TestInfo) {
 func (t *FullObjectCreatorTest) call() (o *gcs.Object, err error) {
 	o, err = t.creator.Create(
 		t.ctx,
+		t.srcObject.Name,
 		&t.srcObject,
-		t.mtime,
+		&t.mtime,
 		strings.NewReader(t.srcContents))
 
 	return
@@ -132,10 +133,10 @@ func (t *FullObjectCreatorTest) CallsCreateObjectsWithObjectProperties() {
 	t.srcObject.ContentDisposition = "inline"
 	t.srcObject.ContentEncoding = "gzip"
 	t.srcObject.ContentType = "text/plain"
-	t.srcObject.CustomTime  = "2022-04-02T00:30:00Z"
+	t.srcObject.CustomTime = "2022-04-02T00:30:00Z"
 	t.srcObject.EventBasedHold = true
 	t.srcObject.StorageClass = "STANDARD"
-	t.srcObject.Metadata = map[string]string {
+	t.srcObject.Metadata = map[string]string{
 		"test_key": "test_value",
 	}
 	t.mtime = time.Now().Add(123 * time.Second).UTC()
@@ -161,6 +162,63 @@ func (t *FullObjectCreatorTest) CallsCreateObjectsWithObjectProperties() {
 	ExpectEq("test_value", req.Metadata["test_key"])
 }
 
+func (t *FullObjectCreatorTest) CallsCreateObjectWhenSrcObjectIsNil() {
+	t.srcContents = "taco"
+	// CreateObject
+	var req *gcs.CreateObjectRequest
+	ExpectCall(t.bucket, "CreateObject")(Any(), Any()).
+		WillOnce(DoAll(SaveArg(1, &req), Return(nil, errors.New(""))))
+
+	// Call
+	_, _ = t.creator.Create(
+		t.ctx,
+		t.srcObject.Name,
+		nil,
+		&t.mtime,
+		strings.NewReader(t.srcContents))
+
+	t.validateEmptyProperties(req)
+	ExpectEq(t.mtime.Format(time.RFC3339Nano), req.Metadata["gcsfuse_mtime"])
+}
+
+func (t *FullObjectCreatorTest) CallsCreateObjectWhenSrcObjectAndMtimeAreNil() {
+	t.srcContents = "taco"
+	// CreateObject
+	var req *gcs.CreateObjectRequest
+	ExpectCall(t.bucket, "CreateObject")(Any(), Any()).
+		WillOnce(DoAll(SaveArg(1, &req), Return(nil, errors.New(""))))
+
+	// Call
+	_, _ = t.creator.Create(
+		t.ctx,
+		t.srcObject.Name,
+		nil,
+		nil,
+		strings.NewReader(t.srcContents))
+
+	t.validateEmptyProperties(req)
+	_, ok := req.Metadata["gcsfuse_mtime"]
+	AssertFalse(ok)
+}
+
+func (t *FullObjectCreatorTest) validateEmptyProperties(req *gcs.CreateObjectRequest) {
+	AssertNe(nil, req)
+	ExpectThat(req.GenerationPrecondition, Pointee(Equals(0)))
+	// All the properties should be empty/nil.
+	AssertEq(nil, req.MetaGenerationPrecondition)
+	AssertEq("", req.CacheControl)
+	AssertEq("", req.ContentDisposition)
+	AssertEq("", req.ContentEncoding)
+	AssertEq("", req.ContentType)
+	AssertEq("", req.CustomTime)
+	AssertEq(false, req.EventBasedHold)
+	AssertEq("", req.StorageClass)
+	// Validate the objecct contents.
+	b, err := ioutil.ReadAll(req.Contents)
+	AssertEq(nil, err)
+	ExpectEq(t.srcContents, string(b))
+}
+
 ////////////////////////////////////////////////////////////////////////
 // fakeObjectCreator
 ////////////////////////////////////////////////////////////////////////
@@ -182,8 +240,9 @@ type fakeObjectCreator struct {
 
 func (oc *fakeObjectCreator) Create(
 	ctx context.Context,
+	fileName string,
 	srcObject *gcs.Object,
-	mtime time.Time,
+	mtime *time.Time,
 	r io.Reader) (o *gcs.Object, err error) {
 	// Have we been called more than once?
 	AssertFalse(oc.called)
@@ -191,7 +250,9 @@ func (oc *fakeObjectCreator) Create(
 
 	// Record args.
 	oc.srcObject = srcObject
-	oc.mtime = mtime
+	if mtime != nil {
+		oc.mtime = *mtime
+	}
 	oc.contents, err = ioutil.ReadAll(r)
 	AssertEq(nil, err)
 
@@ -262,7 +323,7 @@ func (t *SyncerTest) SetUp(ti *TestInfo) {
 }
 
 func (t *SyncerTest) call() (o *gcs.Object, err error) {
-	o, err = t.syncer.SyncObject(t.ctx, t.srcObject, t.content)
+	o, err = t.syncer.SyncObject(t.ctx, t.srcObject.Name, t.srcObject, t.content)
 	return
 }
 
@@ -278,6 +339,14 @@ func (rc dummyReadCloser) Close() error {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
+func (t *SyncerTest) SyncObjectShouldInvokeFullObjectCreatorWhenSrcObjectIsNil() {
+	// It doesn't make sense to validate returned object or error since fake
+	// is not handling them.
+	_, _ = t.syncer.SyncObject(t.ctx, t.srcObject.Name, nil, t.content)
+
+	ExpectTrue(t.fullCreator.called)
+	ExpectFalse(t.appendCreator.called)
+}
 func (t *SyncerTest) NotDirty() {
 	// Call
 	o, err := t.call()
@@ -405,7 +474,7 @@ func (t *SyncerTest) CallsFullCreator() {
 
 	AssertTrue(t.fullCreator.called)
 	ExpectEq(t.srcObject, t.fullCreator.srcObject)
-	ExpectThat(t.fullCreator.mtime, timeutil.TimeEq(mtime.UTC()))
+	ExpectThat(t.fullCreator.mtime, timeutil.TimeEq(mtime))
 	ExpectEq(srcObjectContents[:2], string(t.fullCreator.contents))
 }
 
@@ -471,7 +540,7 @@ func (t *SyncerTest) CallsAppendCreator() {
 
 	AssertTrue(t.appendCreator.called)
 	ExpectEq(t.srcObject, t.appendCreator.srcObject)
-	ExpectThat(t.appendCreator.mtime, timeutil.TimeEq(mtime.UTC()))
+	ExpectThat(t.appendCreator.mtime, timeutil.TimeEq(mtime))
 	ExpectEq("burrito", string(t.appendCreator.contents))
 }
 


### PR DESCRIPTION
### Description
Modified SyncFile, ForgetInode operations to handle local Files.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done manual testing and verified that file is getting uploaded to GCS correctly. Also verified forgetInode by manually throwing an error in writeFile flow. 
2. Unit tests - Added wherever applicable. Fs.go unit tests will be added after lookupinode operation is updated.
3. Integration tests -Yet to run the existing tests. New tests will be added in later PRs.
