### PR TITLE
Adding checks to catch - if cache is deleted externally

### DIFF
--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -124,7 +124,7 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 		filePath := util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucket.Name(), object.Name))
 		_, err := os.Stat(filePath)
 		if err != nil && os.IsNotExist(err) {
-			return fmt.Errorf("%s: %s", util.DataInconsistentErrMsg, filePath)
+			return fmt.Errorf("addFileInfoEntryToCache: %s: %s", util.FileNotPresentInCacheErrMsg, filePath)
 		}
 
 		fileInfoData := fileInfo.(data.FileInfo)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -204,10 +204,10 @@ func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket
 // and delete local file in the cache.
 //
 // Acquires and releases LOCK(CacheHandler.mu)
-func (chr *CacheHandler) InvalidateCache(object *gcs.MinObject, bucket gcs.Bucket) error {
+func (chr *CacheHandler) InvalidateCache(objectName string, bucketName string) error {
 	fileInfoKey := data.FileInfoKey{
-		BucketName: bucket.Name(),
-		ObjectName: object.Name,
+		BucketName: bucketName,
+		ObjectName: objectName,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	if err != nil {

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -124,6 +124,14 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 	if fileInfo == nil {
 		addEntryToCache = true
 	} else {
+		// Throw an error, if there is an entry in the file-info cache and cache file doesn't
+		// exist locally.
+		filePath := util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucket.Name(), object.Name))
+		_, err := os.Stat(filePath)
+		if err != nil && os.IsNotExist(err) {
+			return fmt.Errorf("addFileInfoEntryToCache: data inconsistent - %s file not present", filePath)
+		}
+
 		fileInfoData := fileInfo.(data.FileInfo)
 		if fileInfoData.ObjectGeneration < object.Generation {
 			erasedVal := chr.fileInfoCache.Erase(fileInfoKeyName)

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -269,12 +269,10 @@ func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfNotAlready() {
 	ExpectEq(false, doesFileExist(chrT.downloadPath))
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfLocalFileGotDeleted() {
-	{
-		// Existing cacheHandle.
-		cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-		AssertEq(nil, cacheHandle1.validateCacheHandle())
-	}
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfLocalFileGetsDeleted() {
+	// Existing cacheHandle.
+	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
+	AssertEq(nil, cacheHandle1.validateCacheHandle())
 	// Delete the local cache file.
 	err := os.Remove(chrT.downloadPath)
 	AssertEq(nil, err)
@@ -283,7 +281,7 @@ func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfLocalFileGotDeleted
 	err = chrT.cacheHandler.addFileInfoEntryToCache(chrT.object, chrT.bucket)
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "data inconsistent -"))
+	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsStaleEntry() {
@@ -347,9 +345,10 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WithEviction() {
 	ExpectEq(false, doesFileExist(chrT.downloadPath))
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGotDeleted() {
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGetsDeleted() {
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
 	_, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
+	AssertEq(nil, err)
 	// Delete the local cache file.
 	err = os.Remove(util.GetDownloadPath(chrT.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), minObject.Name)))
 	AssertEq(nil, err)
@@ -357,7 +356,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGotDeleted() {
 	_, err = chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "data inconsistent -"))
+	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -422,7 +422,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryAlreadyInCache() {
 	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 	ExpectEq(nil, err)
 
-	err = chrT.cacheHandler.InvalidateCache(chrT.object, chrT.bucket)
+	err = chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
 
 	ExpectEq(nil, err)
 	jobStatus := cacheHandle.fileDownloadJob.GetStatus()
@@ -433,7 +433,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryAlreadyInCache() {
 func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryNotInCache() {
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
 
-	err := chrT.cacheHandler.InvalidateCache(minObject, chrT.bucket)
+	err := chrT.cacheHandler.InvalidateCache(minObject.Name, chrT.bucket.Name())
 
 	ExpectEq(nil, err)
 }
@@ -449,7 +449,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentSameFile() {
 		defer wg.Done()
 		minObj := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
 
-		err := chrT.cacheHandler.InvalidateCache(minObj, chrT.bucket)
+		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
 
 		AssertEq(nil, err)
 	}
@@ -474,7 +474,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
 		objContent := "object content: content#" + strconv.Itoa(index)
 		minObj := chrT.getMinObject(objName, []byte(objContent))
 
-		err := chrT.cacheHandler.InvalidateCache(minObj, chrT.bucket)
+		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
 
 		AssertEq(nil, err)
 	}
@@ -499,7 +499,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCacheAndGetHandle_Concurrent() {
 		objContent := "object content: content#" + strconv.Itoa(index)
 		minObj := chrT.getMinObject(objName, []byte(objContent))
 
-		err := chrT.cacheHandler.InvalidateCache(minObj, chrT.bucket)
+		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
 
 		AssertEq(nil, err)
 	}

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -277,11 +277,12 @@ func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfLocalFileGetsDelete
 	err := os.Remove(chrT.downloadPath)
 	AssertEq(nil, err)
 
-	// Insertion will happen and that leads to eviction.
+	// There is a fileInfoEntry in the fileInfoCache but the corresponding local file doesn't exist.
+	// Hence, this will return error containing util.FileNotPresentInCacheErrMsg.
 	err = chrT.cacheHandler.addFileInfoEntryToCache(chrT.object, chrT.bucket)
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsStaleEntry() {
@@ -356,7 +357,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGetsDeleted() {
 	_, err = chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -32,7 +32,7 @@ const (
 	ErrInSeekingFileHandleMsg    = "error while seeking file handle"
 	ErrInReadingFileHandleMsg    = "error while reading file handle"
 	FallbackToGCSErrMsg          = "read via gcs"
-	DataInconsistentErrMsg       = "data inconsistent - file is not present"
+	FileNotPresentInCacheErrMsg  = "data inconsistent - file is not present"
 )
 
 const (

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -32,6 +32,7 @@ const (
 	ErrInSeekingFileHandleMsg    = "error while seeking file handle"
 	ErrInReadingFileHandleMsg    = "error while reading file handle"
 	FallbackToGCSErrMsg          = "read via gcs"
+	DataInconsistentErrMsg       = "data inconsistent - file is not present"
 )
 
 const (

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -32,7 +32,7 @@ const (
 	ErrInSeekingFileHandleMsg    = "error while seeking file handle"
 	ErrInReadingFileHandleMsg    = "error while reading file handle"
 	FallbackToGCSErrMsg          = "read via gcs"
-	FileNotPresentInCacheErrMsg  = "data inconsistent - file is not present"
+	FileNotPresentInCacheErrMsg  = "file is not present in cache"
 )
 
 const (

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1244,19 +1244,21 @@ func (fs *fileSystem) symlinkInodeOrDie(
 	return
 }
 
-// invalidateChildCacheIfExist invalidates the read file cache. This is used to
-// invalidate the cache after deletion of gcsObject.
-func (fs *fileSystem) invalidateChildCacheIfExist(parentInode inode.DirInode, objectGCSName string) (err error) {
+// invalidateChildFileCacheIfExist invalidates the file in read cache. This is used to
+// invalidate the file in read cache after deletion of original file.
+//
+// LOCKS_REQUIRED(fs.mu)
+func (fs *fileSystem) invalidateChildFileCacheIfExist(parentInode inode.DirInode, objectGCSName string) (err error) {
 	if fs.fileCacheHandler != nil {
 		if bucketOwnedDirInode, ok := parentInode.(inode.BucketOwnedDirInode); ok {
 			bucketName := bucketOwnedDirInode.Bucket().Name()
 			// Invalidate the file cache entry if it exists.
 			err := fs.fileCacheHandler.InvalidateCache(objectGCSName, bucketName)
 			if err != nil {
-				return fmt.Errorf("invalidateChildCacheIfExist: while invalidating the file cache: %v", err)
+				return fmt.Errorf("invalidateChildFileCacheIfExist: while invalidating the file cache: %v", err)
 			}
 		} else {
-			return fmt.Errorf("invalidateChildCacheIfExist: not an BucketOwnedDirInode: %w", syscall.ENOTSUP)
+			return fmt.Errorf("invalidateChildFileCacheIfExist: not an BucketOwnedDirInode: %w", syscall.ENOTSUP)
 		}
 	}
 
@@ -1855,7 +1857,7 @@ func (fs *fileSystem) renameFile(
 		oldObject.Generation,
 		&oldObject.MetaGeneration)
 
-	if err := fs.invalidateChildCacheIfExist(oldParent, oldObject.Name); err != nil {
+	if err := fs.invalidateChildFileCacheIfExist(oldParent, oldObject.Name); err != nil {
 		return fmt.Errorf("renameFile: while invalidating cache for delete file: %v", err)
 	}
 
@@ -1965,7 +1967,7 @@ func (fs *fileSystem) renameDir(
 			return fmt.Errorf("delete file %q: %w", o.Name, err)
 		}
 
-		if err = fs.invalidateChildCacheIfExist(oldDir, o.Name); err != nil {
+		if err = fs.invalidateChildFileCacheIfExist(oldDir, o.Name); err != nil {
 			return fmt.Errorf("Unlink: while invalidating cache for delete file: %v", err)
 		}
 	}
@@ -2025,7 +2027,7 @@ func (fs *fileSystem) Unlink(
 		return err
 	}
 
-	if err := fs.invalidateChildCacheIfExist(parent, fileName.GcsObjectName()); err != nil {
+	if err := fs.invalidateChildFileCacheIfExist(parent, fileName.GcsObjectName()); err != nil {
 		return fmt.Errorf("Unlink: while invalidating cache for delete file: %v", err)
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1258,6 +1258,9 @@ func (fs *fileSystem) invalidateChildFileCacheIfExist(parentInode inode.DirInode
 				return fmt.Errorf("invalidateChildFileCacheIfExist: while invalidating the file cache: %v", err)
 			}
 		} else {
+			// The parentInode is not owned by any bucket, which means it's the base
+			// directory that holds all the buckets' root directories. So, this op
+			// is to delete a bucket, which is not supported.
 			return fmt.Errorf("invalidateChildFileCacheIfExist: not an BucketOwnedDirInode: %w", syscall.ENOTSUP)
 		}
 	}

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -296,6 +296,7 @@ func (t *FileCacheTest) ReadWithNewHandleAfterDeletingFileFromCacheShould() {
 	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
 	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
 	file, err = os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
+	AssertEq(nil, err)
 	// delete the file in cache
 	err = os.Remove(downloadPath)
 	AssertEq(nil, err)
@@ -327,11 +328,14 @@ func (t *FileCacheTest) ReadWithOldHandleAfterDeletingFileFromCacheShouldNotFail
 	defer closeFile(file)
 	AssertEq(nil, err)
 	_, err = file.Read(buf)
+	AssertEq(nil, err)
 	// delete the file in cache
 	err = os.Remove(downloadPath)
-
+	AssertEq(nil, err)
 	// Read with old handle.
-	file.Seek(0, 0)
+	_, err = file.Seek(0, 0)
+	AssertEq(nil, err)
+
 	_, err = file.Read(buf)
 
 	AssertEq(nil, err)

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -38,7 +38,13 @@ import (
 const (
 	FileCacheSizeInMb     = 10
 	DefaultObjectName     = "foo.txt"
+	RenamedObjectName     = "bar.txt"
 	DefaultObjectSizeInMb = 5
+
+	NestedDefaultObjectName = "dir/foo.txt"
+	DefaultDir              = "dir"
+
+	RenamedDir = "renamed_dir"
 )
 
 var CacheLocation = path.Join(os.Getenv("HOME"), "cache-dir")
@@ -355,6 +361,58 @@ func (t *FileCacheTest) DeletingObjectShouldInvalidateTheCorrespondingCache() {
 	AssertNe(nil, err)
 	AssertTrue(os.IsNotExist(err))
 }
+
+func (t *FileCacheTest) RenamingObjectShouldInvalidateTheCorrespondingCache() {
+	objectContent := generateRandomString(util.MiB)
+	objects := map[string]string{DefaultObjectName: objectContent}
+	err := t.createObjects(objects)
+	AssertEq(nil, err)
+	filePath := path.Join(mntDir, DefaultObjectName)
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
+	AssertEq(nil, err)
+	buf := make([]byte, len(objectContent))
+	_, err = file.Read(buf)
+	AssertEq(nil, err)
+	closeFile(file)
+	renamedPath := path.Join(mntDir, RenamedObjectName)
+
+	// Rename the object.
+	err = os.Rename(filePath, renamedPath)
+	AssertEq(nil, err)
+
+	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
+	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertNe(nil, err)
+	AssertTrue(os.IsNotExist(err))
+}
+
+func (t *FileCacheTest) RenamingDirShouldInvalidateTheCacheOfNestedObject() {
+	objectContent := generateRandomString(util.MiB)
+	objects := map[string]string{NestedDefaultObjectName: objectContent}
+	err := t.createObjects(objects)
+	AssertEq(nil, err)
+	filePath := path.Join(mntDir, NestedDefaultObjectName)
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
+	AssertEq(nil, err)
+	buf := make([]byte, len(objectContent))
+	_, err = file.Read(buf)
+	AssertEq(nil, err)
+	closeFile(file)
+	dir := path.Join(mntDir, DefaultDir)
+	renamedDir := path.Join(mntDir, RenamedDir)
+
+	// Rename dir.
+	err = os.Rename(dir, renamedDir)
+	AssertEq(nil, err)
+
+	objectPath := util.GetObjectPath(bucket.Name(), NestedDefaultObjectName)
+	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertNe(nil, err)
+	AssertTrue(os.IsNotExist(err))
+}
+
 func (t *FileCacheTest) ConcurrentReadsFromSameFileHandle() {
 	objectContent := generateRandomString(DefaultObjectSizeInMb * util.MiB)
 	objects := map[string]string{DefaultObjectName: objectContent}

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -354,13 +354,15 @@ func (t *FileCacheTest) DeletingObjectShouldInvalidateTheCorrespondingCache() {
 	_, err = file.Read(buf)
 	AssertEq(nil, err)
 	closeFile(file)
+	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
+	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertEq(nil, err)
 
 	// Delete the object.
 	err = os.Remove(filePath)
 	AssertEq(nil, err)
 
-	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
-	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
 	_, err = os.Stat(downloadPath)
 	AssertNe(nil, err)
 	AssertTrue(os.IsNotExist(err))
@@ -379,13 +381,15 @@ func (t *FileCacheTest) RenamingObjectShouldInvalidateTheCorrespondingCache() {
 	AssertEq(nil, err)
 	closeFile(file)
 	renamedPath := path.Join(mntDir, RenamedObjectName)
+	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
+	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertEq(nil, err)
 
 	// Rename the object.
 	err = os.Rename(filePath, renamedPath)
 	AssertEq(nil, err)
 
-	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
-	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
 	_, err = os.Stat(downloadPath)
 	AssertNe(nil, err)
 	AssertTrue(os.IsNotExist(err))
@@ -405,13 +409,15 @@ func (t *FileCacheTest) RenamingDirShouldInvalidateTheCacheOfNestedObject() {
 	closeFile(file)
 	dir := path.Join(mntDir, DefaultDir)
 	renamedDir := path.Join(mntDir, RenamedDir)
+	objectPath := util.GetObjectPath(bucket.Name(), NestedDefaultObjectName)
+	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertEq(nil, err)
 
 	// Rename dir.
 	err = os.Rename(dir, renamedDir)
 	AssertEq(nil, err)
 
-	objectPath := util.GetObjectPath(bucket.Name(), NestedDefaultObjectName)
-	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
 	_, err = os.Stat(downloadPath)
 	AssertNe(nil, err)
 	AssertTrue(os.IsNotExist(err))

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -307,6 +307,7 @@ func (t *FileCacheTest) ReadWithNewHandleAfterDeletingFileFromCacheShould() {
 	_, err = file.Read(buf)
 
 	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "input/output error"))
 }
 
 func (t *FileCacheTest) ReadWithOldHandleAfterDeletingFileFromCacheShouldNotFail() {
@@ -317,18 +318,12 @@ func (t *FileCacheTest) ReadWithOldHandleAfterDeletingFileFromCacheShouldNotFail
 	filePath := path.Join(mntDir, DefaultObjectName)
 	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
 	AssertEq(nil, err)
+	defer closeFile(file)
 	buf := make([]byte, len(objectContent))
 	_, err = file.Read(buf)
 	AssertEq(nil, err)
-	closeFile(file)
 	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
 	downloadPath := util.GetDownloadPath(CacheLocation, objectPath)
-	file, err = os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
-	AssertEq(nil, err)
-	defer closeFile(file)
-	AssertEq(nil, err)
-	_, err = file.Read(buf)
-	AssertEq(nil, err)
 	// delete the file in cache
 	err = os.Remove(downloadPath)
 	AssertEq(nil, err)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -196,14 +196,13 @@ func (rr *randomReader) CheckInvariants() {
 // And it returns non-nil error in case something unexpected happens during the execution.
 // In this case, we must abort the Read operation.
 //
-// Important: What happens if the read cached file is deleted externally?
-// That means, for a given object we have fileInfo entry in the fileInfoCache but there is
-// no local cache file containing the object's content.
-// (a) If the fileCacheHandle is nil, it will return a data-inconsistent
-// (file is not present) error.
-// (b) If the fileCacheHandle is not nil, it will return the correct data from the
-// fileHandle contained inside fileCacheHandle.
-// This is because Linux does not delete a file until fileHandle count for a file is zero.
+// Important: What happens if the file in cache deleted externally?
+// That means, we have fileInfo entry in the fileInfoCache for that deleted file.
+// (a) If a new fileCacheHandle is created in that case it will return FileNotPresentInCache
+// error, given by fileCacheHandler.GetCacheHandle().
+// (b) If there is already an open fileCacheHandle then it means there is an open
+// fileHandle to file in cache. So, we will get the correct data from fileHandle
+// because Linux does not delete a file until open fileHandle count for a file is zero.
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	p []byte,
 	offset int64) (n int, cacheHit bool, err error) {

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -195,6 +195,15 @@ func (rr *randomReader) CheckInvariants() {
 // should be read from GCS.
 // And it returns non-nil error in case something unexpected happens during the execution.
 // In this case, we must abort the Read operation.
+//
+// Important: What happens if the cache file is deleted externally?
+// This means that the fileInfoCache contains an entry for the cache file, but the cache
+// file is not available locally.
+// (a) If the fileCacheHandle is nil, in this case it will return a data-inconsistent error.
+// (b) In the case of an old cacheFileHandle, this will return correct data until the handle
+// is closed. This is because Linux does not delete a file until its link count is zero.
+// When the fileHandle is open, it contributes to the link_count and therefore the file
+// is not deleted and serves the data correctly.
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	p []byte,
 	offset int64) (n int, cacheHit bool, err error) {

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -196,14 +196,14 @@ func (rr *randomReader) CheckInvariants() {
 // And it returns non-nil error in case something unexpected happens during the execution.
 // In this case, we must abort the Read operation.
 //
-// Important: What happens if the cache file is deleted externally?
-// This means that the fileInfoCache contains an entry for the cache file, but the cache
-// file is not available locally.
-// (a) If the fileCacheHandle is nil, in this case it will return a data-inconsistent error.
-// (b) In the case of an old cacheFileHandle, this will return correct data until the handle
-// is closed. This is because Linux does not delete a file until its link count is zero.
-// When the fileHandle is open, it contributes to the link_count and therefore the file
-// is not deleted and serves the data correctly.
+// Important: What happens if the read cached file is deleted externally?
+// That means, for a given object we have fileInfo entry in the fileInfoCache but there is
+// no local cache file containing the object's content.
+// (a) If the fileCacheHandle is nil, it will return a data-inconsistent
+// (file is not present) error.
+// (b) If the fileCacheHandle is not nil, it will return the correct data from the
+// fileHandle contained inside fileCacheHandle.
+// This is because Linux does not delete a file until fileHandle count for a file is zero.
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	p []byte,
 	offset int64) (n int, cacheHit bool, err error) {

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -1003,7 +1003,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rc2 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc2)
 
-	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+	_, _, err = t.rr.ReadAt(buf, 0)
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
@@ -1040,7 +1040,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen
 	rc3 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc3)
 
-	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+	_, _, err = t.rr.ReadAt(buf, 0)
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -891,7 +891,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	job := t.jobManager.GetJob(t.object, t.bucket)
 	jobStatus := job.GetStatus()
 	ExpectEq(jobStatus.Name, downloader.COMPLETED)
-	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object, t.bucket)
+	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object.Name, t.bucket.Name())
 	AssertEq(nil, err)
 	// Second reader (rc2) is required, since first reader (rc) is completely read.
 	// Reading again will return EOF.
@@ -921,7 +921,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHitNextToCacheMissIncaseOfInvalidJob
 	job := t.jobManager.GetJob(t.object, t.bucket)
 	jobStatus := job.GetStatus()
 	ExpectEq(jobStatus.Name, downloader.COMPLETED)
-	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object, t.bucket)
+	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object.Name, t.bucket.Name())
 	AssertEq(nil, err)
 	// Second reader (rc2) is required, since first reader (rc) is completely read.
 	// Reading again will return EOF.
@@ -981,7 +981,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHitNextToCacheMissIncaseOfInvalidFil
 func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
-	testContent := getRandomContent(int(objectSize))
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
 	rc1 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
@@ -1012,7 +1012,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen() {
 	t.rr.wrapped.fileCacheHandler = t.cacheHandler
 	objectSize := t.object.Size
-	testContent := getRandomContent(int(objectSize))
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
 	rc1 := getReadCloser(testContent)
 	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -978,6 +978,74 @@ func (t *RandomReaderTest) Test_ReadAt_CacheHitNextToCacheMissIncaseOfInvalidFil
 	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
 }
 
+func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
+	t.rr.wrapped.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := getRandomContent(int(objectSize))
+	rc1 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	buf := make([]byte, objectSize)
+	_, cacheHit, err := t.rr.ReadAt(buf, 0)
+	AssertEq(nil, err)
+	AssertTrue(cacheHit)
+	AssertTrue(reflect.DeepEqual(testContent, buf))
+	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
+	err = t.rr.wrapped.fileCacheHandle.Close()
+	AssertEq(nil, err)
+	t.rr.wrapped.fileCacheHandle = nil
+	// Delete the local cache file.
+	filePath := util.GetDownloadPath(t.cacheLocation, util.GetObjectPath(t.bucket.Name(), t.object.Name))
+	err = os.Remove(filePath)
+	AssertEq(nil, err)
+	// Second reader (rc2) is required, since first reader (rc) is completely read.
+	// Reading again will return EOF.
+	rc2 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc2)
+
+	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+
+	AssertNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
+}
+
+func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen() {
+	t.rr.wrapped.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := getRandomContent(int(objectSize))
+	rc1 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc1)
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	buf := make([]byte, objectSize)
+	_, cacheHit, err := t.rr.ReadAt(buf, 0)
+	AssertEq(nil, err)
+	AssertTrue(cacheHit)
+	AssertTrue(reflect.DeepEqual(testContent, buf))
+	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
+	err = t.rr.wrapped.fileCacheHandle.Close()
+	AssertEq(nil, err)
+	// Delete the local cache file.
+	filePath := util.GetDownloadPath(t.cacheLocation, util.GetObjectPath(t.bucket.Name(), t.object.Name))
+	err = os.Remove(filePath)
+	AssertEq(nil, err)
+	// Second reader (rc2) is required, since first reader (rc) is completely read.
+	// Reading again will return EOF.
+	rc2 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc2)
+	_, cacheHit, err = t.rr.ReadAt(buf, 0) // Read from GCS.
+	ExpectEq(nil, err)
+	ExpectFalse(cacheHit)
+	ExpectTrue(reflect.DeepEqual(testContent, buf))
+	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
+	rc3 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc3)
+
+	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+
+	AssertNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), util.DataInconsistentErrMsg))
+}
+
 // Only writing two unit tests for tryReadingFromFileCache as
 // unit tests of ReadAt method covers all the workflows.
 func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {


### PR DESCRIPTION
### Description
1. Handling error the case when someone deletes the file cache externally.
2. Adding support to invalidate cache in case some deletes the file.


Important: What happens if the cache file is deleted externally? This means that the fileInfoCache contains an entry for the cache file, but the cache file is not available locally.
(a) If the fileCacheHandle is nil, in this case it will return a data-inconsistent error.
(b) In the case of an old cacheFileHandle, if the local file is deleted externally, this will return correct data until the handle is closed. This is because Linux does not delete a file until its link count is zero. When the fileHandle is open, it contributes to the link_count and therefore the file is not deleted and serves the data correctly.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - NA
