### PR TITLE
Handling io.ErrUnexpectedEOF while reading via CacheHandle

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -156,7 +156,8 @@ func (fch *CacheHandle) Read(ctx context.Context, object *gcs.MinObject, offset 
 	}
 
 	n, err = io.ReadFull(fch.fileHandle, dst)
-	if err == io.EOF {
+	// Returns io.ErrUnexpectedEOF when buffer size is more than content to be read.
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
 		err = nil
 	}
 	if err != nil {

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -512,7 +512,9 @@ func (cht *cacheHandleTest) Test_Read_SequentialToRandom() {
 }
 
 func (cht *cacheHandleTest) Test_Read_WhenDstBufferIsMoreContentToBeRead() {
-	dst := make([]byte, ReadContentSize + 1) // Increased the size of buffer.
+	// Add extra buffer.
+	extraBuffer := 2
+	dst := make([]byte, ReadContentSize+extraBuffer)
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = true
 	cht.cacheHandle.prevOffset = offset - util.MiB
@@ -523,6 +525,6 @@ func (cht *cacheHandleTest) Test_Read_WhenDstBufferIsMoreContentToBeRead() {
 
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectGe(jobStatus.Offset, offset)
-	cht.verifyContentRead(offset, dst)
+	cht.verifyContentRead(offset, dst[:len(dst)-extraBuffer])
 	ExpectEq(nil, err)
 }


### PR DESCRIPTION
### Description
Handling io.ErrUnexpectedEOF error while reading via CacheHandle. This is required as kernel always sends the buffer of fixed size. When the objectSize is less the fixed buffer size, in that case we get io.ErrUnexpectedEOF error. Returning success in those cases.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
