### PR TITLE
Add file handle to file cache logs

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2134,13 +2134,8 @@ func (fs *fileSystem) ReadFile(
 	ctx context.Context,
 	op *fuseops.ReadFileOp) (err error) {
 
-	// Save PID, Inode and Handle in Read operation context for access in logs.
-	v := map[string]uint64{
-		gcsx.PID:    uint64(op.OpContext.Pid),
-		gcsx.Inode:  uint64(op.Inode),
-		gcsx.Handle: uint64(op.Handle),
-	}
-	ctx = context.WithValue(ctx, "readOp", v)
+	// Save readOp in context for access in logs.
+	ctx = context.WithValue(ctx, "readOp", op)
 
 	// Find the handle and lock it.
 	fs.mu.Lock()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2136,9 +2136,9 @@ func (fs *fileSystem) ReadFile(
 
 	// Save PID, Inode and Handle in Read operation context for access in logs.
 	v := map[string]uint64{
-		"PID":    uint64(op.OpContext.Pid),
-		"Inode":  uint64(op.Inode),
-		"Handle": uint64(op.Handle),
+		gcsx.PID:    uint64(op.OpContext.Pid),
+		gcsx.Inode:  uint64(op.Inode),
+		gcsx.Handle: uint64(op.Handle),
 	}
 	ctx = context.WithValue(ctx, "readOp", v)
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2133,6 +2133,15 @@ func (fs *fileSystem) OpenFile(
 func (fs *fileSystem) ReadFile(
 	ctx context.Context,
 	op *fuseops.ReadFileOp) (err error) {
+
+	// Save PID, Inode and Handle in Read operation context for access in logs.
+	v := map[string]uint64{
+		"PID":    uint64(op.OpContext.Pid),
+		"Inode":  uint64(op.Inode),
+		"Handle": uint64(op.Handle),
+	}
+	ctx = context.WithValue(ctx, "readOp", v)
+
 	// Find the handle and lock it.
 	fs.mu.Lock()
 	fh := fs.handles[op.Handle].(*handle.FileHandle)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -186,7 +186,11 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 			if rr.fileCacheHandle != nil {
 				isSeq = rr.fileCacheHandle.IsSequential(offset)
 			}
-			requestOutput = fmt.Sprintf("OK (isSeq: %t, hit: %t) (%v)", isSeq, cacheHit, executionTime)
+			readOp := ctx.Value("readOp").(map[string]uint64)
+			requestOutput = fmt.Sprintf("FileCache OK (isSeq: %t, hit: %t, "+
+				"PID: %d, Inode: %d, Handle: %d, Offset: %d, Size: %d, object: %s/%s) (%v)",
+				isSeq, cacheHit, readOp["PID"], readOp["Inode"], readOp["Handle"], offset,
+				len(p), rr.bucket.Name(), rr.object.Name, executionTime)
 		}
 
 		// Here rr.fileCacheHandle will not be nil since we return from the above in those cases.

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -49,6 +49,12 @@ const maxReadSize = 8 * MB
 // Minimum number of seeks before evaluating if the read pattern is random.
 const minSeeksForRandom = 2
 
+const (
+	PID    = "PID"
+	Inode  = "Inode"
+	Handle = "Handle"
+)
+
 // RandomReader is an object that knows how to read ranges within a particular
 // generation of a particular GCS object. Optimised for (large) sequential reads.
 //
@@ -189,7 +195,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 			readOp := ctx.Value("readOp").(map[string]uint64)
 			requestOutput = fmt.Sprintf("FileCache OK (isSeq: %t, hit: %t, "+
 				"PID: %d, Inode: %d, Handle: %d, Offset: %d, Size: %d, object: %s/%s) (%v)",
-				isSeq, cacheHit, readOp["PID"], readOp["Inode"], readOp["Handle"], offset,
+				isSeq, cacheHit, readOp[PID], readOp[Inode], readOp[Handle], offset,
 				len(p), rr.bucket.Name(), rr.object.Name, executionTime)
 		}
 

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -158,7 +158,12 @@ var _ SetUpInterface = &RandomReaderTest{}
 var _ TearDownInterface = &RandomReaderTest{}
 
 func (t *RandomReaderTest) SetUp(ti *TestInfo) {
-	t.rr.ctx = ti.Ctx
+	v := map[string]uint64{
+		PID:    1,
+		Inode:  2,
+		Handle: 3,
+	}
+	t.rr.ctx = context.WithValue(ti.Ctx, "readOp", v)
 
 	// Manufacture an object record.
 	t.object = &gcs.MinObject{

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/internal/util"
+	"github.com/jacobsa/fuse/fuseops"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
@@ -158,12 +159,8 @@ var _ SetUpInterface = &RandomReaderTest{}
 var _ TearDownInterface = &RandomReaderTest{}
 
 func (t *RandomReaderTest) SetUp(ti *TestInfo) {
-	v := map[string]uint64{
-		PID:    1,
-		Inode:  2,
-		Handle: 3,
-	}
-	t.rr.ctx = context.WithValue(ti.Ctx, "readOp", v)
+	readOp := fuseops.ReadFileOp{Handle: 1}
+	t.rr.ctx = context.WithValue(ti.Ctx, "readOp", &readOp)
 
 	// Manufacture an object record.
 	t.object = &gcs.MinObject{


### PR DESCRIPTION
### Description
Updated the file cache logs to also have file handle by storing reference to fuseops.readOp in the read operation context.

Sample log:
```
{"time":{"timestampSeconds":1704433722,"timestampNanos":1704433722741155012},"severity":"TRACE","msg":"0930ffe0-1a86 <- FileCache(<redacted>:/file-10-mb, offset: 262144, size: 262144 handle: 28)"}
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified the logs are updated
2. Unit tests - NA
3. Integration tests - NA
