### PR TITLE
Latest allow other cache dir fix

### DIFF
--- a/internal/cache/data/file_info.go
+++ b/internal/cache/data/file_info.go
@@ -55,7 +55,8 @@ func (fi FileInfo) Size() uint64 {
 }
 
 type FileSpec struct {
-	Path    string
-	Perm    os.FileMode
+	Path string
+	Perm os.FileMode
+	//TODO(Ankita): rename
 	DirPerm os.FileMode
 }

--- a/internal/cache/data/file_info.go
+++ b/internal/cache/data/file_info.go
@@ -55,8 +55,7 @@ func (fi FileInfo) Size() uint64 {
 }
 
 type FileSpec struct {
-	Path string
-	Perm os.FileMode
-	//TODO(Ankita): rename
-	DirPerm os.FileMode
+	Path     string
+	FilePerm os.FileMode
+	DirPerm  os.FileMode
 }

--- a/internal/cache/data/file_info.go
+++ b/internal/cache/data/file_info.go
@@ -55,6 +55,7 @@ func (fi FileInfo) Size() uint64 {
 }
 
 type FileSpec struct {
-	Path string
-	Perm os.FileMode
+	Path    string
+	Perm    os.FileMode
+	DirPerm os.FileMode
 }

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -82,9 +83,10 @@ func (cht *cacheHandleTest) addTestFileInfoEntryInCache() {
 
 func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedContent []byte) {
 	fileStat, err := os.Stat(cht.fileSpec.Path)
+	dirStat, err := os.Stat(filepath.Dir(cht.fileSpec.Path))
 	AssertEq(nil, err)
 	AssertEq(cht.fileSpec.FilePerm, fileStat.Mode())
-	AssertEq(cht.fileSpec.DirPerm, 0700)
+	AssertEq(cht.fileSpec.DirPerm, dirStat.Mode().Perm())
 
 	// Create a byte buffer of same len as expectedContent.
 	buf := make([]byte, len(expectedContent))

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -84,6 +84,7 @@ func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedCon
 	fileStat, err := os.Stat(cht.fileSpec.Path)
 	AssertEq(nil, err)
 	AssertEq(cht.fileSpec.Perm, fileStat.Mode())
+	AssertEq(cht.fileSpec.DirPerm, 0700)
 
 	// Create a byte buffer of same len as expectedContent.
 	buf := make([]byte, len(expectedContent))
@@ -126,7 +127,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	cht.addTestFileInfoEntryInCache()
 
 	localDownloadedPath := path.Join(cht.cacheLocation, cht.bucket.Name(), cht.object.Name)
-	cht.fileSpec = data.FileSpec{Path: localDownloadedPath, Perm: util.DefaultFilePerm}
+	cht.fileSpec = data.FileSpec{Path: localDownloadedPath, Perm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}
 
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
 	AssertEq(nil, err)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -83,9 +83,9 @@ func (cht *cacheHandleTest) addTestFileInfoEntryInCache() {
 
 func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedContent []byte) {
 	fileStat, fileErr := os.Stat(cht.fileSpec.Path)
-	dirStat, dirErr := os.Stat(filepath.Dir(cht.fileSpec.Path))
 	AssertEq(nil, fileErr)
 	AssertEq(cht.fileSpec.FilePerm, fileStat.Mode())
+	dirStat, dirErr := os.Stat(filepath.Dir(cht.fileSpec.Path))
 	AssertEq(nil, dirErr)
 	AssertEq(cht.fileSpec.DirPerm, dirStat.Mode().Perm())
 

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -82,17 +82,18 @@ func (cht *cacheHandleTest) addTestFileInfoEntryInCache() {
 }
 
 func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedContent []byte) {
-	fileStat, err := os.Stat(cht.fileSpec.Path)
-	dirStat, err := os.Stat(filepath.Dir(cht.fileSpec.Path))
-	AssertEq(nil, err)
+	fileStat, fileErr := os.Stat(cht.fileSpec.Path)
+	dirStat, dirErr := os.Stat(filepath.Dir(cht.fileSpec.Path))
+	AssertEq(nil, fileErr)
 	AssertEq(cht.fileSpec.FilePerm, fileStat.Mode())
+	AssertEq(nil, dirErr)
 	AssertEq(cht.fileSpec.DirPerm, dirStat.Mode().Perm())
 
 	// Create a byte buffer of same len as expectedContent.
 	buf := make([]byte, len(expectedContent))
 
 	// Read from file and compare with expectedContent.
-	_, err = cht.cacheHandle.fileHandle.Seek(readStartOffset, 0)
+	_, err := cht.cacheHandle.fileHandle.Seek(readStartOffset, 0)
 	AssertEq(nil, err)
 	_, err = io.ReadFull(cht.cacheHandle.fileHandle, buf)
 	AssertEq(nil, err)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -83,7 +83,7 @@ func (cht *cacheHandleTest) addTestFileInfoEntryInCache() {
 func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedContent []byte) {
 	fileStat, err := os.Stat(cht.fileSpec.Path)
 	AssertEq(nil, err)
-	AssertEq(cht.fileSpec.Perm, fileStat.Mode())
+	AssertEq(cht.fileSpec.FilePerm, fileStat.Mode())
 	AssertEq(cht.fileSpec.DirPerm, 0700)
 
 	// Create a byte buffer of same len as expectedContent.
@@ -127,7 +127,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	cht.addTestFileInfoEntryInCache()
 
 	localDownloadedPath := path.Join(cht.cacheLocation, cht.bucket.Name(), cht.object.Name)
-	cht.fileSpec = data.FileSpec{Path: localDownloadedPath, Perm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}
+	cht.fileSpec = data.FileSpec{Path: localDownloadedPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}
 
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
 	AssertEq(nil, err)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -66,9 +66,9 @@ func NewCacheHandler(fileInfoCache *lru.Cache, jobManager *downloader.JobManager
 
 func (chr *CacheHandler) createLocalFileReadHandle(objectName string, bucketName string) (*os.File, error) {
 	fileSpec := data.FileSpec{
-		Path:    util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucketName, objectName)),
-		Perm:    chr.filePerm,
-		DirPerm: chr.dirPerm,
+		Path:     util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucketName, objectName)),
+		FilePerm: chr.filePerm,
+		DirPerm:  chr.dirPerm,
 	}
 
 	return util.CreateFile(fileSpec, os.O_RDONLY)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -46,24 +46,29 @@ type CacheHandler struct {
 	// filePerm parameter specifies the permission of file in cache.
 	filePerm os.FileMode
 
+	// dirPerm parameter specifies the permission of cache directory.
+	dirPerm os.FileMode
+
 	// mu guards the handling of insertion into and eviction from file cache.
 	mu locker.Locker
 }
 
-func NewCacheHandler(fileInfoCache *lru.Cache, jobManager *downloader.JobManager, cacheLocation string, filePerm os.FileMode) *CacheHandler {
+func NewCacheHandler(fileInfoCache *lru.Cache, jobManager *downloader.JobManager, cacheLocation string, filePerm os.FileMode, dirPerm os.FileMode) *CacheHandler {
 	return &CacheHandler{
 		fileInfoCache: fileInfoCache,
 		jobManager:    jobManager,
 		cacheLocation: cacheLocation,
 		filePerm:      filePerm,
+		dirPerm:       dirPerm,
 		mu:            locker.New("FileCacheHandler", func() {}),
 	}
 }
 
 func (chr *CacheHandler) createLocalFileReadHandle(objectName string, bucketName string) (*os.File, error) {
 	fileSpec := data.FileSpec{
-		Path: util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucketName, objectName)),
-		Perm: chr.filePerm,
+		Path:    util.GetDownloadPath(chr.cacheLocation, util.GetObjectPath(bucketName, objectName)),
+		Perm:    chr.filePerm,
+		DirPerm: chr.dirPerm,
 	}
 
 	return util.CreateFile(fileSpec, os.O_RDONLY)

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -79,7 +79,7 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm, util.DefaultDirPerm, chrT.cacheLocation, DefaultSequentialReadSizeMb)
 
 	// Mocked cached handler object.
