### PR TITLE
Add metadata-cache:type-cache-max-size-mb-per-dir config

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -95,7 +95,14 @@ The negative result for ```foo/``` will be cached, but that only helps with the 
 To alleviate this, Cloud Storage FUSE supports a "type cache" on directory inodes. When type cache is enabled, each directory inode will maintain a mapping from the name of its children to whether those children are known to be files or directories or both. When a child is looked up, if the parent's cache says that the child is a file but not a directory, only one Cloud Storage object will need to be stated. Similarly if the child is a directory but not a file.
 
 The behavior of type cache is controlled by the following flags/config parameters:
-1.  Type-cache TTL: It controls the duration for which Cloud Storage FUSE allows the kernel to inode type attributes. It can be set in one of the following two ways.
+1. Type-cache capacity: This is configurable at per-directory level by setting `metadata-cache: type-cache-max-size-mb-per-dir` in config-file. This is the maximum size of type-cache per-directory in MiBs. By default, this is set at 16, which roughly equates to about a million entries. If you have folders containing more than a million items (folders or files) you may want to increase this, otherwise the caching will not function properly when listing that folder's contents:
+    - ListObjects will return information on the items within the folder. Each item's data is cached
+    - Because there are more objects than cache capacity, the earliest entries will be evicted
+    - The linux kernel then asks for a little more information on each file.
+    - As the earliest cache entries were evicted, this is a fresh List request
+    - This cycle repeats and sends a List request for every page in the folder, as though caching were disabled
+
+2.  Type-cache TTL: It controls the duration for which Cloud Storage FUSE allows the kernel to inode type attributes. It can be set in one of the following two ways.
     * ```metadata-cache: ttl-secs``` in the config-file. This is set as an integer, which sets the TTL in seconds. If this is -1, TTL is taken as infinite i.e. no-TTL based expirations of entries. If this is 0, that disables the type-cache. If this is <-1, then an error is thrown on mount.
     * ```--type-cache-ttl``` commandline flag, which can be set to a value like ```10s``` or ```1.5h```. The default is one minute. This will be deprecated in a future version and is currently only available for backward compatibility. If ```metadata-cache: ttl-secs``` is set, ```--type-cache-ttl``` is ignored.
 

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -23,12 +23,10 @@ const (
 	// The constant value has been chosen deliberately
 	// to be improbable for a user to explicitly set.
 	TtlInSecsUnsetSentinel int64 = math.MinInt64
-	// TypeCacheMaxSizeInMbPerDirectoryUnset is the value internally set for
+	// DefaultTypeCacheMaxSizeInMbPerDirectory is the value internally set for
 	// metadata-cache:type-cache-max-size-mb-per-dir
 	// when it is not set in the gcsfuse mount config file.
-	// The constant value has been chosen deliberately to
-	// to be improbable for a user to explicitly set.
-	TypeCacheMaxSizeInMbPerDirectoryUnset int = math.MinInt
+	DefaultTypeCacheMaxSizeInMbPerDirectory int = 16
 )
 
 type WriteConfig struct {
@@ -80,8 +78,8 @@ func NewMountConfig() *MountConfig {
 		MaxSizeInMB: 0,
 	}
 	mountConfig.MetadataCacheConfig = MetadataCacheConfig{
-		TtlInSeconds: TtlInSecsUnsetSentinel,
-		TypeCacheMaxSizeMbPerDirectory: TypeCacheMaxSizeInMbPerDirectoryUnset,
+		TtlInSeconds:                   TtlInSecsUnsetSentinel,
+		TypeCacheMaxSizeMbPerDirectory: DefaultTypeCacheMaxSizeInMbPerDirectory,
 	}
 	return mountConfig
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -23,6 +23,17 @@ const (
 	// The constant value has been chosen deliberately
 	// to be improbable for a user to explicitly set.
 	TtlInSecsUnsetSentinel int64 = math.MinInt64
+	// TtlInSecsUnset is set when
+	// metadata-cache:type-cache-max-size-mb-per-dir
+	// is not set
+	// in the gcsfuse mount config file.
+	TypeCacheMaxSizeInMbPerDirectoryUnset int = math.MinInt
+	// DefaultTypeCacheMaxSizeInMbPerDirectory is maximum size of
+	// type-cache per directory in MiBs.
+	// This is the value to be used if the user
+	// did not the value of metadata-cache:type-cache-max-size-mb-per-dir
+	// in config file.
+	DefaultTypeCacheMaxSizeInMbPerDirectory int = 16
 )
 
 type WriteConfig struct {
@@ -49,6 +60,21 @@ type MetadataCacheConfig struct {
 	// no cache and > 0 for ttl-controlled metadata-cache.
 	// Any value set below -1 will throw an error.
 	TtlInSeconds int64 `yaml:"ttl-secs,omitempty"`
+	// // TypeCacheMaxEntriesPerDirectory is the upper limit on the number of
+	// // entries of type-cache maps, which are currently
+	// // maintained at per-directory level.
+	// // If this is not set, a default value of
+	// // DefaultTypeCacheMaxEntriesPerDirectory is taken.
+	// // TODO: Delete it.
+	// // This is to be deleted in favour of TypeCacheMaxSizeMbPerDirectory.
+	// TypeCacheMaxEntriesPerDirectory int `yaml:"type-cache-max-entries-per-dir" default:"1048576"`
+	// TypeCacheMaxEntriesPerDirectory is the upper limit
+	// on the maximum size of type-cache maps,
+	// which are currently
+	// maintained at per-directory level.
+	// If this is not set, a default value of
+	// 16 is taken.
+	TypeCacheMaxSizeMbPerDirectory int `yaml:"type-cache-max-size-mb-per-dir,omitempty"`
 }
 
 type MountConfig struct {
@@ -70,6 +96,7 @@ func NewMountConfig() *MountConfig {
 	}
 	mountConfig.MetadataCacheConfig = MetadataCacheConfig{
 		TtlInSeconds: TtlInSecsUnsetSentinel,
+		TypeCacheMaxSizeMbPerDirectory: TypeCacheMaxSizeInMbPerDirectoryUnset,
 	}
 	return mountConfig
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -23,7 +23,7 @@ const (
 	// The constant value has been chosen deliberately
 	// to be improbable for a user to explicitly set.
 	TtlInSecsUnsetSentinel int64 = math.MinInt64
-	// TtlInSecsUnset is the value internally set for
+	// TypeCacheMaxSizeInMbPerDirectoryUnset is the value internally set for
 	// metadata-cache:type-cache-max-size-mb-per-dir
 	// when it is not set in the gcsfuse mount config file.
 	// The constant value has been chosen deliberately to

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -23,17 +23,12 @@ const (
 	// The constant value has been chosen deliberately
 	// to be improbable for a user to explicitly set.
 	TtlInSecsUnsetSentinel int64 = math.MinInt64
-	// TtlInSecsUnset is set when
+	// TtlInSecsUnset is the value internally set for
 	// metadata-cache:type-cache-max-size-mb-per-dir
-	// is not set
-	// in the gcsfuse mount config file.
+	// when it is not set in the gcsfuse mount config file.
+	// The constant value has been chosen deliberately to
+	// to be improbable for a user to explicitly set.
 	TypeCacheMaxSizeInMbPerDirectoryUnset int = math.MinInt
-	// DefaultTypeCacheMaxSizeInMbPerDirectory is maximum size of
-	// type-cache per directory in MiBs.
-	// This is the value to be used if the user
-	// did not the value of metadata-cache:type-cache-max-size-mb-per-dir
-	// in config file.
-	DefaultTypeCacheMaxSizeInMbPerDirectory int = 16
 )
 
 type WriteConfig struct {
@@ -60,20 +55,10 @@ type MetadataCacheConfig struct {
 	// no cache and > 0 for ttl-controlled metadata-cache.
 	// Any value set below -1 will throw an error.
 	TtlInSeconds int64 `yaml:"ttl-secs,omitempty"`
-	// // TypeCacheMaxEntriesPerDirectory is the upper limit on the number of
-	// // entries of type-cache maps, which are currently
-	// // maintained at per-directory level.
-	// // If this is not set, a default value of
-	// // DefaultTypeCacheMaxEntriesPerDirectory is taken.
-	// // TODO: Delete it.
-	// // This is to be deleted in favour of TypeCacheMaxSizeMbPerDirectory.
-	// TypeCacheMaxEntriesPerDirectory int `yaml:"type-cache-max-entries-per-dir" default:"1048576"`
 	// TypeCacheMaxEntriesPerDirectory is the upper limit
 	// on the maximum size of type-cache maps,
 	// which are currently
 	// maintained at per-directory level.
-	// If this is not set, a default value of
-	// 16 is taken.
 	TypeCacheMaxSizeMbPerDirectory int `yaml:"type-cache-max-size-mb-per-dir,omitempty"`
 }
 

--- a/internal/config/testdata/metadata_cache_config_invalid_type-cache-size.yaml
+++ b/internal/config/testdata/metadata_cache_config_invalid_type-cache-size.yaml
@@ -1,0 +1,2 @@
+metadata-cache:
+  type-cache-max-size-mb-per-dir: -2

--- a/internal/config/testdata/metadata_cache_config_type-cache-size_unset.yaml
+++ b/internal/config/testdata/metadata_cache_config_type-cache-size_unset.yaml
@@ -1,0 +1,2 @@
+metadata-cache:
+

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -10,3 +10,4 @@ file-cache:
   download-file-for-random-read: true
 metadata-cache:
   ttl-secs: 5
+  type-cache-max-size-mb-per-dir: 1

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -35,6 +35,7 @@ const (
 	OFF     LogSeverity = "OFF"
 
 	MetadataCacheTtlSecsInvalidValueError = "the value of ttl-secs for metadata-cache can't be less than -1"
+	TypeCacheSizeNegativeError            = "the value of type-cache-max-size-mb-per-dir for metadata-cache can't be less than 0"
 )
 
 func IsValidLogSeverity(severity LogSeverity) bool {
@@ -60,6 +61,9 @@ func (fileCacheConfig *FileCacheConfig) validate() error {
 
 func (metadataCacheConfig *MetadataCacheConfig) validate() error {
 	if metadataCacheConfig.TtlInSeconds < -1 && metadataCacheConfig.TtlInSeconds != TtlInSecsUnsetSentinel {
+		return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
+	}
+	if metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory < 0 {
 		return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
 	}
 	return nil

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -63,7 +63,7 @@ func (metadataCacheConfig *MetadataCacheConfig) validate() error {
 	if metadataCacheConfig.TtlInSeconds < -1 && metadataCacheConfig.TtlInSeconds != TtlInSecsUnsetSentinel {
 		return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
 	}
-	if metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory < -1 && metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory != TypeCacheMaxSizeInMbPerDirectoryUnset {
+	if metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory < -1 {
 		return fmt.Errorf(TypeCacheMaxSizeMbPerDirInvalidValueError)
 	}
 	return nil

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -34,8 +34,8 @@ const (
 	ERROR   LogSeverity = "ERROR"
 	OFF     LogSeverity = "OFF"
 
-	MetadataCacheTtlSecsInvalidValueError = "the value of ttl-secs for metadata-cache can't be less than -1"
-	TypeCacheSizeNegativeError            = "the value of type-cache-max-size-mb-per-dir for metadata-cache can't be less than 0"
+	MetadataCacheTtlSecsInvalidValueError     = "the value of ttl-secs for metadata-cache can't be less than -1"
+	TypeCacheMaxSizeMbPerDirInvalidValueError = "the value of type-cache-max-size-mb-per-dir for metadata-cache can't be less than -1"
 )
 
 func IsValidLogSeverity(severity LogSeverity) bool {
@@ -63,8 +63,8 @@ func (metadataCacheConfig *MetadataCacheConfig) validate() error {
 	if metadataCacheConfig.TtlInSeconds < -1 && metadataCacheConfig.TtlInSeconds != TtlInSecsUnsetSentinel {
 		return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
 	}
-	if metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory < 0 {
-		return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
+	if metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory < -1 && metadataCacheConfig.TypeCacheMaxSizeMbPerDirectory != TypeCacheMaxSizeInMbPerDirectoryUnset {
+		return fmt.Errorf(TypeCacheMaxSizeMbPerDirInvalidValueError)
 	}
 	return nil
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -88,6 +88,7 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 
 	// metadata-cache config
 	AssertEq(5, mountConfig.MetadataCacheConfig.TtlInSeconds)
+	AssertEq(1, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_InvalidValidLogConfig() {
@@ -117,4 +118,19 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TtlNotSet() {
 	AssertEq(nil, err)
 	AssertNe(nil, mountConfig)
 	AssertEq(TtlInSecsUnsetSentinel, mountConfig.MetadataCacheConfig.TtlInSeconds)
+}
+
+func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_InvalidTypeCacheSize() {
+	_, err := ParseConfigFile("testdata/metadata_cache_config_invalid_type-cache-size.yaml")
+
+	AssertNe(nil, err)
+	AssertThat(err, oglematchers.Error(oglematchers.HasSubstr(MetadataCacheTtlSecsInvalidValueError)))
+}
+
+func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TypeCacheSizeNotSet() {
+	mountConfig, err := ParseConfigFile("testdata/metadata_cache_config_type-cache-size_unset.yaml")
+
+	AssertEq(nil, err)
+	AssertNe(nil, mountConfig)
+	AssertEq(TypeCacheMaxSizeInMbPerDirectoryUnset, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -124,7 +124,7 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_InvalidTypeCache
 	_, err := ParseConfigFile("testdata/metadata_cache_config_invalid_type-cache-size.yaml")
 
 	AssertNe(nil, err)
-	AssertThat(err, oglematchers.Error(oglematchers.HasSubstr(MetadataCacheTtlSecsInvalidValueError)))
+	AssertThat(err, oglematchers.Error(oglematchers.HasSubstr(TypeCacheMaxSizeMbPerDirInvalidValueError)))
 }
 
 func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TypeCacheSizeNotSet() {
@@ -132,5 +132,5 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TypeCacheSizeNot
 
 	AssertEq(nil, err)
 	AssertNe(nil, mountConfig)
-	AssertEq(TypeCacheMaxSizeInMbPerDirectoryUnset, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
+	AssertEq(DefaultTypeCacheMaxSizeInMbPerDirectory, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -278,6 +278,7 @@ func makeRootForBucket(
 		&syncerBucket,
 		fs.mtimeClock,
 		fs.cacheClock,
+		fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory,
 	)
 }
 
@@ -699,7 +700,8 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			fs.dirTypeCacheTTL,
 			ic.Bucket,
 			fs.mtimeClock,
-			fs.cacheClock)
+			fs.cacheClock,
+			fs.mountConfig.TypeCacheMaxSizeMbPerDirectory)
 
 		// Implicit directories
 	case ic.FullName.IsDir():
@@ -721,7 +723,8 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			fs.dirTypeCacheTTL,
 			ic.Bucket,
 			fs.mtimeClock,
-			fs.cacheClock)
+			fs.cacheClock,
+			fs.mountConfig.TypeCacheMaxSizeMbPerDirectory)
 
 	case inode.IsSymlink(ic.Object):
 		in = inode.NewSymlinkInode(

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -701,7 +701,7 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			ic.Bucket,
 			fs.mtimeClock,
 			fs.cacheClock,
-			fs.mountConfig.TypeCacheMaxSizeMbPerDirectory)
+			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
 
 		// Implicit directories
 	case ic.FullName.IsDir():
@@ -724,7 +724,7 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			ic.Bucket,
 			fs.mtimeClock,
 			fs.cacheClock,
-			fs.mountConfig.TypeCacheMaxSizeMbPerDirectory)
+			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMbPerDirectory)
 
 	case inode.IsSymlink(ic.Object):
 		in = inode.NewSymlinkInode(

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -77,7 +77,9 @@ func (t *DirHandleTest) resetDirHandle() {
 		0,     // typeCacheTTL
 		&t.bucket,
 		&t.clock,
-		&t.clock)
+		&t.clock,
+		0,
+	)
 
 	t.dh = NewDirHandle(
 		dirInode,

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -209,7 +209,7 @@ func NewDirInode(
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
-	typeCacheCapacity int) (d DirInode) {
+	typeCacheSizeInMbPerDirectory int) (d DirInode) {
 
 	if !name.IsDir() {
 		panic(fmt.Sprintf("Unexpected name: %s", name))
@@ -224,7 +224,7 @@ func NewDirInode(
 		enableNonexistentTypeCache: enableNonexistentTypeCache,
 		name:                       name,
 		attrs:                      attrs,
-		cache:                      newTypeCache(typeCacheCapacity, typeCacheTTL),
+		cache:                      newTypeCache(typeCacheSizeInMbPerDirectory, typeCacheTTL),
 	}
 
 	typed.lc.Init(id)
@@ -245,9 +245,6 @@ func (d *dirInode) checkInvariants() {
 	if !d.name.IsDir() {
 		panic(fmt.Sprintf("Unexpected name: %s", d.name))
 	}
-
-	// cache.CheckInvariants() does not panic.
-	d.cache.CheckInvariants()
 }
 
 func (d *dirInode) lookUpChildFile(ctx context.Context, name string) (*Core, error) {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -208,16 +208,13 @@ func NewDirInode(
 	typeCacheTTL time.Duration,
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
-	cacheClock timeutil.Clock) (d DirInode) {
+	cacheClock timeutil.Clock,
+	typeCacheCapacity int) (d DirInode) {
 
 	if !name.IsDir() {
 		panic(fmt.Sprintf("Unexpected name: %s", name))
 	}
 
-	// Set up the struct.
-	// Temporarily changing the typeCacheCapacity for read_cache_release branch.
-	// TODO (raj-prince): remove this once we will make it configurable.
-	const typeCacheCapacity = 1 << 22
 	typed := &dirInode{
 		bucket:                     bucket,
 		mtimeClock:                 mtimeClock,
@@ -227,7 +224,7 @@ func NewDirInode(
 		enableNonexistentTypeCache: enableNonexistentTypeCache,
 		name:                       name,
 		attrs:                      attrs,
-		cache:                      newTypeCache(typeCacheCapacity/2, typeCacheTTL),
+		cache:                      newTypeCache(typeCacheCapacity, typeCacheTTL),
 	}
 
 	typed.lc.Init(id)

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -46,6 +46,7 @@ const dirInodeID = 17
 const dirInodeName = "foo/bar/"
 const dirMode os.FileMode = 0712 | os.ModeDir
 const typeCacheTTL = time.Second
+const typeCacheMaxSizeMbPerDirectory = 16
 
 type DirTest struct {
 	ctx    context.Context
@@ -104,7 +105,8 @@ func (t *DirTest) resetInode(implicitDirs bool, enableNonexistentTypeCache bool)
 		typeCacheTTL,
 		&t.bucket,
 		&t.clock,
-		&t.clock)
+		&t.clock,
+		typeCacheMaxSizeMbPerDirectory)
 
 	t.in.Lock()
 }

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -43,7 +43,7 @@ func NewExplicitDirInode(
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
-	typeCacheCapacity int) (d ExplicitDirInode) {
+	typeCacheSizeInMbPerDirectory int) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
 		name,
@@ -54,7 +54,7 @@ func NewExplicitDirInode(
 		bucket,
 		mtimeClock,
 		cacheClock,
-		typeCacheCapacity)
+		typeCacheSizeInMbPerDirectory)
 
 	d = &explicitDirInode{
 		dirInode: wrapped.(*dirInode),

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -42,7 +42,8 @@ func NewExplicitDirInode(
 	typeCacheTTL time.Duration,
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
-	cacheClock timeutil.Clock) (d ExplicitDirInode) {
+	cacheClock timeutil.Clock,
+	typeCacheCapacity int) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
 		name,
@@ -52,7 +53,8 @@ func NewExplicitDirInode(
 		typeCacheTTL,
 		bucket,
 		mtimeClock,
-		cacheClock)
+		cacheClock,
+		typeCacheCapacity)
 
 	d = &explicitDirInode{
 		dirInode: wrapped.(*dirInode),

--- a/internal/fs/inode/type_cache.go
+++ b/internal/fs/inode/type_cache.go
@@ -15,6 +15,7 @@
 package inode
 
 import (
+	"fmt"
 	"math"
 	"time"
 	unsafe "unsafe"
@@ -86,10 +87,13 @@ func newTypeCache(sizeInMB int, ttl time.Duration) typeCache {
 // Insert inserts a record to the cache.
 func (tc *typeCache) Insert(now time.Time, name string, it Type) {
 	if tc.entries != nil {
-		tc.entries.Insert(name, cacheEntry{
+		_, err := tc.entries.Insert(name, cacheEntry{
 			expiry:    now.Add(tc.ttl),
 			inodeType: it,
 		})
+		if err != nil {
+			panic(fmt.Errorf("failed to insert entry in typeCache: %v", err))
+		}
 	}
 }
 

--- a/internal/fs/inode/type_cache.go
+++ b/internal/fs/inode/type_cache.go
@@ -63,17 +63,20 @@ type typeCache struct {
 // Create a cache whose information expires with the supplied TTL. If the TTL
 // is zero, nothing will ever be cached.
 func newTypeCache(sizeInMB int, ttl time.Duration) typeCache {
-	if sizeInMB < -1 {
-		panic("unhandled scenario: type-cache-max-size-mb-per-dir < -1")
+	if ttl > 0 && sizeInMB != 0 {
+		if sizeInMB < -1 {
+			panic("unhandled scenario: type-cache-max-size-mb-per-dir < -1")
+		}
+		var lruSizeInBytesToUse uint64 = math.MaxUint64 // default for when sizeInMb = -1, increasing
+		if sizeInMB > 0 {
+			lruSizeInBytesToUse = util.MiBsToBytes(uint64(sizeInMB))
+		}
+		return typeCache{
+			ttl:     ttl,
+			entries: lru.NewCache(lruSizeInBytesToUse),
+		}
 	}
-	var lruSizeInBytesToUse uint64 = math.MaxUint64 // default for when sizeInMb = -1, increasing 
-	if sizeInMB > 0 {
-		lruSizeInBytesToUse = util.MibToBytes(uint64(sizeInMB))
-	}
-	return typeCache{
-		ttl:     ttl,
-		entries: lru.NewCache(lruSizeInBytesToUse),
-	}
+	return typeCache{}
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -82,23 +85,27 @@ func newTypeCache(sizeInMB int, ttl time.Duration) typeCache {
 
 // Insert inserts a record to the cache.
 func (tc *typeCache) Insert(now time.Time, name string, it Type) {
-	// Are we disabled?
-	if tc.ttl == 0 {
-		return
+	if tc.entries != nil {
+		tc.entries.Insert(name, cacheEntry{
+			expiry:    now.Add(tc.ttl),
+			inodeType: it,
+		})
 	}
-	tc.entries.Insert(name, cacheEntry{
-		expiry:    now.Add(tc.ttl),
-		inodeType: it,
-	})
 }
 
 // Erase erases all information about the supplied name.
 func (tc *typeCache) Erase(name string) {
-	tc.entries.Erase(name)
+	if tc.entries != nil {
+		tc.entries.Erase(name)
+	}
 }
 
 // Get gets the record for the given name.
 func (tc *typeCache) Get(now time.Time, name string) Type {
+	if tc.entries == nil {
+		return UnknownType
+	}
+
 	val := tc.entries.LookUp(name)
 	if val == nil {
 		return UnknownType

--- a/internal/fs/inode/type_cache_test.go
+++ b/internal/fs/inode/type_cache_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/internal/util"
+	. "github.com/jacobsa/ogletest"
+)
+
+const (
+	TTL time.Duration = time.Millisecond
+)
+
+var (
+	now               time.Time = time.Now()
+	expiration        time.Time = now.Add(TTL)
+	beforeExpiration  time.Time = expiration.Add(-time.Nanosecond)
+	afterExpiration   time.Time = expiration.Add(time.Nanosecond)
+	now2              time.Time = now.Add(TTL / 2)
+	expiration2       time.Time = now2.Add(TTL)
+	beforeExpiration2 time.Time = expiration2.Add(-time.Nanosecond)
+)
+
+func TestTypeCache(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type TypeCacheTest struct {
+	cache *typeCache
+	ttl   time.Duration
+}
+
+type ZeroSizeTypeCacheTest struct {
+	cache *typeCache
+	ttl   time.Duration
+}
+
+type ZeroTtlTypeCacheTest struct {
+	cache *typeCache
+}
+
+func init() {
+	RegisterTestSuite(&TypeCacheTest{})
+	RegisterTestSuite(&ZeroSizeTypeCacheTest{})
+	RegisterTestSuite(&ZeroTtlTypeCacheTest{})
+}
+
+func (t *TypeCacheTest) SetUp(ti *TestInfo) {
+	t.ttl = TTL
+	t.cache = createNewTypeCache(1, t.ttl)
+}
+
+func (t *ZeroSizeTypeCacheTest) SetUp(ti *TestInfo) {
+	t.ttl = TTL
+	t.cache = createNewTypeCache(0, t.ttl)
+}
+
+func (t *ZeroTtlTypeCacheTest) SetUp(ti *TestInfo) {
+	t.cache = createNewTypeCache(1, 0)
+}
+
+func (t *TypeCacheTest) TearDown() {
+}
+
+func (t *ZeroSizeTypeCacheTest) TearDown() {
+}
+
+func (t *ZeroTtlTypeCacheTest) TearDown() {
+}
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func createNewTypeCache(sizeInMB int, ttl time.Duration) *typeCache {
+	tc := newTypeCache(sizeInMB, ttl)
+	AssertNe(nil, &tc)
+	return &tc
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests for regulat TypeCache - TypeCacheTest
+////////////////////////////////////////////////////////////////////////
+
+func (t *TypeCacheTest) TestNewTypeCache() {
+	input := []struct {
+		sizeInMb           int
+		ttl                time.Duration
+		entriesShouldBeNil bool
+	}{
+		{
+			sizeInMb:           0,
+			ttl:                time.Second,
+			entriesShouldBeNil: true,
+		},
+		{
+			sizeInMb:           1,
+			ttl:                0,
+			entriesShouldBeNil: true,
+		},
+		{
+			sizeInMb: -1,
+			ttl:      time.Second,
+		},
+		{
+			sizeInMb: 1,
+			ttl:      time.Second,
+		}}
+
+	for _, input := range input {
+		tc := createNewTypeCache(input.sizeInMb, input.ttl)
+		AssertEq(input.entriesShouldBeNil, tc.entries == nil)
+	}
+}
+
+func (t *TypeCacheTest) TestGetFromEmptyTypeCache() {
+	ExpectEq(UnknownType, t.cache.Get(now, "abc"))
+}
+
+func (t *TypeCacheTest) TestGetUninsertedEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	ExpectEq(UnknownType, t.cache.Get(beforeExpiration, "abc"))
+}
+
+func (t *TypeCacheTest) TestGetOverwrittenEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	t.cache.Insert(now, "abcd", ExplicitDirType)
+	ExpectEq(ExplicitDirType, t.cache.Get(beforeExpiration, "abcd"))
+}
+
+func (t *TypeCacheTest) TestGetBeforeTtlExpiration() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	ExpectEq(RegularFileType, t.cache.Get(beforeExpiration, "abcd"))
+}
+
+func (t *TypeCacheTest) TestGetAfterTtlExpiration() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	ExpectEq(UnknownType, t.cache.Get(afterExpiration, "abcd"))
+}
+
+func (t *TypeCacheTest) TestGetAfterSizeExpiration() {
+	entriesToBeInserted := int(util.MiBsToBytes(1)/cacheEntry{}.Size()) + 1
+
+	for i := 0; i < entriesToBeInserted; i++ {
+		t.cache.Insert(now, fmt.Sprint(i), RegularFileType)
+	}
+
+	// Verify that Get works by accessing the last entry inserted.
+	ExpectEq(RegularFileType, t.cache.Get(beforeExpiration, fmt.Sprint(entriesToBeInserted-1)))
+
+	// The first inserted entry should have been evicted by all the
+	ExpectEq(UnknownType, t.cache.Get(beforeExpiration, fmt.Sprint(0)))
+}
+
+func (t *TypeCacheTest) TestGetErasedEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	t.cache.Erase("abcd")
+	ExpectEq(UnknownType, t.cache.Get(beforeExpiration, "abcd"))
+}
+
+func (t *TypeCacheTest) TestGetReinsertedEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	t.cache.Erase("abcd")
+	t.cache.Insert(now2, "abcd", ExplicitDirType)
+	ExpectEq(ExplicitDirType, t.cache.Get(beforeExpiration2, "abcd"))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests for TypeCache created with size=0 - ZeroSizeTypeCacheTest
+////////////////////////////////////////////////////////////////////////
+
+func (t *ZeroSizeTypeCacheTest) TestGetFromEmptyTypeCache() {
+	ExpectEq(UnknownType, t.cache.Get(now, "abc"))
+}
+
+func (t *ZeroSizeTypeCacheTest) TestGetInsertedEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	ExpectEq(UnknownType, t.cache.Get(beforeExpiration, "abcd"))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests for TypeCache created with ttl=0 - ZeroTtlTypeCacheTest
+////////////////////////////////////////////////////////////////////////
+
+func (t *ZeroTtlTypeCacheTest) TestGetFromEmptyTypeCache() {
+	ExpectEq(UnknownType, t.cache.Get(now, "abc"))
+}
+
+func (t *ZeroTtlTypeCacheTest) TestGetInsertedEntry() {
+	t.cache.Insert(now, "abcd", RegularFileType)
+	ExpectEq(UnknownType, t.cache.Get(beforeExpiration, "abcd"))
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -80,3 +80,15 @@ func ResolveConfigFilePaths(config *config.MountConfig) (err error) {
 	}
 	return
 }
+
+// MibToBytes returns the bytes equivalent
+// of given no.s of MiBs (Mibi Bytes).
+// For reference, each MiB = 2^20 bytes.
+// It supports only upto 2^44-1 MiBs (~4 Tebi MiBs, or ~4 Ebi bytes)
+// as inputs, and panics for higher inputs.
+func MibToBytes(mib uint64) uint64 {
+	if mib > 0xFFFFFFFFFFF {
+		panic("Inputs above (2^44 - 1) not supported.")
+	}
+	return mib << 20
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -30,6 +31,8 @@ const GCSFUSE_PARENT_PROCESS_DIR = "gcsfuse-parent-process-dir"
 // Constants for read types - Sequential/Random
 const Sequential = "Sequential"
 const Random = "Random"
+
+const MaxMiBsInMaxUint64 uint64 = math.MaxUint64 >> 20
 
 // 1. Returns the same filepath in case of absolute path or empty filename.
 // 2. For child process, it resolves relative path like, ./test.txt, test.txt
@@ -81,13 +84,13 @@ func ResolveConfigFilePaths(config *config.MountConfig) (err error) {
 	return
 }
 
-// MibToBytes returns the bytes equivalent
+// MiBsToBytes returns the bytes equivalent
 // of given no.s of MiBs (Mibi Bytes).
 // For reference, each MiB = 2^20 bytes.
-// It supports only upto 2^44-1 MiBs (~4 Tebi MiBs, or ~4 Ebi bytes)
+// It supports only upto MaxMiBsInMaxUint64 (2^44-1) MiBs (~4 Tebi MiBs, or ~4 Ebi bytes)
 // as inputs, and panics for higher inputs.
-func MibToBytes(mib uint64) uint64 {
-	if mib > 0xFFFFFFFFFFF {
+func MiBsToBytes(mib uint64) uint64 {
+	if mib > MaxMiBsInMaxUint64 {
 		panic("Inputs above (2^44 - 1) not supported.")
 	}
 	return mib << 20

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -157,3 +157,35 @@ func (t *UtilTest) TestResolveConfigFilePaths() {
 	AssertEq(nil, err)
 	ExpectEq(filepath.Join(homeDir, "test.txt"), mountConfig.LogConfig.FilePath)
 }
+
+func (t *UtilTest) TestMibToBytes() {
+	cases := []struct {
+		mib   uint64
+		bytes uint64
+	}{
+		{
+			mib:   0,
+			bytes: 0,
+		},
+		{
+			mib:   1,
+			bytes: 1048576,
+		},
+		{
+			mib:   5,
+			bytes: 5242880,
+		},
+		{
+			mib:   1024,
+			bytes: 1073741824,
+		},
+		{
+			mib:   0xFFFFFFFFFFF,      // 2^44 - 1
+			bytes: 0xFFFFFFFFFFF00000, // 2^20 * (2^44 - 1)
+		},
+	}
+
+	for _, tc := range cases {
+		AssertEq(tc.bytes, MibToBytes(tc.mib))
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -158,7 +158,7 @@ func (t *UtilTest) TestResolveConfigFilePaths() {
 	ExpectEq(filepath.Join(homeDir, "test.txt"), mountConfig.LogConfig.FilePath)
 }
 
-func (t *UtilTest) TestMibToBytes() {
+func (t *UtilTest) TestMiBsToBytes() {
 	cases := []struct {
 		mib   uint64
 		bytes uint64
@@ -180,12 +180,12 @@ func (t *UtilTest) TestMibToBytes() {
 			bytes: 1073741824,
 		},
 		{
-			mib:   0xFFFFFFFFFFF,      // 2^44 - 1
-			bytes: 0xFFFFFFFFFFF00000, // 2^20 * (2^44 - 1)
+			mib:   17592186044415,       // MaxMiBsInMaxUint64 i.e. 2^44 - 1
+			bytes: 18446744073708503040, // 0xFFFFFFFFFFF00000, i.e. 2^20 * (2^44 - 1)
 		},
 	}
 
 	for _, tc := range cases {
-		AssertEq(tc.bytes, MibToBytes(tc.mib))
+		AssertEq(tc.bytes, MiBsToBytes(tc.mib))
 	}
 }


### PR DESCRIPTION
### Description

This adds on top of https://github.com/GoogleCloudPlatform/gcsfuse/pull/1545 .

This change adds the following in GCSFuse config file.

```
metadata-cache: # pre-existing
	type-cache-max-size-mb-per-dir: # new
```

This makes the max size of type-cache configurable at per directory level.

This change adds on top of https://github.com/GoogleCloudPlatform/gcsfuse/pull/1545 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing.
2. Unit tests - Ran locally. Added new tests.
3. Integration tests - Through presubmits.
