### PR TITLE
Fixing review comments: replacing printf error log to returning error

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -480,7 +480,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 	} else {
 		customEndpoint, err = url.Parse(customEndpointStr)
 		if err != nil {
-			fmt.Printf("Could not parse endpoint")
+			err = fmt.Errorf("could not parse custom-endpoint: %w", err)
 			return
 		}
 	}

--- a/flags_test.go
+++ b/flags_test.go
@@ -47,6 +47,7 @@ func parseArgs(args []string) (flags *flagStorage) {
 	var err error
 	app.Action = func(appCtx *cli.Context) {
 		flags, err = populateFlags(appCtx)
+		AssertEq(nil, err)
 	}
 
 	// Simulate argv.


### PR DESCRIPTION
### Description
Removing printf statement to errorf

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - basic operations locally.
2. Unit tests - automation
3. Integration tests - NA