-	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheLocation, util.DefaultFilePerm)
+	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheLocation, util.DefaultFilePerm, util.DefaultDirPerm)
 
 	// Follow consistency, local-cache file and entry in fileInfo cache should exist atomically.
 	chrT.fileInfoKeyName = chrT.addTestFileInfoEntryInCache(storage.TestBucketName, TestObjectName)

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -76,7 +76,7 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	chrT.cache = lru.NewCache(HandlerCacheMaxSize)
 
 	// Job manager
-	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm, chrT.cacheLocation, DefaultSequentialReadSizeMb)
+	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm, util.DefaultDirPerm, chrT.cacheLocation, DefaultSequentialReadSizeMb)
 
 	// Mocked cached handler object.
 	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheLocation, util.DefaultFilePerm)

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -34,6 +34,9 @@ type JobManager struct {
 	// filePerm is passed to Job created by JobManager. filePerm decides the
 	// permission of file in cache created by Job.
 	filePerm os.FileMode
+	// dirPerm is passed to Job created by JobManager. dirPerm decides the
+	// permission of directory at cache location created by Job.
+	dirPerm os.FileMode
 	// cacheLocation is the path to directory where cache files should be created.
 	cacheLocation string
 	// sequentialReadSizeMb is passed to Job created by JobManager, and it decides
@@ -54,9 +57,9 @@ type JobManager struct {
 	mu   locker.Locker
 }
 
-func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, cacheLocation string, sequentialReadSizeMb int32) (jm *JobManager) {
+func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.FileMode, cacheLocation string, sequentialReadSizeMb int32) (jm *JobManager) {
 	jm = &JobManager{fileInfoCache: fileInfoCache, filePerm: filePerm,
-		cacheLocation: cacheLocation, sequentialReadSizeMb: sequentialReadSizeMb}
+		dirPerm: dirPerm, cacheLocation: cacheLocation, sequentialReadSizeMb: sequentialReadSizeMb}
 	jm.mu = locker.New("JobManager", func() {})
 	jm.jobs = make(map[string]*Job)
 	return

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -76,7 +76,7 @@ func (jm *JobManager) GetJob(object *gcs.MinObject, bucket gcs.Bucket) (job *Job
 	job, ok := jm.jobs[objectPath]
 	if !ok {
 		downloadPath := util.GetDownloadPath(jm.cacheLocation, objectPath)
-		fileSpec := data.FileSpec{Path: downloadPath, Perm: jm.filePerm}
+		fileSpec := data.FileSpec{Path: downloadPath, Perm: jm.filePerm, DirPerm: jm.dirPerm}
 		job = NewJob(object, bucket, jm.fileInfoCache, jm.sequentialReadSizeMb, fileSpec)
 		jm.jobs[objectPath] = job
 	}

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -76,7 +76,7 @@ func (jm *JobManager) GetJob(object *gcs.MinObject, bucket gcs.Bucket) (job *Job
 	job, ok := jm.jobs[objectPath]
 	if !ok {
 		downloadPath := util.GetDownloadPath(jm.cacheLocation, objectPath)
-		fileSpec := data.FileSpec{Path: downloadPath, Perm: jm.filePerm, DirPerm: jm.dirPerm}
+		fileSpec := data.FileSpec{Path: downloadPath, FilePerm: jm.filePerm, DirPerm: jm.dirPerm}
 		job = NewJob(object, bucket, jm.fileInfoCache, jm.sequentialReadSizeMb, fileSpec)
 		jm.jobs[objectPath] = job
 	}

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -100,6 +100,20 @@ func (dt *downloaderTest) Test_GetJob_Existing() {
 	ExpectEq(expectedJob, job)
 }
 
+func (dt *downloaderTest) Test_GetJob_Existing_WithDefaultFileAndDirPerm() {
+	// first create new job
+	expectedJob := dt.jm.GetJob(&dt.object, dt.bucket)
+	dt.jm.mu.Lock()
+	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
+	dt.jm.mu.Unlock()
+
+	// again call GetJob
+	job := dt.jm.GetJob(&dt.object, dt.bucket)
+
+	ExpectEq(0700, job.fileSpec.DirPerm.Perm())
+	ExpectEq(0600, job.fileSpec.Perm.Perm())
+}
+
 func (dt *downloaderTest) Test_GetJob_Concurrent() {
 	jobs := [5]*Job{}
 	wg := sync.WaitGroup{}

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -58,7 +58,7 @@ func (dt *downloaderTest) SetUp(*TestInfo) {
 	dt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), 200, CacheMaxSize)
-	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, cacheLocation, DefaultSequentialReadSizeMb)
+	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheLocation, DefaultSequentialReadSizeMb)
 }
 
 func (dt *downloaderTest) TearDown() {

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -111,7 +111,7 @@ func (dt *downloaderTest) Test_GetJob_Existing_WithDefaultFileAndDirPerm() {
 	job := dt.jm.GetJob(&dt.object, dt.bucket)
 
 	ExpectEq(0700, job.fileSpec.DirPerm.Perm())
-	ExpectEq(0600, job.fileSpec.Perm.Perm())
+	ExpectEq(0600, job.fileSpec.FilePerm.Perm())
 }
 
 func (dt *downloaderTest) Test_GetJob_Concurrent() {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -60,7 +60,11 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	err := storageutil.CreateObjects(ctx, dt.bucket, objects)
 	AssertEq(nil, err)
 	dt.object = dt.getMinObject(objectName)
-	dt.fileSpec = data.FileSpec{Path: dt.fileCachePath(dt.bucket.Name(), dt.object.Name), FilePerm: util.DefaultFilePerm}
+	dt.fileSpec = data.FileSpec{
+		Path:     dt.fileCachePath(dt.bucket.Name(), dt.object.Name),
+		FilePerm: util.DefaultFilePerm,
+		DirPerm:  util.DefaultDirPerm,
+	}
 	dt.cache = lru.NewCache(lruCacheSize)
 	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec)
 	fileInfoKey := data.FileInfoKey{

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -60,7 +60,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	err := storageutil.CreateObjects(ctx, dt.bucket, objects)
 	AssertEq(nil, err)
 	dt.object = dt.getMinObject(objectName)
-	dt.fileSpec = data.FileSpec{Path: dt.fileCachePath(dt.bucket.Name(), dt.object.Name), Perm: util.DefaultFilePerm}
+	dt.fileSpec = data.FileSpec{Path: dt.fileCachePath(dt.bucket.Name(), dt.object.Name), FilePerm: util.DefaultFilePerm}
 	dt.cache = lru.NewCache(lruCacheSize)
 	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec)
 	fileInfoKey := data.FileInfoKey{
@@ -82,7 +82,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 func (dt *downloaderTest) verifyFile(content []byte) {
 	fileStat, err := os.Stat(dt.fileSpec.Path)
 	AssertEq(nil, err)
-	AssertEq(dt.fileSpec.Perm, fileStat.Mode())
+	AssertEq(dt.fileSpec.FilePerm, fileStat.Mode())
 	AssertLe(len(content), fileStat.Size())
 	// verify the content of file downloaded. only verified till
 	fileContent, err := os.ReadFile(dt.fileSpec.Path)

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -45,9 +45,9 @@ const (
 	DefaultFilePerm        = os.FileMode(0600)
 	FilePermWithAllowOther = os.FileMode(0644)
 
-	DefaultDirPerm            = os.FileMode(0700)
-	FileDirPermWithAllowOther = os.FileMode(0755)
-	FileCache                 = "gcsfuse-file-cache"
+	DefaultDirPerm        = os.FileMode(0700)
+	DirPermWithAllowOther = os.FileMode(0755)
+	FileCache             = "gcsfuse-file-cache"
 )
 
 // CreateFile creates file with given file spec i.e. permissions and returns

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -74,7 +74,7 @@ func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
 			return
 		}
 	}
-	file, err = os.OpenFile(fileSpec.Path, flag, fileSpec.Perm)
+	file, err = os.OpenFile(fileSpec.Path, flag, fileSpec.FilePerm)
 	if err != nil {
 		err = fmt.Errorf(fmt.Sprintf("error in creating file %s: %v", fileSpec.Path, err))
 		return

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -58,7 +58,7 @@ const (
 func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
 	// Create directory structure if not present
 	fileDir := filepath.Dir(fileSpec.Path)
-	err = os.MkdirAll(fileDir, FileDirPerm)
+	err = os.MkdirAll(fileDir, fileSpec.DirPerm)
 	if err != nil {
 		err = fmt.Errorf(fmt.Sprintf("error in creating directory structure %s: %v", fileDir, err))
 		return
@@ -105,13 +105,14 @@ func IsCacheHandleInvalid(readErr error) bool {
 		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
 }
 
-// Creates directory at given path with FileDirPerm(0755) permissions in case not already present,
+// TODO(Ankita): rename
+// Creates directory at given path with provided permissions in case not already present,
 // returns error in case unable to create directory or directory is not writable.
-func CreateCacheDirectoryIfNotPresentAt(dirPath string) error {
+func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) error {
 	_, statErr := os.Stat(dirPath)
 
 	if os.IsNotExist(statErr) {
-		err := os.MkdirAll(dirPath, FileDirPerm)
+		err := os.MkdirAll(dirPath, dirPerm)
 		if err != nil {
 			return fmt.Errorf("error in creating directory structure %s: %v", dirPath, err)
 		}

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -53,7 +53,7 @@ const (
 // CreateFile creates file with given file spec i.e. permissions and returns
 // file handle for that file opened with given flag.
 //
-// Note: If directories in path are not present, they are created with FileDirPerm
+// Note: If directories in path are not present, they are created with directory permissions provided in fileSpec
 // permission.
 func CreateFile(fileSpec data.FileSpec, flag int) (file *os.File, err error) {
 	// Create directory structure if not present
@@ -105,7 +105,6 @@ func IsCacheHandleInvalid(readErr error) bool {
 		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
 }
 
-// TODO(Ankita): rename
 // Creates directory at given path with provided permissions in case not already present,
 // returns error in case unable to create directory or directory is not writable.
 func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) error {

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -44,7 +44,10 @@ const (
 	KiB                    = 1024
 	DefaultFilePerm        = os.FileMode(0600)
 	FilePermWithAllowOther = os.FileMode(0644)
-	FileCache              = "gcsfuse-file-cache"
+
+	DefaultDirPerm            = os.FileMode(0700)
+	FileDirPermWithAllowOther = os.FileMode(0755)
+	FileCache                 = "gcsfuse-file-cache"
 )
 
 // CreateFile creates file with given file spec i.e. permissions and returns

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -96,7 +96,7 @@ func (ut *utilTest) Test_CreateFileShouldThrowErrorIfFileDirNotPresentAndProvide
 	_, err := CreateFile(ut.fileSpec, ut.flag)
 
 	ExpectNe(nil, err)
-	ExpectEq("error in stating file /usr/local/google/home/lankita/some/dir/foo.txt: stat /usr/local/google/home/lankita/some/dir/foo.txt: permission denied", err.Error())
+	ExpectEq("error in stating file "+ut.fileSpec.Path+": stat "+ut.fileSpec.Path+": permission denied", err.Error())
 }
 
 func (ut *utilTest) Test_CreateFile_FileDirPresent() {

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -52,9 +52,9 @@ func (ut *utilTest) SetUp(*TestInfo) {
 		panic(fmt.Errorf("error while finding home directory: %w", err))
 	}
 	ut.fileSpec = data.FileSpec{
-		Path:    path.Join(homeDir, FileDir, FileName),
-		Perm:    DefaultFilePerm,
-		DirPerm: DefaultDirPerm,
+		Path:     path.Join(homeDir, FileDir, FileName),
+		FilePerm: DefaultFilePerm,
+		DirPerm:  DefaultDirPerm,
 	}
 	ut.uid = os.Getuid()
 	ut.gid = os.Getgid()
@@ -77,7 +77,7 @@ func (ut *utilTest) assertFileAndDirCreationWithGivenDirPerm(file *os.File, err 
 	fileStat, fileErr := os.Stat(file.Name())
 	ExpectEq(false, os.IsNotExist(fileErr))
 	ExpectEq(ut.fileSpec.Path, file.Name())
-	ExpectEq(ut.fileSpec.Perm, fileStat.Mode())
+	ExpectEq(ut.fileSpec.FilePerm, fileStat.Mode())
 	ExpectEq(ut.uid, fileStat.Sys().(*syscall.Stat_t).Uid)
 	ExpectEq(ut.gid, fileStat.Sys().(*syscall.Stat_t).Gid)
 }
@@ -134,7 +134,7 @@ func (ut *utilTest) Test_CreateFile_ReadWriteFile() {
 }
 
 func (ut *utilTest) Test_CreateFile_FilePerm0755() {
-	ut.fileSpec.Perm = os.FileMode(0755)
+	ut.fileSpec.FilePerm = os.FileMode(0755)
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 
@@ -143,7 +143,7 @@ func (ut *utilTest) Test_CreateFile_FilePerm0755() {
 }
 
 func (ut *utilTest) Test_CreateFile_FilePerm0544() {
-	ut.fileSpec.Perm = os.FileMode(0544)
+	ut.fileSpec.FilePerm = os.FileMode(0544)
 
 	file, err := CreateFile(ut.fileSpec, ut.flag)
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -90,6 +90,15 @@ func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
 	ExpectEq(nil, file.Close())
 }
 
+func (ut *utilTest) Test_CreateFileShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient() {
+	ut.fileSpec.DirPerm = 644
+
+	_, err := CreateFile(ut.fileSpec, ut.flag)
+
+	ExpectNe(nil, err)
+	ExpectEq("error in stating file /usr/local/google/home/lankita/some/dir/foo.txt: stat /usr/local/google/home/lankita/some/dir/foo.txt: permission denied", err.Error())
+}
+
 func (ut *utilTest) Test_CreateFile_FileDirPresent() {
 	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -262,7 +262,7 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheLocation,
 		cfg.SequentialReadSizeMb)
 	fileCacheHandler = file.NewCacheHandler(fileInfoCache, jobManager,
-		cacheLocation, filePerm)
+		cacheLocation, filePerm, dirPerm)
 	return
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -253,11 +253,13 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	// When user passes allow_other flag, then other users should be able to
 	// read from cache
 	filePerm := util.DefaultFilePerm
+	dirPerm := util.DefaultDirPerm
 	if cfg.AllowOther {
 		filePerm = util.FilePermWithAllowOther
+		dirPerm = util.DirPermWithAllowOther
 	}
 
-	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, cacheLocation,
+	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheLocation,
 		cfg.SequentialReadSizeMb)
 	fileCacheHandler = file.NewCacheHandler(fileInfoCache, jobManager,
 		cacheLocation, filePerm)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -244,12 +244,6 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	// gcsfuse related files.
 	cacheLocation = path.Join(cacheLocation, util.FileCache)
 
-	// Panic in case cacheLocation does not have required permissions
-	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation)
-	if cacheLocationErr != nil {
-		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheLocationErr.Error()))
-	}
-
 	// When user passes allow_other flag, then other users should be able to
 	// read from cache
 	filePerm := util.DefaultFilePerm
@@ -257,6 +251,12 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	if cfg.AllowOther {
 		filePerm = util.FilePermWithAllowOther
 		dirPerm = util.DirPermWithAllowOther
+	}
+
+	// Panic in case cacheLocation does not have required permissions
+	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation, dirPerm)
+	if cacheLocationErr != nil {
+		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheLocationErr.Error()))
 	}
 
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheLocation,

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -175,7 +175,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	t.cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
 	lruCache := lru.NewCache(CacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheLocation, sequentialReadSizeInMb)
-	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheLocation, util.DefaultFilePerm)
+	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheLocation, util.DefaultFilePerm, util.DefaultDirPerm)
 
 	// Set up the reader.
 	rr := NewRandomReader(t.object, t.bucket, sequentialReadSizeInMb, nil, false)

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -174,7 +174,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 
 	t.cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
 	lruCache := lru.NewCache(CacheMaxSize)
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, t.cacheLocation, sequentialReadSizeInMb)
+	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheLocation, sequentialReadSizeInMb)
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheLocation, util.DefaultFilePerm)
 
 	// Set up the reader.


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
[Link](https://b.corp.google.com/issues/322301637)

### Testing details
1. Manual - Done
[With -o allow_option] Tested by adding allow_other, users other than owner were able to view cache folder and files.
[Without -o allow_option] Tested without allow_other option, users other than owner were NOT able to cd into cache folder and was unable to see cache file name or content of cache dir.
3. Unit tests - Done
4. Integration tests - Added new card for automation
