### PR TITLE
Fix for requirements for e2e tests

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -106,13 +106,6 @@ else
     #install git
     sudo yum -y install git
 
-    # install python3-setuptools tools and python3-pip
-    sudo yum -y install gcc python3-devel python3-setuptools redhat-rpm-config
-    sudo yum -y install python3-pip
-    # Downloading composite object requires integrity checking with CRC32c in gsutil.
-    # it requires to install crcmod.
-    pip3 install --require-hashes -r requirements.txt --user
-
     #install Development tools
     sudo yum -y install gcc gcc-c++ make
 fi
@@ -129,6 +122,17 @@ go version |& tee -a ~/logs.txt
 export PATH=${PATH}:/usr/local/go/bin
 git clone https://github.com/googlecloudplatform/gcsfuse |& tee -a ~/logs.txt
 cd gcsfuse
+
+if grep -q rhel details.txt || grep -q centos details.txt;
+then
+    # install python3-setuptools tools and python3-pip
+    sudo yum -y install gcc python3-devel python3-setuptools redhat-rpm-config
+    sudo yum -y install python3-pip
+    # Downloading composite object requires integrity checking with CRC32c in gsutil.
+    # it requires to install crcmod.
+    pip3 install --require-hashes -r tools/cd_scripts/requirements.txt --user
+fi
+
 git checkout $(sed -n 2p ~/details.txt) |& tee -a ~/logs.txt
 
 #run tests with testbucket flag

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -123,6 +123,8 @@ export PATH=${PATH}:/usr/local/go/bin
 git clone https://github.com/googlecloudplatform/gcsfuse |& tee -a ~/logs.txt
 cd gcsfuse
 
+# Installation of crcmod is working through pip only on rhel and centos.
+# For debian and ubuntu, we are installing through sudo apt.
 if grep -q rhel details.txt || grep -q centos details.txt;
 then
     # install python3-setuptools tools and python3-pip


### PR DESCRIPTION
### Description
louhi pipeline is unable to find [requirements.txt](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/cd_scripts/requirements.txt) file, as we are running script as startup script and we don;t have  [requirements.txt](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/cd_scripts/requirements.txt) in VM.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested on rhel-9,rhel-9-arm64,cenos-9,ubuntu20,centos-7
    1. Created e2e_test.sh locally.   
    2.  Created VM instance with this command
```
gcloud compute instances create release-test-debian-12     --machine-type=MACHINE-TYPE --image-family=IMAGE_FAMILY     --image-project=IMAGE_PROJECT  --zone=ZONE     --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write     --metadata-from-file=startup-script=e2e_test.sh
```
4. Unit tests - NA
5. Integration tests - NA
