### PR TITLE
Export file cache metrics via stackdriver

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,8 +33,8 @@ Note: Both request_count and request_latencies allows grouping by gcs method typ
 cache along with read type - Sequential/Random.
 * **file_cache/read_latencies:** The cumulative distribution of the file cache read 
 latencies along with cache hit - true/false.
-* **file_cache/read_count:** Specifies the number of read requests made via file cache a
-long with type - Sequential/Random and cache hit - true/false.
+* **file_cache/read_count:** Specifies the number of read requests made via file cache 
+along with type - Sequential/Random and cache hit - true/false.
 
 
 # Usage

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,6 +28,15 @@ Read type specifies sequential or random read.
 
 Note: Both request_count and request_latencies allows grouping by gcs method type.
 
+## File cache metrics
+* **file_cache/read_bytes_count:** The cumulative number of bytes read from file 
+cache along with read type - Sequential/Random.
+* **file_cache/read_latencies:** The cumulative distribution of the file cache read 
+latencies along with cache hit - true/false.
+* **file_cache/read_count:** Specifies the number of read requests made via file cache a
+long with type - Sequential/Random and cache hit - true/false.
+
+
 # Usage
 1. We need to set **stackdriver-export-interval** flag to enable exporting metrics to 
 Google cloud monitoring. The value of this flag represents the interval with 

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -92,7 +92,7 @@ func recordOp(ctx context.Context, method string, start time.Time, fsErr error) 
 		opsCount.M(1),
 	); err != nil {
 		// Error in recording opCount.
-		fmt.Printf("Cannot record file system op: %v", err)
+		logger.Errorf("Cannot record file system op: %v", err)
 	}
 
 	// Recording opErrorCount.

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -254,6 +254,10 @@ func (rr *randomReader) ReadAt(
 		return
 	}
 
+	// Note: If we are reading the file for the first time and read type is sequential
+	// then the file cache behavior is write-through i.e. data is first read from
+	// GCS, cached in file and then served from that file. Also, the cacheHit is
+	// true in that case.
 	n, cacheHit, err = rr.tryReadingFromFileCache(ctx, p, offset)
 	if err != nil {
 		err = fmt.Errorf("ReadAt: while reading from cache: %v", err)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -190,7 +190,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		}
 
 		// Here rr.fileCacheHandle will not be nil since we return from the above in those cases.
