### PR TITLE
Support to restart failed async job in the next call

### DIFF
--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -145,7 +145,7 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 		// https://cloud.google.com/storage/docs/metadata#generation-number)
 		//
 		// Also, invalidate the cache for the object corresponding to failed async job, to restart the
-		// failed job and fill the content into file in cache from scratch.
+		// failed job and re-populate the cache for the file from the start.
 		job := chr.jobManager.GetJob(object, bucket)
 		jobStatus := job.GetStatus()
 

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -184,12 +184,8 @@ func (chr *CacheHandler) addFileInfoEntryToCache(object *gcs.MinObject, bucket g
 			}
 		}
 	} else {
-		job := chr.jobManager.GetJob(object, bucket)
-		jobStatus := job.GetStatus()
-		if jobStatus.Name != downloader.FAILED {
-			// Move this entry on top of LRU.
-			_ = chr.fileInfoCache.LookUp(fileInfoKeyName)
-		}
+		// Move this entry on top of LRU.
+		_ = chr.fileInfoCache.LookUp(fileInfoKeyName)
 	}
 
 	return nil

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -289,6 +289,28 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneratio
 	ExpectEq(jobStatusOfNewHandle.Name, downloader.NOT_STARTED)
 }
 
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsObjectHavingFailedAsyncJob() {
+	// Existing cacheHandle.
+	oldCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	AssertEq(nil, err)
+	buf := make([]byte, 3)
+	oldObjectName := chrT.object.Name
+	chrT.object.Name = chrT.object.Name + "test" // Hack: to fail the download job while reading from GCS.
+	_, cacheHit, err := oldCacheHandle.Read(context.Background(), chrT.bucket, chrT.object, 0, buf)
+	ExpectNe(nil, err)
+	ExpectEq(false, cacheHit)
+	jobStatusOfOldHandle := oldCacheHandle.fileDownloadJob.GetStatus()
+	ExpectEq(downloader.FAILED, jobStatusOfOldHandle.Name)
+	// Assigning the correct object before further call.
+	chrT.object.Name = oldObjectName
+
+	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	ExpectEq(nil, err)
+	ExpectEq(nil, newCacheHandle.validateCacheHandle())
+	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()
+	ExpectEq(downloader.NOT_STARTED, jobStatusOfNewHandle.Name)
+}
+
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryAlreadyInCache() {
 	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -305,6 +305,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsObjectHavingF
 	chrT.object.Name = oldObjectName
 
 	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+
 	ExpectEq(nil, err)
 	ExpectEq(nil, newCacheHandle.validateCacheHandle())
 	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -1046,6 +1046,44 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen
 	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
 }
 
+func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit() {
+	t.rr.wrapped.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rc1 := getReadCloser(testContent)
+	// First NewReader-call throws error, hence async job fails.
+	// Later NewReader-call returns a valid readCloser object hence fallback to
+	// GCS read will succeed.
+	ExpectCall(t.bucket, "NewReader")(Any(), Any()).
+		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc1, nil))
+	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	buf := make([]byte, objectSize)
+	_, cacheHit, err := t.rr.ReadAt(buf, 0)
+	AssertEq(nil, err)
+	ExpectFalse(cacheHit)
+	AssertTrue(reflect.DeepEqual(testContent, buf))
+	job := t.jobManager.GetJob(t.object, t.bucket)
+	jobStatus := job.GetStatus()
+	ExpectEq(jobStatus.Name, downloader.FAILED)
+	// Second reader (rc2) is required, since first reader (rc) is completely read.
+	// Reading again will return EOF.
+	rc2 := getReadCloser(testContent)
+	t.mockNewReaderCallForTestBucket(0, objectSize, rc2)
+	// This call will populate the cache again.
+	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+	ExpectEq(nil, err)
+	ExpectFalse(cacheHit)
+	ExpectTrue(reflect.DeepEqual(testContent, buf))
+	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+
+	_, cacheHit, err = t.rr.ReadAt(buf, 0)
+
+	ExpectEq(nil, err)
+	ExpectTrue(cacheHit)
+	ExpectTrue(reflect.DeepEqual(testContent, buf))
+	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+}
+
 // Only writing two unit tests for tryReadingFromFileCache as
 // unit tests of ReadAt method covers all the workflows.
 func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {


### PR DESCRIPTION
### Description
**Before fix:**
We don't restart the async job once failed and always fallback to GCS.

**After fix:**
Invalidate the cache for the object corresponding to failed Download job to initiate the caching from scratch.

Other approach: handling at the time of failure - [PR](https://github.com/GoogleCloudPlatform/gcsfuse/pull/1652)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit test to simulate - failure, invalidate and cacheHit again.
3. Integration tests - Automation.
