### PR TITLE
Throw error in case of unexpected fields

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -81,7 +81,8 @@ func newApp() (app *cli.App) {
 			cli.StringFlag{
 				Name:  "config-file",
 				Value: "",
-				Usage: "The path to the config file where all gcsfuse related config needs to be specified.",
+				Usage: "The path to the config file where all gcsfuse related config needs to be specified. " +
+					"Refer to 'https://cloud.google.com/storage/docs/gcsfuse-cli#config-file' for possible configurations.",
 			},
 
 			/////////////////////////

--- a/internal/config/testdata/invalid_unexpectedfield_config.yaml
+++ b/internal/config/testdata/invalid_unexpectedfield_config.yaml
@@ -1,0 +1,5 @@
+write:
+  create-empty-file: true
+logging:
+  # The correct field is 'format'.
+  formats: text

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -15,7 +15,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -60,11 +62,18 @@ func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 		return
 	}
 
-	err = yaml.Unmarshal(buf, mountConfig)
-	if err != nil {
-		err = fmt.Errorf("error parsing config file: %w", err)
-		return
+	// Ensure error is thrown when unexpected configs are passed in config file.
+	// Ref: https://github.com/go-yaml/yaml/issues/602#issuecomment-623485602
+	decoder := yaml.NewDecoder(bytes.NewReader(buf))
+	decoder.KnownFields(true)
+	if err = decoder.Decode(mountConfig); err != nil {
+		// Decode returns EOF in case of empty config file.
+		if err == io.EOF {
+			return mountConfig, nil
+		}
+		return mountConfig, fmt.Errorf("error parsing config file: %w", err)
 	}
+
 	// convert log severity to upper-case
 	mountConfig.LogConfig.Severity = LogSeverity(strings.ToUpper(string(mountConfig.LogConfig.Severity)))
 	if !IsValidLogSeverity(mountConfig.LogConfig.Severity) {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -64,6 +64,14 @@ func (t *YamlParserTest) TestReadConfigFile_InvalidConfig() {
 	AssertTrue(strings.Contains(err.Error(), "error parsing config file: yaml: unmarshal errors:"))
 }
 
+func (t *YamlParserTest) TestReadConfigFile_Invalid_UnexpectedField_Config() {
+	_, err := ParseConfigFile("testdata/invalid_unexpectedfield_config.yaml")
+
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "error parsing config file: yaml: unmarshal errors:"))
+	AssertTrue(strings.Contains(err.Error(), "line 5: field formats not found in type config.LogConfig"))
+}
+
 func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 	mountConfig, err := ParseConfigFile("testdata/valid_config.yaml")
 


### PR DESCRIPTION
### Description
Throw an error if user passes wrong fields in the config file. e.g. an extra field or typo in the existing field. Used Decoder instead of Unmarshal due to https://github.com/go-yaml/yaml/issues/602#issuecomment-623485602

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit test for invalid file.
3. Integration tests - NA
