### PR TITLE
change file_service_type to random so files in epoch are picked randomly

### DIFF
--- a/perfmetrics/scripts/job_files/read_cache_load_test.fio
+++ b/perfmetrics/scripts/job_files/read_cache_load_test.fio
@@ -10,7 +10,8 @@ thread=1
 openfiles=1
 group_reporting=1
 create_serialize=0
-allrandrepeat=1
+allrandrepeat=0
+file_service_type=random
 numjobs=${NUMJOBS}
 filename_format=$jobname.$jobnum/$filenum
 


### PR DESCRIPTION
### Description
change file_service_type to random so that files in epoch are picked randomly
Ran for 100mb file size - 100% and 50%. 100% see neglible drop in perf (763.4 to 764 seconds and 50% doesn't see gain in perf. We will investigate it more but this change should anyways be done)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran fio script manually.
3. Unit tests - NA
4. Integration tests - NA
