### PR TITLE
Print stack-trace on crash

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"log/syslog"
 	"os"
+	"runtime/debug"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/config"
 )
@@ -155,6 +156,7 @@ func Errorf(format string, v ...interface{}) {
 // Fatal prints an error log and exits with non-zero exit code.
 func Fatal(format string, v ...interface{}) {
 	Errorf(format, v...)
+	Errorf(string(debug.Stack()))
 	os.Exit(1)
 }
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"testing"
@@ -259,6 +260,7 @@ func SetUpTestDirForTestBucketFlag() {
 
 func LogAndExit(s string) {
 	log.Print(s)
+	log.Print(string(debug.Stack()))
 	os.Exit(1)
 }
 


### PR DESCRIPTION
It prints stack-trace whenever logger.Fatalf(...) is called in gcsfuse runtime or LogAndExit is called in the integration tests.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. **Manual** - For testing, an intentional panic needs to be generated in the gcsfuse code, or a LogAndExit call in integration tests. These were not easy, so, I have tested this by manually inserting these calls in the code (code changes parked in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1379 ).

   Log differences
   1. **Panic during gcsfuse runtime**: For testing this, a panic was intentionally inserted during mount whenever a non-empty `--temp-dir` argument was passed (code changes for testing in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1379).
     A. **Before/Without this change**
```
# On a VM with gcsfuse installed with master branch.
$ gcsfuse --temp-dir=abc --log-file=$log $bucket $mntdir ; tail -n 15 $log

{"time":"15/09/2023 10:26:13.035522","severity":"INFO","msg":"Start gcsfuse/unknown (Go version go1.21.0) for app \"\" using mount point: /home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\n"}
daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithStorageHandle: Error writing to temporary directory ("TempFile: open abc/gcsfuse1938049085: no such file or directory"); are you sure it exists with the correct permissions?
{"time":{"timestampSeconds":1694773573,"timestampNanos":1694773573052247839},"severity":"INFO","msg":"Start gcsfuse/unknown (Go version go1.21.0) for app \"\" using mount point: /home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\n"}
{"time":{"timestampSeconds":1694773573,"timestampNanos":1694773573052292169},"severity":"INFO","msg":"Creating Storage handle..."}
{"time":{"timestampSeconds":1694773573,"timestampNanos":1694773573052612253},"severity":"INFO","msg":"Creating a mount at \"/home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\"\n"}
{"time":{"timestampSeconds":1694773573,"timestampNanos":1694773573052624188},"severity":"INFO","msg":"Creating a temporary directory at \"abc\"\n"}
{"time":{"timestampSeconds":1694773573,"timestampNanos":1694773573052830676},"severity":"ERROR","msg":"Error while mounting gcsfuse: mountWithStorageHandle: Error writing to temporary directory (\"TempFile: open abc/gcsfuse1938049085: no such file or directory\"); are you sure it exists with the correct permissions?\n"}
```

     B. **After/With this change** 
See difference in last line of log. The error log differs here, because here I am purposefully causing a panic during mounting when `--temp-dir` is passed as non-empty.

```
# On a VM with gcsfuse .deb package installed built with this branch.
$ gcsfuse --temp-dir=abc --log-file=$log $bucket $mntdir ; tail -n 15 $log

{"time":"15/09/2023 10:20:02.195397","severity":"INFO","msg":"Start gcsfuse/1.1.0-test4 (Go version go1.21.0) for app \"\" using mount point: /home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\n"}
daemonize.Run: readFromProcess: Decode: EOF
{"time":{"timestampSeconds":1694773202,"timestampNanos":1694773202216492774},"severity":"INFO","msg":"Start gcsfuse/1.1.0-test4 (Go version go1.21.0) for app \"\" using mount point: /home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\n"}
{"time":{"timestampSeconds":1694773202,"timestampNanos":1694773202216603436},"severity":"INFO","msg":"Creating Storage handle..."}
{"time":{"timestampSeconds":1694773202,"timestampNanos":1694773202217573778},"severity":"INFO","msg":"Creating a mount at \"/home/gargnitin_google_com/work/gcsfuse/test-buckets/gargnitin-fuse-test-bucket1-mount\"\n"}
{"time":{"timestampSeconds":1694773202,"timestampNanos":1694773202217612550},"severity":"ERROR","msg":"Panic: --temp-dir not really supported in this this particular version of gcsfuse"}
{"time":{"timestampSeconds":1694773202,"timestampNanos":1694773202218394419},"severity":"ERROR","msg":"goroutine 1 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x5e\ngithub.com/googlecloudplatform/gcsfuse/internal/logger.Fatal({0xf28e9b?, 0x40000000000?}, {0xc0006e3320?, 0xc0006e3380?, 0x439405?})\n\t/go/src/github.com/googlecloudplatform/gcsfuse/internal/logger/logger.go:159 +0x25\nmain.handlePanicWhileMounting()\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:375 +0x4b\npanic({0xd56d00?, 0x12aa690?})\n\t/usr/local/go/src/runtime/panic.go:914 +0x21f\nmain.mountWithStorageHandle({0x12b9af8?, 0x1a14980?}, {0x7ffca86cae74?, 0xc0006e36d8?}, {0x7ffca86cae90?, 0xc0006f0780?}, 0x12b9af8?, 0x1a14980?, {0x12acec0, 0xc000612200})\n\t/go/src/github.com/googlecloudplatform/gcsfuse/mount.go:48 +0x665\nmain.mountWithArgs({0x7ffca86cae74, 0x1b}, {0x7ffca86cae90, 0x56}, 0xc0006f2000, 0x4?)\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:138 +0x1e5\nmain.runCLIApp(0xc0006e38a0?)\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:318 +0x111e\nmain.run.func1(0x1?)\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:357 +0x1c\ngithub.com/urfave/cli.HandleAction({0xd59540?, 0xc000230490?}, 0xc0006e4000?)\n\t/tmp/build_gcsfuse_gopath3746746056/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:526 +0x75\ngithub.com/urfave/cli.(*App).Run(0xc0006e4000, {0xc000134120, 0x6, 0x6})\n\t/tmp/build_gcsfuse_gopath3746746056/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:286 +0x745\nmain.run()\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:361 +0xbb\nmain.main()\n\t/go/src/github.com/googlecloudplatform/gcsfuse/main.go:390 +0x5c\n"}
```

   2. **LogAndExit during integration test runs**: For this, a LogAndExit call was intentionally inserted in gzip tests and gzip tests were run (code change for testing in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1379).
     A. **Before/Without this change**

```
$ GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/gzip/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
2023/09/15 09:56:45 Exited as planned!
FAIL	github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip	0.021s
?   	github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip/helpers	[no test files]
FAIL
```

     B. **After/With this change**

Notice the additional stack print.

```
$ GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/gzip/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
2023/09/15 09:57:01 Exited as planned!
2023/09/15 09:57:01 goroutine 1 [running]:
runtime/debug.Stack()
	/usr/lib/google-golang/src/runtime/debug/stack.go:24 +0x5e
github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup.LogAndExit({0xcfff0a?, 0xd0715a?})
	/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/src/gcsfuse/tools/integration_tests/util/setup/setup.go:263 +0x8a
github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip_test.TestMain(0xc000706500)
	/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/src/gcsfuse/tools/integration_tests/gzip/gzip_test.go:188 +0x1c5
main.main()
	_testmain.go:77 +0x1d0
FAIL	github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip	0.024s
?   	github.com/googlecloudplatform/gcsfuse/tools/integration_tests/gzip/helpers	[no test files]
FAIL
```

2. Unit tests - NA

4. Integration tests - NA
