### PR TITLE
Allow other cache dir fix

### DIFF
--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -104,11 +104,11 @@ func IsCacheHandleInvalid(readErr error) bool {
 
 // Creates directory at given path with FileDirPerm(0755) permissions in case not already present,
 // returns error in case unable to create directory or directory is not writable.
-func CreateCacheDirectoryIfNotPresentAt(dirPath string) error {
+func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPermissions os.FileMode) error {
 	_, statErr := os.Stat(dirPath)
 
 	if os.IsNotExist(statErr) {
-		err := os.MkdirAll(dirPath, FileDirPerm)
+		err := os.MkdirAll(dirPath, dirPermissions)
 		if err != nil {
 			return fmt.Errorf("error in creating directory structure %s: %v", dirPath, err)
 		}

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -55,7 +55,7 @@ const (
 func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
 	// Create directory structure if not present
 	fileDir := filepath.Dir(fileSpec.Path)
-	err = os.MkdirAll(fileDir, FileDirPerm)
+	err = os.MkdirAll(fileDir, fileSpec.Perm.Perm())
 	if err != nil {
 		err = fmt.Errorf(fmt.Sprintf("error in creating directory structure %s: %v", fileDir, err))
 		return

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -42,8 +42,8 @@ const (
 	FileDirPerm            = os.FileMode(0755) | os.ModeDir
 	MiB                    = 1024 * 1024
 	KiB                    = 1024
-	DefaultFilePerm        = os.FileMode(0600)
-	FilePermWithAllowOther = os.FileMode(0644)
+	DefaultFilePerm        = os.FileMode(0700)
+	FilePermWithAllowOther = os.FileMode(0755)
 	FileCache              = "gcsfuse-file-cache"
 )
 

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -39,7 +39,6 @@ const (
 )
 
 const (
-	FileDirPerm            = os.FileMode(0755) | os.ModeDir
 	MiB                    = 1024 * 1024
 	KiB                    = 1024
 	DefaultFilePerm        = os.FileMode(0700)

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -49,8 +49,8 @@ const (
 // CreateFile creates file with given file spec i.e. permissions and returns
 // file handle for that file opened with given flag.
 //
-// Note: If directories in path are not present, they are created with FileDirPerm
-// permission.
+// Note: If directories in path are not present, they are also created with permissions
+// provided in file spec.
 func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
 	// Create directory structure if not present
 	fileDir := filepath.Dir(fileSpec.Path)
@@ -101,7 +101,7 @@ func IsCacheHandleInvalid(readErr error) bool {
 		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
 }
 
-// Creates directory at given path with FileDirPerm(0755) permissions in case not already present,
+// Creates directory at given path with provided access permissions in case not already present,
 // returns error in case unable to create directory or directory is not writable.
 func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPermissions os.FileMode) error {
 	_, statErr := os.Stat(dirPath)

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -69,7 +69,7 @@ func (ut *utilTest) assertFileAndDirCreation(file *os.File, err error) {
 	dirStat, dirErr := os.Stat(path.Dir(file.Name()))
 	ExpectEq(false, os.IsNotExist(dirErr))
 	ExpectEq(path.Dir(ut.fileSpec.Path), path.Dir(file.Name()))
-	ExpectEq(FileDirPerm|os.ModeDir, dirStat.Mode())
+	ExpectEq(0755, dirStat.Mode().Perm())
 	ExpectEq(ut.uid, dirStat.Sys().(*syscall.Stat_t).Uid)
 	ExpectEq(ut.gid, dirStat.Sys().(*syscall.Stat_t).Gid)
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -63,10 +63,6 @@ func (ut *utilTest) TearDown() {
 	operations.RemoveDir(path.Dir(ut.fileSpec.Path))
 }
 
-func (ut *utilTest) assertFileAndDirCreation(file *os.File, err error) {
-	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, 0700)
-}
-
 func (ut *utilTest) assertFileAndDirCreationWithGivenDirMode(file *os.File, err error, dirMode os.FileMode) {
 	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, dirMode)
 }
@@ -98,7 +94,7 @@ func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0700)
 	ExpectEq(nil, file.Close())
 }
 
@@ -108,7 +104,7 @@ func (ut *utilTest) Test_CreateFile_FileDirPresent() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0700)
 	ExpectEq(nil, file.Close())
 }
 
@@ -117,7 +113,7 @@ func (ut *utilTest) Test_CreateFile_ReadOnlyFile() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0700)
 	content := "foo"
 	_, err = file.Write([]byte(content))
 	ExpectNe(nil, err)
@@ -133,7 +129,7 @@ func (ut *utilTest) Test_CreateFile_ReadWriteFile() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0700)
 	content := "foo"
 	n, err := file.Write([]byte(content))
 	ExpectEq(nil, err)
