### PR TITLE
Adding changes to run integration and perf tests with label

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -60,16 +60,18 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
+ git stash
  git checkout master
- # Store results
+ echo store results
  touch result.txt
- echo Mounting gcs bucket for master branch and execute perf tests
+ echo Mounting gcs bucket for master branch and execute tests
  execute_perf_test
+
 
  # Executing perf tests for PR branch
  echo checkout PR branch
  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
- echo Mounting gcs bucket from pr branch and execute perf tests
+ echo Mounting gcs bucket from pr branch and execute tests
  execute_perf_test
 
  # Show results

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -62,7 +62,7 @@ then
  # Executing perf tests for master branch
  git stash
  git checkout master
- echo store results
+ # Store results
  touch result.txt
  echo Mounting gcs bucket for master branch and execute tests
  execute_perf_test

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -17,7 +17,6 @@ then
 fi
 
 set -e
-# It will take approx 80 minutes to run the script.
 sudo apt-get update
 echo Installing git
 sudo apt-get install git

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -87,7 +87,7 @@ then
   # The length of the random string
   length=5
   # Generate the random string
-  random_string=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c $length)
+  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
   BUCKET_NAME=$bucketPrefix$random_string
   gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 # Running test only for when PR contains execute-perf-test or execute-integration-tests label
 readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
@@ -17,6 +16,7 @@ then
   exit 0
 fi
 
+set -e
 # It will take approx 80 minutes to run the script.
 sudo apt-get update
 echo Installing git

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -19,7 +19,7 @@ echo Installing git
 sudo apt-get install git
 echo Installing go-lang  1.20.5
 wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
-sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
+sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local &
 export PATH=$PATH:/usr/local/go/bin
 
 # Run on master branch
@@ -27,7 +27,7 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 # Fetch PR branch
 echo '[remote "origin"]
          fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' >> .git/config
-git fetch origin
+git fetch origin &
 
 # execute perf tests.
 if [[ "$perfTestStr" == *"execute-perf-test"* ]];

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -2,9 +2,11 @@
 # Running test only for when PR contains execute-perf-test label
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(cat pr.json | grep "execute-perf-test")
+integrationTests=$(cat pr.json | grep "execute-integration-tests")
 rm pr.json
 perfTestStr="$perfTest"
-if [[ "$perfTestStr" != *"execute-perf-test"* ]]
+integrationTestsStr="$integrationTests"
+if [[ "$perfTestStr" != *"execute-perf-test"*  &&  "$integrationTestsStr" != *"execute-integration-tests"* ]]
 then
   echo "No need to execute tests"
   exit 0
@@ -15,55 +17,83 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing python3-pip
-sudo apt-get -y install python3-pip
-echo Installing libraries to run python script
-pip install google-cloud
-pip install google-cloud-vision
-pip install google-api-python-client
-pip install prettytable
 echo Installing go-lang  1.20.5
 wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
-echo Installing fio
-sudo apt-get install fio -y
 
 # Run on master branch
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
-git checkout master
-echo Mounting gcs bucket for master branch
-mkdir -p gcs
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
-BUCKET_NAME=presubmit-perf-tests
-MOUNT_POINT=gcs
-# The VM will itself exit if the gcsfuse mount fails.
-CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-touch result.txt
-# Running FIO test
-chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-sudo umount gcs
-
 # Fetch PR branch
 echo '[remote "origin"]
          fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' >> .git/config
 git fetch origin
-echo checkout PR branch
-git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
-# Executing integration tests
-GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test -timeout 15m
+# execute perf tests.
+if [ "$perfTestStr" == *"execute-perf-test"* ];
+then
+  # Installing requirements
+  echo Installing python3-pip
+  sudo apt-get -y install python3-pip
+  echo Installing libraries to run python script
+  pip install google-cloud
+  pip install google-cloud-vision
+  pip install google-api-python-client
+  pip install prettytable
+  echo Installing fio
+  sudo apt-get install fio -y
 
-# Executing perf tests
-echo Mounting gcs bucket from pr branch
-mkdir -p gcs
-# The VM will itself exit if the gcsfuse mount fails.
-CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-# Running FIO test
-chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-sudo umount gcs
+  # Executing perf tests for master branch
+  git checkout master
+  echo Mounting gcs bucket for master branch
+  mkdir -p gcs
+  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+  BUCKET_NAME=presubmit-perf-tests
+  MOUNT_POINT=gcs
+  # The VM will itself exit if the gcsfuse mount fails.
+  CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+  touch result.txt
+  # Running FIO test
+  chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  sudo umount gcs
 
