### PR TITLE
skip running unit tests in util package if integration test flag is set

### DIFF
--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -60,6 +61,8 @@ type testCase struct {
 }
 
 func TestParseLogFileSuccessful(t *testing.T) {
+	setup.IgnoreTestIfIntegrationTestFlagIsSet(t)
+
 	tests := []testCase{
 		{
 			name: "Test file cache logs with 1 chunk",
@@ -138,6 +141,8 @@ func TestParseLogFileSuccessful(t *testing.T) {
 }
 
 func TestParseLogFileUnsuccessful(t *testing.T) {
+	setup.IgnoreTestIfIntegrationTestFlagIsSet(t)
+
 	tests := []testCase{
 		{
 			name: "Test file cache logs without Read File log",

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -280,6 +280,14 @@ func ParseSetUpFlags() {
 	}
 }
 
+func IgnoreTestIfIntegrationTestFlagIsSet(t *testing.T) {
+	flag.Parse()
+
+	if *integrationTest {
+		t.SkipNow()
+	}
+}
+
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {
 	ParseSetUpFlags()
 

--- a/tools/integration_tests/util/test_setup/test_setup_test.go
+++ b/tools/integration_tests/util/test_setup/test_setup_test.go
@@ -17,6 +17,7 @@ package test_setup_test
 import (
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 	. "github.com/jacobsa/ogletest"
 )
@@ -41,6 +42,8 @@ func (t *testStructure) Teardown(*testing.T) {
 }
 
 func TestRunTests(t *testing.T) {
+	setup.IgnoreTestIfIntegrationTestFlagIsSet(t)
+
 	testStruct := &testStructure{}
 
 	test_setup.RunTests(t, testStruct)


### PR DESCRIPTION
### Description
Integration tests started failing because all the tests in integration_tests directory run with --integration_test flag which was unused in these unit tests. 
Fix: Skip the tests if integration_test flag is set.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - ran as part of presubmit
3. Integration tests - ran as part of presubmit
