### PR TITLE
[Async object upload 2.5] SplitCreateObjectRequest

### DIFF
--- a/internal/canned/canned.go
+++ b/internal/canned/canned.go
@@ -71,7 +71,9 @@ func MakeFakeBucket(ctx context.Context) (b gcs.Bucket) {
 		_, err := b.CreateObject(
 			ctx,
 			&gcs.CreateObjectRequest{
-				Name:     k,
+				CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+					Name: k,
+				},
 				Contents: strings.NewReader(v),
 			})
 

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -817,9 +817,11 @@ func (t *ForeignModsTest) Mtime() {
 	// Create an object that has an mtime set.
 	expected := time.Date(2001, 2, 3, 4, 5, 6, 7, time.Local)
 	req := &gcs.CreateObjectRequest{
-		Name: "foo",
-		Metadata: map[string]string{
-			"gcsfuse_mtime": expected.UTC().Format(time.RFC3339Nano),
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+			Metadata: map[string]string{
+				"gcsfuse_mtime": expected.UTC().Format(time.RFC3339Nano),
+			},
 		},
 		Contents: ioutil.NopCloser(strings.NewReader("")),
 	}
@@ -841,9 +843,11 @@ func (t *ForeignModsTest) RemoteMtimeChange() {
 	_, err = bucket.CreateObject(
 		ctx,
 		&gcs.CreateObjectRequest{
-			Name: "foo",
-			Metadata: map[string]string{
-				"gcsfuse_mtime": time.Now().UTC().Format(time.RFC3339Nano),
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+				Metadata: map[string]string{
+					"gcsfuse_mtime": time.Now().UTC().Format(time.RFC3339Nano),
+				},
 			},
 			Contents: ioutil.NopCloser(strings.NewReader("")),
 		})
@@ -881,9 +885,11 @@ func (t *ForeignModsTest) Symlink() {
 
 	// Create an object that looks like a symlink.
 	req := &gcs.CreateObjectRequest{
-		Name: "foo",
-		Metadata: map[string]string{
-			"gcsfuse_symlink_target": "bar/baz",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+			Metadata: map[string]string{
+				"gcsfuse_symlink_target": "bar/baz",
+			},
 		},
 		Contents: ioutil.NopCloser(strings.NewReader("")),
 	}

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -359,10 +359,12 @@ func (d *dirInode) createNewObject(
 	// exists.
 	var precond int64
 	createReq := &gcs.CreateObjectRequest{
-		Name:                   name.GcsObjectName(),
-		Contents:               strings.NewReader(""),
-		GenerationPrecondition: &precond,
-		Metadata:               metadata,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   name.GcsObjectName(),
+			GenerationPrecondition: &precond,
+			Metadata:               metadata,
+		},
+		Contents: strings.NewReader(""),
 	}
 
 	o, err = d.bucket.CreateObject(ctx, createReq)

--- a/internal/gcsx/append_object_creator.go
+++ b/internal/gcsx/append_object_creator.go
@@ -99,9 +99,11 @@ func (oc *appendObjectCreator) Create(
 	tmp, err := oc.bucket.CreateObject(
 		ctx,
 		&gcs.CreateObjectRequest{
-			Name:                   tmpName,
-			GenerationPrecondition: &zero,
-			Contents:               r,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   tmpName,
+				GenerationPrecondition: &zero,
+			},
+			Contents: r,
 		})
 	if err != nil {
 		err = fmt.Errorf("CreateObject: %w", err)

--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -47,7 +47,7 @@ func (b contentTypeBucket) CreateObject(
 
 func (b contentTypeBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	// Guess a content type if necessary.

--- a/internal/gcsx/content_type_bucket_test.go
+++ b/internal/gcsx/content_type_bucket_test.go
@@ -87,9 +87,11 @@ func TestContentTypeBucket_CreateObject(t *testing.T) {
 
 		// Create the object.
 		req := &gcs.CreateObjectRequest{
-			Name:        tc.name,
-			ContentType: tc.request,
-			Contents:    strings.NewReader(""),
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:        tc.name,
+				ContentType: tc.request,
+			},
+			Contents: strings.NewReader(""),
 		}
 
 		o, err := bucket.CreateObject(context.Background(), req)
@@ -116,7 +118,9 @@ func TestContentTypeBucket_ComposeObjects(t *testing.T) {
 		// Create a source object.
 		const srcName = "some_src"
 		_, err = bucket.CreateObject(ctx, &gcs.CreateObjectRequest{
-			Name:     srcName,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: srcName,
+			},
 			Contents: strings.NewReader(""),
 		})
 

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -96,7 +96,7 @@ func (b *prefixBucket) CreateObject(
 
 func (b *prefixBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -101,9 +101,11 @@ func (t *PrefixBucketTest) CreateObject() {
 	o, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:            suffix,
-			ContentLanguage: "en-GB",
-			Contents:        strings.NewReader(contents),
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:            suffix,
+				ContentLanguage: "en-GB",
+			},
+			Contents: strings.NewReader(contents),
 		})
 
 	AssertEq(nil, err)

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -92,10 +92,12 @@ func (oc *fullObjectCreator) Create(
 	if srcObject == nil {
 		var precond int64
 		req = &gcs.CreateObjectRequest{
-			Name:                   objectName,
-			Contents:               r,
-			GenerationPrecondition: &precond,
-			Metadata:               metadataMap,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   objectName,
+				GenerationPrecondition: &precond,
+				Metadata:               metadataMap,
+			},
+			Contents: r,
 		}
 	} else {
 		for key, value := range srcObject.Metadata {
@@ -103,18 +105,20 @@ func (oc *fullObjectCreator) Create(
 		}
 
 		req = &gcs.CreateObjectRequest{
-			Name:                       srcObject.Name,
-			GenerationPrecondition:     &srcObject.Generation,
-			MetaGenerationPrecondition: &srcObject.MetaGeneration,
-			Contents:                   r,
-			Metadata:                   metadataMap,
-			CacheControl:               srcObject.CacheControl,
-			ContentDisposition:         srcObject.ContentDisposition,
-			ContentEncoding:            srcObject.ContentEncoding,
-			ContentType:                srcObject.ContentType,
-			CustomTime:                 srcObject.CustomTime,
-			EventBasedHold:             srcObject.EventBasedHold,
-			StorageClass:               srcObject.StorageClass,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                       srcObject.Name,
+				GenerationPrecondition:     &srcObject.Generation,
+				MetaGenerationPrecondition: &srcObject.MetaGeneration,
+				Metadata:                   metadataMap,
+				CacheControl:               srcObject.CacheControl,
+				ContentDisposition:         srcObject.ContentDisposition,
+				ContentEncoding:            srcObject.ContentEncoding,
+				ContentType:                srcObject.ContentType,
+				CustomTime:                 srcObject.CustomTime,
+				EventBasedHold:             srcObject.EventBasedHold,
+				StorageClass:               srcObject.StorageClass,
+			},
+			Contents: r,
 		}
 	}
 

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -304,7 +304,9 @@ func (t *SyncerTest) SetUp(ti *TestInfo) {
 	t.srcObject, err = t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader(srcObjectContents),
 		})
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -139,7 +139,7 @@ func (mb *monitoringBucket) CreateObject(
 
 func (mb *monitoringBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -93,7 +93,7 @@ func (b *throttledBucket) CreateObject(
 
 func (b *throttledBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -189,7 +189,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 
 func (bh *bucketHandle) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (sow gcs.ChunkUploader, err error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -316,7 +316,9 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithValidObject() {
 	content := "Creating a new object"
 	obj, err := t.bucketHandle.CreateObject(context.Background(),
 		&gcs.CreateObjectRequest{
-			Name:     "test_object",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "test_object",
+			},
 			Contents: strings.NewReader(content),
 		})
 
@@ -330,9 +332,11 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZero() {
 	var generation int64 = 0
 	obj, err := t.bucketHandle.CreateObject(context.Background(),
 		&gcs.CreateObjectRequest{
-			Name:                   "test_object",
-			Contents:               strings.NewReader(content),
-			GenerationPrecondition: &generation,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   "test_object",
+				GenerationPrecondition: &generation,
+			},
+			Contents: strings.NewReader(content),
 		})
 
 	AssertEq(obj.Name, "test_object")
@@ -346,9 +350,11 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZeroWhenObjectA
 	var precondition *gcs.PreconditionError
 	obj, err := t.bucketHandle.CreateObject(context.Background(),
 		&gcs.CreateObjectRequest{
-			Name:                   "test_object",
-			Contents:               strings.NewReader(content),
-			GenerationPrecondition: &generation,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   "test_object",
+				GenerationPrecondition: &generation,
+			},
+			Contents: strings.NewReader(content),
 		})
 
 	AssertEq(obj.Name, "test_object")
@@ -357,9 +363,11 @@ func (t *BucketHandleTest) TestCreateObjectMethodWithGenerationAsZeroWhenObjectA
 
 	obj, err = t.bucketHandle.CreateObject(context.Background(),
 		&gcs.CreateObjectRequest{
-			Name:                   "test_object",
-			Contents:               strings.NewReader(content),
-			GenerationPrecondition: &generation,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   "test_object",
+				GenerationPrecondition: &generation,
+			},
+			Contents: strings.NewReader(content),
 		})
 
 	AssertEq(nil, obj)
@@ -374,10 +382,12 @@ func (t *BucketHandleTest) TestCreateObjectMethodWhenGivenGenerationObjectNotExi
 
 	obj, err := t.bucketHandle.CreateObject(context.Background(),
 		&gcs.CreateObjectRequest{
-			Name:                   "test_object",
-			Contents:               strings.NewReader(content),
-			CRC32C:                 &crc32,
-			GenerationPrecondition: &generation,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:                   "test_object",
+				GenerationPrecondition: &generation,
+			},
+			Contents: strings.NewReader(content),
+			CRC32C:   &crc32,
 		})
 
 	AssertEq(nil, obj)

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -147,7 +147,7 @@ func (b *fastStatBucket) CreateObject(
 
 func (b *fastStatBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -84,7 +84,9 @@ func (t *CreateObjectTest) CallsEraseAndWrapped() {
 
 	// Call
 	req := &gcs.CreateObjectRequest{
-		Name: name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 	}
 
 	_, _ = t.bucket.CreateObject(context.TODO(), req)

--- a/internal/storage/chunk_uploader.go
+++ b/internal/storage/chunk_uploader.go
@@ -52,16 +52,16 @@ type chunkUploader struct {
 
 // NewChunkUploader creates a new instance of chunkUploader,
 // for the given inputs.
-func NewChunkUploader(ctx context.Context, obj *storage.ObjectHandle, req *gcs.CreateObjectRequest, writeChunkSize int, progressFunc func(int64)) (gcs.ChunkUploader, error) {
+func NewChunkUploader(ctx context.Context, obj *storage.ObjectHandle, req *gcs.CreateChunkUploaderRequest, writeChunkSize int, progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("ctx is nil")
 	}
 	if obj == nil || req == nil {
-		return nil, fmt.Errorf("nil ObjectHandle or CreateObjectRequest")
+		return nil, fmt.Errorf("nil ObjectHandle or CreateChunkUploaderRequest")
 	}
 
 	if obj.ObjectName() != req.Name {
-		return nil, fmt.Errorf("names of passed ObjectHandle and CreateObjectRequest don't match: ObjectHandle.Name=%s createObjectRequest.Name=%s", obj.ObjectName(), req.Name)
+		return nil, fmt.Errorf("names of passed ObjectHandle and CreateChunkUploaderRequest don't match: ObjectHandle.Name=%s CreateChunkUploaderRequest.Name=%s", obj.ObjectName(), req.Name)
 	}
 
 	if req.GenerationPrecondition != nil && *req.GenerationPrecondition != 0 {
@@ -82,7 +82,7 @@ func NewChunkUploader(ctx context.Context, obj *storage.ObjectHandle, req *gcs.C
 	// Create a NewWriter with the requested attributes, using Go Storage Client.
 	// NewWriter never returns nil, so no nil-check is needed on it.
 	wc := obj.NewWriter(ctx)
-	wc = storageutil.SetAttrsInWriter(wc, req)
+	wc = storageutil.SetAttrsInWriter(wc, &gcs.CreateObjectRequest{CreateChunkUploaderRequest: *req})
 	wc.ChunkSize = writeChunkSize
 	wc.ProgressFunc = func(n int64) {
 		uploader.totalWriteSucceededSoFar.Store(n)

--- a/internal/storage/chunk_uploader.go
+++ b/internal/storage/chunk_uploader.go
@@ -1,0 +1,193 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
+	"google.golang.org/api/googleapi"
+)
+
+type UploaderState int
+
+const (
+	// Initialized is the state of successful initialization, no writes so far.
+	Initialized UploaderState = iota
+	// Uploading is the state when an asynchronous upload is in progress.
+	Uploading
+	// UploadError is the state when an Upload failed.
+	UploadError
+	// Closed is the state of an uploader which has been finalized.
+	Closed
+)
+
+// A chunkUploader is an implementation of ChunkUploader
+// interface, which uses storage.Writer from go-storage-client
+// for resumable upload.
+//
+// It also stores the current state of the uploader.
+type chunkUploader struct {
+	// Internal objects for business logic.
+	writer     *storage.Writer
+	objectName string
+	mu         sync.Mutex
+
+	// Attributes for providing updates to user.
+	totalWriteInitiatedSoFar int64
+	// Total number of bytes successfully written by this writer so far.
+	totalWriteSucceededSoFar atomic.Int64
+	userProgressFunc         func(int64)
+
+	// Internal state for lifecycle management.
+	state UploaderState
+}
+
+// NewChunkUploader creates a new instance of chunkUploader,
+// for the given inputs.
+func NewChunkUploader(ctx context.Context, obj *storage.ObjectHandle, req *gcs.CreateObjectRequest, writeChunkSize int, progressFunc func(int64)) (gcs.ChunkUploader, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("ctx is nil")
+	}
+	if obj == nil || req == nil {
+		return nil, fmt.Errorf("nil ObjectHandle or CreateObjectRequest")
+	}
+
+	if obj.ObjectName() != req.Name {
+		return nil, fmt.Errorf("names of passed ObjectHandle and CreateObjectRequest don't match: ObjectHandle.Name=%s createObjectRequest.Name=%s", obj.ObjectName(), req.Name)
+	}
+
+	if req.GenerationPrecondition != nil && *req.GenerationPrecondition != 0 {
+		return nil, fmt.Errorf("request received for pre-existing object %s, supported only for new objects", req.Name)
+	}
+
+	if writeChunkSize <= 0 {
+		return nil, fmt.Errorf("chunkSize <= 0")
+	}
+
+	// Raw initialization.
+	uploader := chunkUploader{}
+
+	// Store references to necessary parameters.
+	uploader.objectName = obj.ObjectName()
+	uploader.userProgressFunc = progressFunc
+
+	// Create a NewWriter with the requested attributes, using Go Storage Client.
+	// NewWriter never returns nil, so no nil-check is needed on it.
+	wc := obj.NewWriter(ctx)
+	wc = storageutil.SetAttrsInWriter(wc, req)
+	wc.ChunkSize = writeChunkSize
+	wc.ProgressFunc = func(n int64) {
+		uploader.totalWriteSucceededSoFar.Store(n)
+		logger.Debugf("%d bytes copied so far for object/file %s. chunk-size = %d", n, req.Name, wc.ChunkSize)
+
+		if uploader.userProgressFunc != nil {
+			uploader.userProgressFunc(n)
+		}
+	}
+
+	uploader.writer = wc
+	uploader.state = Initialized
+
+	return &uploader, nil
+}
+
+// BytesUploadedSoFar returns the total number of bytes successfully uploaded
+// so far using this uploader.
+// This is thread-safe against the
+// in-progress calls to BytesUploadedSoFar/UploadChunkAsync/Close
+// invoked from other threads/go-routines.
+func (uploader *chunkUploader) BytesUploadedSoFar() int64 {
+	return uploader.totalWriteSucceededSoFar.Load()
+}
+
+func (uploader *chunkUploader) readyToUpload() bool {
+	switch uploader.state {
+	case Initialized, Uploading:
+		return true
+	default:
+		return false
+	}
+}
+
+func (uploader *chunkUploader) readyToClose() bool {
+	switch uploader.state {
+	case Initialized, Uploading, UploadError:
+		return true
+	default:
+		return false
+	}
+}
+
+// UploadChunkAsync uploads the passed content to GCS.
+// This waits (using mutex) until the completion of
+// in-progress calls to BytesUploadedSoFar/UploadChunkAsync/Close
+// invoked from other threads/go-routines.
+// The call times out if it is taking longer than StorageCopyTimeoutDuration.
+func (uploader *chunkUploader) UploadChunkAsync(contents io.Reader) error {
+	uploader.mu.Lock()
+	defer uploader.mu.Unlock()
+
+	if !uploader.readyToUpload() {
+		return fmt.Errorf("writer not ready to write: object: %s, status = %v, writer: %v", uploader.objectName, uploader.state, uploader.writer)
+	}
+
+	n, err := io.Copy(uploader.writer, contents)
+	if err != nil {
+		uploader.state = UploadError
+		return fmt.Errorf("upload failed for object %s: totalSizeUploaded-so-far=%d, successfully-uploaded-in-last-upload=%d, chunk-size=%d, %v", uploader.objectName, uploader.BytesUploadedSoFar(),
+			n, uploader.writer.ChunkSize,
+			err)
+	}
+	if n == 0 {
+		return nil
+	}
+
+	uploader.totalWriteInitiatedSoFar += n
+	uploader.state = Uploading
+	return nil
+}
+
+// Close finalizes the chunk uploads and returns the
+// created GCS object.
+// If a chunk upload was in progress at the time of call,
+// it will be waited on and be completed before going ahead
+// with the finalization.
+// This waits (using mutex) until the completion of
+// in-progress calls to BytesUploadedSoFar/UploadChunkAsync/Close
+// invoked from other threads/go-routines.
+func (uploader *chunkUploader) Close() (*gcs.Object, error) {
+	uploader.mu.Lock()
+	defer uploader.mu.Unlock()
+
+	defer func() {
+		uploader.state = Closed
+		uploader.writer = nil
+	}()
+
+	if !uploader.readyToClose() {
+		return nil, fmt.Errorf("improper state (%v) for finalizing object %s", uploader.state, uploader.objectName)
+	}
+
+	if err := uploader.writer.Close(); err != nil {
+		var gErr *googleapi.Error
+		if errors.As(err, &gErr) {
+			if gErr.Code == http.StatusPreconditionFailed {
+				return nil, &gcs.PreconditionError{Err: err}
+			}
+		}
+		return nil, fmt.Errorf("error in closing writer : %w", err)
+	}
+
+	// Retrieving the attributes of the created object.
+	attrs := uploader.writer.Attrs()
+	// Converting attrs to type *Object.
+	return storageutil.ObjectAttrsToBucketObject(attrs), nil
+}

--- a/internal/storage/chunk_uploader_test.go
+++ b/internal/storage/chunk_uploader_test.go
@@ -1,0 +1,497 @@
+package storage
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
+	. "github.com/jacobsa/ogletest"
+	"google.golang.org/api/googleapi"
+)
+
+func TestChunkUploader(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type ChunkUploaderTest struct {
+	fakeStorage FakeStorage
+	content     string
+	req         *gcs.CreateObjectRequest
+	obj         *storage.ObjectHandle
+}
+
+var _ SetUpInterface = &ChunkUploaderTest{}
+var _ TearDownInterface = &ChunkUploaderTest{}
+
+func init() { RegisterTestSuite(&ChunkUploaderTest{}) }
+
+func (t *ChunkUploaderTest) SetUp(ti *TestInfo) {
+	t.fakeStorage = NewFakeStorage()
+	storageHandle := t.fakeStorage.CreateStorageHandle()
+	bucketHandle := storageHandle.BucketHandle(TestBucketName, "")
+
+	AssertNe(nil, bucketHandle)
+
+	t.content = "Creating a new object"
+	t.req = &gcs.CreateObjectRequest{
+		Name:     "test_object",
+		Contents: strings.NewReader(t.content),
+	}
+
+	t.obj = bucketHandle.bucket.Object(t.req.Name)
+
+	AssertNe(nil, t.obj)
+	AssertEq("test_object", t.obj.ObjectName())
+}
+
+func (t *ChunkUploaderTest) TearDown() {
+	t.fakeStorage.ShutDown()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Helper functions
+////////////////////////////////////////////////////////////////////////
+
+// testNewChunkUploader tests a newky created ChunkUploader and asserts
+// if it hasn't been created properly.
+// If properly created, it casts it to chunkUploader pointer and returns.
+func (t *ChunkUploaderTest) testNewChunkUploader(ctx context.Context,
+	obj *storage.ObjectHandle,
+	req *gcs.CreateObjectRequest,
+	chunkSize int,
+	progressFunc func(int64)) *chunkUploader {
+	uploader, err := NewChunkUploader(ctx, obj, req, chunkSize, progressFunc)
+	AssertNe(nil, uploader)
+	AssertEq(nil, err)
+
+	chunkUploader := uploader.(*chunkUploader)
+
+	AssertNe(nil, chunkUploader)
+	AssertEq(Initialized, chunkUploader.state)
+	AssertEq(0, chunkUploader.totalWriteInitiatedSoFar)
+	AssertEq(0, chunkUploader.BytesUploadedSoFar())
+	AssertNe(nil, chunkUploader.writer)
+	AssertEq(req.Name, chunkUploader.objectName)
+	AssertEq(chunkSize, chunkUploader.writer.ChunkSize)
+
+	return chunkUploader
+}
+
+func (t *ChunkUploaderTest) testUploadChunkAsync(uploader *chunkUploader, contents io.Reader) {
+	err := uploader.UploadChunkAsync(contents)
+	AssertEq(nil, err)
+	AssertEq(Uploading, uploader.state)
+}
+
+func (t *ChunkUploaderTest) testUploadEmptyContent(uploader *chunkUploader, contents io.Reader) {
+	err := uploader.UploadChunkAsync(contents)
+	AssertEq(nil, err)
+}
+
+func (t *ChunkUploaderTest) testFailedUploadChunkAsync(uploader *chunkUploader, contents io.Reader) {
+	err := uploader.UploadChunkAsync(contents)
+	AssertNe(nil, err)
+	AssertEq(UploadError, uploader.state)
+}
+
+func (t *ChunkUploaderTest) testClose(uploader *chunkUploader, objName string, len int) {
+	o, err := uploader.Close()
+	AssertEq(nil, err)
+	AssertNe(nil, o)
+	AssertEq(Closed, uploader.state)
+	AssertEq(objName, o.Name)
+	AssertEq(len, o.Size)
+}
+
+func (t *ChunkUploaderTest) testFailedClose(uploader *chunkUploader, expectedErrStr string) {
+	_, err := uploader.Close()
+	AssertNe(nil, err)
+	AssertTrue(uploader.state == Closed)
+	if !strings.Contains(err.Error(), expectedErrStr) {
+		AddFailure("chunkUploader.Close() failed with wrong error. "+
+			"Expected error-substring: \"%s\", Actual error-string: \"%s\"",
+			expectedErrStr, err.Error())
+	}
+}
+
+type failingContentReader struct{}
+
+func (ilcr *failingContentReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("read failed as intended")
+}
+
+func genRandomContent(size int) string {
+	b := make([]byte, size)
+
+	_, err := rand.Read(b)
+	AssertEq(nil, err)
+
+	return string(b)
+}
+
+func numWholeChunksInContentSize(contentSize, chunkSize int) int {
+	return int(math.Floor(float64(contentSize) / float64(chunkSize)))
+}
+
+func contentSizeFromChunkSizeMultiplier(chunkSize int, chunkSizeMultiplier float32) int {
+	return int(float32(chunkSize) * chunkSizeMultiplier)
+}
+
+func createVarsForMultipleUploads(chunkSize int,
+	chunkSizeMultipliersForUploads []float32) (contentsForNthUploads []string,
+	numWholeChunksUptoNthUploads []int) {
+	var totalContentSizesUptoNthUploads []int
+	for i := range chunkSizeMultipliersForUploads {
+		contentSizeForUpload := contentSizeFromChunkSizeMultiplier(chunkSize,
+			chunkSizeMultipliersForUploads[i])
+		content := genRandomContent(contentSizeForUpload)
+		contentsForNthUploads = append(contentsForNthUploads, content)
+
+		if i == 0 {
+			totalContentSizesUptoNthUploads = append(totalContentSizesUptoNthUploads,
+				contentSizeForUpload)
+		} else {
+			totalContentSizesUptoNthUploads = append(totalContentSizesUptoNthUploads,
+				totalContentSizesUptoNthUploads[i-1]+contentSizeForUpload)
+		}
+
+		numWholeChunksUptoNthUploads =
+			append(numWholeChunksUptoNthUploads,
+				numWholeChunksInContentSize(totalContentSizesUptoNthUploads[i], chunkSize))
+	}
+
+	return
+}
+
+// This function invokes multiple uploads of different sizes,
+// and different random contents using a chunkUploader.
+//
+// It verifies that all the upload calls succeeded, and
+// for all of them, upload callbacks were called on every
+// instance of content-size reaching multiples of chunkSize
+// and that the BytesUploadedSoFar was updated correctly
+// for the uploader.
+//
+// For example, let's take the following sequence of uploads.
+//
+// 1. In the first upload, we upload .25*chunkSize data,
+// then no callback will be received during/after that upload.
+//
+// 2. In the next (second) upload,  we upload 0.5*chunkSize data,
+// then again no callback will be received during/after that upload,
+// as only 0.75*chunkSize data has been received so far by the uploader
+// and a complete chunk has not been received yet.
+//
+// 3. In the next (third) callback, 1.5*chunkSize data is sent,
+// so total 2.25 chunks were uploaded upto that upload.
+// So, after this upload, we
+// expect 2 callbacks to be received, if we wait long enough.
+//
+// 4. In the next (fourth) callback, .775*chunkSize data is sent,
+// so total 3.025 chunks were uploaded upto that upload.
+// So, after this upload, we
+// expect 1 more callbacks to be received, if we wait long enough.
+//
+// This above test generalizes this scenario by taking any general
+// set of uploads through chunk-size-multipliers for uploaders.
+//
+// Keep the multiplier values as multiples of 1/chunkSize for simplicity of floating-point
+// calculations and comparisons.
+func (t *ChunkUploaderTest) testUploadMultipleUploads(chunkSize int, chunkSizeMultipliersForUploads []float32) {
+	// Set up inputs for uploads.
+	numUploads := len(chunkSizeMultipliersForUploads)
+	contentsForNthUploads, numWholeChunksUptoNthUploads :=
+		createVarsForMultipleUploads(chunkSize, chunkSizeMultipliersForUploads)
+	totalNumberOfWholeChunks := numWholeChunksUptoNthUploads[numUploads-1]
+	numBytesSuccessfullyUploadedSoFar := make(chan int64, totalNumberOfWholeChunks)
+	defer close(numBytesSuccessfullyUploadedSoFar)
+	ctx := context.Background()
+	var numCallbacks int
+	uploader := t.testNewChunkUploader(ctx, t.obj, t.req, chunkSize,
+		func(n int64) {
+			numCallbacks++
+			numBytesSuccessfullyUploadedSoFar <- n
+		})
+
+	chunkCallbackIndex := 0
+	progressFuncCallbackTimeout := 10 * time.Millisecond
+	for i := 0; i < numUploads; i++ {
+		t.testUploadChunkAsync(uploader, strings.NewReader(contentsForNthUploads[i]))
+
+		// For all the chunks completed during/after ith upload, confirm that its
+		// callbacks were received and with right values of n.
+		for ; chunkCallbackIndex < numWholeChunksUptoNthUploads[i]; chunkCallbackIndex++ {
+			select {
+			case n := <-numBytesSuccessfullyUploadedSoFar:
+				AssertEq((chunkCallbackIndex+1)*chunkSize, n)
+			case <-time.After(progressFuncCallbackTimeout):
+				AddFailure("Did not not receive write progressFunc callback for "+
+					"chunkSize=%v,chunkSizeMultipliersForUploads=%v,i=%v,chunkCallbackIndex=%v in %v",
+					chunkSize, chunkSizeMultipliersForUploads, i, chunkCallbackIndex, progressFuncCallbackTimeout)
+			}
+		}
+
+		AssertEq(chunkCallbackIndex, numCallbacks)
+		AssertEq(chunkCallbackIndex*chunkSize, uploader.BytesUploadedSoFar())
+	}
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *ChunkUploaderTest) CreateWithImproperInputs() {
+	properReq := t.req
+	properObj := t.obj
+	diffCreateReq := &gcs.CreateObjectRequest{}
+	*diffCreateReq = *properReq
+	diffCreateReq.Name = "FakeName"
+	inputs := []struct {
+		ctx          context.Context
+		obj          *storage.ObjectHandle
+		req          *gcs.CreateObjectRequest
+		chunkSize    int
+		progressFunc func(int64)
+		errStr       string
+	}{{
+		errStr: "ctx is nil",
+	}, {
+		ctx:    context.Background(),
+		errStr: "nil ObjectHandle or CreateObjectRequest",
+	}, {
+		ctx:    context.Background(),
+		obj:    properObj,
+		req:    properReq,
+		errStr: "chunkSize <= 0",
+	}, {
+		ctx:       context.Background(),
+		obj:       properObj,
+		req:       diffCreateReq,
+		errStr:    "names of passed ObjectHandle and CreateObjectRequest don't match",
+		chunkSize: 100,
+	},
+	}
+
+	for _, input := range inputs {
+		uploader, err := NewChunkUploader(input.ctx, input.obj, input.req,
+			input.chunkSize, input.progressFunc)
+
+		AssertEq(nil, uploader)
+		AssertNe(nil, err)
+		AssertTrue(strings.Contains(err.Error(), input.errStr))
+	}
+}
+
+func (t *ChunkUploaderTest) CreateWithProperInputs() {
+	inputs := []struct {
+		ctx          context.Context
+		obj          *storage.ObjectHandle
+		req          *gcs.CreateObjectRequest
+		chunkSize    int
+		progressFunc func(int64)
+	}{{
+		ctx:       context.Background(),
+		obj:       t.obj,
+		req:       t.req,
+		chunkSize: 1,
+	}, {
+		ctx:       context.Background(),
+		obj:       t.obj,
+		req:       t.req,
+		chunkSize: 2 << 24,
+	},
+		{
+			ctx:          context.Background(),
+			obj:          t.obj,
+			req:          t.req,
+			chunkSize:    2 << 24,
+			progressFunc: func(int64) {},
+		},
+	}
+
+	for _, input := range inputs {
+		t.testNewChunkUploader(input.ctx, input.obj, input.req, input.chunkSize, input.progressFunc)
+	}
+}
+
+func (t *ChunkUploaderTest) TestUploadEmptyContent() {
+	// setup
+	obj := t.obj
+	chunkSize := googleapi.MinUploadChunkSize
+	content := ""
+
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+	t.testUploadEmptyContent(uploader, strings.NewReader(content))
+
+	AssertEq(0, uploader.totalWriteInitiatedSoFar)
+}
+
+func (t *ChunkUploaderTest) TestUploadFailingContentReader() {
+	// setup
+	fcr := &failingContentReader{}
+	obj := t.obj
+	chunkSize := googleapi.MinUploadChunkSize
+
+	// test payload
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+	t.testFailedUploadChunkAsync(uploader, fcr)
+
+	AssertEq(0, uploader.totalWriteInitiatedSoFar)
+}
+
+func (t *ChunkUploaderTest) TestUploadSingleSubChunkUpload() {
+	// A sub-chunk means content is smaller than chunkSize in size.
+
+	obj := t.obj
+	chunkSize := googleapi.MinUploadChunkSize
+	content := t.content
+	contentSize := len(content)
+
+	AssertLe(contentSize, chunkSize)
+
+	numBytesSuccessfullyUploadedSoFar := make(chan int64, 1)
+	defer close(numBytesSuccessfullyUploadedSoFar)
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize,
+		func(n int64) {
+			numBytesSuccessfullyUploadedSoFar <- n
+		})
+	t.testUploadChunkAsync(uploader, strings.NewReader(content))
+
+	AssertEq(contentSize, uploader.totalWriteInitiatedSoFar)
+
+	progressFuncCallbackTimeout := 100 * time.Millisecond
+	// Ensure that the progress callback is not called in this case
+	// (i.e. when upload contentSize < chunkSize).
+	// For this, we wait for sometime to see if the unexpected callback
+	// comes. If it doesn't, we call
+	// the test passing.
+	// Alternatively we could put the AddFailure directly in the callback,
+	// but then the test function would not wait for the unexpected
+	// callback to be called at all,
+	// and that would cause a false pass of this test.
+	select {
+	case <-numBytesSuccessfullyUploadedSoFar:
+		AddFailure("Received unexpected progressFunc callback")
+		break
+	case <-time.After(progressFuncCallbackTimeout):
+		break
+	}
+}
+
+func (t *ChunkUploaderTest) TestUploadSingleChunkUpload() {
+	chunkSize := googleapi.MinUploadChunkSize
+	t.testUploadMultipleUploads(chunkSize, []float32{1})
+}
+
+func (t *ChunkUploaderTest) TestUploadSingleSuperChunkUpload() {
+	chunkSize := googleapi.MinUploadChunkSize
+	t.testUploadMultipleUploads(chunkSize, []float32{2.5})
+}
+
+func (t *ChunkUploaderTest) TestUploadMultipleHeterogenousUploads() {
+	chunkSize := googleapi.MinUploadChunkSize
+	t.testUploadMultipleUploads(chunkSize, []float32{0.25, .75, 1.5, .775, 2, 0.5})
+}
+
+func (t *ChunkUploaderTest) TestUploadMultipleHomogeneousUploads() {
+	chunkSize := googleapi.MinUploadChunkSize
+	t.testUploadMultipleUploads(chunkSize, []float32{1, 1, 1, 1, 1, 1})
+}
+
+func (t *ChunkUploaderTest) TestCloseWithoutWrite() {
+	obj := t.obj
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, 1000, nil)
+	t.testClose(uploader, t.req.Name, 0)
+}
+
+func (t *ChunkUploaderTest) TestDoubleClosure() {
+	obj := t.obj
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, 1000, nil)
+
+	t.testClose(uploader, t.req.Name, 0)
+
+	// 2nd closure, expected to fail.
+	t.testFailedClose(uploader,
+		fmt.Sprintf("improper state (%v) for finalizing object", Closed))
+}
+
+func (t *ChunkUploaderTest) TestCloseWithSingleSubChunkUpload() {
+	obj := t.obj
+	chunkSize := googleapi.MinUploadChunkSize
+	contentSize := len(t.content)
+
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+	t.testUploadChunkAsync(uploader, t.req.Contents)
+
+	t.testClose(uploader, t.req.Name, contentSize)
+}
+
+func (t *ChunkUploaderTest) TestCloseWithMultipleSingleChunkUploads() {
+	obj := t.obj
+	chunkSize := 1000
+	contents := [6]string{"hfue", "yrf8934h9", "iru328ry",
+		"iy3rh34r489y8", "ie32hr83hr43rt9y8", "i9r38ry2u9j9"}
+	var contentSize int
+
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+
+	for _, content := range contents {
+		t.testUploadChunkAsync(uploader, strings.NewReader(content))
+		contentSize += len(content)
+	}
+
+	t.testClose(uploader, t.req.Name, contentSize)
+}
+
+func (t *ChunkUploaderTest) TestCloseWithMultipleMultichunkUploads() {
+	obj := t.obj
+	chunkSize := 4
+	contents := [6]string{"hfuerj3ifj3920",
+		"yrf8934h9or329",
+		"iru328ryo9dj320j3",
+		"iy3rh34r489y89j309",
+		"ie32hr83hr43rt9y8do93j9",
+		"i9r38ry2u9j9orj3"}
+	var contentSize int
+
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+
+	for _, content := range contents {
+		t.testUploadChunkAsync(uploader, strings.NewReader(content))
+		contentSize += len(content)
+	}
+
+	t.testClose(uploader, t.req.Name, contentSize)
+}
+
+func (t *ChunkUploaderTest) TestCloseFailedUploader() {
+	// setup
+	fcr := &failingContentReader{}
+	obj := t.obj
+	chunkSize := googleapi.MinUploadChunkSize
+
+	uploader := t.testNewChunkUploader(context.Background(), obj, t.req, chunkSize, nil)
+
+	// A successful upload.
+	uploadedContent := t.content
+	t.testUploadChunkAsync(uploader, strings.NewReader(uploadedContent))
+
+	// test payload - forces failure of upload.
+	t.testFailedUploadChunkAsync(uploader, fcr)
+
+	// The next upload will fail simply because of the WriteError in status.
+	failedContent := "jifhe4guyfbhufg78gufhewh7fgeyuig"
+	t.testFailedUploadChunkAsync(uploader, strings.NewReader(failedContent))
+
+	// Close will pass despite WriteError in status.
+	t.testClose(uploader, t.req.Name, len(uploadedContent))
+}

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -161,7 +161,7 @@ func (b *debugBucket) CreateObject(
 
 func (b *debugBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -561,7 +561,7 @@ func (b *bucket) CreateObject(
 
 func (b *bucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not supported")
@@ -686,12 +686,14 @@ func (b *bucket) ComposeObjects(
 
 	// Create the new object.
 	createReq := &gcs.CreateObjectRequest{
-		Name:                       req.DstName,
-		GenerationPrecondition:     req.DstGenerationPrecondition,
-		MetaGenerationPrecondition: req.DstMetaGenerationPrecondition,
-		Contents:                   io.MultiReader(srcReaders...),
-		ContentType:                req.ContentType,
-		Metadata:                   req.Metadata,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                       req.DstName,
+			GenerationPrecondition:     req.DstGenerationPrecondition,
+			MetaGenerationPrecondition: req.DstMetaGenerationPrecondition,
+			ContentType:                req.ContentType,
+			Metadata:                   req.Metadata,
+		},
+		Contents: io.MultiReader(srcReaders...),
 	}
 
 	_, err = b.createObjectLocked(createReq)

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -476,9 +476,11 @@ func (t *createTest) Overwrite() {
 	_, err = t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name: "foo",
-			Metadata: map[string]string{
-				"foo": "bar",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+				Metadata: map[string]string{
+					"foo": "bar",
+				},
 			},
 			Contents: strings.NewReader("taco"),
 		})
@@ -489,7 +491,9 @@ func (t *createTest) Overwrite() {
 	_, err = t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader("burrito"),
 		})
 
@@ -558,14 +562,16 @@ func (t *createTest) ObjectAttributes_Explicit() {
 	// Create an object with explicit attributes set.
 	createTime := t.clock.Now()
 	req := &gcs.CreateObjectRequest{
-		Name:            "foo",
-		ContentType:     "image/png",
-		ContentLanguage: "fr",
-		ContentEncoding: "gzip",
-		CacheControl:    "public",
-		Metadata: map[string]string{
-			"foo": "bar",
-			"baz": "qux",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:            "foo",
+			ContentType:     "image/png",
+			ContentLanguage: "fr",
+			ContentEncoding: "gzip",
+			CacheControl:    "public",
+			Metadata: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
 		},
 
 		Contents: strings.NewReader("taco"),
@@ -613,7 +619,9 @@ func (t *createTest) ErrorAfterPartialContents() {
 
 	// Set up a reader that will return some successful data, then an error.
 	req := &gcs.CreateObjectRequest{
-		Name: "foo",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+		},
 		Contents: iotest.TimeoutReader(
 			iotest.OneByteReader(
 				strings.NewReader(contents))),
@@ -775,9 +783,11 @@ func (t *createTest) IncorrectCRC32C() {
 	*crc32c++
 
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
-		Contents: strings.NewReader(contents),
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		CRC32C:   crc32c,
+		Contents: strings.NewReader(contents),
 	}
 
 	_, err = t.bucket.CreateObject(t.ctx, req)
@@ -800,7 +810,9 @@ func (t *createTest) CorrectCRC32C() {
 
 	// Create
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		Contents: strings.NewReader(contents),
 		CRC32C:   storageutil.CRC32C([]byte(contents)),
 	}
@@ -820,7 +832,9 @@ func (t *createTest) IncorrectMD5() {
 	(*md5)[13]++
 
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		Contents: strings.NewReader(contents),
 		MD5:      md5,
 	}
@@ -845,7 +859,9 @@ func (t *createTest) CorrectMD5() {
 
 	// Create
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		Contents: strings.NewReader(contents),
 		MD5:      storageutil.MD5([]byte(contents)),
 	}
@@ -862,7 +878,9 @@ func (t *createTest) CorrectCRC32CAndMD5() {
 
 	// Create
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		Contents: strings.NewReader(contents),
 		CRC32C:   storageutil.CRC32C([]byte(contents)),
 		MD5:      storageutil.MD5([]byte(contents)),
@@ -887,9 +905,11 @@ func (t *createTest) GenerationPrecondition_Zero_Unsatisfied() {
 	// saying it shouldn't exist. The request should fail.
 	var gen int64 = 0
 	req := &gcs.CreateObjectRequest{
-		Name:                   "foo",
-		Contents:               strings.NewReader("burrito"),
-		GenerationPrecondition: &gen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   "foo",
+			GenerationPrecondition: &gen,
+		},
+		Contents: strings.NewReader("burrito"),
 	}
 
 	_, err = t.bucket.CreateObject(t.ctx, req)
@@ -920,9 +940,11 @@ func (t *createTest) GenerationPrecondition_Zero_Satisfied() {
 	// The request should succeed.
 	var gen int64 = 0
 	req := &gcs.CreateObjectRequest{
-		Name:                   "foo",
-		Contents:               strings.NewReader("burrito"),
-		GenerationPrecondition: &gen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   "foo",
+			GenerationPrecondition: &gen,
+		},
+		Contents: strings.NewReader("burrito"),
 	}
 
 	o, err := t.bucket.CreateObject(t.ctx, req)
@@ -954,9 +976,11 @@ func (t *createTest) GenerationPrecondition_NonZero_Unsatisfied_Missing() {
 	// should already exist with some generation number. The request should fail.
 	var gen int64 = 17
 	req := &gcs.CreateObjectRequest{
-		Name:                   "foo",
-		Contents:               strings.NewReader("burrito"),
-		GenerationPrecondition: &gen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   "foo",
+			GenerationPrecondition: &gen,
+		},
+		Contents: strings.NewReader("burrito"),
 	}
 
 	_, err := t.bucket.CreateObject(t.ctx, req)
@@ -987,9 +1011,11 @@ func (t *createTest) GenerationPrecondition_NonZero_Unsatisfied_Present() {
 	// the wrong generation. The request should fail.
 	var gen int64 = o.Generation + 1
 	req := &gcs.CreateObjectRequest{
-		Name:                   "foo",
-		Contents:               strings.NewReader("burrito"),
-		GenerationPrecondition: &gen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   "foo",
+			GenerationPrecondition: &gen,
+		},
+		Contents: strings.NewReader("burrito"),
 	}
 
 	_, err = t.bucket.CreateObject(t.ctx, req)
@@ -1030,9 +1056,10 @@ func (t *createTest) GenerationPrecondition_NonZero_Satisfied() {
 	// should succeed.
 	var gen int64 = orig.Generation
 	req := &gcs.CreateObjectRequest{
-		Name:                   "foo",
-		Contents:               strings.NewReader("burrito"),
-		GenerationPrecondition: &gen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                   "foo",
+			GenerationPrecondition: &gen,
+		}, Contents: strings.NewReader("burrito"),
 	}
 
 	o, err := t.bucket.CreateObject(t.ctx, req)
@@ -1066,9 +1093,10 @@ func (t *createTest) MetaGenerationPrecondition_Unsatisfied_ObjectDoesntExist() 
 	// meta-generation. The request should fail.
 	var metagen int64 = 1
 	req := &gcs.CreateObjectRequest{
-		Name:                       "foo",
-		Contents:                   strings.NewReader("burrito"),
-		MetaGenerationPrecondition: &metagen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                       "foo",
+			MetaGenerationPrecondition: &metagen,
+		}, Contents: strings.NewReader("burrito"),
 	}
 
 	_, err = t.bucket.CreateObject(t.ctx, req)
@@ -1099,9 +1127,10 @@ func (t *createTest) MetaGenerationPrecondition_Unsatisfied_ObjectExists() {
 	// the wrong meta-generation. The request should fail.
 	var metagen int64 = o.MetaGeneration + 1
 	req := &gcs.CreateObjectRequest{
-		Name:                       "foo",
-		Contents:                   strings.NewReader("burrito"),
-		MetaGenerationPrecondition: &metagen,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                       "foo",
+			MetaGenerationPrecondition: &metagen,
+		}, Contents: strings.NewReader("burrito"),
 	}
 
 	_, err = t.bucket.CreateObject(t.ctx, req)
@@ -1140,9 +1169,10 @@ func (t *createTest) MetaGenerationPrecondition_Satisfied() {
 	// Request to create another version of the object, with a satisfied
 	// precondition.
 	req := &gcs.CreateObjectRequest{
-		Name:                       "foo",
-		Contents:                   strings.NewReader("burrito"),
-		MetaGenerationPrecondition: &orig.MetaGeneration,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                       "foo",
+			MetaGenerationPrecondition: &orig.MetaGeneration,
+		}, Contents: strings.NewReader("burrito"),
 	}
 
 	o, err := t.bucket.CreateObject(t.ctx, req)
@@ -1210,13 +1240,15 @@ func (t *copyTest) DestinationDoesntExist() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:            "foo",
-			ContentType:     "text/plain",
-			ContentLanguage: "fr",
-			CacheControl:    "public",
-			Metadata: map[string]string{
-				"foo": "bar",
-				"baz": "qux",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:            "foo",
+				ContentType:     "text/plain",
+				ContentLanguage: "fr",
+				CacheControl:    "public",
+				Metadata: map[string]string{
+					"foo": "bar",
+					"baz": "qux",
+				},
 			},
 
 			Contents: strings.NewReader("taco"),
@@ -1278,13 +1310,15 @@ func (t *copyTest) DestinationExists() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:            "foo",
-			ContentType:     "text/plain",
-			ContentLanguage: "fr",
-			CacheControl:    "public",
-			Metadata: map[string]string{
-				"foo": "bar",
-				"baz": "qux",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:            "foo",
+				ContentType:     "text/plain",
+				ContentLanguage: "fr",
+				CacheControl:    "public",
+				Metadata: map[string]string{
+					"foo": "bar",
+					"baz": "qux",
+				},
 			},
 
 			Contents: strings.NewReader("taco"),
@@ -1301,11 +1335,13 @@ func (t *copyTest) DestinationExists() {
 	orig, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:            "bar",
-			ContentType:     "application/octet-stream",
-			ContentLanguage: "de",
-			Metadata: map[string]string{
-				"foo": "blah",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:            "bar",
+				ContentType:     "application/octet-stream",
+				ContentLanguage: "de",
+				Metadata: map[string]string{
+					"foo": "blah",
+				},
 			},
 
 			Contents: strings.NewReader("burrito"),
@@ -1363,13 +1399,15 @@ func (t *copyTest) DestinationIsSameName() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:            "foo",
-			ContentType:     "text/plain",
-			ContentLanguage: "fr",
-			CacheControl:    "public",
-			Metadata: map[string]string{
-				"foo": "bar",
-				"baz": "qux",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name:            "foo",
+				ContentType:     "text/plain",
+				ContentLanguage: "fr",
+				CacheControl:    "public",
+				Metadata: map[string]string{
+					"foo": "bar",
+					"baz": "qux",
+				},
 			},
 
 			Contents: strings.NewReader("taco"),
@@ -1520,7 +1558,9 @@ func (t *copyTest) ParticularSourceGeneration_GenerationDoesntExist() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader("taco"),
 		})
 
@@ -1544,7 +1584,9 @@ func (t *copyTest) ParticularSourceGeneration_Exists() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader("taco"),
 		})
 
@@ -1568,7 +1610,9 @@ func (t *copyTest) SrcMetaGenerationPrecondition_Unsatisfied() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader(""),
 		})
 
@@ -1600,7 +1644,9 @@ func (t *copyTest) SrcMetaGenerationPrecondition_Satisfied() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "foo",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "foo",
+			},
 			Contents: strings.NewReader(""),
 		})
 
@@ -1655,13 +1701,14 @@ func (t *composeTest) createSources(
 				objs[i], err = t.bucket.CreateObject(
 					ctx,
 					&gcs.CreateObjectRequest{
-						Name:            fmt.Sprint(i),
-						Contents:        strings.NewReader(contents[i]),
-						ContentType:     "application/json",
-						ContentLanguage: "de",
-						Metadata: map[string]string{
-							"foo": "bar",
-						},
+						CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+							Name:            fmt.Sprint(i),
+							ContentType:     "application/json",
+							ContentLanguage: "de",
+							Metadata: map[string]string{
+								"foo": "bar",
+							},
+						}, Contents: strings.NewReader(contents[i]),
 					},
 				)
 
@@ -2463,7 +2510,9 @@ func (t *composeTest) TooManySources() {
 	src, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "src",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "src",
+			},
 			Contents: strings.NewReader(""),
 		})
 
@@ -2494,7 +2543,9 @@ func (t *composeTest) ComponentCountLimits() {
 	small, err := t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     "small",
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: "small",
+			},
 			Contents: strings.NewReader("a"),
 		})
 
@@ -3139,13 +3190,15 @@ func (t *updateTest) NonExistentObject() {
 func (t *updateTest) RemoveAllFields() {
 	// Create an object with explicit attributes set.
 	createReq := &gcs.CreateObjectRequest{
-		Name:            "foo",
-		ContentType:     "image/png",
-		ContentEncoding: "gzip",
-		ContentLanguage: "fr",
-		CacheControl:    "public",
-		Metadata: map[string]string{
-			"foo": "bar",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:            "foo",
+			ContentType:     "image/png",
+			ContentEncoding: "gzip",
+			ContentLanguage: "fr",
+			CacheControl:    "public",
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 
 		Contents: strings.NewReader("taco"),
@@ -3192,13 +3245,15 @@ func (t *updateTest) RemoveAllFields() {
 func (t *updateTest) ModifyAllFields() {
 	// Create an object with explicit attributes set.
 	createReq := &gcs.CreateObjectRequest{
-		Name:            "foo",
-		ContentType:     "image/png",
-		ContentEncoding: "gzip",
-		ContentLanguage: "fr",
-		CacheControl:    "public",
-		Metadata: map[string]string{
-			"foo": "bar",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:            "foo",
+			ContentType:     "image/png",
+			ContentEncoding: "gzip",
+			ContentLanguage: "fr",
+			CacheControl:    "public",
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 
 		Contents: strings.NewReader("taco"),
@@ -3245,12 +3300,14 @@ func (t *updateTest) ModifyAllFields() {
 func (t *updateTest) MixedModificationsToFields() {
 	// Create an object with some explicit attributes set.
 	createReq := &gcs.CreateObjectRequest{
-		Name:            "foo",
-		ContentType:     "image/png",
-		ContentEncoding: "gzip",
-		ContentLanguage: "fr",
-		Metadata: map[string]string{
-			"foo": "bar",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:            "foo",
+			ContentType:     "image/png",
+			ContentEncoding: "gzip",
+			ContentLanguage: "fr",
+			Metadata: map[string]string{
+				"foo": "bar",
+			},
 		},
 
 		Contents: strings.NewReader("taco"),
@@ -3341,11 +3398,13 @@ func (t *updateTest) AddUserMetadata() {
 func (t *updateTest) MixedModificationsToUserMetadata() {
 	// Create an object with some user metadata.
 	createReq := &gcs.CreateObjectRequest{
-		Name: "foo",
-		Metadata: map[string]string{
-			"0": "taco",
-			"2": "enchilada",
-			"3": "queso",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+			Metadata: map[string]string{
+				"0": "taco",
+				"2": "enchilada",
+				"3": "queso",
+			},
 		},
 
 		Contents: strings.NewReader("taco"),
@@ -3441,7 +3500,9 @@ func (t *updateTest) ParticularGeneration_NameDoesntExist() {
 func (t *updateTest) ParticularGeneration_GenerationDoesntExist() {
 	// Create an object.
 	createReq := &gcs.CreateObjectRequest{
-		Name:     "foo",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+		},
 		Contents: strings.NewReader(""),
 	}
 
@@ -3473,7 +3534,9 @@ func (t *updateTest) ParticularGeneration_GenerationDoesntExist() {
 func (t *updateTest) ParticularGeneration_Successful() {
 	// Create an object.
 	createReq := &gcs.CreateObjectRequest{
-		Name:     "foo",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+		},
 		Contents: strings.NewReader(""),
 	}
 
@@ -3504,7 +3567,9 @@ func (t *updateTest) ParticularGeneration_Successful() {
 func (t *updateTest) MetaGenerationPrecondition_Unsatisfied() {
 	// Create an object.
 	createReq := &gcs.CreateObjectRequest{
-		Name:     "foo",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+		},
 		Contents: strings.NewReader(""),
 	}
 
@@ -3534,7 +3599,9 @@ func (t *updateTest) MetaGenerationPrecondition_Unsatisfied() {
 func (t *updateTest) MetaGenerationPrecondition_Satisfied() {
 	// Create an object.
 	createReq := &gcs.CreateObjectRequest{
-		Name:     "foo",
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: "foo",
+		},
 		Contents: strings.NewReader(""),
 	}
 
@@ -4326,7 +4393,9 @@ func (t *cancellationTest) CreateObject() {
 	errChan := make(chan error)
 	go func() {
 		req := &gcs.CreateObjectRequest{
-			Name:     name,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: name,
+			},
 			Contents: rc,
 		}
 
@@ -4383,7 +4452,9 @@ func (t *cancellationTest) ReadObject() {
 	_, err = t.bucket.CreateObject(
 		t.ctx,
 		&gcs.CreateObjectRequest{
-			Name:     name,
+			CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+				Name: name,
+			},
 			Contents: io.LimitReader(rand.Reader, size),
 		})
 

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -31,9 +31,6 @@ type ChunkUploader interface {
 	// Progress should be tracked using the progress func
 	// passed during ChunkUploader instance creation.
 	//
-	// io.EOF is an expected error in case the reader has less
-	// data than the writer tries to read from it.
-	//
 	// Unlike the io.Writer interface, it doesn't return number-of-bytes
 	// uploaded in this call, as the write is asynchronous; instead
 	// this interface instead has

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -84,7 +84,7 @@ type Bucket interface {
 		req *CreateObjectRequest) (*Object, error)
 
 	// CreateChunkUploader creates a chunkUploader instance
-	// according to supplied createObjectRequest. This needs
+	// according to supplied createChunkUploaderRequest. This needs
 	// to be used when caller wants control on the resumable
 	// upload api.
 	//
@@ -99,7 +99,7 @@ type Bucket interface {
 	// The progress function callback is expected exactly once for each upload.
 	//
 	// Sample usage:
-	// uploader, err := bucket.CreateChunkUploader(ctx, createObjectReq,
+	// uploader, err := bucket.CreateChunkUploader(ctx, createChunkUploaderReq,
 	//						chunkSize,
 	//						func(n int64) {
 	//							log("n bytes successfully uploaded so far")
@@ -117,7 +117,7 @@ type Bucket interface {
 	//     https://cloud.google.com/storage/docs/resumable-uploads#go
 	CreateChunkUploader(
 		ctx context.Context,
-		req *CreateObjectRequest,
+		req *CreateChunkUploaderRequest,
 		writeChunkSize int,
 		progressFunc func(int64)) (ChunkUploader, error)
 

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -22,8 +22,8 @@ import (
 	storagev1 "google.golang.org/api/storage/v1"
 )
 
-// A request to create an object, accepted by Bucket.CreateObject.
-type CreateObjectRequest struct {
+// A request to create an aysnchronous object uploader, accepted by Bucket.CreateChunkUploader.
+type CreateChunkUploaderRequest struct {
 	// The name with which to create the object. This field must be set.
 	//
 	// Object names must:
@@ -54,6 +54,21 @@ type CreateObjectRequest struct {
 	StorageClass       string
 	Acl                []*storagev1.ObjectAccessControl
 
+	// If non-nil, the object will be created/overwritten only if the current
+	// generation for the object name is equal to the given value. Zero means the
+	// object does not exist.
+	GenerationPrecondition *int64
+
+	// If non-nil, the object will be created/overwritten only if the current
+	// meta-generation for the object name is equal to the given value. This is
+	// only meaningful in conjunction with GenerationPrecondition.
+	MetaGenerationPrecondition *int64
+}
+
+// A request to create an object, accepted by Bucket.CreateObject.
+type CreateObjectRequest struct {
+	CreateChunkUploaderRequest
+
 	// A reader from which to obtain the contents of the object. Must be non-nil.
 	Contents io.Reader
 
@@ -64,16 +79,6 @@ type CreateObjectRequest struct {
 	// If non-nil, the object will not be created if the MD5 sum of the received
 	// contents does not match the supplied value.
 	MD5 *[md5.Size]byte
-
-	// If non-nil, the object will be created/overwritten only if the current
-	// generation for the object name is equal to the given value. Zero means the
-	// object does not exist.
-	GenerationPrecondition *int64
-
-	// If non-nil, the object will be created/overwritten only if the current
-	// meta-generation for the object name is equal to the given value. This is
-	// only meaningful in conjunction with GenerationPrecondition.
-	MetaGenerationPrecondition *int64
 }
 
 // A request to copy an object to a new name, preserving all metadata.

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -133,7 +133,7 @@ func (m *mockBucket) CreateObject(p0 context.Context, p1 *gcs.CreateObjectReques
 
 func (m *mockBucket) CreateChunkUploader(
 	ctx context.Context,
-	req *gcs.CreateObjectRequest,
+	req *gcs.CreateChunkUploaderRequest,
 	writeChunkSize int,
 	progressFunc func(int64)) (gcs.ChunkUploader, error) {
 	return nil, fmt.Errorf("not implemented yet")

--- a/internal/storage/storageutil/create_object.go
+++ b/internal/storage/storageutil/create_object.go
@@ -29,7 +29,9 @@ func CreateObject(
 	name string,
 	contents []byte) (*gcs.Object, error) {
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name: name,
+		},
 		Contents: bytes.NewReader(contents),
 	}
 

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -103,7 +103,7 @@ func ObjectAttrsToBucketObject(attrs *storage.ObjectAttrs) *gcs.Object {
 
 // SetAttrsInWriter - for setting object-attributes filed in storage.Writer object.
 // These attributes will be assigned to the newly created or old object.
-func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage.Writer {
+func setAttrsInWriter(wc *storage.Writer, req *gcs.CreateChunkUploaderRequest) *storage.Writer {
 	wc.Name = req.Name
 	wc.ContentType = req.ContentType
 	wc.ContentLanguage = req.ContentLanguage
@@ -121,6 +121,14 @@ func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage
 		aclRules = append(aclRules, convertObjectAccessControlToACLRule(element))
 	}
 	wc.ACL = aclRules
+
+	return wc
+}
+
+// SetAttrsInWriter - for setting object-attributes filed in storage.Writer object.
+// These attributes will be assigned to the newly created or old object.
+func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage.Writer {
+	setAttrsInWriter(wc, &req.CreateChunkUploaderRequest)
 
 	if req.CRC32C != nil {
 		wc.CRC32C = *req.CRC32C

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -182,21 +182,23 @@ func (t objectAttrsTest) TestSetAttrsInWriterMethod() {
 	md5Hash := md5.Sum([]byte("testing"))
 	timeInRFC3339 := "2006-01-02T15:04:05Z07:00"
 	createObjectRequest := gcs.CreateObjectRequest{
-		Name:                       "test_object",
-		ContentType:                "json",
-		ContentEncoding:            "universal",
-		CacheControl:               "Medium",
-		Metadata:                   map[string]string{"file_name": "test.txt"},
-		ContentDisposition:         "Test content disposition",
-		CustomTime:                 timeInRFC3339,
-		EventBasedHold:             true,
-		StorageClass:               "High Accessibility",
-		Acl:                        nil,
-		Contents:                   strings.NewReader("Creating new object"),
-		CRC32C:                     &crc32c,
-		MD5:                        &md5Hash,
-		GenerationPrecondition:     &generationPrecondition,
-		MetaGenerationPrecondition: &metaGenerationPrecondition,
+		CreateChunkUploaderRequest: gcs.CreateChunkUploaderRequest{
+			Name:                       "test_object",
+			ContentType:                "json",
+			ContentEncoding:            "universal",
+			CacheControl:               "Medium",
+			Metadata:                   map[string]string{"file_name": "test.txt"},
+			ContentDisposition:         "Test content disposition",
+			CustomTime:                 timeInRFC3339,
+			EventBasedHold:             true,
+			StorageClass:               "High Accessibility",
+			Acl:                        nil,
+			GenerationPrecondition:     &generationPrecondition,
+			MetaGenerationPrecondition: &metaGenerationPrecondition,
+		},
+		Contents: strings.NewReader("Creating new object"),
+		CRC32C:   &crc32c,
+		MD5:      &md5Hash,
 	}
 	writer := &storage.Writer{}
 


### PR DESCRIPTION
### Description
This change restructures the struct `CreateObjectRequest` into a sub-structure `CreateChunkUploaderRequest`, which contains all the fields of the `CreateObjectRequest` except its `content` field and checksum fields (`CRC32` and `MD5`).

This is required to remove the redundancy of passing around content and checksum fields for chunk-uploader creation unnecessarily.

```golang
// Before

struct CreateObjectRequest {
  all fields
}
```

```golang
// After

struct CreateChunkUploaderRequest {
  all fields of original CreateObjectRequest except content, checksum fields
}

struct CreateObjectRequest {
  CreateChunkUploaderRequest
  
  content
  checksum fields
}
```

This builds on top of https://github.com/GoogleCloudPlatform/gcsfuse/pull/1411 . Is followed up in 
[Async object upload 3](https://github.com/GoogleCloudPlatform/gcsfuse/pull/1417)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - No new unit tests. All existing unit tests passed.
3. Integration tests - ran through presubmit.
