### PR TITLE
Kokoro is not triggering on the define branch in the config

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,7 +22,7 @@ readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=true
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo "Building and installing gcsfuse..."
 # Get the latest commitId of yesterday in the log file. Build gcsfuse and run
-commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+commitId=$(git log $BRANCH_NAME --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
 echo "Running e2e tests on installed package...."

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+env_vars {
+  key: "BRANCH_NAME"
+  value: "master"
+}
+
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+env_vars {
+  key: "BRANCH_NAME"
+  value: "read_cache_release"
+}
+
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"


### PR DESCRIPTION
### Description
Kokoro is not triggering on the define branch in the config. Kokoro is set up to use the commit hash from the parent configuration's branch for all subjobs, even if those subjobs with different branches. I have asked yaqs question on kokoro team but until it gets resolved we can use this workaround.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
