### PR TITLE
Fix e2e tests for release branch

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -26,7 +26,7 @@ commitId=$(git log origin/$BRANCH_NAME --before='yesterday 23:59:59' --max-count
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
 # To execute tests for a specific branch, ensure you've checked out from that branch first.
-git checkout $BRANCH_NAME
+git checkout origin/$BRANCH_NAME
 
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -25,6 +25,9 @@ echo "Building and installing gcsfuse..."
 commitId=$(git log origin/$BRANCH_NAME --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
+# To execute tests for a specific branch, ensure you've checked out from that branch first.
+git checkout $BRANCH_NAME
+
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage
 ./perfmetrics/scripts/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE


### PR DESCRIPTION
### Description
Problem:
Integration tests were failing due to we are building gcsfuse from release branch and testing from master commit only.
Fix:
To execute tests for a specific branch, ensure you've checked out from that branch first.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested integration tests locally on VM
2. Unit tests - NA
3. Integration tests - NA
