### PR TITLE
Rename read-cache config vars

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -102,7 +102,7 @@ func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedCon
 
 func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	cht.cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
+	cht.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 
 	// Create bucket in fake storage.
 	cht.fakeStorage = storage.NewFakeStorage()

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -49,13 +49,13 @@ const DefaultSequentialReadSizeMb = 17
 func TestCacheHandle(t *testing.T) { RunTests(t) }
 
 type cacheHandleTest struct {
-	bucket        gcs.Bucket
-	fakeStorage   storage.FakeStorage
-	object        *gcs.MinObject
-	cache         *lru.Cache
-	cacheHandle   *CacheHandle
-	cacheLocation string
-	fileSpec      data.FileSpec
+	bucket      gcs.Bucket
+	fakeStorage storage.FakeStorage
+	object      *gcs.MinObject
+	cache       *lru.Cache
+	cacheHandle *CacheHandle
+	cacheDir    string
+	fileSpec    data.FileSpec
 }
 
 func init() {
@@ -102,7 +102,7 @@ func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedCon
 
 func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	cht.cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
+	cht.cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
 
 	// Create bucket in fake storage.
 	cht.fakeStorage = storage.NewFakeStorage()
@@ -129,7 +129,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	cht.cache = lru.NewCache(CacheMaxSize)
 	cht.addTestFileInfoEntryInCache()
 
-	localDownloadedPath := path.Join(cht.cacheLocation, cht.bucket.Name(), cht.object.Name)
+	localDownloadedPath := path.Join(cht.cacheDir, cht.bucket.Name(), cht.object.Name)
 	cht.fileSpec = data.FileSpec{Path: localDownloadedPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}
 
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
@@ -146,7 +146,7 @@ func (cht *cacheHandleTest) TearDown() {
 	err := cht.cacheHandle.Close()
 	AssertEq(nil, err)
 
-	operations.RemoveDir(cht.cacheLocation)
+	operations.RemoveDir(cht.cacheDir)
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileHandle() {

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -60,7 +60,7 @@ func init() { RegisterTestSuite(&cacheHandlerTest{}) }
 
 func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	chrT.cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
+	chrT.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 
 	// Create bucket in fake storage.
 	chrT.fakeStorage = storage.NewFakeStorage()

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -53,14 +53,14 @@ type cacheHandlerTest struct {
 	cacheHandler    *CacheHandler
 	downloadPath    string
 	fileInfoKeyName string
-	cacheLocation   string
+	cacheDir        string
 }
 
 func init() { RegisterTestSuite(&cacheHandlerTest{}) }
 
 func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	chrT.cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
+	chrT.cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
 
 	// Create bucket in fake storage.
 	chrT.fakeStorage = storage.NewFakeStorage()
@@ -77,14 +77,14 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 	chrT.cache = lru.NewCache(HandlerCacheMaxSize)
 
 	// Job manager
-	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm, util.DefaultDirPerm, chrT.cacheLocation, DefaultSequentialReadSizeMb)
+	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm, util.DefaultDirPerm, chrT.cacheDir, DefaultSequentialReadSizeMb)
 
 	// Mocked cached handler object.
-	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheLocation, util.DefaultFilePerm, util.DefaultDirPerm)
+	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 
 	// Follow consistency, local-cache file, entry in fileInfo cache and job should exist initially.
 	chrT.fileInfoKeyName = chrT.addTestFileInfoEntryInCache(storage.TestBucketName, TestObjectName)
