### PR TITLE
Restart the failed job

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -81,9 +81,10 @@ func (fch *CacheHandle) validateCacheHandle() error {
 // shouldReadFromCache returns nil if the data should be read from the local,
 // downloaded file. Otherwise, it returns a non-nil error with an appropriate error message.
 func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, requiredOffset int64) (err error) {
-	if jobStatus.Err != nil ||
-		jobStatus.Name == downloader.INVALID ||
-		jobStatus.Name == downloader.FAILED {
+	if jobStatus.Err != nil || jobStatus.Name == downloader.FAILED {
+		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.FailedFileDownloadJobErrMsg, jobStatus.Name, jobStatus.Err)
+		return err
+	} else if jobStatus.Name == downloader.INVALID {
 		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.InvalidFileDownloadJobErrMsg, jobStatus.Name, jobStatus.Err)
 		return err
 	} else if jobStatus.Offset < requiredOffset {

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -259,7 +259,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FailedFileDownloadJobErrMsg))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {
@@ -373,7 +373,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithNonNilJobStatusErr() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	ExpectTrue(strings.Contains(err.Error(), util.FailedFileDownloadJobErrMsg))
 }
 
 func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoPresent() {

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -27,6 +27,7 @@ import (
 const (
 	InvalidFileHandleErrMsg                   = "invalid file handle"
 	InvalidFileDownloadJobErrMsg              = "invalid download job"
+	FailedFileDownloadJobErrMsg               = "failed download job"
 	InvalidCacheHandleErrMsg                  = "invalid cache handle"
 	InvalidFileInfoCacheErrMsg                = "invalid file info cache"
 	ErrInSeekingFileHandleMsg                 = "error while seeking file handle"
@@ -95,6 +96,7 @@ func GetDownloadPath(cacheLocation string, objectPath string) string {
 func IsCacheHandleInvalid(readErr error) bool {
 	return strings.Contains(readErr.Error(), InvalidFileHandleErrMsg) ||
 		strings.Contains(readErr.Error(), InvalidFileDownloadJobErrMsg) ||
+		strings.Contains(readErr.Error(), FailedFileDownloadJobErrMsg) ||
 		strings.Contains(readErr.Error(), InvalidFileInfoCacheErrMsg) ||
 		strings.Contains(readErr.Error(), ErrInSeekingFileHandleMsg) ||
 		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -233,8 +233,8 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	n = 0
 
 	if cacheutil.IsCacheHandleInvalid(err) {
-		// Sort of hack: this is to restart the failed async download job by invalidating
-		// the cache. Next read call will create fresh async job and download the content if needed.
+		// Invalidate the cache for the object corresponding to async job. Next read call for the object
+		// will create a fresh async job and download the content if needed.
 		if strings.Contains(err.Error(), cacheutil.FailedFileDownloadJobErrMsg) {
 			err = rr.fileCacheHandler.InvalidateCache(rr.object.Name, rr.bucket.Name())
 			if err != nil {

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -1051,8 +1051,8 @@ func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit() {
 	objectSize := t.object.Size
 	testContent := testutil.GenerateRandomBytes(int(objectSize))
 	rc1 := getReadCloser(testContent)
-	// First NewReader call will throw error, hence async job will fail.
-	// Later NewReader call returns a valid readCloser object hence fallback to
+	// First NewReader-call throws error, hence async job fails.
+	// Later NewReader-call returns a valid readCloser object hence fallback to
 	// GCS read will succeed.
 	ExpectCall(t.bucket, "NewReader")(Any(), Any()).
 		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc1, nil))


### PR DESCRIPTION
### Description
**Before fix:**
We don't restart the async job once failed and always fallback to GCS.

**After fix:**
Invalidate the cache for the object corresponding to failed Download job to initiate the caching from scratch.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit test to simulate - failure, invalidate and cacheHit again.
3. Integration tests - Automation.
