### PR TITLE
Increasing the hardcoded type cache capacity to 4 million for read-cache load test

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -215,7 +215,9 @@ func NewDirInode(
 	}
 
 	// Set up the struct.
-	const typeCacheCapacity = 1 << 16
+	// Temporarily changing the typeCacheCapacity to 4194304 for read_cache_release
+	// branch. TODO (raj-prince): remove this once we will make it configurable.
+	const typeCacheCapacity = 1 << 22
 	typed := &dirInode{
 		bucket:                     bucket,
 		mtimeClock:                 mtimeClock,

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -215,8 +215,8 @@ func NewDirInode(
 	}
 
 	// Set up the struct.
-	// Temporarily changing the typeCacheCapacity to 4194304 for read_cache_release
-	// branch. TODO (raj-prince): remove this once we will make it configurable.
+	// Temporarily changing the typeCacheCapacity for read_cache_release branch.
+	// TODO (raj-prince): remove this once we will make it configurable.
 	const typeCacheCapacity = 1 << 22
 	typed := &dirInode{
 		bucket:                     bucket,


### PR DESCRIPTION
### Description
Changing the hardcoded type cache capacity from (1 << 16) to (1 << 22)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
