### PR TITLE
Make ashmeen co-owner of integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
+tools/integration_tests/ @ashmeenkaur
 # These owners will be the default owners for everything in
 # the repo.
 *           @sethiay @vadlakondaswetha @raj-prince
-tools/integration_tests/ @ashmeenkaur
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
+# Co-owners of tools/integration_tests/ directory.
 tools/integration_tests/ @ashmeenkaur
+
 # These owners will be the default owners for everything in
 # the repo.
 *           @sethiay @vadlakondaswetha @raj-prince


### PR DESCRIPTION
### Description
Ashmeen should be co-owner of integration tests (and not the sole-owner).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
