### PR TITLE
Changing flag name to cache-file-for-range-read in experiment perf tests.

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/README.md
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/README.md
@@ -1,6 +1,9 @@
 # Experiment Configuration JSON File README
 
-**NOTE**: If you modify a flag name within the development branch, ensure you also update the corresponding flag name within the experiments_configuration.json file located in the master branch. This synchronization is crucial for running tests correctly.
+**NOTE**: If you modify a flag name within the development branch, ensure you also 
+update the corresponding flag name within the [experiments_configuration.json](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json) 
+file located in the master branch. This synchronization is crucial for running tests correctly.
+
 ## This JSON file contains configurations for different experiments.
 ### Configuration Format:
 ```

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/README.md
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/README.md
@@ -1,4 +1,6 @@
 # Experiment Configuration JSON File README
+
+**NOTE**: If you modify a flag name within the development branch, ensure you also update the corresponding flag name within the experiments_configuration.json file located in the master branch. This synchronization is crucial for running tests correctly.
 ## This JSON file contains configurations for different experiments.
 ### Configuration Format:
 ```

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -7,12 +7,6 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "dec_2023_release",
-      "gcsfuse_flags":"--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
-      "branch": "dec_2023_release",
-      "end_date": "2023-12-30 05:30:00+00:00"
-    },
-    {
       "config_name": "read_cache_cache_file_for_range_read_true",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -18,7 +18,7 @@
       "config_file_flags_as_json": {
         "file-cache": {
           "max-size-in-mb": -1,
-          "download-file-for-random-read": true
+          "cache-file-for-range-read": true
         }
       },
       "branch": "read_cache_release",
@@ -30,7 +30,7 @@
       "config_file_flags_as_json": {
         "file-cache": {
           "max-size-in-mb": -1,
-          "download-file-for-random-read": false
+          "cache-file-for-range-read": false
         }
       },
       "branch": "read_cache_release",

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -13,7 +13,7 @@
       "end_date": "2023-12-30 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_download_for_rand_read",
+      "config_name": "read_cache_cache_file_for_range_read_true",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
@@ -25,7 +25,7 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_not_download_for_rand_read",
+      "config_name": "read_cache_cache_file_for_range_read_false",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {


### PR DESCRIPTION
### Description
The  experiment perf tests are failing as it's looking for `download-file-for-random-read` flag.
This change is due to this PR-https://github.com/GoogleCloudPlatform/gcsfuse/pull/1571

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested locally
2. Unit tests - NA
3. Integration tests - NA
