### PR TITLE
upgrade to go 1.21.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.21.4-alpine as builder
+FROM golang:1.21.5-alpine as builder
 
 RUN apk add git
 

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -17,7 +17,7 @@ PYTORCH_VESRION=$1
 NUM_EPOCHS=80
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -5,7 +5,7 @@
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -34,8 +34,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.21.4
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-amd64.tar.gz -q
+echo Installing go-lang  1.21.5
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -27,8 +27,8 @@ run_e2e_tests_on_package=$1
 
 # e.g. architecture=arm64 or amd64
 architecture=$(dpkg --print-architecture)
-echo "Installing go-lang 1.21.4..."
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-${architecture}.tar.gz -q
+echo "Installing go-lang 1.21.5..."
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.5.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 # install python3-setuptools tools.

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.4.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.21.5.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.21.4 as gcsfuse-package
+FROM golang:1.21.5 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.21.4 as builder
+FROM golang:1.21.5 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 


### PR DESCRIPTION
### Description
Upgrade to go-lang version 1.21.5

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Ran as part of presubmits (passed)
3. Integration tests - Ran as part of presubmits (passed)
4. Perf tests: 
![golang-perf](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/0e3b7ba1-4072-4fa0-b184-7ef1979c7db7)
 (no regression)
