### PR TITLE
Fix stat-cache entry-size at 1

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -81,11 +81,10 @@ type entry struct {
 	expiration time.Time
 }
 
+// Size returns the size of entry.
+// It is currently set to dummy value 1 to avoid
+// the unnecessary actual size calculation.
 func (e entry) Size() uint64 {
-	return 1
-}
-
-func StatCacheEntrySize() uint64 {
 	return 1
 }
 

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -17,8 +17,6 @@ package metadata
 import (
 	"time"
 
-	unsafe "unsafe"
-
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 )
@@ -84,11 +82,11 @@ type entry struct {
 }
 
 func (e entry) Size() uint64 {
-	return uint64(unsafe.Sizeof(gcs.Object{}) + unsafe.Sizeof(entry{}))
+	return 1
 }
 
 func StatCacheEntrySize() uint64 {
-	return entry{}.Size()
+	return 1
 }
 
 // Should the supplied object for a new positive entry replace the given

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -107,14 +107,14 @@ func init() {
 }
 
 func (t *StatCacheTest) SetUp(ti *TestInfo) {
-	cache := lru.NewCache(capacity * metadata.StatCacheEntrySize())
+	cache := lru.NewCache(uint64(capacity))
 	t.cache.wrapped = metadata.NewStatCacheBucketView(cache, "") // this demonstrates
 	// that if you are using a cache for a single bucket, then
 	// its prepending bucketName can be left empty("") without any problem.
 }
 
 func (t *MultiBucketStatCacheTest) SetUp(ti *TestInfo) {
-	sharedCache := lru.NewCache(capacity * metadata.StatCacheEntrySize())
+	sharedCache := lru.NewCache(uint64(capacity))
 	t.multiBucketCache.fruits = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "fruits")}
 	t.multiBucketCache.spices = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "spices")}
 }

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -45,7 +45,7 @@ var (
 )
 
 func newLruCache(capacity uint64) *lru.Cache {
-	return lru.NewCache(metadata.StatCacheEntrySize() * capacity)
+	return lru.NewCache(capacity)
 }
 
 type cachingTestCommon struct {

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -85,10 +85,7 @@ type bucketManager struct {
 func NewBucketManager(config BucketConfig, storageHandle storage.StorageHandle) BucketManager {
 	var c *lru.Cache
 	if config.StatCacheCapacity > 0 {
-		// This conversion is temporary until config.StatCacheCapacity itself is replaced
-		// with config.StatCacheSizeMB, which is a planned change.
-		statCacheSize := uint64(config.StatCacheCapacity) * metadata.StatCacheEntrySize()
-		c = lru.NewCache(statCacheSize)
+		c = lru.NewCache(uint64(config.StatCacheCapacity))
 	}
 
 	bm := &bucketManager{

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -56,7 +56,7 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 
 	// Set up dependencies.
 	const cacheCapacity = 100
-	lruCache := lru.NewCache(cacheCapacity * metadata.StatCacheEntrySize())
+	lruCache := lru.NewCache(uint64(cacheCapacity))
 	cache := metadata.NewStatCacheBucketView(lruCache, "")
 	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName)
 


### PR DESCRIPTION
### Description
This is needed to remove any unnecessary calculations at the stat-cache operations time.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing
2. Unit tests - Passed locally
3. Integration tests - Ran through presubmit
