### PR TITLE
Support local files for ReadDir operations

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1919,7 +1919,7 @@ func (fs *fileSystem) ReadDir(
 	defer dh.Mu.Unlock()
 
 	// Serve the request.
-	if err := dh.ReadDir(ctx, op); err != nil {
+	if err := dh.ReadDir(ctx, op, fs.localFileInodes); err != nil {
 		return err
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -582,7 +582,7 @@ func (fs *fileSystem) checkInvariants() {
 	// INVARIANT: All values are of type *dirHandle or *handle.FileHandle
 	for _, h := range fs.handles {
 		switch h.(type) {
-		case *dirHandle:
+		case *handle.DirHandle:
 		case *handle.FileHandle:
 		default:
 			panic(fmt.Sprintf("Unexpected handle type: %T", h))
@@ -1900,7 +1900,7 @@ func (fs *fileSystem) OpenDir(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	fs.handles[handleID] = newDirHandle(in, fs.implicitDirs)
+	fs.handles[handleID] = handle.NewDirHandle(in, fs.implicitDirs)
 	op.Handle = handleID
 
 	return
@@ -1912,7 +1912,7 @@ func (fs *fileSystem) ReadDir(
 	op *fuseops.ReadDirOp) (err error) {
 	// Find the handle.
 	fs.mu.Lock()
-	dh := fs.handles[op.Handle].(*dirHandle)
+	dh := fs.handles[op.Handle].(*handle.DirHandle)
 	fs.mu.Unlock()
 
 	dh.Mu.Lock()
@@ -1934,7 +1934,7 @@ func (fs *fileSystem) ReleaseDirHandle(
 	defer fs.mu.Unlock()
 
 	// Sanity check that this handle exists and is of the correct type.
-	_ = fs.handles[op.Handle].(*dirHandle)
+	_ = fs.handles[op.Handle].(*handle.DirHandle)
 
 	// Clear the entry from the map.
 	delete(fs.handles, op.Handle)

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fs
+package handle
 
 import (
 	"fmt"
-	"path"
 	"sort"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
@@ -27,8 +26,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// State required for reading from directories.
-type dirHandle struct {
+// DirHandle is the state required for reading from directories.
+type DirHandle struct {
 	/////////////////////////
 	// Constant data
 	/////////////////////////
@@ -57,12 +56,12 @@ type dirHandle struct {
 	entriesValid bool
 }
 
-// Create a directory handle that obtains listings from the supplied inode.
-func newDirHandle(
-		in inode.DirInode,
-		implicitDirs bool) (dh *dirHandle) {
+// NewDirHandle creates a directory handle that obtains listings from the supplied inode.
+func NewDirHandle(
+	in inode.DirInode,
+	implicitDirs bool) (dh *DirHandle) {
 	// Set up the basic struct.
-	dh = &dirHandle{
+	dh = &DirHandle{
 		in:           in,
 		implicitDirs: implicitDirs,
 	}
@@ -77,14 +76,14 @@ func newDirHandle(
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-// Dirents, sorted by name.
+// Directory entries, sorted by name.
 type sortedDirents []fuseutil.Dirent
 
 func (p sortedDirents) Len() int           { return len(p) }
 func (p sortedDirents) Less(i, j int) bool { return p[i].Name < p[j].Name }
 func (p sortedDirents) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
-func (dh *dirHandle) checkInvariants() {
+func (dh *DirHandle) checkInvariants() {
 	// INVARIANT: For each i, entries[i+1].Offset == entries[i].Offset + 1
 	for i := 0; i < len(dh.entries)-1; i++ {
 		if !(dh.entries[i+1].Offset == dh.entries[i].Offset+1) {
@@ -110,12 +109,12 @@ func (dh *dirHandle) checkInvariants() {
 func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 	// Sanity check.
 	if !sort.IsSorted(sortedDirents(entries)) {
-		err = fmt.Errorf("Expected sorted input")
+		err = fmt.Errorf("expected sorted input")
 		return
 	}
 
 	// Examine each adjacent pair of names.
-	for i, _ := range entries {
+	for i := range entries {
 		e := &entries[i]
 
 		// Find the previous entry.
@@ -136,7 +135,7 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 
 		if eIsDir == prevIsDir {
 			err = fmt.Errorf(
-				"Weird dirent type pair for name %q: %v, %v",
+				"weird dirent type pair for name %q: %v, %v",
 				e.Name,
 				e.Type,
 				prev.Type)
@@ -160,10 +159,10 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 //
 // LOCKS_REQUIRED(in)
 func readAllEntries(
-		ctx context.Context,
-		in inode.DirInode,
-		localFileInodes map[inode.Name]inode.Inode) (entries []fuseutil.Dirent, err error) {
-	//Read entries from GCS
+	ctx context.Context,
+	in inode.DirInode,
+	localFileInodes map[inode.Name]inode.Inode) (entries []fuseutil.Dirent, err error) {
+	// Read entries from GCS.
 	// Read one batch at a time.
 	var tok string
 	for {
@@ -185,12 +184,8 @@ func readAllEntries(
 		}
 	}
 
-	//Append local file entries (not synced to GCS)
-	localEntries, err := localFileEntries(in, localFileInodes)
-	if err != nil {
-		err = fmt.Errorf("ReadLocalFileEntries: %w", err)
-		return
-	}
+	// Append local file entries (not synced to GCS).
+	localEntries := in.LocalFileEntries(localFileInodes)
 	entries = append(entries, localEntries...)
 
 	// Ensure that the entries are sorted, for use in fixConflictingNames
@@ -213,7 +208,7 @@ func readAllEntries(
 	//
 	// NOTE(jacobsa): As far as I can tell this is harmless. Minting and
 	// returning a real inode ID is difficult because fuse does not count
-	// readdir as an operation that increases the inode ID's lookup count and
+	// readdir as an operation that increases the inode ID's lookup count, and
 	// we therefore don't get a forget for it later, but we would like to not
 	// have to remember every inode ID that we've ever minted for readdir.
 	//
@@ -222,31 +217,16 @@ func readAllEntries(
 	// about the birthday problem? And more importantly, what about our
 	// semantic of not minting a new inode ID when the generation changes due
 	// to a local action?
-	for i, _ := range entries {
+	for i := range entries {
 		entries[i].Inode = fuseops.RootInodeID + 1
 	}
 
 	return
 }
 
-// localFileEntries lists the local files present in the directory.
-// Local means that the file is not yet present on GCS.
-func localFileEntries(d inode.DirInode, localFileInodes map[inode.Name]inode.Inode) (localEntries []fuseutil.Dirent, err error) {
-	for localInodeName, _ := range localFileInodes {
-		if localInodeName.IsDirectChildOf(d.Name()) {
-			entry := fuseutil.Dirent{
-				Name: path.Base(localInodeName.LocalName()),
-				Type: fuseutil.DT_File,
-			}
-			localEntries = append(localEntries, entry)
-		}
-	}
-	return
-}
-
 // LOCKS_REQUIRED(dh.Mu)
 // LOCKS_EXCLUDED(dh.in)
-func (dh *dirHandle) ensureEntries(ctx context.Context, localFileInodes map[inode.Name]inode.Inode) (err error) {
+func (dh *DirHandle) ensureEntries(ctx context.Context, localFileInodes map[inode.Name]inode.Inode) (err error) {
 	dh.in.Lock()
 	defer dh.in.Unlock()
 
@@ -277,10 +257,10 @@ func (dh *dirHandle) ensureEntries(ctx context.Context, localFileInodes map[inod
 //
 // LOCKS_REQUIRED(dh.Mu)
 // LOCKS_EXCLUDED(du.in)
-func (dh *dirHandle) ReadDir(
-		ctx context.Context,
-		op *fuseops.ReadDirOp,
-		localFileInodes map[inode.Name]inode.Inode) (err error) {
+func (dh *DirHandle) ReadDir(
+	ctx context.Context,
+	op *fuseops.ReadDirOp,
+	localFileInodes map[inode.Name]inode.Inode) (err error) {
 	// If the request is for offset zero, we assume that either this is the first
 	// call or rewinddir has been called. Reset state.
 	if op.Offset == 0 {

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -193,6 +193,17 @@ func readAllEntries(
 	sort.Sort(sortedDirents(entries))
 
 	// Fix name conflicts.
+	// When a local file is synced to GCS but not removed from the local file map,
+	// the entries list will have two duplicate entries.
+	// To handle this scenario, we had 2 options:
+	// Option 1: [Selected]
+	// Throw an error while fixing conflicting names. The error will be fixed in
+	// subsequent ls calls assuming that entry will be removed from localFileInodes.
+	// Option 2: [Not Selected]
+	// Restrict fixConflictingNames to only GCS entries and show duplicate
+	// entries when ReadDir is called. In this case, a local file can have
+	// same name as directory and LookUpInode call will fetch directory details
+	// for both of them.
 	err = fixConflictingNames(entries)
 	if err != nil {
 		err = fmt.Errorf("fixConflictingNames: %w", err)

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -1,0 +1,228 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handle
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/contentcache"
+	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
+	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"github.com/jacobsa/gcloud/gcs/gcsfake"
+	"github.com/jacobsa/gcloud/gcs/gcsutil"
+	. "github.com/jacobsa/ogletest"
+	"github.com/jacobsa/timeutil"
+)
+
+func TestDirHandle(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type DirHandleTest struct {
+	ctx    context.Context
+	bucket gcsx.SyncerBucket
+	clock  timeutil.SimulatedClock
+
+	dh *DirHandle
+}
+
+var _ SetUpInterface = &DirHandleTest{}
+var _ TearDownInterface = &DirHandleTest{}
+
+func init() { RegisterTestSuite(&DirHandleTest{}) }
+
+func (t *DirHandleTest) SetUp(ti *TestInfo) {
+	t.ctx = ti.Ctx
+	t.bucket = gcsx.NewSyncerBucket(
+		1, ".gcsfuse_tmp/", gcsfake.NewFakeBucket(&t.clock, "some_bucket"))
+	t.clock.SetTime(time.Date(2022, 8, 15, 22, 56, 0, 0, time.Local))
+	t.resetDirHandle()
+}
+
+func (t *DirHandleTest) TearDown() {}
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+func (t *DirHandleTest) resetDirHandle() {
+	dirInode := inode.NewDirInode(
+		17,
+		inode.NewDirName(inode.NewRootName(""), "testDir"),
+		fuseops.InodeAttributes{
+			Uid:  123,
+			Gid:  456,
+			Mode: 0712,
+		},
+		false, // implicitDirs
+		false, // enableNonExistentTypeCache
+		0,     // typeCacheTTL
+		&t.bucket,
+		&t.clock,
+		&t.clock)
+
+	t.dh = NewDirHandle(
+		dirInode,
+		true,
+	)
+}
+
+func (t *DirHandleTest) createLocalFileInode(name string, id fuseops.InodeID) (in inode.Inode) {
+	in = inode.NewFileInode(
+		id,
+		inode.NewFileName(t.dh.in.Name(), name),
+		nil,
+		fuseops.InodeAttributes{
+			Uid:  123,
+			Gid:  456,
+			Mode: 0712,
+		},
+		&t.bucket,
+		false, // localFileCache
+		contentcache.New("", &t.clock),
+		&t.clock,
+		true) // localFile
+	return
+}
+
+func (t *DirHandleTest) validateEntry(entry fuseutil.Dirent, name string, filetype fuseutil.DirentType) {
+	AssertEq(name, entry.Name)
+	AssertEq(filetype, entry.Type)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *DirHandleTest) EnsureEntriesWithLocalAndGCSFiles() {
+	var err error
+	// Set up empty GCS objects.
+	// DirHandle holds a DirInode pointing to "testDir".
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject1", nil)
+	AssertEq(nil, err)
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
+	AssertEq(nil, err)
+	// Set up local file inodes.
+	localIn1 := t.createLocalFileInode("localFile1", 10)
+	localIn2 := t.createLocalFileInode("localFile2", 20)
+	// Setup localFileInodes Map.
+	localFileInodes := map[inode.Name]inode.Inode{
+		localIn1.Name(): localIn1,
+		localIn2.Name(): localIn2,
+	}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(4, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], "gcsObject1", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[1], "gcsObject2", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[2], "localFile1", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[3], "localFile2", fuseutil.DT_File)
+}
+
+func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
+	var err error
+	// Set up empty GCS objects.
+	// DirHandle holds a DirInode pointing to "testDir".
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject1", nil)
+	AssertEq(nil, err)
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
+	AssertEq(nil, err)
+	// Setup empty localFileInodes Map.
+	localFileInodes := map[inode.Name]inode.Inode{}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(2, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], "gcsObject1", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[1], "gcsObject2", fuseutil.DT_File)
+}
+
+func (t *DirHandleTest) EnsureEntriesWithOnlyGCSFiles() {
+	var err error
+	// Set up local file inodes.
+	localIn1 := t.createLocalFileInode("localFile1", 10)
+	localIn2 := t.createLocalFileInode("localFile2", 20)
+	// Setup localFileInodes Map.
+	localFileInodes := map[inode.Name]inode.Inode{
+		localIn1.Name(): localIn1,
+		localIn2.Name(): localIn2,
+	}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(2, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], "localFile1", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[1], "localFile2", fuseutil.DT_File)
+}
+
+func (t *DirHandleTest) EnsureEntriesWithSameNameLocalAndGCSFile() {
+	var err error
+	// Set up empty GCS objects.
+	// DirHandle holds a DirInode pointing to "testDir".
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/file1", nil)
+	AssertEq(nil, err)
+	// Set up local file inodes.
+	localIn := t.createLocalFileInode("file1", 10)
+	// Setup localFileInodes Map.
+	localFileInodes := map[inode.Name]inode.Inode{
+		localIn.Name(): localIn,
+	}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+
+	// Validations
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "readAllEntries: fixConflictingNames: "))
+}
+
+func (t *DirHandleTest) EnsureEntriesWithSameNameLocalFileAndGCSDirectory() {
+	var err error
+	// Set up empty GCS objects.
+	// DirHandle holds a DirInode pointing to "testDir".
+	_, err = gcsutil.CreateObject(t.ctx, t.bucket, "testDir/file1/", nil)
+	AssertEq(nil, err)
+	// Set up local file inodes.
+	localIn := t.createLocalFileInode("file1", 10)
+	// Setup localFileInodes Map.
+	localFileInodes := map[inode.Name]inode.Inode{
+		localIn.Name(): localIn,
+	}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(2, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], "file1", fuseutil.DT_Directory)
+	t.validateEntry(t.dh.entries[1], "file1"+inode.ConflictingFileNameSuffix, fuseutil.DT_File)
+}

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -208,3 +208,8 @@ func (d *baseDirInode) DeleteChildDir(
 	err = fuse.ENOSYS
 	return
 }
+
+func (d *baseDirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEntries []fuseutil.Dirent) {
+	// Base directory can not contain local files.
+	return nil
+}

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -1,9 +1,31 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests for a file system where we do not attempt to write to
+// the file system at all. Rather we set up contents in a GCS bucket out of
+// band, wait for them to be available, and then read them via the file system.
+
 package fs_test
 
 import (
 	"errors"
+	"fmt"
+	"io/fs"
+	"log"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
@@ -12,7 +34,13 @@ import (
 	. "github.com/jacobsa/ogletest"
 )
 
+// //////////////////////////////////////////////////////////////////////
+// Boilerplate
+// //////////////////////////////////////////////////////////////////////
 const FileName = "foo"
+const FileName2 = "foo2"
+const implicitLocalFileName = "impicitLocalFile"
+const explicitLocalFileName = "explicitLocalFile"
 const FileContents = "teststring"
 
 type LocalFileTest struct {
@@ -30,6 +58,56 @@ func (t *LocalFileTest) SetUpTestSuite() {
 			CreateEmptyFile: false,
 		}}
 	t.fsTest.SetUpTestSuite()
+}
+
+func (t *LocalFileTest) TearDown() {
+	err := os.RemoveAll(mntDir)
+	AssertNe(nil, err)
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+func (t *LocalFileTest) createLocalFile(fileName string) (filePath string, f *os.File) {
+	// Creating a file shouldn't create file on GCS.
+	filePath = path.Join(mntDir, fileName)
+	f, err := os.Create(filePath)
+
+	AssertEq(nil, err)
+	t.validateObjectNotFoundErr(fileName)
+
+	return
+}
+
+func (t *LocalFileTest) verifyLocalFileEntry(entry os.DirEntry, fileName string, size int) {
+	AssertEq(false, entry.IsDir())
+	AssertEq(fileName, entry.Name())
+
+	fileInfo, err := entry.Info()
+	AssertEq(nil, err)
+	AssertEq(size, fileInfo.Size())
+}
+
+func (t *LocalFileTest) readDirectory(dirPath string) (entries []os.DirEntry) {
+	entries, err := os.ReadDir(dirPath)
+	AssertEq(nil, err)
+	return
+}
+
+func (t *LocalFileTest) validateObjectNotFoundErr(fileName string) {
+	var notFoundErr *gcs.NotFoundError
+	_, err := gcsutil.ReadObject(ctx, bucket, fileName)
+
+	ExpectTrue(errors.As(err, &notFoundErr))
+}
+
+func (t *LocalFileTest) closeFileAndValidateObjectContents(f *os.File, fileName string, contents string) {
+	err := f.Close()
+	AssertEq(nil, err)
+
+	contentBytes, err := gcsutil.ReadObject(ctx, bucket, fileName)
+	AssertEq(nil, err)
+	ExpectEq(contents, string(contentBytes))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -177,29 +255,177 @@ func (t *LocalFileTest) RandomWritesToLocalFile() {
 	t.closeFileAndValidateObjectContents(f, FileName, "stsstring3")
 }
 
-func (t *LocalFileTest) validateObjectNotFoundErr(fileName string) {
-	var notFoundErr *gcs.NotFoundError
-	_, err := gcsutil.ReadObject(ctx, bucket, fileName)
+func (t *LocalFileTest) TestReadDirWithEmptyLocalFiles() {
+	// Create local files.
+	_, f1 := t.createLocalFile(FileName)
+	_, f2 := t.createLocalFile(FileName2)
 
-	ExpectTrue(errors.As(err, &notFoundErr))
+	// Attempt to list mntDir.
+	entries := t.readDirectory(mntDir)
+
+	// Verify entries received successfully.
+	AssertEq(2, len(entries))
+	t.verifyLocalFileEntry(entries[0], FileName, 0)
+	t.verifyLocalFileEntry(entries[1], FileName2, 0)
+	// Close the local files.
+	t.closeFileAndValidateObjectContents(f1, FileName, "")
+	t.closeFileAndValidateObjectContents(f2, FileName2, "")
 }
 
-func (t *LocalFileTest) closeFileAndValidateObjectContents(f *os.File, fileName string, contents string) {
-	err := f.Close()
-	AssertEq(nil, err)
+func (t *LocalFileTest) TestReadDirWithNonEmptyLocalFile() {
+	// Create local files.
+	_, f1 := t.createLocalFile(FileName)
+	_, _ = f1.WriteString(FileContents)
+	//AssertNe(nil, err)
 
-	contentBytes, err := gcsutil.ReadObject(ctx, bucket, fileName)
-	AssertEq(nil, err)
-	ExpectEq(contents, string(contentBytes))
+	// Attempt to list mntDir.
+	entries := t.readDirectory(mntDir)
+
+	// Verify entries received successfully.
+	AssertEq(1, len(entries))
+	t.verifyLocalFileEntry(entries[0], FileName, 10)
+	// Close the local files.
+	t.closeFileAndValidateObjectContents(f1, FileName, FileContents)
 }
 
-func (t *LocalFileTest) createLocalFile(fileName string) (filePath string, f *os.File) {
-	// Creating a file shouldn't create file on GCS.
-	filePath = path.Join(mntDir, fileName)
-	f, err := os.Create(filePath)
+func (t *LocalFileTest) TestReadDirForExplicitDirWithLocalFile() {
+	// Create explicit dir with 2 local files.
+	AssertEq(
+		nil,
+		t.createObjects(
+			map[string]string{
+				"explicitFoo/": "",
+			}))
+	_, f1 := t.createLocalFile("explicitFoo/" + FileName)
+	_, f2 := t.createLocalFile("explicitFoo/" + FileName2)
 
+	// Attempt to list explicit directory.
+	entries := t.readDirectory(path.Join(mntDir, "explicitFoo/"))
+
+	// Verify entries received successfully.
+	AssertEq(2, len(entries))
+	t.verifyLocalFileEntry(entries[0], FileName, 0)
+	t.verifyLocalFileEntry(entries[1], FileName2, 0)
+	// Close the local files.
+	t.closeFileAndValidateObjectContents(f1, "explicitFoo/"+FileName, "")
+	t.closeFileAndValidateObjectContents(f2, "explicitFoo/"+FileName2, "")
+}
+
+func (t *LocalFileTest) TestReadDirForImplicitDirWithLocalFile() {
+	// Create implicit dir with 2 local files and 1 synced file.
+	AssertEq(
+		nil,
+		t.createObjects(
+			map[string]string{
+				// File
+				"implicitFoo/bar": "",
+			}))
+	_, f1 := t.createLocalFile("implicitFoo/" + FileName)
+	_, f2 := t.createLocalFile("implicitFoo/" + FileName2)
+
+	// Attempt to list implicit directory.
+	entries := t.readDirectory(path.Join(mntDir, "implicitFoo/"))
+
+	// Verify entries received successfully.
+	AssertEq(3, len(entries))
+	t.verifyLocalFileEntry(entries[0], "bar", 0)
+	t.verifyLocalFileEntry(entries[1], FileName, 0)
+	t.verifyLocalFileEntry(entries[2], FileName2, 0)
+	// Close the local files.
+	t.closeFileAndValidateObjectContents(f1, "implicitFoo/"+FileName, "")
+	t.closeFileAndValidateObjectContents(f2, "implicitFoo/"+FileName2, "")
+}
+
+func (t *LocalFileTest) TestRecursiveListingWithLocalFiles() {
+	/* Structure
+	mntDir/
+		- baseLocalFile 			--- file
+		- explicitFoo/ 				--- directory
+			- bar								--- file
+			- implicitLocalFile --- file
+		- explicitFoo/				--- directory
+			- explicitLocalFile --- file
+	*/
+
+	// Create implicit dir with 1 local file1 and 1 synced file.
+	AssertEq(
+		nil,
+		t.createObjects(
+			map[string]string{
+				// File
+				"implicitFoo/bar": "",
+			}))
+	_, f1 := t.createLocalFile("implicitFoo/" + implicitLocalFileName)
+	// Create explicit dir with 1 local file.
+	AssertEq(
+		nil,
+		t.createObjects(
+			map[string]string{
+				"explicitFoo/": "",
+			}))
+	_, f2 := t.createLocalFile("explicitFoo/" + explicitLocalFileName)
+	// Create local file in mnt/ dir.
+	_, f3 := t.createLocalFile(FileName)
+
+	// Recursively list mntDir/ directory.
+	err := filepath.WalkDir(mntDir, func(path string, dir fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// The object type is not directory.
+		if !dir.IsDir() {
+			return nil
+		}
+
+		objs, err := os.ReadDir(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Check if mntDir has correct objects.
+		if path == mntDir {
+			// numberOfObjects = 3
+			if len(objs) != 3 {
+				return fmt.Errorf("incorrect number of objects in the mntDir/")
+			}
+
+			if objs[0].Name() != "explicitFoo" || objs[0].IsDir() != true ||
+					objs[1].Name() != FileName || objs[1].IsDir() != false ||
+					objs[2].Name() != "implicitFoo" || objs[2].IsDir() != true {
+				return fmt.Errorf("listed incorrect object in mntDir/")
+			}
+		}
+
+		// Check if mntDir/explicitFoo/ has correct objects.
+		if path == mntDir+"/explicitFoo" {
+			// numberOfObjects = 1
+			if len(objs) != 1 {
+				return fmt.Errorf("incorrect number of objects in mntDir/explicitFoo/")
+			}
+
+			if objs[0].Name() != explicitLocalFileName || objs[0].IsDir() != false {
+				return fmt.Errorf("listed incorrect object in mntDir/explicitFoo/")
+			}
+		}
+
+		// Check if mntDir/implicitFoo/ has correct objects.
+		if path == mntDir+"/implicitFoo" {
+			// numberOfObjects = 2
+			if len(objs) != 2 {
+				return fmt.Errorf("incorrect number of objects in mntDir/implicitFoo/")
+			}
+
+			if objs[0].Name() != "bar" || objs[0].IsDir() != false ||
+					objs[1].Name() != implicitLocalFileName || objs[1].IsDir() != false {
+				return fmt.Errorf("listed incorrect object in mntDir/implicitFoo/")
+			}
+		}
+		return nil
+	})
+
+	// Validate and close the files.
 	AssertEq(nil, err)
-	t.validateObjectNotFoundErr(fileName)
-
-	return
+	t.closeFileAndValidateObjectContents(f1, "implicitFoo/"+implicitLocalFileName, "")
+	t.closeFileAndValidateObjectContents(f2, "explicitFoo/"+explicitLocalFileName, "")
+	t.closeFileAndValidateObjectContents(f3, ""+FileName, "")
 }


### PR DESCRIPTION
### Description
Added support to list local files present in a directory.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - 
 * ls command on mounted directory with local files
 * ls command on explicit dir with local files
 * ls command on implicit dir with local files
 * ls -R command

here 
`l1, l2, l3, l4, l5` and `l6` are local files.
`c` and `d` are explicit directories
`foo` is implicit directory
error `ls: cannot access 'l*': No such file or directory` is because changes are required in lookupInode command.

 ```
 ashmeen@ashmeen:~/Documents/mnt$ ls -R
.:
ls: cannot access 'l1': No such file or directory
ls: cannot access 'l2': No such file or directory
c  d  foo  l1  l2

./c:
ls: cannot access './c/l3': No such file or directory
l3

./d:
ls: cannot access './d/l4': No such file or directory
ls: cannot access './d/l5': No such file or directory
l4  l5

./foo:
ls: cannot access './foo/l6': No such file or directory
bar  l6

 ```
3. Unit tests - Added
4. Integration tests - NA
