### PR TITLE
Fix cache dir permissions

### DIFF
--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -39,15 +39,11 @@ const (
 )
 
 const (
-	FileDirPerm            = os.FileMode(0755) | os.ModeDir
-	MiB                    = 1024 * 1024
-	KiB                    = 1024
-	DefaultFilePerm        = os.FileMode(0600)
-	FilePermWithAllowOther = os.FileMode(0644)
-
-	DefaultDirPerm        = os.FileMode(0700)
-	DirPermWithAllowOther = os.FileMode(0755)
-	FileCache             = "gcsfuse-file-cache"
+	MiB             = 1024 * 1024
+	KiB             = 1024
+	DefaultFilePerm = os.FileMode(0600)
+	DefaultDirPerm  = os.FileMode(0700)
+	FileCache       = "gcsfuse-file-cache"
 )
 
 // CreateFile creates file with given file spec i.e. permissions and returns
@@ -105,8 +101,9 @@ func IsCacheHandleInvalid(readErr error) bool {
 		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
 }
 
-// Creates directory at given path with provided permissions in case not already present,
-// returns error in case unable to create directory or directory is not writable.
+// CreateCacheDirectoryIfNotPresentAt Creates directory at given path with
+// provided permissions in case not already present, returns error in case
+// unable to create directory or directory is not writable.
 func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) error {
 	_, statErr := os.Stat(dirPath)
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -90,7 +90,7 @@ func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
 	ExpectEq(nil, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFileShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient() {
+func (ut *utilTest) Test_CreateFile_ShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient() {
 	ut.fileSpec.DirPerm = 644
 
 	_, err := CreateFile(ut.fileSpec, ut.flag)
@@ -246,7 +246,7 @@ func (ut *utilTest) Test_IsCacheHandleValid_False() {
 	}
 }
 
-func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryExists(t *testing.T) {
+func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryExists(t *testing.T) {
 	base := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirPath := path.Join(base, "/", "path/cachedir")
 	dirCreationErr := os.MkdirAll(dirPath, 0700)
@@ -261,7 +261,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryE
 	AssertEq(0700, fileInfo.Mode().Perm())
 }
 
-func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOwnerPermissions(t *testing.T) {
+func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOwnerPermissions(t *testing.T) {
 	base := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirPath := path.Join(base, "/", "path/cachedir")
 	defer os.RemoveAll(base)
@@ -274,7 +274,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryC
 	AssertEq(0700, fileInfo.Mode().Perm())
 }
 
-func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOthersPermissions(t *testing.T) {
+func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOthersPermissions(t *testing.T) {
 	base := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirPath := path.Join(base, "/", "path/cachedir")
 	defer os.RemoveAll(base)
@@ -287,7 +287,7 @@ func TestCreateCacheDirectoryIfNotPresentAtShouldNotReturnAnyErrorWhenDirectoryC
 	AssertEq(0755, fileInfo.Mode().Perm())
 }
 
-func TestCreateCacheDirectoryIfNotPresentAtShouldReturnErrorWhenDirectoryDoesNotHavePermissions(t *testing.T) {
+func Test_CreateCacheDirectoryIfNotPresentAt_ShouldReturnErrorWhenDirectoryDoesNotHavePermissions(t *testing.T) {
 	dirPath := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirCreationErr := os.MkdirAll(dirPath, 0444)
 	defer os.RemoveAll(dirPath)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -127,9 +127,6 @@ type ServerConfig struct {
 
 	// MountConfig has all the config specified by the user using configFile flag.
 	MountConfig *config.MountConfig
-
-	// AllowOther is true when -o allow_other flag is passed.
-	AllowOther bool
 }
 
 // Create a fuse file system server according to the supplied configuration.
@@ -244,14 +241,8 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	// gcsfuse related files.
 	cacheLocation = path.Join(cacheLocation, util.FileCache)
 
-	// When user passes allow_other flag, then other users should be able to
-	// read from cache
 	filePerm := util.DefaultFilePerm
 	dirPerm := util.DefaultDirPerm
-	if cfg.AllowOther {
-		filePerm = util.FilePermWithAllowOther
-		dirPerm = util.DirPermWithAllowOther
-	}
 
 	// Panic in case cacheLocation does not have required permissions
 	cacheLocationErr := util.CreateCacheDirectoryIfNotPresentAt(cacheLocation, dirPerm)

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -254,7 +254,7 @@ func (t *FileCacheTest) SequentialToRandomReadShouldPopulateCache() {
 	sequentialToRandomReadShouldPopulateCache(&t.fsTest)
 }
 
-func (t *FileCacheTest) CacheFilePermissionWithoutAllowOther() {
+func (t *FileCacheTest) CacheFilePermission() {
 	cacheFilePermissionTest(&t.fsTest, util.DefaultFilePerm)
 }
 
@@ -607,7 +607,6 @@ func (t *FileCacheWithCacheForRangeRead) SetUpTestSuite() {
 		},
 		CacheLocation: config.CacheLocation(CacheLocation),
 	}
-	t.serverCfg.AllowOther = true
 	t.fsTest.SetUpTestSuite()
 }
 
@@ -654,8 +653,8 @@ func (t *FileCacheWithCacheForRangeRead) SequentialReadShouldPopulateCache() {
 	sequentialReadShouldPopulateCache(&t.fsTest, FileCacheLocation)
 }
 
-func (t *FileCacheWithCacheForRangeRead) CacheFilePermissionWithAllowOther() {
-	cacheFilePermissionTest(&t.fsTest, util.FilePermWithAllowOther)
+func (t *FileCacheWithCacheForRangeRead) CacheFilePermission() {
+	cacheFilePermissionTest(&t.fsTest, util.DefaultFilePerm)
 }
 
 func (t *FileCacheWithCacheForRangeRead) WriteShouldNotPopulateCache() {
@@ -713,11 +712,11 @@ func (t *FileCacheTest) ModifyFileInCacheAndThenReadShouldGiveModifiedData() {
 	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
 	downloadPath := util.GetDownloadPath(FileCacheLocation, objectPath)
 	// modify the file in cache
-	err = os.WriteFile(downloadPath, []byte(changedContent), util.FilePermWithAllowOther)
+	err = os.WriteFile(downloadPath, []byte(changedContent), os.FileMode(655))
 	AssertEq(nil, err)
 
 	// read the file again, should give modified content
-	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.FilePermWithAllowOther)
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, os.FileMode(655))
 	defer closeFile(file)
 	AssertEq(nil, err)
 	buf := make([]byte, len(objectContent))
@@ -744,7 +743,6 @@ func (t *FileCacheWithDefaultCacheLocation) SetUpTestSuite() {
 			CacheFileForRangeRead: true,
 		},
 	}
-	t.serverCfg.AllowOther = true
 	t.fsTest.SetUpTestSuite()
 }
 
@@ -756,7 +754,6 @@ func (t *FileCacheWithUserDefinedTempAsCacheLocation) SetUpTestSuite() {
 			CacheFileForRangeRead: true,
 		},
 	}
-	t.serverCfg.AllowOther = true
 	t.serverCfg.TempDir = UserTempLocation
 	t.fsTest.SetUpTestSuite()
 }
@@ -795,7 +792,6 @@ func (t *FileCacheDestroyTest) SetUpTestSuite() {
 		},
 		CacheLocation: config.CacheLocation(CacheLocation),
 	}
-	t.serverCfg.AllowOther = true
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -712,11 +712,11 @@ func (t *FileCacheTest) ModifyFileInCacheAndThenReadShouldGiveModifiedData() {
 	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
 	downloadPath := util.GetDownloadPath(FileCacheLocation, objectPath)
 	// modify the file in cache
-	err = os.WriteFile(downloadPath, []byte(changedContent), os.FileMode(655))
+	err = os.WriteFile(downloadPath, []byte(changedContent), os.FileMode(0655))
 	AssertEq(nil, err)
 
 	// read the file again, should give modified content
-	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, os.FileMode(655))
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, os.FileMode(0655))
 	defer closeFile(file)
 	AssertEq(nil, err)
 	buf := make([]byte, len(objectContent))

--- a/mount.go
+++ b/mount.go
@@ -99,8 +99,6 @@ be interacting with the file system.`)
 	}
 	bm := gcsx.NewBucketManager(bucketCfg, storageHandle)
 
-	_, allowOther := flags.MountOptions["allow_other"]
-
 	// Create a file system server.
 	serverCfg := &fs.ServerConfig{
 		CacheClock:                 timeutil.RealClock(),
@@ -120,7 +118,6 @@ be interacting with the file system.`)
 		SequentialReadSizeMb:       flags.SequentialReadSizeMb,
 		EnableNonexistentTypeCache: flags.EnableNonexistentTypeCache,
 		MountConfig:                mountConfig,
-		AllowOther:                 allowOther,
 	}
 
 	logger.Infof("Creating a new server...\n")


