### PR TITLE
Fix behaviour for boundary values of stat cache capacity

### DIFF
--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"path"
 	"time"
 
@@ -83,11 +84,21 @@ type bucketManager struct {
 }
 
 func NewBucketManager(config BucketConfig, storageHandle storage.StorageHandle) BucketManager {
-	var c *lru.Cache
+	var statCacheSize uint64
 	if config.StatCacheCapacity > 0 {
-		// This conversion is temporary until config.StatCacheCapacity itself is replaced
+		// This conversion from capacity to size is temporary until
+		// config.StatCacheCapacity itself is replaced
 		// with config.StatCacheSizeMB, which is a planned change.
-		statCacheSize := uint64(config.StatCacheCapacity) * metadata.StatCacheEntrySize()
+		statCacheSize = uint64(config.StatCacheCapacity) * metadata.StatCacheEntrySize()
+	} else if config.StatCacheCapacity == -1 {
+		// stat-cache-capacity at -1 implies that the stat-cache
+		// size is unlimited. Using MaxUint64
+		// here to represent infinity for all practical purposes.
+		statCacheSize = math.MaxUint64
+	}
+
+	var c *lru.Cache
+	if statCacheSize > 0 {
 		c = lru.NewCache(statCacheSize)
 	}
 


### PR DESCRIPTION
### Description
It does the following.
1. If stat-cache-capacity is passed as -1, it uses math.Uint64 as size to make size effectively infinite.
2. If stat-cache-capacity is passed as 0, then the shared stat-cache is not 0, which will effectively disable it by not creating fastStatBucket for bucket (in case of static-mount), or for any of the buckets (in case of dynamic-mount).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing
2. Unit tests - Ran locally and passed. No new tests.
3. Integration tests - Ran through presubmits.
