### PR TITLE
Fix integration test failure on read_cache_release branch

### DIFF
--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -15,6 +15,7 @@
 package test_setup_test
 
 import (
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
@@ -41,6 +42,7 @@ func (t *testStructure) Teardown(*testing.T) {
 }
 
 func TestRunTests(t *testing.T) {
+	setup.ParseSetUpFlags()
 	testStruct := &testStructure{}
 
 	test_setup.RunTests(t, testStruct)

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -15,9 +15,9 @@
 package test_setup_test
 
 import (
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 	. "github.com/jacobsa/ogletest"
 )


### PR DESCRIPTION
### Description

The issue with integration tests on the read_cache_release branch.
When attempting to run integration tests on the branch, they're failing with an error: `flag provided but not defined: -integrationTest.`
The root cause appears to be the recent addition of the [test_setup_test.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/read_cache_release/tools/integration_tests/util/test_setup/test_setup_test.go#L44) file. The go test command is now trying to execute tests within this file, which likely requires the -integrationTest flag to function properly.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