-	chrT.downloadPath = util.GetDownloadPath(chrT.cacheHandler.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), chrT.object.Name))
+	chrT.downloadPath = util.GetDownloadPath(chrT.cacheHandler.cacheDir, util.GetObjectPath(chrT.bucket.Name(), chrT.object.Name))
 	_, err = util.CreateFile(data.FileSpec{Path: chrT.downloadPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, os.O_RDONLY)
 	AssertEq(nil, err)
 	_ = chrT.getDownloadJobForTestObject()
@@ -92,7 +92,7 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 
 func (chrT *cacheHandlerTest) TearDown() {
 	chrT.fakeStorage.ShutDown()
-	operations.RemoveDir(chrT.cacheLocation)
+	operations.RemoveDir(chrT.cacheDir)
 }
 
 func (chrT *cacheHandlerTest) addTestFileInfoEntryInCache(bucketName string, objectName string) string {
@@ -490,7 +490,7 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
 	actualJob := chrT.jobManager.GetJob(testObjectName, chrT.bucket.Name())
 	jobStatus := actualJob.GetStatus()
 	ExpectEq(downloader.NotStarted, jobStatus.Name)
-	ExpectTrue(doesFileExist(util.GetDownloadPath(chrT.cacheLocation, util.GetObjectPath(chrT.bucket.Name(), testObjectName))))
+	ExpectTrue(doesFileExist(util.GetDownloadPath(chrT.cacheDir, util.GetObjectPath(chrT.bucket.Name(), testObjectName))))
 }
 
 func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
@@ -568,7 +568,7 @@ func (chrT *cacheHandlerTest) Test_InvalidateCache_Truncates() {
 	AssertEq(nil, cacheHandle.Close())
 	// Open cache file before invalidation
 	objectPath := util.GetObjectPath(chrT.bucket.Name(), minObject.Name)
-	downloadPath := util.GetDownloadPath(chrT.cacheLocation, objectPath)
+	downloadPath := util.GetDownloadPath(chrT.cacheDir, objectPath)
 	file, err := os.OpenFile(downloadPath, os.O_RDONLY, 0600)
 	AssertEq(nil, err)
 	_, err = file.Read(buf)
@@ -694,8 +694,8 @@ func (chrT *cacheHandlerTest) Test_Destroy() {
 	err = chrT.cacheHandler.Destroy()
 
 	AssertEq(nil, err)
-	// Verify the cacheLocation is deleted.
-	_, err = os.Stat(path.Join(chrT.cacheLocation, util.FileCache))
+	// Verify the cacheDir is deleted.
+	_, err = os.Stat(path.Join(chrT.cacheDir, util.FileCache))
 	AssertNe(nil, err)
 	AssertTrue(errors.Is(err, os.ErrNotExist))
 	// Verify jobs are either removed or completed and removed themselves.

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -37,8 +37,8 @@ type JobManager struct {
 	// dirPerm is passed to Job created by JobManager. dirPerm decides the
 	// permission of directory at cache location created by Job.
 	dirPerm os.FileMode
-	// cacheLocation is the path to directory where cache files should be created.
-	cacheLocation string
+	// cacheDir is the path to directory where cache files should be created.
+	cacheDir string
 	// sequentialReadSizeMb is passed to Job created by JobManager, and it decides
 	// the size of GCS read requests by Job at the time of downloading object to
 	// file in cache.
@@ -57,9 +57,9 @@ type JobManager struct {
 	mu   locker.Locker
 }
 
-func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.FileMode, cacheLocation string, sequentialReadSizeMb int32) (jm *JobManager) {
+func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.FileMode, cacheDir string, sequentialReadSizeMb int32) (jm *JobManager) {
 	jm = &JobManager{fileInfoCache: fileInfoCache, filePerm: filePerm,
-		dirPerm: dirPerm, cacheLocation: cacheLocation, sequentialReadSizeMb: sequentialReadSizeMb}
+		dirPerm: dirPerm, cacheDir: cacheDir, sequentialReadSizeMb: sequentialReadSizeMb}
 	jm.mu = locker.New("JobManager", func() {})
 	jm.jobs = make(map[string]*Job)
 	return
@@ -89,7 +89,7 @@ func (jm *JobManager) CreateJobIfNotExists(object *gcs.MinObject, bucket gcs.Buc
 	if ok {
 		return job
 	}
-	downloadPath := util.GetDownloadPath(jm.cacheLocation, objectPath)
+	downloadPath := util.GetDownloadPath(jm.cacheDir, objectPath)
 	fileSpec := data.FileSpec{Path: downloadPath, FilePerm: jm.filePerm, DirPerm: jm.dirPerm}
 	// Pass call back function to Job. When this callback function is called, it
 	// removes the job reference from jobs map.

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var cacheLocation = path.Join(os.Getenv("HOME"), "cache/location")
+var cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
 
 func TestDownloader(t *testing.T) { RunTests(t) }
 
@@ -51,7 +51,7 @@ func init() { RegisterTestSuite(&downloaderTest{}) }
 
 func (dt *downloaderTest) SetUp(*TestInfo) {
 	locker.EnableInvariantsCheck()
-	operations.RemoveDir(cacheLocation)
+	operations.RemoveDir(cacheDir)
 
 	// Create bucket in fake storage.
 	dt.fakeStorage = storage.NewFakeStorage()
@@ -59,13 +59,13 @@ func (dt *downloaderTest) SetUp(*TestInfo) {
 	dt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
-	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheLocation, DefaultSequentialReadSizeMb)
+	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb)
 
 }
 
 func (dt *downloaderTest) TearDown() {
 	dt.fakeStorage.ShutDown()
-	operations.RemoveDir(cacheLocation)
+	operations.RemoveDir(cacheDir)
 }
 
 func (dt *downloaderTest) verifyJob(job *Job, object *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32) {
@@ -74,7 +74,7 @@ func (dt *downloaderTest) verifyJob(job *Job, object *gcs.MinObject, bucket gcs.
 	ExpectEq(object.Generation, job.object.Generation)
 	ExpectEq(object.Name, job.object.Name)
 	ExpectEq(bucket.Name(), job.bucket.Name())
-	downloadPath := util.GetDownloadPath(dt.jm.cacheLocation, util.GetObjectPath(bucket.Name(), object.Name))
+	downloadPath := util.GetDownloadPath(dt.jm.cacheDir, util.GetObjectPath(bucket.Name(), object.Name))
 	ExpectEq(downloadPath, job.fileSpec.Path)
 	ExpectEq(sequentialReadSizeMb, job.sequentialReadSizeMb)
 	ExpectNe(nil, job.removeJobCallback)

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
+var cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 
 func TestDownloader(t *testing.T) { RunTests(t) }
 

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -108,7 +108,7 @@ func (dt *downloaderTest) verifyFileInfoEntry(offset uint64) {
 }
 
 func (dt *downloaderTest) fileCachePath(bucketName string, objectName string) string {
-	return path.Join(cacheLocation, bucketName, objectName)
+	return path.Join(cacheDir, bucketName, objectName)
 }
 
 func (dt *downloaderTest) Test_init() {

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -85,8 +85,8 @@ func GetObjectPath(bucketName string, objectName string) string {
 }
 
 // GetDownloadPath gives file path to file in cache for given object path.
-func GetDownloadPath(cacheLocation string, objectPath string) string {
-	return path.Join(cacheLocation, objectPath)
+func GetDownloadPath(cacheDir string, objectPath string) string {
+	return path.Join(cacheDir, objectPath)
 }
 
 // IsCacheHandleInvalid says either the current cacheHandle is invalid or not, based

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -209,13 +209,13 @@ func (ut *utilTest) Test_getObjectPath() {
 
 func (ut *utilTest) Test_getDownloadPath() {
 	inputs := []string{"/", "a/b", "a/b/c/d", "/a", "a/"}
-	cacheLocation := "/test/dir"
-	expectedOutputs := [5]string{cacheLocation, cacheLocation + "/a/b",
-		cacheLocation + "/a/b/c/d", cacheLocation + "/a", cacheLocation + "/a"}
+	cacheDir := "/test/dir"
+	expectedOutputs := [5]string{cacheDir, cacheDir + "/a/b",
+		cacheDir + "/a/b/c/d", cacheDir + "/a", cacheDir + "/a"}
 
 	results := [5]string{}
 	for i := 0; i < 5; i++ {
-		results[i] = GetDownloadPath(cacheLocation, inputs[i])
+		results[i] = GetDownloadPath(cacheDir, inputs[i])
 	}
 
 	ExpectTrue(reflect.DeepEqual(expectedOutputs, results))

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -51,7 +51,7 @@ type LogConfig struct {
 	LogRotateConfig LogRotateConfig `yaml:"log-rotate"`
 }
 
-type CacheLocation string
+type CacheDir string
 
 type FileCacheConfig struct {
 	MaxSizeInMB           int64 `yaml:"max-size-mb"`
@@ -75,7 +75,7 @@ type MountConfig struct {
 	WriteConfig         `yaml:"write"`
 	LogConfig           `yaml:"logging"`
 	FileCacheConfig     `yaml:"file-cache"`
-	CacheLocation       `yaml:"cache-dir"`
+	CacheDir            `yaml:"cache-dir"`
 	MetadataCacheConfig `yaml:"metadata-cache"`
 }
 

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -54,7 +54,7 @@ type LogConfig struct {
 type CacheDir string
 
 type FileCacheConfig struct {
-	MaxSizeInMB           int64 `yaml:"max-size-mb"`
+	MaxSizeMB             int64 `yaml:"max-size-mb"`
 	CacheFileForRangeRead bool  `yaml:"cache-file-for-range-read"`
 }
 
@@ -111,7 +111,7 @@ func NewMountConfig() *MountConfig {
 		LogRotateConfig: DefaultLogRotateConfig(),
 	}
 	mountConfig.FileCacheConfig = FileCacheConfig{
-		MaxSizeInMB: 0,
+		MaxSizeMB: 0,
 	}
 	mountConfig.MetadataCacheConfig = MetadataCacheConfig{
 		TtlInSeconds:        TtlInSecsUnsetSentinel,

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -54,7 +54,7 @@ type LogConfig struct {
 type CacheLocation string
 
 type FileCacheConfig struct {
-	MaxSizeInMB           int64 `yaml:"max-size-in-mb"`
+	MaxSizeInMB           int64 `yaml:"max-size-mb"`
 	CacheFileForRangeRead bool  `yaml:"cache-file-for-range-read"`
 }
 
@@ -75,7 +75,7 @@ type MountConfig struct {
 	WriteConfig         `yaml:"write"`
 	LogConfig           `yaml:"logging"`
 	FileCacheConfig     `yaml:"file-cache"`
-	CacheLocation       `yaml:"cache-location"`
+	CacheLocation       `yaml:"cache-dir"`
 	MetadataCacheConfig `yaml:"metadata-cache"`
 }
 

--- a/internal/config/testdata/invalid_filecachesize_config.yaml
+++ b/internal/config/testdata/invalid_filecachesize_config.yaml
@@ -1,4 +1,4 @@
 write:
   create-empty-file: true
 file-cache:
-  max-size-in-mb: -100
+  max-size-mb: -100

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -8,9 +8,9 @@ logging:
     max-file-size-mb: 100
     backup-file-count: 5
     compress: false
-cache-location: "/tmp/read_cache/"
+cache-dir: "/tmp/read_cache/"
 file-cache:
-  max-size-in-mb: 100
+  max-size-mb: 100
   cache-file-for-range-read: true
 metadata-cache:
   ttl-secs: 5

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -65,7 +65,7 @@ func IsValidLogRotateConfig(config LogRotateConfig) error {
 }
 
 func (fileCacheConfig *FileCacheConfig) validate() error {
-	if fileCacheConfig.MaxSizeInMB < -1 {
+	if fileCacheConfig.MaxSizeMB < -1 {
 		return fmt.Errorf("the value of max-size-mb for file-cache can't be less than -1")
 	}
 	return nil

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -66,7 +66,7 @@ func IsValidLogRotateConfig(config LogRotateConfig) error {
 
 func (fileCacheConfig *FileCacheConfig) validate() error {
 	if fileCacheConfig.MaxSizeInMB < -1 {
-		return fmt.Errorf("the value of max-size-in-mb for file-cache can't be less than -1")
+		return fmt.Errorf("the value of max-size-mb for file-cache can't be less than -1")
 	}
 	return nil
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -40,7 +40,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	ExpectEq(10, mountConfig.LogConfig.LogRotateConfig.BackupFileCount)
 	ExpectEq(true, mountConfig.LogConfig.LogRotateConfig.Compress)
 	ExpectEq("", mountConfig.CacheDir)
-	ExpectEq(0, mountConfig.FileCacheConfig.MaxSizeInMB)
+	ExpectEq(0, mountConfig.FileCacheConfig.MaxSizeMB)
 	ExpectEq(false, mountConfig.FileCacheConfig.CacheFileForRangeRead)
 }
 

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -142,7 +142,7 @@ func (t *YamlParserTest) TestReadConfigFile_InvalidFileCacheMaxSizeConfig() {
 	_, err := ParseConfigFile("testdata/invalid_filecachesize_config.yaml")
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "error parsing file-cache configs: the value of max-size-in-mb for file-cache can't be less than -1"))
+	AssertTrue(strings.Contains(err.Error(), "error parsing file-cache configs: the value of max-size-mb for file-cache can't be less than -1"))
 }
 
 func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_InvalidTTL() {

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -39,7 +39,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	ExpectEq(512, mountConfig.LogConfig.LogRotateConfig.MaxFileSizeMB)
 	ExpectEq(10, mountConfig.LogConfig.LogRotateConfig.BackupFileCount)
 	ExpectEq(true, mountConfig.LogConfig.LogRotateConfig.Compress)
-	ExpectEq("", mountConfig.CacheLocation)
+	ExpectEq("", mountConfig.CacheDir)
 	ExpectEq(0, mountConfig.FileCacheConfig.MaxSizeInMB)
 	ExpectEq(false, mountConfig.FileCacheConfig.CacheFileForRangeRead)
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -156,7 +156,7 @@ func NewFileSystem(
 
 	// Create file cache handler if cache is enabled by user.
 	var fileCacheHandler *file.CacheHandler
-	if cfg.MountConfig.FileCacheConfig.MaxSizeInMB != 0 {
+	if cfg.MountConfig.FileCacheConfig.MaxSizeMB != 0 {
 		fileCacheHandler = createFileCacheHandler(cfg)
 	}
 
@@ -216,10 +216,10 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	var sizeInBytes uint64
 	// -1 means unlimited size for cache, the underlying LRU cache doesn't handle
 	// -1 explicitly, hence we pass MaxUint64 as capacity in that case.
-	if cfg.MountConfig.FileCacheConfig.MaxSizeInMB == -1 {
+	if cfg.MountConfig.FileCacheConfig.MaxSizeMB == -1 {
 		sizeInBytes = math.MaxUint64
 	} else {
-		sizeInBytes = uint64(cfg.MountConfig.FileCacheConfig.MaxSizeInMB) * util.MiB
+		sizeInBytes = uint64(cfg.MountConfig.FileCacheConfig.MaxSizeMB) * util.MiB
 	}
 	fileInfoCache := lru.NewCache(sizeInBytes)
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -223,37 +223,37 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	}
 	fileInfoCache := lru.NewCache(sizeInBytes)
 
-	cacheLocation := string(cfg.MountConfig.CacheLocation)
+	cacheDir := string(cfg.MountConfig.CacheDir)
 	// Use temp-dir as default cache-dir.
-	if cacheLocation == "" {
+	if cacheDir == "" {
 		if cfg.TempDir == "" {
-			cacheLocation = os.TempDir()
+			cacheDir = os.TempDir()
 		} else {
-			cacheLocation = cfg.TempDir
+			cacheDir = cfg.TempDir
 		}
 	}
-	cacheLocation, err := filepath.Abs(cacheLocation)
+	cacheDir, err := filepath.Abs(cacheDir)
 	if err != nil {
-		panic(fmt.Errorf("createFileCacheHandler: error while resolving cache-dir (%s) in config-file: %w", cacheLocation, err))
+		panic(fmt.Errorf("createFileCacheHandler: error while resolving cache-dir (%s) in config-file: %w", cacheDir, err))
 	}
-	// Adding a new directory inside cacheLocation, so that at the time of Destroy
-	// during unmount we can do os.RemoveAll(cacheLocation) without deleting non
+	// Adding a new directory inside cacheDir, so that at the time of Destroy
+	// during unmount we can do os.RemoveAll(cacheDir) without deleting non
 	// gcsfuse related files.
-	cacheLocation = path.Join(cacheLocation, util.FileCache)
+	cacheDir = path.Join(cacheDir, util.FileCache)
 
 	filePerm := util.DefaultFilePerm
 	dirPerm := util.DefaultDirPerm
 
-	// Panic in case cacheLocation does not have required permissions
-	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation, dirPerm)
-	if cacheLocationErr != nil {
-		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheLocationErr.Error()))
+	// Panic in case cacheDir does not have required permissions
+	cacheDirErr := util.CreateCacheDirectoryIfNotPresentAt(cacheDir, dirPerm)
+	if cacheDirErr != nil {
+		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheDirErr.Error()))
 	}
 
-	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheLocation,
+	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheDir,
 		cfg.SequentialReadSizeMb)
 	fileCacheHandler = file.NewCacheHandler(fileInfoCache, jobManager,
-		cacheLocation, filePerm, dirPerm)
+		cacheDir, filePerm, dirPerm)
 	return
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -224,7 +224,7 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	fileInfoCache := lru.NewCache(sizeInBytes)
 
 	cacheLocation := string(cfg.MountConfig.CacheLocation)
-	// Use temp-dir as default cache-location.
+	// Use temp-dir as default cache-dir.
 	if cacheLocation == "" {
 		if cfg.TempDir == "" {
 			cacheLocation = os.TempDir()
@@ -234,7 +234,7 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	}
 	cacheLocation, err := filepath.Abs(cacheLocation)
 	if err != nil {
-		panic(fmt.Errorf("createFileCacheHandler: error while resolving cache-location (%s) in config-file: %w", cacheLocation, err))
+		panic(fmt.Errorf("createFileCacheHandler: error while resolving cache-dir (%s) in config-file: %w", cacheLocation, err))
 	}
 	// Adding a new directory inside cacheLocation, so that at the time of Destroy
 	// during unmount we can do os.RemoveAll(cacheLocation) without deleting non

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -69,7 +69,7 @@ func (t *FileCacheTest) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           FileCacheSizeInMb,
+			MaxSizeMB:             FileCacheSizeInMb,
 			CacheFileForRangeRead: false,
 		},
 		CacheDir: config.CacheDir(CacheDir),
@@ -602,7 +602,7 @@ func (t *FileCacheWithCacheForRangeRead) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           -1,
+			MaxSizeMB:             -1,
 			CacheFileForRangeRead: true,
 		},
 		CacheDir: config.CacheDir(CacheDir),
@@ -739,7 +739,7 @@ func (t *FileCacheWithDefaultCacheDir) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           -1,
+			MaxSizeMB:             -1,
 			CacheFileForRangeRead: true,
 		},
 	}
@@ -750,7 +750,7 @@ func (t *FileCacheWithUserDefinedTempAsCacheDir) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           -1,
+			MaxSizeMB:             -1,
 			CacheFileForRangeRead: true,
 		},
 	}
@@ -787,7 +787,7 @@ func (t *FileCacheDestroyTest) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           -1,
+			MaxSizeMB:             -1,
 			CacheFileForRangeRead: true,
 		},
 		CacheDir: config.CacheDir(CacheDir),

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -172,7 +172,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	// Create the bucket.
 	t.bucket = storage.NewMockBucket(ti.MockController, "bucket")
 
-	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/location")
+	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 	lruCache := lru.NewCache(CacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb)
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)

--- a/main_test.go
+++ b/main_test.go
@@ -94,7 +94,7 @@ func (t *MainTest) TestStringifyShouldReturnAllFlagsPassedInMountConfigAsMarshal
 
 	actual := util.Stringify(mountConfig)
 
-	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeInMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxEntries\":0}"
+	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxEntries\":0}"
 	AssertEq(expected, actual)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -94,7 +94,7 @@ func (t *MainTest) TestStringifyShouldReturnAllFlagsPassedInMountConfigAsMarshal
 
 	actual := util.Stringify(mountConfig)
 
-	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeInMB\":0,\"CacheFileForRangeRead\":false,\"CacheLocation\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxEntries\":0}"
+	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeInMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxEntries\":0}"
 	AssertEq(expected, actual)
 }
 

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -11,7 +11,7 @@
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
-          "max-size-in-mb": -1,
+          "max-size-mb": -1,
           "cache-file-for-range-read": true
         }
       },
@@ -23,7 +23,7 @@
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
-          "max-size-in-mb": -1,
+          "max-size-mb": -1,
           "cache-file-for-range-read": false
         }
       },

