### PR TITLE
[ready for review] local file tests with implicit dir flag

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -16,13 +16,19 @@
 package explicit_dir_test
 
 import (
+	"os"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 )
 
 func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
 	flags := [][]string{{"--implicit-dirs=false"}}
 
-	implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
+	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
+
+	os.Exit(successCode)
 }

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -15,30 +15,19 @@ package implicit_dir_test
 
 import (
 	"io/fs"
-	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	. "github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"golang.org/x/net/context"
 )
 
 const (
-	FileName1         = "foo1"
-	FileName2         = "foo2"
-	ImplicitDirName   = "implicit"
-	ImplicitFileName1 = "implicitFile1"
-	ExplicitDirName   = "explicit"
-	ExplicitFileName1 = "explicitFile1"
-	FilePerms         = 0644
-	FileContents      = "teststring"
-	ReadSize          = 1024
-	testDirName       = "ImplicitDirTest"
+	testDirName = "ImplicitDirTest"
 )
 
 var (
@@ -48,76 +37,29 @@ var (
 )
 
 // //////////////////////////////////////////////////////////////////////
-// Helpers
-// //////////////////////////////////////////////////////////////////////
-
-func createImplicitDir(t *testing.T) {
-	err := client.CreateObjectOnGCS(
-		storageClient,
-		path.Join(testDirName, ImplicitDirName, ImplicitFileName1),
-		FileContents,
-		ctx)
-	if err != nil {
-		t.Errorf("Error while creating implicit directory, err: %v", err)
-	}
-}
-
-func validateObjectNotFoundErrOnGCS(fileName string, t *testing.T) {
-	_, err := client.ReadObjectFromGCS(storageClient, path.Join(testDirName, fileName), ReadSize, ctx)
-	if err == nil || !strings.Contains(err.Error(), "storage: object doesn't exist") {
-		t.Fatalf("Incorrect error returned from GCS for file %s: %v", fileName, err)
-	}
-}
-
-func validateObjectContentsFromGCS(fileName string, expectedContent string, t *testing.T) {
-	gotContent, err := client.ReadObjectFromGCS(storageClient, path.Join(testDirName, fileName), ReadSize, ctx)
-	if err != nil {
-		t.Fatalf("Error while reading synced local file from GCS, Err: %v", err)
-	}
-
-	if expectedContent != gotContent {
-		t.Fatalf("GCS file %s content mismatch. Got: %s, Expected: %s ", fileName, gotContent, expectedContent)
-	}
-}
-
-func closeFileAndValidateContentFromGCS(fh *os.File, fileName, content string, t *testing.T) {
-	operations.CloseFileShouldNotThrowError(fh, t)
-	validateObjectContentsFromGCS(fileName, content, t)
-}
-
-func createLocalFile(filePath, fileName string, t *testing.T) (fh *os.File) {
-	fh = operations.CreateFile(filePath, FilePerms, t)
-	validateObjectNotFoundErrOnGCS(fileName, t)
-	return
-}
-
-// //////////////////////////////////////////////////////////////////////
 // Tests
 // //////////////////////////////////////////////////////////////////////
 
 func TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose(t *testing.T) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
-	createImplicitDir(t)
+	CreateImplicitDir(ctx, storageClient, testDirName, t)
 	fileName := path.Join(ImplicitDirName, FileName1)
-	filePath := path.Join(testDirPath, fileName)
 
-	fh := createLocalFile(filePath, fileName, t)
+	fh := CreateLocalFile(ctx, storageClient, testDirPath, fileName, t)
 	operations.WriteWithoutClose(fh, FileContents, t)
-	validateObjectNotFoundErrOnGCS(fileName, t)
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
 
 	// Validate.
-	closeFileAndValidateContentFromGCS(fh, fileName, FileContents, t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh, fileName, FileContents, t)
 }
 
 func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
-	createImplicitDir(t)
+	CreateImplicitDir(ctx, storageClient, testDirName, t)
 	fileName1 := path.Join(ImplicitDirName, FileName1)
 	fileName2 := path.Join(ImplicitDirName, FileName2)
