### PR TITLE
add configs for log rotation

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -19,9 +19,10 @@ type WriteConfig struct {
 }
 
 type LogConfig struct {
-	Severity LogSeverity `yaml:"severity"`
-	Format   string      `yaml:"format"`
-	FilePath string      `yaml:"file-path"`
+	Severity  LogSeverity `yaml:"severity"`
+	Format    string      `yaml:"format"`
+	FilePath  string      `yaml:"file-path"`
+	LogRotate LogRotate   `yaml:"log-rotate"`
 }
 
 type MountConfig struct {
@@ -29,11 +30,29 @@ type MountConfig struct {
 	LogConfig   `yaml:"logging"`
 }
 
+type LogRotate struct {
+	MaxSizeInMB uint32 `yaml:"max-size-in-mb"`
+	MaxDays     uint32 `yaml:"max-days"`
+	BackupCount uint32 `yaml:"backup-count"`
+	Compress    bool   `yaml:"compress"`
+}
+
+func DefaultLogRotateConfig() LogRotate {
+	return LogRotate{
+		MaxSizeInMB: 200,
+		MaxDays:     28,
+		BackupCount: 3,
+		Compress:    true,
+	}
+}
+
 func NewMountConfig() *MountConfig {
 	mountConfig := &MountConfig{}
 	mountConfig.LogConfig = LogConfig{
 		// Making the default severity as INFO.
 		Severity: INFO,
+		// Setting default values of log rotate config.
+		LogRotate: DefaultLogRotateConfig(),
 	}
 	return mountConfig
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -32,7 +32,6 @@ type MountConfig struct {
 
 type LogRotate struct {
 	MaxSizeInMB uint32 `yaml:"max-size-in-mb"`
-	MaxDays     uint32 `yaml:"max-days"`
 	BackupCount uint32 `yaml:"backup-count"`
 	Compress    bool   `yaml:"compress"`
 }
@@ -40,7 +39,6 @@ type LogRotate struct {
 func DefaultLogRotateConfig() LogRotate {
 	return LogRotate{
 		MaxSizeInMB: 200,
-		MaxDays:     28,
 		BackupCount: 3,
 		Compress:    true,
 	}

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -6,7 +6,6 @@ logging:
   severity: error
   log-rotate:
     max-size-in-mb: 100
-    max-days: 1
     backup-count: 5
     compress: false
 

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -4,4 +4,10 @@ logging:
   file-path: /tmp/logfile.json
   format: text
   severity: error
+  log-rotate:
+    max-size-in-mb: 100
+    max-days: 1
+    backup-count: 5
+    compress: false
+
 

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -34,6 +34,10 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertEq("INFO", mountConfig.LogConfig.Severity)
 	AssertEq("", mountConfig.LogConfig.Format)
 	AssertEq("", mountConfig.LogConfig.FilePath)
+	AssertEq(200, mountConfig.LogConfig.LogRotate.MaxSizeInMB)
+	AssertEq(28, mountConfig.LogConfig.LogRotate.MaxDays)
+	AssertEq(3, mountConfig.LogConfig.LogRotate.BackupCount)
+	AssertEq(true, mountConfig.LogConfig.LogRotate.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -81,6 +85,10 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 	AssertEq(ERROR, mountConfig.LogConfig.Severity)
 	AssertEq("/tmp/logfile.json", mountConfig.LogConfig.FilePath)
 	AssertEq("text", mountConfig.LogConfig.Format)
+	AssertEq(100, mountConfig.LogConfig.LogRotate.MaxSizeInMB)
+	AssertEq(1, mountConfig.LogConfig.LogRotate.MaxDays)
+	AssertEq(5, mountConfig.LogConfig.LogRotate.BackupCount)
+	AssertEq(false, mountConfig.LogConfig.LogRotate.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogConfig() {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -35,7 +35,6 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertEq("", mountConfig.LogConfig.Format)
 	AssertEq("", mountConfig.LogConfig.FilePath)
 	AssertEq(200, mountConfig.LogConfig.LogRotate.MaxSizeInMB)
-	AssertEq(28, mountConfig.LogConfig.LogRotate.MaxDays)
 	AssertEq(3, mountConfig.LogConfig.LogRotate.BackupCount)
 	AssertEq(true, mountConfig.LogConfig.LogRotate.Compress)
 }
@@ -86,7 +85,6 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 	AssertEq("/tmp/logfile.json", mountConfig.LogConfig.FilePath)
 	AssertEq("text", mountConfig.LogConfig.Format)
 	AssertEq(100, mountConfig.LogConfig.LogRotate.MaxSizeInMB)
-	AssertEq(1, mountConfig.LogConfig.LogRotate.MaxDays)
 	AssertEq(5, mountConfig.LogConfig.LogRotate.BackupCount)
 	AssertEq(false, mountConfig.LogConfig.LogRotate.Compress)
 }

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	}
 
 	if flags.Foreground {
-		err = logger.InitLogFile(mountConfig.LogConfig.FilePath, mountConfig.LogConfig.Format, mountConfig.LogConfig.Severity)
+		err = logger.InitLogFile(mountConfig.LogConfig)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)
 		}


### PR DESCRIPTION
### Description
Added configs for log rotation:
```
logging:
  log-rotate:
    max-size-in-mb (uint32): maximum size in megabytes of the log file before it gets rotated. It defaults to 200 megabytes.
    backup-count (uint32): maximum number of old log files to retain after they are log rotated. It defaults to 3.
    compress (bool):  determines if the rotated log files should be compressed using gzip. It defaults to true.
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