--- a/perfmetrics/scripts/read_cache/generate_yml_config.sh
+++ b/perfmetrics/scripts/read_cache/generate_yml_config.sh
@@ -25,7 +25,7 @@ write:
 logging:
   format: text
   severity: error
-cache-dir: ${CACHE_LOCATION:-/tmp/read_cache/}
+cache-dir: ${CACHE_DIR:-/tmp/read_cache/}
 file-cache:
   max-size-mb: ${MAX_SIZE_IN_MB:-100}
   cache-file-for-range-read: ${CACHE_FILE_FOR_RANGE_READ-false}

--- a/perfmetrics/scripts/read_cache/generate_yml_config.sh
+++ b/perfmetrics/scripts/read_cache/generate_yml_config.sh
@@ -25,9 +25,9 @@ write:
 logging:
   format: text
   severity: error
-cache-location: ${CACHE_LOCATION:-/tmp/read_cache/}
+cache-dir: ${CACHE_LOCATION:-/tmp/read_cache/}
 file-cache:
-  max-size-in-mb: ${MAX_SIZE_IN_MB:-100}
+  max-size-mb: ${MAX_SIZE_IN_MB:-100}
   cache-file-for-range-read: ${CACHE_FILE_FOR_RANGE_READ-false}
 metadata-cache:
   ttl-secs: ${TTL_SECS}