-	filePath1 := path.Join(testDirPath, fileName1)
-	filePath2 := path.Join(testDirPath, fileName2)
-	fh1 := createLocalFile(filePath1, fileName1, t)
-	fh2 := createLocalFile(filePath2, fileName2, t)
+	fh1 := CreateLocalFile(ctx, storageClient, testDirPath, fileName1, t)
+	fh2 := CreateLocalFile(ctx, storageClient, testDirPath, fileName2, t)
 
 	// Attempt to list implicit directory.
 	entries := operations.ReadDirectory(path.Join(testDirPath, ImplicitDirName), t)
@@ -126,10 +68,10 @@ func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
 	operations.VerifyCountOfDirectoryEntries(3, len(entries), t)
 	operations.VerifyFileEntry(entries[0], FileName1, 0, t)
 	operations.VerifyFileEntry(entries[1], FileName2, 0, t)
-	operations.VerifyFileEntry(entries[2], ImplicitFileName1, 10, t)
+	operations.VerifyFileEntry(entries[2], ImplicitFileName1, ImplicitFileSize, t)
 	// Close the local files.
-	closeFileAndValidateContentFromGCS(fh1, fileName1, "", t)
-	closeFileAndValidateContentFromGCS(fh2, fileName2, "", t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh1, fileName1, "", t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh2, fileName2, "", t)
 }
 
 func TestRecursiveListingWithLocalFiles(t *testing.T) {
@@ -143,21 +85,16 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 	// mntDir/implicit/implicitFile1	--- file
 
 	testDirPath = setup.SetupTestDirectory(testDirName)
-
 	fileName2 := path.Join(ExplicitDirName, ExplicitFileName1)
 	fileName3 := path.Join(ImplicitDirName, FileName2)
-	filePath1 := path.Join(testDirPath, FileName1)
-	filePath2 := path.Join(testDirPath, fileName2)
-	filePath3 := path.Join(testDirPath, fileName3)
-
 	// Create local file in mnt/ dir.
-	fh1 := createLocalFile(filePath1, FileName1, t)
+	fh1 := CreateLocalFile(ctx, storageClient, testDirPath, FileName1, t)
 	// Create explicit dir with 1 local file.
 	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
-	fh2 := createLocalFile(filePath2, fileName2, t)
+	fh2 := CreateLocalFile(ctx, storageClient, testDirPath, fileName2, t)
 	// Create implicit dir with 1 local file1 and 1 synced file.
-	createImplicitDir(t)
-	fh3 := createLocalFile(filePath3, fileName3, t)
+	CreateImplicitDir(ctx, storageClient, testDirName, t)
+	fh3 := CreateLocalFile(ctx, storageClient, testDirPath, fileName3, t)
 
 	// Recursively list mntDir/ directory.
 	err := filepath.WalkDir(testDirPath,
@@ -193,7 +130,7 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 				// numberOfObjects = 2
 				operations.VerifyCountOfDirectoryEntries(2, len(objs), t)
 				operations.VerifyFileEntry(objs[0], FileName2, 0, t)
-				operations.VerifyFileEntry(objs[1], ImplicitFileName1, 10, t)
+				operations.VerifyFileEntry(objs[1], ImplicitFileName1, ImplicitFileSize, t)
 			}
 			return nil
 		})
@@ -202,7 +139,7 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 	if err != nil {
 		t.Errorf("filepath.WalkDir() err: %v", err)
 	}
