### PR TITLE
Lower freq of syncs in periodic-perf-tests

### DIFF
--- a/perfmetrics/scripts/job_files/seq_rand_read_write.fio
+++ b/perfmetrics/scripts/job_files/seq_rand_read_write.fio
@@ -34,6 +34,7 @@ directory=gcs/256kb
 filesize=256k
 rw=write
 numjobs=40
+fsync=16
 
 [3_thread]
 stonewall
@@ -49,6 +50,7 @@ directory=gcs/3mb
 filesize=3M
 rw=write
 numjobs=40
+fsync=3
 
 [5_thread]
 stonewall
@@ -64,6 +66,7 @@ directory=gcs/5mb
 filesize=5M
 rw=write
 numjobs=40
+fsync=5
 
 [7_thread]
 stonewall
@@ -79,6 +82,7 @@ directory=gcs/50mb
 filesize=50M
 rw=write
 numjobs=40
+fsync=50
 
 [9_thread]
 stonewall
@@ -97,6 +101,7 @@ directory=gcs/256kb
 filesize=256k
 rw=randwrite
 numjobs=40
+fsync=16
 
 [11_thread]
 stonewall
@@ -113,6 +118,7 @@ directory=gcs/3mb
 filesize=3M
 rw=randwrite
 numjobs=40
+fsync=3
 
 [13_thread]
 stonewall
@@ -129,6 +135,7 @@ directory=gcs/5mb
 filesize=5M
 rw=randwrite
 numjobs=40
+fsync=5
 
 [15_thread]
 stonewall
@@ -145,3 +152,4 @@ directory=gcs/50mb
 filesize=50M
 rw=randwrite
 numjobs=40
+fsync=50


### PR DESCRIPTION
### Description
This is for internal bug id 316284545 .
Currently in the periodic perf tests, we
fsync after each write (set through fsync=1)
in all write tests. This poses two problems.

1. It underrates our write bandwidth as most of the runtime is spent in the sync calls and
little in the actual write operation.
2. This causes frequent sync which result in frequent object generations on GCS, which is
throttled by GCS.

This change should address both these problems.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
