### PR TITLE
log failed mount message in e2e tests

### DIFF
--- a/tools/integration_tests/util/mounting/mounting.go
+++ b/tools/integration_tests/util/mounting/mounting.go
@@ -43,9 +43,10 @@ func MountGcsfuse(binaryFile string, flags []string) error {
 		fmt.Println("Could not write cmd to logFile")
 	}
 
-	_, err = mountCmd.CombinedOutput()
+	output, err := mountCmd.CombinedOutput()
 	if err != nil {
 		log.Println(mountCmd.String())
+		log.Println("Error: ", string(output))
 		return fmt.Errorf("cannot mount gcsfuse: %w\n", err)
 	}
 	return nil


### PR DESCRIPTION
### Description
Log output from the failed mount command for easier debugging in case of failure in GCSFuse integration tests.
Example:
```
2024/01/09 09:04:20 /tmp/gcsfuse_readwrite_test_2044354406/bin/gcsfuse --o=ro --implicit-dirs=true --config-file=/tmp/gcsfuse_readwrite_test_2044354406/config.yaml --debug_gcs --debug_fs --debug_fuse --log-file=/tmp/gcsfuse_readwrite_test_2044354406/gcsfuse.log --log-format=text bucket_name /tmp/gcsfuse_readwrite_test_2044354406/mnt
2024/01/09 09:04:20 Error:  parsing config file failed: error parsing config file: max-file-size-mb should be atleast 1

2024/01/09 09:04:20 mountGcsfuse: cannot mount gcsfuse: exit status 1
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified the log message.
2. Unit tests - NA
3. Integration tests - NA
