### PR TITLE
Increasing the lint timeout to debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@032fa5c5e48499f06cf9d32c02149bfac1284239
       with:
-        args: -E=goimports --timeout 2m0s
+        args: -E=goimports --timeout 10m0s
         only-new-issues: true
 


### PR DESCRIPTION
### Description
Increasing the lint timeout to 10m

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