@@ -194,7 +190,7 @@ func (ut *utilTest) Test_CreateFile_RelativePath() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0700)
 	ExpectEq(nil, file.Close())
 }
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -256,7 +256,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryE
 	defer os.RemoveAll(base)
 	AssertEq(nil, dirCreationErr)
 
-	err := CreateCacheDirectoryIfNotPresentAt(dirPath)
+	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0700)
 
 	AssertEq(nil, err)
 	fileInfo, err := os.Stat(dirPath)
@@ -269,7 +269,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryC
 	dirPath := path.Join(base, "/", "path/cachedir")
 	defer os.RemoveAll(base)
 
-	err := CreateCacheDirectoryIfNotPresentAt(dirPath)
+	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0755)
 
 	AssertEq(nil, err)
 	fileInfo, err := os.Stat(dirPath)
@@ -283,7 +283,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldReturnErrorWhenDirectoryDoesNot
 	defer os.RemoveAll(dirPath)
 	AssertEq(nil, dirCreationErr)
 
-	err := CreateCacheDirectoryIfNotPresentAt(dirPath)
+	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0444)
 
 	AssertNe(nil, err)
 	AssertTrue(strings.Contains(err.Error(), "error creating file at directory ("+dirPath+")"))

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -64,7 +64,11 @@ func (ut *utilTest) TearDown() {
 }
 
 func (ut *utilTest) assertFileAndDirCreation(file *os.File, err error) {
-	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, 0755)
+	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, 0700)
+}
+
+func (ut *utilTest) assertFileAndDirCreationWithGivenDirMode(file *os.File, err error, dirMode os.FileMode) {
+	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, dirMode)
 }
 
 func (ut *utilTest) assertFileAndDirStatsWithGivenFileAndDirPermissions(
@@ -99,7 +103,7 @@ func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
 }
 
 func (ut *utilTest) Test_CreateFile_FileDirPresent() {
-	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
+	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0700)
 	ExpectEq(nil, err)
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
@@ -145,18 +149,19 @@ func (ut *utilTest) Test_CreateFile_FilePerm0755() {
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0755)
 	ExpectEq(nil, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_FilePerm0544() {
-	ut.fileSpec.Perm = os.FileMode(0544)
-
-	file, err := CreateFile(ut.fileSpec, ut.flag)
-
-	ut.assertFileAndDirCreation(file, err)
-	ExpectEq(nil, file.Close())
-}
+// TODO: should we remove this test as we use same perms for file and dir and dir needs min 7 perm as owner to be able to create file
+//func (ut *utilTest) Test_CreateFile_FilePerm0544() {
+//	ut.fileSpec.Perm = os.FileMode(0544)
+//
+//	file, err := CreateFile(ut.fileSpec, ut.flag)
+//
+//	ut.assertFileAndDirCreation(file, err)
+//	ExpectEq(nil, file.Close())
+//}
 
 func (ut *utilTest) Test_CreateFile_FilePresent() {
 	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
@@ -167,7 +172,7 @@ func (ut *utilTest) Test_CreateFile_FilePresent() {
 
 	file, err = CreateFile(ut.fileSpec, ut.flag)
 
-	ut.assertFileAndDirCreation(file, err)
+	ut.assertFileAndDirCreationWithGivenDirMode(file, err, 0755)
 	ExpectEq(nil, file.Close())
 }
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -64,19 +64,28 @@ func (ut *utilTest) TearDown() {
 }
 
 func (ut *utilTest) assertFileAndDirCreation(file *os.File, err error) {
+	ut.assertFileAndDirStatsWithGivenFileAndDirPermissions(file, err, ut.fileSpec.Perm, 0755)
+}
+
+func (ut *utilTest) assertFileAndDirStatsWithGivenFileAndDirPermissions(
+	file *os.File,
+	err error,
+	filePerm os.FileMode,
+	dirPerm os.FileMode,
+) {
 	ExpectEq(nil, err)
 
 	dirStat, dirErr := os.Stat(path.Dir(file.Name()))
 	ExpectEq(false, os.IsNotExist(dirErr))
 	ExpectEq(path.Dir(ut.fileSpec.Path), path.Dir(file.Name()))
-	ExpectEq(0755, dirStat.Mode().Perm())
+	ExpectEq(dirPerm, dirStat.Mode().Perm())
 	ExpectEq(ut.uid, dirStat.Sys().(*syscall.Stat_t).Uid)
 	ExpectEq(ut.gid, dirStat.Sys().(*syscall.Stat_t).Gid)
 
 	fileStat, fileErr := os.Stat(file.Name())
 	ExpectEq(false, os.IsNotExist(fileErr))
 	ExpectEq(ut.fileSpec.Path, file.Name())
-	ExpectEq(ut.fileSpec.Perm, fileStat.Mode())
+	ExpectEq(filePerm, fileStat.Mode())
 	ExpectEq(ut.uid, fileStat.Sys().(*syscall.Stat_t).Uid)
 	ExpectEq(ut.gid, fileStat.Sys().(*syscall.Stat_t).Gid)
 }

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -153,15 +153,15 @@ func (ut *utilTest) Test_CreateFile_FilePerm0755() {
 	ExpectEq(nil, file.Close())
 }
 
-// TODO: should we remove this test as we use same perms for file and dir and dir needs min 7 perm as owner to be able to create file
-//func (ut *utilTest) Test_CreateFile_FilePerm0544() {
-//	ut.fileSpec.Perm = os.FileMode(0544)
-//
-//	file, err := CreateFile(ut.fileSpec, ut.flag)
-//
-//	ut.assertFileAndDirCreation(file, err)
-//	ExpectEq(nil, file.Close())
-//}
+func (ut *utilTest) Test_CreateFileShouldReturnErrorIfDirIsNotPresentAndFileSpecPermissionsAreLessThan700() {
+	ut.fileSpec.Perm = os.FileMode(0544)
+
+	_, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ExpectNe(nil, err)
+	ExpectEq("error in creating file "+ut.fileSpec.Path+
+		": open "+ut.fileSpec.Path+": permission denied", err.Error())
+}
 
 func (ut *utilTest) Test_CreateFile_FilePresent() {
 	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -244,17 +244,17 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	// gcsfuse related files.
 	cacheLocation = path.Join(cacheLocation, util.FileCache)
 
-	// Panic in case cacheLocation does not have required permissions
-	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation)
-	if cacheLocationErr != nil {
-		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheLocationErr.Error()))
-	}
-
 	// When user passes allow_other flag, then other users should be able to
 	// read from cache
 	filePerm := util.DefaultFilePerm
 	if cfg.AllowOther {
 		filePerm = util.FilePermWithAllowOther
+	}
+
+	// Panic in case cacheLocation does not have required permissions
+	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation, filePerm)
+	if cacheLocationErr != nil {
+		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheLocationErr.Error()))
 	}
 
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, cacheLocation,


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
[Bug](https://b.corp.google.com/issues/322301637)

### Testing details
1. Manual - Done
[With -o allow_option] Tested by adding allow_other, users other than owner were able to view cache folder and files.
[Without -o allow_option] Tested without allow_other option, users other than owner were NOT able to cd into cache folder and was unable to see cache file name or content of cache dir.
3. Unit tests - Done
4. Integration tests - NA
