### PR TITLE
Truncate file on invalidation before deletion

### DIFF
--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -210,8 +210,8 @@ func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket
 	return NewCacheHandle(localFileReadHandle, chr.jobManager.GetJob(object, bucket), chr.fileInfoCache, downloadForRandom, initialOffset), nil
 }
 
-// InvalidateCache removes the entry from the fileInfoCache, removes download job,
-// and delete local file in the cache.
+// InvalidateCache removes the file entry from the fileInfoCache and performs clean
+// up for the removed entry.
 //
 // Acquires and releases LOCK(CacheHandler.mu)
 func (chr *CacheHandler) InvalidateCache(objectName string, bucketName string) error {


### PR DESCRIPTION
### Description
Truncate file on invalidation before deletion so that space is not taken because of open file handles.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added where applicable.
3. Integration tests - NA
