### PR TITLE
Add cache-dir to experiment configuration of read cache tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -7,7 +7,7 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_cache_file_for_range_read_true",
+      "config_name": "read_cache_cache_for_range_read_true",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
@@ -20,7 +20,7 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_cache_file_for_range_read_false",
+      "config_name": "read_cache_cache_for_range_read_false",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -7,7 +7,7 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_cache_for_range_read_true",
+      "config_name": "read_cache_cache_file_for_range_read_true_20240220",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {
@@ -20,7 +20,7 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "read_cache_cache_for_range_read_false",
+      "config_name": "read_cache_cache_file_for_range_read_false_20240220",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
       "config_file_flags_as_json": {
         "file-cache": {

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -13,7 +13,8 @@
         "file-cache": {
           "max-size-mb": -1,
           "cache-file-for-range-read": true
-        }
+        },
+        "cache-dir": "/tmp/cache"
       },
       "branch": "read_cache_release",
       "end_date": "2024-03-31 05:30:00+00:00"
@@ -25,7 +26,8 @@
         "file-cache": {
           "max-size-mb": -1,
           "cache-file-for-range-read": false
-        }
+        },
+        "cache-dir": "/tmp/cache"
       },
       "branch": "read_cache_release",
       "end_date": "2024-03-31 05:30:00+00:00"


### PR DESCRIPTION
### Description
Add cache-dir to experiment configuration

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