-echo showing results...
-python3 ./perfmetrics/scripts/presubmit/print_results.py
+  # Executing perf tests for PR branch
+  echo checkout PR branch
+  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+  echo Mounting gcs bucket from pr branch
+  mkdir -p gcs
+  # The VM will itself exit if the gcsfuse mount fails.
+  CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+  # Running FIO test
+  chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  sudo umount gcs
+
+  # Show results
+  echo showing results...
+  python3 ./perfmetrics/scripts/presubmit/print_results.py
+fi
+
+# Execute integration tests.
+if [ "$integrationTestsStr" == *"execute-integration-tests"* ];
+then
+  echo checkout PR branch
+  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+
+  # Create bucket for integration tests.
+  # The prefix for the random string
+  bucketPrefix="gcsfuse-integration-test-"
+  # The length of the random string
+  length=5
+  # Generate the random string
+  random_string=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c $length)
+  BUCKET_NAME=$bucketPrefix$random_string
+  gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
+
+  # Executing integration tests
+  GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout 15m
+
+  # Delete bucket after testing.
+  gcloud alpha storage rm --recursive gs://$BUCKET_NAME/
+fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -30,7 +30,7 @@ echo '[remote "origin"]
 git fetch origin
 
 # execute perf tests.
-if [ "$perfTestStr" == *"execute-perf-test"* ];
+if [[ "$perfTestStr" == *"execute-perf-test"* ]];
 then
   # Installing requirements
   echo Installing python3-pip
@@ -76,7 +76,7 @@ then
 fi
 
 # Execute integration tests.
-if [ "$integrationTestsStr" == *"execute-integration-tests"* ];
+if [[ "$integrationTestsStr" == *"execute-integration-tests"* ]];
 then
   echo checkout PR branch
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -44,6 +44,7 @@ then
   sudo apt-get install fio -y
 
   # Executing perf tests for master branch
+  git stash
   git checkout master
   echo Mounting gcs bucket for master branch
   mkdir -p gcs

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -92,7 +92,7 @@ then
   gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
 
   # Executing integration tests
-  GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout 15m
+  GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout 24m
 
   # Delete bucket after testing.
   gcloud alpha storage rm --recursive gs://$BUCKET_NAME/

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -81,6 +81,7 @@ fi
 if [[ "$integrationTestsStr" == *$EXECUTE_INTEGRATION_TEST_LABEL* ]];
 then
   echo checkout PR branch
+  git stash
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   # Create bucket for integration tests.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -27,7 +27,6 @@ wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 
-# Run on master branch
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 # Fetch PR branch
 echo '[remote "origin"]

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -60,7 +60,6 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
- git stash
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -81,7 +81,6 @@ fi
 if [[ "$integrationTestsStr" == *$EXECUTE_INTEGRATION_TEST_LABEL* ]];
 then
   echo checkout PR branch
-  git stash
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   # Create bucket for integration tests.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Running test only for when PR contains execute-perf-test or execute-integration-tests label
 readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
@@ -16,7 +17,6 @@ then
   exit 0
 fi
 
-set -e
 # It will take approx 80 minutes to run the script.
 sudo apt-get update
 echo Installing git

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -60,18 +60,16 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
- git stash
  git checkout master
- echo store results
+ # Store results
  touch result.txt
- echo Mounting gcs bucket for master branch and execute tests
+ echo Mounting gcs bucket for master branch and execute perf tests
  execute_perf_test
-
 
  # Executing perf tests for PR branch
  echo checkout PR branch
  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
- echo Mounting gcs bucket from pr branch and execute tests
+ echo Mounting gcs bucket from pr branch and execute perf tests
  execute_perf_test
 
  # Show results

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -11,7 +11,7 @@ integrationTests=$(cat pr.json | grep EXECUTE_INTEGRATION_TEST_TAG)
 rm pr.json
 perfTestStr="$perfTest"
 integrationTestsStr="$integrationTests"
