### PR TITLE
Fix clat-percentile accuracy in fio

### DIFF
--- a/perfmetrics/scripts/fio/install_fio.sh
+++ b/perfmetrics/scripts/fio/install_fio.sh
@@ -35,9 +35,9 @@ sudo apt-get install -y libaio-dev
 # The sed command below is to address internal bug#309563824. 
 # As recorded in this bug, fio by-default supports 
 # clat percentile values to be calculated accurately upto only 
-# 2^(FIO_IO_U_PLAT_GROUP_NR + 5) ns = 14 ms 
+# 2^(FIO_IO_U_PLAT_GROUP_NR + 5) ns = 17.17 seconds. 
 # (with default value of FIO_IO_U_PLAT_GROUP_NR = 29). This change increases it upto 32, to allow
-# latencies upto 112 ms to be calculated accurately.
+# latencies upto 137.44s to be calculated accurately.
 sudo rm -rf "$FIO_SRC_DIR" && \
 git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR" && \
 cd  "$FIO_SRC_DIR" && \

--- a/perfmetrics/scripts/fio/install_fio.sh
+++ b/perfmetrics/scripts/fio/install_fio.sh
@@ -32,10 +32,17 @@ echo "Installing fio ..."
 sudo apt-get install -y libaio-dev
 
 # We are building fio from source because of the issue: https://github.com/axboe/fio/issues/1668.
+# The sed command below is to address internal bug#309563824. 
+# As recorded in this bug, fio by-default supports 
+# clat percentile values to be calculated accurately upto only 
+# 2^(FIO_IO_U_PLAT_GROUP_NR + 5) ns = 14 ms 
+# (with default value of FIO_IO_U_PLAT_GROUP_NR = 29). This change increases it upto 32, to allow
+# latencies upto 112 ms to be calculated accurately.
 sudo rm -rf "$FIO_SRC_DIR" && \
 git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR" && \
 cd  "$FIO_SRC_DIR" && \
 git checkout fio-3.36 && \
+sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GROUP_NR 32/g' stat.h && \
 ./configure && make && sudo make install
 
 # Now, print the installed fio version for verification


### PR DESCRIPTION
### Description
This fix is to address internal bug#309563824.
As recorded in this bug, fio by default supports
clat percentile values to be calculated accurately upto only 2^(FIO_IO_U_PLAT_GROUP_NR + 5) ns = 14 ms
(with default value of FIO_IO_U_PLAT_GROUP_NR = 29). This change increases it upto 32, to allow latencies upto 112 ms to be calculated accurately.

This is dependent on https://github.com/GoogleCloudPlatform/gcsfuse/pull/1506 . This fix is bsased on the suggestion in https://github.com/axboe/fio/issues/1668#issuecomment-1795094235 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
