### PR TITLE
Modified lookUpInode operation to check localFileInodes

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -26,7 +26,7 @@ func NewMountConfig() *MountConfig {
 	return &MountConfig{
 		WriteConfig{
 			// Making the default value as true to keep it inline with current behaviour.
-			CreateEmptyFile: false,
+			CreateEmptyFile: true,
 		},
 	}
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -26,7 +26,7 @@ func NewMountConfig() *MountConfig {
 	return &MountConfig{
 		WriteConfig{
 			// Making the default value as true to keep it inline with current behaviour.
-			CreateEmptyFile: true,
+			CreateEmptyFile: false,
 		},
 	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -846,6 +846,15 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 	ctx context.Context,
 	parent inode.DirInode,
 	childName string) (child inode.Inode, err error) {
+	// First check if the requested child is a localFileInode.
+	child = fs.lookUpLocalFileInode(parent, childName)
+	if child != nil {
+		return
+	}
+
+	// If the requested child is not a localFileInode, continue with the existing
+	// flow of checking GCS for file/directory.
+
 	// Set up a function that will find a lookup result for the child with the
 	// given name. Expects no locks to be held.
 	getLookupResult := func() (*inode.Core, error) {
@@ -878,6 +887,57 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 	}
 
 	err = fmt.Errorf("cannot find %q in %q with %v tries", childName, parent.Name(), maxTries)
+	return
+}
+
+// Look up the localFileInodes to check if a file with given name exists.
+// Return inode if it exists, else return nil.
+// LOCKS_EXCLUDED(fs.mu)
+// LOCKS_EXCLUDED(parent)
+// UNLOCK_FUNCTION(fs.mu)
+// LOCK_FUNCTION(child)
+func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName string) (child inode.Inode) {
+	defer func() {
+		if child != nil {
+			child.IncrementLookupCount()
+		}
+		fs.mu.Unlock()
+	}()
+
+	fileName := inode.NewFileName(parent.Name(), childName)
+
+	fs.mu.Lock()
+	var maxTriesToLookupInode = 3
+	for n := 0; n < maxTriesToLookupInode; n++ {
+		child = fs.localFileInodes[fileName]
+
+		if child == nil {
+			return
+		}
+
+		// If the inode already exists, we need to follow the lock ordering rules
+		// to get the lock. First get inode lock and then fs lock.
+		fs.mu.Unlock()
+		child.Lock()
+		// Filesystem lock will be held till we increment lookUpCount to avoid
+		// deletion of inode from fs.inodes/fs.localFileInodes map by other flows.
+		fs.mu.Lock()
+		// Once we get fs lock, validate if the inode is still valid. If not
+		// try to fetch it again. Eg: If the inode is deleted by other thread after
+		// we fetched it from fs.localFileInodes map, then any call to perform
+		// inode operation will crash GCSFuse since the inode is not valid. Hence
+		// it is important to acquire lock and increment lookUpCount before letting
+		// other threads modify it.
+		if fs.localFileInodes[fileName] != child {
+			child.Unlock()
+			continue
+		}
+
+		return
+	}
+
+	// In case we exhausted the retries, return nil object.
+	child = nil
 	return
 }
 
@@ -1371,6 +1431,10 @@ func (fs *fileSystem) createFile(
 	return
 }
 
+// Creates localFileInode with the given name under the parent inode.
+// LOCKS_EXCLUDED(fs.mu)
+// UNLOCK_FUNCTION(fs.mu)
+// LOCK_FUNCTION(in)
 func (fs *fileSystem) createLocalFile(
 	parentID fuseops.InodeID,
 	name string) (child inode.Inode, err error) {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -904,6 +904,11 @@ func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName stri
 		fs.mu.Unlock()
 	}()
 
+	// Trim the suffix assigned to fix conflicting names.
+	if strings.HasSuffix(childName, inode.ConflictingFileNameSuffix) {
+		childName = strings.TrimSuffix(childName, inode.ConflictingFileNameSuffix)
+	}
+
 	fileName := inode.NewFileName(parent.Name(), childName)
 
 	fs.mu.Lock()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -905,10 +905,7 @@ func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName stri
 	}()
 
 	// Trim the suffix assigned to fix conflicting names.
-	if strings.HasSuffix(childName, inode.ConflictingFileNameSuffix) {
-		childName = strings.TrimSuffix(childName, inode.ConflictingFileNameSuffix)
-	}
-
+	childName = strings.TrimSuffix(childName, inode.ConflictingFileNameSuffix)
 	fileName := inode.NewFileName(parent.Name(), childName)
 
 	fs.mu.Lock()

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -138,7 +138,9 @@ func (t *fsTest) SetUpTestSuite() {
 	}
 	t.serverCfg.RenameDirLimit = RenameDirLimit
 	t.serverCfg.SequentialReadSizeMb = SequentialReadSizeMb
