### PR TITLE
add configs for log rotation

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -14,14 +14,22 @@
 
 package config
 
+const (
+	// Default log rotation config values.
+	defaultMaxFileSizeMB = 512
+	defaultFileCount     = 10
+	defaultCompress      = false
+)
+
 type WriteConfig struct {
 	CreateEmptyFile bool `yaml:"create-empty-file"`
 }
 
 type LogConfig struct {
-	Severity LogSeverity `yaml:"severity"`
-	Format   string      `yaml:"format"`
-	FilePath string      `yaml:"file-path"`
+	Severity        LogSeverity     `yaml:"severity"`
+	Format          string          `yaml:"format"`
+	FilePath        string          `yaml:"file-path"`
+	LogRotateConfig LogRotateConfig `yaml:"log-rotate"`
 }
 
 type MountConfig struct {
@@ -29,11 +37,35 @@ type MountConfig struct {
 	LogConfig   `yaml:"logging"`
 }
 
+// LogRotateConfig defines the parameters for log rotation. It consists of three
+// configuration options:
+// 1. max-file-size-mb: specifies the maximum size in megabytes that a log file
+// can reach before it is rotated. The default value is 512 megabytes.
+// 2. file-count: determines the maximum number of log files to retain after they
+// have been rotated. The default value is 10.
+// 3. compress: indicates whether the rotated log files should be compressed
+// using gzip. The default value is False.
+type LogRotateConfig struct {
+	MaxFileSizeMB int  `yaml:"max-file-size-mb"`
+	FileCount     int  `yaml:"file-count"`
+	Compress      bool `yaml:"compress"`
+}
+
+func DefaultLogRotateConfig() LogRotateConfig {
+	return LogRotateConfig{
+		MaxFileSizeMB: defaultMaxFileSizeMB,
+		FileCount:     defaultFileCount,
+		Compress:      defaultCompress,
+	}
+}
+
 func NewMountConfig() *MountConfig {
 	mountConfig := &MountConfig{}
 	mountConfig.LogConfig = LogConfig{
 		// Making the default severity as INFO.
 		Severity: INFO,
+		// Setting default values of log rotate config.
+		LogRotateConfig: DefaultLogRotateConfig(),
 	}
 	return mountConfig
 }

--- a/internal/config/testdata/invalid_log_rotate_config_1.yaml
+++ b/internal/config/testdata/invalid_log_rotate_config_1.yaml
@@ -1,0 +1,7 @@
+write:
+  create-empty-file: true
+logging:
+  severity: error
+  log-rotate:
+    max-file-size-mb: -1
+    file-count: -1

--- a/internal/config/testdata/invalid_log_rotate_config_2.yaml
+++ b/internal/config/testdata/invalid_log_rotate_config_2.yaml
@@ -1,0 +1,6 @@
+write:
+  create-empty-file: true
+logging:
+  severity: error
+  log-rotate:
+    file-count: -1

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -4,4 +4,9 @@ logging:
   file-path: /tmp/logfile.json
   format: text
   severity: error
+  log-rotate:
+    max-file-size-mb: 100
+    file-count: 5
+    compress: false
+
 

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -34,7 +34,7 @@ const (
 	ERROR   LogSeverity = "ERROR"
 	OFF     LogSeverity = "OFF"
 
-	parseConfigFileError = "error parsing config file: %w"
+	parseConfigFileErrMsgFormat = "error parsing config file: %v"
 )
 
 func IsValidLogSeverity(severity LogSeverity) bool {
@@ -53,10 +53,10 @@ func IsValidLogSeverity(severity LogSeverity) bool {
 
 func IsValidLogRotateConfig(config LogRotateConfig) error {
 	if config.MaxFileSizeMB <= 0 {
-		return fmt.Errorf("max-file-size-mb cannot be less than 0")
+		return fmt.Errorf("max-file-size-mb should be atleast 1")
 	}
 	if config.FileCount <= 0 {
-		return fmt.Errorf("file-count cannot be less than 0")
+		return fmt.Errorf("file-count should be atleast 1")
 	}
 	return nil
 }
@@ -83,7 +83,7 @@ func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 		if err == io.EOF {
 			return mountConfig, nil
 		}
-		return mountConfig, fmt.Errorf(parseConfigFileError, err)
+		return mountConfig, fmt.Errorf(parseConfigFileErrMsgFormat, err)
 	}
 
 	// convert log severity to upper-case
@@ -94,7 +94,7 @@ func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 	}
 
 	if err = IsValidLogRotateConfig(mountConfig.LogConfig.LogRotateConfig); err != nil {
-		err = fmt.Errorf(parseConfigFileError, err)
+		err = fmt.Errorf(parseConfigFileErrMsgFormat, err)
 		return
 	}
 

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -33,6 +33,8 @@ const (
 	WARNING LogSeverity = "WARNING"
 	ERROR   LogSeverity = "ERROR"
 	OFF     LogSeverity = "OFF"
+
+	parseConfigFileError = "error parsing config file: %w"
 )
 
 func IsValidLogSeverity(severity LogSeverity) bool {
@@ -47,6 +49,16 @@ func IsValidLogSeverity(severity LogSeverity) bool {
 		return true
 	}
 	return false
+}
+
+func IsValidLogRotateConfig(config LogRotateConfig) error {
+	if config.MaxFileSizeMB <= 0 {
+		return fmt.Errorf("max-file-size-mb cannot be less than 0")
+	}
+	if config.FileCount <= 0 {
+		return fmt.Errorf("file-count cannot be less than 0")
+	}
+	return nil
 }
 
 func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
@@ -71,13 +83,18 @@ func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 		if err == io.EOF {
 			return mountConfig, nil
 		}
-		return mountConfig, fmt.Errorf("error parsing config file: %w", err)
+		return mountConfig, fmt.Errorf(parseConfigFileError, err)
 	}
 
 	// convert log severity to upper-case
 	mountConfig.LogConfig.Severity = LogSeverity(strings.ToUpper(string(mountConfig.LogConfig.Severity)))
 	if !IsValidLogSeverity(mountConfig.LogConfig.Severity) {
 		err = fmt.Errorf("error parsing config file: log severity should be one of [trace, debug, info, warning, error, off]")
+		return
+	}
+
+	if err = IsValidLogRotateConfig(mountConfig.LogConfig.LogRotateConfig); err != nil {
+		err = fmt.Errorf(parseConfigFileError, err)
 		return
 	}
 

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -34,6 +34,9 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertEq("INFO", mountConfig.LogConfig.Severity)
 	AssertEq("", mountConfig.LogConfig.Format)
 	AssertEq("", mountConfig.LogConfig.FilePath)
