### PR TITLE
Adding race detector test for cache directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         build_gcsfuse . /tmp ${GITHUB_SHA}
     - name: Test
       run: CGO_ENABLED=0 go test -p 1 -count 1 -v -cover ./...
+    - name: Cache RaceDetector Test
+      run: CGO_ENABLED=1 go test -p 1 -count 1 -v -race -cover ./internal/cache/...
   lint:
     name: Lint
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Description
Adding race detector test specially for ./internal/cache/... directory.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - (a) Remove locked in the lru_cache.go in insert method. (b) Run the test with `-race` flag - Found below error.

```
  testing.(*T).Run.func1()
      /usr/lib/google-golang/src/testing/testing.go:1648 +0x44
==================
[       OK ] CacheTest.TestRaceCondition
[----------] Finished with tests from CacheTest
    testing.go:1465: race detected during execution of test
--- FAIL: TestCache (0.00s)
=== NAME  
    testing.go:1465: race detected during execution of test
FAIL
coverage: 91.1% of statements
FAIL    github.com/googlecloudplatform/gcsfuse/internal/cache/lru       0.060s
FAIL

```
If we revert changes (a), then test gets succeeded.

3. Unit tests - NA
4. Integration tests - NA