-	closeFileAndValidateContentFromGCS(fh1, FileName1, "", t)
-	closeFileAndValidateContentFromGCS(fh2, fileName2, "", t)
-	closeFileAndValidateContentFromGCS(fh3, fileName3, "", t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh1, FileName1, "", t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh2, fileName2, "", t)
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, testDirName, fh3, fileName3, "", t)
 }

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -1,0 +1,208 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package implicit_dir_test
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+	"golang.org/x/net/context"
+)
+
+const (
+	FileName1         = "foo1"
+	FileName2         = "foo2"
+	ImplicitDirName   = "implicit"
+	ImplicitFileName1 = "implicitFile1"
+	ExplicitDirName   = "explicit"
+	ExplicitFileName1 = "explicitFile1"
+	FilePerms         = 0644
+	FileContents      = "teststring"
+	ReadSize          = 1024
+	testDirName       = "ImplicitDirTest"
+)
+
+var (
+	testDirPath   string
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+
+func createImplicitDir(t *testing.T) {
+	err := client.CreateObjectOnGCS(
+		storageClient,
+		path.Join(testDirName, ImplicitDirName, ImplicitFileName1),
+		FileContents,
+		ctx)
+	if err != nil {
+		t.Errorf("Error while creating implicit directory, err: %v", err)
+	}
+}
+
+func validateObjectNotFoundErrOnGCS(fileName string, t *testing.T) {
+	_, err := client.ReadObjectFromGCS(storageClient, path.Join(testDirName, fileName), ReadSize, ctx)
+	if err == nil || !strings.Contains(err.Error(), "storage: object doesn't exist") {
+		t.Fatalf("Incorrect error returned from GCS for file %s: %v", fileName, err)
+	}
+}
+
+func validateObjectContentsFromGCS(fileName string, expectedContent string, t *testing.T) {
+	gotContent, err := client.ReadObjectFromGCS(storageClient, path.Join(testDirName, fileName), ReadSize, ctx)
+	if err != nil {
+		t.Fatalf("Error while reading synced local file from GCS, Err: %v", err)
+	}
+
+	if expectedContent != gotContent {
+		t.Fatalf("GCS file %s content mismatch. Got: %s, Expected: %s ", fileName, gotContent, expectedContent)
+	}
+}
+
+func closeFileAndValidateContentFromGCS(fh *os.File, fileName, content string, t *testing.T) {
+	operations.CloseFileShouldNotThrowError(fh, t)
+	validateObjectContentsFromGCS(fileName, content, t)
+}
+
+func createLocalFile(filePath, fileName string, t *testing.T) (fh *os.File) {
+	fh = operations.CreateFile(filePath, FilePerms, t)
+	validateObjectNotFoundErrOnGCS(fileName, t)
+	return
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Tests
+// //////////////////////////////////////////////////////////////////////
+
+func TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	createImplicitDir(t)
+	fileName := path.Join(ImplicitDirName, FileName1)
+	filePath := path.Join(testDirPath, fileName)
+
+	fh := createLocalFile(filePath, fileName, t)
+	operations.WriteWithoutClose(fh, FileContents, t)
+	validateObjectNotFoundErrOnGCS(fileName, t)
+
+	// Validate.
+	closeFileAndValidateContentFromGCS(fh, fileName, FileContents, t)
+}
+
+func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	createImplicitDir(t)
+	fileName1 := path.Join(ImplicitDirName, FileName1)
+	fileName2 := path.Join(ImplicitDirName, FileName2)
+	filePath1 := path.Join(testDirPath, fileName1)
+	filePath2 := path.Join(testDirPath, fileName2)
+	fh1 := createLocalFile(filePath1, fileName1, t)
+	fh2 := createLocalFile(filePath2, fileName2, t)
+
+	// Attempt to list implicit directory.
+	entries := operations.ReadDirectory(path.Join(testDirPath, ImplicitDirName), t)
+
+	// Verify entries received successfully.
+	operations.VerifyCountOfDirectoryEntries(3, len(entries), t)
+	operations.VerifyFileEntry(entries[0], FileName1, 0, t)
+	operations.VerifyFileEntry(entries[1], FileName2, 0, t)
+	operations.VerifyFileEntry(entries[2], ImplicitFileName1, 10, t)
+	// Close the local files.
+	closeFileAndValidateContentFromGCS(fh1, fileName1, "", t)
+	closeFileAndValidateContentFromGCS(fh2, fileName2, "", t)
+}
+
+func TestRecursiveListingWithLocalFiles(t *testing.T) {
+	// Structure
+	// mntDir/
+	// mntDir/foo1 										--- file
+	// mntDir/explicit/		    				--- directory
+	// mntDir/explicit/explicitFile1  --- file
+	// mntDir/implicit/ 							--- directory
+	// mntDir/implicit/foo2  					--- file
+	// mntDir/implicit/implicitFile1	--- file
+
+	testDirPath = setup.SetupTestDirectory(testDirName)
+
+	fileName2 := path.Join(ExplicitDirName, ExplicitFileName1)
+	fileName3 := path.Join(ImplicitDirName, FileName2)
+	filePath1 := path.Join(testDirPath, FileName1)
+	filePath2 := path.Join(testDirPath, fileName2)
+	filePath3 := path.Join(testDirPath, fileName3)
+
+	// Create local file in mnt/ dir.
+	fh1 := createLocalFile(filePath1, FileName1, t)
+	// Create explicit dir with 1 local file.
+	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
+	fh2 := createLocalFile(filePath2, fileName2, t)
+	// Create implicit dir with 1 local file1 and 1 synced file.
+	createImplicitDir(t)
+	fh3 := createLocalFile(filePath3, fileName3, t)
+
+	// Recursively list mntDir/ directory.
+	err := filepath.WalkDir(testDirPath,
+		func(walkPath string, dir fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			// The object type is not directory.
+			if !dir.IsDir() {
+				return nil
+			}
+
+			objs := operations.ReadDirectory(walkPath, t)
+
+			// Check if mntDir has correct objects.
+			if walkPath == setup.MntDir() {
+				// numberOfObjects = 3
+				operations.VerifyCountOfDirectoryEntries(3, len(objs), t)
+				operations.VerifyDirectoryEntry(objs[0], ExplicitDirName, t)
+				operations.VerifyFileEntry(objs[1], FileName1, 0, t)
+				operations.VerifyDirectoryEntry(objs[2], ImplicitDirName, t)
+			}
+
+			// Check if mntDir/explicitFoo/ has correct objects.
+			if walkPath == path.Join(testDirPath, ExplicitDirName) {
+				// numberOfObjects = 1
+				operations.VerifyCountOfDirectoryEntries(1, len(objs), t)
+				operations.VerifyFileEntry(objs[0], ExplicitFileName1, 0, t)
+			}
+
+			// Check if mntDir/implicitFoo/ has correct objects.
+			if walkPath == path.Join(testDirPath, ImplicitDirName) {
+				// numberOfObjects = 2
+				operations.VerifyCountOfDirectoryEntries(2, len(objs), t)
+				operations.VerifyFileEntry(objs[0], FileName2, 0, t)
+				operations.VerifyFileEntry(objs[1], ImplicitFileName1, 10, t)
+			}
+			return nil
+		})
+
+	// Validate and close the files.
+	if err != nil {
+		t.Errorf("filepath.WalkDir() err: %v", err)
+	}
+	closeFileAndValidateContentFromGCS(fh1, FileName1, "", t)
+	closeFileAndValidateContentFromGCS(fh2, fileName2, "", t)
+	closeFileAndValidateContentFromGCS(fh3, fileName3, "", t)
+}

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -45,7 +45,7 @@ func TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose(t *testin
 	CreateImplicitDir(ctx, storageClient, testDirName, t)
 	fileName := path.Join(ImplicitDirName, FileName1)
 
-	fh := CreateLocalFile(ctx, storageClient, testDirPath, fileName, t)
+	fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName, t)
 	operations.WriteWithoutClose(fh, FileContents, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
 
@@ -58,8 +58,8 @@ func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
 	CreateImplicitDir(ctx, storageClient, testDirName, t)
 	fileName1 := path.Join(ImplicitDirName, FileName1)
 	fileName2 := path.Join(ImplicitDirName, FileName2)
-	fh1 := CreateLocalFile(ctx, storageClient, testDirPath, fileName1, t)
-	fh2 := CreateLocalFile(ctx, storageClient, testDirPath, fileName2, t)
+	fh1 := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName1, t)
+	fh2 := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName2, t)
 
 	// Attempt to list implicit directory.
 	entries := operations.ReadDirectory(path.Join(testDirPath, ImplicitDirName), t)
