### PR TITLE
fix log-format flag behaviour

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -32,9 +32,8 @@ type MountConfig struct {
 func NewMountConfig() *MountConfig {
 	mountConfig := &MountConfig{}
 	mountConfig.LogConfig = LogConfig{
-		// Making the default severity as INFO and format as json.
+		// Making the default severity as INFO.
 		Severity: INFO,
-		Format:   "json",
 	}
 	return mountConfig
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -32,7 +32,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertNe(nil, mountConfig)
 	AssertEq(false, mountConfig.CreateEmptyFile)
 	AssertEq("INFO", mountConfig.LogConfig.Severity)
-	AssertEq("json", mountConfig.LogConfig.Format)
+	AssertEq("", mountConfig.LogConfig.Format)
 	AssertEq("", mountConfig.LogConfig.FilePath)
 }
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -176,10 +176,10 @@ func (f *loggerFactory) newLogger(level config.LogSeverity) *slog.Logger {
 }
 
 func (f *loggerFactory) createJsonOrTextHandler(writer io.Writer, levelVar *slog.LevelVar, prefix string) slog.Handler {
-	if f.format == "json" {
-		return slog.NewJSONHandler(writer, getHandlerOptions(levelVar, prefix, f.format))
+	if f.format == "text" {
+		return slog.NewTextHandler(writer, getHandlerOptions(levelVar, prefix, f.format))
 	}
-	return slog.NewTextHandler(writer, getHandlerOptions(levelVar, prefix, f.format))
+	return slog.NewJSONHandler(writer, getHandlerOptions(levelVar, prefix, f.format))
 }
 
 func (f *loggerFactory) handler(levelVar *slog.LevelVar, prefix string) slog.Handler {


### PR DESCRIPTION
### Description
Earlier we were assigning default value to log-format as JSON (also the default value of flag) in the config file. 
The config file value takes precedence when both flag and config are set. Due to this the log-format flag stopped working as we were overriding with config value always. 

Fix: do not assign default value. If nothing is set, override with flag. Later on when we deprecate log-format flag, the format value will be empty. In this case, the default behaviour will remain JSON as when format is not text, we return JSON handler.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - 
When log-format flag is used without config
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --log-format=text ashmeen-bucket-1 ~/Documents/mnt
time="14/09/2023 09:54:53.155826" severity=INFO msg="Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt\n"
time="14/09/2023 09:54:53.155847" severity=INFO msg="Creating Storage handle..."
time="14/09/2023 09:54:53.156158" severity=INFO msg="Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt\"\n"

```
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --log-format=json ashmeen-bucket-1 ~/Documents/mnt2
{"time":{"timestampSeconds":1694685313,"timestampNanos":1694685313586814399},"severity":"INFO","msg":"Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt2\n"}
{"time":{"timestampSeconds":1694685313,"timestampNanos":1694685313586855799},"severity":"INFO","msg":"Creating Storage handle..."}
{"time":{"timestampSeconds":1694685313,"timestampNanos":1694685313587353759},"severity":"INFO","msg":"Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt2\"\n"}

```
When config is used without flag
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --config-file=~/Documents/config.yaml  ashmeen-bucket-1 ~/Documents/mnt4
{"time":"14/09/2023 09:58:09.704515","severity":"INFO","msg":"Value of [config-file] resolved from [~/Documents/config.yaml] to [/usr/local/google/home/ashmeen/Documents/config.yaml]\n"}
time="14/09/2023 09:58:09.704612" severity=INFO msg="Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt4\n"
time="14/09/2023 09:58:09.704633" severity=INFO msg="Creating Storage handle..."
time="14/09/2023 09:58:09.706468" severity=INFO msg="Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt4\"\n"
time="14/09/2023 09:58:09.706517" severity=INFO msg="Creating a new server...\n"

```
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --config-file=~/Documents/config.yaml  --log-format=json ashmeen-bucket-1 ~/Documents/mnt4
{"time":"14/09/2023 10:00:05.919857","severity":"INFO","msg":"Value of [config-file] resolved from [~/Documents/config.yaml] to [/usr/local/google/home/ashmeen/Documents/config.yaml]\n"}
{"time":{"timestampSeconds":1694685605,"timestampNanos":1694685605919946641},"severity":"INFO","msg":"Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt4\n"}
{"time":{"timestampSeconds":1694685605,"timestampNanos":1694685605919968751},"severity":"INFO","msg":"Creating Storage handle..."}
{"time":{"timestampSeconds":1694685605,"timestampNanos":1694685605920205091},"severity":"INFO","msg":"Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt4\"\n"}
{"time":{"timestampSeconds":1694685605,"timestampNanos":1694685605920225561},"severity":"INFO","msg":"Creating a new server...\n"}
{"time":{"timestampSeconds":1694685605,"timestampNanos":1694685605920231531},"severity":"INFO","msg":"Set up root directory for bucket ashmeen-bucket-1"}
```


When both flag and config are used 
1. not set in config file, text in flag
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --config-file=~/Documents/config.yaml --log-format=text  ashmeen-bucket-1 ~/Documents/mnt4
{"time":"14/09/2023 10:11:52.730576","severity":"INFO","msg":"Value of [config-file] resolved from [~/Documents/config.yaml] to [/usr/local/google/home/ashmeen/Documents/config.yaml]\n"}
time="14/09/2023 10:11:52.730761" severity=INFO msg="Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt4\n"
time="14/09/2023 10:11:52.730784" severity=INFO msg="Creating Storage handle..."
time="14/09/2023 10:11:52.731019" severity=INFO msg="Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt4\"\n"
time="14/09/2023 10:11:52.731041" severity=INFO msg="Creating a new server...\n"
time="14/09/2023 10:11:52.731048" severity=INFO msg="Set up root directory for bucket ashmeen-bucket-1"
```
2. text in config file, json in flag
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground --config-file=~/Documents/config.yaml --log-format=json ashmeen-bucket-1 ~/Documents/mnt4
{"time":"14/09/2023 10:13:38.954182","severity":"INFO","msg":"Value of [config-file] resolved from [~/Documents/config.yaml] to [/usr/local/google/home/ashmeen/Documents/config.yaml]\n"}
time="14/09/2023 10:13:38.954892" severity=INFO msg="Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt4\n"
time="14/09/2023 10:13:38.954922" severity=INFO msg="Creating Storage handle..."
time="14/09/2023 10:13:38.955247" severity=INFO msg="Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt4\"\n"
time="14/09/2023 10:13:38.955269" severity=INFO msg="Creating a new server...\n"
time="14/09/2023 10:13:38.955276" severity=INFO msg="Set up root directory for bucket ashmeen-bucket-1"
time="14/09/2023 10:13:39.285490" severity=INFO msg="Mounting file system \"ashmeen-bucket-1\"..."

```

When neither are used
```
ashmeen@ashmeen:~/gcsfuse$ go run ./ --foreground ashmeen-bucket-1 ~/Documents/mnt3
{"time":{"timestampSeconds":1694685320,"timestampNanos":1694685320331761749},"severity":"INFO","msg":"Start gcsfuse/unknown (Go version go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/ashmeen/Documents/mnt3\n"}
{"time":{"timestampSeconds":1694685320,"timestampNanos":1694685320331793439},"severity":"INFO","msg":"Creating Storage handle..."}
{"time":{"timestampSeconds":1694685320,"timestampNanos":1694685320332247669},"severity":"INFO","msg":"Creating a mount at \"/usr/local/google/home/ashmeen/Documents/mnt3\"\n"}
{"time":{"timestampSeconds":1694685320,"timestampNanos":1694685320332272569},"severity":"INFO","msg":"Creating a new server...\n"}
{"time":{"timestampSeconds":1694685320,"timestampNanos":1694685320332282639},"severity":"INFO","msg":"Set up root directory for bucket ashmeen-bucket-1"}
```
2. Unit tests - Modified
3. Integration tests - NA
