### PR TITLE
[PR-3] Include ReturnFull in stat object request

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -164,13 +164,13 @@ func (f *FileInode) checkInvariants() {
 }
 
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, returnFullObject bool) (o *gcs.Object, b bool, err error) {
+func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, includeExtendedObjectAttributes bool) (o *gcs.Object, b bool, err error) {
 	// Stat the object in GCS. ForceFetchFromGcs ensures object is fetched from
 	// gcs and not cache.
 	req := &gcs.StatObjectRequest{
-		Name:              f.name.GcsObjectName(),
-		ForceFetchFromGcs: forceFetchFromGcs,
-		ReturnFull:        returnFullObject,
+		Name:                           f.name.GcsObjectName(),
+		ForceFetchFromGcs:              forceFetchFromGcs,
+		ReturnExtendedObjectAttributes: includeExtendedObjectAttributes,
 	}
 	o, err = f.bucket.StatObject(ctx, req)
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -164,12 +164,13 @@ func (f *FileInode) checkInvariants() {
 }
 
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool) (o *gcs.Object, b bool, err error) {
+func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, returnFullObject bool) (o *gcs.Object, b bool, err error) {
 	// Stat the object in GCS. ForceFetchFromGcs ensures object is fetched from
 	// gcs and not cache.
 	req := &gcs.StatObjectRequest{
 		Name:              f.name.GcsObjectName(),
 		ForceFetchFromGcs: forceFetchFromGcs,
+		ReturnFull:        returnFullObject,
 	}
 	o, err = f.bucket.StatObject(ctx, req)
 
@@ -400,7 +401,7 @@ func (f *FileInode) Attributes(
 
 	// If the object has been clobbered, we reflect that as the inode being
 	// unlinked.
-	_, clobbered, err := f.clobbered(ctx, false)
+	_, clobbered, err := f.clobbered(ctx, false, false)
 	if err != nil {
 		err = fmt.Errorf("clobbered: %w", err)
 		return
@@ -564,7 +565,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 	// properties and using that when object is synced below. StatObject by
 	// default sets the projection to full, which fetches all the object
 	// properties.
-	latestGcsObj, isClobbered, err := f.clobbered(ctx, true)
+	latestGcsObj, isClobbered, err := f.clobbered(ctx, true, true)
 
 	// Clobbered is treated as being unlinked. There's no reason to return an
 	// error in that case. We simply return without syncing the object.

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -202,8 +202,8 @@ type StatObjectRequest struct {
 	// to fetch from gcs or from cache.
 	ForceFetchFromGcs bool
 
-	// Controls whether StatObject requests includes GCS ExtendedObjectAttributes.
-	ReturnFull bool
+	// Controls whether StatObject response includes GCS ExtendedObjectAttributes.
+	ReturnExtendedObjectAttributes bool
 }
 
 type Projection int64

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -201,6 +201,9 @@ type StatObjectRequest struct {
 	// Relevant only when fast_stat_bucket is used. This field controls whether
 	// to fetch from gcs or from cache.
 	ForceFetchFromGcs bool
+
+	// Controls whether StatObject requests includes GCS ExtendedObjectAttributes.
+	ReturnFull bool
 }
 
 type Projection int64


### PR DESCRIPTION
### Description
This PR includes ReturnFull parameter in stat object request to determine whether ExtendedObjectAttributes should be returned from StatObject Call.
ReturnFull is only passed true during clobbered check.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran via KOKORO
