### PR TITLE
dependabot should bump only direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   allow:
-  - dependency-type: "all"
+  - dependency-type: "direct"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
### Description
Change dependency type from "all" to "direct" in .github/dependabot.yml file for go.mod dependencies.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
