### PR TITLE
Http proxy fix

### DIFF
--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -47,6 +47,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	// Using http1 makes the client more performant.
 	if storageClientConfig.ClientProtocol == mountpkg.HTTP1 {
 		transport = &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxConnsPerHost:     storageClientConfig.MaxConnsPerHost,
 			MaxIdleConnsPerHost: storageClientConfig.MaxIdleConnsPerHost,
 			// This disables HTTP/2 in transport.
@@ -57,6 +58,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	} else {
 		// For http2, change in MaxConnsPerHost doesn't affect the performance.
 		transport = &http.Transport{
+			Proxy:             http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 			MaxConnsPerHost:   storageClientConfig.MaxConnsPerHost,
 			ForceAttemptHTTP2: true,

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -15,6 +15,8 @@
 package storageutil
 
 import (
+	"golang.org/x/oauth2"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -28,6 +30,22 @@ type clientTest struct {
 }
 
 func init() { RegisterTestSuite(&clientTest{}) }
+
+// Helpers
+
+func (t *clientTest) validateProxyInTransport(httpClient *http.Client) {
+	userAgentRT, ok := httpClient.Transport.(*userAgentRoundTripper)
+	AssertEq(true, ok)
+	oauthTransport, ok := userAgentRT.wrapped.(*oauth2.Transport)
+	AssertEq(true, ok)
+	transport, ok := oauthTransport.Base.(*http.Transport)
+	AssertEq(true, ok)
+	if ok {
+		ExpectEq(http.ProxyFromEnvironment, transport.Proxy)
+	}
+}
+
+// Tests
 
 func (t *clientTest) TestCreateTokenSrcWithCustomEndpoint() {
 	url, err := url.Parse(CustomEndpoint)
@@ -62,6 +80,7 @@ func (t *clientTest) TestCreateHttpClientWithHttp1() {
 	ExpectEq(nil, err)
 	ExpectNe(nil, httpClient)
 	ExpectNe(nil, httpClient.Transport)
+	t.validateProxyInTransport(httpClient)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
 }
 
@@ -74,5 +93,6 @@ func (t *clientTest) TestCreateHttpClientWithHttp2() {
 	ExpectEq(nil, err)
 	ExpectNe(nil, httpClient)
 	ExpectNe(nil, httpClient.Transport)
+	t.validateProxyInTransport(httpClient)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
 }

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -15,13 +15,13 @@
 package storageutil
 
 import (
-	"golang.org/x/oauth2"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
+	"golang.org/x/oauth2"
 )
 
 func TestClient(t *testing.T) { RunTests(t) }


### PR DESCRIPTION
### Description
GCSFuse was not respecting `https_proxy` and `http_proxy` environment variables. This was pointed out in bug https://github.com/GoogleCloudPlatform/gcsfuse/issues/1541
Setting http.ProxyFromEnvironment in the underlying http client fixes the issue. (Ref: [Stackoverflow](https://stackoverflow.com/questions/51845690/how-to-program-go-to-use-a-proxy-when-using-a-custom-transport/51848441#51848441))

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1541

### Testing details
1. Manual - I confirmed through manual checks that requests are successfully flowing through the proxy server, regardless of whetherGCSFuse is running in foreground or background mode.
Proxy server access logs:
    ```
    1703535566.729  20150 127.0.0.1 TCP_TUNNEL/200 5507 CONNECT storage.googleapis.com:443
    1703535566.729  20226 127.0.0.1 TCP_TUNNEL/200 6334 CONNECT oauth2.googleapis.com:443
    ```
      Also verified that requests were not routed via proxy server before this change.

3. Unit tests - Added
4. Integration tests - Passed successfully
5. Perf tests - No regression
<img width="663" alt="Screenshot 2023-12-26 at 10 41 27" src="https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/9a1815c9-d918-418b-b2ea-38f5eed5e8a5">

