### PR TITLE
[Fix] Random reads won't re-use previous reader even if existing reader can serve the request

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -179,7 +179,7 @@ func (rr *randomReader) ReadAt(
 		if rr.reader != nil && rr.start < offset && offset-rr.start < maxReadSize {
 			bytesToSkip := int64(offset - rr.start)
 			p := make([]byte, bytesToSkip)
-			n, _ := rr.reader.Read(p)
+			n, _ := io.ReadFull(rr.reader, p)
 			rr.start += int64(n)
 		}
 

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -222,7 +222,7 @@ func (t *RandomReaderTest) ExistingReader_WrongOffset() {
 	AssertNe(nil, err)
 }
 
-func (t *RandomReaderTest) ExistingReader_WrongOffsetButWithinRange() {
+func (t *RandomReaderTest) ExistingReader_ReadAtOffsetAfterTheReaderPosition() {
 	var currentStartOffset int64 = 2
 	var readerLimit int64 = 15
 	var readAtOffset int64 = 10

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -222,6 +222,23 @@ func (t *RandomReaderTest) ExistingReader_WrongOffset() {
 	AssertNe(nil, err)
 }
 
+func (t *RandomReaderTest) ExistingReader_WrongOffsetButWithinRange() {
+	// Simulate an existing reader.
+	rc := io.NopCloser(strings.NewReader(strings.Repeat("x", 15)))
+	t.rr.wrapped.reader = rc
+	t.rr.wrapped.cancel = func() {}
+	t.rr.wrapped.start = 2
+	t.rr.wrapped.limit = 15
+
+	buf := make([]byte, 1)
+	_, err := t.rr.ReadAt(buf, 10)
+
+	AssertEq(nil, err)
+	ExpectThat(rc, DeepEquals(t.rr.wrapped.reader))
+	ExpectEq(11, t.rr.wrapped.start)
+	ExpectEq(15, t.rr.wrapped.limit)
+}
+
 func (t *RandomReaderTest) NewReaderReturnsError() {
 	ExpectCall(t.bucket, "NewReader")(Any(), Any()).
 		WillOnce(Return(nil, errors.New("taco")))

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -223,20 +223,25 @@ func (t *RandomReaderTest) ExistingReader_WrongOffset() {
 }
 
 func (t *RandomReaderTest) ExistingReader_WrongOffsetButWithinRange() {
+	var currentStartOffset int64 = 2
+	var readerLimit int64 = 15
+	var readAtOffset int64 = 10
+	var readSize int64 = 1
+	var expectedStartOffsetAfterRead = readAtOffset + readSize
 	// Simulate an existing reader.
-	rc := io.NopCloser(strings.NewReader(strings.Repeat("x", 15)))
+	rc := io.NopCloser(strings.NewReader(strings.Repeat("x", int(readerLimit))))
 	t.rr.wrapped.reader = rc
 	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 2
-	t.rr.wrapped.limit = 15
+	t.rr.wrapped.start = currentStartOffset
+	t.rr.wrapped.limit = readerLimit
 
-	buf := make([]byte, 1)
-	_, err := t.rr.ReadAt(buf, 10)
+	buf := make([]byte, readSize)
+	_, err := t.rr.ReadAt(buf, readAtOffset)
 
 	AssertEq(nil, err)
 	ExpectThat(rc, DeepEquals(t.rr.wrapped.reader))
-	ExpectEq(11, t.rr.wrapped.start)
-	ExpectEq(15, t.rr.wrapped.limit)
+	ExpectEq(expectedStartOffsetAfterRead, t.rr.wrapped.start)
+	ExpectEq(readerLimit, t.rr.wrapped.limit)
 }
 
 func (t *RandomReaderTest) NewReaderReturnsError() {


### PR DESCRIPTION
### Description
Random reads were not working as intended; they did not reuse the existing reader, even when existing reader had the data to serve the request. 

This issue occurred because we were using the Read method (instead of ReadFull). According to the [documentation](https://cs.opensource.google/go/go/+/refs/tags/go1.21.6:src/io/io.go;drc=1ff89009f198ad5bae3549dd3b992882bd97e5f8;l=60), this method does not wait for the entire data to be available, preventing the reader's start offset from being moved by the required number of bytes.

Fix: We should use io.ReadFull() instead.

Before this change:
```
time="06/02/2024 08:34:55.221154" severity=TRACE message="fuse_debug: Op 0x0000016e        connection.go:415] <- ReadFile (inode 2, PID 367041, handle 27, offset 41943040, 16384 bytes)"
time="06/02/2024 08:34:55.221364" severity=TRACE message="gcs: Req             0x2c: -> Read(\"1\", [31457280, 32505856)) (330.506132ms): OK"
time="06/02/2024 08:34:55.221400" severity=TRACE message="gcs: Req             0x2d: <- Read(\"1\", [41943040, 42991616))"
time="06/02/2024 08:34:55.576079" severity=TRACE message="fuse_debug: Op 0x0000016e        connection.go:497] -> OK ()"
time="06/02/2024 08:34:55.576375" severity=TRACE message="fuse_debug: Op 0x00000170        connection.go:415] <- ReadFile (inode 2, PID 367041, handle 27, offset 41959424, 32768 bytes)"
time="06/02/2024 08:34:55.751697" severity=TRACE message="fuse_debug: Op 0x00000170        connection.go:497] -> OK ()"
time="06/02/2024 08:34:55.751938" severity=TRACE message="fuse_debug: Op 0x00000172        connection.go:415] <- ReadFile (inode 2, PID 367041, handle 27, offset 42012672, 20480 bytes)"
time="06/02/2024 08:34:55.752120" severity=TRACE message="gcs: Req             0x2d: -> Read(\"1\", [41943040, 42991616)) (530.710831ms): OK"
time="06/02/2024 08:34:55.752174" severity=TRACE message="gcs: Req             0x2e: <- Read(\"1\", [42012672, 43061248))"
time="06/02/2024 08:34:56.002057" severity=TRACE message="fuse_debug: Op 0x00000172        connection.go:497] -> OK ()"
```

After this change:
```
time="06/02/2024 09:58:56.900148" severity=TRACE message="fuse_debug: Op 0x0000015a        connection.go:415] <- ReadFile (inode 2, PID 421837, handle 26, offset 41943040, 16384 bytes)"
time="06/02/2024 09:58:56.900362" severity=TRACE message="gcs: Req             0x29: -> Read(\"1\", [31457280, 32505856)) (256.173234ms): OK"
time="06/02/2024 09:58:56.900407" severity=TRACE message="gcs: Req             0x2a: <- Read(\"1\", [41943040, 42991616))"
time="06/02/2024 09:58:57.124098" severity=TRACE message="fuse_debug: Op 0x0000015a        connection.go:497] -> OK ()"
time="06/02/2024 09:58:57.124378" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:415] <- ReadFile (inode 2, PID 421837, handle 26, offset 41959424, 32768 bytes)"
time="06/02/2024 09:58:57.284816" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:497] -> OK ()"
time="06/02/2024 09:58:57.285058" severity=TRACE message="fuse_debug: Op 0x0000015e        connection.go:415] <- ReadFile (inode 2, PID 421837, handle 26, offset 42012672, 20480 bytes)"
time="06/02/2024 09:58:57.445157" severity=TRACE message="fuse_debug: Op 0x0000015e        connection.go:497] -> OK ()"

```

### Link to the issue in case of a bug fix.
Internal bug [b/322770463 
](b/322770463)

### Testing details
1. Manual - Manually verified from logs
2. Unit tests - added
3. Integration tests - Ran via KOKORO
4. Perf tests - 
![9yBG5pMAZAVgqA3](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/5d56983c-9149-44c3-8809-73160569094e)

