### PR TITLE
Moving monitoring bucket bottom in hierarchy

### DIFF
--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -161,6 +161,11 @@ func setUpRateLimiting(
 func (bm *bucketManager) SetUpGcsBucket(name string) (b gcs.Bucket, err error) {
 	b = bm.storageHandle.BucketHandle(name, bm.config.BillingProject)
 
+	// Enable monitoring
+	if bm.config.EnableMonitoring {
+		b = monitor.NewMonitoringBucket(b)
+	}
+
 	b = storage.NewDebugBucket(b)
 	return
 }
@@ -220,11 +225,6 @@ func (bm *bucketManager) SetUpBucket(
 
 	// Enable content type awareness
 	b = NewContentTypeBucket(b)
-
-	// Enable monitoring
-	if bm.config.EnableMonitoring {
-		b = monitor.NewMonitoringBucket(b)
-	}
 
 	// Enable Syncer
 	if bm.config.TmpObjectPrefix == "" {

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -154,22 +154,6 @@ func setUpRateLimiting(
 	return
 }
 
-// Configure a bucket based on the supplied config.
-//
-// Special case: if the bucket name is canned.FakeBucketName, set up a fake
-// bucket as described in that package.
-func (bm *bucketManager) SetUpGcsBucket(name string) (b gcs.Bucket, err error) {
-	b = bm.storageHandle.BucketHandle(name, bm.config.BillingProject)
-
-	// Enable monitoring
-	if bm.config.EnableMonitoring {
-		b = monitor.NewMonitoringBucket(b)
-	}
-
-	b = storage.NewDebugBucket(b)
-	return
-}
-
 func (bm *bucketManager) SetUpBucket(
 	ctx context.Context,
 	name string,
@@ -180,12 +164,16 @@ func (bm *bucketManager) SetUpBucket(
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
 	} else {
-		b, err = bm.SetUpGcsBucket(name)
-		if err != nil {
-			err = fmt.Errorf("OpenBucket: %w", err)
-			return
-		}
+		b = bm.storageHandle.BucketHandle(name, bm.config.BillingProject)
 	}
+
+	// Enable monitoring.
+	if bm.config.EnableMonitoring {
+		b = monitor.NewMonitoringBucket(b)
+	}
+
+	// Enable gcs logs.
+	b = storage.NewDebugBucket(b)
 
 	// Limit to a requested prefix of the bucket, if any.
 	if bm.config.OnlyDir != "" {

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -61,17 +61,6 @@ func (t *BucketManagerTest) TestNewBucketManagerMethod() {
 	ExpectNe(nil, bm)
 }
 
-func (t *BucketManagerTest) TestSetupGcsBucket() {
-	var bm bucketManager
-	bm.storageHandle = t.storageHandle
-	bm.config.DebugGCS = true
-
-	bucket, err := bm.SetUpGcsBucket(TestBucketName)
-
-	ExpectNe(nil, bucket)
-	ExpectEq(nil, err)
-}
-
 func (t *BucketManagerTest) TestSetUpBucketMethod() {
 	var bm bucketManager
 	bucketConfig := BucketConfig{

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -70,11 +70,6 @@ if [[ "${read_type}" != "read" && "${read_type}" != "randread" ]]; then
   exit 1
 fi
 
-# Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
-# populate the gcsfuse metadata cache by utilizing the list call, which internally
-# works like bulk stat call rather than making individual stat calls.
-time ls -R $workload_dir
-
 cd $WORKING_DIR/gcsfuse/perfmetrics/scripts/read_cache/
 
 for i in $(seq $epoch); do

--- a/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
+++ b/perfmetrics/scripts/read_cache/run_read_cache_fio_workload.sh
@@ -70,6 +70,11 @@ if [[ "${read_type}" != "read" && "${read_type}" != "randread" ]]; then
   exit 1
 fi
 
+# Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
+# populate the gcsfuse metadata cache by utilizing the list call, which internally
+# works like bulk stat call rather than making individual stat calls.
+time ls -R $workload_dir
+
 cd $WORKING_DIR/gcsfuse/perfmetrics/scripts/read_cache/
 
 for i in $(seq $epoch); do


### PR DESCRIPTION
### Description
Moving the monitor bucket in the bottom of the hierarchy, just before the actual bucket implementation which interacts with GCS.

Why?
Currently, monitoring bucket is on the top of hierarchy, above fast-stat bucket. So, we see all the request/response gcs stackdriver metrics which is served by cache (fast-stat-bucket). Ideally, we should only see the metrics which is served by gcs server. Hence, fixing this by moving the monitoring bucket bottom of hierarchy.

Impact:
We don't get false Stat call in gcs stackdriver metrics. As you can see in the below screenshot containing before and after
metrics graph for the same workload.

![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/8597474/5f77c7bf-f839-45cd-bf01-e0b4c0ee9d3f)


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Verified debug gcs logs and exported stackdriver metrics before and after.
2. Unit tests - Automation.
3. Integration tests - Automation
