### PR TITLE
fix tests which started failing because of 0_DIRECT flag in ReadChunkFromFile method

### DIFF
--- a/tools/integration_tests/gzip/read_gzip_test.go
+++ b/tools/integration_tests/gzip/read_gzip_test.go
@@ -88,14 +88,14 @@ func verifyRangedRead(t *testing.T, filename string) {
 	defer operations.RemoveFile(localCopy)
 
 	for _, offsetMultiplier := range []int64{1, 3, 5, 7, 9} {
-		buf1, err := operations.ReadChunkFromFile(mountedFilePath, (readSize), offsetMultiplier*(readOffset))
+		buf1, err := operations.ReadChunkFromFile(mountedFilePath, (readSize), offsetMultiplier*(readOffset), os.O_RDONLY)
 		if err != nil {
 			t.Fatalf("Failed to read mounted file %s: %v", mountedFilePath, err)
 		} else if buf1 == nil {
 			t.Fatalf("Failed to read mounted file %s: buffer returned as nul", mountedFilePath)
 		}
 
-		buf2, err := operations.ReadChunkFromFile(localCopy, (readSize), offsetMultiplier*(readOffset))
+		buf2, err := operations.ReadChunkFromFile(localCopy, (readSize), offsetMultiplier*(readOffset), os.O_RDONLY)
 		if err != nil {
 			t.Fatalf("Failed to read local file %s: %v", localCopy, err)
 		} else if buf2 == nil {

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -59,7 +60,7 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, isSeq bool, t *
 			t.Errorf("Failed to read file sequentially: %v", err)
 		}
 	} else {
-		content, err = operations.ReadChunkFromFile(path.Join(testDirPath, fileName), chunkSizeToRead, randomReadOffset)
+		content, err = operations.ReadChunkFromFile(path.Join(testDirPath, fileName), chunkSizeToRead, randomReadOffset, os.O_RDONLY|syscall.O_DIRECT)
 		if err != nil {
 			t.Errorf("Failed to read random file chunk: %v", err)
 		}

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -37,13 +37,13 @@ func TestReadLargeFileRandomly(t *testing.T) {
 	for i := 0; i < NumberOfRandomReadCalls; i++ {
 		offset := rand.Int63n(MaxReadableByteFromFile - MinReadableByteFromFile)
 		// Randomly read the data from file in mountedDirectory.
-		content, err := operations.ReadChunkFromFile(file, ChunkSize, offset)
+		content, err := operations.ReadChunkFromFile(file, ChunkSize, offset, os.O_RDONLY)
 		if err != nil {
 			t.Errorf("Error in reading file: %v", err)
 		}
 
 		// Read actual content from file located in local disk.
-		actualContent, err := operations.ReadChunkFromFile(fileInLocalDisk, ChunkSize, offset)
+		actualContent, err := operations.ReadChunkFromFile(fileInLocalDisk, ChunkSize, offset, os.O_RDONLY)
 		if err != nil {
 			t.Errorf("Error in reading file: %v", err)
 		}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -278,10 +278,10 @@ func WriteFileSequentially(filePath string, fileSize int64, chunkSize int64) (er
 	return
 }
 
-func ReadChunkFromFile(filePath string, chunkSize int64, offset int64) (chunk []byte, err error) {
+func ReadChunkFromFile(filePath string, chunkSize int64, offset int64, flag int) (chunk []byte, err error) {
 	chunk = make([]byte, chunkSize)
 
-	file, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, FilePermission_0600)
+	file, err := os.OpenFile(filePath, flag, FilePermission_0600)
 	if err != nil {
 		log.Printf("Error in opening file: %v", err)
 		return


### PR DESCRIPTION
### Description
gzip and random read large file tests started failing after ReadChunkFromFile method started using O_DIRECT flag. This is likely due to alignment restrictions when using O_DIRECT flag. Ref: [manpage](https://man7.org/linux/man-pages/man2/read.2.html#:~:text=EINVAL%20fd%20is%20attached%20to%20an%20object%20which%20is%20unsuitable%20for%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20reading%3B%20or%20the%20file%20was%20opened%20with%20the%20O_DIRECT%20flag%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20and%20either%20the%20address%20specified%20in%20buf%2C%20the%20value%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20specified%20in%20count%2C%20or%20the%20file%20offset%20is%20not%20suitably%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20aligned.)

This was unfortunately not caught in PR: https://github.com/GoogleCloudPlatform/gcsfuse/pull/1629 which shows successful KOKORO build. Separate investigations going on for the fix on KOKORO.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - presubmit KOKORO
