### PR TITLE
Write failure improvements (includes fix for local file inode)

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1009,15 +1009,15 @@ func (fs *fileSystem) syncFile(
 	}
 	fs.mu.Unlock()
 
-	// We need not update fileIndex:
+	// We need not update fs.inodes:
 	//
 	// We've held the inode lock the whole time, so there's no way that this
 	// inode could have been booted from the index. Therefore if it's not in the
 	// index at the moment, it must not have been in there when we started. That
-	// is, it must have been clobbered remotely, which we treat as unlinking.
+	// is, it must have been clobbered remotely.
 	//
 	// In other words, either this inode is still in the index or it has been
-	// unlinked and *should* be anonymous.
+	// clobbered and *should* be anonymous.
 
 	return
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -34,6 +34,7 @@ import (
 // A GCS object metadata key for file mtimes. mtimes are UTC, and are stored in
 // the format defined by time.RFC3339Nano.
 const FileMtimeMetadataKey = gcsx.MtimeMetadataKey
+const FileClobberedErrMsg = "file is clobbered i.e, either the file is modified or unlinked remotely"
 
 type FileInode struct {
 	/////////////////////////
@@ -541,8 +542,7 @@ func (f *FileInode) SetMtime(
 }
 
 // Sync writes out contents to GCS. If this fails due to the generation having been
-// clobbered, treat it as a non-error (simulating the inode having been
-// unlinked).
+// clobbered, failure is propagated back to the calling function as an error.
 //
 // After this method succeeds, SourceGeneration will return the new generation
 // by which this inode should be known (which may be the same as before). If it
@@ -565,9 +565,12 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// properties.
 	latestGcsObj, isClobbered, err := f.clobbered(ctx, true)
 
-	// Clobbered is treated as being unlinked. There's no reason to return an
-	// error in that case. We simply return without syncing the object.
-	if err != nil || isClobbered {
+	if err != nil {
+		return
+	}
+
+	if isClobbered {
+		err = fmt.Errorf(FileClobberedErrMsg)
 		return
 	}
 
@@ -576,11 +579,9 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// the latest object fetched from gcs which has all the properties populated.
 	newObj, err := f.bucket.SyncObject(ctx, f.Name().GcsObjectName(), latestGcsObj, f.content)
 
-	// Special case: a precondition error means we were clobbered, which we treat
-	// as being unlinked. There's no reason to return an error in that case.
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
-		err = nil
+		err = fmt.Errorf("SyncObject: %s, %w", FileClobberedErrMsg, err)
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -192,6 +192,12 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool) (o *g
 		return
 	}
 
+	// For localFile, if object exists in GCS then it means file is clobberred.
+	if f.IsLocal() {
+		b = true
+		return
+	}
+
 	// We are clobbered iff the generation doesn't match our source generation.
 	oGen := Generation{o.Generation, o.MetaGeneration}
 	b = f.SourceGeneration().Compare(oGen) != 0

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -669,10 +669,10 @@ func (t *FileTest) Sync_Clobbered() {
 
 	AssertEq(nil, err)
 
-	// Sync. The call should succeed, but nothing should change.
+	// Sync. The call should not succeed to let user know about the error.
 	err = t.in.Sync(t.ctx)
 
-	AssertEq(nil, err)
+	AssertEq(FileClobberedErrMsg, err.Error())
 	ExpectEq(t.backingObj.Generation, t.in.SourceGeneration().Object)
 	ExpectEq(t.backingObj.MetaGeneration, t.in.SourceGeneration().Metadata)
 

--- a/tools/integration_tests/multiwriters/multimounts/multimounts_test.go
+++ b/tools/integration_tests/multiwriters/multimounts/multimounts_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provide integration tests for multi-writers writing to multiple GCSFuse mounts.
+package multimounts_test
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/multiple_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+const (
+	MountName1     = "mnt1"
+	MountName2     = "mnt2"
+	CommonFileName = "data.txt"
+)
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	// Disabling stat cache because that can go stale and interfere with tests.
+	// It is anyway advised to users to disable stat cache in multiwriter scenarios.
+	flags := [][]string{{"--implicit-dirs=false", "--stat-cache-capacity=0"}, {"--implicit-dirs=true", "--stat-cache-capacity=0"}}
+
+	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
+		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
+		os.Exit(1)
+	}
+
+	// Requires two GCSFuse mount inside MountedDirectory named as MountName1 &
+	// MountName 2.
+	// If --mountedDirectory flag is passed the program exits from inside this
+	// method.
+	setup.RunTestsForMountedDirectoryFlag(m)
+
+	setup.SetUpTestDirForTestBucketFlag()
+
+	mountPaths := []string{filepath.Join(setup.MntDir(), MountName1), filepath.Join(setup.MntDir(), MountName2)}
+	successCode := multiple_mounting.RunTests(flags, mountPaths, m)
+
+	setup.RemoveBinFileCopiedForTesting()
+
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/multiwriters/multimounts/multiwriters_from_two_mounts_test.go
+++ b/tools/integration_tests/multiwriters/multimounts/multiwriters_from_two_mounts_test.go
@@ -1,0 +1,230 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multimounts_test
+
+import (
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	operations "github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+	. "github.com/jacobsa/ogletest"
+)
+
+const TwoHundredMiB = 1024 * 1024 * 200
+const InputOutputErrorMsg = "input/output error"
+
+func getMountPath1() string {
+	return path.Join(setup.MntDir(), MountName1)
+}
+
+func getMountPath2() string {
+	return path.Join(setup.MntDir(), MountName2)
+}
+
+func getFilePathInMount1() string {
+	return path.Join(getMountPath1(), CommonFileName)
+}
+
+func getFilePathInMount2() string {
+	return path.Join(getMountPath2(), CommonFileName)
+}
+
+func getGCSObjPath() string {
+	return path.Join(setup.TestBucket(), CommonFileName)
+}
+
+func openFile(t *testing.T, filePath string) (file *os.File) {
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, operations.FilePermission_0600)
+	if err != nil {
+		t.Errorf("error in opening file %s: %v", file.Name(), err)
+	}
+	return
+}
+
+func writeToFile(t *testing.T, file *os.File, fileContent string) {
+	_, err := file.WriteString(fileContent)
+	if err != nil {
+		t.Errorf("error in writing to the file %s: %v", file.Name(), err)
+	}
+}
+
+func syncFile(t *testing.T, file *os.File) {
+	err := file.Sync()
+	if err != nil {
+		t.Errorf("error in syncing file %s: %v", file.Name(), err)
+	}
+}
+
+func cleanAndCreateCommonFileInTestBucket(t *testing.T) {
+	// Cleaning one mount is sufficient as the test bucket is common.
+	err := operations.EmptyDir(getMountPath1())
+	if err != nil {
+		t.Errorf("Error while cleaning mount %v", err)
+	}
+
+	// Create file in mount 1.
+	commonFile, err := os.Create(getFilePathInMount1())
+	if err != nil {
+		t.Errorf("Error creating common file %v", err)
+	}
+	operations.CloseFile(commonFile)
+}
+
+func compareGCSObjContent(t *testing.T, expectedContent string) {
+	actualContent, err := operations.GetGCSObject(getGCSObjPath())
+	if err != nil {
+		t.Errorf("Error while getting object from GCS %v", err)
+	}
+
+	if actualContent != expectedContent {
+		t.Errorf("The content in GCS object: %s is different from expected content %s", actualContent, expectedContent)
+	}
+}
+
+func TestW1OpensW2OpensW1WritesFlushesW2WritesFlushes(t *testing.T) {
+	cleanAndCreateCommonFileInTestBucket(t)
+	//w1 opens
+	w1File := openFile(t, getFilePathInMount1())
+	defer operations.CloseFile(w1File)
+	//w2 opens
+	w2File := openFile(t, getFilePathInMount2())
+	defer operations.CloseFile(w2File)
+	dataToWrite1 := "sample text to write in file by W1\n"
+	// w1 writes
+	writeToFile(t, w1File, dataToWrite1)
+	// w1 flushes
+	syncFile(t, w1File)
+	// Check if content is flushed to GCS
+	compareGCSObjContent(t, dataToWrite1)
+
+	// w2 tries writing when w1 has already flushed. w2 should fail in the read
+	// that happens in the write flow to load file content from GCS into disk.
+	dataToWrite2 := "sample text to write in file by W2\n"
+	_, err := w2File.WriteString(dataToWrite2)
+
+	// Currently, the read flow returns ENOENT error when the object to be read is
+	// clobbered.
+	ExpectEq(true, strings.Contains(err.Error(), "no such file or directory"))
+	// Ensure the object in GCS is not modified.
+	compareGCSObjContent(t, dataToWrite1)
+}
+
+// This tests the case of clobbered error when two writers try to flush to same
+// object concurrently.
+func TestW1OpensWritesW2OpensWritesW1FlushesW2Flushes(t *testing.T) {
+	cleanAndCreateCommonFileInTestBucket(t)
+	//w1 opens
+	w1File := openFile(t, getFilePathInMount1())
+	defer operations.CloseFile(w1File)
+	// w1 writes
+	dataToWrite1 := "sample text to write in file by W1\n"
+	writeToFile(t, w1File, dataToWrite1)
+	//w2 opens
+	w2File := openFile(t, getFilePathInMount2())
+	defer operations.CloseFile(w2File)
+	// w2 writes
+	dataToWrite2 := "sample text to write in file by W2\n"
+	writeToFile(t, w2File, dataToWrite2)
+	// w1 flushes
+	syncFile(t, w1File)
+
+	// w2 tries to flush the file but gets I/O error because the file in the GCS
+	// has been clobbered by w1.
+	err := w2File.Sync()
+
+	ExpectEq(true, strings.Contains(err.Error(), InputOutputErrorMsg))
+	// check the GCS object still has the contents written by w1.
+	compareGCSObjContent(t, dataToWrite1)
+}
+
+// This tests the case of precondition error when two writers concurrently flush
+// to same object.
+func TestW1OpensWritesW2OpensWritesW1W2Flushes(t *testing.T) {
+	cleanAndCreateCommonFileInTestBucket(t)
+	//w1 opens
+	w1File := openFile(t, getFilePathInMount1())
+	defer operations.CloseFile(w1File)
+	// w1 writes (writing large file so that it takes some time to flush to GCS)
+	dataToWrite1 := strings.Repeat("1", TwoHundredMiB)
+	writeToFile(t, w1File, dataToWrite1)
+	//w2 opens
+	w2File := openFile(t, getFilePathInMount2())
+	defer operations.CloseFile(w2File)
+	// w2 writes
+	dataToWrite2 := strings.Repeat("2", TwoHundredMiB)
+	writeToFile(t, w2File, dataToWrite2)
+	// Go routines for W1 and W2 for concurrent flushing.
+	var err1, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	syncW1 := func() {
+		err1 = w1File.Sync()
+		wg.Done()
+	}
+	syncW2 := func() {
+		err2 = w2File.Sync()
+		wg.Done()
+	}
+
+	// Both W1 and W2 tries to flush concurrently but one of them should fail with
+	// I/O error. Because the file size they are flushing is large, it is expected
+	// that both will pass clobbered check and the I/O will come because of
+	// precondition error
+	go syncW1()
+	go syncW2()
+	wg.Wait()
+
+	// if W1 syncs successfully, the other one should fail and vice-versa
+	if err1 == nil {
+		ExpectEq(true, strings.Contains(err2.Error(), InputOutputErrorMsg))
+		compareGCSObjContent(t, dataToWrite1)
+	} else {
+		ExpectEq(nil, err2)
+		ExpectEq(true, strings.Contains(err1.Error(), InputOutputErrorMsg))
+		compareGCSObjContent(t, dataToWrite2)
+	}
+}
+
+func TestW1OpensWritesFlushesW2OpensWritesFlushes(t *testing.T) {
+	cleanAndCreateCommonFileInTestBucket(t)
+	//w1 opens
+	w1File := openFile(t, getFilePathInMount1())
+	defer operations.CloseFile(w1File)
+	// w1 writes
+	dataToWrite1 := "sample text to write in file by W1\n"
+	writeToFile(t, w1File, dataToWrite1)
+	// w1 flushes
+	syncFile(t, w1File)
+	compareGCSObjContent(t, dataToWrite1)
+	// w2 opens
+	w2File := openFile(t, getFilePathInMount2())
+	defer operations.CloseFile(w2File)
+	// w2 writes
+	dataToWrite2 := "sample text to write in file by W2\n"
+	writeToFile(t, w2File, dataToWrite2)
+
+	// w2 flushes
+	err := w2File.Sync()
+
+	// w2 flush should pass as w2 opened the file after w1 wrote and flushed it.
+	ExpectEq(nil, err)
+	// GCS object should have content written by w2
+	compareGCSObjContent(t, dataToWrite2)
+}

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -250,3 +250,20 @@ sudo umount $MOUNT_DIR
 gcsfuse --implicit-dirs=false --rename-dir-limit=3 $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/local_file/... -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
+
+# package multiwriters/multimounts
+# Run tests with multiple mounting. (flags: --implicit-dirs=false --stat-cache-capacity=0)
+mkdir -p $MOUNT_DIR/mnt1 $MOUNT_DIR/mnt2
+gcsfuse --implicit-dirs=false --stat-cache-capacity 0 $TEST_BUCKET_NAME $MOUNT_DIR/mnt1
+gcsfuse --implicit-dirs=false --stat-cache-capacity 0 $TEST_BUCKET_NAME $MOUNT_DIR/mnt2
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/multiwriters/multimounts/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR/mnt1
+sudo umount $MOUNT_DIR/mnt2
+
+# Run tests with multiple mounting. (flags: --implicit-dirs=true --stat-cache-capacity=0)
+mkdir -p $MOUNT_DIR/mnt1 $MOUNT_DIR/mnt2
+gcsfuse --implicit-dirs --stat-cache-capacity 0 $TEST_BUCKET_NAME $MOUNT_DIR/mnt1
+gcsfuse --implicit-dirs --stat-cache-capacity 0 $TEST_BUCKET_NAME $MOUNT_DIR/mnt2
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/multiwriters/multimounts/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR/mnt1
+sudo umount $MOUNT_DIR/mnt2

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -41,7 +41,7 @@ func mountGcsfuseWithDynamicMounting(flags []string) (err error) {
 		flags = append(flags, defaultArg[i])
 	}
 
-	err = mounting.MountGcsfuse(setup.BinFile(), flags)
+	err = mounting.MountGcsfuse(setup.BinFile(), flags, setup.LogFile())
 
 	return err
 }

