### PR TITLE
Unlink and RmDir changes to support local files

### DIFF
--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1269,3 +1269,25 @@ func (t *DirTest) LocalFileEntriesWithNoLocalChildFiles() {
 
 	AssertEq(0, len(entries))
 }
+
+func (t *DirTest) LocalFileEntriesWithUnlinkedLocalChildFiles() {
+	// Create 2 local child inodes and 1 non child inode.
+	in1 := t.createLocalFileInode(t.in.Name(), "1_localChildInode", 1)
+	in2 := t.createLocalFileInode(t.in.Name(), "2_localChildInode", 2)
+	in3 := t.createLocalFileInode(Name{bucketName: "abc", objectName: "def/"}, "3_localNonChildInode", 3)
+	// Unlink local file inode 2.
+	filein2, _ := in2.(*FileInode)
+	filein2.Unlink()
+	// Create local file inodes map.
+	localFileInodes := map[Name]Inode{
+		in1.Name(): in1,
+		in2.Name(): in2,
+		in3.Name(): in3,
+	}
+
+	entries := t.in.LocalFileEntries(localFileInodes)
+
+	// Validate entries contains only linked child files.
+	AssertEq(1, len(entries))
+	AssertEq(entries[0].Name, "1_localChildInode")
+}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -85,6 +85,9 @@ type FileInode struct {
 
 	// Represents a local file which is not yet synced to GCS.
 	local bool
+
+	// Represents if local file has been unlinked.
+	unlinked bool
 }
 
 var _ Inode = &FileInode{}
@@ -118,6 +121,7 @@ func NewFileInode(
 		contentCache:   contentCache,
 		src:            convertObjToMinObject(o),
 		local:          localFile,
+		unlinked:       false,
 	}
 
 	f.lc.Init(id)
@@ -286,6 +290,14 @@ func (f *FileInode) Name() Name {
 
 func (f *FileInode) IsLocal() bool {
 	return f.local
+}
+
+func (f *FileInode) IsUnlinked() bool {
+	return f.unlinked
+}
+
+func (f *FileInode) Unlink() {
+	f.unlinked = true
 }
 
 // Source returns a record for the GCS object from which this inode is branched. The

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -899,3 +899,23 @@ func (t *FileTest) ContentEncodingOther() {
 	AssertEq(contentEncoding, t.in.Source().ContentEncoding)
 	AssertFalse(t.in.Source().HasContentEncodingGzip())
 }
+
+func (t *FileTest) UnlinkLocalFile() {
+	var err error
+	// Create a local file inode.
+	t.createInodeWithLocalParam("test", true)
+	// Create a temp file for the local inode created above.
+	err = t.in.CreateEmptyTempFile()
+	AssertEq(nil, err)
+
+	// Unlink.
+	t.in.Unlink()
+
+	// Verify that fileInode is now unlinked
+	AssertTrue(t.in.IsUnlinked())
+	// Data shouldn't be updated to GCS.
+	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
+	_, err = t.bucket.StatObject(t.ctx, statReq)
+	AssertNe(nil, err)
+	AssertEq("gcs.NotFoundError: Object test not found", err.Error())
+}


### PR DESCRIPTION
### Description
Changes to support unlink and remove directory operation on local files. 

These changes are in sync with non-local file system behaviour, i.e., 
- When FlushFile call is made on an unlinked file, 
  - the file is considered clobbered.
  - we don't return any error in this case.
  - we don't write the file to GCS.
  - ref: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/fs/inode/file.go#L168C35-L168C35
- When WriteFile call is made on an unlinked file, 
   - the write operation fails while writing. 
   - throws IO error while opening a reader.
   - ref: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/fs/inode/file.go#L217
   
<br> <br>

Changes for local files:
* Unlink will remove the local file entry from localFileInodes map.
* RmDir will check for entries in localFileInodes map first (before GCS) to check whether the directory is empty or not.
* syncFile will not write to GCS if the local file has been unlinked.
* WriteFile operation will throw IO error if the local file has been unlinked.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Verified manually
- if empty local file is deleted before sync, no error is thrown at file.close() and file is not written to GCS for both local and synced files.
- all write calls to unlinked local file fails with IO error and file is not written to GCS on file.close() for both local and synced files.
3. Unit tests - Added unit tests for fs.go
4. Integration tests - NA
