### PR TITLE
Fix e2e kokoro tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,7 +22,7 @@ readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=true
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo "Building and installing gcsfuse..."
 # Get the latest commitId of yesterday in the log file. Build gcsfuse and run
-commitId=$(git log $BRANCH_NAME --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+commitId=$(git log origin/$BRANCH_NAME --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
 echo "Running e2e tests on installed package...."


### PR DESCRIPTION
### Description
Issue:
Kokoro tests on the release branch were failing due to Git's inability to identify the intended branch.

**Error Message**:
```
fatal: ambiguous argument 'read_cache_release': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]
```

**Cause**:
Missing remote branch information.

**Resolution**:
Resolved by explicitly specifying the remote branch using origin/$BRANCH_NAME.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested on local VM and kokoro
2. Unit tests - NA
3. Integration tests - NA
