### PR TITLE
[PR-2] Changes to StatObject to return min object and extended object attributes

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -122,7 +122,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	minObject, _, err := cht.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: TestObjectName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
-	cht.object = &minObject
+	cht.object = minObject
 
 	// fileInfoCache with testFileInfoEntry
 	cht.cache = lru.NewCache(CacheMaxSize)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -119,10 +119,10 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	err = storageutil.CreateObjects(ctx, cht.bucket, objects)
 	AssertEq(nil, err)
 
-	gcsObj, err := cht.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: TestObjectName,
+	minObject, _, err := cht.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: TestObjectName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
-	cht.object = storageutil.ConvertObjToMinObject(gcsObj)
+	cht.object = &minObject
 
 	// fileInfoCache with testFileInfoEntry
 	cht.cache = lru.NewCache(CacheMaxSize)

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -122,6 +122,7 @@ func (cht *cacheHandleTest) SetUp(*TestInfo) {
 	minObject, _, err := cht.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: TestObjectName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
+	AssertNe(nil, minObject)
 	cht.object = minObject
 
 	// fileInfoCache with testFileInfoEntry

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -145,6 +145,7 @@ func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *g
 	minObject, _, err := chrT.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
+	AssertNe(nil, minObject)
 	return minObject
 }
 

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -142,10 +142,10 @@ func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *g
 	err := storageutil.CreateObjects(ctx, chrT.bucket, objects)
 	AssertEq(nil, err)
 
-	gcsObj, err := chrT.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
+	minObject, _, err := chrT.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
 		ForceFetchFromGcs: true})
 	AssertEq(nil, err)
-	return storageutil.ConvertObjToMinObject(gcsObj)
+	return minObject
 }
 
 // doesFileExist returns true if the file exists and false otherwise.

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -52,8 +52,11 @@ func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 	if err != nil {
 		panic(fmt.Errorf("error whlie stating object: %w", err))
 	}
-	
-	return *minObject
+
+	if minObject != nil {
+		return *minObject
+	}
+	return gcs.MinObject{}
 }
 
 func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -47,18 +47,13 @@ const DefaultSequentialReadSizeMb = 100
 
 func (dt *downloaderTest) getMinObject(objectName string) gcs.MinObject {
 	ctx := context.Background()
-	object, err := dt.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objectName,
+	minObject, _, err := dt.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objectName,
 		ForceFetchFromGcs: true})
 	if err != nil {
 		panic(fmt.Errorf("error whlie stating object: %w", err))
 	}
-
-	var minObj gcs.MinObject
-	minObjPtr := storageutil.ConvertObjToMinObject(object)
-	if minObjPtr != nil {
-		minObj = *minObjPtr
-	}
-	return minObj
+	
+	return *minObject
 }
 
 func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, sequentialReadSize int32, lruCacheSize uint64, removeCallback func()) {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/syncutil"
@@ -297,7 +298,8 @@ func findExplicitInode(ctx context.Context, bucket *gcsx.SyncerBucket, name Name
 		Name: name.GcsObjectName(),
 	}
 
-	o, err := bucket.StatObject(ctx, req)
+	m, e, err := bucket.StatObject(ctx, req)
+	o := storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
 
 	// Suppress "not found" errors.
 	var gcsErr *gcs.NotFoundError

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -298,8 +298,8 @@ func findExplicitInode(ctx context.Context, bucket *gcsx.SyncerBucket, name Name
 		Name: name.GcsObjectName(),
 	}
 
-	m, e, err := bucket.StatObject(ctx, req)
-	o := storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
+	m, _, err := bucket.StatObject(ctx, req)
+	o := storageutil.ConvertMinObjectToObject(m)
 
 	// Suppress "not found" errors.
 	var gcsErr *gcs.NotFoundError

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -178,9 +178,11 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, inclu
 		ReturnExtendedObjectAttributes: includeExtendedObjectAttributes,
 	}
 	m, e, err := f.bucket.StatObject(ctx, req)
-	// TODO: Change this to use ConvertMinObjectToObject if ReturnFull is false.
-	o = storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
-
+	if includeExtendedObjectAttributes {
+		o = storageutil.ConvertMinObjectAndExtendedObjectAttributesToObject(m, e)
+	} else {
+		o = storageutil.ConvertMinObjectToObject(m)
+	}
 	// Special case: "not found" means we have been clobbered.
 	var notFoundErr *gcs.NotFoundError
 	if errors.As(err, &notFoundErr) {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -178,6 +178,7 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, inclu
 		ReturnExtendedObjectAttributes: includeExtendedObjectAttributes,
 	}
 	m, e, err := f.bucket.StatObject(ctx, req)
+	// TODO: Change this to use ConvertMinObjectToObject if ReturnFull is false.
 	o = storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
 
 	// Special case: "not found" means we have been clobbered.

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -177,7 +177,8 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, inclu
 		ForceFetchFromGcs:              forceFetchFromGcs,
 		ReturnExtendedObjectAttributes: includeExtendedObjectAttributes,
 	}
