### PR TITLE
[DontReview] Fix behavior for boundary values of stat cache capacity

### DIFF
--- a/internal/fs/inode/type_cache.go
+++ b/internal/fs/inode/type_cache.go
@@ -54,7 +54,7 @@ type typeCache struct {
 }
 
 // Create a cache whose information expires with the supplied TTL. If the TTL
-// is zero, nothing will ever be cached.
+// or size, either is zero, nothing will ever be cached.
 func newTypeCache(perTypeCapacity int, ttl time.Duration) typeCache {
 	return typeCache{
 		ttl:     ttl,

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"path"
 	"time"
 
@@ -89,11 +88,6 @@ func createStatCacheLru(statCacheCapacity int) *lru.Cache {
 		// This conversion from capacity to size will not be needed when
 		/// StatCacheCapacity is replaced with StatCacheSizeMB
 		statCacheSize = uint64(statCacheCapacity) * metadata.StatCacheEntrySize()
-	} else if statCacheCapacity == -1 {
-		// stat-cache-capacity at -1 implies that the stat-cache
-		// size is unlimited. Using MaxUint64
-		// here to represent infinity for all practical purposes.
-		statCacheSize = math.MaxUint64
 	}
 
 	var c *lru.Cache

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -42,6 +42,30 @@ func (t *BucketManagerTest) TearDown() {
 	t.fakeStorage.ShutDown()
 }
 
+func (t *BucketManagerTest) TestCreateStatCacheLru() {
+	inputs := []struct {
+		capacity int
+		isNil    bool
+	}{
+		{
+			capacity: 0,
+			isNil:    true,
+		},
+		{
+			capacity: -1,
+			isNil:    false,
+		},
+		{
+			capacity: 10,
+			isNil:    false,
+		},
+	}
+
+	for _, input := range inputs {
+		AssertEq(input.isNil, createStatCacheLru(input.capacity) == nil)
+	}
+}
+
 func (t *BucketManagerTest) TestNewBucketManagerMethod() {
 	bucketConfig := BucketConfig{
 		BillingProject:                     "BillingProject",

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -52,10 +52,6 @@ func (t *BucketManagerTest) TestCreateStatCacheLru() {
 			isNil:    true,
 		},
 		{
-			capacity: -1,
-			isNil:    false,
-		},
-		{
 			capacity: 10,
 			isNil:    false,
 		},


### PR DESCRIPTION
### Description
Handle stat-cache-capacity 0 or -1

It does the following.
1. If stat-cache-capacity is passed as -1, it uses
   math.Uint64 as size to make size effectively infinite.
2. If stat-cache-capacity is passed as 0, then the shared
   stat-cache is not 0, which will effectively disable
   it by not creating fastStatBucket for bucket (in case of
   static-mount), or for any of the buckets (in case of dynamic-mount).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing
2. Unit tests - Ran locally, all passing. Adding one new test.
3. Integration tests - Ran through presubmits.