-		logger.Tracef("%.13v -> %s", requestOutput)
+		logger.Tracef("%.13v -> %s", requestId, requestOutput)
 
 		readType := util.Random
 		if isSeq {
@@ -377,7 +377,7 @@ func (rr *randomReader) Destroy() {
 	}
 
 	if rr.fileCacheHandle != nil {
-		logger.Tracef("Closing cacheHandle:%p for object: %s/:%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
+		logger.Tracef("Closing cacheHandle:%p for object: %s:/%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
 		err := rr.fileCacheHandle.Close()
 		if err != nil {
 			logger.Warnf("rr.Destroy(): while closing cacheFileHandle: %v", err)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -173,7 +173,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 
 	// Request log and start the execution timer.
 	requestId := uuid.New()
-	logger.Tracef("%.13v <- ReadFromCache(%s:/%s, offset: %d, size: %d)", requestId, rr.bucket.Name(), rr.object.Name, offset, len(p))
+	logger.Tracef("%.13v <- FileCache(%s:/%s, offset: %d, size: %d)", requestId, rr.bucket.Name(), rr.object.Name, offset, len(p))
 	startTime := time.Now()
 
 	// Response log
@@ -181,16 +181,16 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		executionTime := time.Since(startTime)
 		var requestOutput string
 		if err != nil {
-			requestOutput = fmt.Sprintf("(error: %v, %v)", err, executionTime)
+			requestOutput = fmt.Sprintf("err: %v (%v)", err, executionTime)
 		} else {
 			if rr.fileCacheHandle != nil {
 				isSeq = rr.fileCacheHandle.IsSequential(offset)
 			}
-			requestOutput = fmt.Sprintf("(isSeq: %t, hit: %t, %v)", isSeq, cacheHit, executionTime)
+			requestOutput = fmt.Sprintf("OK (isSeq: %t, hit: %t) (%v)", isSeq, cacheHit, executionTime)
 		}
 
 		// Here rr.fileCacheHandle will not be nil since we return from the above in those cases.
-		logger.Tracef("%.13v -> ReadFromCache(%s:/%s, offset: %d, size: %d): %s", requestId, rr.bucket.Name(), rr.object.Name, offset, len(p), requestOutput)
+		logger.Tracef("%.13v -> %s", requestOutput)
 
 		readType := util.Random
 		if isSeq {
@@ -229,7 +229,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	n = 0
 
 	if cacheutil.IsCacheHandleInvalid(err) {
-		logger.Tracef("Closing cacheHandle:%p for object: %s//:%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
+		logger.Tracef("Closing cacheHandle:%p for object: %s:/%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
 		err = rr.fileCacheHandle.Close()
 		if err != nil {
 			logger.Warnf("tryReadingFromFileCache: while closing fileCacheHandle: %v", err)
@@ -377,7 +377,7 @@ func (rr *randomReader) Destroy() {
 	}
 
 	if rr.fileCacheHandle != nil {
-		logger.Tracef("Closing cacheHandle:%p for object: %s//:%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
+		logger.Tracef("Closing cacheHandle:%p for object: %s/:%s", rr.fileCacheHandle, rr.bucket.Name(), rr.object.Name)
 		err := rr.fileCacheHandle.Close()
 		if err != nil {
 			logger.Warnf("rr.Destroy(): while closing cacheFileHandle: %v", err)

--- a/internal/monitor/reader.go
+++ b/internal/monitor/reader.go
@@ -38,13 +38,13 @@ var (
 		"Cumulative number of bytes downloaded from GCS along with read type",
 		stats.UnitBytes)
 	fileCacheReadCount = stats.Int64("file_cache/read_count",
-		"Specifies the number of read requests made via file cache along with type- Sequential/Random",
+		"Specifies the number of read requests made via file cache along with type - Sequential/Random and cache hit - true/false",
 		stats.UnitDimensionless)
 	fileCacheReadBytesCount = stats.Int64("file_cache/read_bytes_count",
-		"The cumulative number of bytes read from file cache.",
+		"The cumulative number of bytes read from file cache along with read type - Sequential/Random",
 		stats.UnitBytes)
 	fileCacheReadLatency = stats.Float64("file_cache/read_latency",
-		"Latency of read from file cache",
+		"Latency of read from file cache along with cache hit - true or false",
 		stats.UnitMilliseconds)
 )
 
@@ -72,21 +72,21 @@ func init() {
 		&view.View{
 			Name:        "file_cache/read_count",
 			Measure:     fileCacheReadCount,
-			Description: "Specifies the number of read requests made via file cache along with type- Sequential/Random",
+			Description: "Specifies the number of read requests made via file cache along with type - Sequential/Random and cache hit - true/false",
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{tags.ReadType, tags.CacheHit},
 		},
 		&view.View{
 			Name:        "file_cache/read_bytes_count",
 			Measure:     fileCacheReadBytesCount,
-			Description: "The cumulative number of bytes read from file cache.",
+			Description: "The cumulative number of bytes read from file cache along with read type - Sequential/Random",
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{tags.ReadType},
 		},
 		&view.View{
 			Name:        "file_cache/read_latencies",
 			Measure:     fileCacheReadLatency,
-			Description: "The cumulative distribution of the file cache read latencies.",
+			Description: "The cumulative distribution of the file cache read latencies along with cache hit - true or false",
 			Aggregation: ochttp.DefaultLatencyDistribution,
 			TagKeys:     []tag.Key{tags.CacheHit},
 		},

--- a/internal/monitor/reader.go
+++ b/internal/monitor/reader.go
@@ -86,7 +86,7 @@ func init() {
 		&view.View{
 			Name:        "file_cache/read_latencies",
 			Measure:     fileCacheReadLatency,
-			Description: "The cumulative distribution of the file cache read latencies along with cache hit - true or false",
+			Description: "The cumulative distribution of the file cache read latencies along with cache hit - true/false",
 			Aggregation: ochttp.DefaultLatencyDistribution,
 			TagKeys:     []tag.Key{tags.CacheHit},
 		},

--- a/internal/monitor/reader.go
+++ b/internal/monitor/reader.go
@@ -92,7 +92,7 @@ func init() {
 			TagKeys:     []tag.Key{tags.CacheHit},
 		},
 	); err != nil {
-		log.Fatalf("Failed to register the view: %v", err)
+		log.Fatalf("Failed to register the reader view: %v", err)
 	}
 }
 

--- a/internal/monitor/reader.go
+++ b/internal/monitor/reader.go
@@ -1,0 +1,157 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/monitor/tags"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"golang.org/x/net/context"
+)
+
+var (
+	// When a first read call is made by the user, we either fetch entire file or x number of bytes from GCS based on the request.
+	// Now depending on the pagesize multiple read calls will be issued by user to read the entire file. These
+	// requests will be served from the downloaded data.
+	// This metric captures only the requests made to GCS, not the subsequent page calls.
+	gcsReadCount = stats.Int64("gcs/read_count",
+		"Specifies the count of gcs reads made along with type",
+		stats.UnitDimensionless)
+	downloadBytesCount = stats.Int64("gcs/download_bytes_count",
+		"Cumulative number of bytes downloaded from GCS along with read type",
+		stats.UnitBytes)
+	fileCacheReadCount = stats.Int64("file_cache/read_count",
+		"Specifies the number of read requests made via file cache along with type- Sequential/Random",
+		stats.UnitDimensionless)
+	fileCacheReadBytesCount = stats.Int64("file_cache/read_bytes_count",
+		"The cumulative number of bytes read from file cache.",
+		stats.UnitBytes)
+	fileCacheReadLatency = stats.Float64("file_cache/read_latency",
+		"Latency of read from file cache",
+		stats.UnitMilliseconds)
+)
+
+const NanosecondsInOneMillisecond = 1000000
+
+// Initialize the metrics.
+func init() {
+	// GCS related metrics
+	if err := view.Register(
+		&view.View{
+			Name:        "gcs/read_count",
+			Measure:     gcsReadCount,
+			Description: "Specifies the number of gcs reads made along with type- Sequential/Random",
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{tags.ReadType},
+		},
+		&view.View{
+			Name:        "gcs/download_bytes_count",
+			Measure:     downloadBytesCount,
+			Description: "The cumulative number of bytes downloaded from GCS.",
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{tags.ReadType},
+		},
+		// File cache related metrics
+		&view.View{
+			Name:        "file_cache/read_count",
+			Measure:     fileCacheReadCount,
+			Description: "Specifies the number of read requests made via file cache along with type- Sequential/Random",
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{tags.ReadType, tags.CacheHit},
+		},
+		&view.View{
+			Name:        "file_cache/read_bytes_count",
+			Measure:     fileCacheReadBytesCount,
+			Description: "The cumulative number of bytes read from file cache.",
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{tags.ReadType},
+		},
+		&view.View{
+			Name:        "file_cache/read_latencies",
+			Measure:     fileCacheReadLatency,
+			Description: "The cumulative distribution of the file cache read latencies.",
+			Aggregation: ochttp.DefaultLatencyDistribution,
+			TagKeys:     []tag.Key{tags.CacheHit},
+		},
+	); err != nil {
+		log.Fatalf("Failed to register the view: %v", err)
+	}
+}
+
+func CaptureGCSReadMetrics(ctx context.Context, readType string, requestedDataSize int64) {
+	if err := stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(tags.ReadType, readType),
+		},
+		gcsReadCount.M(1),
+	); err != nil {
+		// Error in recording gcsReadCount.
+		log.Fatalf("Cannot record gcsReadCount %v", err)
+	}
+
+	if err := stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(tags.ReadType, readType),
+		},
+		downloadBytesCount.M(requestedDataSize),
+	); err != nil {
+		// Error in recording gcsReadCount.
+		log.Fatalf("Cannot record downloadBytesCount %v", err)
+	}
+}
+
+func CaptureFileCacheMetrics(ctx context.Context, readType string, readDataSize int, cacheHit bool, readLatencyNs int64) {
+	if err := stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(tags.ReadType, readType),
+			tag.Upsert(tags.CacheHit, strconv.FormatBool(cacheHit)),
+		},
+		fileCacheReadCount.M(1),
+	); err != nil {
+		// Error in recording fileCacheReadCount.
+		log.Fatalf("Cannot record fileCacheReadCount %v", err)
+	}
+
+	if err := stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(tags.ReadType, readType),
+		},
+		fileCacheReadBytesCount.M(int64(readDataSize)),
+	); err != nil {
+		// Error in recording fileCacheReadBytesCount.
+		log.Fatalf("Cannot record fileCacheReadBytesCount %v", err)
+	}
+
+	readLatencyMs := float64(readLatencyNs) / float64(NanosecondsInOneMillisecond)
+	if err := stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(tags.CacheHit, strconv.FormatBool(cacheHit)),
+		},
+		fileCacheReadLatency.M(readLatencyMs),
+	); err != nil {
+		// Error in recording fileCacheReadLatency.
+		log.Fatalf("Cannot record fileCacheReadLatency %v", err)
+	}
+}

--- a/internal/monitor/reader.go
+++ b/internal/monitor/reader.go
@@ -44,7 +44,7 @@ var (
 		"The cumulative number of bytes read from file cache along with read type - Sequential/Random",
 		stats.UnitBytes)
 	fileCacheReadLatency = stats.Float64("file_cache/read_latency",
-		"Latency of read from file cache along with cache hit - true or false",
+		"Latency of read from file cache along with cache hit - true/false",
 		stats.UnitMilliseconds)
 )
 

