### PR TITLE
[ReadCacheFunctionalTest] Test 11 and 12: Single file random read of size more than cache capacity

### DIFF
--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -77,22 +77,23 @@ func (s *disabledCacheTTLTest) TestReadAfterObjectUpdateIsCacheMiss(t *testing.T
 
 func TestDisabledCacheTTLTest(t *testing.T) {
 	// Define flag set to run the tests.
-	mountConfigFilePath := createConfigFile(cacheCapacityInMB)
-	var flagSet = [][]string{
-		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath, "--stat-cache-ttl=0s"},
-		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath, "--stat-cache-ttl=0s"},
-	} // Create storage client before running tests.
+	flagSet := [][]string{
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
+	}
+	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	appendFlags(&flagSet, "--stat-cache-ttl=0s")
+	appendFlags(&flagSet, "--o=ro", "")
+
+	// Create storage client before running tests.
 	ts := &disabledCacheTTLTest{ctx: context.Background()}
 	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
 	defer closeStorageClient()
 
 	// Run tests.
 	for _, flags := range flagSet {
-		// Run tests without ro flag.
 		ts.flags = flags
-		test_setup.RunTests(t, ts)
-		// Run tests with ro flag.
-		ts.flags = append(flags, "--o=ro")
+		t.Logf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)
 	}
 }

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -203,7 +203,7 @@ func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage
 	return expectedOutcome
 }
 
-func ReadFileAndValidateFileIsNotCached(ctx context.Context, storageClient *storage.Client,
+func readFileAndValidateFileIsNotCached(ctx context.Context, storageClient *storage.Client,
 	filename string, isSeq bool, t *testing.T) (expectedOutcome *Expected) {
 	// Read file via gcsfuse mount.
 	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, isSeq, t)

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -39,16 +39,25 @@ type Expected struct {
 	content               string
 }
 
-func readFileAndGetExpectedOutcome(testDirPath, fileName string, t *testing.T) *Expected {
+func readFileAndGetExpectedOutcome(testDirPath, fileName string, isSeq bool, t *testing.T) *Expected {
 	expected := &Expected{
 		StartTimeStampSeconds: time.Now().Unix(),
 		BucketName:            setup.TestBucket(),
 		ObjectName:            path.Join(testDirName, fileName),
 	}
+	var content []byte
+	var err error
 
-	content, err := operations.ReadFileSequentially(path.Join(testDirPath, fileName), chunkSizeToRead)
-	if err != nil {
-		t.Errorf("Failed to read file in first iteration: %v", err)
+	if isSeq {
+		content, err = operations.ReadFileSequentially(path.Join(testDirPath, fileName), chunkSizeToRead)
+		if err != nil {
+			t.Errorf("Failed to read file sequentially: %v", err)
+		}
+	} else {
+		content, err = operations.ReadChunkFromFile(path.Join(testDirPath, fileName), chunkSizeToRead, randomReadOffset)
+		if err != nil {
+			t.Errorf("Failed to read random file chunk: %v", err)
+		}
 	}
 	expected.EndTimeStampSeconds = time.Now().Unix()
 	expected.content = string(content)
@@ -182,7 +191,7 @@ func createStorageClient(t *testing.T, ctx *context.Context, storageClient **sto
 func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage.Client,
 	filename string, fileSize int64, t *testing.T) (expectedOutcome *Expected) {
 	// Read file via gcsfuse mount.
-	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, t)
+	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, true, t)
 	// Validate cached content with gcs.
 	validateFileInCacheDirectory(filename, fileSize, ctx, storageClient, t)
 	// Validate cache size within limit.
@@ -194,15 +203,20 @@ func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage
 	return expectedOutcome
 }
 
-func ReadFileAndValidateFileIsNotCached(ctx context.Context, storageClient *storage.Client, filename string, t *testing.T) (expectedOutcome *Expected) {
+func ReadFileAndValidateFileIsNotCached(ctx context.Context, storageClient *storage.Client,
+	filename string, isSeq bool, t *testing.T) (expectedOutcome *Expected) {
 	// Read file via gcsfuse mount.
-	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, t)
+	expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, filename, isSeq, t)
 	// Validate that the file is not cached.
 	validateFileIsNotCached(filename, t)
 	// validate the content read matches the content on GCS.
-	client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, filename,
-		expectedOutcome.content, t)
-
+	if isSeq {
+		client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, filename,
+			expectedOutcome.content, t)
+	} else {
+		client.ValidateObjectChunkFromGCS(ctx, storageClient, testDirName, filename,
+			randomReadOffset, chunkSizeToRead, expectedOutcome.content, t)
+	}
 	return expectedOutcome
 }
 

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -77,11 +77,11 @@ func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss(t *tes
 
 func TestLocalModificationTest(t *testing.T) {
 	// Define flag set to run the tests.
-	mountConfigFilePath := createConfigFile(cacheCapacityInMB)
 	flagSet := [][]string{
-		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath},
-		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath},
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
 	}
