### PR TITLE
Write to buffer for minimal file buffering flow

### DIFF
--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -15,18 +15,19 @@
 package buffer
 
 import (
-	"bytes"
 	"fmt"
 )
 
 type InMemoryWriteBuffer struct {
 	// Holds the data to be written to GCS. At any time, Buffer holds the data for
 	// 2 GCS write calls.
-	buffer *bytes.Buffer
-	// [ currStartOffset, currEndOffset] is the range of file offset for which the
+	buffer []byte
+	// [ bufferStartOffset, bufferEndOffset] is the range of file offset for which the
 	// data is currently stored in buffer.
-	currStartOffset int64
-	currEndOffset   int64
+	bufferStartOffset int64
+	bufferEndOffset   int64
+
+	fileSize int64
 }
 
 // CreateInMemoryWriteBuffer creates a buffer with InMemoryWriteBuffer.buffer
@@ -43,68 +44,63 @@ func CreateInMemoryWriteBuffer() *InMemoryWriteBuffer {
 func (b *InMemoryWriteBuffer) InitializeBuffer(sizeInMB int) {
 	ChunkSize = int64(sizeInMB * MiB)
 	BufferSize = 2 * ChunkSize
-	b.currEndOffset = ChunkSize
+	b.bufferEndOffset = ChunkSize
 	if b.buffer == nil {
-		b.buffer = bytes.NewBuffer(make([]byte, 0, BufferSize))
+		b.buffer = make([]byte, 0, BufferSize)
 	}
 }
 
-func (b *InMemoryWriteBuffer) WriteAt(data []byte, startOffset int64) error {
-	unreadBuffer := b.buffer.Bytes()
-	size := int64(len(data))
-	endOffset := startOffset + size
+func (b *InMemoryWriteBuffer) WriteAt(data []byte, dataStartOffset int64) error {
+	dataSize := int64(len(data))
+	dataEndOffset := dataStartOffset + dataSize
 
-	// If startOffset is not in the range of current offset in buffer, trigger
-	// temp file flow for writes.
-	if startOffset < b.currStartOffset {
-		// todo: finalise the write and trigger temp file flow.
-		return nil
+	// If dataStartOffset is not in the range of offsets stored in buffer block,
+	// trigger temp file flow for writes.
+	if dataStartOffset < b.bufferStartOffset || b.bufferEndOffset < dataStartOffset {
+		// TODO: finalise write and trigger temp file flow.
+		return fmt.Errorf(NonSequentialWriteError)
 	}
 
-	// get slice of unread buffer that we are currently writing to.
-	bufferStartOffset := b.currStartOffset % BufferSize
-	bufferEndOffset := b.currEndOffset % BufferSize
-	unreadBuffer = unreadBuffer[bufferStartOffset:bufferEndOffset]
-
-	// if data can be completely written without wrapping to previously written
-	// buffer offsets (beyond the current block of buffer), write it.
-	if endOffset <= b.currEndOffset {
-		fmt.Println("startOffset = ", startOffset)
-		fmt.Println("startOffset%BufferSize = ", startOffset%BufferSize)
-		bufferEndOffset = 20
-		fmt.Println("bufferEndOffset = ", bufferEndOffset)
-		n := copy(unreadBuffer[startOffset%BufferSize:bufferEndOffset], data)
-		if int64(n) != size {
-			return fmt.Errorf("could not write all the data to buffer. "+
-				"Expected bytes to be written: %d, actually written: %d", size, n)
-		}
-		fmt.Println("unreadBuffer = ", unreadBuffer[startOffset%BufferSize:bufferEndOffset])
-		fmt.Println("data = ", data)
+	// If data can be completely written without wrapping to previously written
+	// buffer block (beyond the current block of buffer), write it.
+	if dataEndOffset <= b.bufferEndOffset {
+		return b.copyDataToBuffer(dataStartOffset, dataEndOffset, data)
 	} else {
-		// Else write the chunk of data that can be written, check status of last
-		// write to GCS, trigger write call for current buffer block, and write
-		// remaining data by wrapping.
-		l := b.currEndOffset - startOffset
-		n := copy(unreadBuffer[startOffset%BufferSize:bufferEndOffset], data[:l])
-		if int64(n) != l {
-			return fmt.Errorf("could not write all the data to buffer. "+
-				"Expected bytes to be written: %d, actually written: %d", l, n)
+		// Below logic is written with the assumption that the data received in a
+		// single write call from the kernel will never exceed beyond buffer block size.
+
+		// Write the chunk of data that can be written to the current buffer block.
+		l := b.bufferEndOffset - dataStartOffset
+		if err := b.copyDataToBuffer(dataStartOffset, b.bufferEndOffset, data[:l]); err != nil {
+			return err
 		}
-		//TODO: logic to get status of last write and trigger async write.
 
-		// Update buffer offsets.
-		b.currStartOffset = b.currEndOffset + 1
-		b.currEndOffset = b.currEndOffset + ChunkSize
-		bufferStartOffset = b.currStartOffset % BufferSize
-		bufferEndOffset = b.currEndOffset % BufferSize
+		//TODO: get status of last write to GCS, and trigger async write for current block.
 
+		// Update buffer offsets for next buffer block.
+		b.bufferStartOffset = b.bufferEndOffset
+		b.bufferEndOffset += ChunkSize
 		// Write the remaining data by wrapping over to the next buffer block.
-		l = size - l
-		n = copy(unreadBuffer[(startOffset+l)%BufferSize:bufferEndOffset], data[:l])
-		if int64(n) != l {
-			return fmt.Errorf("could not write all the data to buffer. "+
-				"Expected bytes to be written: %d, actually written: %d", l, n)
-		}
+		return b.copyDataToBuffer(b.bufferStartOffset, dataEndOffset, data[l:])
 	}
+}
+
+func (b *InMemoryWriteBuffer) copyDataToBuffer(dataStartOffset, dataEndOffset int64, data []byte) error {
+	dataSize := int64(len(data))
+	si := dataStartOffset % BufferSize
+	ei := si + dataSize
+
+	n := copy(b.buffer[si:ei], data)
+	if int64(n) != dataSize {
+		return fmt.Errorf(DataNOtWrittenCompletelyError, dataSize, n)
+	}
+	b.updateFileSize(dataEndOffset)
 	return nil
+}
+
+// After successful copy of data to buffer, increments the bytes written so far.
+func (b *InMemoryWriteBuffer) updateFileSize(endOffset int64) {
+	if endOffset > b.fileSize {
+		b.fileSize = endOffset
+	}
 }

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -43,14 +43,14 @@ type InMemoryWriteBuffer struct {
 // set to nil. Memory is allocated to the buffer when the first write call comes.
 // This avoids unnecessarily bloating GCSFuse memory consumption.
 //
-// To allocate memory to the buffer, use WriteBuffer.InitializeBuffer.
+// To allocate memory to the buffer, use WriteBuffer.Initialize.
 func CreateInMemoryWriteBuffer() *InMemoryWriteBuffer {
 	b := &InMemoryWriteBuffer{}
 	// TODO: set mtime attribute.
 	return b
 }
 
-func (b *InMemoryWriteBuffer) InitializeBuffer(sizeInMB int) {
+func (b *InMemoryWriteBuffer) Initialize(sizeInMB int) {
 	if ChunkSize == 0 {
 		ChunkSize = int64(sizeInMB * MiB)
 	}
@@ -110,7 +110,7 @@ func (b *InMemoryWriteBuffer) copyDataToBuffer(contentStartOffset, contentEndOff
 
 	n := copy(b.currentBuffer[si:ei], content)
 	if int64(n) != dataSize {
-		return fmt.Errorf(DataNOtWrittenCompletelyError, dataSize, n)
+		return fmt.Errorf(DataNotWrittenCompletelyError, dataSize, n)
 	}
 	b.updateFileSize(contentEndOffset)
 	return nil

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -16,12 +16,17 @@ package buffer
 
 import (
 	"bytes"
+	"fmt"
 )
 
 type InMemoryWriteBuffer struct {
 	// Holds the data to be written to GCS. At any time, Buffer holds the data for
 	// 2 GCS write calls.
 	buffer *bytes.Buffer
+	// [ currStartOffset, currEndOffset] is the range of file offset for which the
+	// data is currently stored in buffer.
+	currStartOffset int64
+	currEndOffset   int64
 }
 
 // CreateInMemoryWriteBuffer creates a buffer with InMemoryWriteBuffer.buffer
@@ -36,12 +41,70 @@ func CreateInMemoryWriteBuffer() *InMemoryWriteBuffer {
 }
 
 func (b *InMemoryWriteBuffer) InitializeBuffer(sizeInMB int) {
-	ChunkSize = sizeInMB * MiB
+	ChunkSize = int64(sizeInMB * MiB)
+	BufferSize = 2 * ChunkSize
+	b.currEndOffset = ChunkSize
 	if b.buffer == nil {
-		b.buffer = bytes.NewBuffer(make([]byte, 0, 2*sizeInMB*MiB))
+		b.buffer = bytes.NewBuffer(make([]byte, 0, BufferSize))
 	}
 }
 
-func (b *InMemoryWriteBuffer) WriteAt(data []byte, offset int64) error {
+func (b *InMemoryWriteBuffer) WriteAt(data []byte, startOffset int64) error {
+	unreadBuffer := b.buffer.Bytes()
+	size := int64(len(data))
+	endOffset := startOffset + size
+
+	// If startOffset is not in the range of current offset in buffer, trigger
+	// temp file flow for writes.
+	if startOffset < b.currStartOffset {
+		// todo: finalise the write and trigger temp file flow.
+		return nil
+	}
+
+	// get slice of unread buffer that we are currently writing to.
+	bufferStartOffset := b.currStartOffset % BufferSize
+	bufferEndOffset := b.currEndOffset % BufferSize
+	unreadBuffer = unreadBuffer[bufferStartOffset:bufferEndOffset]
+
+	// if data can be completely written without wrapping to previously written
+	// buffer offsets (beyond the current block of buffer), write it.
+	if endOffset <= b.currEndOffset {
+		fmt.Println("startOffset = ", startOffset)
+		fmt.Println("startOffset%BufferSize = ", startOffset%BufferSize)
+		bufferEndOffset = 20
+		fmt.Println("bufferEndOffset = ", bufferEndOffset)
+		n := copy(unreadBuffer[startOffset%BufferSize:bufferEndOffset], data)
+		if int64(n) != size {
+			return fmt.Errorf("could not write all the data to buffer. "+
+				"Expected bytes to be written: %d, actually written: %d", size, n)
+		}
+		fmt.Println("unreadBuffer = ", unreadBuffer[startOffset%BufferSize:bufferEndOffset])
+		fmt.Println("data = ", data)
+	} else {
+		// Else write the chunk of data that can be written, check status of last
+		// write to GCS, trigger write call for current buffer block, and write
+		// remaining data by wrapping.
+		l := b.currEndOffset - startOffset
+		n := copy(unreadBuffer[startOffset%BufferSize:bufferEndOffset], data[:l])
+		if int64(n) != l {
+			return fmt.Errorf("could not write all the data to buffer. "+
+				"Expected bytes to be written: %d, actually written: %d", l, n)
+		}
+		//TODO: logic to get status of last write and trigger async write.
+
+		// Update buffer offsets.
+		b.currStartOffset = b.currEndOffset + 1
+		b.currEndOffset = b.currEndOffset + ChunkSize
+		bufferStartOffset = b.currStartOffset % BufferSize
+		bufferEndOffset = b.currEndOffset % BufferSize
+
+		// Write the remaining data by wrapping over to the next buffer block.
+		l = size - l
+		n = copy(unreadBuffer[(startOffset+l)%BufferSize:bufferEndOffset], data[:l])
+		if int64(n) != l {
+			return fmt.Errorf("could not write all the data to buffer. "+
+				"Expected bytes to be written: %d, actually written: %d", l, n)
+		}
+	}
 	return nil
 }

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -18,15 +18,24 @@ import (
 	"fmt"
 )
 
+// InMemoryWriteBuffer implements WriteBuffer and is stored in memory.
 type InMemoryWriteBuffer struct {
-	// Holds the data to be written to GCS. At any time, Buffer holds the data for
-	// 2 GCS write calls.
-	buffer []byte
-	// [ bufferStartOffset, bufferEndOffset] is the range of file offset for which the
-	// data is currently stored in buffer.
-	bufferStartOffset int64
-	bufferEndOffset   int64
+	// Holds the incoming data from kernel write calls.
+	currentBuffer []byte
+	// [ currentBufferStartOffset, currentBufferEndOffset) is the range of file offset for which the
+	// data is currently stored in currentBuffer.
+	currentBufferStartOffset int64
+	currentBufferEndOffset   int64
 
+	// Holds the data that is sent to go storage client for upload. Data in this buffer
+	// will persist until the entire data is successfully uploaded to GCS.
+	flushedBuffer []byte
+	// [ flushedBufferStartOffset, flushedBufferEndOffset) is the range of file offset for which the
+	// data is currently stored in flushedBuffer.
+	flushedBufferStartOffset int64
+	flushedBufferEndOffset   int64
+
+	// Holds the last offset to which data is written.
 	fileSize int64
 }
 
@@ -42,60 +51,76 @@ func CreateInMemoryWriteBuffer() *InMemoryWriteBuffer {
 }
 
 func (b *InMemoryWriteBuffer) InitializeBuffer(sizeInMB int) {
-	ChunkSize = int64(sizeInMB * MiB)
-	BufferSize = 2 * ChunkSize
-	b.bufferEndOffset = ChunkSize
-	if b.buffer == nil {
-		b.buffer = make([]byte, 0, BufferSize)
+	if ChunkSize == 0 {
+		ChunkSize = int64(sizeInMB * MiB)
+	}
+	if b.currentBuffer == nil {
+		b.currentBuffer = make([]byte, 0, ChunkSize)
+		b.currentBufferEndOffset = ChunkSize
+	}
+	if b.flushedBuffer == nil {
+		b.flushedBuffer = make([]byte, 0, ChunkSize)
 	}
 }
 
-func (b *InMemoryWriteBuffer) WriteAt(data []byte, dataStartOffset int64) error {
-	dataSize := int64(len(data))
-	dataEndOffset := dataStartOffset + dataSize
+func (b *InMemoryWriteBuffer) WriteAt(content []byte, receivedContentStartOffset int64) error {
+	dataSize := int64(len(content))
+	receivedContentEndOffset := receivedContentStartOffset + dataSize
 
-	// If dataStartOffset is not in the range of offsets stored in buffer block,
-	// trigger temp file flow for writes.
-	if dataStartOffset < b.bufferStartOffset || b.bufferEndOffset < dataStartOffset {
+	// If receivedContentStartOffset is not in the range of offsets stored in current
+	// buffer, trigger temp file flow for writes.
+	if receivedContentStartOffset < b.currentBufferStartOffset ||
+		b.currentBufferEndOffset < receivedContentStartOffset {
 		// TODO: finalise write and trigger temp file flow.
 		return fmt.Errorf(NonSequentialWriteError)
 	}
 
-	// If data can be completely written without wrapping to previously written
-	// buffer block (beyond the current block of buffer), write it.
-	if dataEndOffset <= b.bufferEndOffset {
-		return b.copyDataToBuffer(dataStartOffset, dataEndOffset, data)
+	// If data can be completely written to the current buffer block, write it.
+	if receivedContentEndOffset <= b.currentBufferEndOffset {
+		return b.copyDataToBuffer(receivedContentStartOffset, receivedContentEndOffset, content)
 	} else {
 		// Below logic is written with the assumption that the data received in a
 		// single write call from the kernel will never exceed beyond buffer block size.
+		// This should always hold true because kernel writes never exceed 1 MiB size.
 
 		// Write the chunk of data that can be written to the current buffer block.
-		l := b.bufferEndOffset - dataStartOffset
-		if err := b.copyDataToBuffer(dataStartOffset, b.bufferEndOffset, data[:l]); err != nil {
+		l := b.currentBufferEndOffset - receivedContentStartOffset
+		if err := b.copyDataToBuffer(receivedContentStartOffset, b.currentBufferEndOffset, content[:l]); err != nil {
 			return err
 		}
 
-		//TODO: get status of last write to GCS, and trigger async write for current block.
+		//TODO: get status of last write to GCS.
+		// If unsuccessful, trigger temp file flow.
+		// Else:
+		b.swapBuffers()
+		// TODO: trigger async upload to GCS for flushedBuffer.
 
 		// Update buffer offsets for next buffer block.
-		b.bufferStartOffset = b.bufferEndOffset
-		b.bufferEndOffset += ChunkSize
-		// Write the remaining data by wrapping over to the next buffer block.
-		return b.copyDataToBuffer(b.bufferStartOffset, dataEndOffset, data[l:])
+		b.currentBufferStartOffset = b.currentBufferEndOffset
+		b.currentBufferEndOffset += ChunkSize
+		// Write the remaining data to currentBuffer.
+		return b.copyDataToBuffer(b.currentBufferStartOffset, receivedContentEndOffset, content[l:])
 	}
 }
 
-func (b *InMemoryWriteBuffer) copyDataToBuffer(dataStartOffset, dataEndOffset int64, data []byte) error {
-	dataSize := int64(len(data))
-	si := dataStartOffset % BufferSize
+func (b *InMemoryWriteBuffer) copyDataToBuffer(contentStartOffset, contentEndOffset int64, content []byte) error {
+	dataSize := int64(len(content))
+	si := contentStartOffset % ChunkSize
 	ei := si + dataSize
 
-	n := copy(b.buffer[si:ei], data)
+	n := copy(b.currentBuffer[si:ei], content)
 	if int64(n) != dataSize {
 		return fmt.Errorf(DataNOtWrittenCompletelyError, dataSize, n)
 	}
-	b.updateFileSize(dataEndOffset)
+	b.updateFileSize(contentEndOffset)
 	return nil
+}
+
+func (b *InMemoryWriteBuffer) swapBuffers() {
+	b.flushedBufferStartOffset = b.currentBufferStartOffset
+	b.flushedBufferEndOffset = b.currentBufferEndOffset
+	b.flushedBuffer, b.currentBuffer = b.currentBuffer, b.flushedBuffer
+	clear(b.currentBuffer)
 }
 
 // After successful copy of data to buffer, increments the bytes written so far.

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -111,7 +111,7 @@ func (b *InMemoryWriteBuffer) WriteAt(content []byte, offset int64) error {
 	}
 
 	var contentWrittenSoFar int64
-	for true {
+	for {
 		n := b.writePartialContentToBuffer(content[contentWrittenSoFar:], offset+contentWrittenSoFar)
 		contentWrittenSoFar += n
 		if contentWrittenSoFar == int64(len(content)) {
@@ -127,7 +127,6 @@ func (b *InMemoryWriteBuffer) WriteAt(content []byte, offset int64) error {
 		// TODO: trigger async upload to GCS for flushedBuffer.
 		logger.Debugf("TODO: trigger async upload to GCS for flushedBuffer.")
 	}
-	return nil
 }
 
 // Helper method to copy received content to currentBuffer.

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -36,7 +36,7 @@ type inMemoryBuffer struct {
 	offset offset
 }
 
-// InMemoryWriteBuffer implements WriteBuffer and is stored in memory.
+// Implements WriteBuffer and is stored in memory.
 // Refer to buffer.WriteBuffer for sample code usage.
 type inMemoryWriteBuffer struct {
 	// Holds the incoming data from kernel write calls, currently being buffered
@@ -54,7 +54,8 @@ type inMemoryWriteBuffer struct {
 	bufferSize int64
 }
 
-// CreateInMemoryWriteBuffer returns a new InMemoryWriteBuffer.
+// CreateInMemoryWriteBuffer returns a buffer.inMemoryWriteBuffer implementation
+// of WriteBuffer.
 // Memory is lazily allocated to current and flushed buffer on their first usage.
 func CreateInMemoryWriteBuffer(bufferSizeMB uint) (WriteBuffer, error) {
 	if bufferSizeMB == 0 {

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -173,7 +173,8 @@ func (b *InMemoryWriteBuffer) advanceToNextChunk() error {
 	b.flushed.offset = b.current.offset
 
 	// Make current buffer ready for new writes coming from kernel.
-	clear(b.current.buffer)
+	// TODO: revisit this when implementing on-disk-write-buffer.
+	clear(b.current.buffer[0:b.bufferSize])
 	b.current.offset.advanceBy(b.bufferSize)
 	return nil
 }

--- a/internal/fs/buffer/inmemory_write_buffer.go
+++ b/internal/fs/buffer/inmemory_write_buffer.go
@@ -38,7 +38,7 @@ type inMemoryBuffer struct {
 
 // InMemoryWriteBuffer implements WriteBuffer and is stored in memory.
 // Refer to buffer.WriteBuffer for sample code usage.
-type InMemoryWriteBuffer struct {
+type inMemoryWriteBuffer struct {
 	// Holds the incoming data from kernel write calls, currently being buffered
 	// for upload in the future.
 	current inMemoryBuffer
@@ -50,57 +50,47 @@ type InMemoryWriteBuffer struct {
 	// Holds the last offset to which data is written.
 	fileSize int64
 
-	// Holds the buffer's size (in bytes) to be allocated to currentBuffer and flushedBuffer.
+	// Holds the buffer's size (in bytes) to be allocated to current and flushed.
 	bufferSize int64
 }
 
 // CreateInMemoryWriteBuffer returns a new InMemoryWriteBuffer.
 // Memory is lazily allocated to current and flushed buffer on their first usage.
-func CreateInMemoryWriteBuffer(bufferSizeMB uint) (*InMemoryWriteBuffer, error) {
+func CreateInMemoryWriteBuffer(bufferSizeMB uint) (WriteBuffer, error) {
 	if bufferSizeMB == 0 {
 		return nil, fmt.Errorf(ZeroSizeBufferError)
 	}
-	b := &InMemoryWriteBuffer{
+	b := inMemoryWriteBuffer{
 		bufferSize: int64(bufferSizeMB * MiB),
 	}
 	// TODO: set mtime attribute.
 	logger.Debugf("TODO: set mtime attribute.")
-	return b, nil
+	return &b, nil
 }
 
 // Allocates memory to currentBuffer if it hasn't been allocated already.
-func (b *InMemoryWriteBuffer) ensureCurrentBuffer() error {
-	if b.bufferSize == 0 {
-		return fmt.Errorf(ZeroSizeBufferError)
-	}
+func (b *inMemoryWriteBuffer) ensureCurrentBuffer() {
 	if b.current.buffer == nil {
 		b.current.buffer = make([]byte, 0, b.bufferSize)
 		b.current.offset.end = b.bufferSize
 	}
-	return nil
 }
 
 // Allocates memory to flushedBuffer if it hasn't been allocated already.
-func (b *InMemoryWriteBuffer) ensureFlushedBuffer() error {
-	if b.bufferSize == 0 {
-		return fmt.Errorf(ZeroSizeBufferError)
-	}
+func (b *inMemoryWriteBuffer) ensureFlushedBuffer() {
 	if b.flushed.buffer == nil {
 		b.flushed.buffer = make([]byte, 0, b.bufferSize)
 	}
-	return nil
 }
 
-func (b *InMemoryWriteBuffer) WriteAt(content []byte, offset int64) error {
+func (b *inMemoryWriteBuffer) WriteAt(content []byte, offset int64) error {
 	contentSize := int64(len(content))
 	if contentSize == 0 {
 		return nil
 	}
 
 	// Ensure b.currentBuffer != nil
-	if err := b.ensureCurrentBuffer(); err != nil {
-		return fmt.Errorf("ensureCurrentBuffer: %w", err)
-	}
+	b.ensureCurrentBuffer()
 
 	if offset < b.current.offset.start ||
 		offset >= b.current.offset.end+b.bufferSize {
@@ -112,25 +102,27 @@ func (b *InMemoryWriteBuffer) WriteAt(content []byte, offset int64) error {
 
 	var contentWrittenSoFar int64
 	for {
-		n := b.writePartialContentToBuffer(content[contentWrittenSoFar:], offset+contentWrittenSoFar)
+		n := b.writePartialContentToCurrentBuffer(content[contentWrittenSoFar:],
+			offset+contentWrittenSoFar)
 		contentWrittenSoFar += n
 		if contentWrittenSoFar == int64(len(content)) {
 			// all content written successfully to buffer.
 			return nil
 		}
+
 		//TODO: Wait/timeout on last write to GCS. If unsuccessful, trigger temp file flow.
 		logger.Debugf("TODO: Wait/timeout on last write to GCS and if " +
 			"unsuccessful, trigger temp file flow.")
-		if err := b.advanceToNextChunk(); err != nil {
-			return fmt.Errorf("advanceToNextChunk: %w", err)
-		}
+
+		b.advanceToNextChunk()
+
 		// TODO: trigger async upload to GCS for flushedBuffer.
 		logger.Debugf("TODO: trigger async upload to GCS for flushedBuffer.")
 	}
 }
 
 // Helper method to copy received content to currentBuffer.
-func (b *InMemoryWriteBuffer) copyDataToBuffer(contentStartOffset int64, content []byte) {
+func (b *inMemoryWriteBuffer) copyDataToBuffer(contentStartOffset int64, content []byte) {
 	contentSize := int64(len(content))
 	contentEndOffset := contentStartOffset + contentSize
 	si := contentStartOffset % b.bufferSize
@@ -140,40 +132,37 @@ func (b *InMemoryWriteBuffer) copyDataToBuffer(contentStartOffset int64, content
 	b.updateFileSize(contentEndOffset)
 }
 
-func (b *InMemoryWriteBuffer) advanceToNextChunk() error {
+func (b *inMemoryWriteBuffer) advanceToNextChunk() {
 	// ensure b.flushed.buffer != nil
-	if err := b.ensureFlushedBuffer(); err != nil {
-		return fmt.Errorf("ensureFlushedBuffer: %w", err)
-	}
+	b.ensureFlushedBuffer()
 
 	// Move current buffer to flushed buffer.
 	b.flushed.buffer, b.current.buffer = b.current.buffer, b.flushed.buffer
 	b.flushed.offset = b.current.offset
 
 	// Make current buffer ready for new writes coming from kernel.
-	// TODO: revisit this when implementing on-disk-write-buffer.
+	// TODO: revisit this decision to clear, when implementing on-disk-write-buffer.
 	clear(b.current.buffer[0:b.bufferSize])
 	b.current.offset.advanceBy(b.bufferSize)
-	return nil
 }
 
 // After successful copy of data to buffer, increments the bytes written so far.
-func (b *InMemoryWriteBuffer) updateFileSize(endOffset int64) {
+func (b *inMemoryWriteBuffer) updateFileSize(endOffset int64) {
 	if endOffset > b.fileSize {
 		b.fileSize = endOffset
 	}
 }
 
-func (b *InMemoryWriteBuffer) writePartialContentToBuffer(content []byte, offset int64) int64 {
+func (b *inMemoryWriteBuffer) writePartialContentToCurrentBuffer(content []byte, offset int64) int64 {
 	if offset < b.current.offset.start ||
 		offset >= b.current.offset.end {
 		// Nothing to copy to current buffer.
 		return 0
 	}
 
-	// copy content to current buffer
-	capacityOfCurrentBuffer := b.current.offset.end - offset
-	l := min(capacityOfCurrentBuffer, int64(len(content)))
+	// Copy content to current buffer.
+	remainingCapacityOfCurrentBuffer := b.current.offset.end - offset
+	l := min(remainingCapacityOfCurrentBuffer, int64(len(content)))
 	b.copyDataToBuffer(offset, content[:l])
 	return l
 }

--- a/internal/fs/buffer/inmemory_write_buffer_test.go
+++ b/internal/fs/buffer/inmemory_write_buffer_test.go
@@ -16,10 +16,13 @@ package buffer
 
 import (
 	"bytes"
+	"math/rand"
 	"testing"
 
 	. "github.com/jacobsa/ogletest"
 )
+
+const KiB = 1024
 
 func TestMemoryBuffer(t *testing.T) { RunTests(t) }
 
@@ -41,6 +44,17 @@ func (t *MemoryBufferTest) SetUp(ti *TestInfo) {
 }
 
 func (t *MemoryBufferTest) TearDown() {}
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+
+func generateRandomData(size int64) []byte {
+	r := rand.New(rand.NewSource(1))
+	data := make([]byte, size)
+	r.Read(data)
+	return data
+}
 
 // //////////////////////////////////////////////////////////////////////
 // Tests
@@ -93,6 +107,66 @@ func (t *MemoryBufferTest) TestMultipleSequentialWritesToInMemoryBuffer() {
 	AssertEq(true, bytes.Equal([]byte("TacoBurritoPizza"), t.mb.buffer[0:t.mb.fileSize]))
 }
 
+func (t *MemoryBufferTest) Test2MBWriteTo2MBInMemoryBuffer() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(MiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+
+	AssertEq(t.mb.fileSize, 2*MiB)
+	AssertEq(true, bytes.Equal(data1, t.mb.buffer[0:MiB]))
+	AssertEq(true, bytes.Equal(data2, t.mb.buffer[MiB:t.mb.fileSize]))
+}
+
+func (t *MemoryBufferTest) Test3MBWriteTo2MBInMemoryBuffer() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(MiB)
+	data3 := generateRandomData(MiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data3, 2*MiB)
+	AssertEq(nil, err)
+
+	AssertEq(t.mb.fileSize, 3*MiB)
+	AssertEq(true, bytes.Equal(data3, t.mb.buffer[0:MiB]))
+	AssertEq(true, bytes.Equal(data2, t.mb.buffer[MiB:2*MiB]))
+}
+
+func (t *MemoryBufferTest) Test4MBWriteTo2MBInMemoryBuffer() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(MiB)
+	data3 := generateRandomData(MiB)
+	data4 := generateRandomData(MiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data3, 2*MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data4, 3*MiB)
+	AssertEq(nil, err)
+
+	AssertEq(t.mb.fileSize, 4*MiB)
+	AssertEq(true, bytes.Equal(data3, t.mb.buffer[0:MiB]))
+	AssertEq(true, bytes.Equal(data4, t.mb.buffer[MiB:2*MiB]))
+}
+
 func (t *MemoryBufferTest) TestMultipleRandomWritesToInMemoryBuffer() {
 	// Allocate a buffer
 	t.TestInitializeInMemoryBuffer()
@@ -143,4 +217,40 @@ func (t *MemoryBufferTest) TestWriteJustAfterChunkSizeOffset() {
 	AssertNe(nil, err)
 	AssertEq(NonSequentialWriteError, err.Error())
 	AssertEq(t.mb.fileSize, 0)
+}
+
+func (t *MemoryBufferTest) TestRandomWriteOnAnAlreadyWrittenBufferBlockShouldFail() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(2 * KiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt([]byte("Hello"), 0)
+
+	AssertNe(nil, err)
+	AssertEq(NonSequentialWriteError, err.Error())
+	AssertEq(t.mb.fileSize, MiB+2*KiB)
+}
+
+func (t *MemoryBufferTest) TestRandomWriteBeyondCurrentBufferBlockAfterSequentialWritesShouldFail() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(2 * KiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, 2*MiB+1)
+
+	AssertNe(nil, err)
+	AssertEq(NonSequentialWriteError, err.Error())
+	AssertEq(t.mb.fileSize, MiB+2*KiB)
 }

--- a/internal/fs/buffer/inmemory_write_buffer_test.go
+++ b/internal/fs/buffer/inmemory_write_buffer_test.go
@@ -219,6 +219,25 @@ func (t *MemoryBufferTest) TestWriteJustAfterChunkSizeOffset() {
 	AssertEq(t.mb.fileSize, 0)
 }
 
+func (t *MemoryBufferTest) TestWriteRollOverFrom2ndTo1stBlock() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+	data1 := generateRandomData(MiB)
+	data2 := generateRandomData(2 * KiB)
+
+	// Write to buffer
+	err := t.mb.WriteAt(data1, 0)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, MiB)
+	AssertEq(nil, err)
+	err = t.mb.WriteAt(data2, 2*MiB-KiB)
+	AssertEq(nil, err)
+
+	AssertEq(t.mb.fileSize, 2*MiB+KiB)
+	AssertEq(true, bytes.Equal(data2[0:KiB], t.mb.buffer[2*MiB-KiB:2*MiB]))
+	AssertEq(true, bytes.Equal(data2[KiB:], t.mb.buffer[0:KiB]))
+}
+
 func (t *MemoryBufferTest) TestRandomWriteOnAnAlreadyWrittenBufferBlockShouldFail() {
 	// Allocate a buffer
 	t.TestInitializeInMemoryBuffer()

--- a/internal/fs/buffer/inmemory_write_buffer_test.go
+++ b/internal/fs/buffer/inmemory_write_buffer_test.go
@@ -53,7 +53,7 @@ func (t *MemoryBufferTest) TestCreateEmptyInMemoryBuffer() {
 }
 
 func (t *MemoryBufferTest) TestInitializeInMemoryBuffer() {
-	bufferSizeMB := 10
+	bufferSizeMB := 1
 	t.mb = CreateInMemoryWriteBuffer()
 
 	t.mb.InitializeBuffer(bufferSizeMB)
@@ -61,4 +61,16 @@ func (t *MemoryBufferTest) TestInitializeInMemoryBuffer() {
 	AssertEq(bufferSizeMB*MiB, ChunkSize)
 	AssertEq(2*bufferSizeMB*MiB, t.mb.buffer.Cap())
 	AssertEq(0, t.mb.buffer.Len())
+}
+
+func (t *MemoryBufferTest) TestWriteToInMemoryBuffer() {
+	// Allocate a buffer
+	t.TestInitializeInMemoryBuffer()
+
+	// Write to buffer
+	err := t.mb.WriteAt([]byte("TacoBell"), 0)
+
+	AssertEq(nil, err)
+	//fmt.Println(t.mb.buffer.Bytes())
+	AssertEq(8, t.mb.buffer.Len())
 }

--- a/internal/fs/buffer/inmemory_write_buffer_test.go
+++ b/internal/fs/buffer/inmemory_write_buffer_test.go
@@ -268,7 +268,7 @@ func (t *MemoryBufferTest) TestWriteJustBeforeChunkSizeOffset() {
 	err := t.mb.WriteAt(smallContent1, MiB-1)
 	AssertEq(nil, err)
 
-	//AssertEq(MiB+smallContent1Size-1, t.mb.fileSize)
+	AssertEq(MiB+smallContent1Size-1, t.mb.fileSize)
 	AssertTrue(bytes.Equal([]byte("T"), t.mb.flushed.buffer[MiB-1:MiB]))
 	AssertTrue(bytes.Equal([]byte("aco"), t.mb.current.buffer[0:3]))
 	t.validateInMemoryBuffer(t.mb.current, bufferSizeInBytes, 0, MiB, 2*MiB)

--- a/internal/fs/buffer/inmemory_write_buffer_test.go
+++ b/internal/fs/buffer/inmemory_write_buffer_test.go
@@ -417,32 +417,6 @@ func (t *MemoryBufferTest) TestBigContentWriteWith2ChunksSkippedShouldFail() {
 	t.validateInMemoryBuffer(t.mb.flushed, bufferSizeInBytes, 0, 0, MiB)
 }
 
-func (t *MemoryBufferTest) TestCopyDataToBufferWithinRange() {
-	t.createAndValidateInMemoryBuffer(bufferSizeInMB)
-	t.mb.ensureCurrentBuffer()
-	data := t.generateRandomData(MiB)
-
-	err := t.mb.copyDataToBuffer(0, data)
-
-	AssertEq(nil, err)
-	AssertEq(MiB, t.mb.fileSize)
-	AssertTrue(bytes.Equal(data, t.mb.current.buffer[:MiB]))
-}
-
-func (t *MemoryBufferTest) TestCopyDataToBufferBeyondRange() {
-	t.createAndValidateInMemoryBuffer(bufferSizeInMB)
-	t.mb.ensureCurrentBuffer()
-	data := t.generateRandomData(MiB)
-
-	err := t.mb.copyDataToBuffer(50, data)
-
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), NotEnoughSpaceInBuffer))
-	AssertEq(0, t.mb.fileSize)
-	t.validateInMemoryBuffer(t.mb.current, bufferSizeInBytes, 0, 0, MiB)
-	t.validateInMemoryBuffer(t.mb.flushed, 0, 0, 0, 0)
-}
-
 // This test case can never happen in real scenarios as kernel writes never
 // exceed 1MiB size.
 func (t *MemoryBufferTest) TestWritingContentSizeMoreThanBufferSizeShouldFail() {

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -27,7 +27,6 @@ const (
 // ChunkSize (bytes) is the size of data to be written in 1 write call to GCS.
 // Ensure ChunkSize <= 100MB to avoid memory bloat.
 var ChunkSize int64
-var BufferSize int64
 
 // WriteBuffer is an interface that buffers the data to be written to GCS during
 // the write flow.

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -24,7 +24,8 @@ const (
 
 // ChunkSize (bytes) is the size of data to be written in 1 write call to GCS.
 // Ensure ChunkSize <= 100MB to avoid memory bloat.
-var ChunkSize int
+var ChunkSize int64
+var BufferSize int64
 
 // WriteBuffer is an interface that buffers the data to be written to GCS during
 // the write flow.

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -19,7 +19,9 @@ const (
 	MiB = 1024 * 1024
 	// InMemoryBufferThresholdMB is the upper limit on the size upto which the buffer should
 	// be created in memory. Beyond this size, buffer should be on disk.
-	InMemoryBufferThresholdMB = 50
+	InMemoryBufferThresholdMB     = 50
+	NonSequentialWriteError       = "non-sequential writes are not supported with buffer"
+	DataNOtWrittenCompletelyError = "could not write all the data to buffer. Expected bytes to be written: %d, actually written: %d"
 )
 
 // ChunkSize (bytes) is the size of data to be written in 1 write call to GCS.

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -21,7 +21,7 @@ const (
 	// be created in memory. Beyond this size, buffer should be on disk.
 	InMemoryBufferThresholdMB     = 50
 	NonSequentialWriteError       = "non-sequential writes are not supported with buffer"
-	DataNOtWrittenCompletelyError = "could not write all the data to buffer. Expected bytes to be written: %d, actually written: %d"
+	DataNotWrittenCompletelyError = "could not write all the data to buffer. Expected bytes to be written: %d, actually written: %d"
 )
 
 // ChunkSize (bytes) is the size of data to be written in 1 write call to GCS.
@@ -34,9 +34,9 @@ var ChunkSize int64
 // at any point in time, only 2x of the configured buffer size is stored in the
 // write buffer.
 type WriteBuffer interface {
-	// InitializeBuffer assigns a buffer of 2*configured buffer size to the WriteBuffer.
-	// InitializeBuffer should be called before any write calls to the buffer.
-	InitializeBuffer(sizeInMB int)
+	// Initialize assigns a buffer of 2*configured buffer size to the WriteBuffer.
+	// Initialize should be called before any write calls to the buffer.
+	Initialize(sizeInMB int)
 
 	// WriteAt writes at an offset to the buffer.
 	WriteAt(data []byte, offset int64) error

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -17,27 +17,29 @@ package buffer
 const (
 	// MiB is the multiplication factor to convert MiB to bytes.
 	MiB = 1024 * 1024
-	// InMemoryBufferThresholdMB is the upper limit on the size upto which the buffer should
-	// be created in memory. Beyond this size, buffer should be on disk.
-	InMemoryBufferThresholdMB     = 50
-	NonSequentialWriteError       = "non-sequential writes are not supported with buffer"
-	DataNotWrittenCompletelyError = "could not write all the data to buffer. Expected bytes to be written: %d, actually written: %d"
+	// maxInMemoryBufferSizeMB is the upper limit on the size upto which the
+	// buffer would be created in memory. Beyond this size, buffer would be on disk.
+	MaxInMemoryBufferSizeMB       = 50
+	NonSequentialWriteError       = "non-sequential writes are not supported with WriteBuffer"
+	NotEnoughSpaceInCurrentBuffer = "not enough space in currentBuffer to write entire content"
+	ZeroSizeBufferError           = "buffer of size 0 cannot be created"
 )
-
-// ChunkSize (bytes) is the size of data to be written in 1 write call to GCS.
-// Ensure ChunkSize <= 100MB to avoid memory bloat.
-var ChunkSize int64
 
 // WriteBuffer is an interface that buffers the data to be written to GCS during
 // the write flow.
 // WriteBuffer is used only in create new file flow with sequential writes and
 // at any point in time, only 2x of the configured buffer size is stored in the
 // write buffer.
+// Sample usage:
+// // Create in-memory write or on-disk write buffer
+// writeBuffer, err := buffer.CreateInMemoryWriteBuffer(bufferSize)
+// // check err
+//
+//	for n times {
+//		err = buffer.WriteAt([]byte("content"), offset)
+//		// check err
+//	}
 type WriteBuffer interface {
-	// Initialize assigns a buffer of 2*configured buffer size to the WriteBuffer.
-	// Initialize should be called before any write calls to the buffer.
-	Initialize(sizeInMB int)
-
 	// WriteAt writes at an offset to the buffer.
 	WriteAt(data []byte, offset int64) error
 }

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -19,10 +19,10 @@ const (
 	MiB = 1024 * 1024
 	// maxInMemoryBufferSizeMB is the upper limit on the size upto which the
 	// buffer would be created in memory. Beyond this size, buffer would be on disk.
-	MaxInMemoryBufferSizeMB       = 50
-	NonSequentialWriteError       = "non-sequential writes are not supported with WriteBuffer"
-	NotEnoughSpaceInCurrentBuffer = "not enough space in currentBuffer to write entire content"
-	ZeroSizeBufferError           = "buffer of size 0 cannot be created"
+	MaxInMemoryBufferSizeMB = 50
+	NonSequentialWriteError = "non-sequential writes are not supported with WriteBuffer"
+	NotEnoughSpaceInBuffer  = "not enough space in write buffer to write entire content"
+	ZeroSizeBufferError     = "buffer of size 0 cannot be created"
 )
 
 // WriteBuffer is an interface that buffers the data to be written to GCS during

--- a/internal/fs/buffer/write_buffer.go
+++ b/internal/fs/buffer/write_buffer.go
@@ -21,7 +21,6 @@ const (
 	// buffer would be created in memory. Beyond this size, buffer would be on disk.
 	MaxInMemoryBufferSizeMB = 50
 	NonSequentialWriteError = "non-sequential writes are not supported with WriteBuffer"
-	NotEnoughSpaceInBuffer  = "not enough space in write buffer to write entire content"
 	ZeroSizeBufferError     = "buffer of size 0 cannot be created"
 )
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2087,7 +2087,6 @@ func (fs *fileSystem) WriteFile(
 	// TODO: add unit tests for the following.
 	if fs.isWriteBufferEnabled(in) {
 		// Trigger write file with buffer flow.
-		logger.Errorf("op.Data = ", op.Data)
 		err = in.WriteToBuffer(fs.mountConfig.WriteConfig.BufferSizeMB, op.Data, op.Offset)
 		if err == nil {
 			return

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -476,20 +476,19 @@ func (f *FileInode) Write(
 	return
 }
 
-func (f *FileInode) CreateEmptyWriteBuffer(bufferSizeMB int) {
-	if bufferSizeMB <= buffer.InMemoryBufferThresholdMB {
-		f.writeBuffer = buffer.CreateInMemoryWriteBuffer()
+func (f *FileInode) CreateEmptyWriteBuffer(bufferSizeMB uint) (err error) {
+	if bufferSizeMB <= buffer.MaxInMemoryBufferSizeMB {
+		f.writeBuffer, err = buffer.CreateInMemoryWriteBuffer(bufferSizeMB)
 	}
 	// TODO: else assign on-disk buffer to f.writeBuffer.
+	return
 }
 
 // Ensures that f.writeBuffer object is not null and is ready to be written to.
-func (f *FileInode) ensureWriteBuffer(bufferSizeMB int) {
+func (f *FileInode) ensureWriteBuffer(bufferSizeMB uint) {
 	if f.writeBuffer == nil {
 		f.CreateEmptyWriteBuffer(bufferSizeMB)
 	}
-	// Initialize a buffer of size 2*bufferSizeMB
-	f.writeBuffer.Initialize(bufferSizeMB)
 }
 
 // WriteToBuffer serves the write request with buffer.
@@ -499,7 +498,7 @@ func (f *FileInode) WriteToBuffer(bufferSizeMB uint,
 	data []byte,
 	offset int64) error {
 	// Ensure that f.writeBuffer != nil.
-	f.ensureWriteBuffer(int(bufferSizeMB))
+	f.ensureWriteBuffer(bufferSizeMB)
 
 	return f.writeBuffer.WriteAt(data, offset)
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -489,7 +489,7 @@ func (f *FileInode) ensureWriteBuffer(bufferSizeMB int) {
 		f.CreateEmptyWriteBuffer(bufferSizeMB)
 	}
 	// Initialize a buffer of size 2*bufferSizeMB
-	f.writeBuffer.InitializeBuffer(bufferSizeMB)
+	f.writeBuffer.Initialize(bufferSizeMB)
 }
 
 // WriteToBuffer serves the write request with buffer.

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -958,7 +958,7 @@ func (t *FileTest) TestMultipleCallsToWriteToBufferCreatesBufferOnce() {
 func (t *FileTest) TestEnsureBufferCreatesInMemoryBufferWhenBufferSizeIsLessThan50() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
-	var bufferSizeMB int = 20
+	var bufferSizeMB uint = 20
 	// verify writeBuffer is nil initially.
 	AssertEq(nil, t.in.writeBuffer)
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -954,17 +954,3 @@ func (t *FileTest) TestMultipleCallsToWriteToBufferCreatesBufferOnce() {
 	AssertEq(bufferCreated, writeToBuffer(t, bufferSizeMB, content, 13))
 	AssertEq(bufferCreated, writeToBuffer(t, bufferSizeMB, content, 25))
 }
-
-func (t *FileTest) TestEnsureBufferCreatesInMemoryBufferWhenBufferSizeIsLessThan50() {
-	// Create a local file inode.
-	t.createInodeWithLocalParam("test", true)
-	var bufferSizeMB uint = 20
-	// verify writeBuffer is nil initially.
-	AssertEq(nil, t.in.writeBuffer)
-
-	t.in.ensureWriteBuffer(bufferSizeMB)
-
-	// Validate that the buffer created is of type InMemoryWriteBuffer
-	_, ok := t.in.writeBuffer.(*buffer.InMemoryWriteBuffer)
-	AssertEq(true, ok)
-}


### PR DESCRIPTION
### Description
Write to buffer when file buffering flow is enabled. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
