### PR TITLE
Unify stat cache for all buckets in dynamic-mount

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -52,10 +52,22 @@ type StatCache interface {
 }
 
 // Create a new bucket-view to the passed shared-cache object.
+// This should be used for dynamic-mount, i.e.
+// mount for a multiple buckets.
 func NewStatCacheBucketView(sc *lru.Cache, bn string) StatCache {
 	return &statCacheBucketView{
 		sharedCache: sc,
 		bucketName:  bn,
+	}
+}
+
+// Create a new dedicated shared-cache object.
+// This keeps bucketName as "".
+// This should be used for static-mount, i.e.
+// mount for a single bucket.
+func NewStatCache(lruCache *lru.Cache) StatCache {
+	return &statCacheBucketView{
+		sharedCache: lruCache,
 	}
 }
 

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -52,22 +52,12 @@ type StatCache interface {
 }
 
 // Create a new bucket-view to the passed shared-cache object.
-// This should be used for dynamic-mount, i.e.
-// mount for a multiple buckets.
+// For dynamic-mount (mount for multiple buckets), pass bn as bucket-name.
+// For static-mout (mount for single bucket), pass bn as "".
 func NewStatCacheBucketView(sc *lru.Cache, bn string) StatCache {
 	return &statCacheBucketView{
 		sharedCache: sc,
 		bucketName:  bn,
-	}
-}
-
-// Create a new dedicated shared-cache object.
-// This keeps bucketName as "".
-// This should be used for static-mount, i.e.
-// mount for a single bucket.
-func NewStatCache(lruCache *lru.Cache) StatCache {
-	return &statCacheBucketView{
-		sharedCache: lruCache,
 	}
 }
 

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -454,7 +454,7 @@ type MultiBucketMountCachingTest struct {
 	fsTest
 }
 
