### PR TITLE
[ReadCacheFunctionalTest] Test 19: Test that cache works as intended on remounting GCSFuse and data is cleared between remount.

### DIFF
--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -52,7 +52,7 @@ func (s *disabledCacheTTLTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *disabledCacheTTLTest) TestReadAfterObjectUpdateIsCacheMiss(t *testing.T) {
-	testFileName := testFileName + setup.GenerateRandomString(4)
+	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
 	// Read file 1st time.

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -88,6 +88,10 @@ func getCachedFilePath(fileName string) string {
 	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, fileName)
 }
 
+func getCacheDirPath() string {
+	return path.Join(cacheLocationPath, cacheSubDirectoryName)
+}
+
 func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testing.T) {
 	// Validate that the file is present in cache location.
 	expectedPathOfCachedFile := getCachedFilePath(fileName)
@@ -133,6 +137,20 @@ func unmountGCSFuseAndDeleteLogFile() {
 		if err != nil {
 			setup.LogAndExit(fmt.Sprintf("Error in deleting log file: %v", err))
 		}
+	}
+}
+
+func remountGCSFuseAndValidateCacheDeleted(flags []string, t *testing.T) {
+	unmountGCSFuseAndDeleteLogFile()
+	mountGCSFuse(flags)
+
+	fi, err := operations.StatFile(getCacheDirPath())
+	if err != nil {
+		t.Errorf("stat cache directory %s: %v", getCacheDirPath(), err)
+	}
+	if (*fi).Size() != 0 {
+		t.Errorf("cache directory %s not empty after unmount. Size: %d",
+			getCacheDirPath(), (*fi).Size())
 	}
 }
 

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -143,13 +142,13 @@ func remountGCSFuseAndValidateCacheDeleted(flags []string, t *testing.T) {
 	mountGCSFuse(flags)
 	setup.SetMntDir(mountDir)
 
-	size, err := cacheSize()
+	cacheSize, err := operations.DirSize(cacheLocationPath)
 	if err != nil {
-		t.Errorf("cacheSize() %v", err)
+		t.Errorf("Error in getting cache size: %v", cacheSize)
 	}
-	if size != 0 {
+	if cacheSize != 0 {
 		t.Errorf("cache directory %s not empty after unmount. Size: %d",
-			cacheLocationPath, size)
+			cacheLocationPath, cacheSize)
 	}
 }
 

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -88,10 +89,6 @@ func getCachedFilePath(fileName string) string {
 	return path.Join(cacheLocationPath, cacheSubDirectoryName, setup.TestBucket(), testDirName, fileName)
 }
 
