### PR TITLE
Switch stat cache to gcsfuse internal lru.Cache

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -20,7 +20,6 @@ import (
 	unsafe "unsafe"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
-	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 )
 
@@ -50,10 +49,6 @@ type StatCache interface {
 	// entry. Return hit == false when there is neither a positive nor a negative
 	// entry, or the entry has expired according to the supplied current time.
 	LookUp(name string, now time.Time) (hit bool, o *gcs.Object)
-
-	// Panic if any internal invariants have been violated. The careful user can
-	// arrange to call this at crucial moments.
-	CheckInvariants()
 }
 
 // Create a new stat cache that holds the given number of entries, which must
@@ -156,8 +151,4 @@ func (sc *statCache) LookUp(
 	o = e.o
 
 	return
-}
-
-func (sc *statCache) CheckInvariants() {
-	logger.Tracef("CheckInvariants() doesn't do any checks.")
 }

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -17,8 +17,11 @@ package metadata
 import (
 	"time"
 
+	unsafe "unsafe"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
-	"github.com/jacobsa/util/lrucache"
 )
 
 // A cache mapping from name to most recent known record for the object of that
@@ -56,15 +59,16 @@ type StatCache interface {
 // Create a new stat cache that holds the given number of entries, which must
 // be positive.
 func NewStatCache(capacity int) (sc StatCache) {
+	sizeOfEntry := entry{}.Size()
 	sc = &statCache{
-		c: lrucache.New(capacity),
+		c: lru.NewCache(uint64(capacity) * sizeOfEntry),
 	}
 
 	return
 }
 
 type statCache struct {
-	c lrucache.Cache
+	c *lru.Cache
 }
 
 // An entry in the cache, pairing an object with the expiration time for the
@@ -72,6 +76,10 @@ type statCache struct {
 type entry struct {
 	o          *gcs.Object
 	expiration time.Time
+}
+
+func (e entry) Size() uint64 {
+	return uint64(unsafe.Sizeof(gcs.Object{}) + unsafe.Sizeof(entry{}))
 }
 
 // Should the supplied object for a new positive entry replace the given
@@ -151,5 +159,5 @@ func (sc *statCache) LookUp(
 }
 
 func (sc *statCache) CheckInvariants() {
-	sc.c.CheckInvariants()
+	logger.Tracef("CheckInvariants() doesn't do any checks.")
 }

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -29,48 +29,48 @@ func TestStatCache(t *testing.T) { RunTests(t) }
 // Invariant-checking cache
 ////////////////////////////////////////////////////////////////////////
 
-type invariantsCache struct {
+type testHelperCache struct {
 	wrapped metadata.StatCache
 }
 
-func (c *invariantsCache) Insert(
+func (c *testHelperCache) Insert(
 	o *gcs.Object,
 	expiration time.Time) {
 	c.wrapped.Insert(o, expiration)
 }
 
-func (c *invariantsCache) AddNegativeEntry(
+func (c *testHelperCache) AddNegativeEntry(
 	name string,
 	expiration time.Time) {
 	c.wrapped.AddNegativeEntry(name, expiration)
 }
 
-func (c *invariantsCache) Erase(name string) {
+func (c *testHelperCache) Erase(name string) {
 	c.wrapped.Erase(name)
 }
 
-func (c *invariantsCache) LookUp(
+func (c *testHelperCache) LookUp(
 	name string,
 	now time.Time) (hit bool, o *gcs.Object) {
 	hit, o = c.wrapped.LookUp(name, now)
 	return
 }
 
-func (c *invariantsCache) LookUpOrNil(
+func (c *testHelperCache) LookUpOrNil(
 	name string,
 	now time.Time) (o *gcs.Object) {
 	_, o = c.LookUp(name, now)
 	return
 }
 
-func (c *invariantsCache) Hit(
+func (c *testHelperCache) Hit(
 	name string,
 	now time.Time) (hit bool) {
 	hit, _ = c.LookUp(name, now)
 	return
 }
 
-func (c *invariantsCache) NegativeEntry(
+func (c *testHelperCache) NegativeEntry(
 	name string,
 	now time.Time) (negative bool) {
 	hit, o := c.LookUp(name, now)
@@ -88,7 +88,7 @@ var someTime = time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local)
 var expiration = someTime.Add(time.Second)
 
 type StatCacheTest struct {
-	cache invariantsCache
+	cache testHelperCache
 }
 
 func init() { RegisterTestSuite(&StatCacheTest{}) }

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -36,34 +36,22 @@ type invariantsCache struct {
 func (c *invariantsCache) Insert(
 	o *gcs.Object,
 	expiration time.Time) {
-	c.wrapped.CheckInvariants()
-	defer c.wrapped.CheckInvariants()
-
 	c.wrapped.Insert(o, expiration)
 }
 
 func (c *invariantsCache) AddNegativeEntry(
 	name string,
 	expiration time.Time) {
-	c.wrapped.CheckInvariants()
-	defer c.wrapped.CheckInvariants()
-
 	c.wrapped.AddNegativeEntry(name, expiration)
 }
 
 func (c *invariantsCache) Erase(name string) {
-	c.wrapped.CheckInvariants()
-	defer c.wrapped.CheckInvariants()
-
 	c.wrapped.Erase(name)
 }
 
 func (c *invariantsCache) LookUp(
 	name string,
 	now time.Time) (hit bool, o *gcs.Object) {
-	c.wrapped.CheckInvariants()
-	defer c.wrapped.CheckInvariants()
-
 	hit, o = c.wrapped.LookUp(name, now)
 	return
 }

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -38,7 +38,6 @@ func TestIntegration(t *testing.T) { RunTests(t) }
 type IntegrationTest struct {
 	ctx context.Context
 
-	cache   metadata.StatCache
 	clock   timeutil.SimulatedClock
 	wrapped gcs.Bucket
 
@@ -55,12 +54,12 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 
 	// Set up dependencies.
 	const cacheCapacity = 100
-	t.cache = metadata.NewStatCache(cacheCapacity)
+	cache := metadata.NewStatCache(cacheCapacity)
 	t.wrapped = fake.NewFakeBucket(&t.clock, "some_bucket")
 
 	t.bucket = caching.NewFastStatBucket(
 		ttl,
-		t.cache,
+		cache,
 		&t.clock,
 		t.wrapped)
 }

--- a/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
+++ b/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
@@ -61,23 +61,6 @@ func (m *mockStatCache) AddNegativeEntry(p0 string, p1 time.Time) {
 	}
 }
 
-func (m *mockStatCache) CheckInvariants() {
-	// Get a file name and line number for the caller.
-	_, file, line, _ := runtime.Caller(1)
-
-	// Hand the call off to the controller, which does most of the work.
-	retVals := m.controller.HandleMethodCall(
-		m,
-		"CheckInvariants",
-		file,
-		line,
-		[]interface{}{})
-
-	if len(retVals) != 0 {
-		panic(fmt.Sprintf("mockStatCache.CheckInvariants: invalid return values: %v", retVals))
-	}
-}
-
 func (m *mockStatCache) Erase(p0 string) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)


### PR DESCRIPTION
### Description
This change switches internal.cache.metadata.statCache
to use gcsfuse-internal lru.Cache from
jacobsa/*lrucache.Cache .
This is a step towards unification of metadata cache with
the readonly cache interface and design. Currently
statCache takes in capacity (count) for initialization,
but is now well-placed to switch to size (in Mbytes)

It also removes CheckInvariants() from StatCache as 
the new lru cache doesn't expose its checkInvariants 
method, so StatCache also cannot implement a CheckInvariants()
method anymore.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Sanity checks done locally: Mounting, listing, reads, writes, copying, unmount.
2. Unit tests - Ran and passed all locally. No new tests.
3. Integration tests - existing tests tested through presubmit tests. No new tests added.
