### PR TITLE
[Async object upload 1] Add CreateChunkUploader in Bucket interface

### DIFF
--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -45,6 +45,20 @@ func (b contentTypeBucket) CreateObject(
 	return
 }
 
+func (b contentTypeBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	// Guess a content type if necessary.
+	if req.ContentType == "" {
+		req.ContentType = mime.TypeByExtension(path.Ext(req.Name))
+	}
+
+	// Pass on the request.
+	return b.Bucket.CreateChunkUploader(ctx, req, writeChunkSize, progressFunc)
+}
+
 func (b contentTypeBucket) ComposeObjects(
 	ctx context.Context,
 	req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -16,6 +16,7 @@ package gcsx
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -91,6 +92,14 @@ func (b *prefixBucket) CreateObject(
 	}
 
 	return
+}
+
+func (b *prefixBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
 }
 
 func (b *prefixBucket) CopyObject(

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -137,6 +137,14 @@ func (mb *monitoringBucket) CreateObject(
 	return o, err
 }
 
+func (mb *monitoringBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
 func (mb *monitoringBucket) CopyObject(
 	ctx context.Context,
 	req *gcs.CopyObjectRequest) (*gcs.Object, error) {

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -15,6 +15,7 @@
 package ratelimit
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
@@ -88,6 +89,14 @@ func (b *throttledBucket) CreateObject(
 	o, err = b.wrapped.CreateObject(ctx, req)
 
 	return
+}
+
+func (b *throttledBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
 }
 
 func (b *throttledBucket) CopyObject(

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -187,6 +187,14 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	return
 }
 
+func (bh *bucketHandle) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (sow gcs.ChunkUploader, err error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
 func (b *bucketHandle) CopyObject(ctx context.Context, req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
 	srcObj := b.bucket.Object(req.SrcName)
 	dstObj := b.bucket.Object(req.DstName)

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -145,6 +145,14 @@ func (b *fastStatBucket) CreateObject(
 	return
 }
 
+func (b *fastStatBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) CopyObject(
 	ctx context.Context,

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -159,6 +159,14 @@ func (b *debugBucket) CreateObject(
 	return
 }
 
+func (b *debugBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
 func (b *debugBucket) CopyObject(
 	ctx context.Context,
 	req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -559,6 +559,14 @@ func (b *bucket) CreateObject(
 	return
 }
 
+func (b *bucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
 // LOCKS_EXCLUDED(b.mu)
 func (b *bucket) CopyObject(
 	ctx context.Context,

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -86,6 +86,44 @@ type Bucket interface {
 		ctx context.Context,
 		req *CreateObjectRequest) (*Object, error)
 
+	// CreateChunkUploader creates a chunkUploader instance
+	// according to supplied createObjectRequest. This needs
+	// to be used when caller wants control on the resumable
+	// upload api.
+	//
+	// This is an alternative to createObject which also uploads
+	// data using resumable upload api, but caller has no control
+	// on the resumable api.
+	//
+	// While creating a chunk-uploader, you can specify a callback called
+	// progressFunc which carries (n int64) the total number of bytes
+	// successfully uploaded by the uploader so far.
+	//
+	// The progress function callback is expected exactly once for each upload.
+	//
+	// Sample usage:
+	// uploader, err := bucket.CreateChunkUploader(ctx, createObjectReq,
+	//						chunkSize,
+	//						func(n int64) {
+	//							log("n bytes successfully uploaded so far")
+	//						}
+	// )
+	// // check err
+	// for n times {
+	// 		err = uploader.UploadChunkAsync(buffer)
+	// 		// check err
+	// }
+	// obj, err := uploader.Close()
+	// // check err
+	//
+	// Official documentation:
+	//     https://cloud.google.com/storage/docs/resumable-uploads#go
+	CreateChunkUploader(
+		ctx context.Context,
+		req *CreateObjectRequest,
+		writeChunkSize int,
+		progressFunc func(int64)) (ChunkUploader, error)
+
 	// Copy an object to a new name, preserving all metadata. Any existing
 	// generation of the destination name will be overwritten.
 	//

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -20,6 +20,36 @@ import (
 	"golang.org/x/net/context"
 )
 
+// ChunkUploader interface represents asynchronous object
+// uploaders which upload a chunk of an object's data in a
+// call using GCS' resumable upload API.
+//
+// On closing, they return a GCS object (gcs.Object)
+// and and error object for error-handling.
+type ChunkUploader interface {
+	// UploadChunkAsync uploads the given chunk to gcs.
+	// Progress should be tracked using the progress func
+	// passed during ChunkUploader instance creation.
+	//
+	// io.EOF is an expected error in case the reader has less
+	// data than the writer tries to read from it.
+	//
+	// Unlike the io.Writer interface, it doesn't return number-of-bytes
+	// uploaded in this call, as the write is asynchronous; instead
+	// this interface instead has
+	// BytesWrittenSoFar function below, which returns the total number
+	// of bytes successfully uploaded so far.
+	UploadChunkAsync(contents io.Reader) error
+
+	// Close finalizes the upload and returns the created object.
+	// Error is returned in case of failures.
+	Close() (*Object, error)
+
+	// Returns the number of bytes successfully uploaded so far
+	// by this uploader.
+	BytesUploadedSoFar() int64
+}
+
 // Bucket represents a GCS bucket, pre-bound with a bucket name and necessary
 // authorization information.
 //

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -131,6 +131,14 @@ func (m *mockBucket) CreateObject(p0 context.Context, p1 *gcs.CreateObjectReques
 	return
 }
 
+func (m *mockBucket) CreateChunkUploader(
+	ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	writeChunkSize int,
+	progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	return nil, fmt.Errorf("not implemented yet")
+}
+
 func (m *mockBucket) DeleteObject(p0 context.Context, p1 *gcs.DeleteObjectRequest) (o0 error) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)


### PR DESCRIPTION
### Description
Adds 
1. ChunkUploader interface
   ChunkUploader interface represents asynchronous object
    uploaders which upload a chunk of an object's data in a
    call using GCS' resumable upload API.
    
    On closing, they return a GCS object (gcs.Object)
    and and error object for error-handling.
2. CreateChunkUploader in Bucket interface
   CreateChunkUploader creates a new object-chunk-uploader (which implements
    the ChunkUploader interface) according to the supplied CreateObjectRequest.
    This is used to uploaded content incrementally.
    On closing this uploader, a gcs.Object is returned.
    
    This is an alternative to CreateObject which is
    a one-shot object content-uploader and creator, and is meant
    to be invoked on file sync/flush operation.
    The CreateChunkUploader is instead called
    when you want to asynchronously upload the file/object content chunk
    by chunk and eventually finalize the gcs object.

It is followed up in [[Async object upload 2] ](https://github.com/GoogleCloudPlatform/gcsfuse/pull/1411)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
5. Unit tests - NA
6. Integration tests - NA