--- a/internal/monitor/tags/tags.go
+++ b/internal/monitor/tags/tags.go
@@ -34,4 +34,7 @@ var (
 
 	// ReadType annotates the read operation with the type - Sequential/Random
 	ReadType = tag.MustNewKey("read_type")
+
+	// CacheHit annotates the read operation from file cache with true or false.
+	CacheHit = tag.MustNewKey("cache_hit")
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -27,6 +27,10 @@ import (
 
 const GCSFUSE_PARENT_PROCESS_DIR = "gcsfuse-parent-process-dir"
 
+// Constants for read types - Sequential/Random
+const Sequential = "Sequential"
+const Random = "Random"
+
 // 1. Returns the same filepath in case of absolute path or empty filename.
 // 2. For child process, it resolves relative path like, ./test.txt, test.txt
 // ../test.txt etc, with respect to GCSFUSE_PARENT_PROCESS_DIR


### PR DESCRIPTION
### Description
Export file cache metrics via stackdriver

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Checked the metrics are exported on console (PTAL at metrics explorer of console to confirm).
2. Unit tests - NA
3. Integration tests - NA

![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/7bef5676-9495-4f61-9040-4942a2c21123)


![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/2832070d-751a-463a-a509-22e11c9a771a)


![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/c8a1bd79-4be3-44ec-bbe9-b3e22ef070e4)

Perf tests:
![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/f23b8a68-2fe6-49b5-84b1-91a0e3e040d9)


