### PR TITLE
Changing the timeout from 15m to 24m for integraotin test of one package

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -53,7 +53,7 @@ echo checkout PR branch
 git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
 # Executing integration tests
-GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test -timeout 15m
+GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/... -p 1 --integrationTest -v --testbucket=gcsfuse-integration-test -timeout 24m
 
 # Executing perf tests
 echo Mounting gcs bucket from pr branch


### PR DESCRIPTION
### Description
Changing the timeout from 15m to 24m for integraotin test of one package

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested locally.
2. Unit tests - NA
3. Integration tests - NA