-if [[ "$perfTestStr" != *EXECUTE_PERF_TEST_TAG*  &&  "$integrationTestsStr" != *EXECUTE_INTEGRATION_TEST_TAG* ]]
+if [[ "$perfTestStr" != *"execute-perf-test"*  &&  "$integrationTestsStr" != *"execute-integration-tests"* ]]
 then
   echo "No need to execute tests"
   exit 0

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -60,6 +60,7 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
+ git stash
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -2,6 +2,7 @@
 # Running test only for when PR contains execute-perf-test or execute-integration-tests label
 readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
+readonly INTEGRATION_TEST_EXECUTION_TIME=24m
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(cat pr.json | grep $EXECUTE_PERF_TEST_LABEL)
@@ -91,10 +92,12 @@ then
   # Generate the random string
   random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
   BUCKET_NAME=$bucketPrefix$random_string
+  echo bucket name
+  echo $BUCKET_NAME
   gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
 
   # Executing integration tests
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout 24m
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout INTEGRATION_TEST_EXECUTION_TIME
 
   # Delete bucket after testing.
   gcloud alpha storage rm --recursive gs://$BUCKET_NAME/

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -5,12 +5,12 @@ readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
 readonly INTEGRATION_TEST_EXECUTION_TIME=24m
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
-perfTest=$(cat pr.json | grep $EXECUTE_PERF_TEST_LABEL)
-integrationTests=$(cat pr.json | grep $EXECUTE_INTEGRATION_TEST_LABEL)
+perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
+integrationTests=$(grep "$EXECUTE_INTEGRATION_TEST_LABEL" pr.json)
 rm pr.json
 perfTestStr="$perfTest"
 integrationTestsStr="$integrationTests"
-if [[ "$perfTestStr" != *$EXECUTE_PERF_TEST_LABEL*  &&  "$integrationTestsStr" != *$EXECUTE_INTEGRATION_TEST_LABEL* ]]
+if [[ "$perfTestStr" != *"$EXECUTE_PERF_TEST_LABEL"*  &&  "$integrationTestsStr" != *"$EXECUTE_INTEGRATION_TEST_LABEL"* ]]
 then
   echo "No need to execute tests"
   exit 0
@@ -46,7 +46,7 @@ function execute_perf_test() {
 }
 
 # execute perf tests.
-if [[ "$perfTestStr" == *$EXECUTE_PERF_TEST_LABEL* ]];
+if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Installing requirements
  echo Installing python3-pip
@@ -79,7 +79,7 @@ then
 fi
 
 # Execute integration tests.
-if [[ "$integrationTestsStr" == *$EXECUTE_INTEGRATION_TEST_LABEL* ]];
+if [[ "$integrationTestsStr" == *"$EXECUTE_INTEGRATION_TEST_LABEL"* ]];
 then
   echo checkout PR branch
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
@@ -92,8 +92,7 @@ then
   # Generate the random string
   random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
   BUCKET_NAME=$bucketPrefix$random_string
-  echo bucket name
-  echo $BUCKET_NAME
+  echo 'bucket name = '$BUCKET_NAME
   gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
 
   # Executing integration tests

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 readonly EXECUTE_PERF_TEST_TAG="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_TAG="execute-integration-tests"
 readonly INTEGRATION_TEST_EXECUTION_TIME=24m
@@ -19,6 +18,7 @@ then
 fi
 
 # It will take approx 80 minutes to run the script.
+set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -1,69 +1,105 @@
 #!/bin/bash
-# Running test only for when PR contains execute-perf-test label
+# Running test only for when PR contains execute-perf-test or execute-integration-tests label
+readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
+readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
+readonly INTEGRATION_TEST_EXECUTION_TIME=24m
+
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
-perfTest=$(cat pr.json | grep "execute-perf-test")
+perfTest=$(cat pr.json | grep $EXECUTE_PERF_TEST_LABEL)
+integrationTests=$(cat pr.json | grep $EXECUTE_INTEGRATION_TEST_LABEL)
 rm pr.json
 perfTestStr="$perfTest"
-if [[ "$perfTestStr" != *"execute-perf-test"* ]]
+integrationTestsStr="$integrationTests"
+if [[ "$perfTestStr" != *$EXECUTE_PERF_TEST_LABEL*  &&  "$integrationTestsStr" != *$EXECUTE_INTEGRATION_TEST_LABEL* ]]
 then
   echo "No need to execute tests"
   exit 0
 fi
 
-# It will take approx 80 minutes to run the script.
 set -e
