### PR TITLE
[ReadCacheFunctionalTest] Test 2: Object modified by another client after read.

### DIFF
--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -89,9 +89,9 @@ func getCachedFilePath() string {
 	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, testFileName)
 }
 
-func validateFileSizeInCacheDirectory(filesize int64, t *testing.T) (expectedPathOfCachedFile string) {
+func validateFileSizeInCacheDirectory(filesize int64, t *testing.T) {
 	// Validate that the file is present in cache location.
-	expectedPathOfCachedFile = getCachedFilePath()
+	expectedPathOfCachedFile := getCachedFilePath()
 	fileInfo, err := operations.StatFile(expectedPathOfCachedFile)
 	if err != nil {
 		t.Errorf("Failed to find cached file %s: %v", expectedPathOfCachedFile, err)
@@ -100,12 +100,12 @@ func validateFileSizeInCacheDirectory(filesize int64, t *testing.T) (expectedPat
 	if (*fileInfo).Size() != filesize {
 		t.Errorf("Incorrect cached file size. Expected %d, Got: %d", filesize, (*fileInfo).Size())
 	}
-	return
 }
 
 func validateFileInCacheDirectory(filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
-	expectedPathOfCachedFile := validateFileSizeInCacheDirectory(filesize, t)
+	validateFileSizeInCacheDirectory(filesize, t)
 	// Validate content of file in cache directory matches GCS.
+	expectedPathOfCachedFile := getCachedFilePath()
 	content, err := operations.ReadFile(expectedPathOfCachedFile)
 	if err != nil {
 		t.Errorf("Failed to read cached file %s: %v", expectedPathOfCachedFile, err)

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -15,11 +15,13 @@
 package read_cache
 
 import (
+	"context"
 	"path"
 	"strings"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
@@ -84,7 +86,7 @@ func getCachedFilePath() string {
 	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, testFileName)
 }
 
-func (s *testStruct) validateFileInCacheDirectory(t *testing.T) {
+func validateFileInCacheDirectory(ctx context.Context, storageClient *storage.Client, t *testing.T) {
 	// Validate that the file is present in cache location.
 	expectedPathOfCachedFile := getCachedFilePath()
 	fileInfo, err := operations.StatFile(expectedPathOfCachedFile)
@@ -100,5 +102,5 @@ func (s *testStruct) validateFileInCacheDirectory(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to read cached file %s: %v", expectedPathOfCachedFile, err)
 	}
-	client.ValidateObjectContentsFromGCS(s.ctx, s.storageClient, testDirName, testFileName, string(content), t)
+	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, testFileName, string(content), t)
 }

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -62,14 +62,14 @@ func (s *smallCacheTTLTest) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *smallCacheTTLTest) TestSecondSequentialReadAfterUpdateIsCacheMiss(t *testing.T) {
+func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *testing.T) {
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
 	validateFileInCacheDirectory(fileSize, s.ctx, s.storageClient, t)
 	client.ValidateObjectContentsFromGCS(s.ctx, s.storageClient, testDirName, testFileName,
 		expectedOutcome1.content, t)
 
-	// Append to the file.
+	// Modify the file.
 	err := client.WriteToObject(s.ctx, s.storageClient, objectName, smallContent, storage.Conditions{})
 	if err != nil {
 		t.Errorf("Could not append to file: %v", err)

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -17,6 +17,7 @@ package read_cache
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ const (
 	smallContent          = "small content"
 	smallContentSize      = 13
 	chunksReadAfterUpdate = 1
-	metadataCacheTTlInSec = 5
+	metadataCacheTTlInSec = 10
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -76,9 +77,12 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *test
 	}
 
 	// Read same file again immediately.
-	// Stale data would be served from cache in this case.
 	expectedOutcome2 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
 	validateFileSizeInCacheDirectory(fileSize, t)
+	// Validate that stale data is served from cache in this case.
+	if strings.Compare(expectedOutcome1.content, expectedOutcome2.content) != 0 {
+		t.Errorf("content mismatch. Expected old data to be served again.")
+	}
 
 	// Wait for metadata cache expiry and read the file again.
 	time.Sleep(metadataCacheTTlInSec * time.Second)

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -29,25 +29,19 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 )
 
-const (
-	MiB             = 1024 * 1024
-	chunkSizeToRead = MiB
-	fileSize        = 3 * MiB
-	chunksRead      = fileSize / MiB
-	testFileName    = "foo"
-)
+const ()
 
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
-type testStruct struct {
+type testStruct1 struct {
 	flags         []string
 	storageClient *storage.Client
 	ctx           context.Context
 }
 
-func (s *testStruct) Setup(t *testing.T) {
+func (s *testStruct1) Setup(t *testing.T) {
 	if setup.MountedDirectory() == "" {
 		// Mount GCSFuse only when tests are not running on mounted directory.
 		if err := mountFunc(s.flags); err != nil {
@@ -59,7 +53,7 @@ func (s *testStruct) Setup(t *testing.T) {
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 }
 
-func (s *testStruct) Teardown(t *testing.T) {
+func (s *testStruct1) Teardown(t *testing.T) {
 	// unmount gcsfuse
 	setup.SetMntDir(rootDir)
 	if setup.MountedDirectory() == "" {
@@ -80,7 +74,7 @@ func (s *testStruct) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *testStruct) TestSecondSequentialReadIsCacheHit(t *testing.T) {
+func (s *testStruct1) TestSecondSequentialReadAfterUpdateIsCacheMiss(t *testing.T) {
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
 	validateFileInCacheDirectory(s.ctx, s.storageClient, t)
@@ -102,12 +96,12 @@ func (s *testStruct) TestSecondSequentialReadIsCacheHit(t *testing.T) {
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestReadOnlyTest(t *testing.T) {
+func TestSmallCacheTTLTest(t *testing.T) {
 	// Define flag set to run the tests.
 	mountConfigFilePath := createConfigFile(9)
 	flagSet := [][]string{
-		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath},
-		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath},
+		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath, "stat-cache-ttl=30s"},
+		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath, "stat-cache-ttl=30s"},
 	}
 
 	// Create storage client before running tests.


### PR DESCRIPTION
### Description
#### Scenario:
R1: Full object read 
Another client has written to make it the file to change object generation
R2: Full object read 
R3: Full object read (after stat cache expiry) 

### Expected Behavior
R1 - cache miss
R2 - cache hit (but stale data)
R3 - cache miss (new data)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