@@ -88,13 +88,13 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 	fileName2 := path.Join(ExplicitDirName, ExplicitFileName1)
 	fileName3 := path.Join(ImplicitDirName, FileName2)
 	// Create local file in mnt/ dir.
-	fh1 := CreateLocalFile(ctx, storageClient, testDirPath, FileName1, t)
+	fh1 := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
 	// Create explicit dir with 1 local file.
 	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
-	fh2 := CreateLocalFile(ctx, storageClient, testDirPath, fileName2, t)
+	fh2 := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName2, t)
 	// Create implicit dir with 1 local file1 and 1 synced file.
 	CreateImplicitDir(ctx, storageClient, testDirName, t)
-	fh3 := CreateLocalFile(ctx, storageClient, testDirPath, fileName3, t)
+	fh3 := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName3, t)
 
 	// Recursively list mntDir/ directory.
 	err := filepath.WalkDir(testDirPath,

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	"context"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+)
+
+const (
+	FileName1            = "foo1"
+	FileName2            = "foo2"
+	ExplicitDirName      = "explicit"
+	ExplicitFileName1    = "explicitFile1"
+	ImplicitDirName      = "implicit"
+	ImplicitFileName1    = "implicitFile1"
+	FileContents         = "testString"
+	ImplicitFileContents = "GCSteststring"
+	ImplicitFileSize     = 13
+	FilePerms            = 0644
+	ReadSize             = 1024
+)
+
+func CreateImplicitDir(ctx context.Context, storageClient *storage.Client,
+	testDirName string, t *testing.T) {
+	err := CreateObjectOnGCS(
+		ctx,
+		storageClient,
+		path.Join(testDirName, ImplicitDirName, ImplicitFileName1),
+		ImplicitFileContents)
+	if err != nil {
+		t.Errorf("Error while creating implicit directory, err: %v", err)
+	}
+}
+
+func ValidateObjectNotFoundErrOnGCS(ctx context.Context, storageClient *storage.Client,
+	testDirName string, fileName string, t *testing.T) {
+	_, err := ReadObjectFromGCS(ctx, storageClient, path.Join(testDirName, fileName), ReadSize)
+	if err == nil || !strings.Contains(err.Error(), "storage: object doesn't exist") {
+		t.Fatalf("Incorrect error returned from GCS for file %s: %v", fileName, err)
+	}
+}
+
+func validateObjectContentsFromGCS(ctx context.Context, storageClient *storage.Client,
+	testDirName string, fileName string, expectedContent string, t *testing.T) {
+	gotContent, err := ReadObjectFromGCS(ctx, storageClient, path.Join(testDirName, fileName), ReadSize)
+	if err != nil {
+		t.Fatalf("Error while reading synced local file from GCS, Err: %v", err)
+	}
+
+	if expectedContent != gotContent {
+		t.Fatalf("GCS file %s content mismatch. Got: %s, Expected: %s ", fileName, gotContent, expectedContent)
+	}
+}
+
+func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *storage.Client,
+	testDirName string, fh *os.File, fileName, content string, t *testing.T) {
+	operations.CloseFileShouldNotThrowError(fh, t)
+	validateObjectContentsFromGCS(ctx, storageClient, testDirName, fileName, content, t)
+}
+
+func CreateLocalFile(ctx context.Context, storageClient *storage.Client,
+	testDirPath, fileName string, t *testing.T) (fh *os.File) {
+	filePath := path.Join(testDirPath, fileName)
+	fh = operations.CreateFile(filePath, FilePerms, t)
+	testDirName := getDirName(testDirPath)
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
+	return
+}
+
+func getDirName(testDirPath string) string {
+	dirName := testDirPath[strings.LastIndex(testDirPath, "/")+1:]
+	return dirName
+}

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -77,7 +77,7 @@ func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *stor
 	validateObjectContentsFromGCS(ctx, storageClient, testDirName, fileName, content, t)
 }
 
