### PR TITLE
Fix perf test

### DIFF
--- a/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+++ b/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
@@ -22,10 +22,17 @@ pip install google-cloud
 pip install google-cloud-vision
 pip install google-api-python-client
 pip install prettytable
-echo Installing fio
-sudo apt-get install fio -y
+# We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
+# The fix is not currently released in a package as of 20th Oct, 2023.
+# TODO: install fio via package when release > 3.35 is available.
+sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
+git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
+cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \
+git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
+./configure && make && sudo make install
 
 echo Running fio test..
+cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 fio ./perfmetrics/scripts/job_files/presubmit_perf_test.fio --lat_percentiles 1 --output-format=json --output='output.json'
 echo fetching results..
 python3 ./perfmetrics/scripts/presubmit/fetch_results.py output.json

--- a/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+++ b/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
@@ -25,6 +25,7 @@ pip install prettytable
 # We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
 # The fix is not currently released in a package as of 20th Oct, 2023.
 # TODO: install fio via package when release > 3.35 is available.
+echo Installing fio
 sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
 git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
 cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \

--- a/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+++ b/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
@@ -14,23 +14,6 @@
 # limitations under the License.
 
 set -e
-# Installing requirements
-echo Installing python3-pip
-sudo apt-get -y install python3-pip
-echo Installing libraries to run python script
-pip install google-cloud
-pip install google-cloud-vision
-pip install google-api-python-client
-pip install prettytable
-# We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
-# The fix is not currently released in a package as of 20th Oct, 2023.
-# TODO: install fio via package when release > 3.35 is available.
-echo Installing fio
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
-git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
-cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \
-git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
-./configure && make && sudo make install
 
 echo Running fio test..
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"

--- a/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+++ b/perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
@@ -16,7 +16,6 @@
 set -e
 
 echo Running fio test..
-cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 fio ./perfmetrics/scripts/job_files/presubmit_perf_test.fio --lat_percentiles 1 --output-format=json --output='output.json'
 echo fetching results..
 python3 ./perfmetrics/scripts/presubmit/fetch_results.py output.json

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -68,6 +68,8 @@ function install_requirements() {
   pip install google-cloud-vision
   pip install google-api-python-client
   pip install prettytable
+  # install libaio as fio has a dependency on libaio
+  sudo apt-get install libaio-dev
   # We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
   # The fix is not currently released in a package as of 20th Oct, 2023.
   # TODO: install fio via package when release > 3.35 is available.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -78,6 +78,7 @@ function install_requirements() {
   git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
   ./configure && make && sudo make install
   fio --version
+  cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 }
 
 # execute perf tests.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -58,10 +58,33 @@ function execute_perf_test() {
   sudo umount gcs
 }
 
+function install_requirements() {
+  # Installing requirements
+  echo installing requirements
+  echo Installing python3-pip
+  sudo apt-get -y install python3-pip
+  echo Installing libraries to run python script
+  pip install google-cloud
+  pip install google-cloud-vision
+  pip install google-api-python-client
+  pip install prettytable
+  # We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
+  # The fix is not currently released in a package as of 20th Oct, 2023.
+  # TODO: install fio via package when release > 3.35 is available.
+  echo Installing fio
+  sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
+  git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
+  cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \
+  git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
+  ./configure && make && sudo make install
+  fio --version
+}
+
 # execute perf tests.
 if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Executing perf tests for master branch
+ install_requirements
  git reset --hard
  git checkout master
  # Store results


### PR DESCRIPTION
### Description
Perf tests were failing because we were using job_start key while fetching the metrics but still using the old fio version which did not support "job_start" key. 
In this PR:
- moved installing requirements before switching to master.
- building fio from source to support job_start key.

### Link to the issue in case of a bug fix.
NA

### Testing details
Ran perf tests
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