-func getCacheDirPath() string {
-	return path.Join(cacheLocationPath, cacheSubDirectoryName)
-}
-
 func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testing.T) {
 	// Validate that the file is present in cache location.
 	expectedPathOfCachedFile := getCachedFilePath(fileName)
@@ -141,16 +138,18 @@ func unmountGCSFuseAndDeleteLogFile() {
 }
 
 func remountGCSFuseAndValidateCacheDeleted(flags []string, t *testing.T) {
+	setup.SetMntDir(rootDir)
 	unmountGCSFuseAndDeleteLogFile()
 	mountGCSFuse(flags)
+	setup.SetMntDir(mountDir)
 
-	fi, err := operations.StatFile(getCacheDirPath())
+	size, err := cacheSize()
 	if err != nil {
-		t.Errorf("stat cache directory %s: %v", getCacheDirPath(), err)
+		t.Errorf("cacheSize() %v", err)
 	}
-	if (*fi).Size() != 0 {
+	if size != 0 {
 		t.Errorf("cache directory %s not empty after unmount. Size: %d",
-			getCacheDirPath(), (*fi).Size())
+			cacheLocationPath, size)
 	}
 }
 

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -52,7 +52,7 @@ func (s *localModificationTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss(t *testing.T) {
-	testFileName := testDirName + setup.GenerateRandomString(4)
+	testFileName := testDirName + setup.GenerateRandomString(testFileNameSuffixLength)
 	operations.CreateFileOfSize(fileSize, path.Join(testDirPath, testFileName), t)
 
 	// Read file 1st time.

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -71,7 +71,7 @@ func validateCacheOfMultipleObjectsUsingStructuredLogs(startIndex int, numFiles 
 ////////////////////////////////////////////////////////////////////////
 
 func (s *readOnlyTest) TestSecondSequentialReadIsCacheHit(t *testing.T) {
-	testFileName := testFileName + setup.GenerateRandomString(4)
+	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
 	// Read file 1st time.

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_cache
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type remountTest struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+}
+
+func (s *remountTest) Setup(t *testing.T) {
+	mountGCSFuse(s.flags)
+	setup.SetMntDir(mountDir)
+	testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+}
+
+func (s *remountTest) Teardown(t *testing.T) {
+	// unmount gcsfuse
+	setup.SetMntDir(rootDir)
+	unmountGCSFuseAndDeleteLogFile()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *remountTest) Test(t *testing.T) {
+	testFileName := testFileName + "1"
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
+
+	// Run read operations on GCSFuse mount.
+	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
+	expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
+	structuredReadLogsMount1 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	// Re-mount GCSFuse and validate cache deleted.
+	remountGCSFuseAndValidateCacheDeleted(s.flags, t)
+	// Run read operations again on GCSFuse mount.
+	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
+	expectedOutcome4 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, t)
+	structuredReadLogsMount2 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+
+	validate(expectedOutcome1, structuredReadLogsMount1[0], true, false, chunksRead, t)
+	validate(expectedOutcome2, structuredReadLogsMount1[1], true, true, chunksRead, t)
+	validate(expectedOutcome3, structuredReadLogsMount2[0], true, false, chunksRead, t)
+	validate(expectedOutcome4, structuredReadLogsMount2[1], true, true, chunksRead, t)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestRemountTest(t *testing.T) {
+	if setup.MountedDirectory() != "" {
+		t.Log("Not running remount tests for GKE environment...")
+		t.SkipNow()
+	}
+	// Define flag set to run the tests.
+	mountConfigFilePath := createConfigFile(9)
+	flagSet := [][]string{
+		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath},
+		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath},
+	}
+
+	// Create storage client before running tests.
+	ts := &readOnlyTest{ctx: context.Background()}
+	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
+	defer closeStorageClient()
+
+	// Run tests.
+	for _, flags := range flagSet {
+		// Run tests without ro flag.
+		ts.flags = flags
+		test_setup.RunTests(t, ts)
+		// Run tests with ro flag.
+		ts.flags = append(flags, "--o=ro")
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -51,8 +51,8 @@ func (s *remountTest) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *remountTest) Test(t *testing.T) {
-	testFileName := testFileName + "1"
+func (s *remountTest) TestCacheClearsOnRemount(t *testing.T) {
+	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
 	// Run read operations on GCSFuse mount.
@@ -82,7 +82,7 @@ func TestRemountTest(t *testing.T) {
 		t.SkipNow()
 	}
 	// Define flag set to run the tests.
-	mountConfigFilePath := createConfigFile(9)
+	mountConfigFilePath := createConfigFile(cacheCapacityInMB)
 	flagSet := [][]string{
 		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath},
 		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath},

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -89,7 +89,7 @@ func TestRemountTest(t *testing.T) {
 	}
 
 	// Create storage client before running tests.
-	ts := &readOnlyTest{ctx: context.Background()}
+	ts := &remountTest{ctx: context.Background()}
 	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
 	defer closeStorageClient()
 

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -46,6 +46,7 @@ const (
 	largeFileChunksRead             = 15
 	chunksReadAfterUpdate           = 1
 	metadataCacheTTlInSec           = 10
+	testFileNameSuffixLength        = 4
 )
 
 var (

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -55,7 +55,7 @@ func (s *smallCacheTTLTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *testing.T) {
-	testFileName := testFileName + setup.GenerateRandomString(4)
+	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
 	// Read file 1st time.
@@ -81,7 +81,7 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss(t *test
 }
 
 func (s *smallCacheTTLTest) TestReadForLowMetaDataCacheTTLIsCacheHit(t *testing.T) {
-	testFileName := testFileName + setup.GenerateRandomString(4)
+	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, t)
 
 	// Read file 1st time.


### PR DESCRIPTION
### Description
#### Scenario:

R1: Read file sequentially
R2: read again
Remount GCSFuse
R3: Read same file again sequentially
R4: Read same file again sequentially

#### Expected Behavior
R1: Cache miss
R2: Cache Hit
Validate cache directory empty
R3: Cache miss
R4: cache hit

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran via presubmits
