### PR TITLE
Wait for termination of async job during Cancel and Invalidate

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -284,7 +284,7 @@ func (job *Job) downloadObjectAsync() {
 	defer job.cancelFunc()
 
 	// Create, open and truncate cache file for writing object into it.
-	cacheFile, err := util.CreateFile(job.fileSpec, os.O_TRUNC|os.O_WRONLY)
+	cacheFile, err := cacheutil.CreateFile(job.fileSpec, os.O_TRUNC|os.O_WRONLY)
 	if err != nil {
 		err = fmt.Errorf("downloadObjectAsync: error in creating cache file: %v", err)
 		job.failWhileDownloading(err)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -278,9 +278,10 @@ func (job *Job) updateFileInfoCache() (err error) {
 // Note: There can only be one async download running for a job at a time.
 // Acquires and releases LOCK(job.mu)
 func (job *Job) downloadObjectAsync() {
-	// Close the job.doneCh in any case - completion/cancellation/failure of this
-	// goroutine.
+	// Close the job.doneCh and call job.canceFunc() in any case -
+	// completion/cancellation/failure of this goroutine.
 	defer close(job.doneCh)
+	defer job.cancelFunc()
 
 	// Create, open and truncate cache file for writing object into it.
 	cacheFile, err := util.CreateFile(job.fileSpec, os.O_TRUNC|os.O_WRONLY)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -278,7 +278,7 @@ func (job *Job) updateFileInfoCache() (err error) {
 // Note: There can only be one async download running for a job at a time.
 // Acquires and releases LOCK(job.mu)
 func (job *Job) downloadObjectAsync() {
-	// Close the job.doneCh and call job.canceFunc() in any case -
+	// Close the job.doneCh and call job.cancelFunc() in any case -
 	// completion/cancellation/failure of this goroutine.
 	defer close(job.doneCh)
 	defer job.cancelFunc()

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -174,7 +174,7 @@ func (job *Job) Cancel() {
 		// we shouldn't change the status to cancelled.
 		if job.status.Name != FAILED && job.status.Name != INVALID {
 			job.status.Name = CANCELLED
-			logger.Tracef("Job:%p (%s://%s) cancelled.", job, job.bucket.Name(), job.object.Name)
+			logger.Tracef("Job:%p (%s:/%s) cancelled.", job, job.bucket.Name(), job.object.Name)
 			job.notifySubscribers()
 		}
 	}


### PR DESCRIPTION
### Description
Wait for termination of async job during cancel and invalidation. 
Details:
Termination of Go routine is co-operative and not preemptive which means that when we signal job.downloadAsync to terminate by running job.cancelFunc() then it may not be immediately terminated and run few statements in the default case of select.
When CacheHandler.cleanUpEvictedEntry is called, it executes job.Invalidate + os.remove(file_in_cache) one after the other, because of that, it may happen that job.Invalidate signals the job.downloadAsync but it takes some time to terminate and meanwhile os.remove is called. If that happens, it's possible that job.downloadAsync is writing to the file in cache at that time and hence the file in cache will appear again which is not correct.
This is more graceful handling of cancellation of async job because job.Invalidate will wait until the job.downloadAsync is terminated and hence fixing the above possible issue.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran 256KB fio job (40 threads) with read cache size = 5 mb and observed no extra files are being created at any point in time.
2. Unit tests - NA
3. Integration tests - NA