-	t.serverCfg.MountConfig = config.NewMountConfig()
+	if t.serverCfg.MountConfig == nil {
+		t.serverCfg.MountConfig = config.NewMountConfig()
+	}
 
 	// Set up ownership.
 	t.serverCfg.Uid, t.serverCfg.Gid, err = perms.MyUserAndGroup()

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -23,6 +23,7 @@ func init() {
 }
 
 func (t *LocalFileTest) SetUpTestSuite() {
+	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		WriteConfig: config.WriteConfig{
 			CreateEmptyFile: false,
@@ -38,11 +39,23 @@ func (t *LocalFileTest) NewFileShouldNotGetSyncedToGCSTillClose() {
 	t.newFileShouldGetSyncedToGCSAtClose(FileName)
 }
 
-func (t *LocalFileTest) NewFileUnderSubDirectoryShouldNotGetSyncedToGCSTillClose() {
-	err := os.Mkdir(path.Join(mntDir, "test"), dirPerms)
+func (t *LocalFileTest) NewFileUnderExplicitDirectoryShouldNotGetSyncedToGCSTillClose() {
+	err := os.Mkdir(path.Join(mntDir, "explicit"), dirPerms)
 	AssertEq(nil, err)
 
-	t.newFileShouldGetSyncedToGCSAtClose("test/foo")
+	t.newFileShouldGetSyncedToGCSAtClose("explicit/foo")
+}
+
+func (t *LocalFileTest) NewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose() {
+	AssertEq(
+		nil,
+		t.createObjects(
+			map[string]string{
+				// File
+				"implicitFoo/bar": "",
+			}))
+
+	t.newFileShouldGetSyncedToGCSAtClose("implicitFoo/foo")
 }
 
 func (t *LocalFileTest) newFileShouldGetSyncedToGCSAtClose(fileName string) {

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -62,7 +62,6 @@ func (t *LocalFileTest) NewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTill
 func (t *LocalFileTest) newFileShouldGetSyncedToGCSAtClose(fileName string) {
 	// Create a local file.
 	_, f := t.createLocalFile(fileName)
-
 	// Writing contents to local file shouldn't create file on GCS.
 	_, err := f.Write([]byte(FileContents))
 	AssertEq(nil, err)
@@ -102,7 +101,6 @@ func (t *LocalFileTest) StatOnLocalFile() {
 func (t *LocalFileTest) StatOnLocalFileWithConflictingFileNameSuffix() {
 	// Create a local file.
 	filePath, f := t.createLocalFile(FileName)
-
 	// Stat the local file.
 	fi, err := os.Stat(filePath + inode.ConflictingFileNameSuffix)
 	AssertEq(nil, err)
@@ -117,7 +115,6 @@ func (t *LocalFileTest) StatOnLocalFileWithConflictingFileNameSuffix() {
 func (t *LocalFileTest) TruncateLocalFile() {
 	// Create a local file.
 	filePath, f := t.createLocalFile(FileName)
-
 	// Writing contents to local file .
 	_, err := f.Write([]byte(FileContents))
 	AssertEq(nil, err)

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/config"
+	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
 	"github.com/jacobsa/gcloud/gcs"
 	"github.com/jacobsa/gcloud/gcs/gcsutil"
 	. "github.com/jacobsa/ogletest"
@@ -101,6 +102,24 @@ func (t *LocalFileTest) StatOnLocalFile() {
 
 	// Close the file and validate if the file is created on GCS.
 	t.closeFileAndValidateObjectContents(f, FileName, FileContents)
+}
+
+func (t *LocalFileTest) StatOnLocalFileWithConflictingFileNameSuffix() {
+	// Creating a file shouldn't create file on GCS.
+	fileName := path.Join(mntDir, FileName)
+	f, err := os.Create(fileName)
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Stat the local file.
+	fi, err := os.Stat(fileName + inode.ConflictingFileNameSuffix)
+	AssertEq(nil, err)
+	ExpectEq(path.Base(fileName)+inode.ConflictingFileNameSuffix, fi.Name())
+	ExpectEq(0, fi.Size())
+	ExpectEq(filePerms, fi.Mode())
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, FileName, "")
 }
 
 func (t *LocalFileTest) TruncateLocalFile() {

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -1,0 +1,54 @@
+package fs_test
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/config"
+	"github.com/jacobsa/gcloud/gcs"
+	"github.com/jacobsa/gcloud/gcs/gcsutil"
+	. "github.com/jacobsa/ogletest"
+)
+
+type LocalFileTest struct {
+	fsTest
+}
+
+func init() {
+	RegisterTestSuite(&LocalFileTest{})
+}
+
+func (t *LocalFileTest) SetUpTestSuite() {
+	t.serverCfg.MountConfig = &config.MountConfig{
+		WriteConfig: config.WriteConfig{
+			// Making the default value as true to keep it inline with current behaviour.
+			CreateEmptyFile: false,
+		}}
+	t.fsTest.SetUpTestSuite()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *LocalFileTest) NewFileShouldNotGetSyncedToGCSTillClose() {
+	f, err := os.Create(path.Join(mntDir, "foo"))
+	AssertEq(nil, err)
+
+	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
+	var notFoundErr *gcs.NotFoundError
+	ExpectTrue(errors.As(err, &notFoundErr))
+
+	_, err = f.Write([]byte("teststring"))
+	AssertEq(nil, err)
+
+	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
+	ExpectTrue(errors.As(err, &notFoundErr))
+
+	err = f.Close()
+	AssertEq(nil, err)
+
+	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
+	ExpectTrue(errors.As(err, &notFoundErr))
+}

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -60,13 +60,11 @@ func (t *LocalFileTest) NewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTill
 }
 
 func (t *LocalFileTest) newFileShouldGetSyncedToGCSAtClose(fileName string) {
-	// Creating a file shouldn't create file on GCS.
-	f, err := os.Create(path.Join(mntDir, fileName))
-	AssertEq(nil, err)
-	t.validateObjectNotFoundErr(fileName)
+	// Create a local file.
+	_, f := t.createLocalFile(fileName)
 
 	// Writing contents to local file shouldn't create file on GCS.
-	_, err = f.Write([]byte(FileContents))
+	_, err := f.Write([]byte(FileContents))
 	AssertEq(nil, err)
 	t.validateObjectNotFoundErr(fileName)
 

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -143,13 +143,11 @@ func (t *LocalFileTest) TruncateLocalFile() {
 }
 
 func (t *LocalFileTest) MultipleWritesToLocalFile() {
-	// Creating a file shouldn't create file on GCS.
-	f, err := os.Create(path.Join(mntDir, FileName))
-	AssertEq(nil, err)
-	t.validateObjectNotFoundErr(FileName)
+	// Create a local file.
+	_, f := t.createLocalFile(FileName)
 
 	// Write some contents to file sequentially.
-	_, err = f.Write([]byte("string1"))
+	_, err := f.Write([]byte("string1"))
 	AssertEq(nil, err)
 	_, err = f.Write([]byte("string2"))
 	AssertEq(nil, err)
@@ -163,13 +161,11 @@ func (t *LocalFileTest) MultipleWritesToLocalFile() {
 }
 
 func (t *LocalFileTest) RandomWritesToLocalFile() {
-	// Creating a file shouldn't create file on GCS.
-	f, err := os.Create(path.Join(mntDir, FileName))
-	AssertEq(nil, err)
-	t.validateObjectNotFoundErr(FileName)
+	// Create a local file.
+	_, f := t.createLocalFile(FileName)
 
 	// Write some contents to file randomly.
-	_, err = f.WriteAt([]byte("string1"), 0)
+	_, err := f.WriteAt([]byte("string1"), 0)
 	AssertEq(nil, err)
 	_, err = f.WriteAt([]byte("string2"), 2)
 	AssertEq(nil, err)

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/jacobsa/ogletest"
 )
 
+const FileName = "foo"
+const FileContents = "teststring"
+
 type LocalFileTest struct {
 	fsTest
 }
@@ -22,7 +25,6 @@ func init() {
 func (t *LocalFileTest) SetUpTestSuite() {
 	t.serverCfg.MountConfig = &config.MountConfig{
 		WriteConfig: config.WriteConfig{
-			// Making the default value as true to keep it inline with current behaviour.
 			CreateEmptyFile: false,
 		}}
 	t.fsTest.SetUpTestSuite()
@@ -33,22 +35,146 @@ func (t *LocalFileTest) SetUpTestSuite() {
 ////////////////////////////////////////////////////////////////////////
 
 func (t *LocalFileTest) NewFileShouldNotGetSyncedToGCSTillClose() {
-	f, err := os.Create(path.Join(mntDir, "foo"))
+	t.newFileShouldGetSyncedToGCSAtClose(FileName)
+}
+
+func (t *LocalFileTest) NewFileUnderSubDirectoryShouldNotGetSyncedToGCSTillClose() {
+	err := os.Mkdir(path.Join(mntDir, "test"), dirPerms)
 	AssertEq(nil, err)
 
-	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
+	t.newFileShouldGetSyncedToGCSAtClose("test/foo")
+}
+
+func (t *LocalFileTest) newFileShouldGetSyncedToGCSAtClose(fileName string) {
+	// Creating a file shouldn't create file on GCS.
+	f, err := os.Create(path.Join(mntDir, fileName))
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(fileName)
+
+	// Writing contents to local file shouldn't create file on GCS.
+	_, err = f.Write([]byte(FileContents))
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(fileName)
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, fileName, FileContents)
+}
+
+func (t *LocalFileTest) StatOnLocalFile() {
+	// Creating a file shouldn't create file on GCS.
+	fileName := path.Join(mntDir, FileName)
+	f, err := os.Create(fileName)
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Stat the local file.
+	fi, err := os.Stat(fileName)
+	AssertEq(nil, err)
+	ExpectEq(path.Base(fileName), fi.Name())
+	ExpectEq(0, fi.Size())
+	ExpectEq(filePerms, fi.Mode())
+
+	// Writing contents to local file shouldn't create file on GCS.
+	_, err = f.Write([]byte(FileContents))
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Stat the local file again to check if new contents are written.
+	fi, err = os.Stat(fileName)
+	AssertEq(nil, err)
+	ExpectEq(path.Base(fileName), fi.Name())
+	ExpectEq(10, fi.Size())
+	ExpectEq(filePerms, fi.Mode())
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, FileName, FileContents)
+}
+
+func (t *LocalFileTest) TruncateLocalFile() {
+	// Creating a file shouldn't create file on GCS.
+	fileName := path.Join(mntDir, FileName)
+	f, err := os.Create(fileName)
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Writing contents to local file .
+	_, err = f.Write([]byte(FileContents))
+	AssertEq(nil, err)
+
+	// Stat the file to validate if new contents are written.
+	fi, err := os.Stat(fileName)
+	AssertEq(nil, err)
+	ExpectEq(path.Base(fileName), fi.Name())
+	ExpectEq(10, fi.Size())
+	ExpectEq(filePerms, fi.Mode())
+
+	// Truncate the file to update the file size.
+	err = os.Truncate(fileName, 5)
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Stat the file to validate if file is truncated correctly.
+	fi, err = os.Stat(fileName)
+	AssertEq(nil, err)
+	ExpectEq(path.Base(fileName), fi.Name())
+	ExpectEq(5, fi.Size())
+	ExpectEq(filePerms, fi.Mode())
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, FileName, "tests")
+}
+
+func (t *LocalFileTest) MultipleWritesToLocalFile() {
+	// Creating a file shouldn't create file on GCS.
+	f, err := os.Create(path.Join(mntDir, FileName))
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Write some contents to file sequentially.
+	_, err = f.Write([]byte("string1"))
+	AssertEq(nil, err)
+	_, err = f.Write([]byte("string2"))
+	AssertEq(nil, err)
+	_, err = f.Write([]byte("string3"))
+	AssertEq(nil, err)
+	// File shouldn't get created on GCS.
+	t.validateObjectNotFoundErr(FileName)
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, FileName, "string1string2string3")
+}
+
+func (t *LocalFileTest) RandomWritesToLocalFile() {
+	// Creating a file shouldn't create file on GCS.
+	f, err := os.Create(path.Join(mntDir, FileName))
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Write some contents to file randomly.
+	_, err = f.WriteAt([]byte("string1"), 0)
+	AssertEq(nil, err)
+	_, err = f.WriteAt([]byte("string2"), 2)
+	AssertEq(nil, err)
+	_, err = f.WriteAt([]byte("string3"), 3)
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(FileName)
+
+	// Close the file and validate if the file is created on GCS.
+	t.closeFileAndValidateObjectContents(f, FileName, "stsstring3")
+}
+
+func (t *LocalFileTest) validateObjectNotFoundErr(fileName string) {
 	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
+	_, err := gcsutil.ReadObject(ctx, bucket, fileName)
 
-	_, err = f.Write([]byte("teststring"))
+	ExpectTrue(errors.As(err, &notFoundErr))
+}
+
+func (t *LocalFileTest) closeFileAndValidateObjectContents(f *os.File, fileName string, contents string) {
+	err := f.Close()
 	AssertEq(nil, err)
 
-	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
-	ExpectTrue(errors.As(err, &notFoundErr))
-
-	err = f.Close()
+	contentBytes, err := gcsutil.ReadObject(ctx, bucket, fileName)
 	AssertEq(nil, err)
-
-	_, err = gcsutil.ReadObject(ctx, bucket, "foo")
-	ExpectTrue(errors.As(err, &notFoundErr))
+	ExpectEq(contents, string(contentBytes))
 }


### PR DESCRIPTION
### Description
Modified lookUpInode operation to check localFileInodes first before calling GCS. Added unit tests for fs.go

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually by mounting gcsfuse and checking if lookUpInode is returning correct inodeId. 
2. Unit tests - Added unit tests for fs.go
3. Integration tests - Yet to run
