### PR TITLE
Optimize memory by removing async job after completion/failure

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -91,12 +91,12 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	return err
 }
 
-// checkEntryInFileInfoCache checks if entry is present for a given object in
+// validateEntryInFileInfoCache checks if entry is present for a given object in
 // file info cache with same generation and at least requiredOffset.
 // It returns nil if entry is present, otherwise returns an appropriate error.
 // Whether to change the order in cache while lookup is controlled via
 // changeCacheOrder.
-func (fch *CacheHandle) checkEntryInFileInfoCache(bucket gcs.Bucket, object *gcs.MinObject, requiredOffset uint64, changeCacheOrder bool) error {
+func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *gcs.MinObject, requiredOffset uint64, changeCacheOrder bool) error {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: bucket.Name(),
 		ObjectName: object.Name,
@@ -200,7 +200,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 		// If fileDownloadJob is nil then it means either the job is successfully
 		// completed or failed. The offset must be equal to size of object for job
 		// to be completed.
-		err = fch.checkEntryInFileInfoCache(bucket, object, object.Size, false)
+		err = fch.validateEntryInFileInfoCache(bucket, object, object.Size, false)
 		if err != nil {
 			return 0, false, err
 		}
@@ -231,7 +231,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	// Look up of file being read in file info cache is required to update the LRU
 	// order on every read request from kernel i.e. with every read request from
 	// kernel, the file being read becomes most recently used.
-	err = fch.checkEntryInFileInfoCache(bucket, object, uint64(requiredOffset), true)
+	err = fch.validateEntryInFileInfoCache(bucket, object, uint64(requiredOffset), true)
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -32,7 +32,8 @@ type CacheHandle struct {
 	// fileHandle to a local file which contains locally downloaded data.
 	fileHandle *os.File
 
-	// fileDownloadJob is a reference to async download Job.
+	// fileDownloadJob is a reference to async download Job. It can be nil if
+	// job is already completed.
 	fileDownloadJob *downloader.Job
 
 	// fileInfoCache contains the reference to fileInfo cache.

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -594,7 +594,7 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload() {
 	n, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
 
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatus.Name, downloader.NotStarted)
+	ExpectEq(downloader.NotStarted, jobStatus.Name)
 	ExpectLt(jobStatus.Offset, offset)
 	ExpectEq(n, 0)
 	ExpectFalse(cacheHit)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -135,7 +135,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
 	AssertEq(nil, err)
 
-	fileDownloadJob := downloader.NewJob(cht.object, cht.bucket, cht.cache, DefaultSequentialReadSizeMb, cht.fileSpec)
+	fileDownloadJob := downloader.NewJob(cht.object, cht.bucket, cht.cache, DefaultSequentialReadSizeMb, cht.fileSpec, func() {})
 
 	cht.cacheHandle = NewCacheHandle(readLocalFileHandle, fileDownloadJob, cht.cache, false, 0)
 }
@@ -162,7 +162,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileDownloadJob() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	ExpectEq(util.InvalidFileDownloadJobErrMsg, err.Error())
+	ExpectEq(nil, err)
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileInfoCache() {
@@ -247,7 +247,7 @@ func (cht *cacheHandleTest) Test_IsSequential_WhenOffsetDiffIsEqualToMaxAllowed(
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsNotStarted() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	AssertEq(downloader.NOT_STARTED, jobStatus.Name)
+	AssertEq(downloader.NotStarted, jobStatus.Name)
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
@@ -258,7 +258,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsNotStarted() 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.FAILED
+	jobStatus.Name = downloader.Failed
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
@@ -269,7 +269,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.INVALID
+	jobStatus.Name = downloader.Invalid
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
@@ -280,7 +280,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsCompleted() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.COMPLETED
+	jobStatus.Name = downloader.Completed
 	jobStatus.Offset = int64(cht.object.Size)
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
@@ -291,7 +291,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsCompleted() {
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsLessThanRequiredOffset() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.DOWNLOADING
+	jobStatus.Name = downloader.Downloading
 	jobStatus.Offset = requiredOffset - 1
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
@@ -303,41 +303,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsLe
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetSameAsRequiredOffset() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.DOWNLOADING
-	jobStatus.Offset = requiredOffset
-
-	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
-
-	ExpectEq(nil, err)
-}
-
-func (cht *cacheHandleTest) Test_shouldReadFromCache_WithCancelledJobOffsetIsGreaterThanRequiredOffset() {
-	requiredOffset := int64(util.MiB)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.CANCELLED
-	jobStatus.Offset = requiredOffset + 1
-
-	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
-
-	ExpectEq(nil, err)
-}
-
-func (cht *cacheHandleTest) Test_shouldReadFromCache_WithCancelledJobOffsetIsLessThanRequiredOffset() {
-	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.CANCELLED
-	jobStatus.Offset = requiredOffset - 1
-
-	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
-
-	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
-}
-
-func (cht *cacheHandleTest) Test_shouldReadFromCache_WithCancelledJobOffsetSameAsRequiredOffset() {
-	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.CANCELLED
+	jobStatus.Name = downloader.Downloading
 	jobStatus.Offset = requiredOffset
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
@@ -348,18 +314,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithCancelledJobOffsetSameA
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsGreaterThanRequiredOffset() {
 	requiredOffset := int64(util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.DOWNLOADING
-	jobStatus.Offset = requiredOffset + 1
-
-	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
-
-	ExpectEq(nil, err)
-}
-
-func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsMoreThanRequiredOffset() {
-	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.DOWNLOADING
+	jobStatus.Name = downloader.Downloading
 	jobStatus.Offset = requiredOffset + 1
 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
@@ -370,7 +325,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsMo
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithNonNilJobStatusErr() {
 	requiredOffset := int64(downloader.ReadChunkSize + util.MiB)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	jobStatus.Name = downloader.DOWNLOADING
+	jobStatus.Name = downloader.Downloading
 	jobStatus.Offset = requiredOffset + 1
 	jobStatus.Err = errors.New("job error")
 
@@ -396,7 +351,7 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoPresent() {
 	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0)
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size, false)
 
 	AssertEq(nil, err)
 }
@@ -410,7 +365,7 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoNotPresent() 
 	AssertEq(nil, err)
 
 	_ = cht.cache.Erase(fileInfoKeyName)
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0)
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
 	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
@@ -432,10 +387,122 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoGenerationCha
 	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, int64(cht.object.Size-1))
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
 	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.InvalidFileInfoCacheErrMsg, fileInfo.ObjectGeneration)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
+}
+
+func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoOffsetLessThanRequired() {
+	fileInfoKey := data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: cht.object.Name,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo := data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: cht.object.Generation,
+		FileSize:         cht.object.Size,
+		Offset:           10, // Insert offset less than required
+	}
+	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
+
+	AssertNe(nil, err)
+	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.InvalidFileInfoCacheErrMsg, 10, 11)
+	AssertEq(expectedErr.Error(), err.Error())
+}
+
+func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsTrue() {
+	// Adding one more entry to file info cache other than the one already added
+	// by cht.addTestFileInfoEntryInCache, such that the file info cache becomes
+	// full
+	newObjectName := "new_test_object"
+	fileInfoKey := data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: newObjectName,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo := data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,                              // Adding random generation.
+		FileSize:         CacheMaxSize - cht.object.Size, // This makes cache size full.
+		Offset:           1,                              // Insert offset less than required
+	}
+	evictedEntries, err := cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(0, len(evictedEntries))
+
+	// Because changeCacheOrder is true, the entry corresponding to cht.object.Size
+	// should come on top
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, true)
+
+	AssertEq(nil, err)
+	// Inserting new entry should evict the newObjectName
+	fileInfoKey = data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: "one more object",
+	}
+	fileInfoKeyName, err = fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo = data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,
+		FileSize:         1,
+		Offset:           1,
+	}
+	evictedEntries, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(1, len(evictedEntries))
+	AssertEq(newObjectName, evictedEntries[0].(data.FileInfo).Key.ObjectName)
+}
+
+func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsFalse() {
+	// Adding one more entry to file info cache other than the one already added
+	// by cht.addTestFileInfoEntryInCache, such that the file info cache becomes
+	// full
+	newObjectName := "new_test_object"
+	fileInfoKey := data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: newObjectName,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo := data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,                              // Adding random generation.
+		FileSize:         CacheMaxSize - cht.object.Size, // This makes cache size full.
+		Offset:           1,                              // Insert offset less than required
+	}
+	evictedEntries, err := cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(0, len(evictedEntries))
+
+	// Because changeCacheOrder is false, the new object entry should remain on top.
+	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
+
+	AssertEq(nil, err)
+	// Inserting new entry should evict the entry corresponding to cht.object.
+	fileInfoKey = data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: "one more object",
+	}
+	fileInfoKeyName, err = fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo = data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,
+		FileSize:         1,
+		Offset:           1,
+	}
+	evictedEntries, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(1, len(evictedEntries))
+	AssertEq(cht.object.Name, evictedEntries[0].(data.FileInfo).Key.ObjectName)
 }
 
 func (cht *cacheHandleTest) Test_Read_RequestingMoreOffsetThanSize() {
@@ -456,10 +523,48 @@ func (cht *cacheHandleTest) Test_Read_WithNilFileHandle() {
 	cht.cacheHandle.fileHandle = nil
 
 	n, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
+
 	ExpectNe(nil, err)
 	ExpectEq(0, n)
 	ExpectFalse(cacheHit)
 	ExpectEq(util.InvalidFileHandleErrMsg, err.Error())
+}
+
+func (cht *cacheHandleTest) Test_Read_WithNilFileDownloadJobAndCacheMiss() {
+	dst := make([]byte, ReadContentSize)
+	offset := int64(5)
+	cht.cacheHandle.fileDownloadJob = nil
+
+	// The file info entry added by cht.addTestFileInfoEntryInCache() has offset 0.
+	// This means file info entry is there but download job and hence this should
+	// throw.
+	n, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
+
+	ExpectNe(nil, err)
+	ExpectEq(0, n)
+	ExpectFalse(cacheHit)
+	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileInfoCacheErrMsg))
+}
+
+func (cht *cacheHandleTest) Test_Read_WithNilFileDownloadJobAndCacheHit() {
+	ctx := context.Background()
+	// Download the complete object via job.
+	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(ctx, int64(cht.object.Size), true)
+	AssertEq(nil, err)
+	AssertEq(downloader.Downloading, jobStatus.Name)
+	dst := make([]byte, cht.object.Size)
+	offset := int64(0)
+	cht.cacheHandle.isSequential = false
+	cht.cacheHandle.fileDownloadJob = nil
+
+	// Because the whole object is downloaded into the cache, file info cache
+	// should have offset equal to object.Size, so even with nil download job,
+	// read should be served from cache.
+	n, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
+
+	ExpectEq(nil, err)
+	ExpectEq(cht.object.Size, n)
+	ExpectTrue(cacheHit)
 }
 
 func (cht *cacheHandleTest) Test_Read_Random() {
@@ -473,7 +578,8 @@ func (cht *cacheHandleTest) Test_Read_Random() {
 
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectLt(jobStatus.Offset, offset)
-	ExpectEq(n, 0)
+	ExpectEq(downloader.Downloading, jobStatus.Name)
+	ExpectEq(0, n)
 	ExpectFalse(cacheHit)
 	ExpectNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
@@ -488,7 +594,7 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload() {
 	n, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
 
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatus.Name, downloader.NOT_STARTED)
+	ExpectEq(jobStatus.Name, downloader.NotStarted)
 	ExpectLt(jobStatus.Offset, offset)
 	ExpectEq(n, 0)
 	ExpectFalse(cacheHit)
@@ -501,7 +607,7 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownloadButCacheHit() {
 	// Download the job till util.MiB
 	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(ctx, int64(2*util.MiB), true)
 	AssertEq(nil, err)
-	AssertEq(jobStatus.Name, downloader.DOWNLOADING)
+	AssertEq(downloader.Downloading, jobStatus.Name)
 	dst := make([]byte, ReadContentSize)
 	offset := int64(1)
 	cht.cacheHandle.isSequential = false
@@ -510,34 +616,10 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownloadButCacheHit() {
 	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
 
 	jobStatus = cht.cacheHandle.fileDownloadJob.GetStatus()
-	ExpectTrue(jobStatus.Name == downloader.DOWNLOADING || jobStatus.Name == downloader.COMPLETED)
+	ExpectTrue(jobStatus.Name == downloader.Downloading || jobStatus.Name == downloader.Completed)
 	ExpectGe(jobStatus.Offset, offset)
-	ExpectEq(cacheHit, true)
-	ExpectEq(nil, err)
-	cht.verifyContentRead(offset, dst)
-}
-
-func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownloadButCacheHitInCancelledState() {
-	ctx := context.Background()
-	// Download the job till util.MiB
-	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(ctx, int64(2*util.MiB), true)
-	AssertEq(nil, err)
-	AssertEq(jobStatus.Name, downloader.DOWNLOADING)
-	cht.cacheHandle.fileDownloadJob.Cancel()
-	jobStatus = cht.cacheHandle.fileDownloadJob.GetStatus()
-	AssertEq(jobStatus.Name, downloader.CANCELLED)
-	dst := make([]byte, ReadContentSize)
-	offset := int64(1)
-	cht.cacheHandle.isSequential = false
-
-	// Since, it's a random read hence will not wait to download till requested offset.
-	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
-
-	jobStatus = cht.cacheHandle.fileDownloadJob.GetStatus()
-	ExpectTrue(jobStatus.Name == downloader.CANCELLED)
-	ExpectGe(jobStatus.Offset, offset)
-	ExpectEq(nil, err)
 	ExpectTrue(cacheHit)
+	ExpectEq(nil, err)
 	cht.verifyContentRead(offset, dst)
 }
 
@@ -546,16 +628,70 @@ func (cht *cacheHandleTest) Test_Read_Sequential() {
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = true
 	cht.cacheHandle.prevOffset = offset - util.MiB
-	cht.cacheHandle.cacheFileForRangeRead = true
+	cht.cacheHandle.cacheFileForRangeRead = false
 
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
 
+	ExpectEq(nil, err)
+	ExpectFalse(cacheHit)
+	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
+	ExpectGe(jobStatus.Offset, offset)
+	cht.verifyContentRead(offset, dst)
+}
+
+func (cht *cacheHandleTest) Test_Read_ChangeCacheOrder() {
+	// Adding one more entry to file info cache other than the one already added
+	// by cht.addTestFileInfoEntryInCache, such that the file info cache becomes
+	// full
+	newObjectName := "new_test_object"
+	fileInfoKey := data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: newObjectName,
+	}
+	fileInfoKeyName, err := fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo := data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,                              // Adding random generation.
+		FileSize:         CacheMaxSize - cht.object.Size, // This makes cache size full.
+		Offset:           1,                              // Insert offset less than required
+	}
+	evictedEntries, err := cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(0, len(evictedEntries))
+	dst := make([]byte, ReadContentSize)
+	offset := int64(cht.object.Size - ReadContentSize)
+	cht.cacheHandle.isSequential = true
+	cht.cacheHandle.prevOffset = offset - util.MiB
+	cht.cacheHandle.cacheFileForRangeRead = false
+
+	// Read should change the order in cache and bring cht.Object to most recently
+	// used.
+	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
+
+	ExpectEq(nil, err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectFalse(cacheHit)
 	ExpectGe(jobStatus.Offset, offset)
 	cht.verifyContentRead(offset, dst)
-	ExpectEq(nil, err)
+	// Inserting new entry should evict the newObjectName
+	fileInfoKey = data.FileInfoKey{
+		BucketName: cht.bucket.Name(),
+		ObjectName: "one more object",
+	}
+	fileInfoKeyName, err = fileInfoKey.Key()
+	AssertEq(nil, err)
+	fileInfo = data.FileInfo{
+		Key:              fileInfoKey,
+		ObjectGeneration: 1,
+		FileSize:         1,
+		Offset:           1,
+	}
+	evictedEntries, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
+	AssertEq(nil, err)
+	AssertEq(1, len(evictedEntries))
+	AssertEq(newObjectName, evictedEntries[0].(data.FileInfo).Key.ObjectName)
 }
 
 func (cht *cacheHandleTest) Test_Read_SequentialToRandom() {
@@ -565,21 +701,21 @@ func (cht *cacheHandleTest) Test_Read_SequentialToRandom() {
 	cht.cacheHandle.cacheFileForRangeRead = true
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, firstReqOffset, dst)
+	AssertEq(nil, err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	AssertGe(jobStatus.Offset, firstReqOffset)
-	AssertEq(nil, err)
 	ExpectFalse(cacheHit)
 	AssertEq(cht.cacheHandle.isSequential, true)
 
 	secondReqOffset := int64(cht.object.Size - ReadContentSize) // type will change to random.
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, secondReqOffset, dst)
 
+	ExpectNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	ExpectFalse(cacheHit)
+	ExpectEq(cht.cacheHandle.isSequential, false)
 	jobStatus = cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectLe(jobStatus.Offset, secondReqOffset)
-	ExpectNe(nil, err)
-	ExpectFalse(cacheHit)
-	ExpectTrue(strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
-	ExpectEq(cht.cacheHandle.isSequential, false)
 }
 
 func (cht *cacheHandleTest) Test_Read_WhenDstBufferIsMoreContentToBeRead() {
@@ -594,11 +730,11 @@ func (cht *cacheHandleTest) Test_Read_WhenDstBufferIsMoreContentToBeRead() {
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
 
+	ExpectEq(nil, err)
+	ExpectFalse(cacheHit)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	ExpectGe(jobStatus.Offset, offset)
-	ExpectFalse(cacheHit)
 	cht.verifyContentRead(offset, dst[:len(dst)-extraBuffer])
-	ExpectEq(nil, err)
 }
 
 func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
@@ -623,6 +759,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	_ = cht.cache.Erase(fileInfoKeyName)
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
+	AssertNe(nil, err)
 	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 	AssertFalse(cacheHit)
@@ -654,6 +791,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	AssertEq(nil, err)
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
+	AssertNe(nil, err)
 	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.InvalidFileInfoCacheErrMsg, fileInfoData.ObjectGeneration)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 	AssertFalse(cacheHit)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -335,7 +335,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithNonNilJobStatusErr() {
 	ExpectTrue(strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoPresent() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoPresent() {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
@@ -351,12 +351,12 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoPresent() {
 	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size, false)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size, false)
 
 	AssertEq(nil, err)
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoNotPresent() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent() {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
@@ -365,13 +365,13 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoNotPresent() 
 	AssertEq(nil, err)
 
 	_ = cht.cache.Erase(fileInfoKeyName)
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
 	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoGenerationChanged() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGenerationChanged() {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
@@ -387,13 +387,13 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoGenerationCha
 	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
 	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.InvalidFileInfoCacheErrMsg, fileInfo.ObjectGeneration)
 	AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoOffsetLessThanRequired() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLessThanRequired() {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
@@ -409,14 +409,14 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_FileInfoOffsetLessTha
 	_, err = cht.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
 
 	AssertNe(nil, err)
 	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.InvalidFileInfoCacheErrMsg, 10, 11)
 	AssertEq(expectedErr.Error(), err.Error())
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsTrue() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_changeCacheOrderIsTrue() {
 	// Adding one more entry to file info cache other than the one already added
 	// by cht.addTestFileInfoEntryInCache, such that the file info cache becomes
 	// full
@@ -439,7 +439,7 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsTru
 
 	// Because changeCacheOrder is true, the entry corresponding to cht.object.Size
 	// should come on top
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, true)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, true)
 
 	AssertEq(nil, err)
 	// Inserting new entry should evict the newObjectName
@@ -461,7 +461,7 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsTru
 	AssertEq(newObjectName, evictedEntries[0].(data.FileInfo).Key.ObjectName)
 }
 
-func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsFalse() {
+func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_changeCacheOrderIsFalse() {
 	// Adding one more entry to file info cache other than the one already added
 	// by cht.addTestFileInfoEntryInCache, such that the file info cache becomes
 	// full
@@ -483,7 +483,7 @@ func (cht *cacheHandleTest) Test_checkEntryInFileInfoCache_changeCacheOrderIsFal
 	AssertEq(0, len(evictedEntries))
 
 	// Because changeCacheOrder is false, the new object entry should remain on top.
-	err = cht.cacheHandle.checkEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
+	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
 	AssertEq(nil, err)
 	// Inserting new entry should evict the entry corresponding to cht.object.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/file/downloader"
@@ -81,11 +82,12 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	// Mocked cached handler object.
 	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheLocation, util.DefaultFilePerm, util.DefaultDirPerm)
 
-	// Follow consistency, local-cache file and entry in fileInfo cache should exist atomically.
+	// Follow consistency, local-cache file, entry in fileInfo cache and job should exist initially.
 	chrT.fileInfoKeyName = chrT.addTestFileInfoEntryInCache(storage.TestBucketName, TestObjectName)
 	chrT.downloadPath = util.GetDownloadPath(chrT.cacheHandler.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), chrT.object.Name))
-	_, err = chrT.cacheHandler.createLocalFileReadHandle(chrT.object.Name, chrT.bucket.Name())
+	_, err = util.CreateFile(data.FileSpec{Path: chrT.downloadPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, os.O_RDONLY)
 	AssertEq(nil, err)
+	_ = chrT.getDownloadJobForTestObject()
 }
 
 func (chrT *cacheHandlerTest) TearDown() {
@@ -128,13 +130,10 @@ func (chrT *cacheHandlerTest) isEntryInFileInfoCache(objectName string, bucketNa
 	return fileInfo != nil
 }
 
-func (chrT *cacheHandlerTest) getCacheHandleForSetupEntryInCache() *CacheHandle {
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
-	AssertEq(nil, err)
-	AssertNe(nil, cacheHandle)
-	AssertEq(true, doesFileExist(chrT.downloadPath))
-
-	return cacheHandle
+func (chrT *cacheHandlerTest) getDownloadJobForTestObject() *downloader.Job {
+	job := chrT.jobManager.CreateJobIfNotExists(chrT.object, chrT.bucket)
+	AssertNe(nil, job)
+	return job
 }
 
 func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *gcs.MinObject {
@@ -177,105 +176,173 @@ func (chrT *cacheHandlerTest) Test_createLocalFileReadHandle_OnlyForRead() {
 }
 
 func (chrT *cacheHandlerTest) Test_cleanUpEvictedFile() {
-	// Existing cacheHandle.
-	cacheHandle := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle.validateCacheHandle())
+	fileDownloadJob := chrT.getDownloadJobForTestObject()
 	fileInfo := chrT.cache.LookUp(chrT.fileInfoKeyName)
 	fileInfoData := fileInfo.(data.FileInfo)
-	jobStatusBefore := cacheHandle.fileDownloadJob.GetStatus()
-	AssertEq(jobStatusBefore.Name, downloader.NOT_STARTED)
-	jobStatusBefore, err := cacheHandle.fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
+	jobStatusBefore := fileDownloadJob.GetStatus()
+	AssertEq(jobStatusBefore.Name, downloader.NotStarted)
+	jobStatusBefore, err := fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
 	AssertEq(nil, err)
-	AssertEq(jobStatusBefore.Name, downloader.DOWNLOADING)
+	AssertEq(jobStatusBefore.Name, downloader.Downloading)
 
 	err = chrT.cacheHandler.cleanUpEvictedFile(&fileInfoData)
 
 	ExpectEq(nil, err)
-	jobStatusAfter := cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusAfter.Name, downloader.INVALID)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	jobStatusAfter := fileDownloadJob.GetStatus()
+	ExpectEq(jobStatusAfter.Name, downloader.Invalid)
+	ExpectFalse(doesFileExist(chrT.downloadPath))
+	// Job should be removed from job manager
+	ExpectEq(nil, chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name()))
 }
 
 func (chrT *cacheHandlerTest) Test_cleanUpEvictedFile_WhenLocalFileNotExist() {
-	cacheHandle := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle.validateCacheHandle())
-	err := os.Remove(chrT.downloadPath)
-	AssertEq(nil, err)
+	fileDownloadJob := chrT.getDownloadJobForTestObject()
 	fileInfo := chrT.cache.LookUp(chrT.fileInfoKeyName)
 	fileInfoData := fileInfo.(data.FileInfo)
-	jobStatusBefore := cacheHandle.fileDownloadJob.GetStatus()
-	AssertEq(jobStatusBefore.Name, downloader.NOT_STARTED)
-	jobStatusBefore, err = cacheHandle.fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
+	jobStatusBefore := fileDownloadJob.GetStatus()
+	AssertEq(jobStatusBefore.Name, downloader.NotStarted)
+	jobStatusBefore, err := fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
 	AssertEq(nil, err)
-	AssertEq(jobStatusBefore.Name, downloader.DOWNLOADING)
+	AssertEq(jobStatusBefore.Name, downloader.Downloading)
+	err = os.Remove(chrT.downloadPath)
+	AssertEq(nil, err)
 
 	err = chrT.cacheHandler.cleanUpEvictedFile(&fileInfoData)
 
 	ExpectEq(nil, err)
+	jobStatusAfter := fileDownloadJob.GetStatus()
+	ExpectEq(jobStatusAfter.Name, downloader.Invalid)
+	ExpectFalse(doesFileExist(chrT.downloadPath))
+	// Job should be removed from job manager
+	ExpectEq(nil, chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfAlready() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfAlready() {
+	existingJob := chrT.getDownloadJobForTestObject()
 
-	err := chrT.cacheHandler.addFileInfoEntryToCache(chrT.object, chrT.bucket)
+	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
 
 	ExpectEq(nil, err)
 	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	// File download job should also be same
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectEq(existingJob, actualJob)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_GenerationChanged() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
-
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_GenerationChanged() {
+	existingJob := chrT.getDownloadJobForTestObject()
 	chrT.object.Generation = chrT.object.Generation + 1
 
-	err := chrT.cacheHandler.addFileInfoEntryToCache(chrT.object, chrT.bucket)
+	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
 
 	ExpectEq(nil, err)
 	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	// File download job should be new as the file info and job should be cleaned
+	// up.
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectNe(existingJob, actualJob)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfNotAlready() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfNotAlready() {
+	oldJob := chrT.getDownloadJobForTestObject()
 	// Content of size more than 20 leads to eviction of initial TestObjectName.
 	// Here, content size is 21.
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
+	// There should be no file download job corresponding to minObject
+	existingJob := chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name())
+	AssertEq(nil, existingJob)
 
 	// Insertion will happen and that leads to eviction.
-	err := chrT.cacheHandler.addFileInfoEntryToCache(minObject, chrT.bucket)
+	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(minObject, chrT.bucket)
 
 	ExpectEq(nil, err)
 	ExpectTrue(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
-	jobStatus := cacheHandle1.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
+	jobStatus := oldJob.GetStatus()
+	ExpectEq(downloader.Invalid, jobStatus.Name)
 	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	// Job should be added for minObject
+	minObjectJob := chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name())
+	ExpectNe(nil, minObjectJob)
+	ExpectEq(downloader.NotStarted, minObjectJob.GetStatus().Name)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryToCache_IfLocalFileGetsDeleted() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfLocalFileGetsDeleted() {
 	// Delete the local cache file.
 	err := os.Remove(chrT.downloadPath)
 	AssertEq(nil, err)
 
 	// There is a fileInfoEntry in the fileInfoCache but the corresponding local file doesn't exist.
 	// Hence, this will return error containing util.FileNotPresentInCacheErrMsg.
-	err = chrT.cacheHandler.addFileInfoEntryToCache(chrT.object, chrT.bucket)
+	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneration() {
-	// Existing cacheHandle.
-	oldCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasCompleted() {
+	existingJob := chrT.getDownloadJobForTestObject()
+	// Make the job completed, so it's removed from job manager.
+	jobStatus, err := existingJob.Download(context.Background(), int64(chrT.object.Size), true)
 	AssertEq(nil, err)
+	AssertEq(jobStatus.Offset, chrT.object.Size)
+	// Give time for execution of callback to remove from job manager
+	time.Sleep(time.Second)
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectEq(nil, actualJob)
+
+	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+
+	ExpectEq(nil, err)
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	// No new job should be added to job manager
+	actualJob = chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectEq(nil, actualJob)
+}
+
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobIsInvalidatedAndRemoved() {
+	chrT.jobManager.InvalidateAndRemoveJob(chrT.object.Name, chrT.bucket.Name())
+	existingJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectEq(nil, existingJob)
+
+	// Because the job has been removed and file info entry is still present, new
+	// file info entry and job should be created.
+	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+
+	ExpectEq(nil, err)
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	// New job should be added to job manager
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectNe(nil, actualJob)
+	ExpectEq(downloader.NotStarted, actualJob.GetStatus().Name)
+}
+
+func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasFailed() {
+	existingJob := chrT.getDownloadJobForTestObject()
+	// Hack to fail the async job
+	correctSize := chrT.object.Size
+	chrT.object.Size = 2
+	jobStatus, err := existingJob.Download(context.Background(), 1, true)
+	AssertEq(nil, err)
+	AssertEq(downloader.Failed, jobStatus.Name)
+	chrT.object.Size = correctSize
+
+	// Because the job has been failed and file info entry is still present with
+	// size less than the object's size (because the async job failed), new job
+	// should be created
+	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+
+	ExpectEq(nil, err)
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	// New job should be added to job manager
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectNe(nil, actualJob)
+	ExpectEq(downloader.NotStarted, actualJob.GetStatus().Name)
+}
+
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneration() {
+	existingJob := chrT.getDownloadJobForTestObject()
+	AssertNe(nil, existingJob)
+	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
 	// Change the version of the object, but cache still keeps old generation
 	chrT.object.Generation = chrT.object.Generation + 1
 
@@ -283,55 +350,65 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneratio
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, newCacheHandle.validateCacheHandle())
-	jobStatusOfOldHandle := oldCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusOfOldHandle.Name, downloader.INVALID)
+	jobStatusOfOldJob := existingJob.GetStatus()
+	ExpectEq(jobStatusOfOldJob.Name, downloader.Invalid)
 	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusOfNewHandle.Name, downloader.NOT_STARTED)
+	ExpectEq(jobStatusOfNewHandle.Name, downloader.NotStarted)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheContainsObjectHavingFailedAsyncJob() {
-	// Existing cacheHandle.
-	oldCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenAsyncDownloadJobHasFailed() {
+	existingJob := chrT.getDownloadJobForTestObject()
+	// Hack to fail the async job
+	correctSize := chrT.object.Size
+	chrT.object.Size = 2
+	jobStatus, err := existingJob.Download(context.Background(), 1, true)
 	AssertEq(nil, err)
-	buf := make([]byte, 3)
-	oldObjectName := chrT.object.Name
-	chrT.object.Name = chrT.object.Name + "test" // Hack: to fail the download job while reading from GCS.
-	_, cacheHit, err := oldCacheHandle.Read(context.Background(), chrT.bucket, chrT.object, 0, buf)
-	ExpectNe(nil, err)
-	ExpectEq(false, cacheHit)
-	jobStatusOfOldHandle := oldCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.FAILED, jobStatusOfOldHandle.Name)
-	// Assigning the correct object before further call.
-	chrT.object.Name = oldObjectName
+	AssertEq(downloader.Failed, jobStatus.Name)
+	chrT.object.Size = correctSize
 
 	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
+	// New job should be created because the earlier job has failed.
 	ExpectEq(nil, err)
 	ExpectEq(nil, newCacheHandle.validateCacheHandle())
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.NOT_STARTED, jobStatusOfNewHandle.Name)
+	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryAlreadyInCache() {
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreAlreadyPresent() {
+	// File info and download job are already present for test object.
+	existingJob := chrT.getDownloadJobForTestObject()
+
 	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle.validateCacheHandle())
+	// Job and file info are still present
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	ExpectEq(existingJob, cacheHandle.fileDownloadJob)
+	jobStatusOfNewHandle := cacheHandle.fileDownloadJob.GetStatus()
+	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenEntryNotInCache() {
+func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreNotPresent() {
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
 
 	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle.validateCacheHandle())
+	// Job and file info are still present
+	ExpectTrue(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
+	jobStatusOfNewHandle := cacheHandle.fileDownloadJob.GetStatus()
+	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_WithEviction() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+	// Start the existing job
+	existingJob := chrT.getDownloadJobForTestObject()
+	_, err := existingJob.Download(context.Background(), 1, false)
+	AssertEq(nil, err)
 	// Content of size more than 20 leads to eviction of initial TestObjectName.
 	// Here, content size is 21.
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
@@ -340,23 +417,28 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WithEviction() {
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle2.validateCacheHandle())
-	jobStatus := cacheHandle1.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	jobStatus := existingJob.GetStatus()
+	ExpectEq(downloader.Invalid, jobStatus.Name)
+	ExpectFalse(doesFileExist(chrT.downloadPath))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGetsDeleted() {
-	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
-	_, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
-	AssertEq(nil, err)
 	// Delete the local cache file.
-	err = os.Remove(util.GetDownloadPath(chrT.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), minObject.Name)))
+	err := os.Remove(chrT.downloadPath)
 	AssertEq(nil, err)
+	existingJob := chrT.getDownloadJobForTestObject()
 
-	_, err = chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
+	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
+	AssertEq(nil, cacheHandle)
+	// Check file info and download job are not removed
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
+	ExpectEq(existingJob, actualJob)
+	ExpectEq(downloader.NotStarted, existingJob.GetStatus().Name)
+
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_CacheForRangeRead() {
@@ -381,16 +463,16 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_CacheForRangeRead() {
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
-
+	// Check async job and file info cache not preset for object_1
+	testObjectName := "object_1"
+	existingJob := chrT.jobManager.GetJob(testObjectName, chrT.bucket.Name())
+	AssertEq(nil, existingJob)
 	wg := sync.WaitGroup{}
-
 	getCacheHandleTestFun := func() {
 		defer wg.Done()
-		minObj := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
+		minObj := chrT.getMinObject(testObjectName, []byte("content of object_1 ..."))
 
+		var err error
 		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
 
 		AssertEq(nil, err)
@@ -404,15 +486,16 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
 	}
 	wg.Wait()
 
-	jobStatus := cacheHandle1.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	// Job should be added now
+	actualJob := chrT.jobManager.GetJob(testObjectName, chrT.bucket.Name())
+	jobStatus := actualJob.GetStatus()
+	ExpectEq(downloader.NotStarted, jobStatus.Name)
+	ExpectTrue(doesFileExist(util.GetDownloadPath(chrT.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), testObjectName))))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+	existingJob := chrT.getDownloadJobForTestObject()
+	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
 	wg := sync.WaitGroup{}
 
 	getCacheHandleTestFun := func(index int) {
@@ -434,29 +517,40 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
 	}
 	wg.Wait()
 
-	jobStatus := cacheHandle1.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
+	// Existing job for default chrT object should be invalidated.
+	ExpectNe(nil, existingJob)
+	ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
 	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	// File info should also be removed.
+	ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryAlreadyInCache() {
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
-	ExpectEq(nil, err)
+func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenAlreadyInCache() {
+	existingJob := chrT.getDownloadJobForTestObject()
+	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 
-	err = chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
+	err := chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
 
 	ExpectEq(nil, err)
-	jobStatus := cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
+	// Existing job for default chrT object should be invalidated.
+	ExpectNe(nil, existingJob)
+	ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
 	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	// File info should also be removed.
+	ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 }
 
 func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryNotInCache() {
 	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
+	ExpectFalse(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
+	ExpectEq(nil, chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name()))
 
 	err := chrT.cacheHandler.InvalidateCache(minObject.Name, chrT.bucket.Name())
 
 	ExpectEq(nil, err)
+	ExpectFalse(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
+	ExpectEq(nil, chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name()))
 }
 
 func (chrT *cacheHandlerTest) Test_InvalidateCache_Truncates() {
@@ -491,19 +585,21 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_Truncates() {
 }
 
 func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentSameFile() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
-
+	existingJob := chrT.getDownloadJobForTestObject()
+	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
+	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 	wg := sync.WaitGroup{}
-
 	InvalidateCacheTestFun := func() {
 		defer wg.Done()
-		minObj := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
 
-		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
+		err := chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
 
 		AssertEq(nil, err)
+		ExpectNe(nil, existingJob)
+		ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
+		ExpectEq(false, doesFileExist(chrT.downloadPath))
+		// File info should also be removed.
+		ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
 	}
 
 	// Start concurrent GetCacheHandle()
@@ -515,9 +611,6 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentSameFile() {
 }
 
 func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
 	wg := sync.WaitGroup{}
 
 	InvalidateCacheTestFun := func(index int) {
@@ -529,6 +622,8 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
 		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
 
 		AssertEq(nil, err)
+		AssertEq(nil, chrT.jobManager.GetJob(objName, chrT.bucket.Name()))
+		AssertFalse(chrT.isEntryInFileInfoCache(objName, chrT.bucket.Name()))
 	}
 
 	// Start concurrent GetCacheHandle()
@@ -539,10 +634,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
 	wg.Wait()
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCacheAndGetHandle_Concurrent() {
-	// Existing cacheHandle.
-	cacheHandle1 := chrT.getCacheHandleForSetupEntryInCache()
-	AssertEq(nil, cacheHandle1.validateCacheHandle())
+func (chrT *cacheHandlerTest) Test_InvalidateCache_GetCacheHandle_Concurrent() {
 	wg := sync.WaitGroup{}
 
 	invalidateCacheTestFun := func(index int) {
@@ -576,12 +668,6 @@ func (chrT *cacheHandlerTest) Test_InvalidateCacheAndGetHandle_Concurrent() {
 		go getCacheHandleTestFun(i)
 	}
 	wg.Wait()
-
-	// Any fileInfo addition with content size greater than ObjectSizeToCauseEviction will
-	// evict the existing cache handle.
-	jobStatus := cacheHandle1.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.INVALID, jobStatus.Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
 }
 
 func (chrT *cacheHandlerTest) Test_Destroy() {
@@ -604,8 +690,6 @@ func (chrT *cacheHandlerTest) Test_Destroy() {
 	AssertEq(nil, err)
 	err = cacheHandle2.Close()
 	AssertEq(nil, err)
-	job1 := cacheHandle1.fileDownloadJob
-	job2 := cacheHandle2.fileDownloadJob
 
 	err = chrT.cacheHandler.Destroy()
 
@@ -614,7 +698,12 @@ func (chrT *cacheHandlerTest) Test_Destroy() {
 	_, err = os.Stat(path.Join(chrT.cacheLocation, util.FileCache))
 	AssertNe(nil, err)
 	AssertTrue(errors.Is(err, os.ErrNotExist))
-	// Verify jobs are invalidated
-	AssertEq(downloader.INVALID, job1.GetStatus().Name)
-	AssertEq(downloader.INVALID, job2.GetStatus().Name)
+	// Verify jobs are either removed or completed and removed themselves.
+	job1 := chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name())
+	job2 := chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name())
+	AssertTrue((job1 == nil) || (job1.GetStatus().Name == downloader.Completed))
+	AssertTrue((job2 == nil) || (job2.GetStatus().Name == downloader.Completed))
+	// Job manager should no longer contain the jobs
+	AssertEq(nil, chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name()))
+	AssertEq(nil, chrT.jobManager.GetJob(minObject2.Name, chrT.bucket.Name()))
 }

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -398,7 +398,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreNotPresen
 
 	ExpectEq(nil, err)
 	ExpectEq(nil, cacheHandle.validateCacheHandle())
-	// Job and file info are still present
+	// New Job and file info are created.
 	ExpectTrue(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
 	jobStatusOfNewHandle := cacheHandle.fileDownloadJob.GetStatus()
 	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -25,13 +25,13 @@ import (
 )
 
 // JobManager is responsible for maintaining, getting and removing file download
-// jobs.
+// jobs. It is created only once at the time of mounting.
 type JobManager struct {
 	/////////////////////////
 	// Constant data
 	/////////////////////////
 
-	// filePerm is passed to Job created by JobManager. filePerm decides the
+	// filePerm is passed to Job created by JobManager. It decides the
 	// permission of file in cache created by Job.
 	filePerm os.FileMode
 	// dirPerm is passed to Job created by JobManager. dirPerm decides the
@@ -65,37 +65,68 @@ func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.Fi
 	return
 }
 
-// GetJob gives downloader.Job for given object and bucket. If there is no
-// existing job then this method creates one.
+// removeJob is a helper function to remove downloader.Job for given object and
+// bucket from jm.jobs if present. It is passed as callback function to job so
+// that job can remove itself after completion/failure/invalidation.
 //
 // Acquires and releases Lock(jm.mu)
-func (jm *JobManager) GetJob(object *gcs.MinObject, bucket gcs.Bucket) (job *Job) {
-	jm.mu.Lock()
-	defer jm.mu.Unlock()
-	objectPath := util.GetObjectPath(bucket.Name(), object.Name)
-	job, ok := jm.jobs[objectPath]
-	if !ok {
-		downloadPath := util.GetDownloadPath(jm.cacheLocation, objectPath)
-		fileSpec := data.FileSpec{Path: downloadPath, FilePerm: jm.filePerm, DirPerm: jm.dirPerm}
-		job = NewJob(object, bucket, jm.fileInfoCache, jm.sequentialReadSizeMb, fileSpec)
-		jm.jobs[objectPath] = job
-	}
-	return job
-}
-
-// RemoveJob removes downloader.Job for given object and bucket. If there is no
-// existing job present then this method does nothing. Also, the job is
-// first invalidated before removing.
-//
-// Acquires and releases Lock(jm.mu)
-func (jm *JobManager) RemoveJob(objectName string, bucketName string) {
+func (jm *JobManager) removeJob(objectName string, bucketName string) {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
 	objectPath := util.GetObjectPath(bucketName, objectName)
+	delete(jm.jobs, objectPath)
+}
+
+// CreateJobIfNotExists creates and returns downloader.Job for given object and bucket.
+// If there is already an existing job then this method returns that.
+//
+// Acquires and releases Lock(jm.mu)
+func (jm *JobManager) CreateJobIfNotExists(object *gcs.MinObject, bucket gcs.Bucket) (job *Job) {
+	objectPath := util.GetObjectPath(bucket.Name(), object.Name)
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
 	job, ok := jm.jobs[objectPath]
 	if ok {
+		return job
+	}
+	downloadPath := util.GetDownloadPath(jm.cacheLocation, objectPath)
+	fileSpec := data.FileSpec{Path: downloadPath, FilePerm: jm.filePerm, DirPerm: jm.dirPerm}
+	// Pass call back function to Job. When this callback function is called, it
+	// removes the job reference from jobs map.
+	removeJobCallback := func() {
+		jm.removeJob(object.Name, bucket.Name())
+	}
+	job = NewJob(object, bucket, jm.fileInfoCache, jm.sequentialReadSizeMb, fileSpec, removeJobCallback)
+	jm.jobs[objectPath] = job
+	return job
+}
+
+// GetJob returns downloader.Job for given object and bucket if present. If the
+// job is not present, it returns nil.
+//
+// Acquires and releases Lock(jm.mu)
+func (jm *JobManager) GetJob(objectName string, bucketName string) *Job {
+	objectPath := util.GetObjectPath(bucketName, objectName)
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	job, _ := jm.jobs[objectPath]
+	return job
+}
+
+// InvalidateAndRemoveJob invalidates downloader.Job for given object and bucket.
+// If there is no existing job present then this method does nothing.
+// Note: Invalidating a job also removes job from jm.jobs map.
+//
+// Acquires and releases Lock(jm.mu)
+func (jm *JobManager) InvalidateAndRemoveJob(objectName string, bucketName string) {
+	objectPath := util.GetObjectPath(bucketName, objectName)
+	jm.mu.Lock()
+	job, ok := jm.jobs[objectPath]
+	// Release the lock while calling downloader.Job.Invalidate to avoid deadlock
+	// as the job calls removeJobCallback in the end which requires Lock(jm.mu).
+	jm.mu.Unlock()
+	if ok {
 		job.Invalidate()
-		delete(jm.jobs, objectPath)
 	}
 }
 
@@ -103,10 +134,16 @@ func (jm *JobManager) RemoveJob(objectName string, bucketName string) {
 //
 // Acquires and releases Lock(jm.mu)
 func (jm *JobManager) Destroy() {
+	// Get all jobs
 	jm.mu.Lock()
-	defer jm.mu.Unlock()
-	for objectPath, job := range jm.jobs {
+	jobs := make([]*Job, 0, len(jm.jobs))
+	for _, job := range jm.jobs {
+		jobs = append(jobs, job)
+	}
+	jm.mu.Unlock()
+
+	// Invalidate all the jobs which internally also removes from jm.jobs.
+	for _, job := range jobs {
 		job.Invalidate()
-		delete(jm.jobs, objectPath)
 	}
 }

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -109,7 +109,7 @@ func (jm *JobManager) GetJob(objectName string, bucketName string) *Job {
 	objectPath := util.GetObjectPath(bucketName, objectName)
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
-	job, _ := jm.jobs[objectPath]
+	job := jm.jobs[objectPath]
 	return job
 }
 

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -106,7 +106,7 @@ func (dt *downloaderTest) Test_CreateJobIfNotExists_Existing() {
 	dt.jm.mu.Unlock()
 
 	// Call CreateJobIfNotExists for existing job.
-	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+	job := dt.jm.CreateJobIfNotExists(dt.object.Name, dt.bucket.Name())
 
 	AssertEq(dt.job, job)
 	dt.jm.mu.Lock()

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -106,7 +106,7 @@ func (dt *downloaderTest) Test_CreateJobIfNotExists_Existing() {
 	dt.jm.mu.Unlock()
 
 	// Call CreateJobIfNotExists for existing job.
-	job := dt.jm.CreateJobIfNotExists(dt.object.Name, dt.bucket.Name())
+	job := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
 
 	AssertEq(dt.job, job)
 	dt.jm.mu.Lock()

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -20,10 +20,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/locker"
+
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/util"
-	"github.com/googlecloudplatform/gcsfuse/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/internal/util"
@@ -57,8 +58,9 @@ func (dt *downloaderTest) SetUp(*TestInfo) {
 	storageHandle := dt.fakeStorage.CreateStorageHandle()
 	dt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
-	dt.initJobTest(DefaultObjectName, []byte("taco"), 200, CacheMaxSize)
+	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
 	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheLocation, DefaultSequentialReadSizeMb)
+
 }
 
 func (dt *downloaderTest) TearDown() {
@@ -75,51 +77,102 @@ func (dt *downloaderTest) verifyJob(job *Job, object *gcs.MinObject, bucket gcs.
 	downloadPath := util.GetDownloadPath(dt.jm.cacheLocation, util.GetObjectPath(bucket.Name(), object.Name))
 	ExpectEq(downloadPath, job.fileSpec.Path)
 	ExpectEq(sequentialReadSizeMb, job.sequentialReadSizeMb)
+	ExpectNe(nil, job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_GetJob_NotExisting() {
+func (dt *downloaderTest) Test_CreateJobIfNotExists_NotExisting() {
+	dt.jm.mu.Lock()
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	_, ok := dt.jm.jobs[objectPath]
+	AssertFalse(ok)
+	dt.jm.mu.Unlock()
 
-	// call GetJob for job which doesn't exist.
-	job := dt.jm.GetJob(&dt.object, dt.bucket)
+	// Call CreateJobIfNotExists for job which doesn't exist.
+	job := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
 
 	dt.jm.mu.Lock()
 	defer dt.jm.mu.Unlock()
 	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	actualJob, ok := dt.jm.jobs[objectPath]
+	AssertTrue(ok)
+	AssertEq(job, actualJob)
 }
 
-func (dt *downloaderTest) Test_GetJob_Existing() {
-	// first create new job
-	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
+func (dt *downloaderTest) Test_CreateJobIfNotExists_Existing() {
+	// First create and store new job
 	dt.jm.mu.Lock()
-	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	dt.jm.jobs[objectPath] = dt.job
 	dt.jm.mu.Unlock()
 
-	// again call GetJob
-	job := dt.jm.GetJob(&dt.object, dt.bucket)
+	// Call CreateJobIfNotExists for existing job.
+	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
 
-	ExpectEq(expectedJob, job)
+	AssertEq(dt.job, job)
+	dt.jm.mu.Lock()
+	defer dt.jm.mu.Unlock()
+	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	actualJob, ok := dt.jm.jobs[objectPath]
+	AssertTrue(ok)
+	AssertEq(job, actualJob)
 }
 
-func (dt *downloaderTest) Test_GetJob_Existing_WithDefaultFileAndDirPerm() {
-	// first create new job
-	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
+func (dt *downloaderTest) Test_CreateJobIfNotExists_NotExisting_WithDefaultFileAndDirPerm() {
 	dt.jm.mu.Lock()
-	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	_, ok := dt.jm.jobs[objectPath]
+	AssertFalse(ok)
 	dt.jm.mu.Unlock()
 
-	// again call GetJob
-	job := dt.jm.GetJob(&dt.object, dt.bucket)
+	// Call CreateJobIfNotExists for job which doesn't exist.
+	job := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
 
 	ExpectEq(0700, job.fileSpec.DirPerm.Perm())
 	ExpectEq(0600, job.fileSpec.FilePerm.Perm())
 }
 
+func (dt *downloaderTest) Test_GetJob_NotExisting() {
+	dt.jm.mu.Lock()
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	_, ok := dt.jm.jobs[objectPath]
+	AssertFalse(ok)
+	dt.jm.mu.Unlock()
+
+	// Call GetJob for job which doesn't exist.
+	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+
+	AssertEq(nil, job)
+	dt.jm.mu.Lock()
+	defer dt.jm.mu.Unlock()
+	_, ok = dt.jm.jobs[objectPath]
+	AssertFalse(ok)
+}
+
+func (dt *downloaderTest) Test_GetJob_Existing() {
+	// First create and store new job
+	dt.jm.mu.Lock()
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	dt.jm.jobs[objectPath] = dt.job
+	dt.jm.mu.Unlock()
+
+	// Call GetJob for existing job.
+	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+
+	AssertEq(dt.job, job)
+	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+}
+
 func (dt *downloaderTest) Test_GetJob_Concurrent() {
+	// First create and store new job
+	dt.jm.mu.Lock()
+	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
+	dt.jm.jobs[objectPath] = dt.job
+	dt.jm.mu.Unlock()
 	jobs := [5]*Job{}
 	wg := sync.WaitGroup{}
 	getFunc := func(i int) {
 		defer wg.Done()
-		job := dt.jm.GetJob(&dt.object, dt.bucket)
+		job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
 		jobs[i] = job
 	}
 
@@ -130,83 +183,69 @@ func (dt *downloaderTest) Test_GetJob_Concurrent() {
 	}
 	wg.Wait()
 
-	// verify any of the job first
-	dt.jm.mu.Lock()
-	defer dt.jm.mu.Unlock()
-	dt.verifyJob(jobs[0], &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
-	// verify all other jobs
-	for i := 1; i < 5; i++ {
-		ExpectEq(jobs[0], jobs[i])
+	dt.verifyJob(dt.job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	// Verify all jobs
+	for i := 0; i < 5; i++ {
+		ExpectEq(dt.job, jobs[i])
 	}
 }
 
-func (dt *downloaderTest) Test_RemoveJob_NotExisting() {
-	// first create new job
-	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
-	dt.jm.mu.Lock()
-	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
-	// verify the created
-	dt.jm.mu.Unlock()
+func (dt *downloaderTest) Test_InvalidateAndRemoveJob_NotExisting() {
+	expectedJob := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+	AssertEq(nil, expectedJob)
 
-	dt.jm.RemoveJob(dt.object.Name, dt.bucket.Name())
+	dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
 
-	// verify no job existing
-	dt.jm.mu.Lock()
-	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
-	_, ok := dt.jm.jobs[objectPath]
-	ExpectFalse(ok)
-	dt.jm.mu.Unlock()
+	// Verify that job is invalidated and removed from job manager.
+	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+	AssertEq(nil, expectedJob)
 }
 
-func (dt *downloaderTest) Test_RemoveJob_Existing() {
-	// first create new job
-	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
+func (dt *downloaderTest) Test_InvalidateAndRemoveJob_Existing() {
+	// First create new job
+	expectedJob := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
 	dt.jm.mu.Lock()
 	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	dt.jm.mu.Unlock()
-	// start the job
-	_, _ = expectedJob.Download(context.Background(), 0, false)
+	// Start the job
+	_, err := expectedJob.Download(context.Background(), 0, false)
+	AssertEq(nil, err)
 
-	// remove the job
-	dt.jm.RemoveJob(dt.object.Name, dt.bucket.Name())
+	// InvalidateAndRemove the job
+	dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
 
-	// verify no job existing
-	dt.jm.mu.Lock()
-	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
-	_, ok := dt.jm.jobs[objectPath]
-	ExpectFalse(ok)
-	dt.jm.mu.Unlock()
-	// verify the job is invalid
-	jobStatus, err := expectedJob.Download(context.Background(), 0, false)
-	ExpectEq(nil, err)
-	ExpectEq(INVALID, jobStatus.Name)
+	// Verify no job existing
+	AssertEq(Invalid, expectedJob.GetStatus().Name)
+	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+	AssertEq(nil, expectedJob)
 }
 
-func (dt *downloaderTest) Test_RemoveJob_Concurrent() {
-	// first create new job
-	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
+func (dt *downloaderTest) Test_InvalidateAndRemoveJob_Concurrent() {
+	// First create new job
+	expectedJob := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
 	dt.jm.mu.Lock()
 	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	dt.jm.mu.Unlock()
+	// Start the job
+	_, err := expectedJob.Download(context.Background(), 0, false)
+	AssertEq(nil, err)
 	wg := sync.WaitGroup{}
 
-	// make concurrent requests
+	// Make concurrent requests
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		removeFunc := func() {
+		invalidateFunc := func() {
+			dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
 			wg.Done()
-			dt.jm.RemoveJob(dt.object.Name, dt.bucket.Name())
 		}
-		go removeFunc()
+		go invalidateFunc()
 	}
 	wg.Wait()
 
-	// verify no job existing
-	dt.jm.mu.Lock()
-	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
-	_, ok := dt.jm.jobs[objectPath]
-	ExpectFalse(ok)
-	dt.jm.mu.Unlock()
+	// Verify job in invalidated and removed from job manager.
+	AssertEq(Invalid, expectedJob.GetStatus().Name)
+	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
+	AssertEq(nil, expectedJob)
 }
 
 func (dt *downloaderTest) Test_Destroy() {
@@ -214,19 +253,52 @@ func (dt *downloaderTest) Test_Destroy() {
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	// Create new jobs
 	objectName1 := "path/in/gcs/foo1.txt"
-	dt.initJobTest(objectName1, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	job1 := dt.jm.GetJob(&dt.object, dt.bucket)
+	dt.initJobTest(objectName1, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
+	object1 := dt.object
+	job1 := dt.jm.CreateJobIfNotExists(&object1, dt.bucket)
 	objectName2 := "path/in/gcs/foo2.txt"
-	dt.initJobTest(objectName2, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	job2 := dt.jm.GetJob(&dt.object, dt.bucket)
+	dt.initJobTest(objectName2, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
+	object2 := dt.object
+	job2 := dt.jm.CreateJobIfNotExists(&object2, dt.bucket)
+	// Start the job
+	_, err := job2.Download(context.Background(), 2, false)
+	AssertEq(nil, err)
 	objectName3 := "path/in/gcs/foo3.txt"
-	dt.initJobTest(objectName3, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	job3 := dt.jm.GetJob(&dt.object, dt.bucket)
+	dt.initJobTest(objectName3, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
+	object3 := dt.object
+	job3 := dt.jm.CreateJobIfNotExists(&object3, dt.bucket)
+	// Start the job
+	_, err = job3.Download(context.Background(), 2, false)
+	AssertEq(nil, err)
 
 	dt.jm.Destroy()
 
 	// Verify all jobs are invalidated
-	AssertEq(INVALID, job1.GetStatus().Name)
-	AssertEq(INVALID, job2.GetStatus().Name)
-	AssertEq(INVALID, job3.GetStatus().Name)
+	AssertEq(Invalid, job1.GetStatus().Name)
+	AssertEq(Invalid, job2.GetStatus().Name)
+	AssertEq(Invalid, job3.GetStatus().Name)
+	// Verify all jobs are removed
+	AssertEq(nil, dt.jm.GetJob(objectName1, dt.bucket.Name()))
+	AssertEq(nil, dt.jm.GetJob(objectName2, dt.bucket.Name()))
+	AssertEq(nil, dt.jm.GetJob(objectName3, dt.bucket.Name()))
+}
+
+func (dt *downloaderTest) Test_CreateJobIfNotExists_InvalidateAndRemoveJob_Concurrent() {
+	wg := sync.WaitGroup{}
+	createNewJob := func() {
+		job := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
+		AssertNe(nil, job)
+		wg.Done()
+	}
+	invalidateJob := func() {
+		dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
+		wg.Done()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(2)
+		go createNewJob()
+		go invalidateJob()
+	}
+	wg.Wait()
 }

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -184,7 +184,6 @@ func (job *Job) Invalidate() {
 		job.removeJobCallback = nil
 	}
 	job.notifySubscribers()
-	return
 }
 
 // subscribe adds subscriber for download job and returns channel which is

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -326,7 +326,7 @@ func (job *Job) downloadObjectAsync() {
 							ReadCompressed: job.object.HasContentEncodingGzip(),
 						})
 					if err != nil {
-						// Context is canceled when job.cancel is called at the tine of
+						// Context is canceled when job.cancel is called at the time of
 						// invalidation and hence caller should be notified as invalid.
 						if errors.Is(err, context.Canceled) {
 							notifyInvalid()
@@ -350,7 +350,7 @@ func (job *Job) downloadObjectAsync() {
 				// Copy the contents from NewReader to cache file.
 				_, readErr := io.CopyN(cacheFile, newReader, maxRead)
 				if readErr != nil {
-					// Context is canceled when job.cancel is called at the tine of
+					// Context is canceled when job.cancel is called at the time of
 					// invalidation and hence caller should be notified as invalid.
 					if errors.Is(readErr, context.Canceled) {
 						notifyInvalid()

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -17,12 +17,14 @@ package downloader
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/data"
@@ -54,7 +56,7 @@ func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 	return storageutil.ConvertObjToMinObject(object)
 }
 
-func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64) {
+func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {
 	ctx := context.Background()
 	objects := map[string][]byte{objectName: objectContent}
 	err := storageutil.CreateObjects(ctx, dt.bucket, objects)
@@ -66,7 +68,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 		DirPerm:  util.DefaultDirPerm,
 	}
 	dt.cache = lru.NewCache(lruCacheSize)
-	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec)
+	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec, removeCallback)
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
 		ObjectName: objectName,
@@ -88,7 +90,7 @@ func (dt *downloaderTest) verifyFile(content []byte) {
 	AssertEq(nil, err)
 	AssertEq(dt.fileSpec.FilePerm, fileStat.Mode())
 	AssertLe(len(content), fileStat.Size())
-	// verify the content of file downloaded. only verified till
+	// Verify the content of file downloaded only till the size of content passed.
 	fileContent, err := os.ReadFile(dt.fileSpec.Path)
 	AssertEq(nil, err)
 	AssertTrue(reflect.DeepEqual(content, fileContent[:len(content)]))
@@ -101,7 +103,7 @@ func (dt *downloaderTest) verifyFileInfoEntry(offset uint64) {
 	fileInfo := dt.cache.LookUp(fileInfoKeyName)
 	AssertTrue(fileInfo != nil)
 	AssertEq(dt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
-	AssertEq(offset, fileInfo.(data.FileInfo).Offset)
+	AssertLe(offset, fileInfo.(data.FileInfo).Offset)
 	AssertEq(dt.object.Size, fileInfo.(data.FileInfo).Size())
 }
 
@@ -111,14 +113,14 @@ func (dt *downloaderTest) fileCachePath(bucketName string, objectName string) st
 
 func (dt *downloaderTest) Test_init() {
 	// Explicitly changing initialized values first.
-	dt.job.status.Name = DOWNLOADING
+	dt.job.status.Name = Downloading
 	dt.job.status.Err = fmt.Errorf("some error")
 	dt.job.status.Offset = -1
 	dt.job.subscribers.PushBack(struct{}{})
 
 	dt.job.init()
 
-	AssertEq(NOT_STARTED, dt.job.status.Name)
+	AssertEq(NotStarted, dt.job.status.Name)
 	AssertEq(nil, dt.job.status.Err)
 	AssertEq(0, dt.job.status.Offset)
 	AssertTrue(reflect.DeepEqual(list.List{}, dt.job.subscribers))
@@ -135,7 +137,7 @@ func (dt *downloaderTest) Test_subscribe() {
 	receivingC := make(<-chan JobStatus, 1)
 	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
 	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
-	// check 1st and 2nd subscribers
+	// Check 1st and 2nd subscribers
 	var subscriber jobSubscriber
 	AssertEq(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Front().Value.(jobSubscriber)))
 	AssertEq(0, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
@@ -143,10 +145,10 @@ func (dt *downloaderTest) Test_subscribe() {
 	AssertEq(1, dt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
 }
 
-func (dt *downloaderTest) Test_notifySubscriber_FAILED() {
+func (dt *downloaderTest) Test_notifySubscriber_Failed() {
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
-	dt.job.status.Name = FAILED
+	dt.job.status.Name = Failed
 	customErr := fmt.Errorf("custom err")
 	dt.job.status.Err = customErr
 
@@ -154,21 +156,21 @@ func (dt *downloaderTest) Test_notifySubscriber_FAILED() {
 
 	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
-	jobStatus := JobStatus{Name: FAILED, Err: customErr, Offset: 0}
+	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 0}
 	AssertTrue(reflect.DeepEqual(jobStatus, notification))
 	AssertEq(true, ok)
 }
 
-func (dt *downloaderTest) Test_notifySubscriber_CANCELLED() {
+func (dt *downloaderTest) Test_notifySubscriber_Invalid() {
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
-	dt.job.status.Name = CANCELLED
+	dt.job.status.Name = Invalid
 
 	dt.job.notifySubscribers()
 
 	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
-	jobStatus := JobStatus{Name: CANCELLED, Err: nil, Offset: 0}
+	jobStatus := JobStatus{Name: Invalid, Err: nil, Offset: 0}
 	AssertTrue(reflect.DeepEqual(jobStatus, notification))
 	AssertEq(true, ok)
 }
@@ -178,17 +180,17 @@ func (dt *downloaderTest) Test_notifySubscriber_SubscribedOffset() {
 	subscriberOffset2 := int64(5)
 	notificationC1 := dt.job.subscribe(subscriberOffset1)
 	_ = dt.job.subscribe(subscriberOffset2)
-	dt.job.status.Name = DOWNLOADING
+	dt.job.status.Name = Downloading
 	dt.job.status.Offset = 4
 
 	dt.job.notifySubscribers()
 
 	AssertEq(1, dt.job.subscribers.Len())
 	notification1, ok := <-notificationC1
-	jobStatus := JobStatus{Name: DOWNLOADING, Err: nil, Offset: 4}
+	jobStatus := JobStatus{Name: Downloading, Err: nil, Offset: 4}
 	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
 	AssertEq(true, ok)
-	// check 2nd subscriber's offset
+	// Check 2nd subscriber's offset
 	AssertEq(subscriberOffset2, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
 }
 
@@ -197,7 +199,7 @@ func (dt *downloaderTest) Test_failWhileDownloading() {
 	subscriberOffset2 := int64(5)
 	notificationC1 := dt.job.subscribe(subscriberOffset1)
 	notificationC2 := dt.job.subscribe(subscriberOffset2)
-	dt.job.status = JobStatus{Name: DOWNLOADING, Err: nil, Offset: 4}
+	dt.job.status = JobStatus{Name: Downloading, Err: nil, Offset: 4}
 
 	customErr := fmt.Errorf("custom error")
 	dt.job.failWhileDownloading(customErr)
@@ -205,7 +207,7 @@ func (dt *downloaderTest) Test_failWhileDownloading() {
 	AssertEq(0, dt.job.subscribers.Len())
 	notification1, ok1 := <-notificationC1
 	notification2, ok2 := <-notificationC2
-	jobStatus := JobStatus{Name: FAILED, Err: customErr, Offset: 4}
+	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 4}
 	// Check 1st and 2nd subscriber notifications
 	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
 	AssertEq(true, ok1)
@@ -234,7 +236,7 @@ func (dt *downloaderTest) Test_updateFileInfoCache_UpdateEntry() {
 	err = dt.job.updateFileInfoCache()
 
 	AssertEq(nil, err)
-	// confirm fileInfoCache is updated with new offset.
+	// Confirm fileInfoCache is updated with new offset.
 	lookupResult := dt.cache.LookUp(fileInfoKeyName)
 	AssertFalse(lookupResult == nil)
 	fileInfo = lookupResult.(data.FileInfo)
@@ -291,52 +293,64 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanSequentialReadSize() 
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 50 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), removeCallback)
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 
-	// start download
+	// Start download
 	dt.job.downloadObjectAsync()
 
-	// check job completed successfully
-	jobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
+	// Check job completed successfully
+	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
-	// verify file is downloaded
+	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
+	// Verify callback is executed and removed
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, 25, uint64(2*objectSize))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, 25, uint64(2*objectSize), removeCallback)
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 
 	// start download
 	dt.job.downloadObjectAsync()
 
 	// check job completed successfully
-	jobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
+	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
-	// verify file is downloaded
+	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
+	// Verify callback is executed and removed
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 25 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), removeCallback)
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	// Add subscriber
-	subscribedOffset := int64(45 * util.MiB)
+	subscribedOffset := int64(9 * util.MiB)
 	notificationC := dt.job.subscribe(subscribedOffset)
 
 	// start download
@@ -346,7 +360,7 @@ func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 	// check the notification is sent after subscribed offset
 	AssertGe(jobStatus.Offset, subscribedOffset)
 	// check job completed successfully
-	jobStatus = JobStatus{COMPLETED, nil, int64(objectSize)}
+	jobStatus = JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
@@ -354,29 +368,30 @@ func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
+	// Verify callback is executed and removed
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Download_WhenNotStarted() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize))
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 
-	// start download
-	offset := int64(25 * util.MiB)
+	// Start download
+	offset := int64(8 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
 	AssertEq(nil, err)
-	// verify that jobStatus is downloading and downloaded more than 25 Mib.
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	// Verify that jobStatus is downloading and downloaded more than 8 Mib.
+	AssertEq(Downloading, jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
 	AssertGe(jobStatus.Offset, offset)
-	// verify that after some time the whole object is downloaded
-	time.Sleep(time.Second * 2)
-	// verify file
-	dt.verifyFile(objectContent)
-	// verify file info cache
-	dt.verifyFileInfoEntry(uint64(objectSize))
+	// Verify file
+	dt.verifyFile(objectContent[:jobStatus.Offset])
+	// Verify fileInfoCache update
+	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
 func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
@@ -384,64 +399,64 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 50 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize))
-	// start download but not wait for download
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
+	// Start download but not wait for download
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, 1, false)
 	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	AssertEq(Downloading, jobStatus.Name)
 
 	// Again call download but wait for download this time.
 	offset := int64(25 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
 	AssertEq(nil, err)
-	// verify that jobStatus is downloading and downloaded at least 25 Mib.
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	// Verify that jobStatus is downloading and downloaded at least 25 Mib.
+	AssertEq(Downloading, jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
 	AssertGe(jobStatus.Offset, offset)
-	// verify that after some time the whole object is downloaded
-	time.Sleep(time.Second * 2)
-	// verify file
-	dt.verifyFile(objectContent)
+	// Verify file
+	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// verify file info cache
-	dt.verifyFileInfoEntry(uint64(objectSize))
+	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
 func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize))
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	// Wait for whole download to be completed.
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize), true)
 	AssertEq(nil, err)
-	// verify that jobStatus is DOWNLOADING but offset is object size
-	expectedJobStatus := JobStatus{DOWNLOADING, nil, int64(objectSize)}
+	// Verify that jobStatus is Downloading but offset is object size
+	expectedJobStatus := JobStatus{Downloading, nil, int64(objectSize)}
 	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
 
-	// try to request for some offset when job was already completed.
-	offset := int64(18 * util.MiB)
+	// Try to request for some offset when job was already completed.
+	offset := int64(16 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
 	AssertEq(nil, err)
-	// verify that jobStatus is completed & offset returned is still 25 MiB
+	// Verify that jobStatus is completed & offset returned is still 16 MiB
 	// this ensures that async job is not started again.
-	AssertEq(COMPLETED, jobStatus.Name)
+	AssertEq(Completed, jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
 	AssertGe(jobStatus.Offset, objectSize)
-	// verify file
+	// Verify file
 	dt.verifyFile(objectContent)
-	// verify file info cache
+	// Verify file info cache
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
 func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), removeCallback)
 	// In real world, object size will not change in between, we are changing it
 	// just to simulate the failure
 	dt.job.object.Size = uint64(objectSize - 10)
@@ -451,58 +466,57 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize-10), true)
 
 	AssertEq(nil, err)
-	// verify that jobStatus is failed
-	AssertEq(FAILED, jobStatus.Name)
-	AssertEq(ReadChunkSize, jobStatus.Offset)
+	// Verify that jobStatus is failed
+	AssertEq(Failed, jobStatus.Name)
+	AssertGe(jobStatus.Offset, 0)
 	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	// Verify callback is executed
+	AssertTrue(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_Download_AlreadyFailed() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	dt.job.object.Size = uint64(objectSize - 1)
-	// Wait for whole download to be completed/failed.
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
+	dt.job.mu.Lock()
+	dt.job.status = JobStatus{Failed, fmt.Errorf(lru.InvalidUpdateEntrySizeErrorMsg), 8}
+	dt.job.mu.Unlock()
+
+	// Requesting again from download job which is in failed state
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize-1), true)
-	AssertEq(nil, err)
-	// verify that jobStatus is failed
-	AssertEq(FAILED, jobStatus.Name)
-	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
-
-	// requesting again from download job which is in failed state
-	jobStatus, err = dt.job.Download(context.Background(), int64(objectSize-1), true)
 
 	AssertEq(nil, err)
-	AssertEq(FAILED, jobStatus.Name)
+	AssertEq(Failed, jobStatus.Name)
 	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
 }
 
 func (dt *downloaderTest) Test_Download_AlreadyInvalid() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 1 * util.MiB
+	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	// make the state as invalid
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
+	// Make the state as invalid
 	dt.job.mu.Lock()
-	dt.job.status.Name = INVALID
+	dt.job.status.Name = Invalid
 	dt.job.mu.Unlock()
 
-	// requesting download when already invalid.
+	// Requesting download when already invalid.
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize), true)
 
 	AssertEq(nil, err)
-	AssertEq(INVALID, jobStatus.Name)
+	AssertEq(Invalid, jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
 }
 
 func (dt *downloaderTest) Test_Download_FileInfoRemovedInBetween() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 20 * util.MiB
+	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
-	fileInfoKey := data.FileInfoKey{BucketName: dt.bucket.Name(),
-		ObjectName: objectName}
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), removeCallback)
+	fileInfoKey := data.FileInfoKey{BucketName: dt.bucket.Name(), ObjectName: objectName}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	AssertEq(nil, err)
 	wg := sync.WaitGroup{}
@@ -510,21 +524,24 @@ func (dt *downloaderTest) Test_Download_FileInfoRemovedInBetween() {
 	go func() {
 		jobStatus, err := dt.job.Download(context.Background(), int64(objectSize), true)
 		AssertEq(nil, err)
-		AssertEq(INVALID, jobStatus.Name)
+		AssertEq(Invalid, jobStatus.Name)
 		wg.Done()
 	}()
 
-	// delete fileinfo from file info cache
+	// Delete fileinfo from file info cache
 	dt.job.fileInfoCache.Erase(fileInfoKeyName)
 
 	wg.Wait()
+	AssertTrue(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_Download_InvalidOffset() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), removeCallback)
 
 	// requesting invalid offset
 	offset := int64(objectSize) + 1
@@ -532,17 +549,20 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 
 	AssertNe(nil, err)
 	AssertTrue(strings.Contains(err.Error(), fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
-	expectedJobStatus := JobStatus{NOT_STARTED, nil, 0}
+	expectedJobStatus := JobStatus{NotStarted, nil, 0}
 	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
+	AssertFalse(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_Download_CtxCancelled() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
 
-	// requesting full download and then the download call should be cancelled after
+	// Requesting full download and then the download call should be cancelled after
 	// timeout but async download shouldn't be cancelled
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond*2)
 	defer cancelFunc()
@@ -550,28 +570,33 @@ func (dt *downloaderTest) Test_Download_CtxCancelled() {
 	jobStatus, err := dt.job.Download(ctx, offset, true)
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "context deadline exceeded"))
+	AssertTrue(errors.Is(err, context.DeadlineExceeded))
 	// jobStatus is empty in this case.
 	AssertEq("", jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
-	// job should be completed after sometime as the timeout is on Download call
-	// and not async download
-	time.Sleep(time.Second * 2)
-	jobStatus, err = dt.job.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
-	expectedJobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-	// verify file
-	dt.verifyFile(objectContent)
-	// verify file info cache
-	dt.verifyFileInfoEntry(uint64(objectSize))
+	// job should be either Downloading or Completed.
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertTrue(dt.job.status.Name == Downloading || dt.job.status.Name == Completed)
+	if dt.job.status.Name == Downloading {
+		AssertFalse(callbackExecuted.Load())
+	} else {
+		AssertTrue(callbackExecuted.Load())
+	}
+	AssertEq(nil, dt.job.status.Err)
+	// Verify file
+	dt.verifyFile(objectContent[:dt.job.status.Offset])
+	// Verify file info cache
+	dt.verifyFileInfoEntry(uint64(dt.job.status.Offset))
 }
 
 func (dt *downloaderTest) Test_Download_Concurrent() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 25 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
+	var callbackExecutionCount atomic.Int32
+	removeCallback := func() { callbackExecutionCount.Add(1) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
 	ctx := context.Background()
 	wg := sync.WaitGroup{}
 	offsets := []int64{0, 4 * util.MiB, 16 * util.MiB, 8 * util.MiB, int64(objectSize), int64(objectSize) + 1}
@@ -581,7 +606,7 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 		var jobStatus JobStatus
 		var err error
 		jobStatus, err = dt.job.Download(ctx, expectedOffset, true)
-		AssertNe(FAILED, jobStatus.Name)
+		AssertNe(Failed, jobStatus.Name)
 		if expectedErr != nil {
 			AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 			return
@@ -591,184 +616,130 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 		AssertGe(jobStatus.Offset, expectedOffset)
 	}
 
-	// start concurrent downloads
+	// Start concurrent downloads
 	for i, offset := range offsets {
 		wg.Add(1)
 		go downloadFunc(offset, expectedErrs[i])
 	}
 	wg.Wait()
 
-	jobStatus, err := dt.job.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
-	expectedJobStatus := JobStatus{COMPLETED, nil, int64(objectSize)}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-	// verify file
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	expectedJobStatus := JobStatus{Completed, nil, int64(objectSize)}
+	AssertTrue(reflect.DeepEqual(expectedJobStatus, dt.job.status))
+	// Verify file
 	dt.verifyFile(objectContent)
-	// verify file info cache
+	// Verify file info cache
 	dt.verifyFileInfoEntry(uint64(objectSize))
-}
-
-func (dt *downloaderTest) Test_Cancel_WhenDownloading() {
-	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
-	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
-	// request for 2 MiB download to start downloading
-	offset := int64(2 * util.MiB)
-	jobStatus, err := dt.job.Download(context.Background(), offset, true)
-	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	AssertGe(jobStatus.Offset, offset)
-
-	dt.job.Cancel()
-
-	jobStatus, err = dt.job.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
-	AssertEq(CANCELLED, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	// verify file downloaded till the offset
-	dt.verifyFile(objectContent[:jobStatus.Offset])
-}
-
-func (dt *downloaderTest) Test_Cancel_WhenAlreadyCompleted() {
-	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
-	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
-	// download complete object
-	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize), true)
-	AssertEq(nil, err)
-	expectedJobStatus := JobStatus{DOWNLOADING, nil, int64(objectSize)}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-
-	dt.job.Cancel()
-
-	// status is not changed to Cancelled
-	jobStatus, err = dt.job.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
-	AssertNe(CANCELLED, jobStatus.Name)
-	AssertEq(nil, err)
-	AssertEq(objectSize, jobStatus.Offset)
-	// verify file downloaded till the offset
-	dt.verifyFile(objectContent)
-	// verify file info cache
-	dt.verifyFileInfoEntry(uint64(objectSize))
-}
-
-func (dt *downloaderTest) Test_Cancel_WhenNotStarted() {
-	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
-	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
-
-	dt.job.Cancel()
-
-	// status is changed to Cancelled
-	expectedJobStatus := JobStatus{CANCELLED, nil, 0}
-	jobStatus, err := dt.job.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-	// verify file is not created
-	_, err = os.Stat(dt.fileSpec.Path)
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "no such file or directory"))
-}
-
-func (dt *downloaderTest) Test_Cancel_Concurrent() {
-	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
-	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
-	ctx := context.Background()
-	// start download without waiting
-	jobStatus, err := dt.job.Download(ctx, 0, false)
-	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
-	// wait for sometime to allow downloading before cancelling
-	time.Sleep(time.Millisecond * 10)
-	wg := sync.WaitGroup{}
-	cancelFunc := func() {
-		defer wg.Done()
-		dt.job.Cancel()
-		currJobStatus, currErr := dt.job.Download(ctx, 1, true)
-		AssertEq(CANCELLED, currJobStatus.Name)
-		AssertEq(nil, currErr)
-		AssertGe(currJobStatus.Offset, 0)
-	}
-
-	// start concurrent cancel
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go cancelFunc()
-	}
-	wg.Wait()
-
-	jobStatus, err = dt.job.Download(ctx, 1, true)
-	AssertEq(nil, err)
-	AssertEq(CANCELLED, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	// verify file
-	dt.verifyFile(objectContent[:jobStatus.Offset])
+	// Verify callback is executed only once and removed
+	AssertEq(1, callbackExecutionCount.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_GetStatus() {
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 20 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), func() {})
 	ctx := context.Background()
-	// start download without waiting
-	jobStatus, err := dt.job.Download(ctx, 0, false)
+	// Start download
+	jobStatus, err := dt.job.Download(ctx, util.MiB, true)
 	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
-	// wait for sometime to get some data downloaded
-	time.Sleep(10 * time.Millisecond)
+	AssertEq(Downloading, jobStatus.Name)
 
 	// GetStatus in between downloading
 	jobStatus = dt.job.GetStatus()
 
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	AssertEq(Downloading, jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
 	AssertGe(jobStatus.Offset, 0)
-	// verify file
+	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 }
 
 func (dt *downloaderTest) Test_Invalidate_WhenDownloading() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := 8 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
 	ctx := context.Background()
-	// start download without waiting
+	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
 	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	AssertEq(Downloading, jobStatus.Name)
 
 	dt.job.Invalidate()
 
-	jobStatus = dt.job.GetStatus()
-	AssertEq(nil, jobStatus.Err)
-	AssertEq(INVALID, jobStatus.Name)
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertEq(nil, dt.job.status.Err)
+	AssertEq(Invalid, dt.job.status.Name)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
+}
+
+func (dt *downloaderTest) Test_Invalidate_NotStarted() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
+
+	dt.job.Invalidate()
+
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertEq(nil, dt.job.status.Err)
+	AssertEq(Invalid, dt.job.status.Name)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
+}
+
+func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	var callbackExecutionCount atomic.Int32
+	removeCallback := func() { callbackExecutionCount.Add(1) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
+	ctx := context.Background()
+	// Start download with waiting
+	_, err := dt.job.Download(ctx, int64(objectSize), true)
+	AssertEq(nil, err)
+	jobStatus := dt.job.GetStatus()
+	AssertEq(Completed, jobStatus.Name)
+
+	dt.job.Invalidate()
+
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertEq(nil, dt.job.status.Err)
+	AssertEq(Invalid, dt.job.status.Name)
+	AssertEq(1, callbackExecutionCount.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 30 * util.MiB
+	objectSize := 20 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
-	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2))
+	var callbackExecutionCount atomic.Int32
+	removeCallback := func() { callbackExecutionCount.Add(1) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
 	ctx := context.Background()
-	// start download without waiting
+	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
 	AssertEq(nil, err)
-	AssertEq(DOWNLOADING, jobStatus.Name)
+	AssertEq(Downloading, jobStatus.Name)
 	wg := sync.WaitGroup{}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		AssertEq(INVALID, currJobStatus.Name)
+		AssertEq(Invalid, currJobStatus.Name)
 		AssertEq(nil, currJobStatus.Err)
 	}
 
@@ -778,4 +749,57 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 		go invalidateFunc()
 	}
 	wg.Wait()
+
+	AssertEq(1, callbackExecutionCount.Load())
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertEq(nil, dt.job.removeJobCallback)
+}
+
+func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 10 * util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	var callbackExecutionCount atomic.Int32
+	removeCallback := func() { callbackExecutionCount.Add(1) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), removeCallback)
+	wg := sync.WaitGroup{}
+	downloadFunc := func(offset int64, waitForDownload bool) {
+		defer wg.Done()
+		ctx := context.Background()
+		// Start download without waiting
+		jobStatus, err := dt.job.Download(ctx, offset, waitForDownload)
+		AssertEq(nil, err)
+		AssertTrue(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
+		// If status is downloading/complete and wait for download is true then
+		// status offset should be at least requested offset.
+		if waitForDownload && (jobStatus.Name == Downloading || jobStatus.Name == Completed) {
+			AssertGe(jobStatus.Offset, offset)
+		}
+	}
+	invalidateFunc := func() {
+		defer wg.Done()
+		dt.job.Invalidate()
+		currJobStatus := dt.job.GetStatus()
+		AssertEq(Invalid, currJobStatus.Name)
+		AssertEq(nil, currJobStatus.Err)
+	}
+
+	// Start concurrent invalidate and download
+	offsets := [6]int64{0, util.MiB, 5 * util.MiB, 0, 2 * util.MiB, 10 * util.MiB}
+	for i := 0; i < len(offsets); i++ {
+		wg.Add(2)
+		waitForDownload := false
+		if i%2 == 0 {
+			waitForDownload = true
+		}
+		go downloadFunc(offsets[i], waitForDownload)
+		go invalidateFunc()
+	}
+	wg.Wait()
+
+	AssertEq(1, callbackExecutionCount.Load())
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	AssertEq(nil, dt.job.removeJobCallback)
 }


### PR DESCRIPTION
### Description
Optimize memory by removing async job after completion/failure
This PR includes the following changes:
Functional change:
1. The async job is removed from memory once the job is stopped (i.e. complete/failed) or invalidated in case of eviction. We are doing this to reduce the overall memory footprint of GCSFuse with read cache is enabled.

Code changes:
1. Documentation fixes and changes corresponding to code changes.
3. Unit test fixes for test files under internal/cache/. This includes not using the same function in "Arrange" part of unit test that is being tested in unit test.
4. Addition of few more unit test cases.
5. job.go: (a) Added a property called removeJobCallback to Job struct which is call back function to remove job from JobManager. (b) Call removeJobCallback function when the downloadAsyncJob stops (completed/failed/cancelled). (c) Call removeJobCallback function when the job.Invalidate function is called. (d) Once the removeJobCallback function is called, we remove it from Job struct so that it's not called more than once for that job. 
6. downloader.go: (a) Changed the behavior of GetJob function to only return Job if JobManager has it. (b) Added new function CreateJobIfNotExists which creates new job and stores it's reference in JobManager if Job does not already exist, if it exists then the existing job is returned. (c) Add removeJob function which simply removes the job reference from jobs map if present (d) Add a callback function to Job while creating new Job, this callback is nothing but job.removeJob function. (e) Rename the RemoveJob function to InvalidateAndRemoveJob, also this function now releases the jm.mu lock while calling job.Invalidate inside it because job needs to acquire lock on jm.mu while executing jm.removeJob.
7. cache_handle.go: (a) Allow having nil download job. (b) if download job is nil, then check the entry in file info cache (without changing it's order) whether the entry has offset equal to object's size (if offset < object size and there is no job then it means job has failed/invalidated). 
8. cache_handler.go: (a) in the GetCacheHandle function for the case where there is already entry in the file info cache, check whether there is non-nil job that is not failed/invalidated. if there is no such job then invalidate the cache for that file and add new entry to  cache for that file.
9. Misc: (a) Removed job.Cancel function as that was not used anywhere functionally in the code at other places. (b) Used camel case for JobStatus.Name as go suggests to use camel case for constants. (c) Remove Cancel state from Job as that is no longer required.

The PR is longer than what the recommended size should be but it was harder to split it into a way such that every split PR passes all presubmit tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran tests for 64K 1million files and observed clear memory improvements, results to be shared internally.
7. Unit tests - Added wherever applicable
9. Integration tests - [Link](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/4c337ea4-38e2-4cbd-8fe8-9f555246ecd7)
