### PR TITLE
Upgrade to go version 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   linux-tests:
     strategy:
       matrix:
-        go: [1.20.x]
+        go: [ 1.21.x ]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
 
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.21"
     - name: checkout code
       uses: actions/checkout@v3
     - name: golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.20.5-alpine as builder
+FROM golang:1.21.0-alpine as builder
 
 RUN apk add git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -6,8 +6,8 @@ echo "Installing git"
 sudo apt-get install git
 echo "Installing pip"
 sudo apt-get install pip -y
-echo "Installing go-lang 1.20.5"
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
+echo "Installing go-lang 1.21.0"
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 echo "Installing fio"

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -5,7 +5,7 @@
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -20,8 +20,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.20.5
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.5.linux-amd64.tar.gz -q
+echo Installing go-lang  1.21.0
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -59,7 +59,6 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
- git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -59,6 +59,7 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
+ git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -49,8 +49,8 @@ RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
 # Branch name for building through a particular branch.
-ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+#ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+RUN git checkout "upgrade_go_1.21"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.20.5 as gcsfuse-package
+FROM golang:1.21.0 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -49,8 +49,8 @@ RUN go get -d ${GCSFUSE_REPO}
 
 WORKDIR ${GCSFUSE_PATH}
 # Branch name for building through a particular branch.
-#ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "upgrade_go_1.21"
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile


### PR DESCRIPTION
### Description
Upgrade to go version 1.21 as it fixes security vulnerabilities in the older version.

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1288

### Testing details
1. Manual - basic sanity checks with go run command
2. Unit tests - NA
3. Integration tests 
   - ran integration tests on KOKORO.
   - ran integration tests on deb and rpm package via louhi on all OS types.
