### PR TITLE
[ReadCacheFunctionalTest] Test 3: Object modified by another client after read with stat cache ttl 0

### DIFF
--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_cache
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
+)
+
+const ()
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type disabledCacheTTLTest struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+}
+
+func (s *disabledCacheTTLTest) Setup(t *testing.T) {
+	mountGCSFuse(s.flags)
+	setup.SetMntDir(mountDir)
+	testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
+}
+
+func (s *disabledCacheTTLTest) Teardown(t *testing.T) {
+	// unmount gcsfuse
+	setup.SetMntDir(rootDir)
+	unmountGCSFuseAndDeleteLogFile()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *disabledCacheTTLTest) TestReadAfterUpdateIsCacheMiss(t *testing.T) {
+	// Read file 1st time.
+	expectedOutcome1 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
+	validateFileInCacheDirectory(fileSize, s.ctx, s.storageClient, t)
+	client.ValidateObjectContentsFromGCS(s.ctx, s.storageClient, testDirName, testFileName,
+		expectedOutcome1.content, t)
+
+	// Modify the file.
+	err := client.WriteToObject(s.ctx, s.storageClient, objectName, smallContent, storage.Conditions{})
+	if err != nil {
+		t.Errorf("Could not append to file: %v", err)
+	}
+
+	// Read same file again immediately. New content should be served as cache ttl is 0.
+	expectedOutcome2 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
+	validateFileInCacheDirectory(smallContentSize, s.ctx, s.storageClient, t)
+	client.ValidateObjectContentsFromGCS(s.ctx, s.storageClient, testDirName, testFileName,
+		expectedOutcome2.content, t)
+
+	// Read the same file again. The data should be served from cache.
+	expectedOutcome3 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
+	validateFileInCacheDirectory(smallContentSize, s.ctx, s.storageClient, t)
+	client.ValidateObjectContentsFromGCS(s.ctx, s.storageClient, testDirName, testFileName,
+		expectedOutcome3.content, t)
+
+	// Parse the log file and validate cache hit or miss from the structured logs.
+	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	validate(expectedOutcome1, structuredReadLogs[0], true, false, chunksRead, t)
+	validate(expectedOutcome2, structuredReadLogs[1], true, false, chunksReadAfterUpdate, t)
+	validate(expectedOutcome3, structuredReadLogs[2], true, true, chunksReadAfterUpdate, t)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestDisabledCacheTTLTest(t *testing.T) {
+	// Define flag set to run the tests.
+	mountConfigFilePath := createConfigFile(9)
+	var flagSet = [][]string{
+		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath, "--stat-cache-ttl=0s"},
+		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath, "--stat-cache-ttl=0s"},
+	} // Create storage client before running tests.
+	ts := &disabledCacheTTLTest{ctx: context.Background()}
+	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
+	defer closeStorageClient()
+
+	// Run tests.
+	for _, flags := range flagSet {
+		// Run tests without ro flag.
+		ts.flags = flags
+		test_setup.RunTests(t, ts)
+		// Run tests with ro flag.
+		ts.flags = append(flags, "--o=ro")
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 )
 
-const ()
-
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
@@ -54,7 +52,7 @@ func (s *disabledCacheTTLTest) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *disabledCacheTTLTest) TestReadAfterUpdateIsCacheMiss(t *testing.T) {
+func (s *disabledCacheTTLTest) TestReadAfterObjectUpdateIsCacheMiss(t *testing.T) {
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
 	validateFileInCacheDirectory(fileSize, s.ctx, s.storageClient, t)

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -62,7 +62,7 @@ func (s *disabledCacheTTLTest) TestReadAfterObjectUpdateIsCacheMiss(t *testing.T
 	// Modify the file.
 	err := client.WriteToObject(s.ctx, s.storageClient, objectName, smallContent, storage.Conditions{})
 	if err != nil {
-		t.Errorf("Could not append to file: %v", err)
+		t.Errorf("Could not modify object %s: %v", objectName, err)
 	}
 
 	// Read same file again immediately. New content should be served as cache ttl is 0.

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -52,7 +51,7 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, t *testing.T) *
 		t.Errorf("Failed to read file in first iteration: %v", err)
 	}
 	expected.EndTimeStampSeconds = time.Now().Unix()
-	expected.content = strings.Trim(string(content), operations.EOFMarker)
+	expected.content = string(content)
 
 	return expected
 }

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -84,13 +84,13 @@ func validate(expected *Expected, logEntry *read_logs.StructuredReadLogEntry,
 	}
 }
 