--- a/perfmetrics/scripts/read_cache/generate_yml_config.sh
+++ b/perfmetrics/scripts/read_cache/generate_yml_config.sh
@@ -27,7 +27,7 @@ logging:
   severity: error
 cache-dir: ${CACHE_DIR:-/tmp/read_cache/}
 file-cache:
-  max-size-mb: ${MAX_SIZE_IN_MB:-100}
+  max-size-mb: ${MAX_SIZE_MB:-100}
   cache-file-for-range-read: ${CACHE_FILE_FOR_RANGE_READ-false}
 metadata-cache:
   ttl-secs: ${TTL_SECS}

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -80,7 +80,7 @@ fi
 # Generate yml config.
 export MAX_SIZE_IN_MB="${max_size_mb}"
 export CACHE_FILE_FOR_RANGE_READ="${cache_file_for_range_read}"
-export CACHE_LOCATION="${cache_dir}"
+export CACHE_DIR="${cache_dir}"
 export TTL_SECS="${stat_or_type_cache_ttl_secs}"
 ./generate_yml_config.sh
 

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -19,7 +19,7 @@ set -e
 print_usage() {
   echo "Help/Supported options..."
   printf "./mount_gcsfuse.sh  "
-  printf "[-s max_size_in_mb] "
+  printf "[-s max_size_mb] "
   printf "[-b bucket_name] "
   printf "[-c cache_dir] "
   printf "[-d (means cache_file_for_range_read is true)] "
@@ -30,7 +30,7 @@ print_usage() {
 # Default value to edit, value via argument will override
 # these values if provided.
 cache_file_for_range_read=false
-max_size_in_mb=100
+max_size_mb=100
 cache_dir=/tmp/read_cache/
 bucket_name=gcsfuse-read-cache-fio-load-test
 stat_or_type_cache_ttl_secs=6048000 # 168h or 1 week
@@ -41,7 +41,7 @@ while getopts lhds:b:c:m: flag
 do
   case "${flag}" in
 
-    s) max_size_in_mb=${OPTARG};;
+    s) max_size_mb=${OPTARG};;
     b) bucket_name=${OPTARG};;
     d) cache_file_for_range_read=true;;
     c) cache_dir=${OPTARG};;
