### PR TITLE
Add lookup and update without changing order in LRU cache

### DIFF
--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -114,8 +114,7 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 	}
 
 	addEntryToCache := false
-	// Todo - (raj-prince) - this lookUp should not change the LRU order.
-	fileInfo := chr.fileInfoCache.LookUp(fileInfoKeyName)
+	fileInfo := chr.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	if fileInfo == nil {
 		addEntryToCache = true
 	} else {

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -309,8 +309,7 @@ func (job *Job) downloadObjectAsync() {
 					// Download job expects entry in file info cache for the file it is
 					// downloading. If the entry is deleted in between which is expected
 					// to happen at the time of eviction, then the job should be
-					// invalidated instead of failing because the failure is propagated by
-					// cache handle to user which is not ideal.
+					// marked INVALID instead of FAILED.
 					job.status.Name = INVALID
 					job.notifySubscribers()
 					job.mu.Unlock()

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -92,7 +92,7 @@ type jobSubscriber struct {
 }
 
 func NewJob(object *gcs.MinObject, bucket gcs.Bucket, fileInfoCache *lru.Cache,
-		sequentialReadSizeMb int32, fileSpec data.FileSpec) (job *Job) {
+	sequentialReadSizeMb int32, fileSpec data.FileSpec) (job *Job) {
 	job = &Job{
 		object:               object,
 		bucket:               bucket,

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
-	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -310,14 +309,10 @@ func (t *CacheTest) TestRaceCondition() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < OperationCount; i++ {
-			err := t.cache.UpdateWithoutChangingOrder("key", testData{
+			_ = t.cache.UpdateWithoutChangingOrder("key", testData{
 				Value:    int64(i),
 				DataSize: uint64(rand.Intn(MaxSize)),
 			})
-			if err != nil && !strings.Contains(err.Error(), lru.EntryNotExistErrMsg) {
-				logger.Errorf("%v", err)
-			}
-			AssertTrue((err == nil) || strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
 		}
 	}()
 

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -17,6 +17,7 @@ package lru_test
 import (
 	"errors"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 
@@ -177,11 +178,100 @@ func (t *CacheTest) TestEraseWhenKeyNotPresent() {
 	ExpectEq(23, t.cache.LookUp("burrito").(testData).Value)
 }
 
+func (t *CacheTest) TestUpdateWhenKeyPresent() {
+	key := "burrito"
+	data := testData{Value: 23, DataSize: 4}
+	t.insertAndAssert(key, data, []int64{}, nil)
+	newData := testData{Value: 2, DataSize: 4}
+
+	err := t.cache.UpdateWithoutChangingOrder(key, newData)
+
+	ExpectEq(nil, err)
+	ExpectEq(2, t.cache.LookUp(key).(testData).Value)
+}
+
+func (t *CacheTest) TestUpdateWhenKeyNotPresent() {
+	key := "burrito"
+	data := testData{Value: 23, DataSize: 4}
+
+	err := t.cache.UpdateWithoutChangingOrder(key, data)
+
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
+}
+
+func (t *CacheTest) TestUpdateWhenSizeIsDifferent() {
+	key := "burrito"
+	data := testData{Value: 23, DataSize: 4}
+	t.insertAndAssert(key, data, []int64{}, nil)
+	newData := testData{Value: 2, DataSize: 3}
+
+	err := t.cache.UpdateWithoutChangingOrder(key, newData)
+
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+}
+
+func (t *CacheTest) TestUpdateNotChangeOrder() {
+	key1 := "burrito1"
+	data1 := testData{Value: 23, DataSize: 10}
+	t.insertAndAssert(key1, data1, []int64{}, nil)
+	key2 := "burrito2"
+	data2 := testData{Value: 2, DataSize: 40}
+	t.insertAndAssert(key2, data2, []int64{}, nil)
+
+	newData := testData{Value: 7, DataSize: 10}
+	err := t.cache.UpdateWithoutChangingOrder(key1, newData)
+
+	ExpectEq(nil, err)
+	// inserting again which should evict key1 because key1 is updated without
+	// changing order
+	key3 := "burrito3"
+	data3 := testData{Value: 3, DataSize: 5}
+	t.insertAndAssert(key3, data3, []int64{7}, nil)
+}
+
+func (t *CacheTest) TestLookUpWithoutChangingOrder_WhenKeyPresent() {
+	key := "burrito"
+	data := testData{Value: 23, DataSize: 4}
+	t.insertAndAssert(key, data, []int64{}, nil)
+
+	value := t.cache.LookUpWithoutChangingOrder(key)
+
+	ExpectEq(23, value.(testData).Value)
+}
+
+func (t *CacheTest) TestLookUpWithoutChangingOrder_WhenKeyNotPresent() {
+	key := "burrito"
+
+	value := t.cache.LookUpWithoutChangingOrder(key)
+
+	ExpectEq(nil, value)
+}
+
+func (t *CacheTest) TestLookUpWithoutChangingOrder_NotChangeOrder() {
+	key1 := "burrito1"
+	data1 := testData{Value: 23, DataSize: 10}
+	t.insertAndAssert(key1, data1, []int64{}, nil)
+	key2 := "burrito2"
+	data2 := testData{Value: 2, DataSize: 40}
+	t.insertAndAssert(key2, data2, []int64{}, nil)
+
+	value := t.cache.LookUpWithoutChangingOrder(key1)
+
+	ExpectEq(23, value.(testData).Value)
+	// inserting again which should evict key1 because key1 is looked up without
+	// changing order
+	key3 := "burrito3"
+	data3 := testData{Value: 3, DataSize: 5}
+	t.insertAndAssert(key3, data3, []int64{23}, nil)
+}
+
 // This will detect race if we run the test with `-race` flag.
 // We get the race condition failure if we remove lock from Insert or Erase method.
 func (t *CacheTest) TestRaceCondition() {
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(5)
 
 	go func() {
 		defer wg.Done()
@@ -206,6 +296,24 @@ func (t *CacheTest) TestRaceCondition() {
 		defer wg.Done()
 		for i := 0; i < OperationCount; i++ {
 			t.cache.LookUp("key")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < OperationCount; i++ {
+			t.cache.LookUpWithoutChangingOrder("key")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < OperationCount; i++ {
+			err := t.cache.UpdateWithoutChangingOrder("key", testData{
+				Value:    int64(i),
+				DataSize: uint64(rand.Intn(MaxSize)),
+			})
+			AssertTrue(err == nil || strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
 		}
 	}()
 

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -313,6 +314,9 @@ func (t *CacheTest) TestRaceCondition() {
 				Value:    int64(i),
 				DataSize: uint64(rand.Intn(MaxSize)),
 			})
+			if err != nil && !strings.Contains(err.Error(), lru.EntryNotExistErrMsg) {
+				logger.Errorf("%v", err)
+			}
 			AssertTrue((err == nil) || strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
 		}
 	}()

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -313,7 +313,7 @@ func (t *CacheTest) TestRaceCondition() {
 				Value:    int64(i),
 				DataSize: uint64(rand.Intn(MaxSize)),
 			})
-			AssertTrue(err == nil || strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
+			AssertTrue((err == nil) || strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
 		}
 	}()
 

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -78,7 +78,9 @@ func (c *rwChecker) RUnlock() {
 	c.locker.RUnlock()
 }
 
-// Note: rwDebugger doesn't check potential deadlock in case of read only lock.
+// Note: rwDebugger doesn't check potential deadlock in case of read only lock as
+// doing that is not straight forward because multiple readers can acquire locks
+// at the time same time and that needs keeping track of every different lock.
 type rwDebugger struct {
 	locker RWLocker
 	name   string

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -107,9 +107,9 @@ func (d *rwDebugger) Unlock() {
 }
 
 func (d *rwDebugger) RLock() {
-	d.locker.Lock()
+	d.locker.RLock()
 }
 
 func (d *rwDebugger) RUnlock() {
-	d.locker.Unlock()
+	d.locker.RUnlock()
 }

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -1,0 +1,115 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides the RWLocker implementations with optional debug utils.
+package locker
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/logger"
+)
+
+type RWLocker interface {
+	sync.Locker
+	RLock()
+	RUnlock()
+}
+
+// NewRW returns a RW locker with potential capability for debugging.
+//
+// Note: The deadlock detection is done only for writer lock and not for reader
+// lock.
+func NewRW(name string, check func()) RWLocker {
+	var l RWLocker = &sync.RWMutex{}
+
+	if gEnableInvariantsCheck {
+		l = &rwChecker{
+			locker: l,
+			check:  check,
+		}
+	}
+
+	if gEnableDebugMessages {
+		l = &rwDebugger{
+			locker: l,
+			name:   name,
+		}
+	}
+
+	return l
+}
+
+type rwChecker struct {
+	locker RWLocker
+	check  func()
+}
+
+func (c *rwChecker) Lock() {
+	c.locker.Lock()
+	c.check()
+}
+
+func (c *rwChecker) Unlock() {
+	c.check()
+	c.locker.Unlock()
+}
+
+func (c *rwChecker) RLock() {
+	c.locker.RLock()
+	c.check()
+}
+
+func (c *rwChecker) RUnlock() {
+	c.check()
+	c.locker.RUnlock()
+}
+
+// Note: rwDebugger doesn't check potential deadlock in case of read only lock.
+type rwDebugger struct {
+	locker RWLocker
+	name   string
+	holder string
+	timer  *time.Timer
+}
+
+func (d *rwDebugger) Lock() {
+	d.locker.Lock()
+
+	buf := make([]byte, 2048)
+	runtime.Stack(buf, false /* all */)
+	d.holder = string(buf)
+
+	d.timer = time.AfterFunc(5*time.Second, func() {
+		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
+	})
+}
+
+func (d *rwDebugger) Unlock() {
+	d.holder = ""
+	d.timer.Stop()
+	d.timer = nil
+
+	d.locker.Unlock()
+}
+
+func (d *rwDebugger) RLock() {
+	d.locker.Lock()
+}
+
+func (d *rwDebugger) RUnlock() {
+	d.locker.Unlock()
+}

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -80,7 +80,7 @@ func (c *rwChecker) RUnlock() {
 
 // Note: rwDebugger doesn't check potential deadlock in case of read only lock as
 // doing that is not straight forward because multiple readers can acquire locks
-// at the time same time and that needs keeping track of every different lock.
+// at the same time and that needs keeping track of every different lock.
 type rwDebugger struct {
 	locker RWLocker
 	name   string


### PR DESCRIPTION
### Description
- Add lookup and update without changing order in LRU cache
- Also removed one of the unit test in job_test.go as it is expected that GetCacheHandle will insert fileInfo in fileInfoCache at the time of creating cache handle and initializing job.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit test.
3. Integration tests - NA