-	o, err = f.bucket.StatObject(ctx, req)
+	m, e, err := f.bucket.StatObject(ctx, req)
+	o = storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
 
 	// Special case: "not found" means we have been clobbered.
 	var notFoundErr *gcs.NotFoundError

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -364,7 +364,7 @@ func (t *FileTest) WriteThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
@@ -411,7 +411,7 @@ func (t *FileTest) WriteToLocalFileThenSync() {
 	AssertFalse(t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 	AssertEq(nil, err)
 	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
 	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
@@ -448,7 +448,7 @@ func (t *FileTest) SyncEmptyLocalFile() {
 	AssertFalse(t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 	AssertEq(nil, err)
 	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
 	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
@@ -492,7 +492,7 @@ func (t *FileTest) AppendThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
@@ -538,7 +538,7 @@ func (t *FileTest) TruncateDownwardThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
@@ -580,7 +580,7 @@ func (t *FileTest) TruncateUpwardThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 	ExpectEq(
 		truncateTime.UTC().Format(time.RFC3339Nano),
 		o.Metadata["gcsfuse_mtime"])
@@ -619,7 +619,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	AssertEq(6, attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	_, err = t.bucket.StatObject(t.ctx, statReq)
+	_, _, err = t.bucket.StatObject(t.ctx, statReq)
 	AssertNe(nil, err)
 	AssertEq("gcs.NotFoundError: Object test not found", err.Error())
 }
@@ -648,7 +648,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	AssertEq(2, attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	_, err = t.bucket.StatObject(t.ctx, statReq)
+	_, _, err = t.bucket.StatObject(t.ctx, statReq)
 	AssertNe(nil, err)
 	AssertEq("gcs.NotFoundError: Object test not found", err.Error())
 }
@@ -678,7 +678,7 @@ func (t *FileTest) Sync_Clobbered() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(newObj.Generation, o.Generation)
@@ -703,7 +703,7 @@ func (t *FileTest) SetMtime_ContentNotFaultedIn() {
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(
@@ -733,7 +733,7 @@ func (t *FileTest) SetMtime_ContentClean() {
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(
@@ -767,7 +767,7 @@ func (t *FileTest) SetMtime_ContentDirty() {
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(
@@ -794,7 +794,7 @@ func (t *FileTest) SetMtime_SourceObjectGenerationChanged() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(newObj.Generation, o.Generation)
@@ -822,7 +822,7 @@ func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, err := t.bucket.StatObject(t.ctx, statReq)
+	o, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
 	ExpectEq(newObj.Generation, o.Generation)
@@ -855,7 +855,7 @@ func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
 	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	_, err = t.bucket.StatObject(t.ctx, statReq)
+	_, _, err = t.bucket.StatObject(t.ctx, statReq)
 	AssertNe(nil, err)
 	AssertEq("gcs.NotFoundError: Object test not found", err.Error())
 }
@@ -925,7 +925,7 @@ func (t *FileTest) UnlinkLocalFile() {
 	AssertTrue(t.in.IsUnlinked())
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	_, err = t.bucket.StatObject(t.ctx, statReq)
+	_, _, err = t.bucket.StatObject(t.ctx, statReq)
 	AssertNe(nil, err)
 	AssertEq("gcs.NotFoundError: Object test not found", err.Error())
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -364,15 +364,16 @@ func (t *FileTest) WriteThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(len("paco"), o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(len("paco"), m.Size)
 	ExpectEq(
 		writeTime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
@@ -411,14 +412,15 @@ func (t *FileTest) WriteToLocalFileThenSync() {
 	AssertFalse(t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(len("tacos"), o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(len("tacos"), m.Size)
 	ExpectEq(
 		writeTime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	AssertEq(nil, err)
@@ -448,13 +450,14 @@ func (t *FileTest) SyncEmptyLocalFile() {
 	AssertFalse(t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(0, o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(0, m.Size)
 	// Validate the mtime.
-	mtimeInBucket, ok := o.Metadata["gcsfuse_mtime"]
+	mtimeInBucket, ok := m.Metadata["gcsfuse_mtime"]
 	AssertTrue(ok)
 	mtime, _ := time.Parse(time.RFC3339Nano, mtimeInBucket)
 	ExpectThat(mtime, timeutil.TimeNear(creationTime, Delta))
@@ -492,15 +495,16 @@ func (t *FileTest) AppendThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(len("tacoburrito"), o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(len("tacoburrito"), m.Size)
 	ExpectEq(
 		writeTime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
@@ -538,15 +542,16 @@ func (t *FileTest) TruncateDownwardThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(2, o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(2, m.Size)
 	ExpectEq(
 		truncateTime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -580,15 +585,16 @@ func (t *FileTest) TruncateUpwardThenSync() {
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	ExpectEq(
 		truncateTime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 
 	AssertEq(nil, err)
-	ExpectEq(t.in.SourceGeneration().Object, o.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, o.MetaGeneration)
-	ExpectEq(6, o.Size)
+	AssertNe(nil, m)
+	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
+	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	ExpectEq(6, m.Size)
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -678,11 +684,12 @@ func (t *FileTest) Sync_Clobbered() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(newObj.Generation, o.Generation)
-	ExpectEq(newObj.Size, o.Size)
+	AssertNe(nil, m)
+	ExpectEq(newObj.Generation, m.Generation)
+	ExpectEq(newObj.Size, m.Size)
 }
 
 func (t *FileTest) SetMtime_ContentNotFaultedIn() {
@@ -703,12 +710,13 @@ func (t *FileTest) SetMtime_ContentNotFaultedIn() {
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
+	AssertNe(nil, m)
 	ExpectEq(
 		mtime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 }
 
 func (t *FileTest) SetMtime_ContentClean() {
@@ -733,12 +741,13 @@ func (t *FileTest) SetMtime_ContentClean() {
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
+	AssertNe(nil, m)
 	ExpectEq(
 		mtime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 }
 
 func (t *FileTest) SetMtime_ContentDirty() {
@@ -767,12 +776,13 @@ func (t *FileTest) SetMtime_ContentDirty() {
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
+	AssertNe(nil, m)
 	ExpectEq(
 		mtime.UTC().Format(time.RFC3339Nano),
-		o.Metadata["gcsfuse_mtime"])
+		m.Metadata["gcsfuse_mtime"])
 }
 
 func (t *FileTest) SetMtime_SourceObjectGenerationChanged() {
@@ -794,11 +804,12 @@ func (t *FileTest) SetMtime_SourceObjectGenerationChanged() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(newObj.Generation, o.Generation)
-	ExpectEq(0, len(o.Metadata))
+	AssertNe(nil, m)
+	ExpectEq(newObj.Generation, m.Generation)
+	ExpectEq(0, len(m.Metadata))
 }
 
 func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
@@ -822,11 +833,12 @@ func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
-	o, _, err := t.bucket.StatObject(t.ctx, statReq)
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	AssertEq(nil, err)
-	ExpectEq(newObj.Generation, o.Generation)
-	ExpectEq(newObj.MetaGeneration, o.MetaGeneration)
+	AssertNe(nil, m)
+	ExpectEq(newObj.Generation, m.Generation)
+	ExpectEq(newObj.MetaGeneration, m.MetaGeneration)
 }
 
 func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -2280,12 +2280,12 @@ func (t *SymlinkTest) CreateLink() {
 	AssertEq(nil, err)
 
 	// Check the object in the bucket.
-	o, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
+	m, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
 
 	AssertEq(nil, err)
-	AssertNe(nil, o)
-	ExpectEq(0, o.Size)
-	ExpectEq("foo", o.Metadata["gcsfuse_symlink_target"])
+	AssertNe(nil, m)
+	ExpectEq(0, m.Size)
+	ExpectEq("foo", m.Metadata["gcsfuse_symlink_target"])
 
 	// Read the link.
 	target, err := os.Readlink(symlinkName)

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -1378,8 +1378,12 @@ func (t *DirectoryTest) ContentTypes() {
 		AssertEq(nil, err)
 
 		// There should be no content type set in GCS.
-		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
+		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{
+			Name:                           name,
+			ForceFetchFromGcs:              true,
+			ReturnExtendedObjectAttributes: true})
 		AssertEq(nil, err)
+		AssertNe(nil, e)
 		ExpectEq("", e.ContentType, "name: %q", name)
 	}
 }
@@ -2051,6 +2055,7 @@ func (t *FileTest) Sync_NotDirty() {
 	}
 	m1, _, err := bucket.StatObject(ctx, statReq)
 	AssertEq(nil, err)
+	AssertNe(nil, m1)
 
 	// Sync the file again.
 	err = t.f1.Sync()
@@ -2059,6 +2064,7 @@ func (t *FileTest) Sync_NotDirty() {
 	// A new generation need not have been written.
 	m2, _, err := bucket.StatObject(ctx, statReq)
 	AssertEq(nil, err)
+	AssertNe(nil, m2)
 	ExpectEq(m1.Generation, m2.Generation)
 }
 
@@ -2231,8 +2237,12 @@ func (t *FileTest) ContentTypes() {
 		AssertEq(nil, err)
 
 		// The GCS content type should still be correct.
-		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
+		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{
+			Name:                           name,
+			ForceFetchFromGcs:              true,
+			ReturnExtendedObjectAttributes: true})
 		AssertEq(nil, err)
+		AssertNe(nil, e)
 		ExpectEq(expected, e.ContentType, "name: %q", name)
 	}
 
@@ -2273,6 +2283,7 @@ func (t *SymlinkTest) CreateLink() {
 	o, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
 
 	AssertEq(nil, err)
+	AssertNe(nil, o)
 	ExpectEq(0, o.Size)
 	ExpectEq("foo", o.Metadata["gcsfuse_symlink_target"])
 

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -1378,9 +1378,9 @@ func (t *DirectoryTest) ContentTypes() {
 		AssertEq(nil, err)
 
 		// There should be no content type set in GCS.
-		o, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
+		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
 		AssertEq(nil, err)
-		ExpectEq("", o.ContentType, "name: %q", name)
+		ExpectEq("", e.ContentType, "name: %q", name)
 	}
 }
 
@@ -2049,7 +2049,7 @@ func (t *FileTest) Sync_NotDirty() {
 	statReq := &gcs.StatObjectRequest{
 		Name: "foo",
 	}
-	o1, err := bucket.StatObject(ctx, statReq)
+	m1, _, err := bucket.StatObject(ctx, statReq)
 	AssertEq(nil, err)
 
 	// Sync the file again.
@@ -2057,9 +2057,9 @@ func (t *FileTest) Sync_NotDirty() {
 	AssertEq(nil, err)
 
 	// A new generation need not have been written.
-	o2, err := bucket.StatObject(ctx, statReq)
+	m2, _, err := bucket.StatObject(ctx, statReq)
 	AssertEq(nil, err)
-	ExpectEq(o1.Generation, o2.Generation)
+	ExpectEq(m1.Generation, m2.Generation)
 }
 
 func (t *FileTest) Sync_Clobbered() {
@@ -2138,7 +2138,7 @@ func (t *FileTest) Close_NotDirty() {
 	statReq := &gcs.StatObjectRequest{
 		Name: "foo",
 	}
-	_, err = bucket.StatObject(ctx, statReq)
+	_, _, err = bucket.StatObject(ctx, statReq)
 	AssertEq(nil, err)
 }
 
@@ -2231,9 +2231,9 @@ func (t *FileTest) ContentTypes() {
 		AssertEq(nil, err)
 
 		// The GCS content type should still be correct.
-		o, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
+		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: name})
 		AssertEq(nil, err)
-		ExpectEq(expected, o.ContentType, "name: %q", name)
+		ExpectEq(expected, e.ContentType, "name: %q", name)
 	}
 
 	for name, expected := range testCases {
@@ -2270,7 +2270,7 @@ func (t *SymlinkTest) CreateLink() {
 	AssertEq(nil, err)
 
 	// Check the object in the bucket.
-	o, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
+	o, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
 
 	AssertEq(nil, err)
 	ExpectEq(0, o.Size)

--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -124,7 +124,7 @@ func (t *IntegrationTest) create(o *gcs.Object) {
 func (t *IntegrationTest) objectGeneration(name string) (gen int64) {
 	// Stat.
 	req := &gcs.StatObjectRequest{Name: name}
-	o, err := t.bucket.StatObject(t.ctx, req)
+	m, _, err := t.bucket.StatObject(t.ctx, req)
 
 	var notFoundErr *gcs.NotFoundError
 	if errors.As(err, &notFoundErr) {
@@ -136,7 +136,7 @@ func (t *IntegrationTest) objectGeneration(name string) (gen int64) {
 		panic(err)
 	}
 
-	gen = o.Generation
+	gen = m.Generation
 	return
 }
 

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -138,13 +138,13 @@ func (b *prefixBucket) ComposeObjects(
 
 func (b *prefixBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.Object, err error) {
+	req *gcs.StatObjectRequest) (o *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// Modify the request and call through.
 	mReq := new(gcs.StatObjectRequest)
 	*mReq = *req
 	mReq.Name = b.wrappedName(req.Name)
 
-	o, err = b.wrapped.StatObject(ctx, mReq)
+	o, e, err = b.wrapped.StatObject(ctx, mReq)
 
 	// Modify the returned object.
 	if o != nil {

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -138,17 +138,17 @@ func (b *prefixBucket) ComposeObjects(
 
 func (b *prefixBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// Modify the request and call through.
 	mReq := new(gcs.StatObjectRequest)
 	*mReq = *req
 	mReq.Name = b.wrappedName(req.Name)
 
-	o, e, err = b.wrapped.StatObject(ctx, mReq)
+	m, e, err = b.wrapped.StatObject(ctx, mReq)
 
 	// Modify the returned object.
-	if o != nil {
-		o.Name = b.localName(o.Name)
+	if m != nil {
+		m.Name = b.localName(m.Name)
 	}
 
 	return

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -196,7 +196,7 @@ func (t *PrefixBucketTest) StatObject() {
 	AssertEq(nil, err)
 
 	// Stat it.
-	o, err := t.bucket.StatObject(
+	o, _, err := t.bucket.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{
 			Name: suffix,
@@ -386,7 +386,7 @@ func (t *PrefixBucketTest) DeleteObject() {
 	AssertEq(nil, err)
 
 	// It should be gone.
-	_, err = t.wrapped.StatObject(
+	_, _, err = t.wrapped.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{
 			Name: name,

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -196,15 +196,16 @@ func (t *PrefixBucketTest) StatObject() {
 	AssertEq(nil, err)
 
 	// Stat it.
-	o, _, err := t.bucket.StatObject(
+	m, _, err := t.bucket.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{
 			Name: suffix,
 		})
 
 	AssertEq(nil, err)
-	ExpectEq(suffix, o.Name)
-	ExpectEq(len(contents), o.Size)
+	AssertNe(nil, m)
+	ExpectEq(suffix, m.Name)
+	ExpectEq(len(contents), m.Size)
 }
 
 func (t *PrefixBucketTest) ListObjects_NoOptions() {

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -157,11 +157,11 @@ func (mb *monitoringBucket) ComposeObjects(
 
 func (mb *monitoringBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (*gcs.Object, error) {
+	req *gcs.StatObjectRequest) (*gcs.MinObject, *gcs.ExtendedObjectAttributes, error) {
 	startTime := time.Now()
-	o, err := mb.wrapped.StatObject(ctx, req)
+	m, e, err := mb.wrapped.StatObject(ctx, req)
 	recordRequest(ctx, "StatObject", startTime)
-	return o, err
+	return m, e, err
 }
 
 func (mb *monitoringBucket) ListObjects(

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -122,7 +122,7 @@ func (b *throttledBucket) ComposeObjects(
 
 func (b *throttledBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// Wait for permission to call through.
 	err = b.opThrottle.Wait(ctx, 1)
 	if err != nil {
@@ -130,7 +130,7 @@ func (b *throttledBucket) StatObject(
 	}
 
 	// Call through.
-	o, e, err = b.wrapped.StatObject(ctx, req)
+	m, e, err = b.wrapped.StatObject(ctx, req)
 
 	return
 }

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -122,7 +122,7 @@ func (b *throttledBucket) ComposeObjects(
 
 func (b *throttledBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.Object, err error) {
+	req *gcs.StatObjectRequest) (o *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// Wait for permission to call through.
 	err = b.opThrottle.Wait(ctx, 1)
 	if err != nil {
@@ -130,7 +130,7 @@ func (b *throttledBucket) StatObject(
 	}
 
 	// Call through.
-	o, err = b.wrapped.StatObject(ctx, req)
+	o, e, err = b.wrapped.StatObject(ctx, req)
 
 	return
 }

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -108,10 +108,6 @@ func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRe
 
 func (b *bucketHandle) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
-	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
-	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
-		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnFull: true")
-	}
 	var attrs *storage.ObjectAttrs
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = b.bucket.Object(req.Name).Attrs(ctx)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -124,9 +124,10 @@ func (b *bucketHandle) StatObject(ctx context.Context,
 
 	// Converting attrs to type *Object
 	o := storageutil.ObjectAttrsToBucketObject(attrs)
-	minObj := storageutil.ConvertObjToMinObject(o)
-	m = &minObj
-	e = storageutil.ConvertObjToExtendedAttributes(o)
+	m = storageutil.ConvertObjToMinObject(o)
+	if req.ReturnExtendedObjectAttributes {
+		e = storageutil.ConvertObjToExtendedObjectAttributes(o)
+	}
 
 	return
 }

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -124,7 +124,8 @@ func (b *bucketHandle) StatObject(ctx context.Context,
 
 	// Converting attrs to type *Object
 	o := storageutil.ObjectAttrsToBucketObject(attrs)
-	m = storageutil.ConvertObjToMinObject(o)
+	minObj := storageutil.ConvertObjToMinObject(o)
+	m = &minObj
 	e = storageutil.ConvertObjToExtendedAttributes(o)
 
 	return

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -108,6 +108,10 @@ func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRe
 
 func (b *bucketHandle) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
+	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
+		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnFull: true")
+	}
 	var attrs *storage.ObjectAttrs
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = b.bucket.Object(req.Name).Attrs(ctx)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -106,7 +106,8 @@ func (b *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRe
 
 }
 
-func (b *bucketHandle) StatObject(ctx context.Context, req *gcs.StatObjectRequest) (o *gcs.Object, err error) {
+func (b *bucketHandle) StatObject(ctx context.Context,
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	var attrs *storage.ObjectAttrs
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = b.bucket.Object(req.Name).Attrs(ctx)
@@ -122,7 +123,9 @@ func (b *bucketHandle) StatObject(ctx context.Context, req *gcs.StatObjectReques
 	}
 
 	// Converting attrs to type *Object
-	o = storageutil.ObjectAttrsToBucketObject(attrs)
+	o := storageutil.ObjectAttrsToBucketObject(attrs)
+	m = storageutil.ConvertObjToMinObject(o)
+	e = storageutil.ConvertObjToExtendedAttributes(o)
 
 	return
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -261,6 +261,30 @@ func (t *BucketHandleTest) TestStatObjectMethodWithValidObject() {
 	AssertEq(nil, err)
 }
 
+func (t *BucketHandleTest) TestStatObjectMethodWithReturnExtendedObjectAttributesTrue() {
+	m, e, err := t.bucketHandle.StatObject(context.Background(),
+		&gcs.StatObjectRequest{
+			Name:                           TestObjectName,
+			ReturnExtendedObjectAttributes: true,
+		})
+
+	AssertEq(nil, err)
+	AssertNe(nil, m)
+	AssertNe(nil, e)
+}
+
+func (t *BucketHandleTest) TestStatObjectMethodWithReturnExtendedObjectAttributesFalse() {
+	m, e, err := t.bucketHandle.StatObject(context.Background(),
+		&gcs.StatObjectRequest{
+			Name:                           TestObjectName,
+			ReturnExtendedObjectAttributes: false,
+		})
+
+	AssertEq(nil, err)
+	AssertNe(nil, m)
+	AssertEq(nil, e)
+}
+
 func (t *BucketHandleTest) TestStatObjectMethodWithMissingObject() {
 	var notfound *gcs.NotFoundError
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -609,6 +609,7 @@ func (t *BucketHandleTest) TestUpdateObjectMethodWithValidObject() {
 		})
 
 	AssertEq(nil, err)
+	AssertNe(nil, minObj)
 	AssertEq(MetaDataValue, minObj.Metadata[MetaDataKey])
 
 	updatedMetaData := time.RFC3339Nano
@@ -680,13 +681,12 @@ func (t *BucketHandleTest) TestComposeObjectMethodWithDstObjectExist() {
 		})
 	ExpectEq(ContentInTestObject, buffer)
 	// Checking if srcObject exists or not
-	srcMinObj, srcExtAttr, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestSubObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj)
-	AssertNe(nil, srcExtAttr)
 
 	// Composing the object
 	composedObj, err := t.bucketHandle.ComposeObjects(context.Background(),
@@ -747,13 +747,12 @@ func (t *BucketHandleTest) TestComposeObjectMethodWithOneSrcObject() {
 			Name: dstObjectName,
 		})
 	AssertTrue(errors.As(err, &notfound))
-	srcMinObj, srcExtAttr, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj)
-	AssertNe(nil, srcExtAttr)
 
 	composedObj, err := t.bucketHandle.ComposeObjects(context.Background(),
 		&gcs.ComposeObjectsRequest{
@@ -810,20 +809,18 @@ func (t *BucketHandleTest) TestComposeObjectMethodWithTwoSrcObjects() {
 			Name: dstObjectName,
 		})
 	AssertTrue(errors.As(err, &notfound))
-	srcMinObj1, srcExtAttr1, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj1, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj1)
-	AssertNe(nil, srcExtAttr1)
-	srcMinObj2, srcExtAttr2, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj2, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestSubObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj2)
-	AssertNe(nil, srcExtAttr2)
 
 	composedObj, err := t.bucketHandle.ComposeObjects(context.Background(),
 		&gcs.ComposeObjectsRequest{
@@ -982,20 +979,18 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 			Name: dstObjectName,
 		})
 	AssertTrue(errors.As(err, &notfound))
-	srcMinObj1, srcExtAttr1, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj1, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj1)
-	AssertNe(nil, srcExtAttr1)
-	srcMinObj2, srcExtAttr2, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj2, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestSubObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj2)
-	AssertNe(nil, srcExtAttr2)
 
 	// Add DstGenerationPrecondition = 0 as the Destination object doesn't exist.
 	// Note: fake-gcs-server doesn't respect precondition checks but still adding
@@ -1069,13 +1064,12 @@ func (t *BucketHandleTest) TestComposeObjectMethodWhenDstObjectDoesNotExist() {
 
 func (t *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstObject() {
 	// Checking source object 1 exists. This will also be the destination object.
-	srcMinObj1, srcExtAttr1, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj1, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj1)
-	AssertNe(nil, srcExtAttr1)
 
 	// Reading source object 1 content before composing it
 	srcObj1Buffer := t.readObjectContent(context.Background(),
@@ -1089,13 +1083,12 @@ func (t *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstObject() 
 	ExpectEq(ContentInTestObject, srcObj1Buffer)
 
 	// Checking source object 2 exists.
-	srcMinObj2, srcExtAttr2, err := t.bucketHandle.StatObject(context.Background(),
+	srcMinObj2, _, err := t.bucketHandle.StatObject(context.Background(),
 		&gcs.StatObjectRequest{
 			Name: TestSubObjectName,
 		})
 	AssertEq(nil, err)
 	AssertNe(nil, srcMinObj2)
-	AssertNe(nil, srcExtAttr2)
 
 	// Reading source object 2 content before composing it
 	srcObj2Buffer := t.readObjectContent(context.Background(),

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -205,10 +205,9 @@ func (b *fastStatBucket) StatObject(
 			return
 		}
 
-		// Otherwise, return object and ExtendedObjectAttributes.
-		minObj := storageutil.ConvertObjToMinObject(entry)
-		m = &minObj
-		e = storageutil.ConvertObjToExtendedAttributes(entry)
+		// Otherwise, return MinObject and nil ExtendedObjectAttributes.
+		m = storageutil.ConvertObjToMinObject(entry)
+		e = nil
 		return
 	}
 
@@ -273,7 +272,7 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 
 	// Put the object in cache.
 	// TODO: Store only MinObject in Stat Cache.
-	o := storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
+	o := storageutil.ConvertMinObjectToObject(m)
 	b.insert(o)
 
 	return

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -191,7 +191,7 @@ func (b *fastStatBucket) StatObject(
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
 	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
-		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnFull: true")
+		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnExtendedObjectAttributes: true")
 	}
 	// If fetching from gcs is enabled, directly make a call to GCS.
 	if req.ForceFetchFromGcs {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -206,7 +206,8 @@ func (b *fastStatBucket) StatObject(
 		}
 
 		// Otherwise, return object and ExtendedObjectAttributes.
-		m = storageutil.ConvertObjToMinObject(entry)
+		minObj := storageutil.ConvertObjToMinObject(entry)
+		m = &minObj
 		e = storageutil.ConvertObjToExtendedAttributes(entry)
 		return
 	}
@@ -271,6 +272,7 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 	}
 
 	// Put the object in cache.
+	// TODO: Store only MinObject in Stat Cache.
 	o := storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
 	b.insert(o)
 

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -334,6 +334,7 @@ func (t *StatObjectTest) CacheHit_Positive() {
 	m, _, err := t.bucket.StatObject(context.TODO(), req)
 	o := storageutil.ConvertMinObjectToObject(m)
 	AssertEq(nil, err)
+	AssertNe(nil, o)
 	ExpectThat(o, Pointee(DeepEquals(*obj)))
 }
 
@@ -381,6 +382,8 @@ func (t *StatObjectTest) IgnoresCacheEntryWhenForceFetchFromGcsIsTrue() {
 
 	m, e, err := t.bucket.StatObject(context.TODO(), req)
 	AssertEq(nil, err)
+	AssertNe(nil, m)
+	AssertNe(nil, e)
 	ExpectEq(minObjFromGcs, m)
 	ExpectEq(extObjAttrFromGcs, e)
 }

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -362,8 +362,9 @@ func (t *StatObjectTest) IgnoresCacheEntryWhenForceFetchFromGcsIsTrue() {
 
 	// Request
 	req := &gcs.StatObjectRequest{
-		Name:              name,
-		ForceFetchFromGcs: true,
+		Name:                           name,
+		ForceFetchFromGcs:              true,
+		ReturnExtendedObjectAttributes: true,
 	}
 
 	// Wrapped

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -331,8 +331,8 @@ func (t *StatObjectTest) CacheHit_Positive() {
 		Name: name,
 	}
 
-	m, e, err := t.bucket.StatObject(context.TODO(), req)
-	o := storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
+	m, _, err := t.bucket.StatObject(context.TODO(), req)
+	o := storageutil.ConvertMinObjectToObject(m)
 	AssertEq(nil, err)
 	ExpectThat(o, Pointee(DeepEquals(*obj)))
 }

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -73,8 +73,8 @@ func (t *IntegrationTest) stat(name string) (o *gcs.Object, err error) {
 		Name: name,
 	}
 
-	m, e, err := t.bucket.StatObject(t.ctx, req)
-	o = storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
+	m, _, err := t.bucket.StatObject(t.ctx, req)
+	o = storageutil.ConvertMinObjectToObject(m)
 	return
 }
 

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -73,7 +73,8 @@ func (t *IntegrationTest) stat(name string) (o *gcs.Object, err error) {
 		Name: name,
 	}
 
-	o, err = t.bucket.StatObject(t.ctx, req)
+	m, e, err := t.bucket.StatObject(t.ctx, req)
+	o = storageutil.ConvertMinObjectAndExtendedAttributesToObject(m, e)
 	return
 }
 

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -188,11 +188,11 @@ func (b *debugBucket) ComposeObjects(
 
 func (b *debugBucket) StatObject(
 	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.Object, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	id, desc, start := b.startRequest("StatObject(%q)", req.Name)
 	defer b.finishRequest(id, desc, start, &err)
 
-	o, err = b.wrapped.StatObject(ctx, req)
+	m, e, err = b.wrapped.StatObject(ctx, req)
 	return
 }
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -709,6 +709,10 @@ func (b *bucket) ComposeObjects(
 // LOCKS_EXCLUDED(b.mu)
 func (b *bucket) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
+	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
+		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnFull: true")
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -711,7 +711,7 @@ func (b *bucket) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
 	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
-		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnFull: true")
+		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnExtendedObjectAttributes: true")
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -28,6 +28,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
 )
@@ -706,9 +707,8 @@ func (b *bucket) ComposeObjects(
 }
 
 // LOCKS_EXCLUDED(b.mu)
-func (b *bucket) StatObject(
-	ctx context.Context,
-	req *gcs.StatObjectRequest) (o *gcs.Object, err error) {
+func (b *bucket) StatObject(ctx context.Context,
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -723,7 +723,9 @@ func (b *bucket) StatObject(
 	}
 
 	// Make a copy to avoid handing back internal state.
-	o = copyObject(&b.objects[index].metadata)
+	o := copyObject(&b.objects[index].metadata)
+	m = storageutil.ConvertObjToMinObject(o)
+	e = storageutil.ConvertObjToExtendedAttributes(o)
 
 	return
 }

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -724,7 +724,8 @@ func (b *bucket) StatObject(ctx context.Context,
 
 	// Make a copy to avoid handing back internal state.
 	o := copyObject(&b.objects[index].metadata)
-	m = storageutil.ConvertObjToMinObject(o)
+	minObj := storageutil.ConvertObjToMinObject(o)
+	m = &minObj
 	e = storageutil.ConvertObjToExtendedAttributes(o)
 
 	return

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -724,10 +724,10 @@ func (b *bucket) StatObject(ctx context.Context,
 
 	// Make a copy to avoid handing back internal state.
 	o := copyObject(&b.objects[index].metadata)
-	minObj := storageutil.ConvertObjToMinObject(o)
-	m = &minObj
-	e = storageutil.ConvertObjToExtendedAttributes(o)
-
+	m = storageutil.ConvertObjToMinObject(o)
+	if req.ReturnExtendedObjectAttributes {
+		e = storageutil.ConvertObjToExtendedObjectAttributes(o)
+	}
 	return
 }
 

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -1235,6 +1235,7 @@ func (t *copyTest) DestinationDoesntExist() {
 	}
 
 	dst, err := t.bucket.CopyObject(t.ctx, req)
+	dstMinObject := storageutil.ConvertObjToMinObject(dst)
 
 	AssertEq(nil, err)
 	ExpectEq("bar", dst.Name)
@@ -1262,13 +1263,12 @@ func (t *copyTest) DestinationDoesntExist() {
 	ExpectEq("taco", string(contents))
 
 	// And stattable.
-	statMinObj, statExtAttr, err := t.bucket.StatObject(
+	statMinObj, _, err := t.bucket.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{Name: "bar"})
-	statO := storageutil.ConvertMinObjectAndExtendedAttributesToObject(statMinObj, statExtAttr)
 
 	AssertEq(nil, err)
-	ExpectThat(statO, Pointee(DeepEquals(*dst)))
+	ExpectThat(statMinObj, Pointee(DeepEquals(dstMinObject)))
 }
 
 func (t *copyTest) DestinationExists() {
@@ -1321,6 +1321,7 @@ func (t *copyTest) DestinationExists() {
 	}
 
 	dst, err := t.bucket.CopyObject(t.ctx, req)
+	dstMinObject := storageutil.ConvertObjToMinObject(dst)
 
 	AssertEq(nil, err)
 	ExpectEq("bar", dst.Name)
@@ -1348,13 +1349,12 @@ func (t *copyTest) DestinationExists() {
 	ExpectEq("taco", string(contents))
 
 	// And stattable.
-	statMinObjO, statExtAttrO, err := t.bucket.StatObject(
+	statMinObjO, _, err := t.bucket.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{Name: "bar"})
-	statO := storageutil.ConvertMinObjectAndExtendedAttributesToObject(statMinObjO, statExtAttrO)
 
 	AssertEq(nil, err)
-	ExpectThat(statO, Pointee(DeepEquals(*dst)))
+	ExpectThat(statMinObjO, Pointee(DeepEquals(dstMinObject)))
 }
 
 func (t *copyTest) DestinationIsSameName() {
@@ -1390,6 +1390,7 @@ func (t *copyTest) DestinationIsSameName() {
 	}
 
 	dst, err := t.bucket.CopyObject(t.ctx, req)
+	dstMinObject := storageutil.ConvertObjToMinObject(dst)
 
 	AssertEq(nil, err)
 	ExpectEq("foo", dst.Name)
@@ -1417,13 +1418,12 @@ func (t *copyTest) DestinationIsSameName() {
 	ExpectEq("taco", string(contents))
 
 	// And stattable.
-	statMinObjO, statExtAttrO, err := t.bucket.StatObject(
+	statMinObjO, _, err := t.bucket.StatObject(
 		t.ctx,
 		&gcs.StatObjectRequest{Name: "foo"})
-	statO := storageutil.ConvertMinObjectAndExtendedAttributesToObject(statMinObjO, statExtAttrO)
 
 	AssertEq(nil, err)
-	ExpectThat(statO, Pointee(DeepEquals(*dst)))
+	ExpectThat(statMinObjO, Pointee(DeepEquals(dstMinObject)))
 }
 
 func (t *copyTest) InterestingNames() {

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -85,7 +85,7 @@ type Bucket interface {
 	//     https://cloud.google.com/storage/docs/json_api/v1/objects/get
 	StatObject(
 		ctx context.Context,
-		req *StatObjectRequest) (*Object, error)
+		req *StatObjectRequest) (*MinObject, *ExtendedObjectAttributes, error)
 
 	// List the objects in the bucket that meet the criteria defined by the
 	// request, returning a result object that contains the results and

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -237,7 +237,8 @@ func (m *mockBucket) NewReader(p0 context.Context, p1 *gcs.ReadObjectRequest) (o
 	return
 }
 
-func (m *mockBucket) StatObject(p0 context.Context, p1 *gcs.StatObjectRequest) (o0 *gcs.Object, o1 error) {
+func (m *mockBucket) StatObject(p0 context.Context,
+	p1 *gcs.StatObjectRequest) (o0 *gcs.MinObject, o1 *gcs.ExtendedObjectAttributes, o2 error) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
 
@@ -249,18 +250,23 @@ func (m *mockBucket) StatObject(p0 context.Context, p1 *gcs.StatObjectRequest) (
 		line,
 		[]interface{}{p0, p1})
 
-	if len(retVals) != 2 {
+	if len(retVals) != 3 {
 		panic(fmt.Sprintf("mockBucket.StatObject: invalid return values: %v", retVals))
 	}
 
-	// o0 *Object
+	// o0 *MinObject
 	if retVals[0] != nil {
-		o0 = retVals[0].(*gcs.Object)
+		o0 = retVals[0].(*gcs.MinObject)
 	}
 
-	// o1 error
+	// o1 *ExtendedObjectAttributes
 	if retVals[1] != nil {
-		o1 = retVals[1].(error)
+		o1 = retVals[1].(*gcs.ExtendedObjectAttributes)
+	}
+
+	// o2 error
+	if retVals[2] != nil {
+		o2 = retVals[2].(error)
 	}
 
 	return


### PR DESCRIPTION
### Description
This PR changes StatObjet method to return MinObject and ExtendedObjectAttributes instead of complete GCS Object. This will enable us to store MinObject in stat cache.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO
