### PR TITLE
[Bug fix] Fix concurrent list directory and file creation

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2074,11 +2074,9 @@ func (fs *fileSystem) ReadDir(
 
 	// Fetch local file entries beforehand and pass it to directory handle as
 	// we need fs lock to fetch local file entries.
-	in.Lock()
 	fs.mu.Lock()
 	localFileEntries := in.LocalFileEntries(fs.localFileInodes)
 	fs.mu.Unlock()
-	in.Unlock()
 
 	dh.Mu.Lock()
 	defer dh.Mu.Unlock()

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -121,28 +121,27 @@ func (t *DirHandleTest) EnsureEntriesWithLocalAndGCSFiles() {
 	AssertEq(nil, err)
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
 	AssertEq(nil, err)
-	// Set up local file inodes.
-	localIn1 := t.createLocalFileInode("localFile1", 10)
-	localIn2 := t.createLocalFileInode("localFile2", 20)
-	// Setup localFileInodes Map.
-	localFileInodes := map[inode.Name]inode.Inode{
-		localIn1.Name(): localIn1,
-		localIn2.Name(): localIn2,
+	localFileName1 := "localFile1"
+	localFileName2 := "localFile2"
+	// Setup localFileEntries.
+	localFileEntries := []fuseutil.Dirent{
+		{Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
+		{Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
-	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
 	AssertEq(nil, err)
 	AssertEq(4, len(t.dh.entries))
 	t.validateEntry(t.dh.entries[0], "gcsObject1", fuseutil.DT_File)
 	t.validateEntry(t.dh.entries[1], "gcsObject2", fuseutil.DT_File)
-	t.validateEntry(t.dh.entries[2], "localFile1", fuseutil.DT_File)
-	t.validateEntry(t.dh.entries[3], "localFile2", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[2], localFileName1, fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[3], localFileName2, fuseutil.DT_File)
 }
 
-func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
+func (t *DirHandleTest) EnsureEntriesWithOnlyGCSFiles() {
 	var err error
 	// Set up empty GCS objects.
 	// DirHandle holds a DirInode pointing to "testDir".
@@ -150,11 +149,11 @@ func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
 	AssertEq(nil, err)
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
 	AssertEq(nil, err)
-	// Setup empty localFileInodes Map.
-	localFileInodes := map[inode.Name]inode.Inode{}
+	// Setup empty localFileEntries.
+	var localFileEntries []fuseutil.Dirent
 
 	// Ensure entries.
-	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
 	AssertEq(nil, err)
@@ -163,25 +162,24 @@ func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
 	t.validateEntry(t.dh.entries[1], "gcsObject2", fuseutil.DT_File)
 }
 
-func (t *DirHandleTest) EnsureEntriesWithOnlyGCSFiles() {
+func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
 	var err error
-	// Set up local file inodes.
-	localIn1 := t.createLocalFileInode("localFile1", 10)
-	localIn2 := t.createLocalFileInode("localFile2", 20)
-	// Setup localFileInodes Map.
-	localFileInodes := map[inode.Name]inode.Inode{
-		localIn1.Name(): localIn1,
-		localIn2.Name(): localIn2,
+	localFileName1 := "localFile1"
+	localFileName2 := "localFile2"
+	// Setup localFileEntries.
+	localFileEntries := []fuseutil.Dirent{
+		{Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
+		{Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
-	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
 	AssertEq(nil, err)
 	AssertEq(2, len(t.dh.entries))
-	t.validateEntry(t.dh.entries[0], "localFile1", fuseutil.DT_File)
-	t.validateEntry(t.dh.entries[1], "localFile2", fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[0], localFileName1, fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[1], localFileName2, fuseutil.DT_File)
 }
 
 func (t *DirHandleTest) EnsureEntriesWithSameNameLocalAndGCSFile() {
@@ -190,15 +188,14 @@ func (t *DirHandleTest) EnsureEntriesWithSameNameLocalAndGCSFile() {
 	// DirHandle holds a DirInode pointing to "testDir".
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/file1", nil)
 	AssertEq(nil, err)
-	// Set up local file inodes.
-	localIn := t.createLocalFileInode("file1", 10)
-	// Setup localFileInodes Map.
-	localFileInodes := map[inode.Name]inode.Inode{
-		localIn.Name(): localIn,
+	localFileName := "file1"
+	// Setup localFileEntries.
+	localFileEntries := []fuseutil.Dirent{
+		{Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
-	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
 	AssertNe(nil, err)
@@ -211,19 +208,18 @@ func (t *DirHandleTest) EnsureEntriesWithSameNameLocalFileAndGCSDirectory() {
 	// DirHandle holds a DirInode pointing to "testDir".
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/file1/", nil)
 	AssertEq(nil, err)
-	// Set up local file inodes.
-	localIn := t.createLocalFileInode("file1", 10)
-	// Setup localFileInodes Map.
-	localFileInodes := map[inode.Name]inode.Inode{
-		localIn.Name(): localIn,
+	localFileName := "file1"
+	// Setup localFileEntries.
+	localFileEntries := []fuseutil.Dirent{
+		{Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
-	err = t.dh.ensureEntries(t.ctx, localFileInodes)
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
 	AssertEq(nil, err)
 	AssertEq(2, len(t.dh.entries))
-	t.validateEntry(t.dh.entries[0], "file1", fuseutil.DT_Directory)
-	t.validateEntry(t.dh.entries[1], "file1"+inode.ConflictingFileNameSuffix, fuseutil.DT_File)
+	t.validateEntry(t.dh.entries[0], localFileName, fuseutil.DT_Directory)
+	t.validateEntry(t.dh.entries[1], localFileName+inode.ConflictingFileNameSuffix, fuseutil.DT_File)
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -130,7 +130,6 @@ type DirInode interface {
 
 	// LocalFileEntries lists the local files present in the directory.
 	// Local means that the file is not yet present on GCS.
-	// LOCKS_REQUIRED(fs)
 	LocalFileEntries(localFileInodes map[Name]Inode) (localEntries []fuseutil.Dirent)
 }
 
@@ -804,6 +803,7 @@ func (d *dirInode) DeleteChildDir(
 	return
 }
 
+// LOCKS_REQUIRED(fs)
 func (d *dirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEntries []fuseutil.Dirent) {
 	for localInodeName, in := range localFileInodes {
 		// It is possible that the local file inode has been unlinked, but

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -128,8 +128,9 @@ type DirInode interface {
 		name string,
 		isImplicitDir bool) (err error)
 
-	// localFileEntries lists the local files present in the directory.
+	// LocalFileEntries lists the local files present in the directory.
 	// Local means that the file is not yet present on GCS.
+	// LOCKS_REQUIRED(fs)
 	LocalFileEntries(localFileInodes map[Name]Inode) (localEntries []fuseutil.Dirent)
 }
 

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -181,9 +181,9 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Concurrently create 200 local files and read directory 400 times.
-	go creatingNLocalFilesShouldNotThrowError(200, &wg, t)
-	go readingDirNTimesShouldNotThrowError(400, &wg, t)
+	// Concurrently create 100 local files and read directory 200 times.
+	go creatingNLocalFilesShouldNotThrowError(100, &wg, t)
+	go readingDirNTimesShouldNotThrowError(200, &wg, t)
 
 	wg.Wait()
 }

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -20,7 +20,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +30,32 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/tools/integration_tests/util/setup"
 )
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+func creatingNLocalFilesShouldNotThrowError(n int, wg *sync.WaitGroup, t *testing.T) {
+	defer wg.Done()
+	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
+	for i := 0; i < n; i++ {
+		filePath := path.Join(testDirPath, ExplicitDirName, FileName1+strconv.FormatInt(int64(i), 10))
+		operations.CreateFile(filePath, FilePerms, t)
+	}
+}
+
+func readingDirNTimesShouldNotThrowError(n int, wg *sync.WaitGroup, t *testing.T) {
+	defer wg.Done()
+	for i := 0; i < n; i++ {
+		_, err := os.ReadDir(setup.MntDir())
+		if err != nil {
+			t.Errorf("Error while reading directory %dth time: %v", i, err)
+		}
+	}
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Tests
+// //////////////////////////////////////////////////////////////////////
 
 func TestReadDir(t *testing.T) {
 	// Structure
@@ -146,4 +174,16 @@ func TestReadDirWithSameNameLocalAndGCSFile(t *testing.T) {
 
 	// Close the local file.
 	operations.CloseFileShouldNotThrowError(fh1, t)
+}
+
+func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T) {
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Concurrently create 200 local files and read directory 400 times.
+	go creatingNLocalFilesShouldNotThrowError(200, &wg, t)
+	go readingDirNTimesShouldNotThrowError(400, &wg, t)
+
+	wg.Wait()
 }


### PR DESCRIPTION
### Description

Concurrently listing a directory along with file creation caused GCSFuse process to crash causing transport endpoint not connected errors. This was happening because fs.localFileInodes map was being read without acquiring a lock. Go maps are not safe for concurrent reads and writes which caused the crash.

Fix: Acquire fs lock before reading localFileInodes map

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1726
https://github.com/GoogleCloudPlatform/gcsfuse/issues/1603

### Testing details
1. Manual - Manually verified that the issue is no longer happening by listing a directory 1000 times and creating 1000 files in a separate directory on GCSFuse mount.
2. Unit tests - Updated
3. Integration tests - Added and ran via KOKORO
4. Perf tests -
![Perf test results](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/57d758f1-524c-4f0a-a5eb-fd06df2a8c8b)
5. List Benchmarks -
![list benchmarks](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/5c8af2b4-60dc-4673-8d79-09f28bda5f68)


