### PR TITLE
Enable or disable file cache via cache-dir

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -412,15 +412,23 @@ type flagStorage struct {
 	DebugMutex      bool
 }
 
-// This method resolves path in the context dictionary.
-func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) {
-	flagValue := c.String(flagKey)
-	resolvedPath, err := util.GetResolvedPath(flagValue)
-	if err != nil {
+func resolveFilePath(filePath string, configKey string) (resolvedPath string, err error) {
+	resolvedPath, err = util.GetResolvedPath(filePath)
+	if filePath == resolvedPath || err != nil {
 		return
 	}
 
-	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n", flagKey, flagValue, resolvedPath)
+	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n", configKey, filePath, resolvedPath)
+	return resolvedPath, nil
+}
+
+// This method resolves path in the context dictionary.
+func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) {
+	flagValue := c.String(flagKey)
+	resolvedPath, err := resolveFilePath(flagValue, flagKey)
+	if err != nil {
+		return
+	}
 
 	err = c.Set(flagKey, resolvedPath)
 	return
@@ -451,21 +459,17 @@ func resolvePathForTheFlagsInContext(c *cli.Context) (err error) {
 
 // resolveConfigFilePaths resolves the config file paths specified in the config file.
 func resolveConfigFilePaths(mountConfig *config.MountConfig) (err error) {
-	filePath := mountConfig.LogConfig.FilePath
-	mountConfig.LogConfig.FilePath, err = util.GetResolvedPath(filePath)
+	mountConfig.LogConfig.FilePath, err = resolveFilePath(mountConfig.LogConfig.FilePath, "logging: file")
 	if err != nil {
 		return
 	}
-	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n", "logging: file", filePath, mountConfig.LogConfig.FilePath)
 
 	// Resolve cache-dir path
-	filePath = string(mountConfig.CacheDir)
-	resolvedPath, err := util.GetResolvedPath(filePath)
+	resolvedPath, err := resolveFilePath(string(mountConfig.CacheDir), "cache-dir")
 	mountConfig.CacheDir = config.CacheDir(resolvedPath)
 	if err != nil {
 		return
 	}
-	logger.Infof("Value of [%s] resolved from [%s] to [%s]\n", "cache-dir", filePath, mountConfig.CacheDir)
 
 	return
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/internal/mount"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/internal/mount"
 	. "github.com/jacobsa/oglematchers"
@@ -359,4 +360,30 @@ func (t *FlagsTest) TestValidateFlagsForValidSequentialReadSizeAndHTTP2ClientPro
 	err := validateFlags(flags)
 
 	AssertEq(nil, err)
+}
+
+func (t *FlagsTest) Test_resolveConfigFilePaths() {
+	mountConfig := &config.MountConfig{}
+	mountConfig.LogConfig = config.LogConfig{
+		FilePath: "~/test.txt",
+	}
+	mountConfig.CacheDir = "~/cache-dir"
+
+	err := resolveConfigFilePaths(mountConfig)
+
+	AssertEq(nil, err)
+	homeDir, err := os.UserHomeDir()
+	AssertEq(nil, err)
+	ExpectEq(filepath.Join(homeDir, "test.txt"), mountConfig.LogConfig.FilePath)
+	ExpectEq(filepath.Join(homeDir, "cache-dir"), mountConfig.CacheDir)
+}
+
+func (t *FlagsTest) Test_resolveConfigFilePaths_WithoutSettingPaths() {
+	mountConfig := &config.MountConfig{}
+
+	err := resolveConfigFilePaths(mountConfig)
+
+	AssertEq(nil, err)
+	ExpectEq("", mountConfig.LogConfig.FilePath)
+	ExpectEq("", mountConfig.CacheDir)
 }

--- a/internal/config/config_util.go
+++ b/internal/config/config_util.go
@@ -14,10 +14,6 @@
 
 package config
 
-import (
-	"github.com/googlecloudplatform/gcsfuse/internal/util"
-)
-
 // OverrideWithLoggingFlags overwrites the configs with the flag values if the
 // config values are empty.
 func OverrideWithLoggingFlags(mountConfig *MountConfig, logFile string, logFormat string,
@@ -35,14 +31,4 @@ func OverrideWithLoggingFlags(mountConfig *MountConfig, logFile string, logForma
 	if debugFuse || debugGCS || debugMutex {
 		mountConfig.LogConfig.Severity = TRACE
 	}
-}
-
-// ResolveConfigFilePaths resolves the config file paths specified in the config file.
-func ResolveConfigFilePaths(config *MountConfig) (err error) {
-	config.LogConfig.FilePath, err = util.ResolveFilePath(config.LogConfig.FilePath, "logging: file")
-	if err != nil {
-		return
-	}
-
-	return
 }

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -15,8 +15,6 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	. "github.com/jacobsa/ogletest"
@@ -89,18 +87,4 @@ func (t *ConfigTest) TestOverrideLoggingFlags_WithEmptyLogConfigs() {
 	AssertEq(mountConfig.LogConfig.Format, "json")
 	AssertEq(mountConfig.LogConfig.FilePath, "a.txt")
 	AssertEq(mountConfig.LogConfig.Severity, INFO)
-}
-
-func (t *ConfigTest) TestResolveConfigFilePaths() {
-	mountConfig := &MountConfig{}
-	mountConfig.LogConfig = LogConfig{
-		FilePath: "~/test.txt",
-	}
-
-	err := ResolveConfigFilePaths(mountConfig)
-
-	AssertEq(nil, err)
-	homeDir, err := os.UserHomeDir()
-	AssertEq(nil, err)
-	ExpectEq(filepath.Join(homeDir, "test.txt"), mountConfig.LogConfig.FilePath)
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -50,6 +50,8 @@ const (
 	// is fixed 80 bytes + length of entry-key string
 	// (which is assumed to be 20 for common cases).
 	AverageTypeCacheEntrySize int = 200
+
+	DefaultFileCacheMaxSizeMB int64 = -1
 )
 
 type WriteConfig struct {
@@ -130,7 +132,7 @@ func NewMountConfig() *MountConfig {
 		LogRotateConfig: DefaultLogRotateConfig(),
 	}
 	mountConfig.FileCacheConfig = FileCacheConfig{
-		MaxSizeMB: 0,
+		MaxSizeMB: DefaultFileCacheMaxSizeMB,
 	}
 	mountConfig.MetadataCacheConfig = MetadataCacheConfig{
 		TtlInSeconds:       TtlInSecsUnsetSentinel,

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -40,7 +40,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	ExpectEq(10, mountConfig.LogConfig.LogRotateConfig.BackupFileCount)
 	ExpectEq(true, mountConfig.LogConfig.LogRotateConfig.Compress)
 	ExpectEq("", mountConfig.CacheDir)
-	ExpectEq(0, mountConfig.FileCacheConfig.MaxSizeMB)
+	ExpectEq(-1, mountConfig.FileCacheConfig.MaxSizeMB)
 	ExpectEq(false, mountConfig.FileCacheConfig.CacheFileForRangeRead)
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -224,9 +224,9 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	fileInfoCache := lru.NewCache(sizeInBytes)
 
 	cacheDir := string(cfg.MountConfig.CacheDir)
-	// Adding a new directory inside cacheDir, so that at the time of Destroy
-	// during unmount we can do os.RemoveAll(cacheDir) without deleting non
-	// gcsfuse related files.
+	// Adding a new directory inside cacheDir to keep file-cache separate from
+	// metadata cache if and when we support storing metadata cache on disk in
+	// the future.
 	cacheDir = path.Join(cacheDir, util.FileCache)
 
 	filePerm := util.DefaultFilePerm

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"syscall"
@@ -154,9 +153,10 @@ func NewFileSystem(
 		}
 	}
 
-	// Create file cache handler if cache is enabled by user.
+	// Create file cache handler if cache is enabled by user. Cache is considered
+	// enabled only if cache-dir is not empty and file-cache:max-size-mb is non 0.
 	var fileCacheHandler *file.CacheHandler
-	if cfg.MountConfig.FileCacheConfig.MaxSizeMB != 0 {
+	if cfg.MountConfig.FileCacheConfig.MaxSizeMB != 0 && string(cfg.MountConfig.CacheDir) != "" {
 		fileCacheHandler = createFileCacheHandler(cfg)
 	}
 
@@ -224,18 +224,6 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	fileInfoCache := lru.NewCache(sizeInBytes)
 
 	cacheDir := string(cfg.MountConfig.CacheDir)
-	// Use temp-dir as default cache-dir.
-	if cacheDir == "" {
-		if cfg.TempDir == "" {
-			cacheDir = os.TempDir()
-		} else {
-			cacheDir = cfg.TempDir
-		}
-	}
-	cacheDir, err := filepath.Abs(cacheDir)
-	if err != nil {
-		panic(fmt.Errorf("createFileCacheHandler: error while resolving cache-dir (%s) in config-file: %w", cacheDir, err))
-	}
 	// Adding a new directory inside cacheDir, so that at the time of Destroy
 	// during unmount we can do os.RemoveAll(cacheDir) without deleting non
 	// gcsfuse related files.

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -52,8 +52,7 @@ func init() {
 	RegisterTestSuite(&FileCacheWithCacheForRangeRead{})
 	RegisterTestSuite(&FileCacheTest{})
 	RegisterTestSuite(&FileCacheDestroyTest{})
-	RegisterTestSuite(&FileCacheWithDefaultCacheDir{})
-	RegisterTestSuite(&FileCacheWithUserDefinedTempAsCacheDir{})
+	RegisterTestSuite(&FileCacheIsDisabledWithCacheDirAndZeroMaxSize{})
 }
 
 var CacheDir = path.Join(os.Getenv("HOME"), "cache-dir")
@@ -725,57 +724,49 @@ func (t *FileCacheTest) ModifyFileInCacheAndThenReadShouldGiveModifiedData() {
 	AssertTrue(reflect.DeepEqual(changedContent, string(buf)))
 }
 
-// A collection of tests for a file system where the file cache is enabled
-// with default cache location.
-type FileCacheWithDefaultCacheDir struct {
+// Tests for file system where the file cache is disabled if cache-dir is passed
+// but file-cache: max-size-mb is 0.
+type FileCacheIsDisabledWithCacheDirAndZeroMaxSize struct {
 	fsTest
 }
 
-type FileCacheWithUserDefinedTempAsCacheDir struct {
-	fsTest
-}
-
-func (t *FileCacheWithDefaultCacheDir) SetUpTestSuite() {
+func (t *FileCacheIsDisabledWithCacheDirAndZeroMaxSize) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeMB:             -1,
+			MaxSizeMB:             0,
 			CacheFileForRangeRead: true,
 		},
+		CacheDir: config.CacheDir(CacheDir),
 	}
 	t.fsTest.SetUpTestSuite()
 }
 
-func (t *FileCacheWithUserDefinedTempAsCacheDir) SetUpTestSuite() {
-	t.serverCfg.ImplicitDirectories = true
-	t.serverCfg.MountConfig = &config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeMB:             -1,
-			CacheFileForRangeRead: true,
-		},
-	}
-	t.serverCfg.TempDir = UserTempLocation
-	t.fsTest.SetUpTestSuite()
-}
-
-func (t *FileCacheWithDefaultCacheDir) TearDown() {
+func (t *FileCacheIsDisabledWithCacheDirAndZeroMaxSize) TearDown() {
 	t.fsTest.TearDown()
-	err := os.RemoveAll(path.Join(os.TempDir(), util.FileCache))
+}
+
+func (t *FileCacheIsDisabledWithCacheDirAndZeroMaxSize) ReadingFileDoesNotPopulateCache() {
+	objectContent := generateRandomString(DefaultObjectSizeInMb * util.MiB)
+	objects := map[string]string{DefaultObjectName: objectContent}
+	err := t.createObjects(objects)
 	AssertEq(nil, err)
-}
-
-func (t *FileCacheWithUserDefinedTempAsCacheDir) TearDown() {
-	t.fsTest.TearDown()
-	err := os.RemoveAll(path.Join(UserTempLocation, util.FileCache))
+	filePath := path.Join(mntDir, DefaultObjectName)
+	file, err := os.OpenFile(filePath, os.O_RDWR|syscall.O_DIRECT, util.DefaultFilePerm)
+	defer closeFile(file)
 	AssertEq(nil, err)
-}
 
-func (t *FileCacheWithDefaultCacheDir) DefaultLocationIsTempDir() {
-	sequentialReadShouldPopulateCache(&t.fsTest, path.Join(os.TempDir(), util.FileCache))
-}
+	// Reading object with cache disabled should not cache the object into file.
+	buf := make([]byte, len(objectContent))
+	_, err = file.Read(buf)
+	AssertEq(nil, err)
+	AssertEq(objectContent, string(buf))
 
-func (t *FileCacheWithUserDefinedTempAsCacheDir) CacheDirIsUserDefinedTempDir() {
-	sequentialReadShouldPopulateCache(&t.fsTest, path.Join(UserTempLocation, util.FileCache))
+	objectPath := util.GetObjectPath(bucket.Name(), DefaultObjectName)
+	downloadPath := util.GetDownloadPath(FileCacheDir, objectPath)
+	_, err = os.Stat(downloadPath)
+	AssertNe(nil, err)
+	AssertTrue(os.IsNotExist(err))
 }
 
 // Test to check cache is deleted at the time of unmounting.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -68,15 +68,6 @@ func GetResolvedPath(filePath string) (resolvedPath string, err error) {
 	}
 }
 
-func ResolveFilePath(filePath string, configKey string) (resolvedPath string, err error) {
-	resolvedPath, err = GetResolvedPath(filePath)
-	if filePath == resolvedPath || err != nil {
-		return
-	}
-
-	return resolvedPath, nil
-}
-
 // Stringify marshals an object (only exported attribute) to a JSON string. If marshalling fails, it returns an empty string.
 func Stringify(input any) (string, error) {
 	inputBytes, err := json.Marshal(input)

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	config.OverrideWithLoggingFlags(mountConfig, flags.LogFile, flags.LogFormat,
 		flags.DebugFuse, flags.DebugGCS, flags.DebugMutex)
 
-	err = config.ResolveConfigFilePaths(mountConfig)
+	err = resolveConfigFilePaths(mountConfig)
 	if err != nil {
 		return fmt.Errorf("Resolving path: %w", err)
 	}

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -13,7 +13,8 @@
         "file-cache": {
           "max-size-mb": -1,
           "cache-file-for-range-read": true
-        }
+        },
+        "cache-dir": "/tmp/cache"
       },
       "branch": "read_cache_release",
       "end_date": "2024-03-31 05:30:00+00:00"
@@ -25,7 +26,8 @@
         "file-cache": {
           "max-size-mb": -1,
           "cache-file-for-range-read": false
-        }
+        },
+        "cache-dir": "/tmp/cache"
       },
       "branch": "read_cache_release",
       "end_date": "2024-03-31 05:30:00+00:00"


### PR DESCRIPTION
### Description
Enable or disable file cache via cache-dir and not via max-size-mb. Also, make max-size-mb default as -1. Also did some refactoring to make sure util.go don't make any other internal package imports and we also don't go into cyclic dependency.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - [kokoro build logs](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/f0049d29-36df-4130-acdd-254755dfc901/summary)