@@ -78,7 +78,7 @@ if mountpoint -q -- "$mount_dir"; then
 fi
 
 # Generate yml config.
-export MAX_SIZE_IN_MB="${max_size_in_mb}"
+export MAX_SIZE_IN_MB="${max_size_mb}"
 export CACHE_FILE_FOR_RANGE_READ="${cache_file_for_range_read}"
 export CACHE_LOCATION="${cache_dir}"
 export TTL_SECS="${stat_or_type_cache_ttl_secs}"

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -78,7 +78,7 @@ if mountpoint -q -- "$mount_dir"; then
 fi
 
 # Generate yml config.
-export MAX_SIZE_IN_MB="${max_size_mb}"
+export MAX_SIZE_MB="${max_size_mb}"
 export CACHE_FILE_FOR_RANGE_READ="${cache_file_for_range_read}"
 export CACHE_DIR="${cache_dir}"
 export TTL_SECS="${stat_or_type_cache_ttl_secs}"

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -21,7 +21,7 @@ print_usage() {
   printf "./mount_gcsfuse.sh  "
   printf "[-s max_size_in_mb] "
   printf "[-b bucket_name] "
-  printf "[-c cache_location] "
+  printf "[-c cache_dir] "
   printf "[-d (means cache_file_for_range_read is true)] "
   printf "[-m (means metadata cache capacity)] "
   printf "[-l (start_logging on $WORKING_DIR/gcsfuse_logs.txt)] \n"
@@ -31,7 +31,7 @@ print_usage() {
 # these values if provided.
 cache_file_for_range_read=false
 max_size_in_mb=100
-cache_location=/tmp/read_cache/
+cache_dir=/tmp/read_cache/
 bucket_name=gcsfuse-read-cache-fio-load-test
 stat_or_type_cache_ttl_secs=6048000 # 168h or 1 week
 stat_cache_capacity=4096
@@ -44,7 +44,7 @@ do
     s) max_size_in_mb=${OPTARG};;
     b) bucket_name=${OPTARG};;
     d) cache_file_for_range_read=true;;
