### PR TITLE
Integration tests to verify symlink and stat operations on local file

### DIFF
--- a/tools/integration_tests/local_file/stat_file_test.go
+++ b/tools/integration_tests/local_file/stat_file_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for stat operation on local files.
+package local_file_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
+	. "github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func TestStatOnLocalFile(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create a local file.
+	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
+
+	// Stat the local file.
+	operations.VerifyStatFile(filePath, 0, FilePerms, t)
+
+	// Writing contents to local file shouldn't create file on GCS.
+	WritingToLocalFileShouldNotWriteToGCS(ctx, storageClient, fh, testDirName, FileName1, t)
+
+	// Stat the local file again to check if new content is written.
+	operations.VerifyStatFile(filePath, SizeOfFileContents, FilePerms, t)
+
+	// Close the file and validate if the file is created on GCS.
+	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+		FileName1, FileContents, t)
+}
+
+func TestStatOnLocalFileWithConflictingFileNameSuffix(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create a local file.
+	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
+
+	// Stat the local file.
+	operations.VerifyStatFile(filePath+inode.ConflictingFileNameSuffix, 0, FilePerms, t)
+
+	// Close the file and validate if the file is created on GCS.
+	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+		FileName1, "", t)
+}
+
+func TestTruncateLocalFile(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create a local file.
+	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
+	// Writing contents to local file .
+	WritingToLocalFileShouldNotWriteToGCS(ctx, storageClient, fh, testDirName, FileName1, t)
+
+	// Stat the file to validate if new contents are written.
+	operations.VerifyStatFile(filePath, SizeOfFileContents, FilePerms, t)
+
+	// Truncate the file to update the file size.
+	err := os.Truncate(filePath, SizeTruncate)
+	if err != nil {
+		t.Fatalf("os.Truncate err: %v", err)
+	}
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
+
+	// Stat the file to validate if file is truncated correctly.
+	operations.VerifyStatFile(filePath, SizeTruncate, FilePerms, t)
+
+	// Close the file and validate if the file is created on GCS.
+	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+		FileName1, "tests", t)
+}

--- a/tools/integration_tests/local_file/stat_file_test.go
+++ b/tools/integration_tests/local_file/stat_file_test.go
@@ -39,8 +39,8 @@ func TestStatOnLocalFile(t *testing.T) {
 	// Stat the local file again to check if new content is written.
 	operations.VerifyStatFile(filePath, SizeOfFileContents, FilePerms, t)
 
-	// Close the file and validate if the file is created on GCS.
-	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+	// Close the file and validate that the file is created on GCS.
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName,
 		FileName1, FileContents, t)
 }
 
@@ -52,8 +52,8 @@ func TestStatOnLocalFileWithConflictingFileNameSuffix(t *testing.T) {
 	// Stat the local file.
 	operations.VerifyStatFile(filePath+inode.ConflictingFileNameSuffix, 0, FilePerms, t)
 
-	// Close the file and validate if the file is created on GCS.
-	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+	// Close the file and validate that the file is created on GCS.
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName,
 		FileName1, "", t)
 }
 
@@ -77,7 +77,7 @@ func TestTruncateLocalFile(t *testing.T) {
 	// Stat the file to validate if file is truncated correctly.
 	operations.VerifyStatFile(filePath, SizeTruncate, FilePerms, t)
 
-	// Close the file and validate if the file is created on GCS.
-	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
-		FileName1, "tests", t)
+	// Close the file and validate that the file is created on GCS.
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName,
+		FileName1, "testS", t)
 }

--- a/tools/integration_tests/local_file/sym_link_test.go
+++ b/tools/integration_tests/local_file/sym_link_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Provides integration tests for symlink operation on local files.
+package local_file_test
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	. "github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func createAndVerifySymLink(t *testing.T) (filePath, symlink string, fh *os.File) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create a local file.
+	filePath, fh = CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
+	WritingToLocalFileShouldNotWriteToGCS(ctx, storageClient, fh, testDirName, FileName1, t)
+
+	// Create the symlink.
+	symlink = path.Join(testDirPath, "bar")
+	operations.CreateSymLink(filePath, symlink, t)
+
+	// Read the link.
+	operations.VerifyReadLink(filePath, symlink, t)
+	operations.VerifyReadFile(symlink, FileContents, t)
+	return
+}
+
+func TestCreateSymlinkForLocalFile(t *testing.T) {
+	_, _, fh := createAndVerifySymLink(t)
+	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+		FileName1, FileContents, t)
+}
+
+func TestReadSymlinkForDeletedLocalFile(t *testing.T) {
+	filePath, symlink, fh := createAndVerifySymLink(t)
+	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
+	operations.RemoveFile(filePath)
+	operations.CloseFileShouldNotThrowError(fh, t)
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
+
+	// Reading symlink should fail.
+	_, err := os.Stat(symlink)
+	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("Reading symlink for deleted local file did not fail.")
+	}
+}

--- a/tools/integration_tests/local_file/sym_link_test.go
+++ b/tools/integration_tests/local_file/sym_link_test.go
@@ -44,7 +44,7 @@ func createAndVerifySymLink(t *testing.T) (filePath, symlink string, fh *os.File
 
 func TestCreateSymlinkForLocalFile(t *testing.T) {
 	_, _, fh := createAndVerifySymLink(t)
-	CloseFileAndValidateObjectContentsFromGCS(ctx, storageClient, fh, testDirName,
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName,
 		FileName1, FileContents, t)
 }
 

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -26,17 +26,19 @@ import (
 )
 
 const (
-	FileName1         = "foo1"
-	FileName2         = "foo2"
-	ExplicitDirName   = "explicit"
-	ExplicitFileName1 = "explicitFile1"
-	ImplicitDirName   = "implicit"
-	ImplicitFileName1 = "implicitFile1"
-	FileContents      = "testString"
-	GCSFileContent    = "GCSteststring"
-	GCSFileSize       = 13
-	FilePerms         = 0644
-	ReadSize          = 1024
+	FileName1          = "foo1"
+	FileName2          = "foo2"
+	ExplicitDirName    = "explicit"
+	ExplicitFileName1  = "explicitFile1"
+	ImplicitDirName    = "implicit"
+	ImplicitFileName1  = "implicitFile1"
+	FileContents       = "testString"
+	SizeOfFileContents = 10
+	GCSFileContent     = "GCSteststring"
+	GCSFileSize        = 13
+	FilePerms          = 0644
+	ReadSize           = 1024
+	SizeTruncate       = 5
 )
 
 func CreateImplicitDir(ctx context.Context, storageClient *storage.Client,
@@ -91,7 +93,8 @@ func getDirName(testDirPath string) string {
 	return dirName
 }
 
-func WritingToLocalFileShouldNotWriteToGCS(ctx context.Context, storageClient *storage.Client, fh *os.File, testDirName, fileName string, t *testing.T) {
+func WritingToLocalFileShouldNotWriteToGCS(ctx context.Context, storageClient *storage.Client,
+	fh *os.File, testDirName, fileName string, t *testing.T) {
 	operations.WriteWithoutClose(fh, FileContents, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
 }

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -470,7 +470,6 @@ func CreateSymLink(filePath, symlink string, t *testing.T) {
 }
 
 func VerifyStatFile(filePath string, fileSize int64, filePerms os.FileMode, t *testing.T) {
-	// Stat the file to validate if file is truncated correctly.
 	fi, err := os.Stat(filePath)
 
 	if err != nil {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -459,6 +460,48 @@ func CreateFile(filePath string, filePerms os.FileMode, t *testing.T) (f *os.Fil
 	return
 }
 
+func CreateSymLink(filePath, symlink string, t *testing.T) {
+	err := os.Symlink(filePath, symlink)
+
+	// Verify os.Symlink operation succeeds.
+	if err != nil {
+		t.Fatalf("os.Symlink(%s, %s): %v", filePath, symlink, err)
+	}
+}
+
+func VerifyStatFile(filePath string, fileSize int64, filePerms os.FileMode, t *testing.T) {
+	// Stat the file to validate if file is truncated correctly.
+	fi, err := os.Stat(filePath)
+
+	if err != nil {
+		t.Fatalf("os.Stat err: %v", err)
+	}
+
+	if fi.Name() != path.Base(filePath) {
+		t.Fatalf("File name mismatch in stat call. Expected: %s, Got: %s", path.Base(filePath), fi.Name())
+	}
+
+	if fi.Size() != fileSize {
+		t.Fatalf("File size mismatch in stat call. Expected: %d, Got: %d", fileSize, fi.Size())
+	}
+
+	if fi.Mode() != filePerms {
+		t.Fatalf("File permissions mismatch in stat call. Expected: %v, Got: %v", filePerms, fi.Mode())
+	}
+}
+
+func VerifyReadFile(filePath, expectedContent string, t *testing.T) {
+	gotContent, err := os.ReadFile(filePath)
+
+	// Verify os.ReadFile operation succeeds.
+	if err != nil {
+		t.Fatalf("os.ReadFile(%s): %v", filePath, err)
+	}
+	if expectedContent != string(gotContent) {
+		t.Fatalf("Content mismatch. Expected: %s, Got: %s", expectedContent, gotContent)
+	}
+}
+
 func VerifyFileEntry(entry os.DirEntry, fileName string, size int64, t *testing.T) {
 	if entry.IsDir() {
 		t.Fatalf("Expected: file entry, Got: directory entry.")
@@ -472,6 +515,18 @@ func VerifyFileEntry(entry os.DirEntry, fileName string, size int64, t *testing.
 	}
 	if fileInfo.Size() != size {
 		t.Fatalf("Local file %s size, Expected: %d, Got: %d", fileName, size, fileInfo.Size())
+	}
+}
+
+func VerifyReadLink(expectedTarget, symlinkName string, t *testing.T) {
+	gotTarget, err := os.Readlink(symlinkName)
+
+	// Verify os.Readlink operation succeeds.
+	if err != nil {
+		t.Fatalf("os.Readlink(%s): %v", symlinkName, err)
+	}
+	if expectedTarget != gotTarget {
+		t.Fatalf("Symlink target mismatch. Expected: %s, Got: %s", expectedTarget, gotTarget)
 	}
 }
 


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual 
- Manually ran on GCP VM using the following commands:
```
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/local_file/...  -p 1 --integrationTest -v --testbucket=$TEST_BUCKET_NAME
``` 
```
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/local_file/...  -p 1 --integrationTest -v --testbucket=$TEST_BUCKET_NAME --testInstalledPackage
``` 
- Ran the following commands for mounted directory tests
```
# package local_file
# Run test with static mounting. (flags: --implicit-dirs=true)
gcsfuse --implicit-dirs=true --rename-dir-limit=3 $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/local_file/... -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR

# Run test with static mounting. (flags: --implicit-dirs=false)
gcsfuse --implicit-dirs=false --rename-dir-limit=3 $TEST_BUCKET_NAME $MOUNT_DIR
GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/local_file/... -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
sudo umount $MOUNT_DIR
```
2. Unit tests - NA
3. Integration tests - NA
