### PR TITLE
update run_tests_mounted_directory.sh with create-empty-file tests

### DIFF
--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -84,6 +84,14 @@ mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=tru
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
 
+# Run tests with config "create-empty-file: true".
+echo "write:
+       create-empty-file: true
+       " > /tmp/gcsfuse_config.yaml
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
+sudo umount $MOUNT_DIR
+
 # package readonly
 # Run tests with static mounting. (flags: --implicit-dirs=true,--o=ro)
 gcsfuse --o=ro --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR


### PR DESCRIPTION
### Description
added commands in `run_tests_mounted_directory.sh` to run tests with "create-empty-file" config set to true.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran the commands on GCE VM.
2. Unit tests - NA
3. Integration tests - NA
