### PR TITLE
Moving private convertObjectToMinObject to storageutil

### DIFF
--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -133,3 +133,20 @@ func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage
 
 	return wc
 }
+
+func ConvertObjToMinObject(o *gcs.Object) gcs.MinObject {
+	var min gcs.MinObject
+	if o == nil {
+		return min
+	}
+
+	return gcs.MinObject{
+		Name:            o.Name,
+		Size:            o.Size,
+		Generation:      o.Generation,
+		MetaGeneration:  o.MetaGeneration,
+		Updated:         o.Updated,
+		Metadata:        o.Metadata,
+		ContentEncoding: o.ContentEncoding,
+	}
+}


### PR DESCRIPTION
### Description
1. Moving private convertObjectToMinObject to storage-util.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - Added unit test.
4. Integration tests - Automation
