### PR TITLE
Update SLO

### DIFF
--- a/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
@@ -28,8 +28,4 @@ Steps to reproduce the behavior:
 Add any other context about the problem here.
 
 **SLO:**
-We strive to respond to all bug reports within 24 business hours during our 
-standard business hours of Monday to Friday, 9:00 AM to 5:00 PM [IST Time zone]. 
-We will then work diligently to resolve the issue, providing updates and mitigation
-steps as available. However, the resolution timeframe may vary depending on the 
-complexity of the issue and our development roadmap.
+We strive to respond to all bug reports within 24 business hours.

--- a/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
@@ -28,4 +28,8 @@ Steps to reproduce the behavior:
 Add any other context about the problem here.
 
 **SLO:**
-24 hrs to respond and 7 days to close the issue.
+SLO: We strive to respond to all bug reports within 24 business hours during our 
+standard business hours of Monday to Friday, 9:00 AM to 5:00 PM [IST Time zone]. 
+We will then work diligently to resolve the issue, providing updates and mitigation
+steps as available. However, the resolution timeframe may vary depending on the 
+complexity of the issue and our development roadmap.

--- a/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
@@ -28,7 +28,7 @@ Steps to reproduce the behavior:
 Add any other context about the problem here.
 
 **SLO:**
-SLO: We strive to respond to all bug reports within 24 business hours during our 
+We strive to respond to all bug reports within 24 business hours during our 
 standard business hours of Monday to Friday, 9:00 AM to 5:00 PM [IST Time zone]. 
 We will then work diligently to resolve the issue, providing updates and mitigation
 steps as available. However, the resolution timeframe may vary depending on the 


### PR DESCRIPTION
### Description
There was a general agreement that we should change this SLO because we are not a 24X7 supported product, plus we are not a service, so if the customer ran into issues, they can rollback the gcsfuse library as a mitigation and wait for us to respond in business hours.

Changing the SLO to fix this issue.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
