### PR TITLE
Read cache job 4 - Adding download async job & test cases

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -210,7 +210,7 @@ func (job *Job) updateFileInfoCache() (err error) {
 // Acquires and releases LOCK(job.mu)
 func (job *Job) downloadObjectAsync() {
 	// Create and open cache file for writing object into it.
-	cacheFile, err := util.CreateFile(job.fileSpec, os.O_RDWR)
+	cacheFile, err := util.CreateFile(job.fileSpec, os.O_WRONLY)
 	defer func(cacheFile *os.File) {
 		err = cacheFile.Close()
 		if err != nil {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -15,6 +15,7 @@
 package downloader
 
 import (
+	"bytes"
 	"container/list"
 	"context"
 	"fmt"
@@ -30,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -41,13 +43,17 @@ const CacheMaxSize = 50
 const DefaultObjectName = "foo"
 const DefaultSequentialReadSizeMb = 200
 
+var cacheLocation string = path.Join(os.Getenv("HOME"), "cache/location")
+
 func TestJob(t *testing.T) { RunTests(t) }
 
 type jobTest struct {
 	job         *Job
 	bucket      gcs.Bucket
+	object      gcs.MinObject
 	cache       *lru.Cache
 	fakeStorage storage.FakeStorage
+	fileSpec    data.FileSpec
 }
 
 func init() { RegisterTestSuite(&jobTest{}) }
@@ -59,46 +65,69 @@ func (jt *jobTest) SetUp(*TestInfo) {
 	storageHandle := jt.fakeStorage.CreateStorageHandle()
 	jt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
-	jt.cache = lru.NewCache(CacheMaxSize)
-
-	ctx := context.Background()
-	defaultObjects := map[string][]byte{
-		// File
-		DefaultObjectName: []byte("taco"),
-		// Directory
-		"bar/": []byte(""),
-		// File
-		"baz": []byte("burrito"),
-	}
-	err := storageutil.CreateObjects(ctx, jt.bucket, defaultObjects)
-	if err != nil {
-		panic(fmt.Errorf("error whlie creating objects: %v", err))
-	}
-	defaultObject, err := jt.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: DefaultObjectName,
-		ForceFetchFromGcs: true})
-	if err != nil {
-		panic(fmt.Errorf("error whlie stating object: %v", err))
-	}
-	defaultMinObject := gcs.MinObject{
-		Name:            defaultObject.Name,
-		Size:            defaultObject.Size,
-		Generation:      defaultObject.Generation,
-		MetaGeneration:  defaultObject.MetaGeneration,
-		Updated:         defaultObject.Updated,
-		Metadata:        defaultObject.Metadata,
-		ContentEncoding: defaultObject.ContentEncoding,
-	}
-
-	fileSpec := data.FileSpec{
-		Path: path.Join("./", storage.TestBucketName, DefaultObjectName),
-		Perm: os.FileMode(0666),
-	}
-
-	jt.job = NewJob(&defaultMinObject, jt.bucket, jt.cache, DefaultSequentialReadSizeMb, fileSpec)
+	jt.initJobTest(DefaultObjectName, []byte("taco"), 200, CacheMaxSize)
+	operations.RemoveDir(cacheLocation)
 }
 
 func (jt *jobTest) TearDown() {
 	jt.fakeStorage.ShutDown()
+	operations.RemoveDir(cacheLocation)
+}
+
+func (jt *jobTest) getMinObject(objectName string) gcs.MinObject {
+	ctx := context.Background()
+	object, err := jt.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objectName,
+		ForceFetchFromGcs: true})
+	if err != nil {
+		panic(fmt.Errorf("error whlie stating object: %v", err))
+	}
+	minObject := gcs.MinObject{
+		Name:            object.Name,
+		Size:            object.Size,
+		Generation:      object.Generation,
+		MetaGeneration:  object.MetaGeneration,
+		Updated:         object.Updated,
+		Metadata:        object.Metadata,
+		ContentEncoding: object.ContentEncoding,
+	}
+	return minObject
+}
+
+func (jt *jobTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64) {
+	ctx := context.Background()
+	objects := map[string][]byte{objectName: objectContent}
+	err := storageutil.CreateObjects(ctx, jt.bucket, objects)
+	ExpectEq(nil, err)
+	jt.object = jt.getMinObject(objectName)
+	jt.fileSpec = data.FileSpec{Path: jt.fileCachePath(jt.bucket.Name(), jt.object.Name), Perm: os.FileMode(0644)}
+	jt.cache = lru.NewCache(lruCacheSize)
+	jt.job = NewJob(&jt.object, jt.bucket, jt.cache, sequentialReadSize, jt.fileSpec)
+}
+
+func (jt *jobTest) verifyFile(content []byte) {
+	fileStat, err := os.Stat(jt.fileSpec.Path)
+	ExpectEq(nil, err)
+	ExpectEq(jt.fileSpec.Perm, fileStat.Mode())
+	ExpectEq(len(content), fileStat.Size())
+	// verify the content of file downloaded. only verified till
+	fileContent, err := os.ReadFile(jt.fileSpec.Path)
+	ExpectEq(nil, err)
+	ExpectTrue(reflect.DeepEqual(content, fileContent[:len(content)]))
+}
+
+func (jt *jobTest) verifyFileInfoEntry(offset uint64) {
+	fileInfoKey := data.FileInfoKey{BucketName: jt.bucket.Name(), ObjectName: jt.object.Name}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	ExpectEq(nil, err)
+	fileInfo := jt.cache.LookUp(fileInfoKeyName)
+	ExpectTrue(fileInfo != nil)
+	ExpectEq(jt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
+	ExpectEq(offset, fileInfo.(data.FileInfo).Offset)
+	ExpectEq(jt.object.Size, fileInfo.(data.FileInfo).Size())
+}
+
+func (jt *jobTest) fileCachePath(bucketName string, objectName string) string {
+	return path.Join(cacheLocation, bucketName, objectName)
 }
 
 func (jt *jobTest) Test_init() {
@@ -279,4 +308,83 @@ func (jt *jobTest) Test_updateFileInfoCache_Fail() {
 	// confirm fileInfoCache is not updated.
 	lookupResult := jt.cache.LookUp(fileInfoKeyName)
 	ExpectTrue(lookupResult == nil)
+}
+
+// Note: We can't test Test_downloadObjectAsync_MoreThanSequentialReadSize as
+// the fake storage bucket/server in the testing environment doesn't support
+// reading ranges (start and limit in NewReader call)
+func (jt *jobTest) Test_downloadObjectAsync_LessThanSequentialReadSize() {
+	// Create new object in bucket and create new job for it.
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 50 * MiB
+	objectContent := bytes.Repeat([]byte("t"), objectSize)
+	jt.initJobTest(objectName, objectContent, 100, uint64(2*objectSize))
+
+	// start download
+	jt.job.downloadObjectAsync()
+
+	// check job completed successfully
+	jobStatus := JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
+	// verify file is downloaded
+	jt.verifyFile(objectContent)
+	// Verify fileInfoCache update
+	jt.verifyFileInfoEntry(jt.object.Size)
+}
+
+func (jt *jobTest) Test_downloadObjectAsync_LessThanChunkSize() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 2 * MiB
+	objectContent := bytes.Repeat([]byte("t"), objectSize)
+	jt.initJobTest(objectName, objectContent, 25, uint64(2*objectSize))
+
+	// start download
+	jt.job.downloadObjectAsync()
+
+	// check job completed successfully
+	jobStatus := JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
+	// verify file is downloaded
+	jt.verifyFile(objectContent)
+	// Verify fileInfoCache update
+	jt.verifyFileInfoEntry(jt.object.Size)
+}
+
+func (jt *jobTest) Test_downloadObjectAsync_Notification() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 50 * MiB
+	objectContent := bytes.Repeat([]byte("t"), objectSize)
+	jt.initJobTest(objectName, objectContent, 100, uint64(2*objectSize))
+	// Add subscriber
+	subscribedOffset := int64(45 * MiB)
+	notificationC := jt.job.subscribe(subscribedOffset)
+
+	// start download
+	jt.job.downloadObjectAsync()
+
+	jobStatus := <-notificationC
+	// check the notification is sent after subscribed offset
+	ExpectGe(jobStatus.Offset, subscribedOffset)
+	// check job completed successfully
+	jobStatus = JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
+	// verify file is downloaded
+	jt.verifyFile(objectContent)
+	// Verify fileInfoCache update
+	jt.verifyFileInfoEntry(jt.object.Size)
+}
+
+func (jt *jobTest) Test_downloadObjectAsync_ErrorWhenFileCacheHasLessSize() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 50 * MiB
+	objectContent := bytes.Repeat([]byte("t"), objectSize)
+	jt.initJobTest(objectName, objectContent, 100, uint64(objectSize-1))
+
+	// start download
+	jt.job.downloadObjectAsync()
+
+	// check job failed
+	ExpectEq(FAILED, jt.job.status.Name)
+	ExpectEq(ReadChunkSize, jt.job.status.Offset)
+	ExpectTrue(strings.Contains(jt.job.status.Err.Error(), "size of the entry is more than the cache's maxSize"))
 }

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -324,12 +324,14 @@ func (jt *jobTest) Test_downloadObjectAsync_LessThanSequentialReadSize() {
 	jt.job.downloadObjectAsync()
 
 	// check job completed successfully
-	jobStatus := JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	jobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
+	jt.job.mu.Lock()
+	defer jt.job.mu.Unlock()
 	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
 	// verify file is downloaded
 	jt.verifyFile(objectContent)
 	// Verify fileInfoCache update
-	jt.verifyFileInfoEntry(jt.object.Size)
+	jt.verifyFileInfoEntry(uint64(objectSize))
 }
 
 func (jt *jobTest) Test_downloadObjectAsync_LessThanChunkSize() {
@@ -342,12 +344,14 @@ func (jt *jobTest) Test_downloadObjectAsync_LessThanChunkSize() {
 	jt.job.downloadObjectAsync()
 
 	// check job completed successfully
-	jobStatus := JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	jobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
+	jt.job.mu.Lock()
+	defer jt.job.mu.Unlock()
 	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
 	// verify file is downloaded
 	jt.verifyFile(objectContent)
 	// Verify fileInfoCache update
-	jt.verifyFileInfoEntry(jt.object.Size)
+	jt.verifyFileInfoEntry(uint64(objectSize))
 }
 
 func (jt *jobTest) Test_downloadObjectAsync_Notification() {
@@ -366,12 +370,14 @@ func (jt *jobTest) Test_downloadObjectAsync_Notification() {
 	// check the notification is sent after subscribed offset
 	ExpectGe(jobStatus.Offset, subscribedOffset)
 	// check job completed successfully
-	jobStatus = JobStatus{COMPLETED, nil, int64(jt.object.Size)}
+	jobStatus = JobStatus{COMPLETED, nil, int64(objectSize)}
+	jt.job.mu.Lock()
+	defer jt.job.mu.Unlock()
 	ExpectTrue(reflect.DeepEqual(jobStatus, jt.job.status))
 	// verify file is downloaded
 	jt.verifyFile(objectContent)
 	// Verify fileInfoCache update
-	jt.verifyFileInfoEntry(jt.object.Size)
+	jt.verifyFileInfoEntry(uint64(objectSize))
 }
 
 func (jt *jobTest) Test_downloadObjectAsync_ErrorWhenFileCacheHasLessSize() {
@@ -384,6 +390,8 @@ func (jt *jobTest) Test_downloadObjectAsync_ErrorWhenFileCacheHasLessSize() {
 	jt.job.downloadObjectAsync()
 
 	// check job failed
+	jt.job.mu.Lock()
+	defer jt.job.mu.Unlock()
 	ExpectEq(FAILED, jt.job.status.Name)
 	ExpectEq(ReadChunkSize, jt.job.status.Offset)
 	ExpectTrue(strings.Contains(jt.job.status.Err.Error(), "size of the entry is more than the cache's maxSize"))

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -23,6 +23,7 @@ import (
 )
 
 const FileDirPerm = os.FileMode(0755) | os.ModeDir
+const MiB = 1024 * 1024
 
 // CreateFile creates file with given file spec i.e. permissions and returns
 // file handle for that file opened with given flag.


### PR DESCRIPTION
### Description
Adding downloadObjectAsync method to download object into a file in cache sequentially. Their can only be one go routine running this method at a time for a download job object. 
This method can be cancelled by job.Cancel method. I will add job.Cancel and job.Download in the next PR along with test cases for job.Download and job.Cancel.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests.
3. Integration tests - NA
