### PR TITLE
[ReadCacheFunctionalTest] add support for setup and teardown methods in tests

### DIFF
--- a/tools/integration_tests/util/test_setup/test_setup.go
+++ b/tools/integration_tests/util/test_setup/test_setup.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-// Interface defines Tester's methods for use in this package.
+// Testable defines Tester's methods for use in this package.
 type Testable interface {
 	Setup(*testing.T)
 	Teardown(*testing.T)
@@ -38,11 +38,11 @@ func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 	return func(*testing.T) {}
 }
 
-// RunSubTests runs all "Test*" functions that are member of x as subtests
+// RunTests runs all "Test*" functions that are member of x as subtests
 // of the current test.  Setup is run before the test function and Teardown is
 // run after each test.
-// x must extend Interface by implementing Setup and TearDown methods.
-func RunSubTests(t *testing.T, x Testable) {
+// x must extend Testable interface by implementing Setup and TearDown methods.
+func RunTests(t *testing.T, x Testable) {
 	xt := reflect.TypeOf(x)
 	xv := reflect.ValueOf(x)
 

--- a/tools/integration_tests/util/test_setup/test_setup.go
+++ b/tools/integration_tests/util/test_setup/test_setup.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Interface defines Tester's methods for use in this package.
-type Interface interface {
+type Testable interface {
 	Setup(*testing.T)
 	Teardown(*testing.T)
 }
@@ -42,7 +42,7 @@ func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 // of the current test.  Setup is run before the test function and Teardown is
 // run after each test.
 // x must extend Interface by implementing Setup and TearDown methods.
-func RunSubTests(t *testing.T, x Interface) {
+func RunSubTests(t *testing.T, x Testable) {
 	xt := reflect.TypeOf(x)
 	xv := reflect.ValueOf(x)
 
@@ -52,7 +52,7 @@ func RunSubTests(t *testing.T, x Interface) {
 			continue
 		}
 		testFunc := getTestFunc(t, xv, methodName)
-		t.Run(strings.TrimPrefix(methodName, "Test"), func(t *testing.T) {
+		t.Run(methodName, func(t *testing.T) {
 			// Execute Teardown in t.Cleanup() to guarantee it is run even if test
 			// function or setup uses t.Fatal().
 			t.Cleanup(func() { x.Teardown(t) })

--- a/tools/integration_tests/util/test_setup/test_setup.go
+++ b/tools/integration_tests/util/test_setup/test_setup.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test_setup implements Setup and Teardown methods to be used in tests.
+package test_setup
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Interface defines Tester's methods for use in this package.
+type Interface interface {
+	Setup(*testing.T)
+	Teardown(*testing.T)
+}
+
+func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
+	if m := xv.MethodByName(name); m.IsValid() {
+		if f, ok := m.Interface().(func(*testing.T)); ok {
+			return f
+		}
+		// Method exists but has the wrong type signature.
+		t.Fatalf("test function %v has unexpected signature (%T)", name, m.Interface())
+	}
+	return func(*testing.T) {}
+}
+
+// RunSubTests runs all "Test*" functions that are member of x as subtests
+// of the current test.  Setup is run before the test function and Teardown is
+// run after each test.
+// x must extend Interface by implementing Setup and TearDown methods.
+func RunSubTests(t *testing.T, x Interface) {
+	xt := reflect.TypeOf(x)
+	xv := reflect.ValueOf(x)
+
+	for i := 0; i < xt.NumMethod(); i++ {
+		methodName := xt.Method(i).Name
+		if !strings.HasPrefix(methodName, "Test") {
+			continue
+		}
+		testFunc := getTestFunc(t, xv, methodName)
+		t.Run(strings.TrimPrefix(methodName, "Test"), func(t *testing.T) {
+			// Execute Teardown in t.Cleanup() to guarantee it is run even if test
+			// function or setup uses t.Fatal().
+			t.Cleanup(func() { x.Teardown(t) })
+			x.Setup(t)
+			testFunc(t)
+		})
+	}
+}

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_setup_test
+
+import (
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
+	. "github.com/jacobsa/ogletest"
+	"testing"
+)
+
+type testStructure struct {
+	setup, test1, test2, teardown bool
+}
+
+func (t *testStructure) Setup(*testing.T) {
+	t.setup = true
+}
+func (t *testStructure) TestExample1(*testing.T) {
+	t.test1 = true
+}
+
+func (t *testStructure) TestExample2(*testing.T) {
+	t.test2 = true
+}
+
+func (t *testStructure) Teardown(*testing.T) {
+	t.teardown = true
+}
+
+func TestRunSubTests(t *testing.T) {
+	testStruct := &testStructure{}
+
+	test_setup.RunSubTests(t, testStruct)
+
+	AssertTrue(testStruct.setup)
+	AssertTrue(testStruct.test1)
+	AssertTrue(testStruct.test2)
+	AssertTrue(testStruct.teardown)
+}

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -22,11 +22,12 @@ import (
 )
 
 type testStructure struct {
-	setup, test1, test2, teardown bool
+	setupCtr, teardownCtr int
+	test1, test2          bool
 }
 
 func (t *testStructure) Setup(*testing.T) {
-	t.setup = true
+	t.setupCtr++
 }
 func (t *testStructure) TestExample1(*testing.T) {
 	t.test1 = true
@@ -37,7 +38,7 @@ func (t *testStructure) TestExample2(*testing.T) {
 }
 
 func (t *testStructure) Teardown(*testing.T) {
-	t.teardown = true
+	t.teardownCtr++
 }
 
 func TestRunSubTests(t *testing.T) {
@@ -45,8 +46,8 @@ func TestRunSubTests(t *testing.T) {
 
 	test_setup.RunSubTests(t, testStruct)
 
-	AssertTrue(testStruct.setup)
+	AssertEq(testStruct.setupCtr, 2)
 	AssertTrue(testStruct.test1)
 	AssertTrue(testStruct.test2)
-	AssertTrue(testStruct.teardown)
+	AssertEq(testStruct.teardownCtr, 2)
 }

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -15,9 +15,10 @@
 package test_setup_test
 
 import (
+	"testing"
+
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 	. "github.com/jacobsa/ogletest"
-	"testing"
 )
 
 type testStructure struct {

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -22,32 +22,31 @@ import (
 )
 
 type testStructure struct {
-	setupCtr, teardownCtr int
-	test1, test2          bool
+	setupCtr, teardownCtr, test1, test2 int
 }
 
 func (t *testStructure) Setup(*testing.T) {
 	t.setupCtr++
 }
 func (t *testStructure) TestExample1(*testing.T) {
-	t.test1 = true
+	t.test1++
 }
 
 func (t *testStructure) TestExample2(*testing.T) {
-	t.test2 = true
+	t.test2++
 }
 
 func (t *testStructure) Teardown(*testing.T) {
 	t.teardownCtr++
 }
 
-func TestRunSubTests(t *testing.T) {
+func TestRunTests(t *testing.T) {
 	testStruct := &testStructure{}
 
-	test_setup.RunSubTests(t, testStruct)
+	test_setup.RunTests(t, testStruct)
 
 	AssertEq(testStruct.setupCtr, 2)
-	AssertTrue(testStruct.test1)
-	AssertTrue(testStruct.test2)
+	AssertEq(testStruct.test1, 1)
+	AssertEq(testStruct.test2, 1)
 	AssertEq(testStruct.teardownCtr, 2)
 }


### PR DESCRIPTION
### Description
Post this change, package test_setup can be imported to support setup and teardown methods in tests. Setup and teardown methods can be used for per test setup and clean up. This is required for GCSFuse ReadCache functional tests to unmount and mount GCSFuse after each test.
Refer to `tools/integration_tests/util/test_setup/test_setup_test.go` for usage.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
