### PR TITLE
Update architecture in DEBIAN control file while building docker

### DIFF
--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-# RUN git checkout "${BRANCH_NAME}"
+RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+# RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
@@ -60,6 +60,10 @@ RUN mv ${GCSFUSE_BIN}/DEBIAN/copyright ${GCSFUSE_DOC} &&  \
 # Update gcsfuse version in changelog and control file
 RUN sed -i "1s/.*/gcsfuse (${GCSFUSE_VERSION}) stable; urgency=medium/" ${GCSFUSE_DOC}/changelog && \
     sed -i "1s/.*/Version: ${GCSFUSE_VERSION}/" ${GCSFUSE_BIN}/DEBIAN/control
+
+# Update ARCHITECTURE in control file.
+RUN sed -i "6s/.*/Architecture: ${ARCHITECTURE}/" ${GCSFUSE_BIN}/DEBIAN/control
+
 # Compress changelog as required by lintian
 RUN gzip -9 -n ${GCSFUSE_DOC}/changelog
 # Strip unneeded from binaries as required by lintian

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -43,6 +43,10 @@ RUN git checkout "${BRANCH_NAME}"
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
 
 ARG ARCHITECTURE="amd64"
+RUN if [ "${ARCHITECTURE}" != "amd64" ] && [ "${ARCHITECTURE}" != "arm64" ]; then \
+    echo "Architecture should be amd64 or arm64"; \
+    exit 1; \
+fi
 ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_${ARCHITECTURE}"
 ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
 WORKDIR ${GOPATH}


### PR DESCRIPTION
### Description
Updating building package docker file to add architecture in control file
Currently due to [Architecture](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/DEBIAN/control#L6) value all, the deb package gets uploaded on  all the cloud [repos](https://packages.cloud.google.com/apt/dists/gcsfuse-jessie/main)(amd64, arm64)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested locally by building docker image and uploading it on artifact registary.
2. Unit tests - NA
3. Integration tests - NA
