### PR TITLE
use default logger instead of separate debug_mutex logger [slog PR-7]

### DIFF
--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -91,7 +91,7 @@ func (d *debugger) Lock() {
 	d.holder = string(buf)
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
-		logger.Debugf("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
+		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
 	})
 }
 

--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -16,7 +16,6 @@
 package locker
 
 import (
-	"log"
 	"runtime"
 	"sync"
 	"time"
@@ -56,7 +55,6 @@ func New(name string, check func()) Locker {
 		l = &debugger{
 			locker: l,
 			name:   name,
-			logger: logger.NewDebug("debug_mutex"),
 		}
 	}
 
@@ -83,7 +81,6 @@ type debugger struct {
 	name   string
 	holder string
 	timer  *time.Timer
-	logger *log.Logger
 }
 
 func (d *debugger) Lock() {
@@ -94,7 +91,7 @@ func (d *debugger) Lock() {
 	d.holder = string(buf)
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
-		d.logger.Printf("Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
+		logger.Debugf("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
 	})
 }
 


### PR DESCRIPTION
### Description
As we are enabling log-levels, removed debug_mutex logger from locker.go and logged via default logger methods instead.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
