### PR TITLE
use default logger instead of separate logger for debug_gcs logs [slog PR-3]

### DIFF
--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/canned"
-	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/monitor"
 	"github.com/googlecloudplatform/gcsfuse/internal/ratelimit"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage"
@@ -150,9 +149,7 @@ func setUpRateLimiting(
 func (bm *bucketManager) SetUpGcsBucket(name string) (b gcs.Bucket, err error) {
 	b = bm.storageHandle.BucketHandle(name, bm.config.BillingProject)
 
-	if bm.config.DebugGCS {
-		b = storage.NewDebugBucket(b, logger.NewDebug("gcs: "))
-	}
+	b = storage.NewDebugBucket(b)
 	return
 }
 

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -21,16 +21,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
 
 // Wrap the supplied bucket in a layer that prints debug messages.
 func NewDebugBucket(
-	wrapped gcs.Bucket,
-	logger *log.Logger) (b gcs.Bucket) {
+	wrapped gcs.Bucket) (b gcs.Bucket) {
 	b = &debugBucket{
-		logger:  logger,
 		wrapped: wrapped,
 	}
 
@@ -57,7 +56,7 @@ func (b *debugBucket) requestLogf(
 	id uint64,
 	format string,
 	v ...interface{}) {
-	b.logger.Printf("Req %#16x: %s", id, fmt.Sprintf(format, v...))
+	logger.Tracef("gcs: Req %#16x: %s", id, fmt.Sprintf(format, v...))
 }
 
 func (b *debugBucket) startRequest(


### PR DESCRIPTION
### Description
As we are enabling log-levels, removed debug logger from debug_bucket.go and logged gcs logs as trace logs instead.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
