### PR TITLE
Update installation steps for not using apt-key

### DIFF
--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -19,7 +19,7 @@ set -x
 #details.txt file contains the release version and commit hash of the current release.
 gsutil cp  gs://gcsfuse-release-packages/version-detail/details.txt .
 # Writing VM instance name to details.txt (Format: release-test-<os-name>)
-vm_instance_name = ${curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google"}
+vm_instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google")
 echo $vm_instance_name >> details.txt
 touch ~/logs.txt
 
@@ -29,9 +29,9 @@ if grep -q ubuntu details.txt || grep -q debian details.txt;
 then
     #  For ubuntu and debian os
     export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
-    if [[grep -q ubuntu details.txt] && ["$vm_instance_name" >= "release-test-ubuntu-21"]] || [[grep -q debian details.txt] && ["$vm_instance_name" >= "release-test-debian-11"]];
+    # Don't use apt-key for Debian 11+ and Ubuntu 21+
+    if { [[ $vm_instance_name == *"debian"*  &&  !( "$vm_instance_name" < "release-test-debian11") ]]; } || { [[ $vm_instance_name == *"ubuntu"*  && !("$vm_instance_name" < "release-test-ubuntu21") ]]; }
     then
-      # Don't use apt-key for Debian 11+ and Ubuntu 21+
       echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
       curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc
     else

--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -30,14 +30,20 @@ then
     #  For ubuntu and debian os
     export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
     # Don't use apt-key for Debian 11+ and Ubuntu 21+
-    if { [[ $vm_instance_name == *"debian"*  &&  !( "$vm_instance_name" < "release-test-debian11") ]]; } || { [[ $vm_instance_name == *"ubuntu"*  && !("$vm_instance_name" < "release-test-ubuntu21") ]]; }
+    if { [[ $vm_instance_name == *"debian"*  &&  !( "$vm_instance_name" < "release-test-debian-11") ]]; } || { [[ $vm_instance_name == *"ubuntu"*  && !("$vm_instance_name" < "release-test-ubuntu-21") ]]; }
     then
       echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
-      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc >> ~/apt_key_logs.txt
     else
       echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
-      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - >> ~/apt_key_logs.txt
     fi
+
+    if grep -q -i warning ~/apt_key_logs.txt;
+    then
+      echo "Failure: Got warning while using apt-key" >> ~/logs.txt
+    fi
+
     sudo apt-get update
     # Install latest released gcsfuse version
     sudo apt-get install -y gcsfuse


### PR DESCRIPTION
### Description
One of the customer asked for providing a way of installation that doesn't require apt-key because that's deprecated from Ubuntu21+ and Debian 11+. This PR changes the release pipeline tests to use installation steps with apt-key command for Ubuntu21+ and Debian11+. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested with our release pipeline.
2. Unit tests - NA
3. Integration tests - NA
