### PR TITLE
Fix tf-resnet model failure

### DIFF
--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
@@ -6,7 +6,8 @@ set -e
 cd "$HOME/github/gcsfuse/perfmetrics/scripts"
 
 echo "Setting up the machine with Docker and Nvidia Driver..."
-source ml_tests/setup_host.sh
+DRIVER_VERSION="450.172.01"
+source ml_tests/setup_host.sh $DRIVER_VERSION
 
 cd "$HOME/github/gcsfuse/"
 mkdir container_artifacts && mkdir container_artifacts/logs && mkdir container_artifacts/output


### PR DESCRIPTION
### Description
curl command was failing due to DRIVER_VERSION variable.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - manually tested.
2. Unit tests - NA
3. Integration tests - NA