+	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
 
 	// Create storage client before running tests.
 	ts := &localModificationTest{ctx: context.Background()}
@@ -90,8 +90,8 @@ func TestLocalModificationTest(t *testing.T) {
 
 	// Run tests.
 	for _, flags := range flagSet {
-		// Run tests without ro flag.
 		ts.flags = flags
+		t.Logf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)
 	}
 }

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -91,9 +91,9 @@ func (s *readOnlyTest) TestReadFileSequentiallyLargerThanCacheCapacity(t *testin
 		largeFileName, largeFileSize, t)
 
 	// Read file 1st time.
-	expectedOutcome1 := ReadFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
+	expectedOutcome1 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
 	// Read file 2nd time.
-	expectedOutcome2 := ReadFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
+	expectedOutcome2 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
 
 	// Parse the log file and validate cache hit or miss from the structured logs.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
@@ -107,9 +107,9 @@ func (s *readOnlyTest) TestReadFileRandomlyLargerThanCacheCapacity(t *testing.T)
 		largeFileName, largeFileSize, t)
 
 	// Do a random read on file.
-	expectedOutcome1 := ReadFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, false, t)
+	expectedOutcome1 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, false, t)
 	// Read file sequentially again.
-	expectedOutcome2 := ReadFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
+	expectedOutcome2 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, largeFileName, true, t)
 
 	// Parse the log file and validate cache hit or miss from the structured logs.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -82,11 +82,12 @@ func TestRemountTest(t *testing.T) {
 		t.SkipNow()
 	}
 	// Define flag set to run the tests.
-	mountConfigFilePath := createConfigFile(cacheCapacityInMB)
 	flagSet := [][]string{
-		{"--implicit-dirs=true", "--config-file=" + mountConfigFilePath},
-		{"--implicit-dirs=false", "--config-file=" + mountConfigFilePath},
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
 	}
+	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	appendFlags(&flagSet, "--o=ro", "")
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}
@@ -95,11 +96,8 @@ func TestRemountTest(t *testing.T) {
 
 	// Run tests.
 	for _, flags := range flagSet {
-		// Run tests without ro flag.
 		ts.flags = flags
-		test_setup.RunTests(t, ts)
-		// Run tests with ro flag.
-		ts.flags = append(flags, "--o=ro")
+		t.Logf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)
 	}
 }

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -78,6 +78,21 @@ func ValidateObjectContentsFromGCS(ctx context.Context, storageClient *storage.C
 	}
 }
 
+func ValidateObjectChunkFromGCS(ctx context.Context, storageClient *storage.Client,
+	testDirName string, fileName string, offset, size int64, expectedContent string,
+	t *testing.T) {
+	gotContent, err := ReadChunkFromGCS(ctx, storageClient,
+		path.Join(testDirName, fileName), offset, size)
+	if err != nil {
+		t.Fatalf("Error while reading file from GCS, Err: %v", err)
+	}
+
+	if expectedContent != gotContent {
+		t.Fatalf("GCS file %s content mismatch. Got file size: %d, Expected "+
+			"file size: %d ", fileName, len(gotContent), len(expectedContent))
+	}
+}
+
 func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *storage.Client,
 	fh *os.File, testDirName, fileName, content string, t *testing.T) {
 	operations.CloseFileShouldNotThrowError(fh, t)

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -281,7 +281,7 @@ func WriteFileSequentially(filePath string, fileSize int64, chunkSize int64) (er
 func ReadChunkFromFile(filePath string, chunkSize int64, offset int64) (chunk []byte, err error) {
 	chunk = make([]byte, chunkSize)
 
-	file, err := os.OpenFile(filePath, os.O_RDONLY, FilePermission_0600)
+	file, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, FilePermission_0600)
 	if err != nil {
 		log.Printf("Error in opening file: %v", err)
 		return

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -620,9 +620,8 @@ func CreateFileWithContent(filePath string, filePerms os.FileMode,
 // CreateFileOfSize creates a file of given size with random data.
 func CreateFileOfSize(fileSize int64, filePath string, t *testing.T) {
 	randomData, err := GenerateRandomData(fileSize)
-	randomDataString := strings.Trim(string(randomData), "\x00")
 	if err != nil {
 		t.Errorf("operations.GenerateRandomData: %v", err)
 	}
-	CreateFileWithContent(filePath, FilePermission_0600, randomDataString, t)
+	CreateFileWithContent(filePath, FilePermission_0600, string(randomData), t)
 }


### PR DESCRIPTION
### Description
#### Scenario 1:
With flag cacheFileForRangeRead true
R1: Single file random read of size more than cache capacity
R2: read again

#### Expected Behavior
R1: Cache miss
R2: Cache Miss (because the file won't be cached)

#### Scenario 2:
With flag cacheFileForRangeRead false
R1: Single file random read of size more than cache capacity
R2: read again

#### Expected Behavior
R1: Cache miss
R2: Cache Miss (because the file won't be cached)

This PR also includes refactoring to make flag setup more efficient.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran via presubmits
