### PR TITLE
Change LRU in file cache on every request from kernel

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -120,11 +120,11 @@ func (fch *CacheHandle) checkEntryInFileInfoCache(bucket gcs.Bucket, object *gcs
 		return err
 	}
 	fileInfoData := fileInfo.(data.FileInfo)
-	if requiredOffset > int64(fileInfoData.Offset) {
-		err = fmt.Errorf("%v: required offset: %v is greater than offset in cache: %v", util.FallbackToGCSErrMsg, requiredOffset, fileInfoData.Offset)
-		return err
-	} else if fileInfoData.ObjectGeneration != object.Generation {
+	if fileInfoData.ObjectGeneration != object.Generation {
 		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.InvalidFileInfoCacheErrMsg, fileInfoData.ObjectGeneration, object.Generation)
+		return err
+	} else if requiredOffset > int64(fileInfoData.Offset) {
+		err = fmt.Errorf("%v: required offset: %v is greater than offset in cache: %v", util.FallbackToGCSErrMsg, requiredOffset, fileInfoData.Offset)
 		return err
 	}
 

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -537,6 +537,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	// First let the cache populated (we are doing this so that we can externally
 	// modify file info cache for this unit test without hampering download job).
 	_, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	AssertEq(nil, err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectGe(jobStatus.Offset, ReadContentSize)
 	fileInfoKey := data.FileInfoKey{
@@ -561,6 +562,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	// First let the cache populated (we are doing this so that we can externally
 	// modify file info cache for this unit test without hampering download job).
 	_, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	AssertEq(nil, err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectGe(jobStatus.Offset, ReadContentSize)
 	fileInfoKey := data.FileInfoKey{
@@ -589,6 +591,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoOffsetChanged() {
 	// First let the cache populated (we are doing this so that we can externally
 	// modify file info cache for this unit test without hampering download job).
 	_, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	AssertEq(nil, err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectGe(jobStatus.Offset, ReadContentSize)
 	fileInfoKey := data.FileInfoKey{

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -470,7 +470,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_Truncates() {
 	buf := make([]byte, 3)
 	ctx := context.Background()
 	// Read to populate cache
-	_, err = cacheHandle.Read(ctx, minObject, 0, buf)
+	_, err = cacheHandle.Read(ctx, chrT.bucket, minObject, 0, buf)
 	AssertEq(nil, err)
 	AssertEq(string(objectContent[:3]), string(buf))
 	AssertEq(nil, cacheHandle.Close())
@@ -596,9 +596,9 @@ func (chrT *cacheHandlerTest) Test_Destroy() {
 	ctx := context.Background()
 	// Read to create and populate file in cache.
 	buf := make([]byte, 3)
-	_, err = cacheHandle1.Read(ctx, minObject1, 4, buf)
+	_, err = cacheHandle1.Read(ctx, chrT.bucket, minObject1, 4, buf)
 	AssertEq(nil, err)
-	_, err = cacheHandle2.Read(ctx, minObject2, 4, buf)
+	_, err = cacheHandle2.Read(ctx, chrT.bucket, minObject2, 4, buf)
 	AssertEq(nil, err)
 	err = cacheHandle1.Close()
 	AssertEq(nil, err)

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -224,6 +224,7 @@ func (t *FileCacheTest) ReadShouldChangeLRU() {
 	// Read file 1, so file 2 becomes LRU and then read file 3. Doing this should
 	// evict file 2 and not file 1.
 	_, err = fileHandle1.ReadAt(buf, 0)
+	AssertEq(nil, err)
 	AssertEq(string(buf), objectContent1[0:len(buf)])
 	fileHandle3, err := os.OpenFile(path.Join(mntDir, objectName3), os.O_RDONLY|syscall.O_DIRECT, 0644)
 	defer closeFile(fileHandle3)

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -203,11 +203,13 @@ func (t *FileCacheTest) ReadShouldChangeLRU() {
 	defer closeFile(fileHandle1)
 	AssertEq(nil, err)
 	_, err = fileHandle1.ReadAt(buf, 0)
+	AssertEq(nil, err)
 	AssertEq(string(buf), objectContent1[0:len(buf)])
 	fileHandle2, err := os.OpenFile(path.Join(mntDir, objectName2), os.O_RDONLY|syscall.O_DIRECT, 0644)
 	defer closeFile(fileHandle2)
 	AssertEq(nil, err)
 	_, err = fileHandle2.ReadAt(buf, 0)
+	AssertEq(nil, err)
 	AssertEq(string(buf), objectContent2[0:len(buf)])
 	// Assert cache files are created.
 	objectPath1 := util.GetObjectPath(bucket.Name(), objectName1)
@@ -227,6 +229,7 @@ func (t *FileCacheTest) ReadShouldChangeLRU() {
 	defer closeFile(fileHandle3)
 	AssertEq(nil, err)
 	_, err = fileHandle3.ReadAt(buf, 0)
+	AssertEq(nil, err)
 	AssertEq(string(buf), objectContent3[0:len(buf)])
 
 	// Cache for file 2 should be evicted.

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -184,6 +184,59 @@ func sequentialToRandomReadShouldPopulateCache(t *fsTest) {
 	AssertTrue(reflect.DeepEqual(cachedContent[offsetForRandom:offsetForRandom+util.MiB], buf))
 }
 
+func (t *FileCacheTest) ReadShouldChangeLRU() {
+	objectName1 := DefaultObjectName + "1"
+	objectContent1 := generateRandomString(DefaultObjectSizeInMb * util.MiB)
+	objectName2 := DefaultObjectName + "2"
+	objectContent2 := generateRandomString((FileCacheSizeInMb - DefaultObjectSizeInMb) * util.MiB)
+	objectName3 := DefaultObjectName + "3"
+	objectContent3 := generateRandomString(DefaultObjectSizeInMb * util.MiB)
+	// Check that file 3 size should be <= min(file size 1, file size 2)
+	AssertLe(len(objectContent3), len(objectContent1))
+	AssertLe(len(objectContent3), len(objectContent2))
+	objects := map[string]string{objectName1: objectContent1, objectName2: objectContent2, objectName3: objectContent3}
+	err := t.createObjects(objects)
+	AssertEq(nil, err)
+	// Open and read files for object 1 & 2, filet 1 should be LRU after that.
+	buf := make([]byte, 10)
+	fileHandle1, err := os.OpenFile(path.Join(mntDir, objectName1), os.O_RDONLY|syscall.O_DIRECT, 0644)
+	defer closeFile(fileHandle1)
+	AssertEq(nil, err)
+	_, err = fileHandle1.ReadAt(buf, 0)
+	AssertEq(string(buf), objectContent1[0:len(buf)])
+	fileHandle2, err := os.OpenFile(path.Join(mntDir, objectName2), os.O_RDONLY|syscall.O_DIRECT, 0644)
+	defer closeFile(fileHandle2)
+	AssertEq(nil, err)
+	_, err = fileHandle2.ReadAt(buf, 0)
+	AssertEq(string(buf), objectContent2[0:len(buf)])
+	// Assert cache files are created.
+	objectPath1 := util.GetObjectPath(bucket.Name(), objectName1)
+	downloadPath1 := util.GetDownloadPath(FileCacheLocation, objectPath1)
+	objectPath2 := util.GetObjectPath(bucket.Name(), objectName2)
+	downloadPath2 := util.GetDownloadPath(FileCacheLocation, objectPath2)
+	_, err = os.Stat(downloadPath1)
+	AssertEq(nil, err)
+	_, err = os.Stat(downloadPath2)
+	AssertEq(nil, err)
+
+	// Read file 1, so file 2 becomes LRU and then read file 3. Doing this should
+	// evict file 2 and not file 1.
+	_, err = fileHandle1.ReadAt(buf, 0)
+	AssertEq(string(buf), objectContent1[0:len(buf)])
+	fileHandle3, err := os.OpenFile(path.Join(mntDir, objectName3), os.O_RDONLY|syscall.O_DIRECT, 0644)
+	defer closeFile(fileHandle3)
+	AssertEq(nil, err)
+	_, err = fileHandle3.ReadAt(buf, 0)
+	AssertEq(string(buf), objectContent3[0:len(buf)])
+
+	// Cache for file 2 should be evicted.
+	_, err = os.Stat(downloadPath2)
+	AssertTrue(os.IsNotExist(err))
+	// Cache for file 1 shouldn't be evicted.
+	_, err = os.Stat(downloadPath1)
+	AssertEq(nil, err)
+}
+
 func (t *FileCacheTest) SequentialReadShouldPopulateCache() {
 	sequentialReadShouldPopulateCache(&t.fsTest, FileCacheLocation)
 }

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -219,7 +219,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		}
 	}
 
-	n, err = rr.fileCacheHandle.Read(ctx, rr.object, offset, p)
+	n, err = rr.fileCacheHandle.Read(ctx, rr.bucket, rr.object, offset, p)
 	if err == nil {
 		cacheHit = true
 		return

--- a/perfmetrics/scripts/job_files/presubmit_perf_test.fio
+++ b/perfmetrics/scripts/job_files/presubmit_perf_test.fio
@@ -85,34 +85,4 @@ filesize=50M
 rw=randwrite
 numjobs=40
 
-[1gb_read]
-stonewall
-startdelay=1520
-directory=gcs/1gb
-filesize=1G
-rw=read
-numjobs=40
 
-[1gb_write]
-stonewall
-startdelay=1710
-directory=gcs/1gb
-filesize=1G
-rw=write
-numjobs=40
-
-[1gb_randread]
-stonewall
-startdelay=1900
-directory=gcs/1gb
-filesize=1G
-rw=randread
-numjobs=40
-
-[1gb_randwrite]
-stonewall
-startdelay=2090
-directory=gcs/1gb
-filesize=1G
-rw=randwrite
-numjobs=40

--- a/perfmetrics/scripts/job_files/presubmit_perf_test.fio
+++ b/perfmetrics/scripts/job_files/presubmit_perf_test.fio
@@ -85,4 +85,34 @@ filesize=50M
 rw=randwrite
 numjobs=40
 
+[1gb_read]
+stonewall
+startdelay=1520
+directory=gcs/1gb
+filesize=1G
+rw=read
+numjobs=40
 
+[1gb_write]
+stonewall
+startdelay=1710
+directory=gcs/1gb
+filesize=1G
+rw=write
+numjobs=40
+
+[1gb_randread]
+stonewall
+startdelay=1900
+directory=gcs/1gb
+filesize=1G
+rw=randread
+numjobs=40
+
+[1gb_randwrite]
+stonewall
+startdelay=2090
+directory=gcs/1gb
+filesize=1G
+rw=randwrite
+numjobs=40

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -47,7 +47,12 @@ git fetch origin -q
 
 function execute_perf_test() {
   mkdir -p gcs
-  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+  echo "file-cache:
+       max-size-in-mb: -1
+       download-file-for-random-read: true
+cache-location: ./cache-dir
+       " > /tmp/gcsfuse_config.yaml
+  GCSFUSE_FLAGS="--config-file /tmp/gcsfuse_config.yaml --implicit-dirs --max-conns-per-host 100"
   BUCKET_NAME=presubmit-perf-tests
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.
@@ -78,7 +83,7 @@ if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Executing perf tests for master branch
  install_requirements
- git checkout master
+ git checkout read_cache_release
  # Store results
  touch result.txt
  echo Mounting gcs bucket for master branch and execute tests

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -50,7 +50,7 @@ function execute_perf_test() {
   echo "file-cache:
        max-size-in-mb: -1
        download-file-for-random-read: true
-cache-location: ./cache-dir
+cache-location: ./tmp/cache-dir
        " > /tmp/gcsfuse_config.yaml
   GCSFUSE_FLAGS="--config-file /tmp/gcsfuse_config.yaml --implicit-dirs --max-conns-per-host 100"
   BUCKET_NAME=presubmit-perf-tests

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -48,7 +48,7 @@ git fetch origin -q
 function execute_perf_test() {
   mkdir -p gcs
   echo "file-cache:
-       max-size-in-mb: -1
+       max-size-in-mb: 40960
        download-file-for-random-read: true
 cache-location: ./tmp/cache-dir
        " > /tmp/gcsfuse_config.yaml

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -47,21 +47,14 @@ git fetch origin -q
 
 function execute_perf_test() {
   mkdir -p gcs
-  echo "file-cache:
-       max-size-in-mb: 40960
-       download-file-for-random-read: true
-cache-location: ./tmp/cache-dir
-       " > /tmp/gcsfuse_config.yaml
-  GCSFUSE_FLAGS="--config-file /tmp/gcsfuse_config.yaml --implicit-dirs --max-conns-per-host 100"
+  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
   BUCKET_NAME=presubmit-perf-tests
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.
   go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
-  git checkout change_lru_order
   # Running FIO test
   ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
   sudo umount gcs
-  sleep 10s
 }
 
 function install_requirements() {
@@ -85,7 +78,7 @@ if [[ "$perfTestStr" == *"$EXECUTE_PERF_TEST_LABEL"* ]];
 then
  # Executing perf tests for master branch
  install_requirements
- git checkout read_cache_release
+ git checkout master
  # Store results
  touch result.txt
  echo Mounting gcs bucket for master branch and execute tests

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -57,6 +57,7 @@ cache-location: ./tmp/cache-dir
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.
   go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
+  git checkout change_lru_order
   # Running FIO test
   ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
   sudo umount gcs

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -60,6 +60,7 @@ cache-location: ./cache-dir
   # Running FIO test
   ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
   sudo umount gcs
+  sleep 10s
 }
 
 function install_requirements() {


### PR DESCRIPTION
### Description
Change LRU in file cache on every request from kernel. Also replaced file.Seek + io.ReadFull with file.ReadAt along with a check that number of bytes read into dst buffer is equal to requested number of bytes.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added for LRU order.
3. Integration tests - Ran existing integration tests [here](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/28180e6a-2ac8-4dfe-9ba2-dc092fbf03a9)