### PR DESCRIPTION
### Description
Problem
1. GCSFuse supports two more permissions related flags that are file-mode and dir-mode which decides the permissions of files and directories inside the gcsfuse mount. Note if file-mode is set 777 but allow-other is not passed then other users except owner will still not be able to access the files via GCSFuse mount. So allow-other tells whether to even respect file-mode and dir-mode for users other than mounting user or not.
2. Mounting gcsfuse with --allow-other flag and setting file-mode 700 is a completely valid thing to do from user's perspective. If user mounts gcsfuse with this config then other users on machine will not be able to access files via GCSFuse mount but will be able to access cache directory directly which is wrong. 

Solution
Always set 700 and 600 permissions for directory and file respectively in cache directory irrespective of allow-other flag. 
With this way, the permissions will be controlled solely via GCSFuse mount and we will not face the above problems described above. 
Also, it doesn't mean that users other than mounting user will not be able to get benefit of cache via GCSFuse mount if allow-other is passed because on read it is gcsfuse daemon that access files and directories in cache directory and not the user accessing GCSFuse mount.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual 

Without allow-other
 - Mount gcsfuse with uid X at mount point P and cache dir C
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - both don't work.
 - Mount gcsfuse with uid X at mount point P and cache dir C with file-mode 777 and dir-mode 777
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - both don't work.

With allow-other
 - Mount gcsfuse with uid X at mount point P and cache dir C
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - works for P and not for C.
 - Mount gcsfuse with uid X at mount point P and cache dir C with file-mode 777 and dir-mode 777
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - works for P and not for C.
  - Mount gcsfuse with uid X at mount point P and cache dir C with file-mode 700 and dir-mode 700
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - don't work.
  - Mount gcsfuse with uid X at mount point P and cache dir C with --file-mode 700 and --dir-mode 700 and --uid Y
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Check perm of files in P - owner is Y.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - don't work.
  - Mount gcsfuse with uid X at mount point P and cache dir C with --file-mode 744 and --dir-mode 744 and --uid Y
    - Check perm of files and dirs in C - 600 & 700 with owner X.
    - Check perm of files in P - owner is Y.
    - Access P and C with uid X - Works.
    - Access P and C with uid Y - works with P and don't work with C.
3. Unit tests - NA
4. Integration tests - NA
