### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/jacobsa/gcloud/gcs"
 	"golang.org/x/oauth2"
@@ -31,7 +31,7 @@ func newTokenSourceFromPath(
 	scope string,
 ) (ts oauth2.TokenSource, err error) {
 	// Read the file.
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		err = fmt.Errorf("ReadFile(%q): %w", path, err)
 		return

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -75,7 +74,7 @@ func (ts proxyTokenSource) Token() (token *oauth2.Token, err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		err = fmt.Errorf("proxyTokenSource cannot load body: %w", err)
 		return

--- a/internal/contentcache/contentcache_test.go
+++ b/internal/contentcache/contentcache_test.go
@@ -17,7 +17,6 @@ package contentcache_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -76,7 +75,7 @@ func TestReadWriteMetadataCheckpointFile(t *testing.T) {
 	metadataFileName, err := contentCache.WriteMetadataCheckpointFile(objectMetadata.ObjectName, &objectMetadata)
 	AssertEq(err, nil)
 	newObjectMetadata := contentcache.CacheFileObjectMetadata{}
-	contents, err := ioutil.ReadFile(metadataFileName)
+	contents, err := os.ReadFile(metadataFileName)
 	AssertEq(err, nil)
 	err = json.Unmarshal(contents, &newObjectMetadata)
 	AssertEq(err, nil)

--- a/internal/fs/all_buckets_test.go
+++ b/internal/fs/all_buckets_test.go
@@ -16,7 +16,6 @@ package fs_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -56,13 +55,13 @@ func (t *AllBucketsTest) SetUpTestSuite() {
 ////////////////////////////////////////////////////////////////////////
 
 func (t *AllBucketsTest) BaseDir_Ls() {
-	_, err := ioutil.ReadDir(mntDir)
+	_, err := os.ReadDir(mntDir)
 	ExpectThat(err, Error(HasSubstr("operation not supported")))
 }
 
 func (t *AllBucketsTest) BaseDir_Write() {
 	filename := path.Join(mntDir, "foo")
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filename, []byte("content"), os.FileMode(0644))
 	ExpectThat(err, Error(HasSubstr("input/output error")))
 }
@@ -72,7 +71,7 @@ func (t *AllBucketsTest) BaseDir_Rename() {
 	ExpectThat(err, Error(HasSubstr("operation not supported")))
 
 	filename := path.Join(mntDir + "/bucket-0/foo")
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filename, []byte("content"), os.FileMode(0644))
 	AssertEq(nil, err)
 
@@ -92,7 +91,7 @@ func (t *AllBucketsTest) SingleBucket_ReadAfterWrite() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			filename,
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -143,7 +142,7 @@ func (t *AllBucketsTest) SingleBucket_ReadAfterWrite() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(filename)
+	fileContents, err := os.ReadFile(filename)
 
 	AssertEq(nil, err)
 	ExpectEq("000o111ritoenchilada222", string(fileContents))

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -16,7 +16,6 @@ package fs_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -119,15 +118,15 @@ func (t *CachingTest) FileCreatedRemotely() {
 	ExpectEq(len(contents), fi.Size())
 
 	// And read it.
-	b, err := ioutil.ReadFile(path.Join(mntDir, name))
+	b, err := os.ReadFile(path.Join(mntDir, name))
 	AssertEq(nil, err)
 	ExpectEq(contents, string(b))
 
 	// And overwrite it, and read it back again.
-	err = ioutil.WriteFile(path.Join(mntDir, name), []byte("burrito"), 0500)
+	err = os.WriteFile(path.Join(mntDir, name), []byte("burrito"), 0500)
 	AssertEq(nil, err)
 
-	b, err = ioutil.ReadFile(path.Join(mntDir, name))
+	b, err = os.ReadFile(path.Join(mntDir, name))
 	AssertEq(nil, err)
 	ExpectEq("burrito", string(b))
 }
@@ -138,7 +137,7 @@ func (t *CachingTest) FileChangedRemotely() {
 	var err error
 
 	// Create a file via the file system.
-	err = ioutil.WriteFile(path.Join(mntDir, name), []byte("taco"), 0500)
+	err = os.WriteFile(path.Join(mntDir, name), []byte("taco"), 0500)
 	AssertEq(nil, err)
 
 	// Overwrite the object in GCS.
@@ -164,7 +163,7 @@ func (t *CachingTest) FileChangedRemotely() {
 	ExpectEq(len("burrito"), fi.Size())
 
 	// Reading should work as expected.
-	b, err := ioutil.ReadFile(path.Join(mntDir, name))
+	b, err := os.ReadFile(path.Join(mntDir, name))
 	AssertEq(nil, err)
 	ExpectEq("burrito", string(b))
 }
@@ -249,7 +248,7 @@ func (t *CachingTest) TypeOfNameChanges_LocalModifier() {
 	err = os.Remove(path.Join(mntDir, name))
 	AssertEq(nil, err)
 
-	err = ioutil.WriteFile(path.Join(mntDir, name), []byte("taco"), 0400)
+	err = os.WriteFile(path.Join(mntDir, name), []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// All caches should have been updated.
@@ -368,7 +367,7 @@ func (t *CachingWithImplicitDirsTest) SymlinksWork() {
 	fileName := path.Join(mntDir, "foo")
 	const contents = "taco"
 
-	err = ioutil.WriteFile(fileName, []byte(contents), 0400)
+	err = os.WriteFile(fileName, []byte(contents), 0400)
 	AssertEq(nil, err)
 
 	// Create a symlink to it.

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -21,7 +21,6 @@ package fs_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -500,7 +499,7 @@ func (t *ForeignModsTest) ReadFromFile_Small() {
 	defer func() { AssertEq(nil, f.Close()) }()
 
 	// Read its entire contents.
-	slice, err := ioutil.ReadAll(f)
+	slice, err := io.ReadAll(f)
 	AssertEq(nil, err)
 	ExpectEq("tacoburritoenchilada", string(slice))
 
@@ -649,11 +648,11 @@ func (t *ForeignModsTest) ObjectIsOverwritten_File() {
 	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
 
 	// Reading from the old file handle should give the old data.
-	contents, err := ioutil.ReadAll(f1)
+	contents, err := io.ReadAll(f1)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 
-	contents, err = ioutil.ReadAll(f2)
+	contents, err = io.ReadAll(f2)
 	AssertEq(nil, err)
 	ExpectEq("burrito", string(contents))
 }
@@ -821,7 +820,7 @@ func (t *ForeignModsTest) Mtime() {
 		Metadata: map[string]string{
 			"gcsfuse_mtime": expected.UTC().Format(time.RFC3339Nano),
 		},
-		Contents: ioutil.NopCloser(strings.NewReader("")),
+		Contents: io.NopCloser(strings.NewReader("")),
 	}
 
 	_, err = bucket.CreateObject(ctx, req)
@@ -845,7 +844,7 @@ func (t *ForeignModsTest) RemoteMtimeChange() {
 			Metadata: map[string]string{
 				"gcsfuse_mtime": time.Now().UTC().Format(time.RFC3339Nano),
 			},
-			Contents: ioutil.NopCloser(strings.NewReader("")),
+			Contents: io.NopCloser(strings.NewReader("")),
 		})
 
 	AssertEq(nil, err)
@@ -885,7 +884,7 @@ func (t *ForeignModsTest) Symlink() {
 		Metadata: map[string]string{
 			"gcsfuse_symlink_target": "bar/baz",
 		},
-		Contents: ioutil.NopCloser(strings.NewReader("")),
+		Contents: io.NopCloser(strings.NewReader("")),
 	}
 
 	_, err = bucket.CreateObject(ctx, req)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -147,7 +146,7 @@ func (t *fsTest) SetUpTestSuite() {
 	t.serverCfg.DirPerms = dirPerms
 
 	// Set up a temporary directory for mounting.
-	mntDir, err = ioutil.TempDir("", "fs_test")
+	mntDir, err = os.MkdirTemp("", "fs_test")
 	AssertEq(nil, err)
 
 	// Create a file system server.

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -224,7 +223,7 @@ func (t *OpenTest) NonExistent_CreateFlagSet() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("012", string(fileContents))
@@ -237,7 +236,7 @@ func (t *OpenTest) ExistingFile() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -265,7 +264,7 @@ func (t *OpenTest) ExistingFile() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("012oburritoenchilada", string(fileContents))
@@ -277,7 +276,7 @@ func (t *OpenTest) ExistingFile_Truncate() {
 	// Create a file.
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte("blahblahblah"),
 			os.FileMode(0644)))
@@ -303,7 +302,7 @@ func (t *OpenTest) ExistingFile_Truncate() {
 	_, err = t.f1.Seek(0, 0)
 	AssertEq(nil, err)
 
-	contentsSlice, err := ioutil.ReadAll(t.f1)
+	contentsSlice, err := io.ReadAll(t.f1)
 	AssertEq(nil, err)
 	ExpectEq("012", string(contentsSlice))
 
@@ -312,7 +311,7 @@ func (t *OpenTest) ExistingFile_Truncate() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("012", string(fileContents))
@@ -350,7 +349,7 @@ func (t *OpenTest) AlreadyOpenedFile() {
 	AssertEq(2, n)
 
 	// Check the overall contents now.
-	contents, err := ioutil.ReadFile(t.f2.Name())
+	contents, err := os.ReadFile(t.f2.Name())
 	AssertEq(nil, err)
 	ExpectEq("tank", string(contents))
 }
@@ -363,7 +362,7 @@ func (t *OpenTest) LegalNames() {
 
 	// We should be able to create each name.
 	for _, n := range names {
-		err = ioutil.WriteFile(path.Join(mntDir, n), []byte(n), 0400)
+		err = os.WriteFile(path.Join(mntDir, n), []byte(n), 0400)
 		AssertEq(nil, err, "Name: %q", n)
 	}
 
@@ -379,7 +378,7 @@ func (t *OpenTest) LegalNames() {
 
 	// We should be able to read them all.
 	for _, n := range names {
-		contents, err := ioutil.ReadFile(path.Join(mntDir, n))
+		contents, err := os.ReadFile(path.Join(mntDir, n))
 		AssertEq(nil, err, "Name: %q", n)
 		ExpectEq(n, string(contents), "Name: %q", n)
 	}
@@ -409,7 +408,7 @@ func (t *OpenTest) IllegalNames() {
 
 	// We should not be able to create any of these names.
 	for _, tc := range testCases {
-		err = ioutil.WriteFile(path.Join(mntDir, tc.name), []byte{}, 0400)
+		err = os.WriteFile(path.Join(mntDir, tc.name), []byte{}, 0400)
 		ExpectThat(err, Error(HasSubstr(tc.err)), "Name: %q", tc.name)
 	}
 }
@@ -448,7 +447,7 @@ func (t *MknodTest) File() {
 	ExpectEq(filePerms, fi.Mode())
 
 	// Read
-	contents, err := ioutil.ReadFile(p)
+	contents, err := os.ReadFile(p)
 	AssertEq(nil, err)
 	ExpectEq("", string(contents))
 }
@@ -478,7 +477,7 @@ func (t *MknodTest) AlreadyExists() {
 	p := path.Join(mntDir, "foo")
 
 	// Create (first)
-	err = ioutil.WriteFile(p, []byte("taco"), 0600)
+	err = os.WriteFile(p, []byte("taco"), 0600)
 	AssertEq(nil, err)
 
 	// Create (second)
@@ -486,7 +485,7 @@ func (t *MknodTest) AlreadyExists() {
 	ExpectEq(syscall.EEXIST, err)
 
 	// Read
-	contents, err := ioutil.ReadFile(p)
+	contents, err := os.ReadFile(p)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 }
@@ -523,7 +522,7 @@ func (t *ModesTest) ReadOnlyMode() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -533,7 +532,7 @@ func (t *ModesTest) ReadOnlyMode() {
 	AssertEq(nil, err)
 
 	// Read its contents.
-	fileContents, err := ioutil.ReadAll(t.f1)
+	fileContents, err := io.ReadAll(t.f1)
 	AssertEq(nil, err)
 	ExpectEq(contents, string(fileContents))
 
@@ -552,7 +551,7 @@ func (t *ModesTest) WriteOnlyMode() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -562,7 +561,7 @@ func (t *ModesTest) WriteOnlyMode() {
 	AssertEq(nil, err)
 
 	// Reading should fail.
-	_, err = ioutil.ReadAll(t.f1)
+	_, err = io.ReadAll(t.f1)
 
 	AssertNe(nil, err)
 	ExpectThat(err, Error(HasSubstr("bad file descriptor")))
@@ -592,7 +591,7 @@ func (t *ModesTest) WriteOnlyMode() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("000o111ritoenchilada222", string(fileContents))
@@ -605,7 +604,7 @@ func (t *ModesTest) ReadWriteMode() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -656,7 +655,7 @@ func (t *ModesTest) ReadWriteMode() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("000o111ritoenchilada222", string(fileContents))
@@ -669,13 +668,13 @@ func (t *ModesTest) FuzzyReadWriteMode() {
 	const contents = "baz\u1100\u1161"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Read back its contents.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 	AssertEq(nil, err)
 	ExpectEq("baz\u1100\u1161", string(fileContents))
 
@@ -721,7 +720,7 @@ func (t *ModesTest) FuzzyReadWriteMode() {
 	t.f1 = nil
 
 	// Read back its contents.
-	fileContents, err = ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err = os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("타코世界\u0041\u030a", string(fileContents))
@@ -734,7 +733,7 @@ func (t *ModesTest) AppendMode_SeekAndWrite() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -769,7 +768,7 @@ func (t *ModesTest) AppendMode_SeekAndWrite() {
 	ExpectEq(contents+"222", string(buf[:n]))
 
 	// Read the full contents with another file handle.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq(contents+"222", string(fileContents))
@@ -782,7 +781,7 @@ func (t *ModesTest) AppendMode_WriteAt() {
 	const contents = "tacoburritoenchilada"
 	AssertEq(
 		nil,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
@@ -817,7 +816,7 @@ func (t *ModesTest) AppendMode_WriteAt() {
 	ExpectEq("taco111ritoenchilada", string(buf[:n]))
 
 	// Read the full contents with another file handle.
-	fileContents, err := ioutil.ReadFile(path.Join(mntDir, "foo"))
+	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
 	AssertEq(nil, err)
 	ExpectEq("taco111ritoenchilada", string(fileContents))
@@ -850,7 +849,7 @@ func (t *ModesTest) AppendMode_WriteAt_PastEOF() {
 	ExpectEq(3, off)
 
 	// Read the full contents of the file.
-	contents, err := ioutil.ReadFile(t.f1.Name())
+	contents, err := os.ReadFile(t.f1.Name())
 	AssertEq(nil, err)
 
 	ExpectEq("111\x00\x00\x00222", string(contents))
@@ -1006,7 +1005,7 @@ func (t *DirectoryTest) Mkdir_IntermediateIsFile() {
 
 	// Create a file.
 	fileName := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(fileName, []byte{}, 0700)
+	err = os.WriteFile(fileName, []byte{}, 0700)
 	AssertEq(nil, err)
 
 	// Attempt to create a directory within the file.
@@ -1087,7 +1086,7 @@ func (t *DirectoryTest) ReadDir_Root() {
 
 	// Create a file and a directory.
 	createTime := mtimeClock.Now()
-	err = ioutil.WriteFile(path.Join(mntDir, "bar"), []byte("taco"), 0700)
+	err = os.WriteFile(path.Join(mntDir, "bar"), []byte("taco"), 0700)
 	AssertEq(nil, err)
 
 	err = os.Mkdir(path.Join(mntDir, "foo"), 0700)
@@ -1131,7 +1130,7 @@ func (t *DirectoryTest) ReadDir_SubDirectory() {
 
 	// Create a file and a directory within it.
 	createTime := mtimeClock.Now()
-	err = ioutil.WriteFile(path.Join(parent, "bar"), []byte("taco"), 0700)
+	err = os.WriteFile(path.Join(parent, "bar"), []byte("taco"), 0700)
 	AssertEq(nil, err)
 
 	err = os.Mkdir(path.Join(parent, "foo"), 0700)
@@ -1283,7 +1282,7 @@ func (t *DirectoryTest) CreateHardLink() {
 	var err error
 
 	// Write a file.
-	err = ioutil.WriteFile(path.Join(mntDir, "foo"), []byte(""), 0700)
+	err = os.WriteFile(path.Join(mntDir, "foo"), []byte(""), 0700)
 	AssertEq(nil, err)
 
 	// Attempt to hard link it. We don't support doing so.
@@ -1414,7 +1413,7 @@ func (t *FileTest) WriteOverlapsEndOfFile() {
 	AssertEq(4, n)
 
 	// Read the full contents of the file.
-	contents, err := ioutil.ReadAll(t.f1)
+	contents, err := io.ReadAll(t.f1)
 	AssertEq(nil, err)
 	ExpectEq("\x00\x00taco", string(contents))
 }
@@ -1437,7 +1436,7 @@ func (t *FileTest) WriteStartsAtEndOfFile() {
 	AssertEq(4, n)
 
 	// Read the full contents of the file.
-	contents, err := ioutil.ReadAll(t.f1)
+	contents, err := io.ReadAll(t.f1)
 	AssertEq(nil, err)
 	ExpectEq("\x00\x00taco", string(contents))
 }
@@ -1456,7 +1455,7 @@ func (t *FileTest) WriteStartsPastEndOfFile() {
 	AssertEq(4, n)
 
 	// Read the full contents of the file.
-	contents, err := ioutil.ReadAll(t.f1)
+	contents, err := io.ReadAll(t.f1)
 	AssertEq(nil, err)
 	ExpectEq("\x00\x00taco", string(contents))
 }
@@ -1557,7 +1556,7 @@ func (t *FileTest) Truncate_Smaller() {
 	fileName := path.Join(mntDir, "foo")
 
 	// Create a file.
-	err = ioutil.WriteFile(fileName, []byte("taco"), 0600)
+	err = os.WriteFile(fileName, []byte("taco"), 0600)
 	AssertEq(nil, err)
 
 	// Open it for modification.
@@ -1574,7 +1573,7 @@ func (t *FileTest) Truncate_Smaller() {
 	ExpectEq(2, fi.Size())
 
 	// Read the contents.
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq("ta", string(contents))
 }
@@ -1584,7 +1583,7 @@ func (t *FileTest) Truncate_SameSize() {
 	fileName := path.Join(mntDir, "foo")
 
 	// Create a file.
-	err = ioutil.WriteFile(fileName, []byte("taco"), 0600)
+	err = os.WriteFile(fileName, []byte("taco"), 0600)
 	AssertEq(nil, err)
 
 	// Open it for modification.
@@ -1601,7 +1600,7 @@ func (t *FileTest) Truncate_SameSize() {
 	ExpectEq(4, fi.Size())
 
 	// Read the contents.
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 }
@@ -1611,7 +1610,7 @@ func (t *FileTest) Truncate_Larger() {
 	fileName := path.Join(mntDir, "foo")
 
 	// Create a file.
-	err = ioutil.WriteFile(fileName, []byte("taco"), 0600)
+	err = os.WriteFile(fileName, []byte("taco"), 0600)
 	AssertEq(nil, err)
 
 	// Open it for modification.
@@ -1628,7 +1627,7 @@ func (t *FileTest) Truncate_Larger() {
 	ExpectEq(6, fi.Size())
 
 	// Read the contents.
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq("taco\x00\x00", string(contents))
 }
@@ -1701,7 +1700,7 @@ func (t *FileTest) StatUnopenedFile() {
 	time.Sleep(timeSlop + timeSlop/2)
 	createTime := mtimeClock.Now()
 
-	err = ioutil.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
+	err = os.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
 	AssertEq(nil, err)
 
 	time.Sleep(timeSlop + timeSlop/2)
@@ -1727,7 +1726,7 @@ func (t *FileTest) LstatUnopenedFile() {
 	time.Sleep(timeSlop + timeSlop/2)
 	createTime := mtimeClock.Now()
 
-	err = ioutil.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
+	err = os.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
 	AssertEq(nil, err)
 
 	time.Sleep(timeSlop + timeSlop/2)
@@ -1751,7 +1750,7 @@ func (t *FileTest) UnlinkFile_Exists() {
 
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(fileName, []byte("Hello, world!"), 0600)
+	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
 	AssertEq(nil, err)
 
 	// Unlink it.
@@ -1828,7 +1827,7 @@ func (t *FileTest) UnlinkFile_NoLongerInBucket() {
 
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(fileName, []byte("Hello, world!"), 0600)
+	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
 	AssertEq(nil, err)
 
 	// Delete it from the bucket through the back door.
@@ -1857,7 +1856,7 @@ func (t *FileTest) UnlinkFile_FromSubDirectory() {
 
 	// Write a file to that directory.
 	fileName := path.Join(dirName, "foo")
-	err = ioutil.WriteFile(fileName, []byte("Hello, world!"), 0600)
+	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
 	AssertEq(nil, err)
 
 	// Unlink it.
@@ -1881,7 +1880,7 @@ func (t *FileTest) UnlinkFile_ThenRecreateWithSameName() {
 
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(fileName, []byte("Hello, world!"), 0600)
+	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
 	AssertEq(nil, err)
 
 	// Unlink it.
@@ -1889,7 +1888,7 @@ func (t *FileTest) UnlinkFile_ThenRecreateWithSameName() {
 	AssertEq(nil, err)
 
 	// Re-create a file with the same name.
-	err = ioutil.WriteFile(fileName, []byte("taco"), 0600)
+	err = os.WriteFile(fileName, []byte("taco"), 0600)
 	AssertEq(nil, err)
 
 	// Statting should result in a record for the new contents.
@@ -1907,7 +1906,7 @@ func (t *FileTest) Chmod() {
 
 	// Write a file.
 	p := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(p, []byte(""), 0700)
+	err = os.WriteFile(p, []byte(""), 0700)
 	AssertEq(nil, err)
 
 	// Attempt to chmod it. Chmod should succeed even though we don't do anything
@@ -1922,7 +1921,7 @@ func (t *FileTest) Chtimes_InactiveFile() {
 
 	// Create a file.
 	p := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(p, []byte{}, 0600)
+	err = os.WriteFile(p, []byte{}, 0600)
 	AssertEq(nil, err)
 
 	// Change its mtime.
@@ -1941,7 +1940,7 @@ func (t *FileTest) Chtimes_OpenFile_Clean() {
 
 	// Create a file.
 	p := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(p, []byte{}, 0600)
+	err = os.WriteFile(p, []byte{}, 0600)
 	AssertEq(nil, err)
 
 	// Open it for reading.
@@ -2185,7 +2184,7 @@ func (t *FileTest) AtimeAndCtime() {
 	// Create a file.
 	p := path.Join(mntDir, "foo")
 	createTime := mtimeClock.Now()
-	err = ioutil.WriteFile(p, []byte{}, 0400)
+	err = os.WriteFile(p, []byte{}, 0400)
 	AssertEq(nil, err)
 
 	// Stat it.
@@ -2258,7 +2257,7 @@ func (t *SymlinkTest) CreateLink() {
 	fileName := path.Join(mntDir, "foo")
 	const contents = "taco"
 
-	err = ioutil.WriteFile(fileName, []byte(contents), 0400)
+	err = os.WriteFile(fileName, []byte(contents), 0400)
 	AssertEq(nil, err)
 
 	// Create a symlink to it.
@@ -2310,7 +2309,7 @@ func (t *SymlinkTest) CreateLink_Exists() {
 
 	// Create a file and a directory.
 	fileName := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(fileName, []byte{}, 0400)
+	err = os.WriteFile(fileName, []byte{}, 0400)
 	AssertEq(nil, err)
 
 	dirName := path.Join(mntDir, "bar")
@@ -2377,7 +2376,7 @@ func (t *RenameTest) DirectoryNamingConflicts() {
 	AssertEq(nil, err)
 
 	conflictingFile := path.Join(conflictingPath, "placeholder.txt")
-	err = ioutil.WriteFile(conflictingFile, []byte("taco"), 0400)
+	err = os.WriteFile(conflictingFile, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	err = syscall.Rename(oldPath, conflictingPath)
@@ -2400,7 +2399,7 @@ func (t *RenameTest) DirectoryContainingFiles() {
 
 	for i := 0; i < int(RenameDirLimit); i++ {
 		file := fmt.Sprintf("%s/%d.txt", oldPath, i)
-		err = ioutil.WriteFile(file, []byte("taco"), 0400)
+		err = os.WriteFile(file, []byte("taco"), 0400)
 		AssertEq(nil, err)
 	}
 
@@ -2411,7 +2410,7 @@ func (t *RenameTest) DirectoryContainingFiles() {
 
 	// File count exceeds the limit.
 	file := fmt.Sprintf("%s/%d.txt", newPath, RenameDirLimit)
-	err = ioutil.WriteFile(file, []byte("taco"), 0400)
+	err = os.WriteFile(file, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// Attempt to rename it.
@@ -2439,17 +2438,17 @@ func (t *RenameTest) DirectoryContainingDirectories() {
 
 	// Create files.
 	filePath1 := path.Join(subPath, "file1")
-	err = ioutil.WriteFile(filePath1, []byte("taco"), 0400)
+	err = os.WriteFile(filePath1, []byte("taco"), 0400)
 	AssertEq(nil, err)
 	filePath2 := path.Join(subSubPath, "file2")
-	err = ioutil.WriteFile(filePath2, []byte("taco"), 0400)
+	err = os.WriteFile(filePath2, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// Rename the directory.
 	newPath := path.Join(mntDir, "bar")
 	err = os.Rename(oldPath, newPath)
 	AssertEq(nil, err)
-	files, err := ioutil.ReadDir(newPath)
+	files, err := os.ReadDir(newPath)
 	AssertEq(nil, err)
 	AssertEq(1, len(files))
 	ExpectEq("baz", files[0].Name())
@@ -2489,7 +2488,7 @@ func (t *RenameTest) WithinDir() {
 	// And a file within it.
 	oldPath := path.Join(parentPath, "foo")
 
-	err = ioutil.WriteFile(oldPath, []byte("taco"), 0400)
+	err = os.WriteFile(oldPath, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// Rename it.
@@ -2502,7 +2501,7 @@ func (t *RenameTest) WithinDir() {
 	_, err = os.Stat(oldPath)
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 
-	_, err = ioutil.ReadFile(oldPath)
+	_, err = os.ReadFile(oldPath)
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 
 	// The new name should.
@@ -2510,7 +2509,7 @@ func (t *RenameTest) WithinDir() {
 	AssertEq(nil, err)
 	ExpectEq(len("taco"), fi.Size())
 
-	contents, err := ioutil.ReadFile(newPath)
+	contents, err := os.ReadFile(newPath)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 
@@ -2540,7 +2539,7 @@ func (t *RenameTest) AcrossDirs() {
 	// And a file within the first.
 	oldPath := path.Join(oldParentPath, "foo")
 
-	err = ioutil.WriteFile(oldPath, []byte("taco"), 0400)
+	err = os.WriteFile(oldPath, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// Rename it.
@@ -2553,7 +2552,7 @@ func (t *RenameTest) AcrossDirs() {
 	_, err = os.Stat(oldPath)
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 
-	_, err = ioutil.ReadFile(oldPath)
+	_, err = os.ReadFile(oldPath)
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 
 	// The new name should.
@@ -2561,7 +2560,7 @@ func (t *RenameTest) AcrossDirs() {
 	AssertEq(nil, err)
 	ExpectEq(len("taco"), fi.Size())
 
-	contents, err := ioutil.ReadFile(newPath)
+	contents, err := os.ReadFile(newPath)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 
@@ -2586,11 +2585,11 @@ func (t *RenameTest) OutOfFileSystem() {
 	// Create a file.
 	oldPath := path.Join(mntDir, "foo")
 
-	err = ioutil.WriteFile(oldPath, []byte("taco"), 0400)
+	err = os.WriteFile(oldPath, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	// Attempt to move it out of the file system.
-	tempDir, err := ioutil.TempDir("", "memfs_test")
+	tempDir, err := os.MkdirTemp("", "memfs_test")
 	AssertEq(nil, err)
 	defer os.RemoveAll(tempDir)
 
@@ -2602,7 +2601,7 @@ func (t *RenameTest) IntoFileSystem() {
 	var err error
 
 	// Create a file outside of our file system.
-	f, err := ioutil.TempFile("", "memfs_test")
+	f, err := os.CreateTemp("", "memfs_test")
 	AssertEq(nil, err)
 	defer f.Close()
 
@@ -2619,11 +2618,11 @@ func (t *RenameTest) OverExistingFile() {
 
 	// Create two files.
 	oldPath := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(oldPath, []byte("taco"), 0400)
+	err = os.WriteFile(oldPath, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	newPath := path.Join(mntDir, "bar")
-	err = ioutil.WriteFile(newPath, []byte("burrito"), 0600)
+	err = os.WriteFile(newPath, []byte("burrito"), 0600)
 	AssertEq(nil, err)
 
 	// Rename one over the other.
@@ -2631,7 +2630,7 @@ func (t *RenameTest) OverExistingFile() {
 	AssertEq(nil, err)
 
 	// Check the file contents.
-	contents, err := ioutil.ReadFile(newPath)
+	contents, err := os.ReadFile(newPath)
 	AssertEq(nil, err)
 	ExpectEq("taco", string(contents))
 
@@ -2650,7 +2649,7 @@ func (t *RenameTest) OverExisting_WrongType() {
 
 	// Create a file and a directory.
 	filePath := path.Join(mntDir, "foo")
-	err = ioutil.WriteFile(filePath, []byte("taco"), 0400)
+	err = os.WriteFile(filePath, []byte("taco"), 0400)
 	AssertEq(nil, err)
 
 	dirPath := path.Join(mntDir, "bar")

--- a/internal/fs/read_only_test.go
+++ b/internal/fs/read_only_test.go
@@ -15,7 +15,6 @@
 package fs_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -46,7 +45,7 @@ func (t *ReadOnlyTest) SetUpTestSuite() {
 ////////////////////////////////////////////////////////////////////////
 
 func (t *ReadOnlyTest) CreateFile() {
-	err := ioutil.WriteFile(path.Join(mntDir, "foo"), []byte{}, 0700)
+	err := os.WriteFile(path.Join(mntDir, "foo"), []byte{}, 0700)
 	ExpectThat(err, Error(HasSubstr("read-only")))
 }
 

--- a/internal/fs/stress_test.go
+++ b/internal/fs/stress_test.go
@@ -16,7 +16,6 @@ package fs_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -106,7 +105,7 @@ func (t *StressTest) CreateAndReadManyFilesInParallel() {
 	err = forEachName(
 		names,
 		func(n string) (err error) {
-			err = ioutil.WriteFile(path.Join(mntDir, n), []byte(n), 0400)
+			err = os.WriteFile(path.Join(mntDir, n), []byte(n), 0400)
 			return
 		})
 
@@ -116,7 +115,7 @@ func (t *StressTest) CreateAndReadManyFilesInParallel() {
 	err = forEachName(
 		names,
 		func(n string) (err error) {
-			contents, err := ioutil.ReadFile(path.Join(mntDir, n))
+			contents, err := os.ReadFile(path.Join(mntDir, n))
 			if err != nil {
 				err = fmt.Errorf("ReadFile: %w", err)
 				return

--- a/internal/gcsx/append_object_creator_test.go
+++ b/internal/gcsx/append_object_creator_test.go
@@ -17,7 +17,7 @@ package gcsx
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -115,7 +115,7 @@ func (t *AppendObjectCreatorTest) CallsCreateObject() {
 	ExpectTrue(strings.HasPrefix(req.Name, prefix), "Name: %s", req.Name)
 	ExpectThat(req.GenerationPrecondition, Pointee(Equals(0)))
 
-	b, err := ioutil.ReadAll(req.Contents)
+	b, err := io.ReadAll(req.Contents)
 	AssertEq(nil, err)
 	ExpectEq(t.srcContents, string(b))
 }

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -16,7 +16,7 @@ package gcsx_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -87,7 +87,7 @@ func (t *PrefixBucketTest) NewReader() {
 	AssertEq(nil, err)
 	defer rc.Close()
 
-	actual, err := ioutil.ReadAll(rc)
+	actual, err := io.ReadAll(rc)
 	AssertEq(nil, err)
 	ExpectEq(contents, string(actual))
 }

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -17,7 +17,6 @@ package gcsx
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -89,7 +88,7 @@ func (t *FullObjectCreatorTest) CallsCreateObject() {
 	AssertNe(nil, req)
 	ExpectThat(req.GenerationPrecondition, Pointee(Equals(0)))
 
-	b, err := ioutil.ReadAll(req.Contents)
+	b, err := io.ReadAll(req.Contents)
 	AssertEq(nil, err)
 	ExpectEq(t.srcContents, string(b))
 }
@@ -192,7 +191,7 @@ func (oc *fakeObjectCreator) Create(
 	// Record args.
 	oc.srcObject = srcObject
 	oc.mtime = mtime
-	oc.contents, err = ioutil.ReadAll(r)
+	oc.contents, err = io.ReadAll(r)
 	AssertEq(nil, err)
 
 	// Return results.

--- a/internal/gcsx/temp_file_test.go
+++ b/internal/gcsx/temp_file_test.go
@@ -17,7 +17,6 @@ package gcsx_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +41,7 @@ func readAll(rs io.ReadSeeker) (content []byte, err error) {
 		return
 	}
 
-	content, err = ioutil.ReadAll(rs)
+	content, err = io.ReadAll(rs)
 	if err != nil {
 		err = fmt.Errorf("ReadFull: %w", err)
 		return

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -17,7 +17,6 @@ package integration_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -156,7 +155,7 @@ func (t *GcsfuseTest) NonEmptyMountPoint() {
 
 	// Write a file into the mount point.
 	p := path.Join(t.dir, "foo")
-	err = ioutil.WriteFile(p, nil, 0600)
+	err = os.WriteFile(p, nil, 0600)
 	AssertEq(nil, err)
 
 	defer os.Remove(p)
@@ -175,7 +174,7 @@ func (t *GcsfuseTest) MountPointIsAFile() {
 	// Write a file.
 	p := path.Join(t.dir, "foo")
 
-	err = ioutil.WriteFile(p, []byte{}, 0500)
+	err = os.WriteFile(p, []byte{}, 0500)
 	AssertEq(nil, err)
 	defer os.Remove(p)
 
@@ -240,7 +239,7 @@ func (t *GcsfuseTest) CannedContents() {
 	AssertEq(nil, err)
 	ExpectEq(os.FileMode(0644), fi.Mode())
 
-	contents, err := ioutil.ReadFile(path.Join(t.dir, canned.TopLevelFile))
+	contents, err := os.ReadFile(path.Join(t.dir, canned.TopLevelFile))
 	AssertEq(nil, err)
 	ExpectEq(canned.TopLevelFile_Contents, string(contents))
 
@@ -265,7 +264,7 @@ func (t *GcsfuseTest) ReadOnlyMode() {
 	defer util.Unmount(t.dir)
 
 	// Writing to the file system should fail.
-	err = ioutil.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
+	err = os.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
 	ExpectThat(err, Error(HasSubstr("read-only")))
 }
 
@@ -282,10 +281,10 @@ func (t *GcsfuseTest) ReadWriteMode() {
 	// Overwrite the canned file.
 	p := path.Join(t.dir, canned.TopLevelFile)
 
-	err = ioutil.WriteFile(p, []byte("enchilada"), 0400)
+	err = os.WriteFile(p, []byte("enchilada"), 0400)
 	AssertEq(nil, err)
 
-	contents, err := ioutil.ReadFile(p)
+	contents, err := os.ReadFile(p)
 	AssertEq(nil, err)
 	ExpectEq("enchilada", string(contents))
 }

--- a/tools/integration_tests/mounting/mount_helper_test.go
+++ b/tools/integration_tests/mounting/mount_helper_test.go
@@ -16,7 +16,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -66,7 +65,7 @@ func (t *MountHelperTest) SetUp(_ *TestInfo) {
 	}
 
 	// Set up the temporary directory.
-	t.dir, err = ioutil.TempDir("", "mount_helper_test")
+	t.dir, err = os.MkdirTemp("", "mount_helper_test")
 	AssertEq(nil, err)
 }
 
@@ -199,7 +198,7 @@ func (t *MountHelperTest) ReadOnlyMode() {
 	defer util.Unmount(t.dir)
 
 	// Writing to the file system should fail.
-	err = ioutil.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
+	err = os.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
 	ExpectThat(err, Error(HasSubstr("read-only")))
 }
 
@@ -236,7 +235,7 @@ func (t *MountHelperTest) LinuxArgumentOrder() {
 	defer util.Unmount(t.dir)
 
 	// Writing to the file system should fail.
-	err = ioutil.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
+	err = os.WriteFile(path.Join(t.dir, "blah"), []byte{}, 0400)
 	ExpectThat(err, Error(HasSubstr("read-only")))
 }
 

--- a/tools/prefetch_cache_gcsfuse/prefetch.go
+++ b/tools/prefetch_cache_gcsfuse/prefetch.go
@@ -19,8 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -39,10 +39,10 @@ func downloadFile(ctx context.Context, client *storage.Client, object *storage.O
 	// and either resuming the download or discarding and redownloading the file
 	// We may also want to do cleanup if files are created on disk but aren't populated in time
 
-	f, err := ioutil.TempFile(cacheDir, contentcache.CacheFilePrefix)
+	f, err := os.CreateTemp(cacheDir, contentcache.CacheFilePrefix)
 
 	if err != nil {
-		err = fmt.Errorf("ioutil.TempFile: %w", err)
+		err = fmt.Errorf("os.CreateTemp: %w", err)
 		return
 	}
 	defer f.Close()
@@ -67,7 +67,7 @@ func downloadFile(ctx context.Context, client *storage.Client, object *storage.O
 	}
 
 	file, err := json.MarshalIndent(*metadata, "", " ")
-	err = ioutil.WriteFile(fmt.Sprintf("%s.json", f.Name()), file, 0644)
+	err = os.WriteFile(fmt.Sprintf("%s.json", f.Name()), file, 0644)
 	if err != nil {
 		err = fmt.Errorf("downloadFile failed to write metadata: %w", err)
 	}


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
