### PR TITLE
fix config_file integration test

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -105,6 +105,9 @@ func TestMain(m *testing.M) {
 		WriteConfig: config.WriteConfig{
 			CreateEmptyFile: false,
 		},
+		LogConfig: config.LogConfig{
+			Severity: config.TRACE,
+		},
 	}
 	configFile := setup.YAMLConfigFile(mountConfig)
 	// Set up flags to run tests on.


### PR DESCRIPTION
### Description
integration tests started failing because of empty log severity in config.yaml file. The issue happened because the PRs were submitted in parallel.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran integration tests again
2. Unit tests - NA
3. Integration tests - NA
