### PR TITLE
make log compression on by default

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -18,7 +18,7 @@ const (
 	// Default log rotation config values.
 	defaultMaxFileSizeMB   = 512
 	defaultBackupFileCount = 10
-	defaultCompress        = false
+	defaultCompress        = true
 )
 
 type WriteConfig struct {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -37,7 +37,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	ExpectEq("", mountConfig.LogConfig.FilePath)
 	ExpectEq(512, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
 	ExpectEq(10, mountConfig.LogConfig.LogRotateConfig.BackupFileCount)
-	ExpectEq(false, mountConfig.LogConfig.LogRotateConfig.Compress)
+	ExpectEq(true, mountConfig.LogConfig.LogRotateConfig.Compress)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {


### PR DESCRIPTION
### Description
This PR changes the default value of `compress` log rotate config to true by default so that rotated logs are compressed.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