+# It will take approx 80 minutes to run the script.
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing python3-pip
-sudo apt-get -y install python3-pip
-echo Installing libraries to run python script
-pip install google-cloud
-pip install google-cloud-vision
-pip install google-api-python-client
-pip install prettytable
 echo Installing go-lang  1.20.5
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
-echo Installing fio
-sudo apt-get install fio -y
-
-# Run on master branch
+export CGO_ENABLED=0
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
-git checkout master
-echo Mounting gcs bucket for master branch
-mkdir -p gcs
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
-BUCKET_NAME=presubmit-perf-tests
-MOUNT_POINT=gcs
-# The VM will itself exit if the gcsfuse mount fails.
-CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-touch result.txt
-# Running FIO test
-chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-sudo umount gcs
-
 # Fetch PR branch
 echo '[remote "origin"]
          fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' >> .git/config
-git fetch origin
-echo checkout PR branch
-git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+git fetch origin -q
 
-# Executing integration tests
-GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test -timeout 24m
+function execute_perf_test() {
+  mkdir -p gcs
+  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+  BUCKET_NAME=presubmit-perf-tests
+  MOUNT_POINT=gcs
+  # The VM will itself exit if the gcsfuse mount fails.
+  go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+  # Running FIO test
+  chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  sudo umount gcs
+}
 
-# Executing perf tests
-echo Mounting gcs bucket from pr branch
-mkdir -p gcs
-# The VM will itself exit if the gcsfuse mount fails.
-CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-# Running FIO test
-chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-sudo umount gcs
+# execute perf tests.
+if [[ "$perfTestStr" == *$EXECUTE_PERF_TEST_LABEL* ]];
+then
+ # Installing requirements
+ echo Installing python3-pip
+ sudo apt-get -y install python3-pip
+ echo Installing libraries to run python script
+ pip install google-cloud
+ pip install google-cloud-vision
+ pip install google-api-python-client
+ pip install prettytable
+ echo Installing fio
+ sudo apt-get install fio -y
 
-echo showing results...
-python3 ./perfmetrics/scripts/presubmit/print_results.py
+ # Executing perf tests for master branch
+ git stash
+ git checkout master
+ # Store results
+ touch result.txt
+ echo Mounting gcs bucket for master branch and execute tests
+ execute_perf_test
+
+
+ # Executing perf tests for PR branch
+ echo checkout PR branch
+ git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+ echo Mounting gcs bucket from pr branch and execute tests
+ execute_perf_test
+
+ # Show results
+ echo showing results...
+ python3 ./perfmetrics/scripts/presubmit/print_results.py
+fi
+
+# Execute integration tests.
+if [[ "$integrationTestsStr" == *$EXECUTE_INTEGRATION_TEST_LABEL* ]];
+then
+  echo checkout PR branch
+  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+
+  # Create bucket for integration tests.
+  # The prefix for the random string
+  bucketPrefix="gcsfuse-integration-test-"
+  # The length of the random string
+  length=5
+  # Generate the random string
+  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
+  BUCKET_NAME=$bucketPrefix$random_string
+  echo bucket name
+  echo $BUCKET_NAME
+  gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
+
+  # Executing integration tests
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout $INTEGRATION_TEST_EXECUTION_TIME
+
+  # Delete bucket after testing.
+  gcloud alpha storage rm --recursive gs://$BUCKET_NAME/
+fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -44,7 +44,6 @@ then
   sudo apt-get install fio -y
 
   # Executing perf tests for master branch
-  git stash
   git checkout master
   echo Mounting gcs bucket for master branch
   mkdir -p gcs

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -1,105 +1,69 @@
 #!/bin/bash
-set -e
-# Running test only for when PR contains execute-perf-test or execute-integration-tests label
-readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
-readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
-readonly INTEGRATION_TEST_EXECUTION_TIME=24m
-
+# Running test only for when PR contains execute-perf-test label
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
-perfTest=$(cat pr.json | grep $EXECUTE_PERF_TEST_LABEL)
-integrationTests=$(cat pr.json | grep $EXECUTE_INTEGRATION_TEST_LABEL)
+perfTest=$(cat pr.json | grep "execute-perf-test")
 rm pr.json
 perfTestStr="$perfTest"
