### PR TITLE
Adding --disable-auth flag changes

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -187,6 +187,12 @@ func newApp() (app *cli.App) {
 				Usage: "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported",
 			},
 
+			cli.BoolFlag{
+				Name: "disable-auth",
+				Usage: "Authorization will be enabled by default. With this flag, authorization will be disabled. If one " +
+					"wants to use a custom endpoint for testing purposes; they need to pass --disable-auth flag.",
+			},
+
 			/////////////////////////
 			// Tuning
 			/////////////////////////
@@ -378,6 +384,7 @@ type flagStorage struct {
 	EgressBandwidthLimitBytesPerSecond float64
 	OpRateLimitHz                      float64
 	SequentialReadSizeMb               int32
+	DisableAuth                        bool
 
 	// Tuning
 	MaxRetrySleep              time.Duration
@@ -488,6 +495,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		EgressBandwidthLimitBytesPerSecond: c.Float64("limit-bytes-per-sec"),
 		OpRateLimitHz:                      c.Float64("limit-ops-per-sec"),
 		SequentialReadSizeMb:               int32(c.Int("sequential-read-size-mb")),
+		DisableAuth:                        c.Bool("disable-auth"),
 
 		// Tuning,
 		MaxRetrySleep:              c.Duration("max-retry-sleep"),

--- a/flags.go
+++ b/flags.go
@@ -189,8 +189,8 @@ func newApp() (app *cli.App) {
 
 			cli.BoolFlag{
 				Name: "disable-auth",
-				Usage: "Authorization will be enabled by default. With this flag, authorization will be disabled. If one " +
-					"wants to use a custom endpoint for testing purposes; they need to pass --disable-auth flag.",
+				Usage: "Authentication is enabled by default. The --disable-auth flag disables authentication. For users of the --custom-endpoint flag," +
+					" please pass --disable-auth flag explicitly if you do not want authentication enabled for your workflow.",
 			},
 
 			/////////////////////////

--- a/flags_test.go
+++ b/flags_test.go
@@ -80,6 +80,7 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq(-1, f.OpRateLimitHz)
 	ExpectTrue(f.ReuseTokenFromUrl)
 	ExpectEq(nil, f.CustomEndpoint)
+	ExpectFalse(f.DisableAuth)
 
 	// Tuning
 	ExpectEq(4096, f.StatCacheCapacity)
@@ -111,6 +112,7 @@ func (t *FlagsTest) Bools() {
 		"debug_invariants",
 		"enable-nonexistent-type-cache",
 		"experimental-enable-json-read",
+		"disable-auth",
 	}
 
 	var args []string
@@ -132,6 +134,7 @@ func (t *FlagsTest) Bools() {
 	ExpectTrue(f.DebugInvariants)
 	ExpectTrue(f.EnableNonexistentTypeCache)
 	ExpectTrue(f.ExperimentalEnableJsonRead)
+	ExpectTrue(f.DisableAuth)
 
 	// --foo=false form
 	args = nil
@@ -148,6 +151,7 @@ func (t *FlagsTest) Bools() {
 	ExpectFalse(f.DebugHTTP)
 	ExpectFalse(f.DebugInvariants)
 	ExpectFalse(f.EnableNonexistentTypeCache)
+	ExpectFalse(f.DisableAuth)
 
 	// --foo=true form
 	args = nil
@@ -164,6 +168,7 @@ func (t *FlagsTest) Bools() {
 	ExpectTrue(f.DebugHTTP)
 	ExpectTrue(f.DebugInvariants)
 	ExpectTrue(f.EnableNonexistentTypeCache)
+	ExpectTrue(f.DisableAuth)
 }
 
 func (t *FlagsTest) DecimalNumbers() {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -71,7 +70,6 @@ func GetTokenSource(
 		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)
-		log.Print("default token ")
 		method = "DefaultTokenSource"
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -70,6 +71,7 @@ func GetTokenSource(
 		method = "newProxyTokenSource"
 	} else {
 		tokenSrc, err = google.DefaultTokenSource(ctx, scope)
+		log.Print("default token ")
 		method = "DefaultTokenSource"
 	}
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -43,6 +43,7 @@ type storageClient struct {
 // customized http client. We can configure the http client using the
 // storageClientConfig parameter.
 func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClientConfig) (sh StorageHandle, err error) {
+
 	var clientOpts []option.ClientOption
 	// Add WithHttpClient option.
 	if clientConfig.ClientProtocol == mountpkg.HTTP1 || clientConfig.ClientProtocol == mountpkg.HTTP2 {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,6 +57,10 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		clientOpts = append(clientOpts, option.WithHTTPClient(httpClient))
 	}
 
+	if clientConfig.DisableAuth {
+		clientOpts = append(clientOpts, option.WithoutAuthentication())
+	}
+
 	// Create client with JSON read flow, if EnableJasonRead flag is set.
 	if clientConfig.ExperimentalEnableJsonRead {
 		clientOpts = append(clientOpts, storage.WithJSONReads())

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -43,7 +43,6 @@ type storageClient struct {
 // customized http client. We can configure the http client using the
 // storageClientConfig parameter.
 func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClientConfig) (sh StorageHandle, err error) {
-
 	var clientOpts []option.ClientOption
 	// Add WithHttpClient option.
 	if clientConfig.ClientProtocol == mountpkg.HTTP1 || clientConfig.ClientProtocol == mountpkg.HTTP2 {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -49,8 +49,14 @@ func (t *StorageHandleTest) TearDown() {
 	t.fakeStorage.ShutDown()
 }
 
-func (t *StorageHandleTest) invokeAndVerifyStorageHandle(sc storageutil.StorageClientConfig) {
+func (t *StorageHandleTest) invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc storageutil.StorageClientConfig) {
 	sc.DisableAuth = true
+	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
+}
+
+func (t *StorageHandleTest) invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc storageutil.StorageClientConfig) {
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
 	AssertNe(nil, err)
@@ -88,102 +94,140 @@ func (t *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNonEmptyBi
 	AssertEq(nil, bucketHandle.Bucket)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
+func (t *StorageHandleTest) TestNewStorageHandleHttp2DisabledWhenDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig() // by default http1 enabled
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleHttp2Enabled() {
+func (t *StorageHandleTest) TestNewStorageHandleHttp2DisabledWhenDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig() // by default http1 enabled
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleHttp2EnabledWhenDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = mountpkg.HTTP2
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHost() {
+func (t *StorageHandleTest) TestNewStorageHandleHttp2EnabledWhenDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.ClientProtocol = mountpkg.HTTP2
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHostWhenDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.MaxConnsPerHost = 0
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSet() {
+func (t *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHostWhenDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.MaxConnsPerHost = 0
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSetWhenDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.UserAgent = "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) appName (GPN:Gcsfuse-DLC)"
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWithCustomEndpoint() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSetWhenDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.UserAgent = "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) appName (GPN:Gcsfuse-DLC)"
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWithCustomEndpointWhenDisableAuthIsTrue() {
 	url, err := url.Parse(storageutil.CustomEndpoint)
 	AssertEq(nil, err)
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
-	sc.DisableAuth = true
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
-
-	AssertNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	AssertEq(nil, handleCreated)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.CustomEndpoint = nil
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDisableAuthIsFalse() {
 	url, err := url.Parse(storageutil.CustomEndpoint)
 	AssertEq(nil, err)
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
-
-	AssertNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	AssertEq(nil, handleCreated)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDisableAuthIsFalse() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = nil
+	sc.KeyFile = ""
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
-	AssertNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	AssertEq(nil, handleCreated)
+	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
 }
 
-//func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
-//	sc := storageutil.GetDefaultStorageClientConfig()
-//	sc.KeyFile = ""
-//
-//	t.invokeAndVerifyStorageHandle(sc)
-//}
-
-func (t *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalse() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalseAndDisableAuthTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ReuseTokenFromUrl = false
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenTokenUrlIsSet() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalseAndDisableAuthFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.ReuseTokenFromUrl = false
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenTokenUrlIsSetAndDisableAuthTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.TokenUrl = storageutil.CustomTokenUrl
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenJsonReadEnabled() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenTokenUrlIsSetAndDisableAuthFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.TokenUrl = storageutil.CustomTokenUrl
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenJsonReadEnabledAndDisableAuthTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ExperimentalEnableJsonRead = true
 
-	t.invokeAndVerifyStorageHandle(sc)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenJsonReadEnabledAndDisableAuthFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.ExperimentalEnableJsonRead = true
+
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -137,7 +137,7 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisabl
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
-	AssertNe(nil, err)
+	AssertEq(nil, err)
 	AssertNe(nil, handleCreated)
 }
 

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -180,14 +180,11 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDis
 	t.invokeAndVerifyStorageHandleWhenDisableAuthIsFalse(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmptyAndDisableAuthTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.KeyFile = ""
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
-
-	AssertEq(nil, err)
-	AssertNe(nil, handleCreated)
+	t.invokeAndVerifyStorageHandleWhenDisableAuthIsTrue(sc)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalseAndDisableAuthTrue() {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -50,6 +50,7 @@ func (t *StorageHandleTest) TearDown() {
 }
 
 func (t *StorageHandleTest) invokeAndVerifyStorageHandle(sc storageutil.StorageClientConfig) {
+	sc.DisableAuth = true
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 	AssertEq(nil, err)
 	AssertNe(nil, handleCreated)
@@ -124,6 +125,7 @@ func (t *StorageHandleTest) TestNewStorageHandleWithCustomEndpoint() {
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
+	sc.DisableAuth = true
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
@@ -136,7 +138,6 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisabl
 	AssertEq(nil, err)
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
-	sc.DisableAuth = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
@@ -148,7 +149,6 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisabl
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDisableAuthIsFalse() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
-	sc.DisableAuth = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -21,6 +21,7 @@ import (
 
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
+	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -131,14 +132,29 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
+	url, err := url.Parse(storageutil.CustomEndpoint)
+	AssertEq(nil, err)
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.CustomEndpoint = url
+	sc.DisableAuth = false
+
+	handleCreated, err := NewStorageHandle(context.Background(), sc)
+
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, handleCreated)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDisableAuthIsFalse() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
 	sc.DisableAuth = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
-	AssertEq(nil, err)
-	AssertNe(nil, handleCreated)
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, handleCreated)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -120,7 +120,6 @@ func (t *StorageHandleTest) TestNewStorageHandleWithCustomEndpoint() {
 	t.invokeAndVerifyStorageHandle(sc)
 }
 
-// This will fail while fetching the token-source, since key-file doesn't exist.
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
@@ -128,6 +127,17 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
 	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
+}
+
+func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.CustomEndpoint = nil
+	sc.DisableAuth = false
+
+	handleCreated, err := NewStorageHandle(context.Background(), sc)
+
+	AssertNe(nil, err)
 	AssertNe(nil, handleCreated)
 }
 

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -21,7 +21,6 @@ import (
 
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
-	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -128,9 +127,8 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
-	AssertNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	AssertEq(nil, handleCreated)
+	AssertEq(nil, err)
+	AssertNe(nil, handleCreated)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -52,8 +52,10 @@ func (t *StorageHandleTest) TearDown() {
 func (t *StorageHandleTest) invokeAndVerifyStorageHandle(sc storageutil.StorageClientConfig) {
 	sc.DisableAuth = true
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
-	AssertEq(nil, err)
-	AssertNe(nil, handleCreated)
+
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, handleCreated)
 }
 
 func (t *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
@@ -122,15 +124,16 @@ func (t *StorageHandleTest) TestNewStorageHandleWithCustomEndpoint() {
 	t.invokeAndVerifyStorageHandle(sc)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNil() {
+func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
 	sc.DisableAuth = true
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
-	AssertEq(nil, err)
-	AssertNe(nil, handleCreated)
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, handleCreated)
 }
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
@@ -157,12 +160,12 @@ func (t *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNotNilAndDis
 	AssertEq(nil, handleCreated)
 }
 
-func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
-	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.KeyFile = ""
-
-	t.invokeAndVerifyStorageHandle(sc)
-}
+//func (t *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
+//	sc := storageutil.GetDefaultStorageClientConfig()
+//	sc.KeyFile = ""
+//
+//	t.invokeAndVerifyStorageHandle(sc)
+//}
 
 func (t *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalse() {
 	sc := storageutil.GetDefaultStorageClientConfig()

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -98,5 +98,4 @@ func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth
 	} else {
 		return oauth2.StaticTokenSource(&oauth2.Token{}), nil
 	}
-	return nil, nil
 }

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -40,6 +40,7 @@ type StorageClientConfig struct {
 	TokenUrl                   string
 	ReuseTokenFromUrl          bool
 	ExperimentalEnableJsonRead bool
+	DisableAuth                bool
 }
 
 func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *http.Client, err error) {
@@ -91,9 +92,11 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 // is nil, it creates the token-source from the provided key-file or using ADC search
 // order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
-	if storageClientConfig.CustomEndpoint == nil {
+	// Create token src only if disable-auth flag is false.
+	if !storageClientConfig.DisableAuth {
 		return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
 	} else {
 		return oauth2.StaticTokenSource(&oauth2.Token{}), nil
 	}
+	return nil, nil
 }

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -64,17 +64,18 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 		}
 	}
 
-	tokenSrc, err := createTokenSource(storageClientConfig)
-	if err != nil {
-		err = fmt.Errorf("while fetching tokenSource: %w", err)
-		return
-	}
-
 	if storageClientConfig.DisableAuth {
 		httpClient = &http.Client{
 			Timeout: storageClientConfig.HttpClientTimeout,
 		}
 	} else {
+		var tokenSrc oauth2.TokenSource
+		tokenSrc, err = createTokenSource(storageClientConfig)
+		if err != nil {
+			err = fmt.Errorf("while fetching tokenSource: %w", err)
+			return
+		}
+
 		// Custom http client for Go Client.
 		httpClient = &http.Client{
 			Transport: &oauth2.Transport{
@@ -93,8 +94,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	return httpClient, err
 }
 
-// It creates dummy token-source in case of disable-auth flag. If the disable-auth flag
-// is false which is default behaviour, it creates the token-source from the provided
+// it creates the token-source from the provided
 // key-file or using ADC search order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
 	return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -89,8 +89,8 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 }
 
 // It creates dummy token-source in case of disable-auth flag. If the disable-auth flag
-// is true, it creates the token-source from the provided key-file or using ADC search
-// order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
+// is false which is default behaviour, it creates the token-source from the provided
+// key-file or using ADC search order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
 	if !storageClientConfig.DisableAuth {
 		return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -88,11 +88,10 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	return httpClient, err
 }
 
-// It creates dummy token-source in case of non-nil custom url. If the custom-endpoint
-// is nil, it creates the token-source from the provided key-file or using ADC search
+// It creates dummy token-source in case of disable-auth flag. If the disable-auth flag
+// is true, it creates the token-source from the provided key-file or using ADC search
 // order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
-	// Create token src only if disable-auth flag is false.
 	if !storageClientConfig.DisableAuth {
 		return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
 	} else {

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -34,6 +34,7 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsTrue()
 	AssertEq(nil, err)
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
+	sc.DisableAuth = true
 
 	tokenSrc, err := createTokenSource(&sc)
 
@@ -46,7 +47,6 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsFalse(
 	AssertEq(nil, err)
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
-	sc.DisableAuth = false
 
 	// It will try to create the actual auth token and fail since key-file doesn't exist.
 	tokenSrc, err := createTokenSource(&sc)
@@ -59,6 +59,7 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsFalse(
 func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
+	sc.DisableAuth = true
 
 	tokenSrc, err := createTokenSource(&sc)
 
@@ -69,7 +70,6 @@ func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTr
 func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
-	sc.DisableAuth = false
 
 	// It will try to create the actual auth token and fail since key-file doesn't exist.
 	tokenSrc, err := createTokenSource(&sc)
@@ -81,7 +81,7 @@ func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsFa
 
 func (t *clientTest) TestCreateHttpClientWithHttp1() {
 	sc := GetDefaultStorageClientConfig() // By default http1 enabled
-
+	sc.DisableAuth = true
 	// Act: this method add tokenSource and clientOptions.
 	httpClient, err := CreateHttpClient(&sc)
 
@@ -93,6 +93,7 @@ func (t *clientTest) TestCreateHttpClientWithHttp1() {
 
 func (t *clientTest) TestCreateHttpClientWithHttp2() {
 	sc := GetDefaultStorageClientConfig()
+	sc.DisableAuth = true
 
 	// Act: this method add tokenSource and clientOptions.
 	httpClient, err := CreateHttpClient(&sc)

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -34,7 +34,6 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsTrue()
 	AssertEq(nil, err)
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
-	sc.DisableAuth = true
 
 	tokenSrc, err := createTokenSource(&sc)
 
@@ -60,7 +59,6 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsFalse(
 func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
-	sc.DisableAuth = true
 
 	tokenSrc, err := createTokenSource(&sc)
 
@@ -83,7 +81,6 @@ func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsFa
 
 func (t *clientTest) TestCreateHttpClientWithHttp1() {
 	sc := GetDefaultStorageClientConfig() // By default http1 enabled
-	sc.DisableAuth = true
 
 	// Act: this method add tokenSource and clientOptions.
 	httpClient, err := CreateHttpClient(&sc)
@@ -96,7 +93,6 @@ func (t *clientTest) TestCreateHttpClientWithHttp1() {
 
 func (t *clientTest) TestCreateHttpClientWithHttp2() {
 	sc := GetDefaultStorageClientConfig()
-	sc.DisableAuth = true
 
 	// Act: this method add tokenSource and clientOptions.
 	httpClient, err := CreateHttpClient(&sc)

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -15,9 +15,9 @@
 package storageutil
 
 import (
-	"net/url"
 	"testing"
 
+	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -28,43 +28,19 @@ type clientTest struct {
 
 func init() { RegisterTestSuite(&clientTest{}) }
 
-func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsTrue() {
-	url, err := url.Parse(CustomEndpoint)
-	AssertEq(nil, err)
-	sc := GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = url
-	sc.DisableAuth = true
-
-	tokenSrc, err := createTokenSource(&sc)
-
-	ExpectEq(nil, err)
-	ExpectNe(nil, &tokenSrc)
-}
-
-func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
-	sc := GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = nil
-	sc.DisableAuth = true
-
-	tokenSrc, err := createTokenSource(&sc)
-
-	ExpectEq(nil, err)
-	ExpectNe(nil, &tokenSrc)
-}
-
-func (t *clientTest) TestCreateHttpClientWithHttp1() {
+func (t *clientTest) TestCreateHttpClientWithHttp1WhenDisableAuthTrue() {
 	sc := GetDefaultStorageClientConfig() // By default http1 enabled
 	sc.DisableAuth = true
+
 	// Act: this method add tokenSource and clientOptions.
 	httpClient, err := CreateHttpClient(&sc)
 
 	ExpectEq(nil, err)
 	ExpectNe(nil, httpClient)
-	ExpectNe(nil, httpClient.Transport)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
 }
 
-func (t *clientTest) TestCreateHttpClientWithHttp2() {
+func (t *clientTest) TestCreateHttpClientWithHttp2WhenDisableAuthTrue() {
 	sc := GetDefaultStorageClientConfig()
 	sc.DisableAuth = true
 
@@ -73,6 +49,37 @@ func (t *clientTest) TestCreateHttpClientWithHttp2() {
 
 	ExpectEq(nil, err)
 	ExpectNe(nil, httpClient)
-	ExpectNe(nil, httpClient.Transport)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
+}
+
+func (t *clientTest) TestCreateHttpClientWithHttp1WhenDisableAuthFalse() {
+	sc := GetDefaultStorageClientConfig() // By default http1 enabled
+
+	// Act: this method add tokenSource and clientOptions.
+	httpClient, err := CreateHttpClient(&sc)
+
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, httpClient)
+}
+
+func (t *clientTest) TestCreateHttpClientWithHttp2WhenDisableAuthFalse() {
+	sc := GetDefaultStorageClientConfig()
+
+	// Act: this method add tokenSource and clientOptions.
+	httpClient, err := CreateHttpClient(&sc)
+
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	AssertEq(nil, httpClient)
+}
+
+func (t *clientTest) TestCreateTokenSrc() {
+	sc := GetDefaultStorageClientConfig()
+
+	tokenSrc, err := createTokenSource(&sc)
+
+	AssertNe(nil, err)
+	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
+	ExpectNe(nil, &tokenSrc)
 }

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -42,20 +41,6 @@ func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsTrue()
 	ExpectNe(nil, &tokenSrc)
 }
 
-func (t *clientTest) TestCreateTokenSrcWithCustomEndpointWhenDisableAuthIsFalse() {
-	url, err := url.Parse(CustomEndpoint)
-	AssertEq(nil, err)
-	sc := GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = url
-
-	// It will try to create the actual auth token and fail since key-file doesn't exist.
-	tokenSrc, err := createTokenSource(&sc)
-
-	ExpectNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	ExpectNe(nil, &tokenSrc)
-}
-
 func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTrue() {
 	sc := GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
@@ -65,18 +50,6 @@ func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsTr
 
 	ExpectEq(nil, err)
 	ExpectNe(nil, &tokenSrc)
-}
-
-func (t *clientTest) TestCreateTokenSrcWhenCustomEndpointIsNilAndDisableAuthIsFalse() {
-	sc := GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = nil
-
-	// It will try to create the actual auth token and fail since key-file doesn't exist.
-	tokenSrc, err := createTokenSource(&sc)
-
-	ExpectNe(nil, err)
-	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))
-	ExpectEq(nil, tokenSrc)
 }
 
 func (t *clientTest) TestCreateHttpClientWithHttp1() {

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -41,6 +41,6 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		TokenUrl:                   "",
 		ReuseTokenFromUrl:          true,
 		ExperimentalEnableJsonRead: false,
-		DisableAuth:                true,
+		DisableAuth:                false,
 	}
 }

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -15,7 +15,6 @@
 package storageutil
 
 import (
-	"net/url"
 	"time"
 
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
@@ -36,7 +35,6 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		MaxRetryDuration:           30 * time.Second,
 		RetryMultiplier:            2,
 		UserAgent:                  "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) (GCP:gcsfuse)",
-		CustomEndpoint:             &url.URL{},
 		KeyFile:                    DummyKeyFile,
 		TokenUrl:                   "",
 		ReuseTokenFromUrl:          true,

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -41,5 +41,6 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		TokenUrl:                   "",
 		ReuseTokenFromUrl:          true,
 		ExperimentalEnableJsonRead: false,
+		DisableAuth:                true,
 	}
 }

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -15,6 +15,7 @@
 package storageutil
 
 import (
+	"net/url"
 	"time"
 
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
@@ -34,6 +35,7 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		HttpClientTimeout:          800 * time.Millisecond,
 		MaxRetryDuration:           30 * time.Second,
 		RetryMultiplier:            2,
+		CustomEndpoint:             &url.URL{},
 		UserAgent:                  "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) (GCP:gcsfuse)",
 		KeyFile:                    DummyKeyFile,
 		TokenUrl:                   "",

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func createStorageHandle(flags *flagStorage) (storageHandle storage.StorageHandl
 		TokenUrl:                   flags.TokenUrl,
 		ReuseTokenFromUrl:          flags.ReuseTokenFromUrl,
 		ExperimentalEnableJsonRead: flags.ExperimentalEnableJsonRead,
+		DisableAuth:                flags.DisableAuth,
 	}
 
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -85,7 +85,8 @@ func makeGcsfuseArgs(
 			"experimental_local_file_cache",
 			"reuse_token_from_url",
 			"enable_nonexistent_type_cache",
-			"experimental_enable_json_read":
+			"experimental_enable_json_read",
+			"disable_auth":
 			if value == "" {
 				value = "true"
 			}


### PR DESCRIPTION
### Description
Adding new flag --disable-auth.
1. when we will pass --disable-auth flag it will not authenticate.(creates dummy token)
2. Customer who are using custom-endpoint for testing - they need to pass --disable-auth flag additionally.
3. Customer who wants to use custom-endpoint with authentication - they can authenticate now, as default value of --disable-auth is false.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested using storage test bench server.
                   1. with --disable-auth flag, with credentials  and with custom endpoint - (gcsfuse mounts successfully)
                   2. without --disable-auth flag, without credentials and with custom endpoint - (throwing auth error as expected)
                   3. without --disable-auth flag, with credentials and with custom endpoint - (gcsfuse mounts successfully)
                   4. with --disable-auth flag, without credentials and with custom endpoint - (gcsfuse mounts successfully)
                   5. with --disable-auth flag, with credentials, without custom endpoint - (gcsfuse mount stuck as we don't have necessary permisisons on the bucket, it stucks on first list call itself.)
                   6. Able to mount public readonly bucket(able to do list and cat)(In create, write it stucks due to retry issue)
7. Unit tests - Added unit tests
8. Integration tests - integration tests are working with kokoro test label