-func getCachedFilePath() string {
-	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, testFileName)
+func getCachedFilePath(fileName string) string {
+	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, fileName)
 }
 
-func validateFileSizeInCacheDirectory(filesize int64, t *testing.T) {
+func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testing.T) {
 	// Validate that the file is present in cache location.
-	expectedPathOfCachedFile := getCachedFilePath()
+	expectedPathOfCachedFile := getCachedFilePath(fileName)
 	fileInfo, err := operations.StatFile(expectedPathOfCachedFile)
 	if err != nil {
 		t.Errorf("Failed to find cached file %s: %v", expectedPathOfCachedFile, err)
@@ -101,15 +101,15 @@ func validateFileSizeInCacheDirectory(filesize int64, t *testing.T) {
 	}
 }
 
-func validateFileInCacheDirectory(filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
-	validateFileSizeInCacheDirectory(filesize, t)
+func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
+	validateFileSizeInCacheDirectory(fileName, filesize, t)
 	// Validate content of file in cache directory matches GCS.
-	expectedPathOfCachedFile := getCachedFilePath()
+	expectedPathOfCachedFile := getCachedFilePath(fileName)
 	content, err := operations.ReadFile(expectedPathOfCachedFile)
 	if err != nil {
 		t.Errorf("Failed to read cached file %s: %v", expectedPathOfCachedFile, err)
 	}
-	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, testFileName, string(content), t)
+	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, fileName, string(content), t)
 }
 
 func unmountGCSFuseAndDeleteLogFile() {

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -154,14 +154,22 @@ func createStorageClient(t *testing.T, ctx *context.Context, storageClient **sto
 	}
 }
 
-func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage.Client, fileSize int64, t *testing.T) (expectedOutcome *Expected) {
+func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage.Client, filename string, fileSize int64, t *testing.T) (expectedOutcome *Expected) {
 	// Read file with gcsfuse mount.
-	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
+	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, t)
 	// Validate cached content with gcs.
-	validateFileInCacheDirectory(fileSize, ctx, storageClient, t)
+	validateFileInCacheDirectory(filename, fileSize, ctx, storageClient, t)
 	// Validate content read via gcsfuse with gcs.
-	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, testFileName,
+	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, filename,
 		expectedOutcome.content, t)
 
 	return expectedOutcome