-func CreateLocalFile(ctx context.Context, storageClient *storage.Client,
+func CreateLocalFileInTestDir(ctx context.Context, storageClient *storage.Client,
 	testDirPath, fileName string, t *testing.T) (fh *os.File) {
 	filePath := path.Join(testDirPath, fileName)
 	fh = operations.CreateFile(filePath, FilePerms, t)

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func separateBucketAndObjectName(bucket, object *string) {
+	bucketAndObjectPath := strings.SplitN(*bucket, "/", 2)
+	*bucket = bucketAndObjectPath[0]
+	*object = path.Join(bucketAndObjectPath[1], *object)
+}
+
+func setBucketAndObjectBasedOnTypeOfMount(bucket, object *string) {
+	*bucket = setup.TestBucket()
+	if strings.Contains(setup.TestBucket(), "/") {
+		// This case arises when we run tests on mounted directory and pass
+		// bucket/directory in testbucket flag.
+		separateBucketAndObjectName(bucket, object)
+	}
+	if setup.DynamicBucketMounted() != "" {
+		*bucket = setup.DynamicBucketMounted()
+	}
+	if setup.OnlyDirMounted() != "" {
+		*object = path.Join(setup.OnlyDirMounted(), *object)
+	}
+}
+
+func CreateStorageClient(ctx context.Context) (*storage.Client, error) {
+	// Create new storage client.
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("storage.NewClient: %w", err)
+	}
+	return client, nil
+}
+
+// ReadObjectFromGCS downloads the object from GCS and returns the data.
+func ReadObjectFromGCS(client *storage.Client, object string, size int64, ctx context.Context) (string, error) {
+	var bucket string
+	setBucketAndObjectBasedOnTypeOfMount(&bucket, &object)
+
+	// Create storage reader to read from GCS.
+	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("Object(%q).NewReader: %w", object, err)
+	}
+	defer rc.Close()
+
+	// Variable buf will contain the output from reader.
+	buf := make([]byte, size)
+	_, err = rc.Read(buf)
+	if err != nil && !strings.Contains(err.Error(), "EOF") {
+		return "", fmt.Errorf("rc.Read: %w", err)
+	}
+
+	// Remove any extra null characters from buf before returning.
+	return strings.Trim(string(buf), "\x00"), nil
+}
+
+// CreateObjectOnGCS creates an object with given name and content on GCS.
+func CreateObjectOnGCS(client *storage.Client, object, content string, ctx context.Context) error {
+	var bucket string
+	setBucketAndObjectBasedOnTypeOfMount(&bucket, &object)
+
+	o := client.Bucket(bucket).Object(object)
+	o = o.If(storage.Conditions{DoesNotExist: true})
+
+	// Upload an object with storage.Writer.
+	wc := o.NewWriter(ctx)
+	if _, err := io.WriteString(wc, content); err != nil {
+		return fmt.Errorf("io.WriteSTring: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("Writer.Close: %w", err)
+	}
+
+	return nil
+}

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -56,7 +56,7 @@ func CreateStorageClient(ctx context.Context) (*storage.Client, error) {
 }
 
 // ReadObjectFromGCS downloads the object from GCS and returns the data.
-func ReadObjectFromGCS(client *storage.Client, object string, size int64, ctx context.Context) (string, error) {
+func ReadObjectFromGCS(ctx context.Context, client *storage.Client, object string, size int64) (string, error) {
 	var bucket string
 	setBucketAndObjectBasedOnTypeOfMount(&bucket, &object)
 
@@ -79,7 +79,7 @@ func ReadObjectFromGCS(client *storage.Client, object string, size int64, ctx co
 }
 
 // CreateObjectOnGCS creates an object with given name and content on GCS.
-func CreateObjectOnGCS(client *storage.Client, object, content string, ctx context.Context) error {
+func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, content string) error {
 	var bucket string
 	setBucketAndObjectBasedOnTypeOfMount(&bucket, &object)
 

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -27,6 +27,7 @@ import (
 
 const FilePermission_0600 = 0600
 const FilePermission_0777 = 0777
+const DirPermission_0755 = 0755
 
 func executeCommandForCopyOperation(cmd *exec.Cmd) (err error) {
 	err = cmd.Run()
@@ -106,6 +107,38 @@ func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string,
 
 func RemoveDir(dirPath string) {
 	if err := os.RemoveAll(dirPath); err != nil {
-		log.Printf("Error in removing direcitory: %v", err)
+		log.Printf("os.RemoveAll(%s): %v", dirPath, err)
+	}
+}
+
+func ReadDirectory(dirPath string, t *testing.T) (entries []os.DirEntry) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%s) err: %v", dirPath, err)
+	}
+	return
+}
+
+func VerifyDirectoryEntry(entry os.DirEntry, dirName string, t *testing.T) {
+	if !entry.IsDir() {
+		t.Fatalf("Expected: directory entry, Got: file entry.")
+	}
+	if entry.Name() != dirName {
+		t.Fatalf("File name, Expected: %s, Got: %s", dirName, entry.Name())
+	}
+}
+
+func VerifyCountOfDirectoryEntries(expected, got int, t *testing.T) {
+	if expected != got {
+		t.Fatalf("directory entry count mismatch, expected: %d, got: %d", expected, got)
+	}
+}
+
+func CreateDirectory(dirPath string, t *testing.T) {
+	err := os.Mkdir(dirPath, DirPermission_0755)
+
+	// Verify MkDir operation succeeds.
+	if err != nil {
+		t.Fatalf("Error while creating directory, err: %v", err)
 	}
 }

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"testing"
 )
 
 func copyFile(srcFileName, dstFileName string, allowOverwrite bool) (err error) {
@@ -167,7 +168,7 @@ func CloseFile(file *os.File) {
 func RemoveFile(filePath string) {
 	err := os.Remove(filePath)
 	if err != nil {
-		log.Printf("Error in removing file:%v", err)
+		log.Printf("os.Remove(%s): %v", filePath, err)
 	}
 }
 
@@ -436,4 +437,49 @@ func ClearCacheControlOnGcsObject(gcsObjPath string) error {
 	// implementation for updating object metadata is missing on the kokoro VM.
 	_, err := ExecuteGsutilCommandf("setmeta -h \"Cache-Control:\" gs://%s ", gcsObjPath)
 	return err
+}
+
+func CreateFile(filePath string, filePerms os.FileMode, t *testing.T) (f *os.File) {
+	// Creating a file shouldn't create file on GCS.
+	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePerms)
+	if err != nil {
+		t.Fatalf("CreateFile(%s): %v", filePath, err)
+	}
+	return
+}
+
+func VerifyFileEntry(entry os.DirEntry, fileName string, size int64, t *testing.T) {
+	if entry.IsDir() {
+		t.Fatalf("Expected: file entry, Got: directory entry.")
+	}
+	if entry.Name() != fileName {
+		t.Fatalf("File name, Expected: %s, Got: %s", fileName, entry.Name())
+	}
+	fileInfo, err := entry.Info()
+	if err != nil {
+		t.Fatalf("%s.Info() err: %v", fileName, err)
+	}
+	if fileInfo.Size() != size {
+		t.Fatalf("Local file %s size, Expected: %d, Got: %d", fileName, size, fileInfo.Size())
+	}
+}
+
+func WriteWithoutClose(fh *os.File, content string, t *testing.T) {
+	_, err := fh.Write([]byte(content))
+	if err != nil {
+		t.Fatalf("Error while writing to local file. err: %v", err)
+	}
+}
+
+func WriteAt(content string, offset int64, fh *os.File, t *testing.T) {
+	_, err := fh.WriteAt([]byte(content), offset)
+	if err != nil {
+		t.Fatalf("%s.WriteAt(%s, %d): %v", fh.Name(), content, offset, err)
+	}
+}
+
+func CloseFileShouldNotThrowError(file *os.File, t *testing.T) {
+	if err := file.Close(); err != nil {
+		t.Fatalf("file.Close() for file %s: %v", file.Name(), err)
+	}
 }

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -41,9 +41,7 @@ const SecondFileInExplicitDirectory = "fileInExplicitDir2"
 const FileInImplicitDirectory = "fileInImplicitDir1"
 const FileInImplicitSubDirectory = "fileInImplicitDir2"
 
-func RunTestsForImplicitDirAndExplicitDir(flags [][]string, m *testing.M) {
-	setup.ParseSetUpFlags()
-
+func RunTestsForImplicitDirAndExplicitDir(flags [][]string, m *testing.M) int {
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
@@ -64,8 +62,7 @@ func RunTestsForImplicitDirAndExplicitDir(flags [][]string, m *testing.M) {
 	}
 
 	setup.RemoveBinFileCopiedForTesting()
-
-	os.Exit(successCode)
+	return successCode
 }
 
 func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) {


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
Add tests to verify that file is not created on GCS until local files are synced to run with implicit_dir flag.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - 
Ran implicit_dir and explicit_dir tests locally on a VM with 
- test-bucket flag
- The following commands:
```
# package implicit_dir
# Run tests with static mounting. (flags: --implicit-dirs)
gcsfuse --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR

# Run test with persistent mounting. (flags: --implicit-dirs)
mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR

# Run tests with static mounting. (flags: --implicit-dirs, --only-dir testDir)
gcsfuse --only-dir testDir --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
sudo umount $MOUNT_DIR

# Run test with persistent mounting. (flags: --implicit-dirs,--only-dir=testDir)
mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
sudo umount $MOUNT_DIR
```
```
# package explicit_dir
# Run tests with static mounting. (flags: --implicit-dirs=false)
gcsfuse --implicit-dirs=false $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/explicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR

# Run test with persistent mounting. (flags: --implicit-dirs=false)
mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=false
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/explicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR

# Run tests with static mounting. (flags: --implicit-dirs=false, --only-dir testDir)
gcsfuse --only-dir testDir  --implicit-dirs=false $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/explicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
sudo umount $MOUNT_DIR

# Run test with persistent mounting. (flags: --implicit-dirs=false, --only-dir=testDir)
mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=false
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/explicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
sudo umount $MOUNT_DIR

```


