### PR TITLE
[ReadCacheFunctionalTest] Test 14, 15, 16: Range read tests

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -55,7 +55,7 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	// Do a random read on file and validate from gcs.
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForFirstRangeRead, t)
 	// Wait for the cache to propagate the updates before proceeding to get cache hit.
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 	// Validate cached content with gcs.
 	validateFileInCacheDirectory(testFileName, fileSizeForRangeRead, s.ctx, s.storageClient, t)
 	// Validate cache size within limit.

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -53,7 +53,7 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
 	// Do a random read on file and validate from gcs.
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, false, offsetForFirstRangeRead, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForFirstRangeRead, t)
 	// Wait for the cache to propagate the updates before proceeding to get cache hit.
 	time.Sleep(1 * time.Second)
 	// Validate cached content with gcs.
@@ -61,7 +61,7 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	// Validate cache size within limit.
 	validateCacheSizeWithinLimit(cacheCapacityInMB, t)
 	// Read file again from zeroOffset 1000 and validate from gcs.
-	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, false, offsetForSecondRangeRead, t)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForSecondRangeRead, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
 	validate(expectedOutcome1, structuredReadLogs[0], false, false, 1, t)
@@ -79,7 +79,7 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 		{"--implicit-dirs=false"},
 	}
 	appendFlags(&flagSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName))
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName))
 	appendFlags(&flagSet, "--o=ro", "")
 
 	// Create storage client before running tests.

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -59,7 +59,7 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	// Validate cached content with gcs.
 	validateFileInCacheDirectory(testFileName, fileSizeForRangeRead, s.ctx, s.storageClient, t)
 	// Validate cache size within limit.
