### PR TITLE
use default logger instead of separate logger for exporter logs [slog PR-8]

### DIFF
--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/monitor/tags"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	"go.opencensus.io/plugin/ochttp"
@@ -81,7 +82,7 @@ func recordRequest(ctx context.Context, method string, start time.Time) {
 		requestCount.M(1),
 	); err != nil {
 		// The error should be caused by a bad tag
-		errorLogger.Printf("Cannot record request count: %v", err)
+		logger.Errorf("Cannot record request count: %v", err)
 	}
 
 	latencyUs := time.Since(start).Microseconds()
@@ -94,7 +95,7 @@ func recordRequest(ctx context.Context, method string, start time.Time) {
 		requestLatency.M(latencyMs),
 	); err != nil {
 		// The error should be caused by a bad tag
-		errorLogger.Printf("Cannot record request latency: %v", err)
+		logger.Errorf("Cannot record request latency: %v", err)
 	}
 }
 
@@ -199,7 +200,7 @@ func recordReader(ctx context.Context, ioMethod string) {
 		},
 		readerCount.M(1),
 	); err != nil {
-		errorLogger.Printf("Cannot record a reader %v: %v", ioMethod, err)
+		logger.Errorf("Cannot record a reader %v: %v", ioMethod, err)
 	}
 }
 

--- a/internal/monitor/exporter.go
+++ b/internal/monitor/exporter.go
@@ -16,7 +16,6 @@ package monitor
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -25,14 +24,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"go.opencensus.io/stats/view"
 )
-
-var infoLogger *log.Logger
-var errorLogger *log.Logger
-
-func init() {
-	infoLogger = logger.NewInfo("")
-	errorLogger = logger.NewError("")
-}
 
 var stackdriverExporter *stackdriver.Exporter
 
@@ -47,7 +38,7 @@ func EnableStackdriverExporter(interval time.Duration) error {
 	if stackdriverExporter, err = stackdriver.NewExporter(stackdriver.Options{
 		ReportingInterval: interval,
 		OnError: func(err error) {
-			errorLogger.Printf("Fail to send metric: %v", err)
+			logger.Errorf("Fail to send metric: %v", err)
 		},
 
 		// For a local metric "http_sent_bytes", the Stackdriver metric type
@@ -68,7 +59,7 @@ func EnableStackdriverExporter(interval time.Duration) error {
 		return fmt.Errorf("start stackdriver exporter: %w", err)
 	}
 
-	infoLogger.Printf("Stackdriver exporter started")
+	logger.Info("Stackdriver exporter started")
 	return nil
 }
 
@@ -102,7 +93,7 @@ func EnableOpenTelemetryCollectorExporter(address string) error {
 	}
 
 	view.RegisterExporter(ocExporter)
-	infoLogger.Printf("OpenTelemetry collector exporter started")
+	logger.Info("OpenTelemetry collector exporter started")
 	return nil
 }
 


### PR DESCRIPTION
### Description
As we are enabling log-levels, removed loggers from monitor/exporter.go and monitor/bucket.go and logged via default logger methods instead.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
