### PR TITLE
Upgrade tensorflow model dependencies

### DIFF
--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
@@ -12,7 +12,7 @@ cd "$HOME/github/gcsfuse/"
 mkdir container_artifacts && mkdir container_artifacts/logs && mkdir container_artifacts/output
 
 echo "Building tf DLC docker image containing all tensorflow libraries..."
-sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf-gpu.2-10
+sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf2-gpu.2-12
 
 echo "Running the docker image build in the previous step..."
 sudo docker run --gpus all --name tf_model_container --privileged -d \

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
@@ -12,7 +12,7 @@ cd "$HOME/github/gcsfuse/"
 mkdir container_artifacts && mkdir container_artifacts/logs && mkdir container_artifacts/output
 
 echo "Building tf DLC docker image containing all tensorflow libraries..."
-sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf2-gpu.2-12
+sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf-gpu.2-13
 
 echo "Running the docker image build in the previous step..."
 sudo docker run --gpus all --name tf_model_container --privileged -d \

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -24,8 +24,8 @@ pip3 install --user tf-models-official==2.15.0
 
 echo "Updating the tensorflow library code to bypass the kernel-cache..."
 # Fail building the container image if train_lib.py and controller.py are not at expected location.
-if [ -f "/root/.local/lib/python3.7/site-packages/official/core/train_lib.py" ]; then echo "file exists"; else echo "train_lib.py file not present in expected location. Please correct the location. Exiting"; exit 1; fi
-if [ -f "/root/.local/lib/python3.7/site-packages/orbit/controller.py" ]; then echo "file exists"; else echo "controller.py file not present in expected location. Please correct the location. Exiting"; exit 1; fi
+if [ -f "/root/.local/lib/python3.10/site-packages/official/core/train_lib.py" ]; then echo "file exists"; else echo "train_lib.py file not present in expected location. Please correct the location. Exiting"; exit 1; fi
+if [ -f "/root/.local/lib/python3.10/site-packages/orbit/controller.py" ]; then echo "file exists"; else echo "controller.py file not present in expected location. Please correct the location. Exiting"; exit 1; fi
 
 # Adding cache clearing functionality and epochs in controller.py
 echo "
@@ -63,7 +63,7 @@ echo "
       self._maybe_save_checkpoint(check_interval=False)
 " > bypassed_code.py
 
-controller_file="/root/.local/lib/python3.7/site-packages/orbit/controller.py"
+controller_file="/root/.local/lib/python3.10/site-packages/orbit/controller.py"
 x=$(grep -n "def train(self, steps: int, checkpoint_at_completion: bool = True):" $controller_file | cut -f1 -d ':')
 y=$(grep -n "def evaluate(self, steps: int = -1)" $controller_file | cut -f1 -d ':')
 y=$((y - 2))
@@ -139,7 +139,7 @@ def run_experiment(
   return runner.run(epochs=epochs, clear_kernel_cache=clear_kernel_cache)
 " > bypassed_code.py
 
-train_lib_file="/root/.local/lib/python3.7/site-packages/official/core/train_lib.py"
+train_lib_file="/root/.local/lib/python3.10/site-packages/official/core/train_lib.py"
 x=$(grep -n "def run_experiment(" $train_lib_file | cut -f1 -d ':')
 y=$(grep -n "return runner.run()" $train_lib_file | cut -f1 -d ':')
 lines="$x,$y"

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Installs go1.19 on the container, builds gcsfuse using log_rotation file
-# and installs tf-models-official v2.10.0, makes update to include clear_kernel_cache
+# Installs go1.21 on the container, builds gcsfuse using log_rotation file
+# and installs tf-models-official v2.15.0, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
@@ -20,7 +20,7 @@ echo "Mounting the bucket"
 nohup gcsfuse/gcsfuse --foreground --implicit-dirs --debug_fuse --debug_gcs --max-conns-per-host 100 --log-format "text" --log-file /home/logs/gcsfuse.log --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
-pip3 install --user tf-models-official==2.10.0
+pip3 install --user tf-models-official==2.15.0
 
 echo "Updating the tensorflow library code to bypass the kernel-cache..."
 # Fail building the container image if train_lib.py and controller.py are not at expected location.

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Installs go1.21 on the container, builds gcsfuse using log_rotation file
-# and installs tf-models-official v2.12.0, makes update to include clear_kernel_cache
+# and installs tf-models-official v2.13.0, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
@@ -20,7 +20,7 @@ echo "Mounting the bucket"
 nohup gcsfuse/gcsfuse --foreground --implicit-dirs --debug_fuse --debug_gcs --max-conns-per-host 100 --log-format "text" --log-file /home/logs/gcsfuse.log --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
-pip3 install --user tf-models-official==2.12.0
+pip3 install --user tf-models-official==2.13.2
 
 echo "Updating the tensorflow library code to bypass the kernel-cache..."
 # Fail building the container image if train_lib.py and controller.py are not at expected location.

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Installs go1.21 on the container, builds gcsfuse using log_rotation file
-# and installs tf-models-official v2.15.0, makes update to include clear_kernel_cache
+# and installs tf-models-official v2.12.0, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
@@ -20,7 +20,7 @@ echo "Mounting the bucket"
 nohup gcsfuse/gcsfuse --foreground --implicit-dirs --debug_fuse --debug_gcs --max-conns-per-host 100 --log-format "text" --log-file /home/logs/gcsfuse.log --stackdriver-export-interval 60s ml-models-data-gcsfuse myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
-pip3 install --user tf-models-official==2.15.0
+pip3 install --user tf-models-official==2.12.0
 
 echo "Updating the tensorflow library code to bypass the kernel-cache..."
 # Fail building the container image if train_lib.py and controller.py are not at expected location.


### PR DESCRIPTION
### Description
This PR upgrades tf-models-official to version 2.13.2 (latest stable minor version with tensorflow 2.13) and DLC conatiner image to [tf-gpu.2-13](https://pantheon.corp.google.com/gcr/images/deeplearning-platform-release/GLOBAL/tf-gpu.2-13?e=13803378&mods=local_coliseum) (latest DLC image with compatible CUDA drivers).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran the model. It is running successfully with better steps/sec values than previous runs.
2. Unit tests - NA
3. Integration tests - NA
