### PR TITLE
Remove branch name env variable in periodic e2e tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -25,6 +25,9 @@ echo "Building and installing gcsfuse..."
 commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
+# To execute tests for a specific commitId, ensure you've checked out from that commitId first.
+git checkout $commitId
+
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage
 ./perfmetrics/scripts/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,11 +22,8 @@ readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=true
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo "Building and installing gcsfuse..."
 # Get the latest commitId of yesterday in the log file. Build gcsfuse and run
-commitId=$(git log origin/$BRANCH_NAME --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
-
-# To execute tests for a specific branch, ensure you've checked out from that branch first.
-git checkout origin/$BRANCH_NAME
 
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-env_vars {
-  key: "BRANCH_NAME"
-  value: "master"
-}
-
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-env_vars {
-  key: "BRANCH_NAME"
-  value: "read_cache_release"
-}
-
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"


### PR DESCRIPTION
### Description
We did temporary fix to fix this issue - https://github.com/GoogleCloudPlatform/gcsfuse/pull/1561 and  https://github.com/GoogleCloudPlatform/gcsfuse/pull/1567
We got solution so, undoing the changes did earlier.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
