### PR TITLE
Using locker with invariant check in LRU cache

### DIFF
--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -84,7 +84,7 @@ func NewCache(maxSize uint64) *Cache {
 	return c
 }
 
-// CheckInvariants panic if any internal invariants have been violated.
+// checkInvariants panic if any internal invariants have been violated.
 func (c *Cache) checkInvariants() {
 	// INVARIANT: maxSize > 0
 	if !(c.maxSize > 0) {

--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -71,19 +71,21 @@ type entry struct {
 	Value ValueType
 }
 
-// Init initialize a cache with the supplied maxSize, which must be greater than
-// zero.
-func (c *Cache) Init(maxSize uint64) {
-	c.maxSize = maxSize
-	c.index = make(map[string]*list.Element)
+// NewCache returns the reference of cache object by initialising the cache with
+// the supplied maxSize, which must be greater than zero.
+func NewCache(maxSize uint64) *Cache {
+	c := &Cache{
+		maxSize: maxSize,
+		index:   make(map[string]*list.Element),
+	}
 
 	// Set up invariant checking.
-	c.mu = locker.New("LRUCache", c.CheckInvariants)
+	c.mu = locker.New("LRUCache", c.checkInvariants)
+	return c
 }
 
 // CheckInvariants panic if any internal invariants have been violated.
-// The careful user can arrange to call this at crucial moments.
-func (c *Cache) CheckInvariants() {
+func (c *Cache) checkInvariants() {
 	// INVARIANT: maxSize > 0
 	if !(c.maxSize > 0) {
 		panic(fmt.Sprintf("Invalid maxSize: %v", c.maxSize))

--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -56,7 +56,7 @@ type Cache struct {
 	// INVARIANT: Contains all and only the elements of entries
 	index map[string]*list.Element
 
-	// All public methods of this Cache uses this mutex while accessing/updating
+	// All public methods of this Cache uses this mutex based locker while accessing/updating
 	// Cache's data. This means when one method is accessing/updating Cache's data,
 	// other methods will be blocked until the method in execution completes.
 	mu locker.Locker

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -35,14 +35,14 @@ const MaxSize = 50
 const OperationCount = 100
 
 type CacheTest struct {
-	cache lru.Cache
+	cache *lru.Cache
 }
 
 func init() { RegisterTestSuite(&CacheTest{}) }
 
 func (t *CacheTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	t.cache.Init(MaxSize)
+	t.cache = lru.NewCache(MaxSize)
 }
 
 type testData struct {


### PR DESCRIPTION
### Description
Changing the normal mutex with the customise locker which supports debugging and invariant check.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Automation
3. Integration tests - NA
