### PR TITLE
Integration test for local files

### DIFF
--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -40,7 +40,8 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if objName != statObjName {
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
-	if (preCreateTime.After(oStat.ModTime())) || (postCreateTime.Before(oStat.ModTime())) {
+	statModTime := oStat.ModTime().Round(time.Second)
+	if (preCreateTime.After(statModTime)) || (postCreateTime.Before(statModTime)) {
 		t.Errorf("File modification time not in the expected time-range")
 	}
 
@@ -53,9 +54,11 @@ func TestFileAttributes(t *testing.T) {
 	// Clean the mountedDirectory before running test.
 	setup.CleanMntDir()
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so rounding off
+	// times to seconds. Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Round(time.Second)
 	fileName := setup.CreateTempFile()
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Round(time.Second)
 
 	// The file size in createTempFile() is BytesWrittenInFile bytes
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -16,7 +16,6 @@
 package operations_test
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -41,12 +40,7 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if objName != statObjName {
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
-	fmt.Println(preCreateTime.String(), "+++", oStat.ModTime(), "+++", postCreateTime.String())
-	fmt.Println(preCreateTime.UnixNano(), "+++", oStat.ModTime().UnixNano(), "+++", postCreateTime.UnixNano())
-	fmt.Println("diff: ", postCreateTime.Sub(preCreateTime), " or ", postCreateTime.UnixNano()-preCreateTime.UnixNano())
 	if (preCreateTime.After(oStat.ModTime())) || (postCreateTime.Before(oStat.ModTime())) {
-		fmt.Println("preCreateTime.After(oStat.ModTime())) = ", preCreateTime.After(oStat.ModTime()))
-		fmt.Println("postCreateTime.Before(oStat.ModTime()) = ", postCreateTime.Before(oStat.ModTime()))
 		t.Errorf("File modification time not in the expected time-range")
 	}
 

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -16,6 +16,7 @@
 package operations_test
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -41,7 +42,12 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
 	statModTime := oStat.ModTime().Round(time.Second)
+	fmt.Println(preCreateTime.String(), "+++", statModTime.String(), "+++", postCreateTime.String())
+	fmt.Println(preCreateTime.UnixNano(), "+++", statModTime.UnixNano(), "+++", postCreateTime.UnixNano())
+	fmt.Println("diff: ", postCreateTime.Sub(preCreateTime), " or ", postCreateTime.UnixNano()-preCreateTime.UnixNano())
 	if (preCreateTime.After(statModTime)) || (postCreateTime.Before(statModTime)) {
+		fmt.Println("preCreateTime.After(oStat.ModTime())) = ", preCreateTime.After(statModTime))
+		fmt.Println("postCreateTime.Before(oStat.ModTime()) = ", postCreateTime.Before(statModTime))
 		t.Errorf("File modification time not in the expected time-range")
 	}
 

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -16,6 +16,7 @@
 package operations_test
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -40,7 +41,12 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if objName != statObjName {
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
+	fmt.Println(preCreateTime.String(), "+++", oStat.ModTime(), "+++", postCreateTime.String())
+	fmt.Println(preCreateTime.UnixNano(), "+++", oStat.ModTime().UnixNano(), "+++", postCreateTime.UnixNano())
+	fmt.Println("diff: ", postCreateTime.Sub(preCreateTime), " or ", postCreateTime.UnixNano()-preCreateTime.UnixNano())
 	if (preCreateTime.After(oStat.ModTime())) || (postCreateTime.Before(oStat.ModTime())) {
+		fmt.Println("preCreateTime.After(oStat.ModTime())) = ", preCreateTime.After(oStat.ModTime()))
+		fmt.Println("postCreateTime.Before(oStat.ModTime()) = ", postCreateTime.Before(oStat.ModTime()))
 		t.Errorf("File modification time not in the expected time-range")
 	}
 

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -16,7 +16,6 @@
 package operations_test
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -42,12 +41,7 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
 	statModTime := oStat.ModTime().Round(time.Second)
-	fmt.Println(preCreateTime.String(), "+++", statModTime.String(), "+++", postCreateTime.String())
-	fmt.Println(preCreateTime.UnixNano(), "+++", statModTime.UnixNano(), "+++", postCreateTime.UnixNano())
-	fmt.Println("diff: ", postCreateTime.Sub(preCreateTime), " or ", postCreateTime.UnixNano()-preCreateTime.UnixNano())
 	if (preCreateTime.After(statModTime)) || (postCreateTime.Before(statModTime)) {
-		fmt.Println("preCreateTime.After(oStat.ModTime())) = ", preCreateTime.After(statModTime))
-		fmt.Println("postCreateTime.Before(oStat.ModTime()) = ", postCreateTime.Before(statModTime))
 		t.Errorf("File modification time not in the expected time-range")
 	}
 

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -75,10 +75,12 @@ func TestEmptyDirAttributes(t *testing.T) {
 	// Clean the mountedDirectory before running test.
 	setup.CleanMntDir()
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so rounding off
+	// times to seconds. Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Round(time.Second)
 	dirName := path.Join(setup.MntDir(), DirAttrTest)
 	operations.CreateDirectoryWithNFiles(0, dirName, "", t)
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Round(time.Second)
 
 	checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
 }
@@ -87,10 +89,12 @@ func TestNonEmptyDirAttributes(t *testing.T) {
 	// Clean the mountedDirectory before running test.
 	setup.CleanMntDir()
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so rounding off
+	// times to seconds. Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Round(time.Second)
 	dirName := path.Join(setup.MntDir(), DirAttrTest)
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Round(time.Second)
 
 	checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -103,9 +103,9 @@ func TestMain(m *testing.M) {
 	configFile := setup.YAMLConfig(false)
 	// Set up flags to run tests on.
 	flags := [][]string{
-		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
-		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
+		//{"--implicit-dirs=true"},
+		//{"--implicit-dirs=false"},
+		//{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
 		{"--config-file=" + configFile}}
 
 	successCode := static_mounting.RunTests(flags, m)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
@@ -100,7 +101,12 @@ func TestMain(m *testing.M) {
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()
 	// Set up config file with create-empty-file: false.
-	configFile := setup.YAMLConfig(false)
+	mountConfig := config.MountConfig{
+		WriteConfig: config.WriteConfig{
+			CreateEmptyFile: false,
+		},
+	}
+	configFile := setup.YAMLConfigFile(mountConfig)
 	// Set up flags to run tests on.
 	flags := [][]string{
 		{"--implicit-dirs=true"},

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -86,10 +86,6 @@ const ContentInFileInDirThreeInCreateThreeLevelDirTest = "Hello world!!"
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
-		{"--experimental-enable-json-read=true", "--implicit-dirs=true"}}
-
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 
 	if setup.TestBucket() != "" && setup.MountedDirectory() != "" {
@@ -101,7 +97,16 @@ func TestMain(m *testing.M) {
 	setup.RunTestsForMountedDirectoryFlag(m)
 
 	// Run tests for testBucket
+	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()
+	// Set up config file with create-empty-file: false.
+	configFile := setup.YAMLConfig(false)
+	// Set up flags to run tests on.
+	flags := [][]string{
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
+		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
+		{"--config-file=" + configFile}}
 
 	successCode := static_mounting.RunTests(flags, m)
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -103,9 +103,9 @@ func TestMain(m *testing.M) {
 	configFile := setup.YAMLConfig(false)
 	// Set up flags to run tests on.
 	flags := [][]string{
-		//{"--implicit-dirs=true"},
-		//{"--implicit-dirs=false"},
-		//{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
+		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
 		{"--config-file=" + configFile}}
 
 	successCode := static_mounting.RunTests(flags, m)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/util"
+	"gopkg.in/yaml.v2"
 )
 
 var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
@@ -44,6 +45,14 @@ var (
 	mntDir   string
 	sbinFile string
 )
+
+type Config struct {
+	Write Write `yaml:"write"`
+}
+
+type Write struct {
+	CreateEmptyFile bool `yaml:"create-empty-file"`
+}
 
 // Run the shell script to prepare the testData in the specified bucket.
 // First argument will be name of scipt script
@@ -230,6 +239,25 @@ func ParseSetUpFlags() {
 		log.Print("Pass --integrationTest flag to run the tests.")
 		os.Exit(0)
 	}
+}
+
+func YAMLConfig(createEmptyFile bool) (filepath string) {
+	config := Config{
+		Write: Write{CreateEmptyFile: createEmptyFile},
+	}
+
+	yamlData, err := yaml.Marshal(&config)
+	if err != nil {
+		LogAndExit(fmt.Sprintf("Error while marshaling config file: %v", err))
+	}
+
+	fileName := "config.yaml"
+	filepath = path.Join(TestDir(), fileName)
+	err = os.WriteFile(filepath, yamlData, 0644)
+	if err != nil {
+		LogAndExit("Unable to write data into config file.")
+	}
+	return
 }
 
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/util"
-	"gopkg.in/yaml.v2"
 )
 
 var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
@@ -45,14 +44,6 @@ var (
 	mntDir   string
 	sbinFile string
 )
-
-type Config struct {
-	Write Write `yaml:"write"`
-}
-
-type Write struct {
-	CreateEmptyFile bool `yaml:"create-empty-file"`
-}
 
 // Run the shell script to prepare the testData in the specified bucket.
 // First argument will be name of scipt script
@@ -239,25 +230,6 @@ func ParseSetUpFlags() {
 		log.Print("Pass --integrationTest flag to run the tests.")
 		os.Exit(0)
 	}
-}
-
-func YAMLConfig(createEmptyFile bool) (filepath string) {
-	config := Config{
-		Write: Write{CreateEmptyFile: createEmptyFile},
-	}
-
-	yamlData, err := yaml.Marshal(&config)
-	if err != nil {
-		LogAndExit(fmt.Sprintf("Error while marshaling config file: %v", err))
-	}
-
-	fileName := "config.yaml"
-	filepath = path.Join(TestDir(), fileName)
-	err = os.WriteFile(filepath, yamlData, 0644)
-	if err != nil {
-		LogAndExit("Unable to write data into config file.")
-	}
-	return
 }
 
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {

--- a/tools/integration_tests/util/setup/yaml-config.go
+++ b/tools/integration_tests/util/setup/yaml-config.go
@@ -1,0 +1,29 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	config2 "github.com/googlecloudplatform/gcsfuse/internal/config"
+	"gopkg.in/yaml.v2"
+)
+
+func YAMLConfig(createEmptyFile bool) (filepath string) {
+	config := config2.MountConfig{
+		WriteConfig: config2.WriteConfig{CreateEmptyFile: createEmptyFile},
+	}
+
+	yamlData, err := yaml.Marshal(&config)
+	if err != nil {
+		LogAndExit(fmt.Sprintf("Error while marshaling config file: %v", err))
+	}
+
+	fileName := "config.yaml"
+	filepath = path.Join(TestDir(), fileName)
+	err = os.WriteFile(filepath, yamlData, 0644)
+	if err != nil {
+		LogAndExit("Unable to write data into config file.")
+	}
+	return
+}

--- a/tools/integration_tests/util/setup/yaml-config.go
+++ b/tools/integration_tests/util/setup/yaml-config.go
@@ -5,23 +5,19 @@ import (
 	"os"
 	"path"
 
-	config2 "github.com/googlecloudplatform/gcsfuse/internal/config"
+	"github.com/googlecloudplatform/gcsfuse/internal/config"
 	"gopkg.in/yaml.v2"
 )
 
-func YAMLConfig(createEmptyFile bool) (filepath string) {
-	config := config2.MountConfig{
-		WriteConfig: config2.WriteConfig{CreateEmptyFile: createEmptyFile},
-	}
-
+func YAMLConfigFile(config config.MountConfig) (filePath string) {
 	yamlData, err := yaml.Marshal(&config)
 	if err != nil {
 		LogAndExit(fmt.Sprintf("Error while marshaling config file: %v", err))
 	}
 
 	fileName := "config.yaml"
-	filepath = path.Join(TestDir(), fileName)
-	err = os.WriteFile(filepath, yamlData, 0644)
+	filePath = path.Join(TestDir(), fileName)
+	err = os.WriteFile(filePath, yamlData, 0644)
 	if err != nil {
 		LogAndExit("Unable to write data into config file.")
 	}


### PR DESCRIPTION
### Description
- Added local files tests to operation_test.go .
- Fixed flaky test:
  Attributes tests were flaky as the kernel clock was slightly out of sync of time.Now() 
  ref bug: https://github.com/golang/go/issues/33510
  
ref logs: 
  time in SetInodeAttributes() call `11:15:03.322725758` is behind CreateFile() call time `11:15:03.326389`.
  ```
  D0901 11:15:03.326389 fuse_debug: Op 0x000007d2        connection.go:416] <- CreateFile (parent 1, name "tmpFile", PID 190957)
  D0901 11:15:03.326603 fuse_debug: Op 0x000007d2        connection.go:498] -> OK (inode 51)
  D0901 11:15:03.326728 fuse_debug: Op 0x000007d4        connection.go:416] <- WriteFile (inode 51, PID 190957, handle 114, offset 0, 14 bytes)
  D0901 11:15:03.326830 fuse_debug: Op 0x000007d4        connection.go:498] -> OK ()
  D0901 11:15:03.326899 fuse_debug: Op 0x000007d6        connection.go:416] <- SetInodeAttributes (inode 51, PID 190957, mtime 2023-09-01 11:15:03.322725758 +0000 UTC)
  D0901 11:15:03.326954 fuse_debug: Op 0x000007d6        connection.go:498] -> OK ()
  D0901 11:15:03.327005 fuse_debug: Op 0x000007d8        connection.go:416] <- FlushFile (inode 51, PID 190957)
  D0901 11:15:03.327042 gcs: Req            0x159: <- StatObject("Test/tmpFile")
  D0901 11:15:03.350819 gcs: Req            0x159: -> StatObject("Test/tmpFile") (23.772224ms): gcs.NotFoundError: storage: object doesn't exist
  D0901 11:15:03.350861 gcs: Req            0x15a: <- CreateObject("Test/tmpFile")
  D0901 11:15:03.492421 gcs: Req            0x15a: -> CreateObject("Test/tmpFile") (141.548736ms): OK
  D0901 11:15:03.492539 fuse_debug: Op 0x000007d8        connection.go:498] -> OK ()
  D0901 11:15:03.492751 fuse_debug: Op 0x000007da        connection.go:416] <- ReleaseFileHandle (PID 0)
  ```
Fix: Round off time to second

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran on GCP VM.
