### PR TITLE
Change max-size-in-mb to max-size-mb

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -11,7 +11,7 @@
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
-          "max-size-in-mb": -1,
+          "max-size-mb": -1,
           "cache-file-for-range-read": true
         }
       },
@@ -23,7 +23,7 @@
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
-          "max-size-in-mb": -1,
+          "max-size-mb": -1,
           "cache-file-for-range-read": false
         }
       },


### PR DESCRIPTION
### Description
Change max-size-in-mb to max-size-mbin file-cache in
perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json.
This is a parallel of https://github.com/GoogleCloudPlatform/gcsfuse/pull/1703 which is for read_cache_release branch.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
