### PR TITLE
use constant for read operation in context

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2135,7 +2135,7 @@ func (fs *fileSystem) ReadFile(
 	op *fuseops.ReadFileOp) (err error) {
 
 	// Save readOp in context for access in logs.
-	ctx = context.WithValue(ctx, "readOp", op)
+	ctx = context.WithValue(ctx, gcsx.ReadOp, op)
 
 	// Find the handle and lock it.
 	fs.mu.Lock()

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -50,6 +50,9 @@ const maxReadSize = 8 * MB
 // Minimum number of seeks before evaluating if the read pattern is random.
 const minSeeksForRandom = 2
 
+// "readOp" is the value used in read context to store pointer to the read operation.
+const ReadOp = "readOp"
+
 // RandomReader is an object that knows how to read ranges within a particular
 // generation of a particular GCS object. Optimised for (large) sequential reads.
 //
@@ -174,7 +177,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 
 	// Request log and start the execution timer.
 	requestId := uuid.New()
-	readOp := ctx.Value("readOp").(*fuseops.ReadFileOp)
+	readOp := ctx.Value(ReadOp).(*fuseops.ReadFileOp)
 	logger.Tracef("%.13v <- FileCache(%s:/%s, offset: %d, size: %d handle: %d)", requestId, rr.bucket.Name(), rr.object.Name, offset, len(p), readOp.Handle)
 	startTime := time.Now()
 

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -160,7 +160,7 @@ var _ TearDownInterface = &RandomReaderTest{}
 
 func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	readOp := fuseops.ReadFileOp{Handle: 1}
-	t.rr.ctx = context.WithValue(ti.Ctx, "readOp", &readOp)
+	t.rr.ctx = context.WithValue(ti.Ctx, ReadOp, &readOp)
 
 	// Manufacture an object record.
 	t.object = &gcs.MinObject{


### PR DESCRIPTION
### Description
use constant for read operation in context instead of using "readOp" string multiple times.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
