### PR TITLE
[Don't review]Remove the custom retry for 401 code in GCSFuse 

### DIFF
--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -107,7 +107,7 @@ func createTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth
 func getTokenWithExpiry(tokenSrc oauth2.TokenSource)(expiryTokenSrc oauth2.TokenSource, err error){
 	token, err := tokenSrc.Token()
 	if err != nil {
-		err = fmt.Errorf("while fetching tokenSource: %w", err)
+		err = fmt.Errorf("while fetching token: %w", err)
 		return nil, err
 	}
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -17,6 +17,7 @@ package storageutil
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -64,6 +65,13 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	}
 
 	tokenSrc, err := createTokenSource(storageClientConfig)
+
+	token, err := tokenSrc.Token()
+	if err!= nil{
+		log.Printf("Error in getting token: %v",err)
+	}
+	expiryTokenSrc := oauth2.ReuseTokenSourceWithExpiry(token,tokenSrc,10*time.Second)
+
 	if err != nil {
 		err = fmt.Errorf("while fetching tokenSource: %w", err)
 		return
@@ -73,7 +81,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	httpClient = &http.Client{
 		Transport: &oauth2.Transport{
 			Base:   transport,
-			Source: tokenSrc,
+			Source: expiryTokenSrc,
 		},
 		Timeout: storageClientConfig.HttpClientTimeout,
 	}

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -67,7 +67,8 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	if err != nil {
 		err = fmt.Errorf("while fetching tokenSource: %w", err)
 	}
-  expiryTokenSrc, err := getTokenWithExpiry(tokenSrc)
+
+	expiryTokenSrc, err := getTokenWithExpiry(tokenSrc)
 	if err != nil {
 		err = fmt.Errorf("while fetching token with expiry: %w", err)
 	}

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -64,6 +64,9 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *htt
 	}
 
 	tokenSrc, err := createTokenSource(storageClientConfig)
+	if err != nil {
+		err = fmt.Errorf("while fetching tokenSource: %w", err)
+	}
   expiryTokenSrc, err := getTokenWithExpiry(tokenSrc)
 	if err != nil {
 		err = fmt.Errorf("while fetching token with expiry: %w", err)

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -107,7 +107,7 @@ func getTokenWithExpiry(tokenSrc oauth2.TokenSource)(expiryTokenSrc oauth2.Token
 		return nil, err
 	}
 
-	expiryTokenSrc = oauth2.ReuseTokenSourceWithExpiry(token,tokenSrc,10*time.Second)
+	expiryTokenSrc = oauth2.ReuseTokenSourceWithExpiry(token,tokenSrc,20*time.Second)
 
   return expiryTokenSrc,nil
 }

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -82,6 +82,6 @@ func TestGetTokenWithExpiry_Success(t *testing.T) {
 	expiryTokenSrc, err := getTokenWithExpiry(mockToken)
 
 	// Assert that the returned token source is a ReuseTokenSourceWithExpiry
-	AssertEq(nil,err)
-  AssertNe(nil,expiryTokenSrc)
+	ExpectEq(nil,err)
+  ExpectNe(nil,expiryTokenSrc)
 }

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -15,11 +15,11 @@
 package storageutil
 
 import (
-	"net/url"
-	"testing"
-
 	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
+	"golang.org/x/oauth2"
+	"net/url"
+	"testing"
 )
 
 func TestClient(t *testing.T) { RunTests(t) }
@@ -75,4 +75,13 @@ func (t *clientTest) TestCreateHttpClientWithHttp2() {
 	ExpectNe(nil, httpClient)
 	ExpectNe(nil, httpClient.Transport)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
+}
+
+func TestGetTokenWithExpiry_Success(t *testing.T) {
+	mockToken := oauth2.StaticTokenSource(&oauth2.Token{})
+	expiryTokenSrc, err := getTokenWithExpiry(mockToken)
+
+	// Assert that the returned token source is a ReuseTokenSourceWithExpiry
+	AssertEq(nil,err)
+  AssertNe(nil,expiryTokenSrc)
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -16,7 +16,6 @@ package storageutil
 
 import (
 	"cloud.google.com/go/storage"
-	"google.golang.org/api/googleapi"
 )
 
 func ShouldRetry(err error) (b bool) {
@@ -25,18 +24,18 @@ func ShouldRetry(err error) (b bool) {
 		return
 	}
 
-	// HTTP 401 errors - Invalid Credentials
-	// This is a work-around to fix the corner case where GCSFuse checks the token
-	// as valid but GCS says invalid. This might be due to client-server timer
-	// issues. Actual fix will be refresh the token earlier than 1 hr.
-	// Changes will be done post resolution of the below issue:
-	// https://github.com/golang/oauth2/issues/623
-	// TODO: Please incorporate the correct fix post resolution of the above issue.
-	if typed, ok := err.(*googleapi.Error); ok {
-		if typed.Code == 401 {
-			b = true
-			return
-		}
-	}
+	//// HTTP 401 errors - Invalid Credentials
+	//// This is a work-around to fix the corner case where GCSFuse checks the token
+	//// as valid but GCS says invalid. This might be due to client-server timer
+	//// issues. Actual fix will be refresh the token earlier than 1 hr.
+	//// Changes will be done post resolution of the below issue:
+	//// https://github.com/golang/oauth2/issues/623
+	//// TODO: Please incorporate the correct fix post resolution of the above issue.
+	//if typed, ok := err.(*googleapi.Error); ok {
+	//	if typed.Code == 401 {
+	//		b = true
+	//		return
+	//	}
+	//}
 	return
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -24,18 +24,5 @@ func ShouldRetry(err error) (b bool) {
 		return
 	}
 
-	//// HTTP 401 errors - Invalid Credentials
-	//// This is a work-around to fix the corner case where GCSFuse checks the token
-	//// as valid but GCS says invalid. This might be due to client-server timer
-	//// issues. Actual fix will be refresh the token earlier than 1 hr.
-	//// Changes will be done post resolution of the below issue:
-	//// https://github.com/golang/oauth2/issues/623
-	//// TODO: Please incorporate the correct fix post resolution of the above issue.
-	//if typed, ok := err.(*googleapi.Error); ok {
-	//	if typed.Code == 401 {
-	//		b = true
-	//		return
-	//	}
-	//}
 	return
 }

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,6 @@ func (t *MainTest) TestCreateStorageHandle() {
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
 		AppName:             "app",
-		KeyFile:             "testdata/test_creds.json",
 	}
 
 	storageHandle, err := createStorageHandle(flags)


### PR DESCRIPTION
### Description
Using [this](https://pkg.go.dev/golang.org/x/oauth2#ReuseTokenSourceWithExpiry) method to expire the generated token early than the default configuration (10s).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
