### PR TITLE
Fix failure status in KOKORO tests

### DIFF
--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -76,7 +76,7 @@ func executeTestsForPersistentMounting(flags [][]string, m *testing.M) (successC
 		if err = mountGcsfuseWithPersistentMounting(flags[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
-		setup.ExecuteTestForFlagsSet(flags[i], m)
+		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
 	}
 	return
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -48,7 +48,7 @@ func executeTestsForStaticMounting(flags [][]string, m *testing.M) (successCode 
 		if err = mountGcsfuseWithStaticMounting(flags[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
-		setup.ExecuteTestForFlagsSet(flags[i], m)
+		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
 	}
 	return
 }


### PR DESCRIPTION
### Description
Noticed that the KOKORO build was passing despite having failure in tests. This was happening because success code was not propagated correctly in static and persistent mounting tests.

Before the change:
![not_failing](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/5bcb349f-2fb8-4a78-83bb-da5dfde77208)


After the change
![Failing](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/7bc84a4c-d590-40e7-9651-2200fcc3677f)


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Verified that tests are now failing
2. Unit tests - NA
3. Integration tests - KOKORO
