### PR TITLE
make logging keys fluentD compatible

### DIFF
--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"log/slog"
 	"os"
-	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/config"
@@ -26,16 +26,17 @@ import (
 )
 
 const (
-	textTraceString   = "severity=TRACE msg=\"TestLogs: www.traceExample.com\""
-	textDebugString   = "severity=DEBUG msg=\"TestLogs: www.debugExample.com\""
-	textInfoString    = "severity=INFO msg=\"TestLogs: www.infoExample.com\""
-	textWarningString = "severity=WARNING msg=\"TestLogs: www.warningExample.com\""
-	textErrorString   = "severity=ERROR msg=\"TestLogs: www.errorExample.com\""
-	jsonTraceString   = "\"severity\":\"TRACE\",\"msg\":\"TestLogs: www.traceExample.com\"}"
-	jsonDebugString   = "\"severity\":\"DEBUG\",\"msg\":\"TestLogs: www.debugExample.com\"}"
-	jsonInfoString    = "\"severity\":\"INFO\",\"msg\":\"TestLogs: www.infoExample.com\"}"
-	jsonWarningString = "\"severity\":\"WARNING\",\"msg\":\"TestLogs: www.warningExample.com\"}"
-	jsonErrorString   = "\"severity\":\"ERROR\",\"msg\":\"TestLogs: www.errorExample.com\"}"
+	textTraceString   = "^time=\"[a-zA-Z0-9/:. ]{26}\" severity=TRACE message=\"TestLogs: www.traceExample.com\""
+	textDebugString   = "^time=\"[a-zA-Z0-9/:. ]{26}\" severity=DEBUG message=\"TestLogs: www.debugExample.com\""
+	textInfoString    = "^time=\"[a-zA-Z0-9/:. ]{26}\" severity=INFO message=\"TestLogs: www.infoExample.com\""
+	textWarningString = "^time=\"[a-zA-Z0-9/:. ]{26}\" severity=WARNING message=\"TestLogs: www.warningExample.com\""
+	textErrorString   = "^time=\"[a-zA-Z0-9/:. ]{26}\" severity=ERROR message=\"TestLogs: www.errorExample.com\""
+
+	jsonTraceString   = "^{\"timestamp\":{\"seconds\":\\d{10},\"nanos\":\\d{9}},\"severity\":\"TRACE\",\"message\":\"TestLogs: www.traceExample.com\"}"
+	jsonDebugString   = "^{\"timestamp\":{\"seconds\":\\d{10},\"nanos\":\\d{9}},\"severity\":\"DEBUG\",\"message\":\"TestLogs: www.debugExample.com\"}"
+	jsonInfoString    = "^{\"timestamp\":{\"seconds\":\\d{10},\"nanos\":\\d{9}},\"severity\":\"INFO\",\"message\":\"TestLogs: www.infoExample.com\"}"
+	jsonWarningString = "^{\"timestamp\":{\"seconds\":\\d{10},\"nanos\":\\d{9}},\"severity\":\"WARNING\",\"message\":\"TestLogs: www.warningExample.com\"}"
+	jsonErrorString   = "^{\"timestamp\":{\"seconds\":\\d{10},\"nanos\":\\d{9}},\"severity\":\"ERROR\",\"message\":\"TestLogs: www.errorExample.com\"}"
 )
 
 func TestLogger(t *testing.T) { RunTests(t) }
@@ -99,7 +100,8 @@ func validateOutput(expected []string, output []string) {
 		if expected[i] == "" {
 			AssertEq(expected[i], output[i])
 		} else {
-			AssertTrue(strings.Contains(output[i], expected[i]))
+			expectedRegexp := regexp.MustCompile(expected[i])
+			AssertTrue(expectedRegexp.MatchString(output[i]))
 		}
 	}
 }

--- a/internal/logger/slog_helper.go
+++ b/internal/logger/slog_helper.go
@@ -30,10 +30,11 @@ const (
 	LevelWarn  = slog.LevelWarn
 	LevelError = slog.LevelError
 	// LevelOff value is set to 12, so that nothing is logged.
-	LevelOff = slog.Level(12)
-
-	timestampSecondsKey = "timestampSeconds"
-	timestampNanosKey   = "timestampNanos"
+	LevelOff     = slog.Level(12)
+	messageKey   = "message"
+	timestampKey = "timestamp"
+	secondsKey   = "seconds"
+	nanosKey     = "nanos"
 )
 
 func setLoggingLevel(level config.LogSeverity, programLevel *slog.LevelVar) {
@@ -82,6 +83,9 @@ func customiseLevels(a *slog.Attr) {
 
 // AddPrefixToMessage adds the prefix to the log message.
 func addPrefixToMessage(a *slog.Attr, prefix string) {
+	// Change key name to "message" so that it is compatible with fluentD.
+	a.Key = messageKey
+	// Add prefix to the message.
 	message := a.Value.Any().(string)
 	var sb strings.Builder
 	sb.WriteString(prefix)
@@ -91,13 +95,13 @@ func addPrefixToMessage(a *slog.Attr, prefix string) {
 
 // CustomiseTimeFormat converts the time to below specified format:
 // 1. for json logs:
-// "time":{"timestampSeconds":1694164762,"timestampNanos":1694164762084862036}
+// "timestamp":{"seconds":1704697907,"nanos":553918512}
 // 2. for text logs:
 // time="08/09/2023 09:24:54.437193"
 func customiseTimeFormat(a *slog.Attr, format string) {
 	currTime := a.Value.Any().(time.Time).Round(0)
 	if format == "json" {
-		*a = slog.Group(slog.TimeKey, timestampSecondsKey, currTime.Unix(), timestampNanosKey, currTime.UnixNano())
+		*a = slog.Group(timestampKey, secondsKey, currTime.Unix(), nanosKey, currTime.Nanosecond())
 	} else {
 		a.Value = slog.StringValue(currTime.Round(0).Format("02/01/2006 03:04:05.000000"))
 	}


### PR DESCRIPTION
### Description
This PR changes GCSFuse logging keys to be compatible with fluentD based on the following references:
1. https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing
2. https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields

Changes summary:
1. JSON log structure time changed 
    `"time":{"timestampSeconds":1694164762,"timestampNanos":1694164762084862036}`
    to
    `"timestamp":{"seconds":1704697907,"nanos":553918512}`

2. JSON log structure message changed from  
     ` "msg":"<log message>"`
      to
     ` "message":"<log message>"`

Sample log:
```
{"timestamp":{"seconds":1704703429,"nanos":670828386},"severity":"TRACE","message":"fuse_debug: Op 0x00000144        connection.go:415] <- ReleaseDirHandle (PID 0)"}
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified the log format
2. Unit tests - Changed unit tests to match regular expression of log.
4. Integration tests - NA