-integrationTestsStr="$integrationTests"
-if [[ "$perfTestStr" != *$EXECUTE_PERF_TEST_LABEL*  &&  "$integrationTestsStr" != *$EXECUTE_INTEGRATION_TEST_LABEL* ]]
+if [[ "$perfTestStr" != *"execute-perf-test"* ]]
 then
   echo "No need to execute tests"
   exit 0
 fi
 
 # It will take approx 80 minutes to run the script.
+set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
+echo Installing python3-pip
+sudo apt-get -y install python3-pip
+echo Installing libraries to run python script
+pip install google-cloud
+pip install google-cloud-vision
+pip install google-api-python-client
+pip install prettytable
 echo Installing go-lang  1.20.5
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
-export CGO_ENABLED=0
+echo Installing fio
+sudo apt-get install fio -y
+
+# Run on master branch
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
+git checkout master
+echo Mounting gcs bucket for master branch
+mkdir -p gcs
+GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+BUCKET_NAME=presubmit-perf-tests
+MOUNT_POINT=gcs
+# The VM will itself exit if the gcsfuse mount fails.
+CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+touch result.txt
+# Running FIO test
+chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+sudo umount gcs
+
 # Fetch PR branch
 echo '[remote "origin"]
          fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' >> .git/config
-git fetch origin -q
+git fetch origin
+echo checkout PR branch
+git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
-function execute_perf_test() {
-  mkdir -p gcs
-  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
-  BUCKET_NAME=presubmit-perf-tests
-  MOUNT_POINT=gcs
-  # The VM will itself exit if the gcsfuse mount fails.
-  go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-  # Running FIO test
-  chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-  ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
-  sudo umount gcs
-}
+# Executing integration tests
+GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test -timeout 24m
 
-# execute perf tests.
-if [[ "$perfTestStr" == *$EXECUTE_PERF_TEST_LABEL* ]];
-then
- # Installing requirements
- echo Installing python3-pip
- sudo apt-get -y install python3-pip
- echo Installing libraries to run python script
- pip install google-cloud
- pip install google-cloud-vision
- pip install google-api-python-client
- pip install prettytable
- echo Installing fio
- sudo apt-get install fio -y
+# Executing perf tests
+echo Mounting gcs bucket from pr branch
+mkdir -p gcs
+# The VM will itself exit if the gcsfuse mount fails.
+CGO_ENABLED=0 go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+# Running FIO test
+chmod +x perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+sudo umount gcs
 
- # Executing perf tests for master branch
- git stash
- git checkout master
- # Store results
- touch result.txt
- echo Mounting gcs bucket for master branch and execute tests
- execute_perf_test
-
-
- # Executing perf tests for PR branch
- echo checkout PR branch
- git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
- echo Mounting gcs bucket from pr branch and execute tests
- execute_perf_test
-
- # Show results
- echo showing results...
- python3 ./perfmetrics/scripts/presubmit/print_results.py
-fi
-
-# Execute integration tests.
-if [[ "$integrationTestsStr" == *$EXECUTE_INTEGRATION_TEST_LABEL* ]];
-then
-  echo checkout PR branch
-  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
-
-  # Create bucket for integration tests.
-  # The prefix for the random string
-  bucketPrefix="gcsfuse-integration-test-"
-  # The length of the random string
-  length=5
-  # Generate the random string
-  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
-  BUCKET_NAME=$bucketPrefix$random_string
-  echo bucket name
-  echo $BUCKET_NAME
-  gcloud alpha storage buckets create gs://$BUCKET_NAME --project=gcs-fuse-test-ml --location=us-west1 --uniform-bucket-level-access
-
-  # Executing integration tests
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=$BUCKET_NAME -timeout INTEGRATION_TEST_EXECUTION_TIME
-
-  # Delete bucket after testing.
-  gcloud alpha storage rm --recursive gs://$BUCKET_NAME/
-fi
+echo showing results...
+python3 ./perfmetrics/scripts/presubmit/print_results.py


### PR DESCRIPTION
### Description
1. If anyone wants to run only integration tests - attach  execute-integration-test label.
2. If anyone wants to run only perf tests - attach execute-perf-tes label.
3. If anyone wants to run both the tests - attach  execute-perf-tes and execute-integration-test  labels.

For integration test
Create bucket with gcsfuse-integration-test-xxxxx name.
Perform tests.
Delete bucket after testing.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested on kokoro VM.
5. Unit tests - NA
6. Integration tests - NA
