### PR TITLE
[Async object upload 3] Invoke ChunkUploader from bucket implementations

### DIFF
--- a/internal/gcsx/content_type_bucket_test.go
+++ b/internal/gcsx/content_type_bucket_test.go
@@ -128,7 +128,7 @@ func TestContentTypeBucket_CreateChunkUploader(t *testing.T) {
 		}
 
 		o, err := uploader.Close(context.Background())
-		if o == nil || nil != err {
+		if o == nil || err != nil {
 			t.Errorf("Test case %d. Close(): got = %v, %v want = non-nil, nil", i, o, err)
 		}
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -142,7 +142,10 @@ func (mb *monitoringBucket) CreateChunkUploader(
 	req *gcs.CreateObjectRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	startTime := time.Now()
+	o, err := mb.wrapped.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
+	recordRequest(ctx, "CreateChunkUploader", startTime)
+	return o, err
 }
 
 func (mb *monitoringBucket) CopyObject(

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -144,6 +144,10 @@ func (mb *monitoringBucket) CreateChunkUploader(
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	startTime := time.Now()
 	o, err := mb.wrapped.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
+	// TODO: Add monitoring for bytes being written
+	// by this chunk-uploader. This will be similar
+	// to the monitoring initiated in the NewReader method.
+
 	recordRequest(ctx, "CreateChunkUploader", startTime)
 	return o, err
 }

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -15,7 +15,6 @@
 package ratelimit
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
@@ -96,7 +95,14 @@ func (b *throttledBucket) CreateChunkUploader(
 	req *gcs.CreateObjectRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	// Wait for permission to call through.
+	err := b.opThrottle.Wait(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// Call through.
+	return b.wrapped.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
 }
 
 func (b *throttledBucket) CopyObject(

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -206,7 +206,7 @@ func (bh *bucketHandle) CreateChunkUploader(
 		return nil, fmt.Errorf("method not supported for pre-existing GCS objects")
 	}
 
-	uploader, err = NewChunkUploader(ctx, obj, req, writeChunkSize, nil)
+	uploader, err = NewChunkUploader(ctx, obj, req, writeChunkSize, progressFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -127,9 +127,7 @@ func (b *bucketHandle) StatObject(ctx context.Context, req *gcs.StatObjectReques
 	return
 }
 
-func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
-	obj := bh.bucket.Object(req.Name)
-
+func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateChunkUploaderRequest) (*storage.ObjectHandle, bool) {
 	// GenerationPrecondition - If non-nil, the object will be created/overwritten
 	// only if the current generation for the object name is equal to the given value.
 	// Zero means the object does not exist.
@@ -155,6 +153,13 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	if isStorageConditionsNotEmpty(preconditions) {
 		obj = obj.If(preconditions)
 	}
+
+	return obj, (req.GenerationPrecondition == nil || preconditions.DoesNotExist)
+}
+
+func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
+	obj := bh.bucket.Object(req.Name)
+	obj, _ = withCreatePreconditions(obj, &req.CreateChunkUploaderRequest)
 
 	// Creating a NewWriter with requested attributes, using Go Storage Client.
 	// Chuck size for resumable upload is default i.e. 16MB.
@@ -191,8 +196,22 @@ func (bh *bucketHandle) CreateChunkUploader(
 	ctx context.Context,
 	req *gcs.CreateObjectRequest,
 	writeChunkSize int,
-	progressFunc func(int64)) (sow gcs.ChunkUploader, err error) {
-	return nil, fmt.Errorf("not implemented yet")
+	progressFunc func(int64)) (uploader gcs.ChunkUploader, err error) {
+	obj := bh.bucket.Object(req.Name)
+
+	var doesNotExist bool
+	obj, doesNotExist = withCreatePreconditions(obj, req)
+
+	if !doesNotExist {
+		return nil, fmt.Errorf("method not supported for pre-existing GCS objects")
+	}
+
+	uploader, err = NewChunkUploader(ctx, obj, req, writeChunkSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return uploader, err
 }
 
 func (b *bucketHandle) CopyObject(ctx context.Context, req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -127,7 +127,7 @@ func (b *bucketHandle) StatObject(ctx context.Context, req *gcs.StatObjectReques
 	return
 }
 
-func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateChunkUploaderRequest) (*storage.ObjectHandle, bool) {
+func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateObjectRequest) (*storage.ObjectHandle, bool) {
 	// GenerationPrecondition - If non-nil, the object will be created/overwritten
 	// only if the current generation for the object name is equal to the given value.
 	// Zero means the object does not exist.
@@ -159,7 +159,7 @@ func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateChunkUplo
 
 func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
 	obj := bh.bucket.Object(req.Name)
-	obj, _ = withCreatePreconditions(obj, &req.CreateChunkUploaderRequest)
+	obj, _ = withCreatePreconditions(obj, req)
 
 	// Creating a NewWriter with requested attributes, using Go Storage Client.
 	// Chuck size for resumable upload is default i.e. 16MB.

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -127,6 +127,11 @@ func (b *bucketHandle) StatObject(ctx context.Context, req *gcs.StatObjectReques
 	return
 }
 
+// withCreatePreconditions adds preconditions to the passed ObjectHandle,
+// based on the CreateObjectRequest.
+// It returns the same ObjectHandle and a boolean which is true if
+// this request is for a new object to be created, i.e. the passed
+// object does not already exist.
 func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateObjectRequest) (*storage.ObjectHandle, bool) {
 	// GenerationPrecondition - If non-nil, the object will be created/overwritten
 	// only if the current generation for the object name is equal to the given value.
@@ -154,6 +159,10 @@ func withCreatePreconditions(obj *storage.ObjectHandle, req *gcs.CreateObjectReq
 		obj = obj.If(preconditions)
 	}
 
+	// if the passed CreateObjectRequest doesn't have a GenerationPrecondition in it, or
+	// its GenerationPrecondition is 0, then object does not exist yet,
+	// and a new object needs to be created, rather than a new generation
+	// of the object.
 	return obj, (req.GenerationPrecondition == nil || preconditions.DoesNotExist)
 }
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -370,7 +370,7 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZeroWhenObjectA
 func (t *BucketHandleTest) TestCreateChunkUploaderMethodWithValidObject() {
 	chunkSize := googleapi.MinUploadChunkSize
 	uploader, err := t.bucketHandle.CreateChunkUploader(context.Background(),
-		&gcs.CreateChunkUploaderRequest{
+		&gcs.CreateObjectRequest{
 			Name: "test_object",
 		},
 		chunkSize,
@@ -386,7 +386,7 @@ func (t *BucketHandleTest) TestCreateChunkUploaderMethodWithGenerationAsZero() {
 	var generation int64 = 0
 	chunkSize := googleapi.MinUploadChunkSize
 	uploader, err := t.bucketHandle.CreateChunkUploader(context.Background(),
-		&gcs.CreateChunkUploaderRequest{
+		&gcs.CreateObjectRequest{
 			Name:                   "test_object",
 			GenerationPrecondition: &generation,
 		},
@@ -402,7 +402,7 @@ func (t *BucketHandleTest) TestCreateChunkUploaderMethodWithGenerationAsNonZero(
 	var generation int64 = 47367842389354
 	chunkSize := googleapi.MinUploadChunkSize
 	uploader, err := t.bucketHandle.CreateChunkUploader(context.Background(),
-		&gcs.CreateChunkUploaderRequest{
+		&gcs.CreateObjectRequest{
 			Name:                   "test_object",
 			GenerationPrecondition: &generation,
 		}, chunkSize, nil)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -410,6 +410,11 @@ func (t *BucketHandleTest) TestCreateChunkUploaderMethodWithGenerationAsNonZero(
 	// only to objects that don't exist already.
 	AssertEq(nil, uploader)
 	AssertNe(nil, err)
+	expectedErrorSubstring := "method not supported for pre-existing GCS objects"
+	actualErrorString := err.Error()
+	if !strings.Contains(actualErrorString, expectedErrorSubstring) {
+		AddFailure("Actual error \"%s\" does not contain expected error \"%s\"", actualErrorString, expectedErrorSubstring)
+	}
 }
 
 func (t *BucketHandleTest) TestCreateObjectMethodWhenGivenGenerationObjectNotExist() {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -185,6 +185,10 @@ func (b *fastStatBucket) CreateChunkUploader(
 	if err != nil {
 		return
 	}
+	if wrapped == nil {
+		uploader = nil
+		return
+	}
 
 	uploader = &fastStatChunkUploader{b: b, wrapped: wrapped}
 	return

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -169,45 +169,57 @@ func (t *CreateChunkUploaderTest) CallsEraseAndWrapped() {
 
 func (t *CreateChunkUploaderTest) WrappedFails() {
 	var err error
+	const name = "taco"
 
 	// Erase
 	ExpectCall(t.cache, "Erase")(Any())
 
 	// Wrapped
 	ExpectCall(t.wrapped, "CreateChunkUploader")(Any(), Any(), Any(), Any()).
-		WillOnce(Return(nil, errors.New("taco")))
+		WillOnce(Return(nil, errors.New(name)))
 
 	// Call
 	_, err = t.bucket.CreateChunkUploader(context.TODO(), &gcs.CreateObjectRequest{}, 1, nil)
 
-	ExpectThat(err, Error(HasSubstr("taco")))
+	ExpectThat(err, Error(HasSubstr(name)))
 }
 
-func (t *CreateChunkUploaderTest) WrappedSucceeds() {
-	const name = "taco"
-	var err error
+// func (t *CreateChunkUploaderTest) WrappedSucceeds() {
+// 	const name = "taco"
+// 	var err error
+// 	chunkSize := googleapi.MinUploadChunkSize
 
-	// Erase
-	ExpectCall(t.cache, "Erase")(Any())
+// 	// Erase
+// 	ExpectCall(t.cache, "Erase")(Any())
 
-	// Wrapped
-	obj := &gcs.Object{
-		Name:       name,
-		Generation: 1234,
-	}
+// 	// Wrapped
+// 	obj := &gcs.Object{
+// 		Name:       name,
+// 		Generation: 1234,
+// 	}
 
-	ExpectCall(t.wrapped, "CreateObject")(Any(), Any()).
-		WillOnce(Return(obj, nil))
+// 	// uploader gcs.ChunkUploader{}
 
-	// Insert
-	ExpectCall(t.cache, "Insert")(obj, timeutil.TimeEq(t.clock.Now().Add(ttl)))
+// 	ExpectCall(t.wrapped, "CreateChunkUploader")(Any(), Any(), Any(), Any())
 
-	// Call
-	o, err := t.bucket.CreateObject(context.TODO(), &gcs.CreateObjectRequest{})
+// 	// Insert
+// 	ExpectCall(t.cache, "Insert")(obj, timeutil.TimeEq(t.clock.Now().Add(ttl)))
 
-	AssertEq(nil, err)
-	ExpectEq(obj, o)
-}
+// 	// Call
+// 	uploader, err := t.bucket.CreateChunkUploader(context.TODO(), &gcs.CreateObjectRequest{}, chunkSize, nil)
+
+// 	AssertEq(nil, err)
+// 	ExpectNe(nil, uploader)
+
+// 	err = uploader.Upload(context.Background(), strings.NewReader(""))
+
+// 	AssertEq(nil, err)
+
+// 	o, err := uploader.Close(context.Background())
+
+// 	AssertEq(nil, err)
+// 	AssertNe(nil, o)
+// }
 
 ////////////////////////////////////////////////////////////////////////
 // CopyObject

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -184,43 +184,6 @@ func (t *CreateChunkUploaderTest) WrappedFails() {
 	ExpectThat(err, Error(HasSubstr(name)))
 }
 
-// func (t *CreateChunkUploaderTest) WrappedSucceeds() {
-// 	const name = "taco"
-// 	var err error
-// 	chunkSize := googleapi.MinUploadChunkSize
-
-// 	// Erase
-// 	ExpectCall(t.cache, "Erase")(Any())
-
-// 	// Wrapped
-// 	obj := &gcs.Object{
-// 		Name:       name,
-// 		Generation: 1234,
-// 	}
-
-// 	// uploader gcs.ChunkUploader{}
-
-// 	ExpectCall(t.wrapped, "CreateChunkUploader")(Any(), Any(), Any(), Any())
-
-// 	// Insert
-// 	ExpectCall(t.cache, "Insert")(obj, timeutil.TimeEq(t.clock.Now().Add(ttl)))
-
-// 	// Call
-// 	uploader, err := t.bucket.CreateChunkUploader(context.TODO(), &gcs.CreateObjectRequest{}, chunkSize, nil)
-
-// 	AssertEq(nil, err)
-// 	ExpectNe(nil, uploader)
-
-// 	err = uploader.Upload(context.Background(), strings.NewReader(""))
-
-// 	AssertEq(nil, err)
-
-// 	o, err := uploader.Close(context.Background())
-
-// 	AssertEq(nil, err)
-// 	AssertNe(nil, o)
-// }
-
 ////////////////////////////////////////////////////////////////////////
 // CopyObject
 ////////////////////////////////////////////////////////////////////////

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -174,8 +174,7 @@ type debugChunkUploader struct {
 
 func (dcu *debugChunkUploader) Upload(ctx context.Context, contents io.Reader) error {
 	err := dcu.wrapped.Upload(ctx, contents)
-	// Don't log EOF errors, which are par for the course.
-	if err != nil && err != io.EOF {
+	if err != nil {
 		dcu.bucket.requestLogf(dcu.requestID, "-> Upload error: %v", err)
 	}
 
@@ -208,7 +207,7 @@ func (b *debugBucket) CreateChunkUploader(
 	uploader, err = b.wrapped.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
 	if err != nil {
 		uploader = nil
-		return nil, err
+		return
 	}
 
 	// Return a special chunk-uploader that prings debug info.

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -163,8 +163,12 @@ func (b *debugBucket) CreateChunkUploader(
 	ctx context.Context,
 	req *gcs.CreateObjectRequest,
 	writeChunkSize int,
-	progressFunc func(int64)) (gcs.ChunkUploader, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	progressFunc func(int64)) (uploader gcs.ChunkUploader, err error) {
+	id, desc, start := b.startRequest("CreateChunkUploader(%q)", req.Name)
+	defer b.finishRequest(id, desc, start, &err)
+
+	uploader, err = b.wrapped.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
+	return
 }
 
 func (b *debugBucket) CopyObject(

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -559,12 +559,167 @@ func (b *bucket) CreateObject(
 	return
 }
 
+// Implementation of gcs.ChunkUploader interface
+// for fake bucket.
+type fakeChunkUploader struct {
+	// inputs for creation
+	b            *bucket
+	req          *gcs.CreateObjectRequest
+	chunkSize    int
+	progressFunc func(int64)
+
+	// state
+	contents                            bytes.Buffer
+	existingIndex                       int
+	existingRecord                      *fakeObject
+	totalBytesSuccessfullyUploadedSoFar atomic.Int64
+	closed                              bool
+}
+
 func (b *bucket) CreateChunkUploader(
 	ctx context.Context,
 	req *gcs.CreateObjectRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
-	return nil, fmt.Errorf("not supported")
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Check that the name is legal.
+	err := checkName(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find any existing record for this name.
+	existingIndex := b.objects.find(req.Name)
+	uploader := fakeChunkUploader{
+		b:            b,
+		req:          req,
+		chunkSize:    writeChunkSize,
+		progressFunc: progressFunc,
+	}
+
+	if existingIndex < len(b.objects) {
+		uploader.existingRecord = &b.objects[existingIndex]
+	}
+
+	// Check preconditions.
+	if req.GenerationPrecondition != nil {
+		if *req.GenerationPrecondition == 0 && uploader.existingRecord != nil {
+			return nil, &gcs.PreconditionError{
+				Err: errors.New("Precondition failed: object exists"),
+			}
+		}
+
+		if *req.GenerationPrecondition > 0 {
+			if uploader.existingRecord == nil {
+				return nil, &gcs.PreconditionError{
+					Err: errors.New("Precondition failed: object doesn't exist"),
+				}
+			}
+
+			existingGen := uploader.existingRecord.metadata.Generation
+			if existingGen != *req.GenerationPrecondition {
+				return nil, &gcs.PreconditionError{
+					Err: fmt.Errorf(
+						"Precondition failed: object has generation %v",
+						existingGen),
+				}
+			}
+		}
+	}
+
+	if req.MetaGenerationPrecondition != nil {
+		if uploader.existingRecord == nil {
+			return nil, &gcs.PreconditionError{
+				Err: errors.New("Precondition failed: object doesn't exist"),
+			}
+		}
+
+		existingMetaGen := uploader.existingRecord.metadata.MetaGeneration
+		if existingMetaGen != *req.MetaGenerationPrecondition {
+			return nil, &gcs.PreconditionError{
+				Err: fmt.Errorf(
+					"Precondition failed: object has meta-generation %v",
+					existingMetaGen),
+			}
+		}
+	}
+
+	return &uploader, nil
+}
+
+func (uploader *fakeChunkUploader) Upload(ctx context.Context, contents io.Reader) error {
+	if uploader != nil {
+		if uploader.closed {
+			return fmt.Errorf("uploading using a closed uploader")
+		}
+
+		origSize := uploader.contents.Len()
+		var numChunksOriginal int
+		var bytesCopied int64
+		var err error
+		ioCopyCompleted := make(chan bool)
+
+		go func() {
+			numChunksOriginal = origSize / uploader.chunkSize
+			bytesCopied, err = io.Copy(&uploader.contents, contents)
+			ioCopyCompleted <- true
+		}()
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Upload() timed out")
+		case <-ioCopyCompleted:
+			finalSize := origSize + int(bytesCopied)
+			numChunksFinal := finalSize / uploader.chunkSize
+			if uploader.progressFunc != nil {
+				for i := numChunksOriginal + 1; i <= numChunksFinal; i++ {
+					numBytesUploadedSoFar := int64(i) * int64(uploader.chunkSize)
+					uploader.totalBytesSuccessfullyUploadedSoFar.Store(numBytesUploadedSoFar)
+					uploader.progressFunc(numBytesUploadedSoFar)
+				}
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (uploader *fakeChunkUploader) Close(ctx context.Context) (*gcs.Object, error) {
+	uploader.b.mu.Lock()
+	defer uploader.b.mu.Unlock()
+
+	if uploader.closed {
+		return nil, fmt.Errorf("closing a closed uploader")
+	}
+
+	defer func() {
+		uploader.closed = true
+	}()
+
+	// Snarf the contents.
+	contents := uploader.contents.Bytes()
+
+	// Create an object record from the given attributes.
+	var fo fakeObject = uploader.b.mintObject(uploader.req, contents)
+	o := copyObject(&fo.metadata)
+
+	// Replace an entry in or add an entry to our list of objects.
+	if uploader.existingIndex < len(uploader.b.objects) {
+		uploader.b.objects[uploader.existingIndex] = fo
+	} else {
+		uploader.b.objects = append(uploader.b.objects, fo)
+		sort.Sort(uploader.b.objects)
+	}
+
+	return o, nil
+}
+
+func (uploader *fakeChunkUploader) BytesUploadedSoFar() int64 {
+	return uploader.totalBytesSuccessfullyUploadedSoFar.Load()
 }
 
 // LOCKS_EXCLUDED(b.mu)

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -25,7 +25,7 @@ import (
 // call using GCS' resumable upload API.
 //
 // On closing, they return a GCS object (gcs.Object)
-// and and error object for error-handling.
+// and error object for error-handling.
 type ChunkUploader interface {
 	// Upload uploads the given chunk to gcs.
 	// Progress should be tracked using the progress func

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -132,11 +132,36 @@ func (m *mockBucket) CreateObject(p0 context.Context, p1 *gcs.CreateObjectReques
 }
 
 func (m *mockBucket) CreateChunkUploader(
-	ctx context.Context,
-	req *gcs.CreateObjectRequest,
-	writeChunkSize int,
-	progressFunc func(int64)) (gcs.ChunkUploader, error) {
-	return nil, fmt.Errorf("not implemented yet")
+	p0 context.Context,
+	p1 *gcs.CreateObjectRequest,
+	p2 int,
+	p3 func(int64)) (o0 gcs.ChunkUploader, o1 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"CreateChunkUploader",
+		file,
+		line,
+		[]interface{}{p0, p1, p2, p3})
+
+	if len(retVals) != 2 {
+		panic(fmt.Sprintf("mockBucket.CreateChunkUploader: invalid return values: %v", retVals))
+	}
+
+	// o0 *Object
+	if retVals[0] != nil {
+		o0 = retVals[0].(gcs.ChunkUploader)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
+	}
+
+	return
 }
 
 func (m *mockBucket) DeleteObject(p0 context.Context, p1 *gcs.DeleteObjectRequest) (o0 error) {


### PR DESCRIPTION
### Description
This adds implementation of gcs.ChunkUploader interface and CreateChunkUploader for all bucket types, and their corresponding unit tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - All unit tests passed.
3. Integration tests - Ran as presubmit
