### PR TITLE
Random reader change to support reading from cache

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -78,8 +78,7 @@ func (fch *CacheHandle) validateCacheHandle() error {
 func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, requiredOffset int64) (err error) {
 	if jobStatus.Err != nil ||
 		jobStatus.Name == downloader.INVALID ||
-		jobStatus.Name == downloader.FAILED ||
-		jobStatus.Name == downloader.NOT_STARTED {
+		jobStatus.Name == downloader.FAILED {
 		errMsg := fmt.Sprintf("%s: jobStatus: %s jobError: %v", util.InvalidFileDownloadJobErrMsg, jobStatus.Name, jobStatus.Err)
 		return errors.New(errMsg)
 	} else if jobStatus.Offset < requiredOffset {

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -198,6 +198,9 @@ func (fch *CacheHandle) IsSequential(currentOffset int64) bool {
 func (fch *CacheHandle) Close() (err error) {
 	if fch.fileHandle != nil {
 		err = fch.fileHandle.Close()
+		if err != nil {
+			err = fmt.Errorf("cacheHandle.Close(): while closing read file handle: %v", err)
+		}
 		fch.fileHandle = nil
 	}
 

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -37,6 +37,10 @@ type CacheHandle struct {
 	// fileInfoCache contains the reference of fileInfo cache.
 	fileInfoCache *lru.Cache
 
+	// downloadForRandomRead if true, object content will be downloaded for random
+	// reads as well too. Generally, we don't cache the content for random-read.
+	downloadForRandomRead bool
+
 	// isSequential saves if the current read performed via cache handle is sequential or
 	// random.
 	isSequential bool
@@ -46,13 +50,14 @@ type CacheHandle struct {
 	prevOffset int64
 }
 
-func NewCacheHandle(localFileHandle *os.File, fileDownloadJob *downloader.Job, fileInfoCache *lru.Cache, initialOffset int64) *CacheHandle {
+func NewCacheHandle(localFileHandle *os.File, fileDownloadJob *downloader.Job, fileInfoCache *lru.Cache, downloadForRandomRead bool, initialOffset int64) *CacheHandle {
 	return &CacheHandle{
-		fileHandle:      localFileHandle,
-		fileDownloadJob: fileDownloadJob,
-		fileInfoCache:   fileInfoCache,
-		isSequential:    initialOffset == 0,
-		prevOffset:      initialOffset,
+		fileHandle:            localFileHandle,
+		fileDownloadJob:       fileDownloadJob,
+		fileInfoCache:         fileInfoCache,
+		downloadForRandomRead: downloadForRandomRead,
+		isSequential:          initialOffset == 0,
+		prevOffset:            initialOffset,
 	}
 }
 
@@ -92,8 +97,8 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 // For sequential reads, it will wait to download the requested chunk
 // if it is not already present. For random reads, it does not wait for
 // download. Additionally, for random reads, the download will not be
-// initiated if downloadForRandomRead is false.
-func (fch *CacheHandle) Read(ctx context.Context, object *gcs.MinObject, downloadForRandomRead bool, offset int64, dst []byte) (n int, err error) {
+// initiated if fch.downloadForRandomRead is false.
+func (fch *CacheHandle) Read(ctx context.Context, object *gcs.MinObject, offset int64, dst []byte) (n int, err error) {
 	err = fch.validateCacheHandle()
 	if err != nil {
 		return
@@ -123,7 +128,7 @@ func (fch *CacheHandle) Read(ctx context.Context, object *gcs.MinObject, downloa
 	}
 
 	// If downloadForRandomRead is false and readType is random, download will not be initiated.
-	if !downloadForRandomRead && !isSequentialRead {
+	if !fch.downloadForRandomRead && !isSequentialRead {
 		jobStatus := fch.fileDownloadJob.GetStatus()
 		if err = fch.shouldReadFromCache(&jobStatus, requiredOffset); err != nil {
 			return 0, err

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -402,7 +402,7 @@ func (cht *cacheHandleTest) Test_Read_Random() {
 	dst := make([]byte, ReadContentSize)
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = false
-	cht.cacheHandle.downloadForRandomRead = true
+	cht.cacheHandle.downloadFileForRandomRead = true
 
 	// Since, it's a random read hence will not wait to download till requested offset.
 	n, err := cht.cacheHandle.Read(context.Background(), cht.object, offset, dst)
@@ -478,7 +478,7 @@ func (cht *cacheHandleTest) Test_Read_Sequential() {
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = true
 	cht.cacheHandle.prevOffset = offset - util.MiB
-	cht.cacheHandle.downloadForRandomRead = true
+	cht.cacheHandle.downloadFileForRandomRead = true
 
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, err := cht.cacheHandle.Read(context.Background(), cht.object, offset, dst)
@@ -493,7 +493,7 @@ func (cht *cacheHandleTest) Test_Read_SequentialToRandom() {
 	dst := make([]byte, ReadContentSize)
 	firstReqOffset := int64(0)
 	cht.cacheHandle.isSequential = true
-	cht.cacheHandle.downloadForRandomRead = true
+	cht.cacheHandle.downloadFileForRandomRead = true
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, err := cht.cacheHandle.Read(context.Background(), cht.object, firstReqOffset, dst)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -248,7 +248,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsNotStarted() 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
@@ -426,7 +426,7 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload() {
 	ExpectLt(jobStatus.Offset, offset)
 	ExpectEq(n, 0)
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
 }
 
 func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownloadButCacheHit() {

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -177,7 +177,7 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 // contains the reference to downloader.Job and the local file handle.
 //
 // Acquires and releases LOCK(CacheHandler.mu)
-func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket, initialOffset int64) (*CacheHandle, error) {
+func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket, downloadForRandom bool, initialOffset int64) (*CacheHandle, error) {
 	err := chr.addFileInfoEntryToCache(object, bucket)
 	if err != nil {
 		return nil, fmt.Errorf("GetCacheHandle: while adding the entry in the cache: %v", err)
@@ -188,7 +188,7 @@ func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket
 		return nil, fmt.Errorf("GetCacheHandle: while create local-file read handle: %v", err)
 	}
 
-	return NewCacheHandle(localFileReadHandle, chr.jobManager.GetJob(object, bucket), chr.fileInfoCache, initialOffset), nil
+	return NewCacheHandle(localFileReadHandle, chr.jobManager.GetJob(object, bucket), chr.fileInfoCache, downloadForRandom, initialOffset), nil
 }
 
 // InvalidateCache removes the entry from the fileInfoCache, and removes download job,

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -125,7 +125,7 @@ func (chrT *cacheHandlerTest) isEntryInFileInfoCache(objectName string, bucketNa
 }
 
 func (chrT *cacheHandlerTest) getCacheHandleForSetupEntryInCache() *CacheHandle {
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 	AssertEq(nil, err)
 	AssertNe(nil, cacheHandle)
 	AssertEq(true, doesFileExist(chrT.downloadPath))
@@ -268,12 +268,12 @@ func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfNotAlready() {
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsStaleEntry() {
 	// Existing cacheHandle.
-	oldCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	oldCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 	AssertEq(nil, err)
 	// Upgrade the version of the object, but cache still keeps old generation
 	chrT.object.Generation = chrT.object.Generation + 1
 
-	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, newCacheHandle.validateCacheHandle())
@@ -287,7 +287,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsInvalidEntry(
 	//  Cache contains higher generation
 	chrT.object.Generation = chrT.object.Generation - 1
 
-	_, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	_, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
 	ExpectNe(nil, err)
 	errMsg := fmt.Sprintf("cache generation %d is more than object generation", chrT.object.Generation+1)
@@ -295,7 +295,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsInvalidEntry(
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryAlreadyInCache() {
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle.validateCacheHandle())
@@ -304,7 +304,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryAlreadyInCache() {
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryNotInCache() {
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
 
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, 0)
+	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle.validateCacheHandle())
@@ -318,7 +318,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WithEviction() {
 	// Here, content size is 21.
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
 
-	cacheHandle2, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, 0)
+	cacheHandle2, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle2.validateCacheHandle())
@@ -338,7 +338,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
 		defer wg.Done()
 		minObj := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
 
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, 0)
+		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
 
 		AssertEq(nil, err)
 		AssertEq(nil, cacheHandle.validateCacheHandle())
@@ -368,7 +368,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
 		objContent := "object content: content#" + strconv.Itoa(index)
 		minObj := chrT.getMinObject(objName, []byte(objContent))
 
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, 0)
+		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
 
 		AssertEq(nil, err)
 		AssertEq(nil, cacheHandle.validateCacheHandle())
@@ -387,7 +387,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
 }
 
 func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryAlreadyInCache() {
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, 0)
+	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 	ExpectEq(nil, err)
 
 	err = chrT.cacheHandler.InvalidateCache(chrT.object, chrT.bucket)
@@ -478,7 +478,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCacheAndGetHandle_Concurrent() {
 		objContent := "object content: content#" + strconv.Itoa(index)
 		minObj := chrT.getMinObject(objName, []byte(objContent))
 
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, 0)
+		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
 
 		AssertEq(nil, err)
 		AssertEq(nil, cacheHandle.validateCacheHandle())

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
 )
@@ -78,4 +79,16 @@ func GetObjectPath(bucketName string, objectName string) string {
 // GetDownloadPath gives file path to file in cache for given object path.
 func GetDownloadPath(cacheLocation string, objectPath string) string {
 	return path.Join(cacheLocation, objectPath)
+}
+
+// IsCacheHandleInvalid says either the current cacheHandle is invalid or not, based
+// on the error we got while reading with the cacheHandle.
+// If it's invalid then we should close that cacheHandle and create new cacheHandle
+// for next call onwards.
+func IsCacheHandleInvalid(readErr error) bool {
+	return strings.Contains(readErr.Error(), InvalidFileHandleErrMsg) ||
+		strings.Contains(readErr.Error(), InvalidFileDownloadJobErrMsg) ||
+		strings.Contains(readErr.Error(), InvalidFileInfoCacheErrMsg) ||
+		strings.Contains(readErr.Error(), ErrInSeekingFileHandleMsg) ||
+		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
 }

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -206,4 +207,29 @@ func (ut *utilTest) Test_getDownloadPath() {
 	}
 
 	ExpectTrue(reflect.DeepEqual(expectedOutputs, results))
+}
+
+func (ut *utilTest) Test_IsCacheHandleValid_True() {
+	errMessages := []string{
+		InvalidFileHandleErrMsg + "test",
+		InvalidFileDownloadJobErrMsg + "test",
+		InvalidFileInfoCacheErrMsg + "test",
+		ErrInSeekingFileHandleMsg + "test",
+		ErrInReadingFileHandleMsg + "test",
+	}
+
+	for _, errMsg := range errMessages {
+		ExpectTrue(IsCacheHandleInvalid(errors.New(errMsg)))
+	}
+}
+
+func (ut *utilTest) Test_IsCacheHandleValid_False() {
+	errMessages := []string{
+		FallbackToGCSErrMsg + "test",
+		"random error message",
+	}
+
+	for _, errMsg := range errMessages {
+		ExpectFalse(IsCacheHandleInvalid(errors.New(errMsg)))
+	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1521,7 +1521,7 @@ func (fs *fileSystem) CreateFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	// TODO (raj-prince) - pass correct value of fileCacheHandler and downloadForRandomRead
+	// TODO (raj-prince) - pass correct value of fileCacheHandler and downloadFileForRandomRead
 	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), nil, false)
 	op.Handle = handleID
 
@@ -2012,7 +2012,7 @@ func (fs *fileSystem) OpenFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	// TODO (raj-prince) - Pass correct value of fileCacheHandler and downloadForRandomRead
+	// TODO (raj-prince) - Pass correct value of fileCacheHandler and downloadFileForRandomRead
 	fs.handles[handleID] = handle.NewFileHandle(in, nil, false)
 	op.Handle = handleID
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1521,7 +1521,8 @@ func (fs *fileSystem) CreateFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode))
+	// TODO (raj-prince) - pass correct value of fileCacheHandler and downloadForRandomRead
+	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), nil, false)
 	op.Handle = handleID
 
 	fs.mu.Unlock()
@@ -2011,7 +2012,8 @@ func (fs *fileSystem) OpenFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	fs.handles[handleID] = handle.NewFileHandle(in)
+	// TODO (raj-prince) - Pass correct value of fileCacheHandler and downloadForRandomRead
+	fs.handles[handleID] = handle.NewFileHandle(in, nil, false)
 	op.Handle = handleID
 
 	// When we observe object generations that we didn't create, we assign them
@@ -2138,7 +2140,7 @@ func (fs *fileSystem) ReleaseFileHandle(
 	defer fs.mu.Unlock()
 
 	// Destroy the handle.
-	fs.handles[op.Handle].(*handle.FileHandle).Destroy()
+	err = fs.handles[op.Handle].(*handle.FileHandle).Destroy()
 
 	// Update the map.
 	delete(fs.handles, op.Handle)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2140,7 +2140,7 @@ func (fs *fileSystem) ReleaseFileHandle(
 	defer fs.mu.Unlock()
 
 	// Destroy the handle.
-	err = fs.handles[op.Handle].(*handle.FileHandle).Destroy()
+	fs.handles[op.Handle].(*handle.FileHandle).Destroy()
 
 	// Update the map.
 	delete(fs.handles, op.Handle)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -38,8 +38,8 @@ type FileHandle struct {
 	// GUARDED_BY(mu)
 	reader gcsx.RandomReader
 
-	// fileCacheHandler is used to read the objectContent from cache. This will be
-	// nil if the file cache is disabled.
+	// fileCacheHandler is used to get file cache handle and read happens using that.
+	// This will be nil if the file cache is disabled.
 	fileCacheHandler *file.CacheHandler
 
 	// downloadForRandomRead is also valid for cache workflow, if true, object content
@@ -105,7 +105,7 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	if fh.reader != nil {
 		fh.inode.Unlock()
 
-		n, err = fh.reader.ReadAt(ctx, dst, offset)
+		n, _, err = fh.reader.ReadAt(ctx, dst, offset)
 		switch {
 		case err == io.EOF:
 			return

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -42,17 +42,17 @@ type FileHandle struct {
 	// This will be nil if the file cache is disabled.
 	fileCacheHandler *file.CacheHandler
 
-	// downloadForRandomRead is also valid for cache workflow, if true, object content
+	// downloadFileForRandomRead is also valid for cache workflow, if true, object content
 	// will be downloaded for random reads as well too. Generally, we don't cache the
 	// content for random-read.
-	downloadForRandomRead bool
+	downloadFileForRandomRead bool
 }
 
-func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, downloadForRandomRead bool) (fh *FileHandle) {
+func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, downloadFileForRandomRead bool) (fh *FileHandle) {
 	fh = &FileHandle{
-		inode:                 inode,
-		fileCacheHandler:      fileCacheHandler,
-		downloadForRandomRead: downloadForRandomRead,
+		inode:                     inode,
+		fileCacheHandler:          fileCacheHandler,
+		downloadFileForRandomRead: downloadFileForRandomRead,
 	}
 
 	fh.mu = syncutil.NewInvariantMutex(fh.checkInvariants)
@@ -171,7 +171,7 @@ func (fh *FileHandle) tryEnsureReader(ctx context.Context, sequentialReadSizeMb 
 	}
 
 	// Attempt to create an appropriate reader.
-	rr := gcsx.NewRandomReader(fh.inode.Source(), fh.inode.Bucket(), sequentialReadSizeMb, fh.fileCacheHandler, fh.downloadForRandomRead)
+	rr := gcsx.NewRandomReader(fh.inode.Source(), fh.inode.Bucket(), sequentialReadSizeMb, fh.fileCacheHandler, fh.downloadFileForRandomRead)
 
 	fh.reader = rr
 	return

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -62,15 +62,10 @@ func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, 
 
 // Destroy any resources associated with the handle, which must not be used
 // again.
-func (fh *FileHandle) Destroy() error {
+func (fh *FileHandle) Destroy() {
 	if fh.reader != nil {
-		err := fh.reader.Destroy()
-		if err != nil {
-			return fmt.Errorf("fh.Destroy(): while destroying reader: %v", err)
-		}
+		fh.reader.Destroy()
 	}
-
-	return nil
 }
 
 // Inode returns the inode backing this handle.
@@ -158,10 +153,7 @@ func (fh *FileHandle) tryEnsureReader(ctx context.Context, sequentialReadSizeMb 
 	// we have one.
 	if !fh.inode.SourceGenerationIsAuthoritative() {
 		if fh.reader != nil {
-			err = fh.reader.Destroy()
-			if err != nil {
-				return fmt.Errorf("tryEnsure: while destroying random-reader: %v", err)
-			}
+			fh.reader.Destroy()
 			fh.reader = nil
 		}
 
@@ -174,7 +166,6 @@ func (fh *FileHandle) tryEnsureReader(ctx context.Context, sequentialReadSizeMb 
 		if fh.reader.Object().Generation == fh.inode.SourceGeneration().Object {
 			return
 		}
-
 		fh.reader.Destroy()
 		fh.reader = nil
 	}

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -43,8 +43,7 @@ type FileHandle struct {
 	fileCacheHandler *file.CacheHandler
 
 	// downloadFileForRandomRead is also valid for cache workflow, if true, object content
-	// will be downloaded for random reads as well too. Generally, we don't cache the
-	// content for random-read.
+	// will be downloaded for random reads as well too.
 	downloadFileForRandomRead bool
 }
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -144,6 +144,8 @@ type randomReader struct {
 	//
 	// INVARIANT: start <= limit
 	// INVARIANT: limit < 0 implies reader != nil
+	// All these properties will be used only in case of GCS reads and not for
+	// reads from cache.
 	start          int64
 	limit          int64
 	seeks          uint64

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -105,7 +105,7 @@ type RandomReader interface {
 
 	// Clean up any resources associated with the reader, which must not be used
 	// again.
-	Destroy() error
+	Destroy()
 }
 
 // NewRandomReader create a random reader for the supplied object record that
@@ -332,7 +332,7 @@ func (rr *randomReader) Object() (o *gcs.MinObject) {
 	return
 }
 
-func (rr *randomReader) Destroy() error {
+func (rr *randomReader) Destroy() {
 	// Close out the reader, if we have one.
 	if rr.reader != nil {
 		err := rr.reader.Close()
@@ -343,14 +343,12 @@ func (rr *randomReader) Destroy() error {
 		}
 	}
 
-	if rr.fileCacheHandler != nil {
-		err := rr.fileCacheHandler.InvalidateCache(rr.object, rr.bucket)
+	if rr.fileCacheHandler != nil && rr.fileCacheHandle != nil {
+		err := rr.fileCacheHandle.Close()
 		if err != nil {
-			return fmt.Errorf("rr.Destroy(): while invalidating file-cache: %v", err)
+			logger.Warnf("rr.Destroy(): while closing cacheFileHandle: %v", err)
 		}
 	}
-
-	return nil
 }
 
 // Like io.ReadFull, but deals with the cancellation issues.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -56,9 +56,9 @@ func (rr *checkingRandomReader) ReadAt(p []byte, offset int64) (int, error) {
 	return rr.wrapped.ReadAt(rr.ctx, p, offset)
 }
 
-func (rr *checkingRandomReader) Destroy() {
+func (rr *checkingRandomReader) Destroy() error {
 	rr.wrapped.CheckInvariants()
-	rr.wrapped.Destroy()
+	return rr.wrapped.Destroy()
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -181,8 +181,8 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 }
 
 func (t *RandomReaderTest) TearDown() {
-	t.rr.Destroy()
-
+	err := t.rr.Destroy()
+	AssertEq(nil, err)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -140,6 +140,7 @@ func rangeLimitIs(expected uint64) (m Matcher) {
 
 const sequentialReadSizeInMb = 10
 const sequentialReadSizeInBytes = sequentialReadSizeInMb * MB
+const CacheMaxSize = 20 * MB
 
 type RandomReaderTest struct {
 	object        *gcs.MinObject
@@ -169,10 +170,8 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	t.bucket = storage.NewMockBucket(ti.MockController, "bucket")
 
 	t.cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
-	CacheMaxSize := 100 * util.MiB
-	lruCache := lru.NewCache(uint64(CacheMaxSize))
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, t.cacheLocation, 100)
-
+	lruCache := lru.NewCache(CacheMaxSize)
+	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, t.cacheLocation, sequentialReadSizeInMb)
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheLocation, util.DefaultFilePerm)
 
 	// Set up the reader.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -56,9 +56,9 @@ func (rr *checkingRandomReader) ReadAt(p []byte, offset int64) (int, error) {
 	return rr.wrapped.ReadAt(rr.ctx, p, offset)
 }
 
-func (rr *checkingRandomReader) Destroy() error {
+func (rr *checkingRandomReader) Destroy() {
 	rr.wrapped.CheckInvariants()
-	return rr.wrapped.Destroy()
+	rr.wrapped.Destroy()
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -180,8 +180,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 }
 
 func (t *RandomReaderTest) TearDown() {
-	err := t.rr.Destroy()
-	AssertEq(nil, err)
+	t.rr.Destroy()
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -1016,13 +1016,9 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 
 func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheMiss() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	//objectSize := t.object.Size
 	t.rr.wrapped.downloadForRandomRead = false
-	//testContent := getRandomContent(int(objectSize))
 	start := 5
-	end := 10 // not included
-	//rc := getReadCloser(testContent[start:])
-	//t.mockNewReaderCallForTestBucket(uint64(start), objectSize, rc)
+	end := 10
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
 
@@ -1032,3 +1028,5 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheMiss() {
 	ExpectFalse(cacheHit)
 	ExpectEq(nil, err)
 }
+
+// TODO (raj-prince) - to add unit tests for failed scenario while reading via cache.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -710,10 +710,9 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialFullObject() {
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
-
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
+
 	_, cacheHit, err := t.rr.ReadAt(buf, 0)
 
 	ExpectTrue(cacheHit)
@@ -727,13 +726,12 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialRangeRead() {
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	start := 0
 	end := 10 // not included
 	AssertLt(end, objectSize)
-
 	buf := make([]byte, end-start)
+
 	_, cacheHit, err := t.rr.ReadAt(buf, int64(start))
 
 	ExpectTrue(cacheHit)
@@ -748,8 +746,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanRea
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -774,16 +771,15 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanRea
 func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenDownloadForRandomIsFalse() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
-	t.rr.wrapped.downloadForRandomRead = false
+	t.rr.wrapped.downloadFileForRandomRead = false
 	testContent := getRandomContent(int(objectSize))
 	start := 5
 	end := 10 // not included
 	rc := getReadCloser(testContent[start:])
 	t.mockNewReaderCallForTestBucket(uint64(start), objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
-
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, end-start)
+
 	_, cacheHit, err := t.rr.ReadAt(buf, int64(start))
 
 	ExpectFalse(cacheHit)
@@ -797,7 +793,7 @@ func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenDownl
 func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenDownloadForRandomIsTrue() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
-	t.rr.wrapped.downloadForRandomRead = true
+	t.rr.wrapped.downloadFileForRandomRead = true
 	testContent := getRandomContent(int(objectSize))
 	start := 5
 	end := 10 // not included
@@ -805,10 +801,9 @@ func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenDownl
 	t.mockNewReaderCallForTestBucket(uint64(start), objectSize, rc) // Mock for random-reader's NewReader call
 	rc2 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc2) // Mock for download job's NewReader call
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
-
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, end-start)
+
 	_, cacheHit, err := t.rr.ReadAt(buf, int64(start))
 
 	ExpectFalse(cacheHit)
@@ -826,8 +821,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetMor
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -858,8 +852,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetLes
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -896,8 +889,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	testContent := getRandomContent(int(objectSize))
 	rc1 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
 	_, cacheHit, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -927,8 +919,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHitNextToCacheMissIncaseOfInvalidJob
 	testContent := getRandomContent(int(objectSize))
 	rc1 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
 	_, cacheHit, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -965,8 +956,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHitNextToCacheMissIncaseOfInvalidFil
 	testContent := getRandomContent(int(objectSize))
 	rc1 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
 	_, cacheHit, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -1003,10 +993,9 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	testContent := getRandomContent(int(objectSize))
 	rc := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc)
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
-
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
+
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
 
 	ExpectTrue(cacheHit)
@@ -1016,13 +1005,12 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 
 func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheMiss() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.rr.wrapped.downloadForRandomRead = false
+	t.rr.wrapped.downloadFileForRandomRead = false
 	start := 5
 	end := 10
-	ExpectCall(t.bucket, "Name")().
-		WillRepeatedly(Return("test"))
-
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
 	buf := make([]byte, end-start)
+
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, int64(start))
 
 	ExpectFalse(cacheHit)
@@ -1030,3 +1018,5 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheMiss() {
 }
 
 // TODO (raj-prince) - to add unit tests for failed scenario while reading via cache.
+// This requires mocking CacheHandle object, whose read method will return some unexpected
+// error.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -674,7 +674,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHit() {
 	rc := ioutil.NopCloser(r)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
@@ -694,12 +694,12 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHit() {
 func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
-	r := strings.NewReader(strings.Repeat("x", int(objectSize)))
-	rc := ioutil.NopCloser(r)
+	r1 := strings.NewReader(strings.Repeat("x", int(objectSize)))
+	rc1 := ioutil.NopCloser(r1)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
-		WillRepeatedly(Return(rc, nil))
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
+		WillRepeatedly(Return(rc1, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
 	buf := make([]byte, objectSize)
@@ -715,10 +715,13 @@ func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	AssertEq(nil, err)
 	r2 := strings.NewReader(strings.Repeat("x", int(objectSize)))
 	rc2 := ioutil.NopCloser(r2)
+	// Second reader (rc2) is required, since first reader (rc) is completely read.
+	// Reading again will return EOF.
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc2, nil))
+
 	_, err = t.rr.ReadAt(buf, 0)
 
 	ExpectEq(nil, err)
@@ -733,7 +736,7 @@ func (t *RandomReaderTest) Test_readFromCache_SuccessfulRead() {
 	rc := ioutil.NopCloser(r)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
@@ -751,17 +754,13 @@ func (t *RandomReaderTest) Test_readFromCache_SuccessfulRead() {
 }
 
 func (t *RandomReaderTest) Test_readFromCache_InvalidJob() {
-	// Setup:
-	// (a) Firstly read the data correctly via cache
-	// (b) Job will be in completed state, check that.
-	// (c) Invalidate the cache
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
 	r := strings.NewReader(strings.Repeat("x", int(objectSize)))
 	rc := ioutil.NopCloser(r)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
@@ -792,7 +791,7 @@ func (t *RandomReaderTest) Test_readFromCache_RandomReadWithRandomDownloadTrue()
 	rc := ioutil.NopCloser(r)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))
@@ -817,7 +816,7 @@ func (t *RandomReaderTest) Test_readFromCache_RandomReadWithRandomDownloadFalse(
 	rc := ioutil.NopCloser(r)
 	ExpectCall(t.bucket, "NewReader")(
 		Any(),
-		AllOf(rangeStartIs(0), rangeLimitIs(17))).
+		AllOf(rangeStartIs(0), rangeLimitIs(objectSize))).
 		WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().
 		WillRepeatedly(Return("test"))


### PR DESCRIPTION
### Description
1. Random reader change to support reading from cache.
2. Changes in FileHandle and fs.go to propagate CacheHandler and downloadForRandom
3. Semantic changes for Destroy method, now it returns an error.
4. Correction in CacheHandler.go, now we will not destroy the cacheHandle if the job is NOT_STARTED.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
5. Unit tests - Automation
6. Integration tests - (will run the automatic integration test in the last)
