### PR TITLE
Fixing printing gcsfuse pid bug in the script

### DIFF
--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -89,8 +89,8 @@ gcsfuse --stackdriver-export-interval 30s \
         --config-file ./config.yml \
         $bucket_name $mount_dir
 
-
-gcsfuseID=$(ps -ax | grep "gcsfuse" | head -n 1 | awk '{print $1}')
+# Using "gcsfuse --foreground" as grep search query to uniquely identify gcsfuse running process.
+gcsfuseID=$(ps -ax | grep "gcsfuse --foreground" | head -n 1 | awk '{print $1}')
 echo "Running GCSFuse process-id: $gcsfuseID"
 
 # Back to old dir in the last.


### PR DESCRIPTION
### Description
As we run the grep command as part of mount_gcsfuse process, hence, we used to print the pid of mount_gcsfuse process.
Corrected by using more gcsfuse specific grep search to uniquely identify the currently running gcsfuse process.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
