### PR TITLE
Add create file util , update fileinfocache, remove ownership, bucket creation time

### DIFF
--- a/internal/cache/data/file_info.go
+++ b/internal/cache/data/file_info.go
@@ -32,7 +32,7 @@ type FileInfoKey struct {
 // Key will return a string, combining all the attributes of FileInfoKey.
 // Returns error in case of uninitialized value.
 func (fik FileInfoKey) Key() (string, error) {
-	if fik.BucketName == "" || fik.BucketCreationTime.IsZero() || fik.ObjectName == "" {
+	if fik.BucketName == "" || fik.ObjectName == "" {
 		return "", errors.New(InvalidKeyAttributes)
 	}
 	unixTimeString := fmt.Sprintf("%d", fik.BucketCreationTime.Unix())
@@ -41,7 +41,7 @@ func (fik FileInfoKey) Key() (string, error) {
 
 type FileInfo struct {
 	Key              FileInfoKey
-	ObjectGeneration string
+	ObjectGeneration int64
 	Offset           uint64
 	FileSize         uint64
 }
@@ -51,8 +51,6 @@ func (fi FileInfo) Size() uint64 {
 }
 
 type FileSpec struct {
-	Path     string
-	Perm     os.FileMode
-	OwnerUid uint32
-	OwnerGid uint32
+	Path string
+	Perm os.FileMode
 }

--- a/internal/cache/data/file_info_test.go
+++ b/internal/cache/data/file_info_test.go
@@ -15,6 +15,7 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ const TestDataFileSize uint64 = 23
 const TestTimeInEpoch int64 = 1654041600
 const TestBucketName = "test_bucket"
 const TestObjectName = "test/a.txt"
-const TestGeneration = "test-generation"
+const TestGeneration = 12345678
 const ExpectedFileInfoKey = "test_bucket1654041600test/a.txt"
 
 func init() {
@@ -70,13 +71,12 @@ func (t *fileInfoTestKey) TestKeyMethodWithEmptyBucketName() {
 
 func (t *fileInfoTestKey) TestKeyMethodWithZeroBucketCreationTime() {
 	fik := getTestFileInfoKey()
-	var tt time.Time
-	fik.BucketCreationTime = tt
 
 	key, err := fik.Key()
-	AssertEq(InvalidKeyAttributes, err.Error())
 
-	ExpectEq("", key)
+	ExpectEq(nil, err)
+	unixCreationTimeString := fmt.Sprintf("%d", fik.BucketCreationTime.Unix())
+	ExpectEq(fik.BucketName+unixCreationTimeString+fik.ObjectName, key)
 }
 
 func (t *fileInfoTestKey) TestKeyMethodWithEmptyObjectName() {

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -128,7 +128,7 @@ func (job *Job) Cancel() {
 
 // subscribe adds subscriber for download job and returns channel which is
 // notified when the download is completed at least till the subscribed offset
-// or in case of failure.
+// or in case of failure and cancellation.
 //
 // Not concurrency safe and requires LOCK(job.mu)
 func (job *Job) subscribe(subscribedOffset int64) (notificationC <-chan JobStatus) {
@@ -177,7 +177,8 @@ func (job *Job) updateFileInfoCache() (err error) {
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	if err != nil {
-		err = fmt.Errorf(fmt.Sprintf("error while calling FileInfoKey.Key() for %s %v", fileInfoKeyName, err))
+		err = fmt.Errorf(fmt.Sprintf("init: error while calling FileInfoKey.Key() for bucket %s and object %s %v",
+			fileInfoKey.BucketName, fileInfoKey.ObjectName, err))
 		return
 	}
 

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -239,6 +239,8 @@ func (jt *jobTest) Test_updateFileInfoCache_UpdateEntry() {
 	ExpectEq(jt.job.object.Size, fileInfo.FileSize)
 }
 
+// This test should fail when we shift to only updating fileInfoCache in Job.
+// This test should be removed when that happens.
 func (jt *jobTest) Test_updateFileInfoCache_InsertNew() {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
@@ -89,10 +90,8 @@ func (jt *jobTest) SetUp(*TestInfo) {
 	}
 
 	fileSpec := data.FileSpec{
-		Path:     path.Join("./", storage.TestBucketName, DefaultObjectName),
-		Perm:     os.FileMode(0666),
-		OwnerUid: uint32(os.Getuid()),
-		OwnerGid: uint32(os.Getgid()),
+		Path: path.Join("./", storage.TestBucketName, DefaultObjectName),
+		Perm: os.FileMode(0666),
 	}
 
 	jt.job = NewJob(&defaultMinObject, jt.bucket, jt.cache, DefaultSequentialReadSizeMb, fileSpec)
@@ -208,4 +207,74 @@ func (jt *jobTest) Test_failWhileDownloading() {
 	ExpectEq(true, ok1)
 	ExpectTrue(reflect.DeepEqual(jobStatus, notification2))
 	ExpectEq(true, ok2)
+}
+
+func (jt *jobTest) Test_updateFileInfoCache_UpdateEntry() {
+	// Add an entry into
+	fileInfoKey := data.FileInfoKey{
+		BucketName: storage.TestBucketName,
+		ObjectName: DefaultObjectName,
+	}
+	fileInfo := data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: jt.job.object.Generation,
+		FileSize:         jt.job.object.Size,
+		Offset:           0,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	ExpectEq(nil, err)
+	_, err = jt.cache.Insert(fileInfoKeyName, fileInfo)
+	ExpectEq(nil, err)
+	jt.job.status.Offset = 1
+
+	err = jt.job.updateFileInfoCache()
+
+	ExpectEq(nil, err)
+	// confirm fileInfoCache is updated with new offset.
+	lookupResult := jt.cache.LookUp(fileInfoKeyName)
+	ExpectFalse(lookupResult == nil)
+	fileInfo = lookupResult.(data.FileInfo)
+	ExpectEq(1, fileInfo.Offset)
+	ExpectEq(jt.job.object.Generation, fileInfo.ObjectGeneration)
+	ExpectEq(jt.job.object.Size, fileInfo.FileSize)
+}
+
+func (jt *jobTest) Test_updateFileInfoCache_InsertNew() {
+	fileInfoKey := data.FileInfoKey{
+		BucketName: storage.TestBucketName,
+		ObjectName: DefaultObjectName,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	ExpectEq(nil, err)
+	jt.job.status.Offset = 1
+
+	err = jt.job.updateFileInfoCache()
+
+	ExpectEq(nil, err)
+	// confirm fileInfoCache is updated with new offset.
+	lookupResult := jt.cache.LookUp(fileInfoKeyName)
+	ExpectFalse(lookupResult == nil)
+	fileInfo := lookupResult.(data.FileInfo)
+	ExpectEq(1, fileInfo.Offset)
+	ExpectEq(jt.job.object.Generation, fileInfo.ObjectGeneration)
+	ExpectEq(jt.job.object.Size, fileInfo.FileSize)
+}
+
+func (jt *jobTest) Test_updateFileInfoCache_Fail() {
+	fileInfoKey := data.FileInfoKey{
+		BucketName: storage.TestBucketName,
+		ObjectName: DefaultObjectName,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	ExpectEq(nil, err)
+	// set size of object more than MaxSize of cache.
+	jt.job.object.Size = 100
+
+	err = jt.job.updateFileInfoCache()
+
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), lru.InvalidEntrySizeErrorMsg))
+	// confirm fileInfoCache is not updated.
+	lookupResult := jt.cache.LookUp(fileInfoKeyName)
+	ExpectTrue(lookupResult == nil)
 }

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
+)
+
+const FileDirPerm = os.FileMode(0755) | os.ModeDir
+
+// CreateFile creates file with given file spec i.e. permissions and returns
+// file handle for that file opened with given flag.
+//
+// Note: If directories in path are not present, they are created with FileDirPerm
+// permission.
+func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
+	// Create directory structure if not present
+	fileDir := filepath.Dir(fileSpec.Path)
+	err = os.MkdirAll(fileDir, FileDirPerm)
+	if err != nil {
+		err = fmt.Errorf(fmt.Sprintf("error in creating directory structure %s: %v", fileDir, err))
+		return
+	}
+
+	// Create file if not present.
+	_, err = os.Stat(fileSpec.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			flag = flag | os.O_CREATE
+		} else {
+			err = fmt.Errorf(fmt.Sprintf("error in stating file %s: %v", fileSpec.Path, err))
+			return
+		}
+	}
+	file, err = os.OpenFile(fileSpec.Path, flag, fileSpec.Perm)
+	if err != nil {
+		err = fmt.Errorf(fmt.Sprintf("error in creating file %s: %v", fileSpec.Path, err))
+		return
+	}
+	return
+}

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -1,0 +1,165 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestUtil(t *testing.T) { RunTests(t) }
+
+type utilTest struct {
+	fileSpec data.FileSpec
+	flag     int
+	uid      int
+	gid      int
+}
+
+const FileDir = "/some/dir/"
+const FileName = "foo.txt"
+
+func init() { RegisterTestSuite(&utilTest{}) }
+
+func (ut *utilTest) SetUp(*TestInfo) {
+	operations.RemoveDir(FileDir)
+	ut.flag = os.O_RDWR
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Errorf("error while finding home directory: %v", err))
+	}
+	ut.fileSpec = data.FileSpec{
+		Path: path.Join(homeDir, FileDir, FileName),
+		Perm: os.FileMode(0644),
+	}
+	ut.uid = os.Getuid()
+	ut.gid = os.Getgid()
+}
+
+func (ut *utilTest) TearDown() {
+	operations.RemoveDir(path.Dir(ut.fileSpec.Path))
+}
+
+func (ut *utilTest) assertFileAndDirCreation(file *os.File, err error) {
+	ExpectEq(nil, err)
+
+	dirStat, dirErr := os.Stat(path.Dir(file.Name()))
+	ExpectEq(false, os.IsNotExist(dirErr))
+	ExpectEq(path.Dir(ut.fileSpec.Path), path.Dir(file.Name()))
+	ExpectEq(FileDirPerm|os.ModeDir, dirStat.Mode())
+	ExpectEq(ut.uid, dirStat.Sys().(*syscall.Stat_t).Uid)
+	ExpectEq(ut.gid, dirStat.Sys().(*syscall.Stat_t).Gid)
+
+	fileStat, fileErr := os.Stat(file.Name())
+	ExpectEq(false, os.IsNotExist(fileErr))
+	ExpectEq(ut.fileSpec.Path, file.Name())
+	ExpectEq(ut.fileSpec.Perm, fileStat.Mode())
+	ExpectEq(ut.uid, fileStat.Sys().(*syscall.Stat_t).Uid)
+	ExpectEq(ut.gid, fileStat.Sys().(*syscall.Stat_t).Gid)
+}
+
+func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_FileDirPresent() {
+	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
+	ExpectEq(nil, err)
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_ReadOnlyFile() {
+	ut.flag = os.O_RDONLY
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	_, err = file.Write([]byte("foo"))
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), "bad file descriptor"))
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_ReadWriteFile() {
+	ut.flag = os.O_RDWR
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	n, err := file.Write([]byte("foo"))
+	ExpectEq(nil, err)
+	ExpectEq(3, n)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_FilePerm0755() {
+	ut.fileSpec.Perm = os.FileMode(0755)
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_FilePerm0644() {
+	ut.fileSpec.Perm = os.FileMode(0644)
+
+	file, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_FilePresent() {
+	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
+	ExpectEq(nil, err)
+	file, err := os.Create(ut.fileSpec.Path)
+	ExpectEq(nil, err)
+	ExpectEq(nil, file.Close())
+
+	file, err = CreateFile(ut.fileSpec, ut.flag)
+
+	ut.assertFileAndDirCreation(file, err)
+	ExpectEq(nil, file.Close())
+}
+
+func (ut *utilTest) Test_CreateFile_FilePresentWithLessAccess() {
+	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
+	ExpectEq(nil, err)
+	file, err := os.OpenFile(ut.fileSpec.Path, os.O_CREATE, os.FileMode(0544))
+	ExpectEq(nil, err)
+	ExpectEq(nil, file.Close())
+
+	_, err = CreateFile(ut.fileSpec, ut.flag)
+
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(strings.ToLower(err.Error()), "permission denied"))
+}


### PR DESCRIPTION
### Description
Changes involve:
1. Added create file util to create file in the file cache at the time of downloading.
2. Helper to update file info cache at the time of downloading.
3. Realized from the design that we don't need to put specific uid and gid for files in cache. So removed that from file spec. Haven't deleted file spec in case we need to add more parameters in future.
4. Ignored check in fileinfokey for bucket creation time till we support bucket creation time via metadata call.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran unit tests.
5. Unit tests - Added unit tests wherever applicable.
6. Integration tests - NA