--- a/tools/integration_tests/util/mounting/mounting.go
+++ b/tools/integration_tests/util/mounting/mounting.go
@@ -21,17 +21,16 @@ import (
 	"os/exec"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
-func MountGcsfuse(binaryFile string, flags []string) error {
+func MountGcsfuse(binaryFile string, flags []string, logFile string) error {
 	mountCmd := exec.Command(
 		binaryFile,
 		flags...,
 	)
 
 	// Adding mount command in LogFile
-	file, err := os.OpenFile(setup.LogFile(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		fmt.Println("Could not open logfile")
 	}
@@ -47,6 +46,18 @@ func MountGcsfuse(binaryFile string, flags []string) error {
 	if err != nil {
 		log.Println(mountCmd.String())
 		return fmt.Errorf("cannot mount gcsfuse: %w\n", err)
+	}
+	return nil
+}
+
+func UnMountGcsfuse(mountPath string) error {
+	fusermount, err := exec.LookPath("fusermount")
+	if err != nil {
+		return fmt.Errorf("cannot find fusermount: %w", err)
+	}
+	cmd := exec.Command(fusermount, "-uz", mountPath)
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("fusermount error: %w", err)
 	}
 	return nil
 }

--- a/tools/integration_tests/util/mounting/multiple_mounting/multiple_mounting.go
+++ b/tools/integration_tests/util/mounting/multiple_mounting/multiple_mounting.go
@@ -1,0 +1,126 @@
+//Copyright 2023 Google Inc. All Rights Reserved.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package multiple_mounting
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+)
+
+func getLogFilePaths(numOfMounts int) (logFilePaths []string) {
+	logFilePaths = make([]string, numOfMounts)
+	for i := 0; i < numOfMounts; i++ {
+		logFilePaths[i] = path.Join(setup.TestDir(), "gcsfuse"+strconv.Itoa(i)+".log")
+	}
+	return
+}
+
+func mountMultipleGCSfuseMounts(flags []string, mountPaths []string) (err error) {
+	commonFlags := []string{"--debug_gcs",
+		"--debug_fs",
+		"--debug_fuse",
+		"--log-format=text"}
+
+	for i := 0; i < len(commonFlags); i++ {
+		flags = append(flags, commonFlags[i])
+	}
+
+	// Unmount the mounts in case of failure mounting any one of the mounts.
+	shouldUnMount := false
+	unMount := func(mountPath string) {
+		if shouldUnMount {
+			err := mounting.UnMountGcsfuse(mountPath)
+			if err != nil {
+				log.Printf("failure in unmounting: %s\n", err.Error())
+			}
+			operations.RemoveDir(mountPath)
+			return
+		}
+	}
+
+	logFilePaths := getLogFilePaths(len(mountPaths))
+	for i := 0; i < len(mountPaths); i++ {
+		// Add mount path to flags
+		mountFlags := make([]string, len(flags)+3)
+		copy(mountFlags, flags)
+		// set separate log file, bucket name and mount path
+		mountFlags[len(flags)] = "--log-file=" + logFilePaths[i]
+		mountFlags[len(flags)+1] = setup.TestBucket()
+		mountFlags[len(flags)+2] = mountPaths[i]
+		err := os.Mkdir(mountPaths[i], 0755)
+		if err != nil {
+			shouldUnMount = true
+			return err
+		}
+		err = mounting.MountGcsfuse(setup.BinFile(), mountFlags, setup.LogFile())
+		if err != nil {
+			shouldUnMount = true
+			return err
+		}
+		defer unMount(mountPaths[i])
+	}
+
+	return err
+}
+
+func executeTestsForMultipleMounting(flags [][]string, mountPaths []string, m *testing.M) (successCode int) {
+	var err error
+
+	for i := 0; i < len(flags); i++ {
+		setup.CleanMntDir()
+		if err = mountMultipleGCSfuseMounts(flags[i], mountPaths); err != nil {
+			setup.LogAndExit(fmt.Sprintf("mountMultipleGCSfuseMounts: %v\n", err))
+		}
+
+		successCode = setup.ExecuteTest(m)
+
+		var unmountingFailed bool
+		for i := 0; i < len(mountPaths); i++ {
+			err := mounting.UnMountGcsfuse(mountPaths[i])
+			if err != nil {
+				unmountingFailed = true
+				log.Printf("Error while unMounting %s: %s", mountPaths[i], err.Error())
+			}
+		}
+
+		if successCode != 0 {
+			// Print flag on which test failed.
+			f := strings.Join(flags[i], " ")
+			log.Print("Test Fails on " + f)
+		}
+
+		if unmountingFailed {
+			setup.LogAndExit("Error in unmounting one or more bucket")
+		}
+	}
+	return
+}
+
+func RunTests(flags [][]string, mountPaths []string, m *testing.M) (successCode int) {
+	successCode = executeTestsForMultipleMounting(flags, mountPaths, m)
+
+	log.Printf("GCSFuse log files(gcsfuse*.log) under: %s\n", setup.TestDir())
+
+	return successCode
+}

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -41,7 +41,7 @@ func mountGcsfuseWithOnlyDir(flags []string, dir string) (err error) {
 		flags = append(flags, defaultArg[i])
 	}
 
-	err = mounting.MountGcsfuse(setup.BinFile(), flags)
+	err = mounting.MountGcsfuse(setup.BinFile(), flags, setup.LogFile())
 
 	return err
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -64,7 +64,7 @@ func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
 		defaultArg = append(defaultArg, "-o", persistentMountingArgs[i])
 	}
 
-	err = mounting.MountGcsfuse(setup.SbinFile(), defaultArg)
+	err = mounting.MountGcsfuse(setup.SbinFile(), defaultArg, setup.LogFile())
 
 	return err
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -36,7 +36,7 @@ func mountGcsfuseWithStaticMounting(flags []string) (err error) {
 		flags = append(flags, defaultArg[i])
 	}
 
-	err = mounting.MountGcsfuse(setup.BinFile(), flags)
+	err = mounting.MountGcsfuse(setup.BinFile(), flags, setup.LogFile())
 
 	return err
 }

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -143,3 +143,18 @@ func CreateDirectory(dirPath string, t *testing.T) {
 		t.Fatalf("Error while creating directory, err: %v", err)
 	}
 }
