### PR TITLE
Remove unnecessary warning logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,11 +228,6 @@ func runCLIApp(c *cli.Context) (err error) {
 	logger.Infof("GCSFuse mount command flags: %s", util.Stringify(*flags))
 	logger.Infof("GCSFuse mount config flags: %s", util.Stringify(*mountConfig))
 
-	// the following will not warn if the user explicitly passed the default value for StatCacheCapacity.
-	if flags.StatCacheCapacity != DefaultStatCacheCapacity {
-		logger.Warnf("Old flag stat-cache-capacity used! Please switch to config parameter 'metadata-cache: stat-cache-max-size-mb'.")
-	}
-
 	// the following will not warn if the user explicitly passed the default value for StatCacheTTL or TypeCacheTTL.
 	if flags.StatCacheTTL != mount.DefaultStatOrTypeCacheTTL || flags.TypeCacheTTL != mount.DefaultStatOrTypeCacheTTL {
 		logger.Warnf("Old flag stat-cache-ttl and/or type-cache-ttl used! Please switch to config parameter 'metadata-cache: ttl-secs' .")


### PR DESCRIPTION
### Description
Remove obsolete warning for stat-cache-capacity

This is an outdated warning that was supposed for warn for use
of flag `stat-cache-capacity` and suggested to switch to
`metadata-cache:stat-cache-max-size-mb` . Now
`metadata-cache:stat-cache-max-size-mb` itself has become irrelevant,
and stat-cache-capacity is no longer meant to be deprecated soon, so
removing this warning.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing. Also the following warning went away after the change.
```
{"time":"30/01/2024 07:57:46.029872","severity":"WARNING","message":"Old flag stat-cache-capacity used! Please switch to config parameter 'metadata-cache: stat-cache-max-size-mb'."}
```
3. Unit tests - Ran locally.
4. Integration tests - Not needed.
