### PR TITLE
Download file using storage client

### DIFF
--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -15,13 +15,14 @@
 package client
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 )
 
 const (

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -15,14 +15,13 @@
 package client
 
 import (
+	"cloud.google.com/go/storage"
 	"context"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"os"
 	"path"
 	"strings"
 	"testing"
-
-	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 )
 
 const (

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -121,13 +121,13 @@ func createStorageClient(ctx *context.Context, storageClient **storage.Client, t
 }
 
 // Downloads an object to a file.
-func DownloadFileWithStorageClient(gcsFile string, destFileName string,t *testing.T) error {
+func DownloadFileWithStorageClient(gcsFile string, destFileName string, t *testing.T) error {
 	var bucket string
 	setBucketAndObjectBasedOnTypeOfMount(&bucket, &gcsFile)
 
-	ctx:=context.Background()
-	var  storageClient *storage.Client
-	closeStorageClient := createStorageClient(&ctx, &storageClient,t)
+	ctx := context.Background()
+	var storageClient *storage.Client
+	closeStorageClient := createStorageClient(&ctx, &storageClient, t)
 	defer closeStorageClient()
 
 	f, err := os.Create(destFileName)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -135,7 +135,11 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 	if err != nil {
 		return err
 	}
-	defer closeStorageClient()
+	defer func() {
+		if err := closeStorageClient(); err != nil {
+			t.Errorf("Error in closing client (deferred): %v", err)
+		}
+	}()
 
 	f := operations.CreateFile(destFileName, setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -102,7 +102,7 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 	return nil
 }
 
-func createStorageClient(ctx *context.Context, storageClient **storage.Client, t *testing.T) func() {
+func CreateStorageClientWithTimeOut(ctx *context.Context, storageClient **storage.Client, t *testing.T) func() {
 	var err error
 	var cancel context.CancelFunc
 	*ctx, cancel = context.WithTimeout(*ctx, time.Minute*15)
@@ -127,7 +127,7 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 
 	ctx := context.Background()
 	var storageClient *storage.Client
-	closeStorageClient := createStorageClient(&ctx, &storageClient, t)
+	closeStorageClient := CreateStorageClientWithTimeOut(&ctx, &storageClient, t)
 	defer closeStorageClient()
 
 	f, err := os.Create(destFileName)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -132,10 +131,7 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 	closeStorageClient := CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*5, t)
 	defer closeStorageClient()
 
-	f, err := os.Create(destFileName)
-	if err != nil {
-		return fmt.Errorf("os.Create: %w", err)
-	}
+	f := operations.CreateFile(destFileName, setup.FilePermission_0600, t)
 
 	rc, err := storageClient.Bucket(bucket).Object(gcsFile).NewReader(ctx)
 	if err != nil {

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -132,6 +132,7 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 	defer closeStorageClient()
 
 	f := operations.CreateFile(destFileName, setup.FilePermission_0600, t)
+	defer operations.CloseFile(f)
 
 	rc, err := storageClient.Bucket(bucket).Object(gcsFile).NewReader(ctx)
 	if err != nil {
@@ -142,8 +143,6 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 	if _, err := io.Copy(f, rc); err != nil {
 		return fmt.Errorf("io.Copy: %w", err)
 	}
-
-	operations.CloseFile(f)
 
 	return nil
 }

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -112,7 +112,7 @@ func CreateStorageClientWithTimeOut(ctx *context.Context, storageClient **storag
 	if err != nil {
 		log.Fatalf("client.CreateStorageClient: %v", err)
 	}
-	// return func to close storage client and release resources.
+	// Return func to close storage client and release resources.
 	return func() {
 		err := (*storageClient).Close()
 		if err != nil {

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -102,7 +102,6 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 	return nil
 }
 
-
 func createStorageClient(ctx *context.Context, storageClient **storage.Client, t *testing.T) func() {
 	var err error
 	var cancel context.CancelFunc

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -121,7 +121,7 @@ func createStorageClient(ctx *context.Context, storageClient **storage.Client, t
 }
 
 // Downloads an object to a file.
-func DownloadFileWithStorageClient(gcsFile string, destFileName string, t *testing.T) error {
+func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) error {
 	var bucket string
 	setBucketAndObjectBasedOnTypeOfMount(&bucket, &gcsFile)
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -103,7 +103,7 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 	return nil
 }
 
-// Create storage client with a configurable timeout and return a function to cancel the storage client
+// CreateStorageClientWithTimeOut creates storage client with a configurable timeout and return a function to cancel the storage client
 func CreateStorageClientWithTimeOut(ctx *context.Context, storageClient **storage.Client, time time.Duration, t *testing.T) func() {
 	var err error
 	var cancel context.CancelFunc
@@ -122,7 +122,7 @@ func CreateStorageClientWithTimeOut(ctx *context.Context, storageClient **storag
 	}
 }
 
-// Downloads an object to a file.
+// DownloadObjectFromGCS downloads an object to a local file.
 func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) error {
 	var bucket string
 	setBucketAndObjectBasedOnTypeOfMount(&bucket, &gcsFile)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -114,7 +114,6 @@ func CreateStorageClientWithTimeOut(ctx *context.Context, storageClient **storag
 	}
 
 	// return func to close storage client and release resources.
-	// Return a closure to close the client and cancel the context
 	return func() error {
 		err := (*storageClient).Close()
 		defer cancel()

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -17,7 +17,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"io"
 	"log"
 	"os"
@@ -25,6 +24,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"

--- a/tools/integration_tests/write_large_files/concurrent_write_files_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_files_test.go
@@ -48,7 +48,7 @@ func writeFile(fileName string, fileSize int64, t *testing.T) error {
 		return fmt.Errorf("Error: %v", err)
 	}
 
-	filePathInGcsBucket := path.Join(setup.TestBucket(), DirForConcurrentWrite, fileName)
+	filePathInGcsBucket := path.Join(DirForConcurrentWrite, fileName)
 	localFilePath := path.Join(TmpDir, fileName)
 	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
 	if err != nil {

--- a/tools/integration_tests/write_large_files/concurrent_write_files_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_files_test.go
@@ -33,7 +33,7 @@ const (
 	DirForConcurrentWrite = "dirForConcurrentWrite"
 )
 
-func writeFile(fileName string, fileSize int64) error {
+func writeFile(fileName string, fileSize int64, t *testing.T) error {
 	filePath := path.Join(setup.MntDir(), DirForConcurrentWrite, fileName)
 	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|syscall.O_DIRECT, WritePermission_0200)
 	if err != nil {
@@ -50,7 +50,7 @@ func writeFile(fileName string, fileSize int64) error {
 
 	filePathInGcsBucket := path.Join(setup.TestBucket(), DirForConcurrentWrite, fileName)
 	localFilePath := path.Join(TmpDir, fileName)
-	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath)
+	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
 	if err != nil {
 		return fmt.Errorf("Error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestMultipleFilesAtSameTime(t *testing.T) {
 
 		// Thread to write the current file.
 		eG.Go(func() error {
-			return writeFile(files[fileIndex], FiveHundredMB)
+			return writeFile(files[fileIndex], FiveHundredMB,t)
 		})
 	}
 

--- a/tools/integration_tests/write_large_files/concurrent_write_files_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_files_test.go
@@ -50,7 +50,7 @@ func writeFile(fileName string, fileSize int64, t *testing.T) error {
 
 	filePathInGcsBucket := path.Join(DirForConcurrentWrite, fileName)
 	localFilePath := path.Join(TmpDir, fileName)
-	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
+	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath, t)
 	if err != nil {
 		return fmt.Errorf("Error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestMultipleFilesAtSameTime(t *testing.T) {
 
 		// Thread to write the current file.
 		eG.Go(func() error {
-			return writeFile(files[fileIndex], FiveHundredMB,t)
+			return writeFile(files[fileIndex], FiveHundredMB, t)
 		})
 	}
 

--- a/tools/integration_tests/write_large_files/random_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/random_write_large_file_test.go
@@ -66,7 +66,7 @@ func TestWriteLargeFileRandomly(t *testing.T) {
 
 		filePathInGcsBucket := path.Join(setup.TestBucket(), DirForRandomWrite, FiveHundredMBFile)
 		localFilePath := path.Join(TmpDir, FiveHundredMBFileForRandomWriteInLocalSystem)
-		err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath)
+		err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/tools/integration_tests/write_large_files/random_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/random_write_large_file_test.go
@@ -64,7 +64,7 @@ func TestWriteLargeFileRandomly(t *testing.T) {
 			t.Fatalf("Error: %v", err)
 		}
 
-		filePathInGcsBucket := path.Join(setup.TestBucket(), DirForRandomWrite, FiveHundredMBFile)
+		filePathInGcsBucket := path.Join(DirForRandomWrite, FiveHundredMBFile)
 		localFilePath := path.Join(TmpDir, FiveHundredMBFileForRandomWriteInLocalSystem)
 		err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
 		if err != nil {

--- a/tools/integration_tests/write_large_files/random_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/random_write_large_file_test.go
@@ -66,7 +66,7 @@ func TestWriteLargeFileRandomly(t *testing.T) {
 
 		filePathInGcsBucket := path.Join(DirForRandomWrite, FiveHundredMBFile)
 		localFilePath := path.Join(TmpDir, FiveHundredMBFileForRandomWriteInLocalSystem)
-		err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath,t)
+		err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath, t)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/tools/integration_tests/write_large_files/seq_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/seq_write_large_file_test.go
@@ -52,7 +52,7 @@ func TestWriteLargeFileSequentially(t *testing.T) {
 	// the file content we wrote in mntDir.
 	filePathInGcsBucket := path.Join(setup.TestBucket(), DirForSeqWrite, FiveHundredMBFile)
 	localFilePath := path.Join(TmpDir, FiveHundredMBFileForSeqWriteInLocalSystem)
-	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath)
+	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath, t)
 	if err != nil {
 		t.Fatalf("Error:%v", err)
 	}

--- a/tools/integration_tests/write_large_files/seq_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/seq_write_large_file_test.go
@@ -50,7 +50,7 @@ func TestWriteLargeFileSequentially(t *testing.T) {
 
 	// Download the file from a bucket in which we write the content and compare with
 	// the file content we wrote in mntDir.
-	filePathInGcsBucket := path.Join(setup.TestBucket(), DirForSeqWrite, FiveHundredMBFile)
+	filePathInGcsBucket := path.Join(DirForSeqWrite, FiveHundredMBFile)
 	localFilePath := path.Join(TmpDir, FiveHundredMBFileForSeqWriteInLocalSystem)
 	err = compareFileFromGCSBucketAndMntDir(filePathInGcsBucket, filePath, localFilePath, t)
 	if err != nil {

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -17,10 +17,11 @@ package write_large_files
 
 import (
 	"fmt"
-	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
 
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownloadGcsFile string, t *testing.T) error {
-	err := client.DownloadFileWithStorageClient(gcsFile,localFilePathToDownloadGcsFile,t)
+	err := client.DownloadFileWithStorageClient(gcsFile, localFilePathToDownloadGcsFile, t)
 	if err != nil {
 		return fmt.Errorf("Error in downloading object: %v", err)
 	}

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -17,6 +17,7 @@ package write_large_files
 
 import (
 	"fmt"
+	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/client"
 	"log"
 	"os"
 	"testing"
@@ -32,8 +33,8 @@ const (
 	WritePermission_0200 = 0200
 )
 
-func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownloadGcsFile string) error {
-	err := operations.DownloadGcsObject(gcsFile, localFilePathToDownloadGcsFile)
+func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownloadGcsFile string, t *testing.T) error {
+	err := client.DownloadFileWithStorageClient(gcsFile,localFilePathToDownloadGcsFile,t)
 	if err != nil {
 		return fmt.Errorf("Error in downloading object: %v", err)
 	}

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownloadGcsFile string, t *testing.T) error {
-	err := client.DownloadFileWithStorageClient(gcsFile, localFilePathToDownloadGcsFile, t)
+	err := client.DownloadObjectFromGCS(gcsFile, localFilePathToDownloadGcsFile, t)
 	if err != nil {
 		return fmt.Errorf("Error in downloading object: %v", err)
 	}


### PR DESCRIPTION
### Description
We were using `gsutil` or `gcloud` command to download file from gcs which is suddenly breaking with crcmod issue on arm64 machines. Changing that approach to download with storageclient instead of `gsutil` or `gcloud`.

CreateStorageClientWithTimeOut function is getting used in read_cache functional tests, we will remove [this](https://github.com/GoogleCloudPlatform/gcsfuse/blob/read_cache_release/tools/integration_tests/read_cache/helpers_test.go#L181) function whenever we will back merge.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually on VM
2. Unit tests - NA
3. Integration tests - louhi and kokoro
