### PR TITLE
[PR-1] Add struct for extended object attribute

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -122,8 +122,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	gcsObj, err := cht.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: TestObjectName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
-	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	cht.object = &minObject
+	cht.object = storageutil.ConvertObjToMinObject(gcsObj)
 
 	// fileInfoCache with testFileInfoEntry
 	cht.cache = lru.NewCache(CacheMaxSize)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -123,7 +123,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
 	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	cht.object = minObject
+	cht.object = &minObject
 
 	// fileInfoCache with testFileInfoEntry
 	cht.cache = lru.NewCache(CacheMaxSize)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -123,7 +123,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
 	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	cht.object = &minObject
+	cht.object = minObject
 
 	// fileInfoCache with testFileInfoEntry
 	cht.cache = lru.NewCache(CacheMaxSize)

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -146,7 +146,7 @@ func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *g
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
 	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	return minObject
+	return &minObject
 }
 
 // doesFileExist returns true if the file exists and false otherwise.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -146,7 +146,7 @@ func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *g
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
 	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	return &minObject
+	return minObject
 }
 
 // doesFileExist returns true if the file exists and false otherwise.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -145,8 +145,7 @@ func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *g
 	gcsObj, err := chrT.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
-	minObject := storageutil.ConvertObjToMinObject(gcsObj)
-	return &minObject
+	return storageutil.ConvertObjToMinObject(gcsObj)
 }
 
 // doesFileExist returns true if the file exists and false otherwise.

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -53,7 +53,7 @@ func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 		panic(fmt.Errorf("error whlie stating object: %w", err))
 	}
 
-	return *storageutil.ConvertObjToMinObject(object)
+	return storageutil.ConvertObjToMinObject(object)
 }
 
 func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -53,7 +53,12 @@ func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 		panic(fmt.Errorf("error whlie stating object: %w", err))
 	}
 
-	return storageutil.ConvertObjToMinObject(object)
+	var minObj gcs.MinObject
+	minObjPtr := storageutil.ConvertObjToMinObject(object)
+	if minObjPtr != nil {
+		minObj = *minObjPtr
+	}
+	return minObj
 }
 
 func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -53,7 +53,7 @@ func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 		panic(fmt.Errorf("error whlie stating object: %w", err))
 	}
 
-	return storageutil.ConvertObjToMinObject(object)
+	return *storageutil.ConvertObjToMinObject(object)
 }
 
 func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -111,6 +111,11 @@ func NewFileInode(
 	mtimeClock timeutil.Clock,
 	localFile bool) (f *FileInode) {
 	// Set up the basic struct.
+	var minObj gcs.MinObject
+	minObjPtr := storageutil.ConvertObjToMinObject(o)
+	if minObjPtr != nil {
+		minObj = *minObjPtr
+	}
 	f = &FileInode{
 		bucket:         bucket,
 		mtimeClock:     mtimeClock,
@@ -119,12 +124,9 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
+		src:            minObj,
 		local:          localFile,
 		unlinked:       false,
-	}
-	minObjPtr := storageutil.ConvertObjToMinObject(o)
-	if minObjPtr != nil {
-		f.src = *minObjPtr
 	}
 
 	f.lc.Init(id)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -119,9 +119,12 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
-		src:            storageutil.ConvertObjToMinObject(o),
 		local:          localFile,
 		unlinked:       false,
+	}
+	minObjPtr := storageutil.ConvertObjToMinObject(o)
+	if minObjPtr != nil {
+		f.src = *minObjPtr
 	}
 
 	f.lc.Init(id)
@@ -517,7 +520,10 @@ func (f *FileInode) SetMtime(
 
 	o, err := f.bucket.UpdateObject(ctx, req)
 	if err == nil {
-		f.src = storageutil.ConvertObjToMinObject(o)
+		minObjPtr := storageutil.ConvertObjToMinObject(o)
+		if minObjPtr != nil {
+			f.src = *minObjPtr
+		}
 		return
 	}
 
@@ -593,7 +599,10 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
-		f.src = storageutil.ConvertObjToMinObject(newObj)
+		minObjPtr := storageutil.ConvertObjToMinObject(newObj)
+		if minObjPtr != nil {
+			f.src = *minObjPtr
+		}
 		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -119,7 +119,7 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
-		src:            *storageutil.ConvertObjToMinObject(o),
+		src:            storageutil.ConvertObjToMinObject(o),
 		local:          localFile,
 		unlinked:       false,
 	}