-func getMultiMntBucketDirByName(bucketName string) string {
+func getMultiMountBucketDir(bucketName string) string {
 	return mntDir + "/" + bucketName
 }
 
@@ -489,7 +489,7 @@ func init() {
 func (t *MultiBucketMountCachingTest) TestBucketsAreEmptyInitially() {
 	// ReadDir
 	for _, bucketName := range []string{bucket1Name, bucket2Name} {
-		entries, err := fusetesting.ReadDirPicky(getMultiMntBucketDirByName(bucketName))
+		entries, err := fusetesting.ReadDirPicky(getMultiMountBucketDir(bucketName))
 		AssertEq(nil, err)
 
 		ExpectThat(entries, ElementsAre())
@@ -499,8 +499,8 @@ func (t *MultiBucketMountCachingTest) TestBucketsAreEmptyInitially() {
 func (t *MultiBucketMountCachingTest) FileCreatedRemotely() {
 	const name = "foo"
 	const contents = "taco"
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
-	bucket2MntDir := getMultiMntBucketDirByName(bucket2Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
+	bucket2MntDir := getMultiMountBucketDir(bucket2Name)
 
 	var fi os.FileInfo
 
@@ -554,7 +554,7 @@ func (t *MultiBucketMountCachingTest) FileChangedRemotely() {
 	const contents = "taco"
 	var fi os.FileInfo
 	var err error
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
 
 	// Create an object in GCS.
 	_, err = storageutil.CreateObject(
@@ -603,7 +603,7 @@ func (t *MultiBucketMountCachingTest) DirectoryRemovedRemotely() {
 	const name = "foo"
 	var fi os.FileInfo
 	var err error
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
 
 	// Create a directory via the file system.
 	err = os.Mkdir(path.Join(bucket1MntDir, name), 0700)
@@ -634,7 +634,7 @@ func (t *MultiBucketMountCachingTest) ConflictingNames_RemoteModifier() {
 	const name = "foo"
 	var fi os.FileInfo
 	var err error
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
 
 	// Create a directory via the file system.
 	err = os.Mkdir(path.Join(bucket1MntDir, name), 0700)
@@ -676,7 +676,7 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_LocalModifier() {
 	const name = "test"
 	var fi os.FileInfo
 	var err error
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
 
 	// Create a directory via the file system.
 	err = os.Mkdir(path.Join(bucket1MntDir, name), 0700)
@@ -702,7 +702,7 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_RemoteModifier() {
 	const name = "foo"
 	var fi os.FileInfo
 	var err error
-	bucket1MntDir := getMultiMntBucketDirByName(bucket1Name)
+	bucket1MntDir := getMultiMountBucketDir(bucket1Name)
 	bucket1 := buckets[bucket1Name]
 
 	os.RemoveAll(path.Join(bucket1MntDir, name))

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/caching"
@@ -52,8 +53,9 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 	// system.
 	uncachedBucket = fake.NewFakeBucket(timeutil.RealClock(), "some_bucket")
 
-	const statCacheCapacity = 1000
-	statCache := metadata.NewStatCache(statCacheCapacity)
+	const statCacheCapacity uint64 = 1000
+	sharedCache := lru.NewCache(metadata.StatCacheEntrySize() * statCacheCapacity)
+	statCache := metadata.NewStatCacheBucketView(sharedCache, "some_bucket")
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -57,7 +57,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 	// system.
 	uncachedBucket = fake.NewFakeBucket(timeutil.RealClock(), "some_bucket")
 	lruCache := newLruCache(uint64(1000))
-	statCache := metadata.NewStatCache(lruCache)
+	statCache := metadata.NewStatCacheBucketView(lruCache, "")
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -15,7 +15,6 @@
 package fs_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -271,13 +270,11 @@ func (t *CachingTest) TypeOfNameChanges_RemoteModifier() {
 	var err error
 
 	// Create a directory via the file system.
-	fmt.Printf("Mkdir\n")
 	err = os.Mkdir(path.Join(mntDir, name), 0700)
 	AssertEq(nil, err)
 
 	// Remove the backing object in GCS, updating the bucket cache (but not the
 	// file system type cache)
-	fmt.Printf("DeleteObject\n")
 	err = bucket.DeleteObject(
 		ctx,
 		&gcs.DeleteObjectRequest{Name: name + "/"})
@@ -285,7 +282,6 @@ func (t *CachingTest) TypeOfNameChanges_RemoteModifier() {
 	AssertEq(nil, err)
 
 	// Create a file with the same name via GCS, again updating the bucket cache.
-	fmt.Printf("CreateObject\n")
 	_, err = storageutil.CreateObject(
 		ctx,
 		bucket,
@@ -295,7 +291,6 @@ func (t *CachingTest) TypeOfNameChanges_RemoteModifier() {
 	AssertEq(nil, err)
 
 	// Because the file system is caching types, it will fail to find the name.
-	fmt.Printf("Stat\n")
 	_, err = os.Stat(path.Join(mntDir, name))
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 
@@ -705,7 +700,6 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_RemoteModifier() {
 	bucket1 := buckets[bucket1Name]
 
 	// Create a directory via the file system.
-	fmt.Printf("Mkdir\n")
 	err = os.Mkdir(path.Join(bucket1MntDir, name), 0700)
 	AssertEq(nil, err)
 
@@ -713,7 +707,6 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_RemoteModifier() {
 
 	// Remove the backing object in GCS, updating the bucket cache (but not the
 	// file system type cache)
-	fmt.Printf("DeleteObject\n")
 	err = bucket1.DeleteObject(
 		ctx,
 		&gcs.DeleteObjectRequest{Name: name + "/"})
@@ -721,7 +714,6 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_RemoteModifier() {
 	AssertEq(nil, err)
 
 	// Create a file with the same name via GCS, again updating the bucket cache.
-	fmt.Printf("CreateObject\n")
 	_, err = storageutil.CreateObject(
 		ctx,
 		bucket1,
@@ -731,7 +723,6 @@ func (t *MultiBucketMountCachingTest) TypeOfNameChanges_RemoteModifier() {
 	AssertEq(nil, err)
 
 	// Because the file system is caching types, it will fail to find the name.
-	fmt.Printf("Stat\n")
 	_, err = os.Stat(path.Join(bucket1MntDir, name))
 	ExpectTrue(os.IsNotExist(err), "err: %v", err)
 

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -55,7 +55,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 
 	const statCacheCapacity uint64 = 1000
 	sharedCache := lru.NewCache(metadata.StatCacheEntrySize() * statCacheCapacity)
-	statCache := metadata.NewStatCacheBucketView(sharedCache, "some_bucket")
+	statCache := metadata.NewStatCacheBucketView(sharedCache, "")
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -525,6 +525,7 @@ func (t *MultiBucketMountCachingTest) FileCreatedRemotely() {
 	// we should not be able to stat it in the bucket2 mount directory
 	_, err = os.Stat(path.Join(bucket2MntDir, name))
 	AssertNe(nil, err)
+	AssertThat(err, Error(HasSubstr("no such file or directory")))
 
 	// And we should be able to stat it in bucket1 mount directory.
 	fi, err = os.Stat(path.Join(bucket1MntDir, name))

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -56,8 +56,8 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 	// Wrap the bucket in a stat caching layer for the purposes of the file
 	// system.
 	uncachedBucket = fake.NewFakeBucket(timeutil.RealClock(), "some_bucket")
-	sharedCache := newLruCache(uint64(1000))
-	statCache := metadata.NewStatCacheBucketView(sharedCache, "")
+	lruCache := newLruCache(uint64(1000))
+	statCache := metadata.NewStatCache(lruCache)
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -198,7 +198,7 @@ func NewFileSystem(
 		root = makeRootForAllBuckets(fs)
 	} else {
 		logger.Info("Set up root directory for bucket " + cfg.BucketName)
-		syncerBucket, err := fs.bucketManager.SetUpBucket(ctx, cfg.BucketName)
+		syncerBucket, err := fs.bucketManager.SetUpBucket(ctx, cfg.BucketName, false)
 		if err != nil {
 			return nil, fmt.Errorf("SetUpBucket: %w", err)
 		}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -328,7 +328,7 @@ func (bm *fakeBucketManager) ShutDown() {}
 
 func (bm *fakeBucketManager) SetUpBucket(
 	ctx context.Context,
-	name string) (sb gcsx.SyncerBucket, err error) {
+	name string, isMultibucketMount bool) (sb gcsx.SyncerBucket, err error) {
 	bucket, ok := bm.buckets[name]
 	if ok {
 		sb = gcsx.NewSyncerBucket(

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -132,7 +132,7 @@ func (d *baseDirInode) LookUpChild(ctx context.Context, name string) (*Core, err
 	var err error
 	bucket, ok := d.buckets[name]
 	if !ok {
-		bucket, err = d.bucketManager.SetUpBucket(ctx, name)
+		bucket, err = d.bucketManager.SetUpBucket(ctx, name, true)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -85,7 +85,7 @@ type fakeBucketManager struct {
 
 func (bm *fakeBucketManager) SetUpBucket(
 	ctx context.Context,
-	name string) (sb gcsx.SyncerBucket, err error) {
+	name string, isMultibucketMount bool) (sb gcsx.SyncerBucket, err error) {
 	bm.setupTimes++
 
 	var ok bool

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -208,7 +208,7 @@ func (bm *bucketManager) SetUpBucket(
 		if isMultibucketMount {
 			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, name)
 		} else {
-			statCache = metadata.NewStatCache(bm.sharedStatCache)
+			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, "")
 		}
 
 		b = caching.NewFastStatBucket(

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -97,7 +97,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethod() {
 	ExpectEq(nil, err)
 }
 
-func (t *BucketManagerTest) TestSetUpBucketMethod2() {
+func (t *BucketManagerTest) TestSetUpBucketMethod_IsMultiBucketMountTrue() {
 	var bm bucketManager
 	bucketConfig := BucketConfig{
 		BillingProject:                     "BillingProject",
@@ -147,7 +147,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	ExpectNe(nil, bucket.Syncer)
 }
 
-func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist2() {
+func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist_IsMultiBucketMountTrue() {
 	var bm bucketManager
 	bucketConfig := BucketConfig{
 		BillingProject:                     "BillingProject",

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -97,6 +97,31 @@ func (t *BucketManagerTest) TestSetUpBucketMethod() {
 	ExpectEq(nil, err)
 }
 
+func (t *BucketManagerTest) TestSetUpBucketMethod2() {
+	var bm bucketManager
+	bucketConfig := BucketConfig{
+		BillingProject:                     "BillingProject",
+		OnlyDir:                            "OnlyDir",
+		EgressBandwidthLimitBytesPerSecond: 7,
+		OpRateLimitHz:                      11,
+		StatCacheCapacity:                  100,
+		StatCacheTTL:                       20 * time.Second,
+		EnableMonitoring:                   true,
+		DebugGCS:                           true,
+		AppendThreshold:                    2,
+		TmpObjectPrefix:                    "TmpObjectPrefix",
+	}
+	ctx := context.Background()
+	bm.storageHandle = t.storageHandle
+	bm.config = bucketConfig
+	bm.gcCtx = ctx
+
+	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, true)
+
+	ExpectNe(nil, bucket.Syncer)
+	ExpectEq(nil, err)
+}
+
 func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	var bm bucketManager
 	bucketConfig := BucketConfig{
@@ -117,6 +142,31 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	bm.gcCtx = ctx
 
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false)
+
+	ExpectEq("Error in iterating through objects: storage: bucket doesn't exist", err.Error())
+	ExpectNe(nil, bucket.Syncer)
+}
+
+func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist2() {
+	var bm bucketManager
+	bucketConfig := BucketConfig{
+		BillingProject:                     "BillingProject",
+		OnlyDir:                            "OnlyDir",
+		EgressBandwidthLimitBytesPerSecond: 7,
+		OpRateLimitHz:                      11,
+		StatCacheCapacity:                  100,
+		StatCacheTTL:                       20 * time.Second,
+		EnableMonitoring:                   true,
+		DebugGCS:                           true,
+		AppendThreshold:                    2,
+		TmpObjectPrefix:                    "TmpObjectPrefix",
+	}
+	ctx := context.Background()
+	bm.storageHandle = t.storageHandle
+	bm.config = bucketConfig
+	bm.gcCtx = ctx
+
+	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, true)
 
 	ExpectEq("Error in iterating through objects: storage: bucket doesn't exist", err.Error())
 	ExpectNe(nil, bucket.Syncer)

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -91,7 +91,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethod() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName)
+	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, false)
 
 	ExpectNe(nil, bucket.Syncer)
 	ExpectEq(nil, err)
@@ -116,7 +116,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName)
+	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false)
 
 	ExpectEq("Error in iterating through objects: storage: bucket doesn't exist", err.Error())
 	ExpectNe(nil, bucket.Syncer)

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/fake"
@@ -48,14 +49,16 @@ func init() { RegisterTestSuite(&IntegrationTest{}) }
 
 func (t *IntegrationTest) SetUp(ti *TestInfo) {
 	t.ctx = context.Background()
+	bucketName := "some_bucket"
 
 	// Set up a fixed, non-zero time.
 	t.clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
 
 	// Set up dependencies.
 	const cacheCapacity = 100
-	cache := metadata.NewStatCache(cacheCapacity)
-	t.wrapped = fake.NewFakeBucket(&t.clock, "some_bucket")
+	globalCache := lru.NewCache(cacheCapacity * metadata.StatCacheEntrySize())
+	cache := metadata.NewStatCacheBucketView(globalCache, bucketName)
+	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName)
 
 	t.bucket = caching.NewFastStatBucket(
 		ttl,

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -57,7 +57,7 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 	// Set up dependencies.
 	const cacheCapacity = 100
 	lruCache := lru.NewCache(cacheCapacity * metadata.StatCacheEntrySize())
-	cache := metadata.NewStatCache(lruCache)
+	cache := metadata.NewStatCacheBucketView(lruCache, "")
 	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName)
 
 	t.bucket = caching.NewFastStatBucket(

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -56,8 +56,8 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 
 	// Set up dependencies.
 	const cacheCapacity = 100
-	globalCache := lru.NewCache(cacheCapacity * metadata.StatCacheEntrySize())
-	cache := metadata.NewStatCacheBucketView(globalCache, bucketName)
+	lruCache := lru.NewCache(cacheCapacity * metadata.StatCacheEntrySize())
+	cache := metadata.NewStatCache(lruCache)
 	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName)
 
 	t.bucket = caching.NewFastStatBucket(

--- a/internal/storage/storageutil/create_object.go
+++ b/internal/storage/storageutil/create_object.go
@@ -35,3 +35,17 @@ func CreateObject(
 
 	return bucket.CreateObject(ctx, req)
 }
+
+// Deletes the supplied object in the given bucket.
+func DeleteObject(
+	ctx context.Context,
+	bucket gcs.Bucket,
+	obj *gcs.Object) error {
+	req := &gcs.DeleteObjectRequest{
+		Name:                       obj.Name,
+		Generation:                 obj.Generation,
+		MetaGenerationPrecondition: &obj.MetaGeneration,
+	}
+
+	return bucket.DeleteObject(ctx, req)
+}

--- a/internal/storage/storageutil/create_object.go
+++ b/internal/storage/storageutil/create_object.go
@@ -35,17 +35,3 @@ func CreateObject(
 
 	return bucket.CreateObject(ctx, req)
 }
-
-// Deletes the supplied object in the given bucket.
-func DeleteObject(
-	ctx context.Context,
-	bucket gcs.Bucket,
-	obj *gcs.Object) error {
-	req := &gcs.DeleteObjectRequest{
-		Name:                       obj.Name,
-		Generation:                 obj.Generation,
-		MetaGenerationPrecondition: &obj.MetaGeneration,
-	}
-
-	return bucket.DeleteObject(ctx, req)
-}


### PR DESCRIPTION
### Description
Currently during dynamic-mount case,
each mounted bucket has its own dedicated
stat-cache instance. This change combines
all of them into one. This change does the
following:
1. Creates an instance of lru.Cache (called globalStatCache) in bucketManager, which is shared among all buckets (through their corresponding statCache objects).
2. Passes globalStatCache and a bucket names for creation of individual statCache objects.
3. Corresponding unit tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Sanity testing done.
2. Unit tests - Ran locally and all passed. New tests added for this change.
3. Integration tests - Ran through presubmit.
