### PR TITLE
Upgrade go1.21

### DIFF
--- a/perfmetrics/scripts/ml_tests/setup.sh
+++ b/perfmetrics/scripts/ml_tests/setup.sh
@@ -4,7 +4,7 @@
 # >> source setup.sh
 
 # Go version to be installed.
-GO_VERSION=go1.20.5.linux-amd64.tar.gz
+GO_VERSION=go1.21.0.linux-amd64.tar.gz
 
 # This function will install the given module/dependency if it's not alredy 
 # installed.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -59,7 +59,6 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
- git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -59,6 +59,7 @@ then
  sudo apt-get install fio -y
 
  # Executing perf tests for master branch
+ git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -92,7 +92,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "upgrade_go1.21"
+RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+RUN git checkout "upgrade_go1.21"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.20.5 as builder
+FROM golang:1.21.0 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 


### PR DESCRIPTION
### Description
Missed upgrading go version in a few files in PR https://github.com/GoogleCloudPlatform/gcsfuse/pull/1317 

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1288

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran on louhi (passed) and kokoro (Kokoro failed on the flaky test - [link](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/e20d1387-5b91-4e23-a3a7-6d6fb58d04e5/summary) )
4. Perf test results: https://screenshot.googleplex.com/72Hty4qck98wVWa.png
