### PR TITLE
[execute-integration-tests]Fixing mtime for empty local files synced to GCS

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -636,6 +636,8 @@ func (f *FileInode) CreateEmptyTempFile() (err error) {
 	// Creating a file with no contents. The contents will be updated with
 	// writeFile operations.
 	f.content, err = f.contentCache.NewTempFile(io.NopCloser(strings.NewReader("")))
+	// Setting the initial mtime to creation time.
+	f.content.SetMtime(f.mtimeClock.Now())
 	return
 }
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -47,6 +47,7 @@ const gid = 456
 const fileInodeID = 17
 const fileName = "foo/bar"
 const fileMode os.FileMode = 0641
+const Delta = 30 * time.Minute
 
 type FileTest struct {
 	ctx    context.Context
@@ -456,7 +457,7 @@ func (t *FileTest) SyncEmptyLocalFile() {
 	mtimeInBucket, ok := o.Metadata["gcsfuse_mtime"]
 	AssertTrue(ok)
 	mtime, _ := time.Parse(time.RFC3339Nano, mtimeInBucket)
-	ExpectThat(mtime, timeutil.TimeNear(creationTime, 30*time.Minute))
+	ExpectThat(mtime, timeutil.TimeNear(creationTime, Delta))
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	AssertEq(nil, err)
@@ -838,7 +839,7 @@ func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
 	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, 30*time.Minute))
+	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -44,6 +44,7 @@ const FileName2 = "foo2"
 const implicitLocalFileName = "implicitLocalFile"
 const explicitLocalFileName = "explicitLocalFile"
 const FileContents = "teststring"
+const Delta = 30 * time.Minute
 
 type LocalFileTest struct {
 	// fsTest has f1 *osFile and f2 *osFile which we will reuse here.
@@ -803,8 +804,8 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 
 	// Check if mtime is returned correctly for unsynced file.
 	_, _, mtime := fusetesting.GetTimes(fi)
-	const delta = 30 * time.Minute
-	ExpectThat(mtime, timeutil.TimeNear(createTime, delta))
+
+	ExpectThat(mtime, timeutil.TimeNear(createTime, Delta))
 
 	// Write some contents.
 	_, err = t.f1.Write([]byte("test contents"))
@@ -816,7 +817,7 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 
 	// We require only that atime and ctime be "reasonable".
 	atime, ctime, mtime := fusetesting.GetTimes(fi)
-	ExpectThat(mtime, timeutil.TimeNear(createTime, delta))
-	ExpectThat(atime, timeutil.TimeNear(createTime, delta))
-	ExpectThat(ctime, timeutil.TimeNear(createTime, delta))
+	ExpectThat(mtime, timeutil.TimeNear(createTime, Delta))
+	ExpectThat(atime, timeutil.TimeNear(createTime, Delta))
+	ExpectThat(ctime, timeutil.TimeNear(createTime, Delta))
 }


### PR DESCRIPTION
### Description
Any modification to the file will result in a setInodeAttributes call to GCSFuse to update mtime. But when a file is created and synced without writing any content, then mtime is not set. Fixing it by setting mtime on file when it is created.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually by mounting.
3. Unit tests - NA
4. Integration tests - NA