+	AssertEq(512, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
+	AssertEq(10, mountConfig.LogConfig.LogRotateConfig.FileCount)
+	AssertEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -81,6 +84,9 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 	AssertEq(ERROR, mountConfig.LogConfig.Severity)
 	AssertEq("/tmp/logfile.json", mountConfig.LogConfig.FilePath)
 	AssertEq("text", mountConfig.LogConfig.Format)
+	AssertEq(100, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
+	AssertEq(5, mountConfig.LogConfig.LogRotateConfig.FileCount)
+	AssertEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogConfig() {
@@ -88,4 +94,18 @@ func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogConfig() {
 
 	AssertNe(nil, err)
 	AssertTrue(strings.Contains(err.Error(), "error parsing config file: log severity should be one of [trace, debug, info, warning, error, off]"))
+}
+
+func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogRotateConfig1() {
+	_, err := ParseConfigFile("testdata/invalid_log_rotate_config_1.yaml")
+
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "error parsing config file: max-file-size-mb cannot be less than 0"))
+}
+
+func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogRotateConfig2() {
+	_, err := ParseConfigFile("testdata/invalid_log_rotate_config_2.yaml")
+
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "error parsing config file: file-count cannot be less than 0"))
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -30,13 +31,13 @@ func init() { RegisterTestSuite(&YamlParserTest{}) }
 
 func validateDefaultConfig(mountConfig *MountConfig) {
 	AssertNe(nil, mountConfig)
-	AssertEq(false, mountConfig.CreateEmptyFile)
-	AssertEq("INFO", mountConfig.LogConfig.Severity)
-	AssertEq("", mountConfig.LogConfig.Format)
-	AssertEq("", mountConfig.LogConfig.FilePath)
-	AssertEq(512, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
-	AssertEq(10, mountConfig.LogConfig.LogRotateConfig.FileCount)
-	AssertEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
+	ExpectEq(false, mountConfig.CreateEmptyFile)
+	ExpectEq("INFO", mountConfig.LogConfig.Severity)
+	ExpectEq("", mountConfig.LogConfig.Format)
+	ExpectEq("", mountConfig.LogConfig.FilePath)
+	ExpectEq(512, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
+	ExpectEq(10, mountConfig.LogConfig.LogRotateConfig.FileCount)
+	ExpectEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -80,32 +81,35 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 
 	AssertEq(nil, err)
 	AssertNe(nil, mountConfig)
-	AssertEq(true, mountConfig.WriteConfig.CreateEmptyFile)
-	AssertEq(ERROR, mountConfig.LogConfig.Severity)
-	AssertEq("/tmp/logfile.json", mountConfig.LogConfig.FilePath)
-	AssertEq("text", mountConfig.LogConfig.Format)
-	AssertEq(100, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
-	AssertEq(5, mountConfig.LogConfig.LogRotateConfig.FileCount)
-	AssertEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
+	ExpectEq(true, mountConfig.WriteConfig.CreateEmptyFile)
+	ExpectEq(ERROR, mountConfig.LogConfig.Severity)
+	ExpectEq("/tmp/logfile.json", mountConfig.LogConfig.FilePath)
+	ExpectEq("text", mountConfig.LogConfig.Format)
+	ExpectEq(100, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
+	ExpectEq(5, mountConfig.LogConfig.LogRotateConfig.FileCount)
+	ExpectEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
 }
 
-func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogConfig() {
+func (t *YamlParserTest) TestReadConfigFile_InvalidLogConfig() {
 	_, err := ParseConfigFile("testdata/invalid_log_config.yaml")
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "error parsing config file: log severity should be one of [trace, debug, info, warning, error, off]"))
+	AssertTrue(strings.Contains(err.Error(),
+		fmt.Sprintf(parseConfigFileErrMsgFormat, "log severity should be one of [trace, debug, info, warning, error, off]")))
 }
 
-func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogRotateConfig1() {
+func (t *YamlParserTest) TestReadConfigFile_InvalidLogRotateConfig1() {
 	_, err := ParseConfigFile("testdata/invalid_log_rotate_config_1.yaml")
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "error parsing config file: max-file-size-mb cannot be less than 0"))
+	AssertTrue(strings.Contains(err.Error(),
+		fmt.Sprintf(parseConfigFileErrMsgFormat, "max-file-size-mb should be atleast 1")))
 }
 
-func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogRotateConfig2() {
+func (t *YamlParserTest) TestReadConfigFile_InvalidLogRotateConfig2() {
 	_, err := ParseConfigFile("testdata/invalid_log_rotate_config_2.yaml")
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "error parsing config file: file-count cannot be less than 0"))
+	AssertTrue(strings.Contains(err.Error(),
+		fmt.Sprintf(parseConfigFileErrMsgFormat, "file-count should be atleast 1")))
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -283,11 +283,11 @@ func (t *LoggerTest) TestInitLogFile() {
 	err := InitLogFile(logConfig)
 
 	AssertEq(nil, err)
-	AssertEq(filePath, defaultLoggerFactory.file.Name())
-	AssertEq(nil, defaultLoggerFactory.sysWriter)
-	AssertEq(format, defaultLoggerFactory.format)
-	AssertEq(config.DEBUG, defaultLoggerFactory.level)
-	AssertEq(fileSize, defaultLoggerFactory.logRotateConfig.MaxFileSizeMB)
-	AssertEq(fileCount, defaultLoggerFactory.logRotateConfig.FileCount)
-	AssertEq(true, defaultLoggerFactory.logRotateConfig.Compress)
+	ExpectEq(filePath, defaultLoggerFactory.file.Name())
+	ExpectEq(nil, defaultLoggerFactory.sysWriter)
+	ExpectEq(format, defaultLoggerFactory.format)
+	ExpectEq(config.DEBUG, defaultLoggerFactory.level)
+	ExpectEq(fileSize, defaultLoggerFactory.logRotateConfig.MaxFileSizeMB)
+	ExpectEq(fileCount, defaultLoggerFactory.logRotateConfig.FileCount)
+	ExpectEq(true, defaultLoggerFactory.logRotateConfig.Compress)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -17,6 +17,7 @@ package logger
 import (
 	"bytes"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
@@ -260,4 +261,33 @@ func (t *LoggerTest) TestSetLoggingLevel() {
 		setLoggingLevel(test.inputLevel, test.programLevel)
 		AssertEq(test.programLevel.Level(), test.expectedProgramLevel)
 	}
+}
+
+func (t *LoggerTest) TestInitLogFile() {
+	format := "text"
+	filePath, _ := os.UserHomeDir()
+	filePath += "/log.txt"
+	fileSize := 100
+	fileCount := 2
+	logConfig := config.LogConfig{
+		Severity: config.DEBUG,
+		Format:   format,
+		FilePath: filePath,
+		LogRotateConfig: config.LogRotateConfig{
+			MaxFileSizeMB: fileSize,
+			FileCount:     fileCount,
+			Compress:      true,
+		},
+	}
+
+	err := InitLogFile(logConfig)
+
+	AssertEq(nil, err)
+	AssertEq(filePath, defaultLoggerFactory.file.Name())
+	AssertEq(nil, defaultLoggerFactory.sysWriter)
+	AssertEq(format, defaultLoggerFactory.format)
+	AssertEq(config.DEBUG, defaultLoggerFactory.level)
+	AssertEq(fileSize, defaultLoggerFactory.logRotateConfig.MaxFileSizeMB)
+	AssertEq(fileCount, defaultLoggerFactory.logRotateConfig.FileCount)
+	AssertEq(true, defaultLoggerFactory.logRotateConfig.Compress)
 }

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	}
 
 	if flags.Foreground {
-		err = logger.InitLogFile(mountConfig.LogConfig.FilePath, mountConfig.LogConfig.Format, mountConfig.LogConfig.Severity)
+		err = logger.InitLogFile(mountConfig.LogConfig)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)
 		}


### PR DESCRIPTION
### Description
Added the following configs for log rotation.
1. max-file-size-mb: specifies the maximum size in megabytes that a log file
can reach before it is rotated. The default value is 512 megabytes.
2. file-count: determines the maximum number of log files to retain after they
have been rotated. The default value is 10.
3. compress: indicates whether the rotated log files should be compressed
using gzip. The default value is False.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
