### PR TITLE
Adding logic to add and notify subscriber

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -78,6 +78,8 @@ type JobStatus struct {
 // jobSubscriber represents a subscriber waiting on async download of job to
 // complete downloading at least till the subscribed offset.
 type jobSubscriber struct {
+	notificationC    chan<- JobStatus
+	subscribedOffset int64
 }
 
 func NewJob(object *gcs.MinObject, bucket gcs.Bucket, fileInfoCache *lru.Cache,
@@ -122,6 +124,47 @@ func (job *Job) init() {
 func (job *Job) Cancel() {
 	job.mu.Lock()
 	defer job.mu.Unlock()
+}
+
+// addSubscriber adds subscriber for download job and returns channel which is
+// notified when the download is completed at least till the subscribed offset
+// or in case of failure.
+//
+// Not concurrency safe and requires LOCK(job.mu)
+func (job *Job) addSubscriber(subscribedOffset int64) (notificationC <-chan JobStatus) {
+	subscriberC := make(chan JobStatus, 1)
+	job.subscribers.PushBack(jobSubscriber{subscriberC, subscribedOffset})
+	return subscriberC
+}
+
+// notifySubscribers notifies all the subscribers of download job in case of
+// error/cancellation or when download is completed till the subscribed offset.
+//
+// Not concurrency safe and requires LOCK(job.mu)
+func (job *Job) notifySubscribers() {
+	subItr := job.subscribers.Front()
+	for subItr != nil {
+		subItrValue := subItr.Value.(jobSubscriber)
+		nextSubItr := subItr.Next()
+		if job.status.Name == FAILED || job.status.Name == CANCELLED || job.status.Offset >= subItrValue.subscribedOffset {
+			subItrValue.notificationC <- job.status
+			close(subItrValue.notificationC)
+			job.subscribers.Remove(subItr)
+		}
+		subItr = nextSubItr
+	}
+}
+
+// errWhileDownloading changes the status of job to failed and notifies
+// subscribers about the download error.
+//
+// Acquires and releases LOCK(job.mu)
+func (job *Job) failWhileDownloading(downloadErr error) {
+	job.mu.Lock()
+	job.status.Err = downloadErr
+	job.status.Name = FAILED
+	job.notifySubscribers()
+	job.mu.Unlock()
 }
 
 // Download downloads object till the given offset if not already downloaded

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -38,6 +38,7 @@ import (
 
 const CacheMaxSize = 50
 const DefaultObjectName = "foo"
+const DefaultSequentialReadSizeMb = 200
 
 func TestJob(t *testing.T) { RunTests(t) }
 
@@ -94,7 +95,7 @@ func (jt *jobTest) SetUp(*TestInfo) {
 		OwnerGid: uint32(os.Getgid()),
 	}
 
-	jt.job = NewJob(&defaultMinObject, jt.bucket, jt.cache, 200, fileSpec)
+	jt.job = NewJob(&defaultMinObject, jt.bucket, jt.cache, DefaultSequentialReadSizeMb, fileSpec)
 }
 
 func (jt *jobTest) TearDown() {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -16,34 +16,87 @@ package downloader
 
 import (
 	"container/list"
+	"context"
 	"fmt"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
 	. "github.com/jacobsa/ogletest"
+	"github.com/jacobsa/timeutil"
 )
 
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
+const TestBucketName = "test_bucket"
+const CacheMaxSize = 50
+const DefaultObjectName = "foo"
+
 func TestJob(t *testing.T) { RunTests(t) }
 
 type jobTest struct {
-	job *Job
+	job    *Job
+	bucket gcs.Bucket
+	cache  *lru.Cache
 }
 
 func init() { RegisterTestSuite(&jobTest{}) }
 
 func (jt *jobTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	var fileSpec data.FileSpec
-	jt.job = NewJob(nil, nil, nil, 200, fileSpec)
+
+	jt.bucket = fake.NewFakeBucket(timeutil.RealClock(), TestBucketName)
+	cache := lru.NewCache(CacheMaxSize)
+	jt.cache = &cache
+
+	ctx := context.Background()
+	defaultObjects := map[string][]byte{
+		// File
+		DefaultObjectName: []byte("taco"),
+		// Directory
+		"bar/": []byte(""),
+		// File
+		"baz": []byte("burrito"),
+	}
+	err := storageutil.CreateObjects(ctx, jt.bucket, defaultObjects)
+	if err != nil {
+		panic(fmt.Errorf("error whlie creating objects: %v", err))
+	}
+	defaultObject, err := jt.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: DefaultObjectName,
+		ForceFetchFromGcs: true})
+	if err != nil {
+		panic(fmt.Errorf("error whlie stating object: %v", err))
+	}
+	defaultMinObject := gcs.MinObject{
+		Name:            defaultObject.Name,
+		Size:            defaultObject.Size,
+		Generation:      defaultObject.Generation,
+		MetaGeneration:  defaultObject.MetaGeneration,
+		Updated:         defaultObject.Updated,
+		Metadata:        defaultObject.Metadata,
+		ContentEncoding: defaultObject.ContentEncoding,
+	}
+
+	fileSpec := data.FileSpec{
+		Path:     path.Join("./", TestBucketName, DefaultObjectName),
+		Perm:     os.FileMode(0666),
+		OwnerUid: uint32(os.Getuid()),
+		OwnerGid: uint32(os.Getgid()),
+	}
+
+	jt.job = NewJob(&defaultMinObject, jt.bucket, jt.cache, 200, fileSpec)
 }
 
-func (jt *jobTest) TestInit() {
+func (jt *jobTest) Test_init() {
 	// Explicitly changing initialized values first.
 	jt.job.status.Name = DOWNLOADING
 	jt.job.status.Err = fmt.Errorf("some error")
@@ -60,4 +113,93 @@ func (jt *jobTest) TestInit() {
 	ExpectTrue(reflect.DeepEqual(list.List{}, jt.job.subscribers))
 	ExpectNe(nil, jt.job.cancelCtx)
 	ExpectNe(nil, jt.job.cancelFunc)
+}
+
+func (jt *jobTest) Test_addSubscriber() {
+	subscriberOffset1 := int64(0)
+	subscriberOffset2 := int64(1)
+
+	notificationC1 := jt.job.addSubscriber(subscriberOffset1)
+	notificationC2 := jt.job.addSubscriber(subscriberOffset2)
+
+	ExpectEq(2, jt.job.subscribers.Len())
+	receivingC := make(<-chan JobStatus, 1)
+	ExpectEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
+	ExpectEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
+	// check 1st and 2nd subscribers
+	var subscriber jobSubscriber
+	ExpectEq(reflect.TypeOf(subscriber), reflect.TypeOf(jt.job.subscribers.Front().Value.(jobSubscriber)))
+	ExpectEq(0, jt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+	ExpectEq(reflect.TypeOf(subscriber), reflect.TypeOf(jt.job.subscribers.Back().Value.(jobSubscriber)))
+	ExpectEq(1, jt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
+}
+
+func (jt *jobTest) Test_notifySubscriber_FAILED() {
+	subscriberOffset := int64(1)
+	notificationC := jt.job.addSubscriber(subscriberOffset)
+	jt.job.status.Name = FAILED
+	customErr := fmt.Errorf("custom err")
+	jt.job.status.Err = customErr
+
+	jt.job.notifySubscribers()
+
+	ExpectEq(0, jt.job.subscribers.Len())
+	notification, ok := <-notificationC
+	jobStatus := JobStatus{Name: FAILED, Err: customErr, Offset: 0}
+	ExpectTrue(reflect.DeepEqual(jobStatus, notification))
+	ExpectEq(true, ok)
+}
+
+func (jt *jobTest) Test_notifySubscriber_CANCELLED() {
+	subscriberOffset := int64(1)
+	notificationC := jt.job.addSubscriber(subscriberOffset)
+	jt.job.status.Name = CANCELLED
+
+	jt.job.notifySubscribers()
+
+	ExpectEq(0, jt.job.subscribers.Len())
+	notification, ok := <-notificationC
+	jobStatus := JobStatus{Name: CANCELLED, Err: nil, Offset: 0}
+	ExpectTrue(reflect.DeepEqual(jobStatus, notification))
+	ExpectEq(true, ok)
+}
+
+func (jt *jobTest) Test_notifySubscriber_SubscribedOffset() {
+	subscriberOffset1 := int64(3)
+	subscriberOffset2 := int64(5)
+	notificationC1 := jt.job.addSubscriber(subscriberOffset1)
+	_ = jt.job.addSubscriber(subscriberOffset2)
+	jt.job.status.Name = DOWNLOADING
+	jt.job.status.Offset = 4
+
+	jt.job.notifySubscribers()
+
+	ExpectEq(1, jt.job.subscribers.Len())
+	notification1, ok := <-notificationC1
+	jobStatus := JobStatus{Name: DOWNLOADING, Err: nil, Offset: 4}
+	ExpectTrue(reflect.DeepEqual(jobStatus, notification1))
+	ExpectEq(true, ok)
+	// check 2nd subscriber's offset
+	ExpectEq(subscriberOffset2, jt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+}
+
+func (jt *jobTest) Test_failWhileDownloading() {
+	subscriberOffset1 := int64(3)
+	subscriberOffset2 := int64(5)
+	notificationC1 := jt.job.addSubscriber(subscriberOffset1)
+	notificationC2 := jt.job.addSubscriber(subscriberOffset2)
+	jt.job.status = JobStatus{Name: DOWNLOADING, Err: nil, Offset: 4}
+
+	customErr := fmt.Errorf("custom error")
+	jt.job.failWhileDownloading(customErr)
+
+	ExpectEq(0, jt.job.subscribers.Len())
+	notification1, ok1 := <-notificationC1
+	notification2, ok2 := <-notificationC2
+	jobStatus := JobStatus{Name: FAILED, Err: customErr, Offset: 4}
+	// Check 1st and 2nd subscriber notifications
+	ExpectTrue(reflect.DeepEqual(jobStatus, notification1))
+	ExpectEq(true, ok1)
+	ExpectTrue(reflect.DeepEqual(jobStatus, notification2))
+	ExpectEq(true, ok2)
 }

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -120,7 +120,7 @@ func (jt *jobTest) Test_init() {
 	ExpectNe(nil, jt.job.cancelFunc)
 }
 
-func (jt *jobTest) Test_addSubscriber() {
+func (jt *jobTest) Test_subscribe() {
 	subscriberOffset1 := int64(0)
 	subscriberOffset2 := int64(1)
 


### PR DESCRIPTION
### Description
Adding helper functions for adding and notifying subscriber in download job and a function to fail while downloading. Also setup fake GCS object and bucket in job_test.go. I

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests for newly added functions
3. Integration tests - NA
