### PR TITLE
[ReadCacheFunctionalTest] Test Concurrent Reads results in non sequential read behavior if download for range read flag is false

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -62,7 +62,6 @@ func readFileAsync(t *testing.T, wg *sync.WaitGroup, testFileName string, expect
 ////////////////////////////////////////////////////////////////////////
 
 func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.T) {
-	t.SkipNow()
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
 	// Do a random read on file and validate from gcs.

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -17,13 +17,14 @@ package read_cache
 import (
 	"context"
 	"log"
+	"sync"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
-
 	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
+	"github.com/jacobsa/ogletest"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -45,10 +46,23 @@ func (s *cacheFileForRangeReadFalseTest) Teardown(t *testing.T) {
 }
 
 ////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func readFileAsync(t *testing.T, wg *sync.WaitGroup, testFileName string, expectedOutcome **Expected) {
+	go func() {
+		defer wg.Done()
+		*expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, testFileName, true, zeroOffset, t)
+	}()
+	return
+}
+
+////////////////////////////////////////////////////////////////////////
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
 func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.T) {
+	t.SkipNow()
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
 	// Do a random read on file and validate from gcs.
@@ -60,6 +74,38 @@ func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.
 	validate(expectedOutcome1, structuredReadLogs[0], false, false, 1, t)
 	validate(expectedOutcome2, structuredReadLogs[1], false, false, 1, t)
 	validateFileIsNotCached(testFileName, t)
+}
+
+func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache(t *testing.T) {
+	var testFileNames [2]string
+	var expectedOutcome [2]*Expected
+	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+	testFileNames[1] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		readFileAsync(t, &wg, testFileNames[i], &expectedOutcome[i])
+	}
+	wg.Wait()
+
+	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	// Goroutine execution order isn't guaranteed.
+	// If the object name in expected outcome doesn't align with the logs, swap
+	// the expected outcome objects and file names at positions 0 and 1.
+	if expectedOutcome[0].ObjectName != structuredReadLogs[0].ObjectName {
+		expectedOutcome[0], expectedOutcome[1] = expectedOutcome[1], expectedOutcome[0]
+		testFileNames[0], testFileNames[1] = testFileNames[1], testFileNames[0]
+	}
+	validate(expectedOutcome[0], structuredReadLogs[0], true, false, randomReadChunkCount, t)
+	validate(expectedOutcome[1], structuredReadLogs[1], true, false, randomReadChunkCount, t)
+	for i := 1; i < randomReadChunkCount; i++ {
+		ogletest.ExpectEq(false, structuredReadLogs[0].Chunks[i].IsSequential)
+		ogletest.ExpectEq(false, structuredReadLogs[0].Chunks[i].CacheHit)
+		ogletest.ExpectEq(true, structuredReadLogs[1].Chunks[i].IsSequential)
+	}
+	validateFileIsNotCached(testFileNames[0], t)
+	validateFileInCacheDirectory(testFileNames[1], fileSizeForRangeRead, s.ctx, s.storageClient, t)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -54,7 +54,6 @@ func readFileAsync(t *testing.T, wg *sync.WaitGroup, testFileName string, expect
 		defer wg.Done()
 		*expectedOutcome = readFileAndGetExpectedOutcome(testDirPath, testFileName, true, zeroOffset, t)
 	}()
-	return
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -20,9 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
-
 	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/log_parser/json_parser/read_logs"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/test_setup"
 )

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -22,15 +22,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/dynamic_mounting"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
-
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/internal/config"
-
-	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
 
@@ -63,6 +61,7 @@ const (
 	offsetEndOfFile                    = fileSizeForRangeRead - 1*util.MiB
 	offset10MiB                        = 10 * util.MiB
 	cacheCapacityForRangeReadTestInMiB = 100
+	randomReadChunkCount               = 100
 )
 
 var (


### PR DESCRIPTION
### Description
Scenario:
With cacheFileForRangeRead config false
cache size: 50 MiB:
R1 50 MiB file (parallel)
R2 50MiB file (parallel)

Expected: 
R1 cache evicted, follow up read calls (from R1 operation) will not cache R1 50MiB file as the reads will be considered non sequential. In the end R2 file should be cached.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran via KOKORO