+
+func EmptyDir(dirPath string) (err error) {
+	dir, err := os.ReadDir(dirPath)
+	if err != nil {
+		return
+	}
+
+	for _, d := range dir {
+		err = os.RemoveAll(path.Join([]string{dirPath, d.Name()}...))
+		if err != nil {
+			return
+		}
+	}
+	return nil
+}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -609,3 +609,10 @@ func SyncFile(fh *os.File, t *testing.T) {
 		t.Fatalf("%s.Sync(): %v", fh.Name(), err)
 	}
 }
+
+// GetGCSObject gets content of a given GCS object as string (using GCS path without 'gs://')
+func GetGCSObject(gcsObjPath string) (objContent string, err error) {
+	byteContent, err := ExecuteGsutilCommandf("cat gs://%s", gcsObjPath)
+	objContent = string(byteContent)
+	return
+}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/util"
 )
@@ -215,15 +216,8 @@ func RemoveBinFileCopiedForTesting() {
 }
 
 func UnMount() error {
-	fusermount, err := exec.LookPath("fusermount")
-	if err != nil {
-		return fmt.Errorf("cannot find fusermount: %w", err)
-	}
-	cmd := exec.Command(fusermount, "-uz", mntDir)
-	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("fusermount error: %w", err)
-	}
-	return nil
+	err := mounting.UnMountGcsfuse(mntDir)
+	return err
 }
 
 func ExecuteTest(m *testing.M) (successCode int) {


### PR DESCRIPTION
### Description
Write failure improvements (includes fix for local file inode)
Gives error in case of following scenarios:
1.  If two writers concurrently sync to same object from different mounts, one of them succeed and one of them fails with clobbered error.
2.  If two writers concurrently try to create  same object from different mounts, one of them succeed and one of them fails with clobbered error.
3. Error is not given in case of multiple writers writing to same file from same mount.

Note: The above changes are not tested for unlink concurrency i.e. if a writer trying to create same file (first local file is created) and another user unlinks the file, then the first user doesn't get any error. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
5. Unit tests - NA
6. Integration tests - NA
