### PR TITLE
Upgrading go version from 1.21.0 to 1.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.21.0-alpine as builder
+FROM golang:1.21.1-alpine as builder
 
 RUN apk add git
 

--- a/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/dino/setup_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/setup.sh
+++ b/perfmetrics/scripts/ml_tests/setup.sh
@@ -4,7 +4,7 @@
 # >> source setup.sh
 
 # Go version to be installed.
-GO_VERSION=go1.21.0.linux-amd64.tar.gz
+GO_VERSION=go1.21.1.linux-amd64.tar.gz
 
 # This function will install the given module/dependency if it's not alredy 
 # installed.

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -5,7 +5,7 @@
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -34,8 +34,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.21.0
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-amd64.tar.gz -q
+echo Installing go-lang  1.21.1
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.1.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -62,6 +62,7 @@ function execute_perf_test() {
 if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Executing perf tests for master branch
+ git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -62,7 +62,6 @@ function execute_perf_test() {
 if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Executing perf tests for master branch
- git reset --hard
  git checkout master
  # Store results
  touch result.txt

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -27,8 +27,8 @@ run_e2e_tests_on_package=$1
 
 # e.g. architecture=arm64 or amd64
 architecture=$(dpkg --print-architecture)
-echo "Installing go-lang 1.21.0..."
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-${architecture}.tar.gz -q
+echo "Installing go-lang 1.21.1..."
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.1.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 # install python3-setuptools tools.

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.0.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.1.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.21.0 as gcsfuse-package
+FROM golang:1.21.1 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.21.0 as builder
+FROM golang:1.21.1 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+RUN git checkout "go_1_21_1"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -37,7 +37,7 @@ ARG DEBFULLNAME="GCSFuse Team"
 # Build Arg for building through a particular branch/commit. By default, it uses
 # the tag corresponding to passed GCSFUSE VERSION
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "go_1_21_1"
+RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile


### PR DESCRIPTION
### Description
Upgrading the go version from 1.21.0 to 1.21.1

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1398

### Testing details
1. Manual - NA
2. Unit tests - Automation
3. Integration tests - Automation (passed integration test)
