### PR TITLE
Merge "Run tests with static mounting only to reduce run time in e2e tests" to master

### DIFF
--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -271,3 +271,10 @@ func runTestsOnlyForDynamicMount(t *testing.T) {
 		t.SkipNow()
 	}
 }
+
+func runTestsOnlyForStaticMount(t *testing.T) {
+	if strings.Contains(mountDir, setup.TestBucket()) || setup.OnlyDirMounted() != "" {
+		log.Println("This test will run only for static mounting...")
+		t.SkipNow()
+	}
+}

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -92,6 +92,7 @@ func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithoutChunkDownloaded(
 ////////////////////////////////////////////////////////////////////////
 
 func TestRangeReadTest(t *testing.T) {
+	runTestsOnlyForStaticMount(t)
 	// Define flag set to run the tests.
 	flagSet := [][]string{
 		{"--implicit-dirs=true"},


### PR DESCRIPTION
### Description
Merge [Run tests with static mounting only to reduce run time in e2e tests](https://github.com/GoogleCloudPlatform/gcsfuse/commit/01ad85a9c076a53f7ce8e89aafb3af71eb8cc096) ([1736](https://github.com/GoogleCloudPlatform/gcsfuse/commit/01ad85a9c076a53f7ce8e89aafb3af71eb8cc096)) to master.

This is cherry-picking the fix in high runtime of the e2e tests from read_cache_release branch to the master branch.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Through presubmit
