### PR TITLE
Unlinked local file should throw IO error

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -989,6 +989,7 @@ func (fs *fileSystem) syncFile(
 	// another user/terminal. Hence, ignoring the syncFile call for local file.
 	if f.IsLocal() && f.IsUnlinked() {
 		// Silently ignore the syncFile call. This is in sync with non-local file behaviour.
+		err = fmt.Errorf("file is unlinked")
 		return
 	}
 

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -20,6 +20,7 @@ package fs_test
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -149,6 +150,12 @@ func (t *LocalFileTest) validateNoFileOrDirError(filename string) {
 	AssertTrue(strings.Contains(err.Error(), "no such file or directory"))
 }
 
+func (t *LocalFileTest) validateIOError(err error) {
+	AssertNe(nil, err)
+	fmt.Println(err.Error())
+	AssertTrue(strings.Contains(err.Error(), "input/output error"))
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
@@ -230,9 +237,11 @@ func (t *LocalFileTest) StatOnUnlinkedLocalFile() {
 	// Stat the local file and validate error.
 	t.validateNoFileOrDirError(FileName)
 
-	// Close the file and validate that file is not created on GCS.
+	// Close the file and validate that
+	// 1. flush file throws IO error
+	// 2. file is not created on GCS.
 	err = t.closeLocalFile(&t.f1)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr(FileName)
 }
 
@@ -576,7 +585,7 @@ func (t *LocalFileTest) TestReadDirContainingUnlinkedLocalFiles() {
 	t.closeFileAndValidateObjectContents(&t.f2, FileName+"2", "")
 	// Verify unlinked file is not written to GCS
 	err = t.closeLocalFile(&t.f3)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr(FileName + "3")
 }
 
@@ -592,7 +601,7 @@ func (t *LocalFileTest) TestUnlinkOfLocalFile() {
 	AssertEq(nil, err)
 	t.validateNoFileOrDirError(FileName)
 	err = t.closeLocalFile(&t.f1)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	// Validate file it is not present on GCS.
 	t.validateObjectNotFoundErr(FileName)
 }
@@ -611,13 +620,13 @@ func (t *LocalFileTest) TestWriteOnUnlinkedLocalFileSucceeds() {
 	AssertEq(nil, err)
 	err = t.closeLocalFile(&t.f1)
 
-	// Validate flush file does not throw error.
-	AssertEq(nil, err)
+	// Validate flush file throws IO error.
+	t.validateIOError(err)
 	// Validate unlinked file is not written to GCS
 	t.validateObjectNotFoundErr(FileName)
 }
 
-func (t *LocalFileTest) TestSyncOnUnlinkedLocalFile() {
+func (t *LocalFileTest) TestSyncOnUnlinkedLocalFileThrowsIOError() {
 	// Create local file.
 	var filepath string
 	filepath, t.f1 = t.createLocalFile(FileName)
@@ -628,13 +637,13 @@ func (t *LocalFileTest) TestSyncOnUnlinkedLocalFile() {
 	// Verify unlink operation succeeds.
 	AssertEq(nil, err)
 	t.validateNoFileOrDirError(FileName)
-	// Validate sync operation does not write to GCS after unlink.
+	// Validate sync operation does not write to GCS after unlink and throws IO error.
 	err = t.f1.Sync()
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr(FileName)
 	// Close the local file and validate it is not present on GCS.
 	err = t.closeLocalFile(&t.f1)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr(FileName)
 }
 
@@ -676,9 +685,9 @@ func (t *LocalFileTest) TestRmDirOfDirectoryContainingGCSAndLocalFiles() {
 	// Validate writing content to unlinked local file does not throw error
 	_, err = t.f1.WriteString(FileContents)
 	AssertEq(nil, err)
-	// Validate flush file does not create object on GCS
+	// Validate flush file throws IO error and does not create object on GCS
 	err = t.closeLocalFile(&t.f1)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr("explicit/" + explicitLocalFileName)
 	// Validate synced files are also deleted.
 	t.validateObjectNotFoundErr("explicit/foo")
@@ -702,10 +711,10 @@ func (t *LocalFileTest) TestRmDirOfDirectoryContainingOnlyLocalFiles() {
 	t.validateNoFileOrDirError("explicit")
 	// Close the local files and validate they are not present on GCS.
 	err = t.closeLocalFile(&t.f1)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr("explicit/" + explicitLocalFileName)
 	err = t.closeLocalFile(&t.f2)
-	AssertEq(nil, err)
+	t.validateIOError(err)
 	t.validateObjectNotFoundErr("explicit/" + FileName)
 	// Validate directory is also deleted.
 	t.validateObjectNotFoundErr("explicit/")

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -20,7 +20,6 @@ package fs_test
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -152,7 +151,6 @@ func (t *LocalFileTest) validateNoFileOrDirError(filename string) {
 
 func (t *LocalFileTest) validateIOError(err error) {
 	AssertNe(nil, err)
-	fmt.Println(err.Error())
 	AssertTrue(strings.Contains(err.Error(), "input/output error"))
 }
 


### PR DESCRIPTION
### Description
Throw IO error during sync or flush file calls when a local file is unlinked.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that IO error is thrown.
Logs:
```
D0907 13:29:04.384908 fuse_debug: Op 0x00000194        connection.go:416] <- FlushFile (inode 3, PID 1949237)
E0907 13:29:04.385009 FlushFile: input/output error, file is unlinked
D0907 13:29:04.385058 fuse_debug: Op 0x00000194        connection.go:500] -> Error: "input/output error"
E0907 13:29:04.385074 fuse: *fuseops.FlushFileOp error: input/output error
```
2. Unit tests - Updated
3. Integration tests - NA
