### PR TITLE
fix flaky log rotation test

### DIFF
--- a/tools/integration_tests/log_rotation/logrotate_logfile_test.go
+++ b/tools/integration_tests/log_rotation/logrotate_logfile_test.go
@@ -52,6 +52,7 @@ func runOperationsOnFileTillLogRotation(t *testing.T, wg *sync.WaitGroup, fileNa
 
 	// Keep performing operations in mounted directory until log file is rotated.
 	var lastLogFileSize int64 = 0
+	var retryStatLogFile = true
 	for {
 		// Perform Read operation to generate logs.
 		_, err = operations.ReadFile(filePath)
@@ -62,7 +63,12 @@ func runOperationsOnFileTillLogRotation(t *testing.T, wg *sync.WaitGroup, fileNa
 		// Break the loop when log file is rotated.
 		fi, err := operations.StatFile(logFilePath)
 		if err != nil {
-			t.Errorf("stat operation on file %s: %v", logFilePath, err)
+			t.Logf("stat operation on file %s failed: %v", logFilePath, err)
+			if !retryStatLogFile {
+				t.FailNow()
+			}
+			retryStatLogFile = false
+			continue
 		}
 		if (*fi).Size() < lastLogFileSize {
 			// Log file got rotated as current log file size < last log file size.


### PR DESCRIPTION
### Description
There is an edge case that rarely happens in log rotation integration tests where we try to stat a log file when the logs are getting rotated (the old log file getting renamed and new log file being created). This was causing failure in the integration tests. In order to fix the issue, we will retry the stat call once again before failing the test. If two consecutive  stat calls fail, we will fail the test.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit.
