### PR TITLE
Fixing script to fix the lazy deletion issue in file-cache

### DIFF
--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -64,6 +64,13 @@ mkdir -p $mount_dir
 if mountpoint -q -- "$mount_dir"; then
   echo "Unmounting previous mount..."
   umount $mount_dir
+
+  # Allowing sufficient time for the completion of the previous unmount process.
+  # Why? - Intermittent failures have been observed in the file-cache flow, particularly
+  # when the next mount occurs immediately after the unmount. By default, the unmount happens
+  # lazily, and during this process, the cache folder is deleted. This lazy deletion causes
+  # issues in the subsequent mount process.
+  sleep 10
 fi
 
 # Generate yml config.

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -66,10 +66,13 @@ if mountpoint -q -- "$mount_dir"; then
   umount $mount_dir
 
   # Allowing sufficient time for the completion of the previous unmount process.
-  # Why? - Intermittent failures have been observed in the file-cache flow, particularly
-  # when the next mount occurs immediately after the unmount. By default, the unmount happens
-  # lazily, and during this process, the cache folder is deleted. This lazy deletion causes
-  # issues in the subsequent mount process.
+  # Why? - Sporadic failures have been observed within the file-cache flow, particularly
+  # when the subsequent mount operation immediately follows the unmount operation. By default,
+  # the unmount process occurs lazily, during which time the cache folder is deleted.
+  # This lazy deletion creates challenges in the subsequent mount process. Specifically,
+  # it is possible that the lazy deletion will delete a file after it has been created during
+  # the next mount operation. This results in an inconsistency where the fileInfoCache contains
+  # an entry for a file that is no longer present on the system.
   sleep 10
 fi
 


### PR DESCRIPTION
### Description
Adding sleep after the unmount

Why?
Sporadic failures have been observed within the file-cache flow, particularly when the subsequent mount operation immediately follows the unmount operation. By default, the unmount process occurs lazily, during which time the cache folder is deleted. This lazy deletion creates challenges in the subsequent mount process. Specifically, it is possible that the lazy deletion will delete a file after it has been created during the next mount operation. This results in an inconsistency where the fileInfoCache contains an entry for a file that is no longer present on the system.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
