### PR TITLE
Making sync call in the last for Fio sequential write workflow

### DIFF
--- a/perfmetrics/scripts/job_files/presubmit_perf_test.fio
+++ b/perfmetrics/scripts/job_files/presubmit_perf_test.fio
@@ -33,6 +33,7 @@ bs=16k
 directory=gcs/256kb
 filesize=256k
 rw=write
+fsync=16
 numjobs=40
 
 [256kb_randread]
@@ -67,6 +68,7 @@ startdelay=950
 directory=gcs/50mb
 filesize=50M
 rw=write
+fsync=50
 numjobs=40
 
 [50mb_randread]
@@ -99,6 +101,7 @@ startdelay=1710
 directory=gcs/1gb
 filesize=1G
 rw=write
+fsync=1024
 numjobs=40
 
 [1gb_randread]

--- a/perfmetrics/scripts/job_files/seq_rand_read_write.fio
+++ b/perfmetrics/scripts/job_files/seq_rand_read_write.fio
@@ -33,6 +33,7 @@ bs=16k
 directory=gcs/256kb
 filesize=256k
 rw=write
+fsync=16
 numjobs=40
 
 [3_thread]
@@ -48,6 +49,7 @@ startdelay=690
 directory=gcs/3mb
 filesize=3M
 rw=write
+fsync=3
 numjobs=40
 
 [5_thread]
@@ -63,6 +65,7 @@ startdelay=1070
 directory=gcs/5mb
 filesize=5M
 rw=write
+fsync=5
 numjobs=40
 
 [7_thread]
@@ -78,6 +81,7 @@ startdelay=1450
 directory=gcs/50mb
 filesize=50M
 rw=write
+fsync=50
 numjobs=40
 
 [9_thread]


### PR DESCRIPTION
### Description
Currently, in the sequential write operation of FIO workload `SyncFile` call happens after every `WriteFile` call, which shows less bandwidth for write flow.

Now, for sequential workflow, `SyncFile` call will happen in the last.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
