### PR TITLE
Collate fio installations at one place

### DIFF
--- a/perfmetrics/scripts/fio/install_fio.sh
+++ b/perfmetrics/scripts/fio/install_fio.sh
@@ -13,21 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Args: 
+# $1: <path-to-clone-fio-source-code> e.g. ~/github/
+
 set -e
+
+if [[ $# -eq 0 ]] ; then
+    echo 'No argument passed.'
+    echo 'Args: <path-to-clone-fio-source-code>'
+    exit 1
+fi
+
+SRC_DIR="$1"
+FIO_SRC_DIR="${SRC_DIR}/fio"
 
 echo "Installing fio ..."
 # install libaio as fio has a dependency on libaio
 sudo apt-get install -y libaio-dev
 
-# We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
-# The fix is not currently released in a package as of 20th Oct, 2023.
-# TODO: install fio via package when release > 3.35 is available.
-FIO_SRC_DIR="${KOKORO_ARTIFACTS_DIR}/github/fio"
-sudo rm -rf "${FIO_SRC_DIR}" && \
-git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR"
+# We are building fio from source because of the issue: https://github.com/axboe/fio/issues/1668.
+sudo rm -rf "$FIO_SRC_DIR" && \
+git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR" && \
 cd  "$FIO_SRC_DIR" && \
-git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
+git checkout fio-3.35 && \
 ./configure && make && sudo make install
 
 # Now, print the installed fio version for verification
 echo 'fio version='$(fio -version)
+
+# go back to the original directory
+cd -

--- a/perfmetrics/scripts/fio/install_fio.sh
+++ b/perfmetrics/scripts/fio/install_fio.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Installing fio ..."
+# install libaio as fio has a dependency on libaio
+sudo apt-get install -y libaio-dev
+
+# We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
+# The fix is not currently released in a package as of 20th Oct, 2023.
+# TODO: install fio via package when release > 3.35 is available.
+FIO_SRC_DIR="${KOKORO_ARTIFACTS_DIR}/github/fio"
+sudo rm -rf "${FIO_SRC_DIR}" && \
+git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR"
+cd  "$FIO_SRC_DIR" && \
+git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
+./configure && make && sudo make install
+
+# Now, print the installed fio version for verification
+echo 'fio version='$(fio -version)

--- a/perfmetrics/scripts/fio/install_fio.sh
+++ b/perfmetrics/scripts/fio/install_fio.sh
@@ -35,7 +35,7 @@ sudo apt-get install -y libaio-dev
 sudo rm -rf "$FIO_SRC_DIR" && \
 git clone https://github.com/axboe/fio.git "$FIO_SRC_DIR" && \
 cd  "$FIO_SRC_DIR" && \
-git checkout fio-3.35 && \
+git checkout fio-3.36 && \
 ./configure && make && sudo make install
 
 # Now, print the installed fio version for verification

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -69,18 +69,7 @@ function install_requirements() {
   pip install google-cloud-vision
   pip install google-api-python-client
   pip install prettytable
-  # install libaio as fio has a dependency on libaio
-  sudo apt-get install libaio-dev
-  # We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
-  # The fix is not currently released in a package as of 20th Oct, 2023.
-  # TODO: install fio via package when release > 3.35 is available.
-  echo Installing fio
-  sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
-  git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
-  cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \
-  git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
-  ./configure && make && sudo make install
-  fio --version
+  "${KOKORO_ARTIFACTS_DIR}"/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh
   cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 }
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -69,7 +69,7 @@ function install_requirements() {
   pip install google-cloud-vision
   pip install google-api-python-client
   pip install prettytable
-  "${KOKORO_ARTIFACTS_DIR}"/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh
+  "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh" "${KOKORO_ARTIFACTS_DIR}/github"
   cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 }
 

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -17,7 +17,7 @@ set -e
 
 echo "Installing pip"
 sudo apt-get install pip -y
-"${KOKORO_ARTIFACTS_DIR}"/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh
+"${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh" "${KOKORO_ARTIFACTS_DIR}/github"
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts"
 

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -17,17 +17,7 @@ set -e
 
 echo "Installing pip"
 sudo apt-get install pip -y
-echo "Installing fio"
-# install libaio as fio has a dependency on libaio
-sudo apt-get install libaio-dev
-# We are building fio from source because of issue: https://github.com/axboe/fio/issues/1640.
-# The fix is not currently released in a package as of 20th Oct, 2023.
-# TODO: install fio via package when release > 3.35 is available.
-sudo rm -rf "${KOKORO_ARTIFACTS_DIR}/github/fio"
-git clone https://github.com/axboe/fio.git "${KOKORO_ARTIFACTS_DIR}/github/fio"
-cd  "${KOKORO_ARTIFACTS_DIR}/github/fio" && \
-git checkout c5d8ce3fc736210ded83b126c71e3225c7ffd7c9 && \
-./configure && make && sudo make install
+"${KOKORO_ARTIFACTS_DIR}"/github/gcsfuse/perfmetrics/scripts/fio/install_fio.sh
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts"
 


### PR DESCRIPTION
### Description
Currently the commands for installing fio
is duplicated at two different places. This change merges them and puts it into a common script at
perfmetrics/scripts/fio/install_fio.sh and invokes it from both the places.

fio version 3.36 has been released, so we could directly installed that from the fio-3.36 package, but we need to build fio from source for the [fix in clat latency calculations](https://github.com/GoogleCloudPlatform/gcsfuse/pull/1503) .

This is precursor to https://github.com/GoogleCloudPlatform/gcsfuse/pull/1503.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