-    c) cache_location=${OPTARG};;
+    c) cache_dir=${OPTARG};;
     m) stat_cache_capacity=${OPTARG};;
     h) print_usage
         exit 0 ;;
@@ -80,7 +80,7 @@ fi
 # Generate yml config.
 export MAX_SIZE_IN_MB="${max_size_in_mb}"
 export CACHE_FILE_FOR_RANGE_READ="${cache_file_for_range_read}"
-export CACHE_LOCATION="${cache_location}"
+export CACHE_LOCATION="${cache_dir}"
 export TTL_SECS="${stat_or_type_cache_ttl_secs}"
 ./generate_yml_config.sh
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -86,7 +86,7 @@ const FileInDirThreeInCreateThreeLevelDirTest = "fileInDirThreeInCreateThreeLeve
 const ContentInFileInDirThreeInCreateThreeLevelDirTest = "Hello world!!"
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
-	cacheLocationPath := path.Join(os.Getenv("HOME"), "cache-dri")
+	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
 
 	// Set up config file with create-empty-file: false.
 	mountConfig1 := config.MountConfig{
@@ -108,7 +108,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 			// files
 			MaxSizeInMB: 2,
 		},
-		CacheLocation: config.CacheLocation(cacheLocationPath),
+		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{
 			Severity:        config.TRACE,
 			LogRotateConfig: config.DefaultLogRotateConfig(),

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -106,7 +106,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as low because the operations are performed on small
 			// files
-			MaxSizeInMB: 2,
+			MaxSizeMB: 2,
 		},
 		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -104,7 +104,7 @@ func getCachedFilePath(fileName string) string {
 	if setup.DynamicBucketMounted() != "" {
 		bucketName = setup.DynamicBucketMounted()
 	}
-	return path.Join(cacheLocationPath, cacheSubDirectoryName, bucketName, testDirName, fileName)
+	return path.Join(cacheDirPath, cacheSubDirectoryName, bucketName, testDirName, fileName)
 }
 
 func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testing.T) {
@@ -248,7 +248,7 @@ func modifyFile(ctx context.Context, storageClient *storage.Client, testFileName
 }
 
 func validateCacheSizeWithinLimit(cacheCapacity int64, t *testing.T) {
-	cacheSize, err := operations.DirSizeMiB(cacheLocationPath)
+	cacheSize, err := operations.DirSizeMiB(cacheDirPath)
 	if err != nil {
 		t.Errorf("Error in getting cache size: %v", cacheSize)
 	}

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -92,7 +92,7 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as low because the operations are performed on small
 			// files
-			MaxSizeInMB:           cacheSize,
+			MaxSizeMB:             cacheSize,
 			CacheFileForRangeRead: cacheFileForRangeRead,
 		},
 		CacheDir: config.CacheDir(cacheDirPath),

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -65,9 +65,9 @@ const (
 )
 
 var (
-	testDirPath       string
-	cacheLocationPath string
-	mountFunc         func([]string) error
+	testDirPath  string
+	cacheDirPath string
+	mountFunc    func([]string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
@@ -85,7 +85,7 @@ func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageCli
 }
 
 func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName string) string {
-	cacheLocationPath = path.Join(setup.TestDir(), "cache-dir")
+	cacheDirPath = path.Join(setup.TestDir(), "cache-dir")
 
 	// Set up config file for file cache.
 	mountConfig := config.MountConfig{
@@ -95,7 +95,7 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 			MaxSizeInMB:           cacheSize,
 			CacheFileForRangeRead: cacheFileForRangeRead,
 		},
-		CacheLocation: config.CacheLocation(cacheLocationPath),
+		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{
 			Severity:        config.TRACE,
 			Format:          "json",

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -44,7 +44,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as high because the operations are performed on large
 			// files
-			MaxSizeInMB:           700,
+			MaxSizeMB:             700,
 			CacheFileForRangeRead: true,
 		},
 		CacheDir: config.CacheDir(cacheDirPath),
@@ -59,7 +59,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	// Set up config file for file cache with unlimited capacity
 	mountConfig2 := config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeInMB:           -1,
+			MaxSizeMB:             -1,
 			CacheFileForRangeRead: false,
 		},
 		CacheDir: config.CacheDir(cacheDirPath),

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -37,7 +37,7 @@ const MinReadableByteFromFile = 0
 const MaxReadableByteFromFile = 500 * OneMB
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
-	cacheLocationPath := path.Join(os.Getenv("HOME"), "cache-dri")
+	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
 
 	// Set up config file for file cache with cache-file-for-range-read: false
 	mountConfig1 := config.MountConfig{
@@ -47,7 +47,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 			MaxSizeInMB:           700,
 			CacheFileForRangeRead: true,
 		},
-		CacheLocation: config.CacheLocation(cacheLocationPath),
+		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{
 			Severity:        config.TRACE,
 			LogRotateConfig: config.DefaultLogRotateConfig(),
@@ -62,7 +62,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 			MaxSizeInMB:           -1,
 			CacheFileForRangeRead: false,
 		},
-		CacheLocation: config.CacheLocation(cacheLocationPath),
+		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{
 			Severity:        config.TRACE,
 			LogRotateConfig: config.DefaultLogRotateConfig(),

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -58,7 +58,7 @@ func checkErrorForObjectNotExist(err error, t *testing.T) {
 }
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
-	cacheLocationPath := path.Join(os.Getenv("HOME"), "cache-dir")
+	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dir")
 
 	// Set up config file for file cache
 	mountConfig := config.MountConfig{
@@ -67,7 +67,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 			// files
 			MaxSizeInMB: 3,
 		},
-		CacheLocation: config.CacheLocation(cacheLocationPath),
+		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{
 			Severity:        config.TRACE,
 			LogRotateConfig: config.DefaultLogRotateConfig(),

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -65,7 +65,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as small because the operations are performed on small
 			// files
-			MaxSizeInMB: 3,
+			MaxSizeMB: 3,
 		},
 		CacheDir: config.CacheDir(cacheDirPath),
 		LogConfig: config.LogConfig{

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -92,10 +92,10 @@ gcsfuse --config-file=/tmp/gcsfuse_config.yaml $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
 
-# Run tests with config "file-cache: max-size-in-mb" static mounting.
+# Run tests with config "file-cache: max-size-mb" static mounting.
 echo "file-cache:
-       max-size-in-mb: 2
-cache-location: ./cache-dir
+       max-size-mb: 2
+cache-dir: ./cache-dir
        " > /tmp/gcsfuse_config.yaml
 gcsfuse --config-file=/tmp/gcsfuse_config.yaml $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
@@ -142,10 +142,10 @@ mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,file_mode=544,dir
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readonly/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
-# Run tests with config "file-cache: max-size-in-mb" static mounting.
+# Run tests with config "file-cache: max-size-mb" static mounting.
 echo "file-cache:
-       max-size-in-mb: 3
-cache-location: ./cache-dir
+       max-size-mb: 3
+cache-dir: ./cache-dir
        " > /tmp/gcsfuse_config.yaml
 gcsfuse --config-file /tmp/gcsfuse_config.yaml --only-dir testDir --file-mode=544 --dir-mode=544 --implicit-dirs=true  $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readonly/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
@@ -246,21 +246,21 @@ gcsfuse --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
 
-# Run tests with config "file-cache: max-size-in-mb, cache-file-for-range-read".
+# Run tests with config "file-cache: max-size-mb, cache-file-for-range-read".
 echo "file-cache:
-       max-size-in-mb: 700
+       max-size-mb: 700
        cache-file-for-range-read: true
-cache-location: ./cache-dir
+cache-dir: ./cache-dir
        " > /tmp/gcsfuse_config.yaml
 gcsfuse --config-file /tmp/gcsfuse_config.yaml --implicit-dirs=true  $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
 
-# Run tests with config "file-cache: max-size-in-mb".
+# Run tests with config "file-cache: max-size-mb".
 echo "file-cache:
-       max-size-in-mb: -1
+       max-size-mb: -1
        cache-file-for-range-read: false
-cache-location: ./cache-dir
+cache-dir: ./cache-dir
        " > /tmp/gcsfuse_config.yaml
 gcsfuse --config-file /tmp/gcsfuse_config.yaml --implicit-dirs=true  $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR


### PR DESCRIPTION
### Description
1. Rename read-cache config-file variables
    1. "max-size-in-mb" -> "max-size-mb"
    2. "cache-location" -> "cache-dir"
2. Did deep replacement of similar identifiers (using regex) throughout the code.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran sanity tests.
2. Unit tests - Ran and passed locally. No new tests.
4. Integration tests - Ran and passed through presubmit. No new tests.
