### PR TITLE
Reduce epoches in pytorch2.0 model

### DIFF
--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -75,7 +75,7 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 # will be available.
 if [ ${PYTORCH_VESRION} == "v2" ];
 then
-  EPOCHS=35
+  EPOCHS=36
 
   allowed_functions_file="/opt/conda/lib/python3.10/site-packages/torch/_dynamo/allowed_functions.py"
   # Update the pytorch library code to bypass the kernel-cache

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 PYTORCH_VESRION=$1
-EPOCHS=80
+NUM_NUM_EPOCHS=80
 
 # Install golang
 wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
@@ -75,7 +75,7 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 # will be available.
 if [ ${PYTORCH_VESRION} == "v2" ];
 then
-  EPOCHS=36
+  NUM_EPOCHS=36
 
   allowed_functions_file="/opt/conda/lib/python3.10/site-packages/torch/_dynamo/allowed_functions.py"
   # Update the pytorch library code to bypass the kernel-cache
@@ -196,7 +196,7 @@ gsutil cp start_time.txt $ARTIFACTS_BUCKET_PATH/
     --norm_last_layer False \
     --use_fp16 False \
     --clip_grad 0 \
-    --epochs $EPOCHS \
+    --epochs $NUM_EPOCHS \
     --global_crops_scale 0.25 1.0 \
     --local_crops_number 10 \
     --local_crops_scale 0.05 0.25 \

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 PYTORCH_VESRION=$1
-EPOCHES=80
+EPOCHS=80
 
 # Install golang
 wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
@@ -70,9 +70,13 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 # (TulsiShah) TODO: Pytorch 2.0 compile mode has issues (https://github.com/pytorch/pytorch/issues/94599),
 # which is fixed in pytorch version 2.1.0 (https://github.com/pytorch/pytorch/pull/100071).
 # We'll remove this workaround once we update our Docker image to use Pytorch 2.1.0 or greater version.
+# Reducing the epochs as pytorch2 long haul tests are running on NVIDIA L4 machines, which lack the powerful GPU of
+# the NVIDIA A100. So it is taking longer time to complete the training. We will set it back to 80 when the NVIDIA A100 GPU machine
+# will be available.
 if [ ${PYTORCH_VESRION} == "v2" ];
 then
-  EPOCHES=35
+  EPOCHS=35
+
   allowed_functions_file="/opt/conda/lib/python3.10/site-packages/torch/_dynamo/allowed_functions.py"
   # Update the pytorch library code to bypass the kernel-cache
   echo "Updating the pytorch library code to Disallow_in_graph distributed API.."
@@ -192,7 +196,7 @@ gsutil cp start_time.txt $ARTIFACTS_BUCKET_PATH/
     --norm_last_layer False \
     --use_fp16 False \
     --clip_grad 0 \
-    --epochs $EPOCHES \
+    --epochs $EPOCHS \
     --global_crops_scale 0.25 1.0 \
     --local_crops_number 10 \
     --local_crops_scale 0.05 0.25 \

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 PYTORCH_VESRION=$1
-NUM_NUM_EPOCHS=80
+NUM_EPOCHS=80
 
 # Install golang
 wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 PYTORCH_VESRION=$1
+EPOCHES=80
 
 # Install golang
 wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
@@ -71,6 +72,7 @@ python -c 'import torch;torch.hub.list("facebookresearch/xcit:main")'
 # We'll remove this workaround once we update our Docker image to use Pytorch 2.1.0 or greater version.
 if [ ${PYTORCH_VESRION} == "v2" ];
 then
+  EPOCHES=35
   allowed_functions_file="/opt/conda/lib/python3.10/site-packages/torch/_dynamo/allowed_functions.py"
   # Update the pytorch library code to bypass the kernel-cache
   echo "Updating the pytorch library code to Disallow_in_graph distributed API.."
@@ -190,7 +192,7 @@ gsutil cp start_time.txt $ARTIFACTS_BUCKET_PATH/
     --norm_last_layer False \
     --use_fp16 False \
     --clip_grad 0 \
-    --epochs 80 \
+    --epochs $EPOCHES \
     --global_crops_scale 0.25 1.0 \
     --local_crops_number 10 \
     --local_crops_scale 0.05 0.25 \


### PR DESCRIPTION
### Description
Reducing the epochs as pytorch2 long haul tests are running on NVIDIA L4 machines, which lack the powerful GPU of
the NVIDIA A100. So it is taking longer time to complete the training. We will set it back to 80 when the NVIDIA A100 GPU machine will be available.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