-	validateCacheSizeWithinLimit(cacheCapacityInMB, t)
+	validateCacheSizeWithinLimit(cacheCapacityForRangeReadTestInMiB, t)
 	// Read file again from zeroOffset 1000 and validate from gcs.
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForSecondRangeRead, t)
 

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -64,7 +64,7 @@ func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithWait(t *testing.T) 
 
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	// Sleep until file is downloaded.
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadBeyond8MB, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -51,7 +51,7 @@ func (s *rangeReadTest) Teardown(t *testing.T) {
 func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadWithin8MB, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
@@ -62,7 +62,7 @@ func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
 func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithWait(t *testing.T) {
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	// Sleep until file is downloaded.
 	time.Sleep(1 * time.Second)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadBeyond8MB, t)
@@ -77,7 +77,7 @@ func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithWait(t *testing.T) 
 func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithoutWait(t *testing.T) {
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadBeyond8MB, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_cache
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type rangeReadTest struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+}
+
+func (s *rangeReadTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient, testDirName)
+}
+
+func (s *rangeReadTest) Teardown(t *testing.T) {
+	unmountGCSFuseAndDeleteLogFile()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
+	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadWithin8MB, t)
+
+	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	validate(expectedOutcome1, structuredReadLogs[0], true, false, 1, t)
+	validate(expectedOutcome2, structuredReadLogs[1], false, true, 1, t)
+}
+
+func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithWait(t *testing.T) {
+	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	// Sleep until file is downloaded.
+	time.Sleep(1 * time.Second)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadBeyond8MB, t)
+
+	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	validate(expectedOutcome1, structuredReadLogs[0], true, false, 1, t)
+	validate(expectedOutcome2, structuredReadLogs[1], false, true, 1, t)
+	validateFileInCacheDirectory(testFileName, fileSizeForRangeRead, s.ctx, s.storageClient, t)
+	validateCacheSizeWithinLimit(cacheCapacityForRangeReadTestInMiB, t)
+}
+
+func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithoutWait(t *testing.T) {
+	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, t)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadBeyond8MB, t)
+
+	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	validate(expectedOutcome1, structuredReadLogs[0], true, false, 1, t)
+	validate(expectedOutcome2, structuredReadLogs[1], false, false, 1, t)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestRangeReadTest(t *testing.T) {
+	// Define flag set to run the tests.
+	flagSet := [][]string{
+		{"--implicit-dirs=true"},
+		{"--implicit-dirs=false"},
+	}
+	appendFlags(&flagSet,
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName+"1"),
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName+"2"))
+	appendFlags(&flagSet, "--o=ro", "")
+
+	// Create storage client before running tests.
+	ts := &rangeReadTest{ctx: context.Background()}
+	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
+	defer closeStorageClient()
+
+	// Run tests.
+	for _, flags := range flagSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -42,7 +42,7 @@ const (
 	smallContentSize                   = 13
 	chunkSizeToRead                    = util.MiB
 	fileSize                           = 3 * util.MiB
-	fileSizeForRangeRead               = 40 * util.MiB
+	fileSizeForRangeRead               = 50 * util.MiB
 	chunksRead                         = fileSize / util.MiB
 	testFileName                       = "foo"
 	cacheCapacityInMB                  = 9
@@ -60,8 +60,8 @@ const (
 	offsetForFirstRangeRead            = 5000
 	offsetForSecondRangeRead           = 1000
 	offsetForRangeReadWithin8MB        = 4 * util.MiB
-	offsetForRangeReadBeyond8MB        = fileSizeForRangeRead - 2*util.MiB
-	cacheCapacityForRangeReadTestInMiB = 40
+	offsetForRangeReadBeyond8MB        = fileSizeForRangeRead - 1*util.MiB
+	cacheCapacityForRangeReadTestInMiB = 50
 )
 
 var (

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -35,30 +35,33 @@ import (
 )
 
 const (
-	testDirName                     = "ReadCacheTest"
-	onlyDirMounted                  = "Test"
-	cacheSubDirectoryName           = "gcsfuse-file-cache"
-	smallContent                    = "small content"
-	smallContentSize                = 13
-	chunkSizeToRead                 = util.MiB
-	fileSize                        = 3 * util.MiB
-	fileSizeForRangeRead            = 9 * util.MiB
-	chunksRead                      = fileSize / util.MiB
-	testFileName                    = "foo"
-	cacheCapacityInMB               = 9
-	NumberOfFilesWithinCacheLimit   = (cacheCapacityInMB * util.MiB) / fileSize
-	NumberOfFilesMoreThanCacheLimit = (cacheCapacityInMB*util.MiB)/fileSize + 1
-	largeFileSize                   = 15 * util.MiB
-	largeFileName                   = "15MBFile"
-	largeFileChunksRead             = 15
-	chunksReadAfterUpdate           = 1
-	metadataCacheTTlInSec           = 10
-	testFileNameSuffixLength        = 4
-	zeroOffset                      = 0
-	randomReadOffset                = 9 * util.MiB
-	configFileName                  = "config"
-	offsetForFirstRangeRead         = 5000
-	offsetForSecondRangeRead        = 1000
+	testDirName                        = "ReadCacheTest"
+	onlyDirMounted                     = "Test"
+	cacheSubDirectoryName              = "gcsfuse-file-cache"
+	smallContent                       = "small content"
+	smallContentSize                   = 13
+	chunkSizeToRead                    = util.MiB
+	fileSize                           = 3 * util.MiB
+	fileSizeForRangeRead               = 40 * util.MiB
+	chunksRead                         = fileSize / util.MiB
+	testFileName                       = "foo"
+	cacheCapacityInMB                  = 9
+	NumberOfFilesWithinCacheLimit      = (cacheCapacityInMB * util.MiB) / fileSize
+	NumberOfFilesMoreThanCacheLimit    = (cacheCapacityInMB*util.MiB)/fileSize + 1
+	largeFileSize                      = 15 * util.MiB
+	largeFileName                      = "15MBFile"
+	largeFileChunksRead                = 15
+	chunksReadAfterUpdate              = 1
+	metadataCacheTTlInSec              = 10
+	testFileNameSuffixLength           = 4
+	zeroOffset                         = 0
+	randomReadOffset                   = 9 * util.MiB
+	configFileName                     = "config"
+	offsetForFirstRangeRead            = 5000
+	offsetForSecondRangeRead           = 1000
+	offsetForRangeReadWithin8MB        = 4 * util.MiB
+	offsetForRangeReadBeyond8MB        = fileSizeForRangeRead - 2*util.MiB
+	cacheCapacityForRangeReadTestInMiB = 40
 )
 
 var (


### PR DESCRIPTION
### Description

#### Scenario 1:
TestRangeReadsWithinReadChunkSize
R1: Read a file starting at offset 0
R2: read again within range of read chunk size (8 MiB)

#### Expected Behavior
R1: Cache miss
R2: Cache Hit

#### Scenario 2:
TestRangeReadsBeyondReadChunkSizeWithWait
R1: Read a file starting at offset 0
wait for file to be cached
R2: read again at offset 38MiB

#### Expected Behavior
R1: Cache miss
R2: Cache Hit

#### Scenario 2:
TestRangeReadsBeyondReadChunkSizeWithoutWait
R1: Read a file starting at offset 0
do not wait for file to be cached
R2: read again at offset 38MiB

#### Expected Behavior
R1: Cache miss
R2: Cache miss (file not yet cached)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - ran via kokoro