### PR TITLE
[PR-4] Store min object in stat cache

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -86,7 +86,7 @@ type entry struct {
 
 // Size returns the memory-size (resident set size) of the receiver entry.
 // The size calculated by the unsafe.Sizeof calls, and
-// NestedSizeOfGcsObject etc. does not account for
+// NestedSizeOfGcsMinObject etc. does not account for
 // hidden members in data structures like maps, slices, linked-lists etc.
 // To account for those, we are adding a fixed constant of 553 bytes (deduced from
 // benchmark runs) to heap-size per positive stat-cache entry

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -35,7 +35,7 @@ type StatCache interface {
 	// replace negative entries.
 	//
 	// The entry will expire after the supplied time.
-	Insert(o *gcs.Object, expiration time.Time)
+	Insert(o *gcs.MinObject, expiration time.Time)
 
 	// Set up a negative entry for the given name, indicating that the name
 	// doesn't exist. Overwrite any existing entry for the name, positive or
@@ -48,7 +48,7 @@ type StatCache interface {
 	// Return the current entry for the given name, or nil if there is a negative
 	// entry. Return hit == false when there is neither a positive nor a negative
 	// entry, or the entry has expired according to the supplied current time.
-	LookUp(name string, now time.Time) (hit bool, o *gcs.Object)
+	LookUp(name string, now time.Time) (hit bool, o *gcs.MinObject)
 }
 
 // Create a new bucket-view to the passed shared-cache object.
@@ -79,7 +79,7 @@ type statCacheBucketView struct {
 // An entry in the cache, pairing an object with the expiration time for the
 // entry. Nil object means negative entry.
 type entry struct {
-	o          *gcs.Object
+	m          *gcs.MinObject
 	expiration time.Time
 	key        string
 }
@@ -95,8 +95,8 @@ func (e entry) Size() (size uint64) {
 	// First, calculate size on heap.
 	// Additional 2*util.UnsafeSizeOf(&e.key) is to account for the copies of string
 	// struct stored in the cache map and in the cache linked-list.
-	size = uint64(util.UnsafeSizeOf(&e) + len(e.key) + 2*util.UnsafeSizeOf(&e.key) + util.NestedSizeOfGcsObject(e.o))
-	if e.o != nil {
+	size = uint64(util.UnsafeSizeOf(&e) + len(e.key) + 2*util.UnsafeSizeOf(&e.key) + util.NestedSizeOfGcsMinObject(e.m))
+	if e.m != nil {
 		size += 553
 	}
 
@@ -108,20 +108,20 @@ func (e entry) Size() (size uint64) {
 
 // Should the supplied object for a new positive entry replace the given
 // existing entry?
-func shouldReplace(o *gcs.Object, existing entry) bool {
+func shouldReplace(o *gcs.MinObject, existing entry) bool {
 	// Negative entries should always be replaced with positive entries.
-	if existing.o == nil {
+	if existing.m == nil {
 		return true
 	}
 
 	// Compare first on generation.
-	if o.Generation != existing.o.Generation {
-		return o.Generation > existing.o.Generation
+	if o.Generation != existing.m.Generation {
+		return o.Generation > existing.m.Generation
 	}
 
 	// Break ties on metadata generation.
-	if o.MetaGeneration != existing.o.MetaGeneration {
-		return o.MetaGeneration > existing.o.MetaGeneration
+	if o.MetaGeneration != existing.m.MetaGeneration {
+		return o.MetaGeneration > existing.m.MetaGeneration
 	}
 
 	// Break ties by preferring fresher entries.
@@ -139,19 +139,19 @@ func (sc *statCacheBucketView) key(objectName string) string {
 	return objectName
 }
 
-func (sc *statCacheBucketView) Insert(o *gcs.Object, expiration time.Time) {
-	name := sc.key(o.Name)
+func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
+	name := sc.key(m.Name)
 
 	// Is there already a better entry?
 	if existing := sc.sharedCache.LookUp(name); existing != nil {
-		if !shouldReplace(o, existing.(entry)) {
+		if !shouldReplace(m, existing.(entry)) {
 			return
 		}
 	}
 
 	// Insert an entry.
 	e := entry{
-		o:          o,
+		m:          m,
 		expiration: expiration,
 		key:        name,
 	}
@@ -166,7 +166,7 @@ func (sc *statCacheBucketView) AddNegativeEntry(objectName string, expiration ti
 
 	// Insert a negative entry.
 	e := entry{
-		o:          nil,
+		m:          nil,
 		expiration: expiration,
 		key:        name,
 	}
@@ -183,7 +183,7 @@ func (sc *statCacheBucketView) Erase(objectName string) {
 
 func (sc *statCacheBucketView) LookUp(
 	objectName string,
-	now time.Time) (hit bool, o *gcs.Object) {
+	now time.Time) (hit bool, m *gcs.MinObject) {
 	// Look up in the LRU cache.
 	value := sc.sharedCache.LookUp(sc.key(objectName))
 	if value == nil {
@@ -199,7 +199,7 @@ func (sc *statCacheBucketView) LookUp(
 	}
 
 	hit = true
-	o = e.o
+	m = e.m
 
 	return
 }

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -35,7 +35,7 @@ type StatCache interface {
 	// replace negative entries.
 	//
 	// The entry will expire after the supplied time.
-	Insert(o *gcs.MinObject, expiration time.Time)
+	Insert(m *gcs.MinObject, expiration time.Time)
 
 	// Set up a negative entry for the given name, indicating that the name
 	// doesn't exist. Overwrite any existing entry for the name, positive or
@@ -48,7 +48,7 @@ type StatCache interface {
 	// Return the current entry for the given name, or nil if there is a negative
 	// entry. Return hit == false when there is neither a positive nor a negative
 	// entry, or the entry has expired according to the supplied current time.
-	LookUp(name string, now time.Time) (hit bool, o *gcs.MinObject)
+	LookUp(name string, now time.Time) (hit bool, m *gcs.MinObject)
 }
 
 // Create a new bucket-view to the passed shared-cache object.
@@ -108,20 +108,20 @@ func (e entry) Size() (size uint64) {
 
 // Should the supplied object for a new positive entry replace the given
 // existing entry?
-func shouldReplace(o *gcs.MinObject, existing entry) bool {
+func shouldReplace(m *gcs.MinObject, existing entry) bool {
 	// Negative entries should always be replaced with positive entries.
 	if existing.m == nil {
 		return true
 	}
 
 	// Compare first on generation.
-	if o.Generation != existing.m.Generation {
-		return o.Generation > existing.m.Generation
+	if m.Generation != existing.m.Generation {
+		return m.Generation > existing.m.Generation
 	}
 
 	// Break ties on metadata generation.
-	if o.MetaGeneration != existing.m.MetaGeneration {
-		return o.MetaGeneration > existing.m.MetaGeneration
+	if m.MetaGeneration != existing.m.MetaGeneration {
+		return m.MetaGeneration > existing.m.MetaGeneration
 	}
 
 	// Break ties by preferring fresher entries.

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -158,6 +158,7 @@ func (t *StatCacheTest) FillUpToCapacity() {
 	m1 := &gcs.MinObject{Name: "taco"}
 	m2 := &gcs.MinObject{Name: "quesadilla"}
 
+	//TODO: to update the sizes in comments.
 	t.cache.Insert(m0, expiration)                    // size = 1886 bytes
 	t.cache.Insert(m1, expiration)                    // size = 1874 bytes (cumulative = 3760 bytes)
 	t.cache.AddNegativeEntry("enchilada", expiration) // size = 178 bytes (cumulative = 3938 bytes)

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -84,12 +84,8 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 }
 
 // LOCKS_EXCLUDED(b.mu)
-func (b *fastStatBucket) insert(m *gcs.MinObject) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	expiration := b.clock.Now().Add(b.ttl)
-	b.cache.Insert(m, expiration)
+func (b *fastStatBucket) insert(o *gcs.Object) {
+	b.insertMultiple([]*gcs.Object{o})
 }
 
 // LOCKS_EXCLUDED(b.mu)
@@ -147,8 +143,7 @@ func (b *fastStatBucket) CreateObject(
 	}
 
 	// Record the new object.
-	m := storageutil.ConvertObjToMinObject(o)
-	b.insert(m)
+	b.insert(o)
 
 	return
 }
@@ -167,8 +162,7 @@ func (b *fastStatBucket) CopyObject(
 	}
 
 	// Record the new version.
-	m := storageutil.ConvertObjToMinObject(o)
-	b.insert(m)
+	b.insert(o)
 
 	return
 }
@@ -187,8 +181,7 @@ func (b *fastStatBucket) ComposeObjects(
 	}
 
 	// Record the new version.
-	m := storageutil.ConvertObjToMinObject(o)
-	b.insert(m)
+	b.insert(o)
 
 	return
 }
@@ -259,8 +252,7 @@ func (b *fastStatBucket) UpdateObject(
 	}
 
 	// Record the new version.
-	m := storageutil.ConvertObjToMinObject(o)
-	b.insert(m)
+	b.insert(o)
 
 	return
 }
@@ -287,7 +279,8 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 	}
 
 	// Put the object in cache.
-	b.insert(m)
+	o := storageutil.ConvertMinObjectToObject(m)
+	b.insert(o)
 
 	return
 }

--- a/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
+++ b/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
@@ -78,7 +78,7 @@ func (m *mockStatCache) Erase(p0 string) {
 	}
 }
 
-func (m *mockStatCache) Insert(p0 *gcs.Object, p1 time.Time) {
+func (m *mockStatCache) Insert(p0 *gcs.MinObject, p1 time.Time) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
 
@@ -95,7 +95,7 @@ func (m *mockStatCache) Insert(p0 *gcs.Object, p1 time.Time) {
 	}
 }
 
-func (m *mockStatCache) LookUp(p0 string, p1 time.Time) (o0 bool, o1 *gcs.Object) {
+func (m *mockStatCache) LookUp(p0 string, p1 time.Time) (o0 bool, o1 *gcs.MinObject) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
 
@@ -118,7 +118,7 @@ func (m *mockStatCache) LookUp(p0 string, p1 time.Time) (o0 bool, o1 *gcs.Object
 
 	// o1 *gcs.Object
 	if retVals[1] != nil {
-		o1 = retVals[1].(*gcs.Object)
+		o1 = retVals[1].(*gcs.MinObject)
 	}
 
 	return

--- a/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
+++ b/internal/storage/caching/mock_gcscaching/mock_stat_cache.go
@@ -116,7 +116,7 @@ func (m *mockStatCache) LookUp(p0 string, p1 time.Time) (o0 bool, o1 *gcs.MinObj
 		o0 = retVals[0].(bool)
 	}
 
-	// o1 *gcs.Object
+	// o1 *gcs.MinObject
 	if retVals[1] != nil {
 		o1 = retVals[1].(*gcs.MinObject)
 	}

--- a/internal/util/sizeof.go
+++ b/internal/util/sizeof.go
@@ -234,31 +234,29 @@ func contentSizeOfArrayOfAclPointers(acls *[]*storagev1.ObjectAccessControl) (si
 }
 
 // NestedSizeOfGcsMinObject returns the full nested memory size
-// of the gcs.Object pointed by the passed pointer.
+// of the gcs.MinObject pointed by the passed pointer.
 // Improvement scope: This can be generalized to a general-struct
 // but that needs better understanding of the reflect package
 // and other related packages.
-func NestedSizeOfGcsMinObject(o *gcs.MinObject) (size int) {
-	if o == nil {
+func NestedSizeOfGcsMinObject(m *gcs.MinObject) (size int) {
+	if m == nil {
 		return
 	}
 
 	// Get raw size of the structure.
-	size = UnsafeSizeOf(o)
+	size = UnsafeSizeOf(m)
 
 	// Account for string members.
-	for _, strPtr := range []*string{
-		&o.Name, &o.ContentEncoding} {
+	for _, strPtr := range []*string{&m.Name, &m.ContentEncoding} {
 		size += contentSizeOfString(strPtr)
 	}
 
-	// Account for integer members - Size, Generation, MetaGeneration, ComponentCount.
-	// Account for time members - Deleted, Updated.
-	// Account for boolean members - EventBasedHold.
+	// Account for integer members - Size, Generation, MetaGeneration.
+	// Account for time members - Updated.
 	// Nothing to be added for any built-in types - already accounted for in unsafeSizeOf(o).
 
 	// Account for map members.
-	size += contentSizeOfStringToStringMap(&o.Metadata)
+	size += contentSizeOfStringToStringMap(&m.Metadata)
 
 	return
 }

--- a/internal/util/sizeof.go
+++ b/internal/util/sizeof.go
@@ -233,12 +233,12 @@ func contentSizeOfArrayOfAclPointers(acls *[]*storagev1.ObjectAccessControl) (si
 	return
 }
 
-// NestedSizeOfGcsObject returns the full nested memory size
+// NestedSizeOfGcsMinObject returns the full nested memory size
 // of the gcs.Object pointed by the passed pointer.
 // Improvement scope: This can be generalized to a general-struct
 // but that needs better understanding of the reflect package
 // and other related packages.
-func NestedSizeOfGcsObject(o *gcs.Object) (size int) {
+func NestedSizeOfGcsMinObject(o *gcs.MinObject) (size int) {
 	if o == nil {
 		return
 	}
@@ -248,16 +248,9 @@ func NestedSizeOfGcsObject(o *gcs.Object) (size int) {
 
 	// Account for string members.
 	for _, strPtr := range []*string{
-		&o.Name, &o.ContentType, &o.ContentLanguage, &o.CacheControl,
-		&o.Owner, &o.ContentEncoding, &o.MediaLink, &o.StorageClass,
-		&o.ContentDisposition, &o.CustomTime} {
+		&o.Name, &o.ContentEncoding} {
 		size += contentSizeOfString(strPtr)
 	}
-
-	// Account for integer-pointer members.
-	size += UnsafeSizeOf(o.CRC32C)
-	// Account for pointer-to-integer-array members.
-	size += UnsafeSizeOf(o.MD5)
 
 	// Account for integer members - Size, Generation, MetaGeneration, ComponentCount.
 	// Account for time members - Deleted, Updated.
@@ -266,9 +259,6 @@ func NestedSizeOfGcsObject(o *gcs.Object) (size int) {
 
 	// Account for map members.
 	size += contentSizeOfStringToStringMap(&o.Metadata)
-
-	// Account for slice members.
-	size += contentSizeOfArrayOfAclPointers(&o.Acl)
 
 	return
 }

--- a/internal/util/sizeof_test.go
+++ b/internal/util/sizeof_test.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"crypto/md5"
 	"net/http"
 	"testing"
 	"time"
@@ -24,7 +23,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/internal/storage/gcs"
 	. "github.com/jacobsa/ogletest"
 	"google.golang.org/api/googleapi"
-	storagev1 "google.golang.org/api/storage/v1"
 )
 
 func TestSizeof(t *testing.T) { RunTests(t) }
@@ -50,7 +48,6 @@ var (
 	sizeOfEmptyIntArray     int
 	sizeOfEmptyStringIntMap int
 	sizeOfEmptyStruct       int
-	sizeOfEmptyGcsObject    int
 	sizeOfEmptyMinObject    int
 )
 
@@ -66,7 +63,6 @@ func init() {
 	sizeOfEmptyStruct = int(unsafe.Sizeof(emptyStruct{}))
 	AssertEq(0, sizeOfEmptyStruct)
 
-	sizeOfEmptyGcsObject = int(unsafe.Sizeof(gcs.Object{}))
 	sizeOfEmptyMinObject = int(unsafe.Sizeof(gcs.MinObject{}))
 }
 
@@ -277,86 +273,30 @@ func (t *SizeofTest) TestContentSizeOfServerResponse() {
 
 func (t *SizeofTest) TestNestedSizeOfGcsObject() {
 	const name string = "my-object"
-	const contentType string = "plain/bin/gzip"
-	const contentLanguage string = "en/fr/jp"
-	const cacheControl string = "off/on"
 	const contentEncoding string = "gzip/none"
-	const owner string = "my-user"
-	var md5Value [md5.Size]byte = [md5.Size]byte{0, 2, 42, 2, 4, 54, 3}
-	var crc32 uint32 = 758734925
-	var mediaLink string = "media-link"
 	var generation int64 = 858734898
 	var metaGeneration int64 = 858734899
-	const storageClass string = "standard"
-	deleted := time.Now()
 	updated := time.Now()
-	const componentCount int64 = 1
-	const contentDisposition string = "my-content-disposition"
-	const customTime string = "my-custom-time"
-	const eventBasedHold bool = true
 	customMetadaField1 := "google-symlink"
 	customMetadaValue1 := "true"
 	customMetadaField2 := "google-xyz-field"
 	customMetadaValue2 := "google-symlink"
 	customMetadataFields := map[string]string{customMetadaField1: customMetadaValue1, customMetadaField2: customMetadaValue2}
 	customMetadataFieldsContentSize := emptyStringSize + contentSizeOfString(&customMetadaField1) + emptyStringSize + contentSizeOfString(&customMetadaValue1) + emptyStringSize + contentSizeOfString(&customMetadaField2) + emptyStringSize + contentSizeOfString(&customMetadaValue2)
-	customAcls := []*storagev1.ObjectAccessControl{
-		{
-			Bucket:     "my-bucket",
-			Domain:     "my-domain",
-			Email:      "my-email@my-domain.com",
-			Entity:     "my-entity",
-			EntityId:   "my-entity-id",
-			Etag:       "my-etag",
-			Generation: generation,
-			Id:         "object-id",
-			Kind:       "object-kind",
-			Object:     "my-object",
-			ProjectTeam: &storagev1.ObjectAccessControlProjectTeam{
-				ProjectNumber: "78358753894",
-				Team:          "project-team",
-				ForceSendFields: []string{
-					"field1", "field2", "field3",
-				},
-			},
-			Role:            "my-role",
-			SelfLink:        "",
-			ServerResponse:  googleapi.ServerResponse{},
-			ForceSendFields: []string{},
-			NullFields:      []string{},
-		},
+
+	m := gcs.MinObject{
+		Name:            name,
+		Size:            100,
+		ContentEncoding: contentEncoding,
+		Metadata:        customMetadataFields,
+		Generation:      generation,
+		MetaGeneration:  metaGeneration,
+		Updated:         updated,
 	}
 
-	o := gcs.Object{
-		Name:               name,
-		ContentType:        contentType,
-		ContentLanguage:    contentLanguage,
-		CacheControl:       cacheControl,
-		Owner:              owner,
-		Size:               100,
-		ContentEncoding:    contentEncoding,
-		MD5:                &md5Value,
-		CRC32C:             &crc32,
-		MediaLink:          mediaLink,
-		Metadata:           customMetadataFields,
-		Generation:         generation,
-		MetaGeneration:     metaGeneration,
-		StorageClass:       storageClass,
-		Deleted:            deleted,
-		Updated:            updated,
-		ComponentCount:     componentCount,
-		ContentDisposition: contentDisposition,
-		CustomTime:         customTime,
-		EventBasedHold:     eventBasedHold,
-		Acl:                customAcls,
-	}
-
-	var expectedSize int = sizeOfEmptyGcsObject
-	expectedSize += len(contentType) + len(name) + len(contentLanguage) + len(cacheControl) + len(contentEncoding) + len(owner) + len(mediaLink) + len(storageClass) + len(contentDisposition) + len(customTime)
-	expectedSize += md5.Size // for MD5 [md5.Size]byte
-	expectedSize += 4        // for CRC 32 uint32
+	var expectedSize int = sizeOfEmptyMinObject
+	expectedSize += len(name) + len(contentEncoding)
 	expectedSize += customMetadataFieldsContentSize
-	expectedSize += contentSizeOfArrayOfAclPointers(&customAcls)
 
-	AssertEq(expectedSize, NestedSizeOfGcsObject(&o))
+	AssertEq(expectedSize, NestedSizeOfGcsMinObject(&m))
 }

--- a/internal/util/sizeof_test.go
+++ b/internal/util/sizeof_test.go
@@ -271,7 +271,7 @@ func (t *SizeofTest) TestContentSizeOfServerResponse() {
 	}
 }
 
-func (t *SizeofTest) TestNestedSizeOfGcsObject() {
+func (t *SizeofTest) TestNestedSizeOfGcsMinObject() {
 	const name string = "my-object"
 	const contentEncoding string = "gzip/none"
 	var generation int64 = 858734898


### PR DESCRIPTION
### Description
This PR includes changes to store minimal object in GCSFuse stat cache instead of all the attributes of object.
Insert and LookUp method of stat cache interface & all the implementations are also changed to use gcs.MinObject instead of gcs.Object.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - Ran via KOKORO
