### PR TITLE
Fixing 2nd epoch onwards slowness in read-cache fio test

### DIFF
--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -23,6 +23,7 @@ print_usage() {
   printf "[-b bucket_name] "
   printf "[-c cache_location] "
   printf "[-d (means download_for_random_read is true)] "
+  printf "[-m (means metadata cache capacity)] "
   printf "[-l (start_logging on $WORKING_DIR/gcsfuse_logs.txt)] \n"
 }
 
@@ -33,10 +34,10 @@ max_size_in_mb=100
 cache_location=/tmp/read_cache/
 bucket_name=gcsfuse-read-cache-fio-load-test
 stat_or_type_cache_ttl_secs=6048000 # 168h or 1 week
-stat_cache_capacity=3200000 # 2 million + buffer 1.2 million
+stat_cache_capacity=4096
 enable_log=0
 
-while getopts lhds:b:c: flag
+while getopts lhds:b:c:m: flag
 do
   case "${flag}" in
 
@@ -44,6 +45,7 @@ do
     b) bucket_name=${OPTARG};;
     d) download_for_random_read=true;;
     c) cache_location=${OPTARG};;
+    m) stat_cache_capacity=${OPTARG};;
     h) print_usage
         exit 0 ;;
     l) enable_log=1 ;;

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -33,7 +33,7 @@ max_size_in_mb=100
 cache_location=/tmp/read_cache/
 bucket_name=gcsfuse-read-cache-fio-load-test
 stat_or_type_cache_ttl_secs=6048000 # 168h or 1 week
-stat_cache_capacity=1200000 # 1 million + buffer 200k
+stat_cache_capacity=3200000 # 2 million + buffer 1.2 million
 enable_log=0
 
 while getopts lhds:b:c: flag

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -73,7 +73,8 @@ fi
 # Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
 # populate the gcsfuse metadata cache by utilizing the list call, which internally
 # works like bulk stat call rather than making individual stat calls.
-time ls -R $workload_dir
+# And to reduce the logs moving the command standard-output to /dev/null.
+time ls -R $workload_dir 1> /dev/null
 
 cd $WORKING_DIR/gcsfuse/perfmetrics/scripts/read_cache/
 

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -80,8 +80,16 @@ for i in $(seq $epoch); do
   free -mh # Memory usage after workload completion.
   echo "[Epoch ${i}] end time:" `date +%s`
 
-  # To free pagecache, dentries and inodes.
-  sudo sh -c "/usr/bin/echo 3 > /proc/sys/vm/drop_caches"
+  # To free pagecache.
+  # Intentionally not clearing dentries and inodes: clearing them
+  # will necessitate the repopulation of the type cache in gcsfuse 2nd epoch onwards.
+  # Since we use "ls -R workload_dir" to populate the cache (sort of hack to fill the cache quickly)
+  # efficiently in the first epoch, it does not populate the negative
+  # entry for the stat cache.
+  # So just to stop the execution of  “ls -R workload_dir” command at the start
+  # of every epoch, not clearing the inodes.
+
+  sudo sh -c "/usr/bin/echo 1 > /proc/sys/vm/drop_caches"
 
   sleep $pause_in_seconds
 done

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -73,7 +73,7 @@ fi
 # Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
 # populate the gcsfuse metadata cache by utilizing the list call, which internally
 # works like bulk stat call rather than making individual stat calls.
-# And to reduce the logs moving the command standard-output to /dev/null.
+# And to reduce the logs redirecting the command standard-output to /dev/null.
 time ls -R $workload_dir 1> /dev/null
 
 cd $WORKING_DIR/gcsfuse/perfmetrics/scripts/read_cache/

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -70,6 +70,11 @@ if [[ "${read_type}" != "read" && "${read_type}" != "randread" ]]; then
   exit 1
 fi
 
+# Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
+# populate the gcsfuse metadata cache by utilizing the list call, which internally
+# works like bulk stat call rather than making individual stat calls.
+time ls -R $workload_dir
+
 cd $WORKING_DIR/gcsfuse/perfmetrics/scripts/read_cache/
 
 for i in $(seq $epoch); do

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -70,6 +70,9 @@ if [[ "${read_type}" != "read" && "${read_type}" != "randread" ]]; then
   exit 1
 fi
 
+# Cleaning the pagecache, dentries and inode cache before the starting the workload.
+sudo sh -c "/usr/bin/echo 3 > /proc/sys/vm/drop_caches"
+
 # Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
 # populate the gcsfuse metadata cache by utilizing the list call, which internally
 # works like bulk stat call rather than making individual stat calls.
@@ -94,7 +97,6 @@ for i in $(seq $epoch); do
   # entry for the stat cache.
   # So just to stop the execution of  “ls -R workload_dir” command at the start
   # of every epoch, not clearing the inodes.
-
   sudo sh -c "/usr/bin/echo 1 > /proc/sys/vm/drop_caches"
 
   sleep $pause_in_seconds


### PR DESCRIPTION
### Description
Fixing 2nd epoch onwards slowness in read-cache fio test
(a) Increasing the stat-cache capacity to more than 3 millions.
(b) Only clearing the page cache not inodes, just to keep type-cache intact for further epochs. Otherwise, it will try to populate the type-cache again and in the process it will make two stat calls for each in which one of them will be served from the stat-cache and another one will be served GCS since (during list negative entry is not stored in the stat-cache).


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