@@ -517,7 +517,7 @@ func (f *FileInode) SetMtime(
 
 	o, err := f.bucket.UpdateObject(ctx, req)
 	if err == nil {
-		f.src = *storageutil.ConvertObjToMinObject(o)
+		f.src = storageutil.ConvertObjToMinObject(o)
 		return
 	}
 
@@ -593,7 +593,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
-		f.src = *storageutil.ConvertObjToMinObject(newObj)
+		f.src = storageutil.ConvertObjToMinObject(newObj)
 		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -522,10 +522,12 @@ func (f *FileInode) SetMtime(
 
 	o, err := f.bucket.UpdateObject(ctx, req)
 	if err == nil {
+		var minObj gcs.MinObject
 		minObjPtr := storageutil.ConvertObjToMinObject(o)
 		if minObjPtr != nil {
-			f.src = *minObjPtr
+			minObj = *minObjPtr
 		}
+		f.src = minObj
 		return
 	}
 
@@ -601,10 +603,12 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
+		var minObj gcs.MinObject
 		minObjPtr := storageutil.ConvertObjToMinObject(newObj)
 		if minObjPtr != nil {
-			f.src = *minObjPtr
+			minObj = *minObjPtr
 		}
+		f.src = minObj
 		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -119,7 +119,7 @@ func NewFileInode(
 		attrs:          attrs,
 		localFileCache: localFileCache,
 		contentCache:   contentCache,
-		src:            storageutil.ConvertObjToMinObject(o),
+		src:            *storageutil.ConvertObjToMinObject(o),
 		local:          localFile,
 		unlinked:       false,
 	}
@@ -517,7 +517,7 @@ func (f *FileInode) SetMtime(
 
 	o, err := f.bucket.UpdateObject(ctx, req)
 	if err == nil {
-		f.src = storageutil.ConvertObjToMinObject(o)
+		f.src = *storageutil.ConvertObjToMinObject(o)
 		return
 	}
 
@@ -593,7 +593,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	// If we wrote out a new object, we need to update our state.
 	if newObj != nil && !f.localFileCache {
-		f.src = storageutil.ConvertObjToMinObject(newObj)
+		f.src = *storageutil.ConvertObjToMinObject(newObj)
 		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -97,7 +97,7 @@ type ExtendedObjectAttributes struct {
 	CacheControl       string
 	Owner              string
 	MD5                *[md5.Size]byte // Missing for composite objects
-	CRC32C             *uint32         //Missing for CMEK buckets
+	CRC32C             *uint32         // Missing for CMEK buckets
 	MediaLink          string
 	StorageClass       string
 	Deleted            time.Time

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -90,6 +90,24 @@ type MinObject struct {
 	ContentEncoding string
 }
 
+// ExtendedObjectAttributes contains the missing attributes of Object which are not present in MinObject.
+type ExtendedObjectAttributes struct {
+	ContentType        string
+	ContentLanguage    string
+	CacheControl       string
+	Owner              string
+	MD5                *[md5.Size]byte // Missing for composite objects
+	CRC32C             *uint32         //Missing for CMEK buckets
+	MediaLink          string
+	StorageClass       string
+	Deleted            time.Time
+	ComponentCount     int64
+	ContentDisposition string
+	CustomTime         string
+	EventBasedHold     bool
+	Acl                []*storagev1.ObjectAccessControl
+}
+
 func (mo MinObject) HasContentEncodingGzip() bool {
 	return mo.ContentEncoding == ContentEncodingGzip
 }

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -181,12 +181,13 @@ func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
 	}
 
 	o := gcs.Object{
-		Name:           m.Name,
-		Size:           m.Size,
-		Generation:     m.Generation,
-		MetaGeneration: m.MetaGeneration,
-		Updated:        m.Updated,
-		Metadata:       m.Metadata,
+		Name:            m.Name,
+		Size:            m.Size,
+		Generation:      m.Generation,
+		MetaGeneration:  m.MetaGeneration,
+		Updated:         m.Updated,
+		Metadata:        m.Metadata,
+		ContentEncoding: m.ContentEncoding,
 	}
 
 	if e != nil {
@@ -198,6 +199,8 @@ func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
 		o.CRC32C = e.CRC32C
 		o.MediaLink = e.MediaLink
 		o.StorageClass = e.StorageClass
+		o.Deleted = e.Deleted
+		o.ComponentCount = e.ComponentCount
 		o.ContentDisposition = e.ContentDisposition
 		o.CustomTime = e.CustomTime
 		o.EventBasedHold = e.EventBasedHold

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -134,13 +134,13 @@ func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage
 	return wc
 }
 
-func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
-	var min gcs.MinObject
+func ConvertObjToMinObject(o *gcs.Object) gcs.MinObject {
+	var minObj gcs.MinObject
 	if o == nil {
-		return &min
+		return minObj
 	}
 
-	return &gcs.MinObject{
+	return gcs.MinObject{
 		Name:            o.Name,
 		Size:            o.Size,
 		Generation:      o.Generation,

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -134,13 +134,13 @@ func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage
 	return wc
 }
 
-func ConvertObjToMinObject(o *gcs.Object) gcs.MinObject {
+func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 	var min gcs.MinObject
 	if o == nil {
-		return min
+		return &min
 	}
 
-	return gcs.MinObject{
+	return &gcs.MinObject{
 		Name:            o.Name,
 		Size:            o.Size,
 		Generation:      o.Generation,
@@ -149,4 +149,60 @@ func ConvertObjToMinObject(o *gcs.Object) gcs.MinObject {
 		Metadata:        o.Metadata,
 		ContentEncoding: o.ContentEncoding,
 	}
+}
+
+func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes {
+	if o == nil {
+		return nil
+	}
+
+	return &gcs.ExtendedObjectAttributes{
+		ContentType:        o.ContentType,
+		ContentLanguage:    o.ContentLanguage,
+		CacheControl:       o.CacheControl,
+		Owner:              o.Owner,
+		MD5:                o.MD5,
+		CRC32C:             o.CRC32C,
+		MediaLink:          o.MediaLink,
+		StorageClass:       o.StorageClass,
+		Deleted:            o.Deleted,
+		ComponentCount:     o.ComponentCount,
+		ContentDisposition: o.ContentDisposition,
+		CustomTime:         o.CustomTime,
+		EventBasedHold:     o.EventBasedHold,
+		Acl:                o.Acl,
+	}
+}
+
+func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
+	e *gcs.ExtendedObjectAttributes) *gcs.Object {
+	if m == nil {
+		return nil
+	}
+
+	o := gcs.Object{
+		Name:           m.Name,
+		Size:           m.Size,
+		Generation:     m.Generation,
+		MetaGeneration: m.MetaGeneration,
+		Updated:        m.Updated,
+		Metadata:       m.Metadata,
+	}
+
+	if e != nil {
+		o.ContentType = e.ContentType
+		o.ContentLanguage = e.ContentLanguage
+		o.CacheControl = e.CacheControl
+		o.Owner = e.Owner
+		o.MD5 = e.MD5
+		o.CRC32C = e.CRC32C
+		o.MediaLink = e.MediaLink
+		o.StorageClass = e.StorageClass
+		o.ContentDisposition = e.ContentDisposition
+		o.CustomTime = e.CustomTime
+		o.EventBasedHold = e.EventBasedHold
+		o.Acl = e.Acl
+	}
+
+	return &o
 }

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -134,13 +134,12 @@ func SetAttrsInWriter(wc *storage.Writer, req *gcs.CreateObjectRequest) *storage
 	return wc
 }
 
-func ConvertObjToMinObject(o *gcs.Object) gcs.MinObject {
-	var minObj gcs.MinObject
+func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 	if o == nil {
-		return minObj
+		return nil
 	}
 
-	return gcs.MinObject{
+	return &gcs.MinObject{
 		Name:            o.Name,
 		Size:            o.Size,
 		Generation:      o.Generation,

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -152,9 +152,8 @@ func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 }
 
 func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes {
-	var extObjAttr gcs.ExtendedObjectAttributes
 	if o == nil {
-		return &extObjAttr
+		return nil
 	}
 
 	return &gcs.ExtendedObjectAttributes{
@@ -177,12 +176,41 @@ func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes
 
 func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
 	e *gcs.ExtendedObjectAttributes) *gcs.Object {
-	var object gcs.Object
-	if m == nil {
-		return &object
+	if m == nil || e == nil {
+		return nil
 	}
 
-	o := gcs.Object{
+	return &gcs.Object{
+		Name:               m.Name,
+		Size:               m.Size,
+		Generation:         m.Generation,
+		MetaGeneration:     m.MetaGeneration,
+		Updated:            m.Updated,
+		Metadata:           m.Metadata,
+		ContentEncoding:    m.ContentEncoding,
+		ContentType:        e.ContentType,
+		ContentLanguage:    e.ContentLanguage,
+		CacheControl:       e.CacheControl,
+		Owner:              e.Owner,
+		MD5:                e.MD5,
+		CRC32C:             e.CRC32C,
+		MediaLink:          e.MediaLink,
+		StorageClass:       e.StorageClass,
+		Deleted:            e.Deleted,
+		ComponentCount:     e.ComponentCount,
+		ContentDisposition: e.ContentDisposition,
+		CustomTime:         e.CustomTime,
+		EventBasedHold:     e.EventBasedHold,
+		Acl:                e.Acl,
+	}
+}
+
+func ConvertMinObjectToObject(m *gcs.MinObject) *gcs.Object {
+	if m == nil {
+		return nil
+	}
+
+	return &gcs.Object{
 		Name:            m.Name,
 		Size:            m.Size,
 		Generation:      m.Generation,
@@ -191,23 +219,4 @@ func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
 		Metadata:        m.Metadata,
 		ContentEncoding: m.ContentEncoding,
 	}
-
-	if e != nil {
-		o.ContentType = e.ContentType
-		o.ContentLanguage = e.ContentLanguage
-		o.CacheControl = e.CacheControl
-		o.Owner = e.Owner
-		o.MD5 = e.MD5
-		o.CRC32C = e.CRC32C
-		o.MediaLink = e.MediaLink
-		o.StorageClass = e.StorageClass
-		o.Deleted = e.Deleted
-		o.ComponentCount = e.ComponentCount
-		o.ContentDisposition = e.ContentDisposition
-		o.CustomTime = e.CustomTime
-		o.EventBasedHold = e.EventBasedHold
-		o.Acl = e.Acl
-	}
-
-	return &o
 }

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -150,7 +150,7 @@ func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 	}
 }
 
-func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes {
+func ConvertObjToExtendedObjectAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes {
 	if o == nil {
 		return nil
 	}
@@ -173,7 +173,7 @@ func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes
 	}
 }
 
-func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
+func ConvertMinObjectAndExtendedObjectAttributesToObject(m *gcs.MinObject,
 	e *gcs.ExtendedObjectAttributes) *gcs.Object {
 	if m == nil || e == nil {
 		return nil

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -152,8 +152,9 @@ func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 }
 
 func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes {
+	var extObjAttr gcs.ExtendedObjectAttributes
 	if o == nil {
-		return nil
+		return &extObjAttr
 	}
 
 	return &gcs.ExtendedObjectAttributes{
@@ -176,8 +177,9 @@ func ConvertObjToExtendedAttributes(o *gcs.Object) *gcs.ExtendedObjectAttributes
 
 func ConvertMinObjectAndExtendedAttributesToObject(m *gcs.MinObject,
 	e *gcs.ExtendedObjectAttributes) *gcs.Object {
+	var object gcs.Object
 	if m == nil {
-		return nil
+		return &object
 	}
 
 	o := gcs.Object{

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -222,7 +222,7 @@ func (t objectAttrsTest) TestSetAttrsInWriterMethod() {
 func (t objectAttrsTest) Test_ConvertObjToMinObject_WithNilObject() {
 	var gcsObject *gcs.Object
 
-	gcsMinObject := ConvertObjToMinObject(gcsObject)
+	gcsMinObject := *ConvertObjToMinObject(gcsObject)
 
 	ExpectTrue(reflect.DeepEqual(gcs.MinObject{}, gcsMinObject))
 }

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -259,9 +259,9 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilObject() {
 	var gcsObject *gcs.Object
 
-	extendedObjAttr := *ConvertObjToExtendedAttributes(gcsObject)
+	extendedObjAttr := ConvertObjToExtendedAttributes(gcsObject)
 
-	ExpectTrue(reflect.DeepEqual(gcs.ExtendedObjectAttributes{}, extendedObjAttr))
+	ExpectEq(nil, extendedObjAttr)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObject() {
@@ -307,9 +307,9 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAnd
 	var minObject *gcs.MinObject
 	var extendedObjectAttr *gcs.ExtendedObjectAttributes
 
-	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
 
-	ExpectTrue(reflect.DeepEqual(gcs.Object{}, object))
+	ExpectEq(nil, object)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAndNonNilAttributes() {
@@ -318,9 +318,9 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAnd
 		ContentType: "ContentType",
 	}
 
-	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
 
-	ExpectTrue(reflect.DeepEqual(gcs.Object{}, object))
+	ExpectEq(nil, object)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNilAttributes() {
@@ -330,9 +330,9 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObject
 	}
 	var extendedObjectAttr *gcs.ExtendedObjectAttributes
 
-	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
 
-	ExpectTrue(reflect.DeepEqual(gcs.Object{Name: name}, object))
+	ExpectEq(nil, object)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNonNilAttributes() {
@@ -388,4 +388,52 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObject
 	ExpectEq(gcsObject.CustomTime, extendedObjAttr.CustomTime)
 	ExpectEq(gcsObject.EventBasedHold, extendedObjAttr.EventBasedHold)
 	ExpectEq(gcsObject.Acl, extendedObjAttr.Acl)
+}
+
+func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNilMinObject() {
+	var minObject *gcs.MinObject
+
+	object := ConvertMinObjectToObject(minObject)
+
+	ExpectEq(nil, object)
+}
+
+func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNonNilMinObject() {
+	var attrMd5 *[16]byte
+	var crc32C *uint32 = nil
+
+	timeAttr := time.Now()
+	minObject := &gcs.MinObject{
+		Name:            "test",
+		Size:            uint64(36),
+		Generation:      int64(444),
+		MetaGeneration:  int64(555),
+		Updated:         timeAttr,
+		Metadata:        map[string]string{"test_key": "test_value"},
+		ContentEncoding: "test_encoding",
+	}
+
+	gcsObject := *ConvertMinObjectToObject(minObject)
+
+	ExpectEq(gcsObject.Name, minObject.Name)
+	ExpectEq(gcsObject.Size, minObject.Size)
+	ExpectEq(gcsObject.Generation, minObject.Generation)
+	ExpectEq(gcsObject.MetaGeneration, minObject.MetaGeneration)
+	ExpectEq(0, gcsObject.Updated.Compare(minObject.Updated))
+	ExpectEq(gcsObject.Metadata, minObject.Metadata)
+	ExpectEq(gcsObject.ContentEncoding, minObject.ContentEncoding)
+	ExpectEq(gcsObject.ContentType, "")
+	ExpectEq(gcsObject.ContentLanguage, "")
+	ExpectEq(gcsObject.CacheControl, "")
+	ExpectEq(gcsObject.Owner, "")
+	ExpectEq(gcsObject.MD5, attrMd5)
+	ExpectEq(gcsObject.CRC32C, crc32C)
+	ExpectEq(gcsObject.MediaLink, "")
+	ExpectEq(gcsObject.StorageClass, "")
+	ExpectEq(0, gcsObject.Deleted.Compare(time.Time{}))
+	ExpectEq(gcsObject.ComponentCount, 0)
+	ExpectEq(gcsObject.ContentDisposition, "")
+	ExpectEq(gcsObject.CustomTime, "")
+	ExpectEq(gcsObject.EventBasedHold, false)
+	ExpectEq(gcsObject.Acl, []*storagev1.ObjectAccessControl(nil))
 }

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -222,7 +222,7 @@ func (t objectAttrsTest) TestSetAttrsInWriterMethod() {
 func (t objectAttrsTest) Test_ConvertObjToMinObject_WithNilObject() {
 	var gcsObject *gcs.Object
 
-	gcsMinObject := *ConvertObjToMinObject(gcsObject)
+	gcsMinObject := ConvertObjToMinObject(gcsObject)
 
 	ExpectTrue(reflect.DeepEqual(gcs.MinObject{}, gcsMinObject))
 }
@@ -365,7 +365,7 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObject
 		Acl:                nil,
 	}
 
-	gcsObject := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjAttr)
+	gcsObject := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjAttr)
 
 	ExpectEq(gcsObject.Name, minObject.Name)
 	ExpectEq(gcsObject.Size, minObject.Size)
@@ -413,7 +413,7 @@ func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNonNilMinObject() {
 		ContentEncoding: "test_encoding",
 	}
 
-	gcsObject := *ConvertMinObjectToObject(minObject)
+	gcsObject := ConvertMinObjectToObject(minObject)
 
 	ExpectEq(gcsObject.Name, minObject.Name)
 	ExpectEq(gcsObject.Size, minObject.Size)

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -259,7 +259,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilObject() {
 	var gcsObject *gcs.Object
 
-	extendedObjAttr := ConvertObjToExtendedAttributes(gcsObject)
+	extendedObjAttr := ConvertObjToExtendedObjectAttributes(gcsObject)
 
 	ExpectEq(nil, extendedObjAttr)
 }
@@ -285,7 +285,7 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObje
 		Acl:                nil,
 	}
 
-	extendedObjAttr := ConvertObjToExtendedAttributes(&gcsObject)
+	extendedObjAttr := ConvertObjToExtendedObjectAttributes(&gcsObject)
 
 	AssertNe(nil, extendedObjAttr)
 	ExpectEq(gcsObject.ContentType, extendedObjAttr.ContentType)
@@ -304,39 +304,39 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObje
 	ExpectEq(gcsObject.Acl, extendedObjAttr.Acl)
 }
 
-func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAndNilAttributes() {
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilMinObjectAndNilAttributes() {
 	var minObject *gcs.MinObject
 	var extendedObjectAttr *gcs.ExtendedObjectAttributes
 
-	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedObjectAttributesToObject(minObject, extendedObjectAttr)
 
 	ExpectEq(nil, object)
 }
 
-func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAndNonNilAttributes() {
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilMinObjectAndNonNilAttributes() {
 	var minObject *gcs.MinObject
 	extendedObjectAttr := &gcs.ExtendedObjectAttributes{
 		ContentType: "ContentType",
 	}
 
-	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedObjectAttributesToObject(minObject, extendedObjectAttr)
 
 	ExpectEq(nil, object)
 }
 
-func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNilAttributes() {
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMinObjectAndNilAttributes() {
 	name := "test"
 	minObject := &gcs.MinObject{
 		Name: name,
 	}
 	var extendedObjectAttr *gcs.ExtendedObjectAttributes
 
-	object := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+	object := ConvertMinObjectAndExtendedObjectAttributesToObject(minObject, extendedObjectAttr)
 
 	ExpectEq(nil, object)
 }
 
-func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNonNilAttributes() {
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMinObjectAndNonNilAttributes() {
 	var attrMd5 *[16]byte
 	var crc32C uint32 = 0
 	timeAttr := time.Now()
@@ -366,7 +366,7 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObject
 		Acl:                nil,
 	}
 
-	gcsObject := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjAttr)
+	gcsObject := ConvertMinObjectAndExtendedObjectAttributesToObject(minObject, extendedObjAttr)
 
 	AssertNe(nil, gcsObject)
 	ExpectEq(gcsObject.Name, minObject.Name)

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -255,3 +255,137 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 	ExpectEq(contentEncode, gcsMinObject.ContentEncoding)
 	ExpectEq(metadata, gcsMinObject.Metadata)
 }
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilObject() {
+	var gcsObject *gcs.Object
+
+	extendedObjAttr := *ConvertObjToExtendedAttributes(gcsObject)
+
+	ExpectTrue(reflect.DeepEqual(gcs.ExtendedObjectAttributes{}, extendedObjAttr))
+}
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObject() {
+	var attrMd5 *[16]byte
+	var crc32C uint32 = 0
+	timeAttr := time.Now()
+	gcsObject := gcs.Object{
+		ContentType:        "ContentType",
+		ContentLanguage:    "ContentLanguage",
+		CacheControl:       "CacheControl",
+		Owner:              "Owner",
+		MD5:                attrMd5,
+		CRC32C:             &crc32C,
+		MediaLink:          "MediaLink",
+		StorageClass:       "StorageClass",
+		Deleted:            timeAttr,
+		ComponentCount:     7,
+		ContentDisposition: "ContentDisposition",
+		CustomTime:         timeAttr.String(),
+		EventBasedHold:     true,
+		Acl:                nil,
+	}
+
+	extendedObjAttr := *ConvertObjToExtendedAttributes(&gcsObject)
+
+	ExpectEq(gcsObject.ContentType, extendedObjAttr.ContentType)
+	ExpectEq(gcsObject.ContentLanguage, extendedObjAttr.ContentLanguage)
+	ExpectEq(gcsObject.CacheControl, extendedObjAttr.CacheControl)
+	ExpectEq(gcsObject.Owner, extendedObjAttr.Owner)
+	ExpectEq(gcsObject.MD5, extendedObjAttr.MD5)
+	ExpectEq(gcsObject.CRC32C, extendedObjAttr.CRC32C)
+	ExpectEq(gcsObject.MediaLink, extendedObjAttr.MediaLink)
+	ExpectEq(gcsObject.StorageClass, extendedObjAttr.StorageClass)
+	ExpectEq(0, gcsObject.Deleted.Compare(extendedObjAttr.Deleted))
+	ExpectEq(gcsObject.ComponentCount, extendedObjAttr.ComponentCount)
+	ExpectEq(gcsObject.ContentDisposition, extendedObjAttr.ContentDisposition)
+	ExpectEq(gcsObject.CustomTime, extendedObjAttr.CustomTime)
+	ExpectEq(gcsObject.EventBasedHold, extendedObjAttr.EventBasedHold)
+	ExpectEq(gcsObject.Acl, extendedObjAttr.Acl)
+}
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAndNilAttributes() {
+	var minObject *gcs.MinObject
+	var extendedObjectAttr *gcs.ExtendedObjectAttributes
+
+	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+
+	ExpectTrue(reflect.DeepEqual(gcs.Object{}, object))
+}
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNilMinObjectAndNonNilAttributes() {
+	var minObject *gcs.MinObject
+	extendedObjectAttr := &gcs.ExtendedObjectAttributes{
+		ContentType: "ContentType",
+	}
+
+	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+
+	ExpectTrue(reflect.DeepEqual(gcs.Object{}, object))
+}
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNilAttributes() {
+	name := "test"
+	minObject := &gcs.MinObject{
+		Name: name,
+	}
+	var extendedObjectAttr *gcs.ExtendedObjectAttributes
+
+	object := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjectAttr)
+
+	ExpectTrue(reflect.DeepEqual(gcs.Object{Name: name}, object))
+}
+
+func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObjectAndNonNilAttributes() {
+	var attrMd5 *[16]byte
+	var crc32C uint32 = 0
+	timeAttr := time.Now()
+	minObject := &gcs.MinObject{
+		Name:            "test",
+		Size:            uint64(36),
+		Generation:      int64(444),
+		MetaGeneration:  int64(555),
+		Updated:         timeAttr,
+		Metadata:        map[string]string{"test_key": "test_value"},
+		ContentEncoding: "test_encoding",
+	}
+	extendedObjAttr := &gcs.ExtendedObjectAttributes{
+		ContentType:        "ContentType",
+		ContentLanguage:    "ContentLanguage",
+		CacheControl:       "CacheControl",
+		Owner:              "Owner",
+		MD5:                attrMd5,
+		CRC32C:             &crc32C,
+		MediaLink:          "MediaLink",
+		StorageClass:       "StorageClass",
+		Deleted:            timeAttr,
+		ComponentCount:     7,
+		ContentDisposition: "ContentDisposition",
+		CustomTime:         timeAttr.String(),
+		EventBasedHold:     true,
+		Acl:                nil,
+	}
+
+	gcsObject := *ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjAttr)
+
+	ExpectEq(gcsObject.Name, minObject.Name)
+	ExpectEq(gcsObject.Size, minObject.Size)
+	ExpectEq(gcsObject.Generation, minObject.Generation)
+	ExpectEq(gcsObject.MetaGeneration, minObject.MetaGeneration)
+	ExpectEq(0, gcsObject.Updated.Compare(minObject.Updated))
+	ExpectEq(gcsObject.Metadata, minObject.Metadata)
+	ExpectEq(gcsObject.ContentEncoding, minObject.ContentEncoding)
+	ExpectEq(gcsObject.ContentType, extendedObjAttr.ContentType)
+	ExpectEq(gcsObject.ContentLanguage, extendedObjAttr.ContentLanguage)
+	ExpectEq(gcsObject.CacheControl, extendedObjAttr.CacheControl)
+	ExpectEq(gcsObject.Owner, extendedObjAttr.Owner)
+	ExpectEq(gcsObject.MD5, extendedObjAttr.MD5)
+	ExpectEq(gcsObject.CRC32C, extendedObjAttr.CRC32C)
+	ExpectEq(gcsObject.MediaLink, extendedObjAttr.MediaLink)
+	ExpectEq(gcsObject.StorageClass, extendedObjAttr.StorageClass)
+	ExpectEq(0, gcsObject.Deleted.Compare(extendedObjAttr.Deleted))
+	ExpectEq(gcsObject.ComponentCount, extendedObjAttr.ComponentCount)
+	ExpectEq(gcsObject.ContentDisposition, extendedObjAttr.ContentDisposition)
+	ExpectEq(gcsObject.CustomTime, extendedObjAttr.CustomTime)
+	ExpectEq(gcsObject.EventBasedHold, extendedObjAttr.EventBasedHold)
+	ExpectEq(gcsObject.Acl, extendedObjAttr.Acl)
+}

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -16,7 +16,6 @@ package storageutil
 
 import (
 	"crypto/md5"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -224,7 +223,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithNilObject() {
 
 	gcsMinObject := ConvertObjToMinObject(gcsObject)
 
-	ExpectTrue(reflect.DeepEqual(gcs.MinObject{}, gcsMinObject))
+	ExpectEq(nil, gcsMinObject)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
@@ -247,6 +246,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 
 	gcsMinObject := ConvertObjToMinObject(&gcsObject)
 
+	AssertNe(nil, gcsMinObject)
 	ExpectEq(name, gcsMinObject.Name)
 	ExpectEq(size, gcsMinObject.Size)
 	ExpectEq(generation, gcsMinObject.Generation)
@@ -285,8 +285,9 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObje
 		Acl:                nil,
 	}
 
-	extendedObjAttr := *ConvertObjToExtendedAttributes(&gcsObject)
+	extendedObjAttr := ConvertObjToExtendedAttributes(&gcsObject)
 
+	AssertNe(nil, extendedObjAttr)
 	ExpectEq(gcsObject.ContentType, extendedObjAttr.ContentType)
 	ExpectEq(gcsObject.ContentLanguage, extendedObjAttr.ContentLanguage)
 	ExpectEq(gcsObject.CacheControl, extendedObjAttr.CacheControl)
@@ -367,6 +368,7 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedAttributes_WithNonNilMinObject
 
 	gcsObject := ConvertMinObjectAndExtendedAttributesToObject(minObject, extendedObjAttr)
 
+	AssertNe(nil, gcsObject)
 	ExpectEq(gcsObject.Name, minObject.Name)
 	ExpectEq(gcsObject.Size, minObject.Size)
 	ExpectEq(gcsObject.Generation, minObject.Generation)
@@ -414,6 +416,7 @@ func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNonNilMinObject() {
 
 	gcsObject := ConvertMinObjectToObject(minObject)
 
+	AssertNe(nil, gcsObject)
 	ExpectEq(gcsObject.Name, minObject.Name)
 	ExpectEq(gcsObject.Size, minObject.Size)
 	ExpectEq(gcsObject.Generation, minObject.Generation)

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -401,7 +401,6 @@ func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNilMinObject() {
 func (t objectAttrsTest) Test_ConvertMinObjectToObject_WithNonNilMinObject() {
 	var attrMd5 *[16]byte
 	var crc32C *uint32 = nil
-
 	timeAttr := time.Now()
 	minObject := &gcs.MinObject{
 		Name:            "test",


### PR DESCRIPTION
### Description
1. This PR adds struct for ExtendedObjectAttributes which contains the missing attributes of Object which are not present in MinObject.
2. This PR also adds following converters to storageutil package:
     1. ConvertObjToExtendedAttributes
     2. ConvertMinObjectAndExtendedAttributesToObject

### Link to the issue in case of a bug fix.
Internal bug b/325024088

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