+}
+
+func modifyFile(ctx context.Context, storageClient *storage.Client, testFileName string, t *testing.T) {
+	objectName := path.Join(testDirName, testFileName)
+	err := client.WriteToObject(ctx, storageClient, objectName, smallContent, storage.Conditions{})
+	if err != nil {
+		t.Errorf("Could not modify object %s: %v", objectName, err)
+	}
 }

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -47,7 +47,6 @@ func (s *readOnlyTest) Setup(t *testing.T) {
 	mountGCSFuse(s.flags)
 	setup.SetMntDir(mountDir)
 	testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 }
 
 func (s *readOnlyTest) Teardown(t *testing.T) {
@@ -61,6 +60,8 @@ func (s *readOnlyTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *readOnlyTest) TestSecondSequentialReadIsCacheHit(t *testing.T) {
+	testFileName := testFileName + "1"
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
 	// Read file 2nd time.

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -62,10 +62,11 @@ func (s *readOnlyTest) Teardown(t *testing.T) {
 func (s *readOnlyTest) TestSecondSequentialReadIsCacheHit(t *testing.T) {
 	testFileName := testFileName + "1"
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
+
 	// Read file 1st time.
-	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
+	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 	// Read file 2nd time.
-	expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
+	expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 
 	// Parse the log file and validate cache hit or miss from the structured logs.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -17,7 +17,6 @@ package read_cache
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +49,6 @@ func (s *smallCacheTTLTest) Setup(t *testing.T) {
 	mountGCSFuse(s.flags)
 	setup.SetMntDir(mountDir)
 	testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 }
 
 func (s *smallCacheTTLTest) Teardown(t *testing.T) {
@@ -66,16 +64,11 @@ func (s *smallCacheTTLTest) Teardown(t *testing.T) {
 func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *testing.T) {
 	testFileName := testFileName + "2"
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
+
 	// Read file 1st time.
-	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
-
+	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 	// Modify the file.
-	objectName := path.Join(testDirName, testFileName)
-	err := client.WriteToObject(s.ctx, s.storageClient, objectName, smallContent, storage.Conditions{})
-	if err != nil {
-		t.Errorf("Could not modify object %s: %v", objectName, err)
-	}
-
+	modifyFile(s.ctx, s.storageClient, testFileName, t)
 	// Read same file again immediately.
 	expectedOutcome2 := readFileAndGetExpectedOutcome(testDirPath, testFileName, t)
 	validateFileSizeInCacheDirectory(testFileName, fileSize, t)
@@ -83,10 +76,9 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *test
 	if strings.Compare(expectedOutcome1.content, expectedOutcome2.content) != 0 {
 		t.Errorf("content mismatch. Expected old data to be served again.")
 	}
-
 	// Wait for metadata cache expiry and read the file again.
 	time.Sleep(metadataCacheTTlInSec * time.Second)
-	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, smallContentSize, t)
+	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, smallContentSize, t)
 
 	// Parse the log file and validate cache hit or miss from the structured logs.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
@@ -96,15 +88,16 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *test
 }
 
 func (s *smallCacheTTLTest) TestReadForLowMetaDataCacheTTLIsCacheHit(t *testing.T) {
-	// Read file 1st time.
-	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
+	testFileName := testFileName + "4"
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
+	// Read file 1st time.
+	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 	// Wait for metadata cache expiry and read the file again.
 	time.Sleep(metadataCacheTTlInSec * time.Second)
-	expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
-
+	expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 	// Read same file again immediately.
-	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, fileSize, t)
+	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
 
 	// Parse the log file and validate cache hit or miss from the structured logs.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -70,7 +70,7 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *test
 	// Modify the file.
 	err := client.WriteToObject(s.ctx, s.storageClient, objectName, smallContent, storage.Conditions{})
 	if err != nil {
-		t.Errorf("Could not append to file: %v", err)
+		t.Errorf("Could not modify object %s: %v", objectName, err)
 	}
 
 	// Read same file again immediately.

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -110,7 +110,7 @@ func CreateObjectInGCSTestDir(ctx context.Context, storageClient *storage.Client
 func SetupFileInTestDirectory(ctx context.Context, storageClient *storage.Client,
 	testDirName, testFileName string, size int64, t *testing.T) {
 	randomData, err := operations.GenerateRandomData(size)
-	randomDataString := strings.Trim(string(randomData), "\x00")
+	randomDataString := string(randomData)
 	if err != nil {
 		t.Errorf("operations.GenerateRandomData: %v", err)
 	}

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -70,7 +70,7 @@ func ValidateObjectContentsFromGCS(ctx context.Context, storageClient *storage.C
 	testDirName string, fileName string, expectedContent string, t *testing.T) {
 	gotContent, err := ReadObjectFromGCS(ctx, storageClient, path.Join(testDirName, fileName))
 	if err != nil {
-		t.Fatalf("Error while reading synced local file from GCS, Err: %v", err)
+		t.Fatalf("Error while reading file from GCS, Err: %v", err)
 	}
 
 	if expectedContent != gotContent {

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -78,8 +78,7 @@ func ReadObjectFromGCS(ctx context.Context, client *storage.Client, object strin
 		return "", fmt.Errorf("io.ReadAll failed: %v", err)
 	}
 
-	// Remove any extra null characters from content before returning.
-	return strings.Trim(string(content), "\x00"), nil
+	return string(content), nil
 }
 
 func WriteToObject(ctx context.Context, client *storage.Client, object, content string, precondition storage.Conditions) error {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -36,7 +36,6 @@ const (
 	OneMiB = OneKiB * OneKiB
 	// ChunkSizeForContentComparison is currently set to 1 MiB.
 	ChunkSizeForContentComparison int = OneMiB
-	EOFMarker                         = "\x00"
 )
 
 func copyFile(srcFileName, dstFileName string, allowOverwrite bool) (err error) {


### PR DESCRIPTION
### Description
#### Scenario:
With stat cache ttl = 0
R1: Full object read 
Another client has written to make it the file to change object generation
R2: Full object read 
R3: Full object read

### Expected Behavior
R1 - cache miss
R2 - cache miss (serves updated data as cache ttl is 0)
R3 - cache hit (serves updated data)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - In progress