### PR TITLE
[PR-5] Store min object in core inode instead of complete object

### DIFF
--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -140,9 +140,9 @@ func (d *baseDirInode) LookUpChild(ctx context.Context, name string) (*Core, err
 	}
 
 	return &Core{
-		Bucket:   &bucket,
-		FullName: NewRootName(bucket.Name()),
-		Object:   nil,
+		Bucket:    &bucket,
+		FullName:  NewRootName(bucket.Name()),
+		MinObject: nil,
 	}, nil
 }
 
@@ -180,7 +180,7 @@ func (d *baseDirInode) CreateLocalChildFile(name string) (*Core, error) {
 	return nil, fuse.ENOSYS
 }
 
-func (d *baseDirInode) CloneToChildFile(ctx context.Context, name string, src *gcs.Object) (*Core, error) {
+func (d *baseDirInode) CloneToChildFile(ctx context.Context, name string, src *gcs.MinObject) (*Core, error) {
 	return nil, fuse.ENOSYS
 }
 

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -171,7 +171,7 @@ func (t *BaseDirTest) LookUpChild_BucketFound() {
 	ExpectTrue(result.FullName.IsBucketRoot())
 	ExpectEq("bucketA/", result.FullName.LocalName())
 	ExpectEq("", result.FullName.GcsObjectName())
-	ExpectEq(nil, result.Object)
+	ExpectEq(nil, result.MinObject)
 	ExpectEq(metadata.ImplicitDirType, result.Type())
 
 	result, err = t.in.LookUpChild(t.ctx, "bucketB")
@@ -183,7 +183,7 @@ func (t *BaseDirTest) LookUpChild_BucketFound() {
 	ExpectTrue(result.FullName.IsBucketRoot())
 	ExpectEq("bucketB/", result.FullName.LocalName())
 	ExpectEq("", result.FullName.GcsObjectName())
-	ExpectEq(nil, result.Object)
+	ExpectEq(nil, result.MinObject)
 	ExpectEq(metadata.ImplicitDirType, result.Type())
 }
 

--- a/internal/fs/inode/core.go
+++ b/internal/fs/inode/core.go
@@ -33,7 +33,7 @@ type Core struct {
 
 	// The GCS object in the bucket above that backs up the inode. Can be empty
 	// if the inode is the base directory or an implicit directory.
-	Object *gcs.Object
+	MinObject *gcs.MinObject
 
 	// Specifies a local object which is not yet synced to GCS.
 	Local bool
@@ -48,11 +48,11 @@ func (c *Core) Type() metadata.Type {
 	switch {
 	case c == nil:
 		return metadata.UnknownType
-	case c.Object == nil && !c.Local:
+	case c.MinObject == nil && !c.Local:
 		return metadata.ImplicitDirType
 	case c.FullName.IsDir():
 		return metadata.ExplicitDirType
-	case IsSymlink(c.Object):
+	case IsSymlink(c.MinObject):
 		return metadata.SymlinkType
 	default:
 		return metadata.RegularFileType
@@ -62,11 +62,11 @@ func (c *Core) Type() metadata.Type {
 // SanityCheck returns an error if the object is conflicting with itself, which
 // means the metadata of the file system is broken.
 func (c Core) SanityCheck() error {
-	if c.Object != nil && c.FullName.objectName != c.Object.Name {
-		return fmt.Errorf("inode name %q mismatches object name %q", c.FullName, c.Object.Name)
+	if c.MinObject != nil && c.FullName.objectName != c.MinObject.Name {
+		return fmt.Errorf("inode name %q mismatches object name %q", c.FullName, c.MinObject.Name)
 	}
 
-	if c.Object == nil && !c.Local && !c.FullName.IsDir() {
+	if c.MinObject == nil && !c.Local && !c.FullName.IsDir() {
 		return fmt.Errorf("object missing for %q", c.FullName)
 	}
 

--- a/internal/fs/inode/core_test.go
+++ b/internal/fs/inode/core_test.go
@@ -60,13 +60,14 @@ func (t *CoreTest) TearDown() {}
 
 func (t *CoreTest) File() {
 	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
+	m := storageutil.ConvertObjToMinObject(o)
 	AssertEq(nil, err)
 
-	name := inode.NewFileName(inode.NewRootName(t.bucket.Name()), o.Name)
+	name := inode.NewFileName(inode.NewRootName(t.bucket.Name()), m.Name)
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: name,
-		Object:   o,
+		Bucket:    &t.bucket,
+		FullName:  name,
+		MinObject: m,
 	}
 	ExpectTrue(c.Exists())
 	ExpectEq(metadata.RegularFileType, c.Type())
@@ -75,10 +76,10 @@ func (t *CoreTest) File() {
 func (t *CoreTest) LocalFile() {
 	name := inode.NewFileName(inode.NewRootName(t.bucket.Name()), "test")
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: name,
-		Object:   nil,
-		Local:    true,
+		Bucket:    &t.bucket,
+		FullName:  name,
+		MinObject: nil,
+		Local:     true,
 	}
 	ExpectTrue(c.Exists())
 	ExpectEq(metadata.RegularFileType, c.Type())
@@ -86,13 +87,14 @@ func (t *CoreTest) LocalFile() {
 
 func (t *CoreTest) ExplicitDir() {
 	o, err := storageutil.CreateObject(t.ctx, t.bucket, "bar/", []byte(""))
+	m := storageutil.ConvertObjToMinObject(o)
 	AssertEq(nil, err)
 
-	name := inode.NewDirName(inode.NewRootName(t.bucket.Name()), o.Name)
+	name := inode.NewDirName(inode.NewRootName(t.bucket.Name()), m.Name)
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: name,
-		Object:   o,
+		Bucket:    &t.bucket,
+		FullName:  name,
+		MinObject: m,
 	}
 	ExpectTrue(c.Exists())
 	ExpectEq(metadata.ExplicitDirType, c.Type())
@@ -101,9 +103,9 @@ func (t *CoreTest) ExplicitDir() {
 func (t *CoreTest) ImplicitDir() {
 	name := inode.NewDirName(inode.NewRootName(t.bucket.Name()), "bar/")
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: name,
-		Object:   nil,
+		Bucket:    &t.bucket,
+		FullName:  name,
+		MinObject: nil,
 	}
 	ExpectTrue(c.Exists())
 	ExpectEq(metadata.ImplicitDirType, c.Type())
@@ -111,9 +113,9 @@ func (t *CoreTest) ImplicitDir() {
 
 func (t *CoreTest) BucketRootDir() {
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewRootName(t.bucket.Name()),
-		Object:   nil,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewRootName(t.bucket.Name()),
+		MinObject: nil,
 	}
 	ExpectTrue(c.Exists())
 	ExpectEq(metadata.ImplicitDirType, c.Type())
@@ -128,42 +130,43 @@ func (t *CoreTest) Nonexistent() {
 func (t *CoreTest) SanityCheck() {
 	root := inode.NewRootName(t.bucket.Name())
 	o, err := storageutil.CreateObject(t.ctx, t.bucket, "bar", []byte(""))
+	m := storageutil.ConvertObjToMinObject(o)
 	AssertEq(nil, err)
 
 	c := &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewDirName(root, "bar"),
-		Object:   nil,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewDirName(root, "bar"),
+		MinObject: nil,
 	}
 	ExpectEq(nil, c.SanityCheck()) // implicit dir is okay
 
 	c = &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewFileName(root, o.Name),
-		Object:   o,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewFileName(root, m.Name),
+		MinObject: m,
 	}
 	ExpectEq(nil, c.SanityCheck()) // name match
 
 	c = &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewFileName(root, "foo"),
-		Object:   o,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewFileName(root, "foo"),
+		MinObject: m,
 	}
 	ExpectNe(nil, c.SanityCheck()) // name mismatch
 
 	c = &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewFileName(root, "foo"),
-		Object:   nil,
-		Local:    true,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewFileName(root, "foo"),
+		MinObject: nil,
+		Local:     true,
 	}
 	ExpectEq(nil, c.SanityCheck()) // object is nil for local fileInode.
 
 	c = &inode.Core{
-		Bucket:   &t.bucket,
-		FullName: inode.NewFileName(root, "foo"),
-		Object:   nil,
-		Local:    false,
+		Bucket:    &t.bucket,
+		FullName:  inode.NewFileName(root, "foo"),
+		MinObject: nil,
+		Local:     false,
 	}
 	ExpectNe(nil, c.SanityCheck()) // Missing object for non-local fileInode.
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -234,13 +234,13 @@ func (t *DirTest) LookUpChild_FileOnly() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
 	ExpectEq(objName, result.FullName.GcsObjectName())
-	ExpectEq(objName, result.Object.Name)
-	ExpectEq(createObj.Generation, result.Object.Generation)
-	ExpectEq(createObj.Size, result.Object.Size)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectEq(createObj.Generation, result.MinObject.Generation)
+	ExpectEq(createObj.Size, result.MinObject.Size)
 
 	// A conflict marker name shouldn't work.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
@@ -263,13 +263,13 @@ func (t *DirTest) LookUpChild_DirOnly() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(objName, result.FullName.GcsObjectName())
-	ExpectEq(objName, result.Object.Name)
-	ExpectEq(createObj.Generation, result.Object.Generation)
-	ExpectEq(createObj.Size, result.Object.Size)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectEq(createObj.Generation, result.MinObject.Generation)
+	ExpectEq(createObj.Size, result.MinObject.Size)
 
 	// A conflict marker name shouldn't work.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
@@ -318,7 +318,7 @@ func (t *DirTest) LookUpChild_ImplicitDirOnly_Enabled() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	ExpectEq(nil, result.Object)
+	ExpectEq(nil, result.MinObject)
 	ExpectEq(metadata.ImplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(objName, result.FullName.GcsObjectName())
@@ -349,25 +349,25 @@ func (t *DirTest) LookUpChild_FileAndDir() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(dirObjName, result.FullName.GcsObjectName())
-	ExpectEq(dirObjName, result.Object.Name)
-	ExpectEq(dirObj.Generation, result.Object.Generation)
-	ExpectEq(dirObj.Size, result.Object.Size)
+	ExpectEq(dirObjName, result.MinObject.Name)
+	ExpectEq(dirObj.Generation, result.MinObject.Generation)
+	ExpectEq(dirObj.Size, result.MinObject.Size)
 
 	// Look up with the conflict marker name.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	AssertEq(metadata.UnknownType, t.getTypeFromCache(name+ConflictingFileNameSuffix))
 
 	ExpectEq(fileObjName, result.FullName.GcsObjectName())
-	ExpectEq(fileObjName, result.Object.Name)
-	ExpectEq(fileObj.Generation, result.Object.Generation)
-	ExpectEq(fileObj.Size, result.Object.Size)
+	ExpectEq(fileObjName, result.MinObject.Name)
+	ExpectEq(fileObj.Generation, result.MinObject.Generation)
+	ExpectEq(fileObj.Size, result.MinObject.Size)
 }
 
 func (t *DirTest) LookUpChild_SymlinkAndDir() {
@@ -391,7 +391,7 @@ func (t *DirTest) LookUpChild_SymlinkAndDir() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 
 	// The following check should have been for metadata.SymlinkType,
 	// because of the t.setSymlinkTarget call above, but it is not.
@@ -402,21 +402,21 @@ func (t *DirTest) LookUpChild_SymlinkAndDir() {
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(dirObjName, result.FullName.GcsObjectName())
-	ExpectEq(dirObjName, result.Object.Name)
-	ExpectEq(dirObj.Generation, result.Object.Generation)
-	ExpectEq(dirObj.Size, result.Object.Size)
+	ExpectEq(dirObjName, result.MinObject.Name)
+	ExpectEq(dirObj.Generation, result.MinObject.Generation)
+	ExpectEq(dirObj.Size, result.MinObject.Size)
 
 	// Look up with the conflict marker name.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.UnknownType, t.getTypeFromCache(name+ConflictingFileNameSuffix))
 
 	ExpectEq(linkObjName, result.FullName.GcsObjectName())
-	ExpectEq(linkObjName, result.Object.Name)
-	ExpectEq(linkObj.Generation, result.Object.Generation)
-	ExpectEq(linkObj.Size, result.Object.Size)
+	ExpectEq(linkObjName, result.MinObject.Name)
+	ExpectEq(linkObj.Generation, result.MinObject.Generation)
+	ExpectEq(linkObj.Size, result.MinObject.Size)
 }
 
 func (t *DirTest) LookUpChild_FileAndDirAndImplicitDir_Disabled() {
@@ -442,25 +442,25 @@ func (t *DirTest) LookUpChild_FileAndDirAndImplicitDir_Disabled() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 	ExpectEq(metadata.UnknownType, t.getTypeFromCache(path.Join(dirInodeName, name)))
 
 	ExpectEq(dirObjName, result.FullName.GcsObjectName())
-	ExpectEq(dirObjName, result.Object.Name)
-	ExpectEq(dirObj.Generation, result.Object.Generation)
-	ExpectEq(dirObj.Size, result.Object.Size)
+	ExpectEq(dirObjName, result.MinObject.Name)
+	ExpectEq(dirObj.Generation, result.MinObject.Generation)
+	ExpectEq(dirObj.Size, result.MinObject.Size)
 
 	// Look up with the conflict marker name.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 
 	ExpectEq(fileObjName, result.FullName.GcsObjectName())
-	ExpectEq(fileObjName, result.Object.Name)
-	ExpectEq(fileObj.Generation, result.Object.Generation)
-	ExpectEq(fileObj.Size, result.Object.Size)
+	ExpectEq(fileObjName, result.MinObject.Name)
+	ExpectEq(fileObj.Generation, result.MinObject.Generation)
+	ExpectEq(fileObj.Size, result.MinObject.Size)
 }
 
 func (t *DirTest) LookUpChild_FileAndDirAndImplicitDir_Enabled() {
@@ -489,26 +489,26 @@ func (t *DirTest) LookUpChild_FileAndDirAndImplicitDir_Enabled() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 	ExpectEq(metadata.UnknownType, t.getTypeFromCache(path.Join(dirInodeName, name)))
 
 	ExpectEq(dirObjName, result.FullName.GcsObjectName())
-	ExpectEq(dirObjName, result.Object.Name)
-	ExpectEq(dirObj.Generation, result.Object.Generation)
-	ExpectEq(dirObj.Size, result.Object.Size)
+	ExpectEq(dirObjName, result.MinObject.Name)
+	ExpectEq(dirObj.Generation, result.MinObject.Generation)
+	ExpectEq(dirObj.Size, result.MinObject.Size)
 
 	// Look up with the conflict marker name.
 	result, err = t.in.LookUpChild(t.ctx, name+ConflictingFileNameSuffix)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.UnknownType, t.getTypeFromCache(name+ConflictingFileNameSuffix))
 
 	ExpectEq(fileObjName, result.FullName.GcsObjectName())
-	ExpectEq(fileObjName, result.Object.Name)
-	ExpectEq(fileObj.Generation, result.Object.Generation)
-	ExpectEq(fileObj.Size, result.Object.Size)
+	ExpectEq(fileObjName, result.MinObject.Name)
+	ExpectEq(fileObj.Generation, result.MinObject.Generation)
+	ExpectEq(fileObj.Size, result.MinObject.Size)
 }
 
 func (t *DirTest) LookUpChild_TypeCaching() {
@@ -526,10 +526,10 @@ func (t *DirTest) LookUpChild_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
-	ExpectEq(fileObjName, result.Object.Name)
+	ExpectEq(fileObjName, result.MinObject.Name)
 
 	// Create a backing object for a directory.
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, dirObjName, []byte("taco"))
@@ -540,10 +540,10 @@ func (t *DirTest) LookUpChild_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
-	ExpectEq(fileObjName, result.Object.Name)
+	ExpectEq(fileObjName, result.MinObject.Name)
 
 	// But after the TTL expires, the behavior should flip.
 	t.clock.AdvanceTime(typeCacheTTL + time.Millisecond)
@@ -551,10 +551,10 @@ func (t *DirTest) LookUpChild_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) LookUpChild_NonExistentTypeCache_ImplicitDirsDisabled() {
@@ -588,13 +588,13 @@ func (t *DirTest) LookUpChild_NonExistentTypeCache_ImplicitDirsDisabled() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(objName, result.FullName.GcsObjectName())
-	ExpectEq(objName, result.Object.Name)
-	ExpectEq(createObj.Generation, result.Object.Generation)
-	ExpectEq(createObj.Size, result.Object.Size)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectEq(createObj.Generation, result.MinObject.Generation)
+	ExpectEq(createObj.Size, result.MinObject.Size)
 }
 
 func (t *DirTest) LookUpChild_NonExistentTypeCache_ImplicitDirsEnabled() {
@@ -630,7 +630,7 @@ func (t *DirTest) LookUpChild_NonExistentTypeCache_ImplicitDirsEnabled() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	ExpectEq(nil, result.Object)
+	ExpectEq(nil, result.MinObject)
 
 	ExpectEq(objName, result.FullName.GcsObjectName())
 	ExpectEq(metadata.ImplicitDirType, result.Type())
@@ -877,10 +877,10 @@ func (t *DirTest) ReadEntries_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
-	ExpectEq(fileObjName, result.Object.Name)
+	ExpectEq(fileObjName, result.MinObject.Name)
 
 	// But after the TTL expires, the behavior should flip.
 	t.clock.AdvanceTime(typeCacheTTL + time.Millisecond)
@@ -888,10 +888,10 @@ func (t *DirTest) ReadEntries_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) CreateChildFile_DoesntExist() {
@@ -902,18 +902,18 @@ func (t *DirTest) CreateChildFile_DoesntExist() {
 	result, err := t.in.CreateChildFile(t.ctx, name)
 	AssertEq(nil, err)
 	AssertNe(nil, result)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 
 	ExpectEq(t.bucket.Name(), result.Bucket.Name())
-	ExpectEq(result.FullName.GcsObjectName(), result.Object.Name)
-	ExpectEq(objName, result.Object.Name)
-	ExpectFalse(IsSymlink(result.Object))
+	ExpectEq(result.FullName.GcsObjectName(), result.MinObject.Name)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectFalse(IsSymlink(result.MinObject))
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
-	ExpectEq(1, len(result.Object.Metadata))
+	ExpectEq(1, len(result.MinObject.Metadata))
 	ExpectEq(
 		t.clock.Now().UTC().Format(time.RFC3339Nano),
-		result.Object.Metadata["gcsfuse_mtime"])
+		result.MinObject.Metadata["gcsfuse_mtime"])
 }
 
 func (t *DirTest) CreateChildFile_Exists() {
@@ -954,10 +954,10 @@ func (t *DirTest) CreateChildFile_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache(name))
 
-	ExpectEq(fileObjName, result.Object.Name)
+	ExpectEq(fileObjName, result.MinObject.Name)
 
 	// But after the TTL expires, the behavior should flip.
 	t.clock.AdvanceTime(typeCacheTTL + time.Millisecond)
@@ -965,10 +965,10 @@ func (t *DirTest) CreateChildFile_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) CloneToChildFile_SourceDoesntExist() {
@@ -988,7 +988,8 @@ func (t *DirTest) CloneToChildFile_SourceDoesntExist() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	_, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	srcMinObject := storageutil.ConvertObjToMinObject(src)
+	_, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), srcMinObject)
 	var notFoundErr *gcs.NotFoundError
 	ExpectTrue(errors.As(err, &notFoundErr))
 	ExpectEq(metadata.UnknownType, t.getTypeFromCache(dstName))
@@ -1003,16 +1004,17 @@ func (t *DirTest) CloneToChildFile_DestinationDoesntExist() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	result, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	srcMinObject := storageutil.ConvertObjToMinObject(src)
+	result, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), srcMinObject)
 	AssertEq(nil, err)
 	AssertNe(nil, result)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache("qux"))
 
 	ExpectEq(t.bucket.Name(), result.Bucket.Name())
-	ExpectEq(result.FullName.GcsObjectName(), result.Object.Name)
-	ExpectEq(dstName, result.Object.Name)
-	ExpectFalse(IsSymlink(result.Object))
+	ExpectEq(result.FullName.GcsObjectName(), result.MinObject.Name)
+	ExpectEq(dstName, result.MinObject.Name)
+	ExpectFalse(IsSymlink(result.MinObject))
 
 	// Check resulting contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, dstName)
@@ -1034,17 +1036,18 @@ func (t *DirTest) CloneToChildFile_DestinationExists() {
 	AssertEq(nil, err)
 
 	// Call the inode.
-	result, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	srcMinObject := storageutil.ConvertObjToMinObject(src)
+	result, err := t.in.CloneToChildFile(t.ctx, path.Base(dstName), srcMinObject)
 	AssertEq(nil, err)
 	AssertNe(nil, result)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache("qux"))
 
 	ExpectEq(t.bucket.Name(), result.Bucket.Name())
-	ExpectEq(result.FullName.GcsObjectName(), result.Object.Name)
-	ExpectEq(dstName, result.Object.Name)
-	ExpectFalse(IsSymlink(result.Object))
-	ExpectEq(len("taco"), result.Object.Size)
+	ExpectEq(result.FullName.GcsObjectName(), result.MinObject.Name)
+	ExpectEq(dstName, result.MinObject.Name)
+	ExpectFalse(IsSymlink(result.MinObject))
+	ExpectEq(len("taco"), result.MinObject.Size)
 
 	// Check resulting contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, dstName)
@@ -1064,7 +1067,8 @@ func (t *DirTest) CloneToChildFile_TypeCaching() {
 	AssertEq(nil, err)
 
 	// Clone to the destination.
-	_, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), src)
+	srcMinObject := storageutil.ConvertObjToMinObject(src)
+	_, err = t.in.CloneToChildFile(t.ctx, path.Base(dstName), srcMinObject)
 	AssertEq(nil, err)
 
 	// Create a backing object for a directory.
@@ -1077,10 +1081,10 @@ func (t *DirTest) CloneToChildFile_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, path.Base(dstName))
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.RegularFileType, t.getTypeFromCache("qux"))
 
-	ExpectEq(dstName, result.Object.Name)
+	ExpectEq(dstName, result.MinObject.Name)
 
 	// But after the TTL expires, the behavior should flip.
 	t.clock.AdvanceTime(typeCacheTTL + time.Millisecond)
@@ -1088,10 +1092,10 @@ func (t *DirTest) CloneToChildFile_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, path.Base(dstName))
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache("qux"))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) CreateChildSymlink_DoesntExist() {
@@ -1103,13 +1107,13 @@ func (t *DirTest) CreateChildSymlink_DoesntExist() {
 	result, err := t.in.CreateChildSymlink(t.ctx, name, target)
 	AssertEq(nil, err)
 	AssertNe(nil, result)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.SymlinkType, t.getTypeFromCache(name))
 
 	ExpectEq(t.bucket.Name(), result.Bucket.Name())
-	ExpectEq(result.FullName.GcsObjectName(), result.Object.Name)
-	ExpectEq(objName, result.Object.Name)
-	ExpectEq(target, result.Object.Metadata[SymlinkMetadataKey])
+	ExpectEq(result.FullName.GcsObjectName(), result.MinObject.Name)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectEq(target, result.MinObject.Metadata[SymlinkMetadataKey])
 }
 
 func (t *DirTest) CreateChildSymlink_Exists() {
@@ -1151,10 +1155,10 @@ func (t *DirTest) CreateChildSymlink_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.SymlinkType, t.getTypeFromCache(name))
 
-	ExpectEq(linkObjName, result.Object.Name)
+	ExpectEq(linkObjName, result.MinObject.Name)
 
 	// But after the TTL expires, the behavior should flip.
 	t.clock.AdvanceTime(typeCacheTTL + time.Millisecond)
@@ -1162,10 +1166,10 @@ func (t *DirTest) CreateChildSymlink_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) CreateChildDir_DoesntExist() {
@@ -1176,13 +1180,13 @@ func (t *DirTest) CreateChildDir_DoesntExist() {
 	result, err := t.in.CreateChildDir(t.ctx, name)
 	AssertEq(nil, err)
 	AssertNe(nil, result)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
 	ExpectEq(t.bucket.Name(), result.Bucket.Name())
-	ExpectEq(result.FullName.GcsObjectName(), result.Object.Name)
-	ExpectEq(objName, result.Object.Name)
-	ExpectFalse(IsSymlink(result.Object))
+	ExpectEq(result.FullName.GcsObjectName(), result.MinObject.Name)
+	ExpectEq(objName, result.MinObject.Name)
+	ExpectFalse(IsSymlink(result.MinObject))
 }
 
 func (t *DirTest) CreateChildDir_Exists() {
@@ -1313,8 +1317,8 @@ func (t *DirTest) DeleteChildFile_TypeCaching() {
 	result, err := t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
-	AssertEq(fileObjName, result.Object.Name)
+	AssertNe(nil, result.MinObject)
+	AssertEq(fileObjName, result.MinObject.Name)
 
 	// But after deleting the file via the inode, the directory should be
 	// revealed.
@@ -1324,10 +1328,10 @@ func (t *DirTest) DeleteChildFile_TypeCaching() {
 	result, err = t.in.LookUpChild(t.ctx, name)
 
 	AssertEq(nil, err)
-	AssertNe(nil, result.Object)
+	AssertNe(nil, result.MinObject)
 	ExpectEq(metadata.ExplicitDirType, t.getTypeFromCache(name))
 
-	ExpectEq(dirObjName, result.Object.Name)
+	ExpectEq(dirObjName, result.MinObject.Name)
 }
 
 func (t *DirTest) DeleteChildDir_DoesntExist() {
@@ -1372,7 +1376,7 @@ func (t *DirTest) CreateLocalChildFile_ShouldnotCreateObjectInGCS() {
 
 	AssertEq(nil, err)
 	AssertEq(true, core.Local)
-	AssertEq(nil, core.Object)
+	AssertEq(nil, core.MinObject)
 
 	// Object shouldn't get created in GCS.
 	result, err := t.in.LookUpChild(t.ctx, name)

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -35,7 +35,7 @@ type ExplicitDirInode interface {
 func NewExplicitDirInode(
 	id fuseops.InodeID,
 	name Name,
-	o *gcs.Object,
+	m *gcs.MinObject,
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
 	enableNonexistentTypeCache bool,
@@ -59,8 +59,8 @@ func NewExplicitDirInode(
 	d = &explicitDirInode{
 		dirInode: wrapped.(*dirInode),
 		generation: Generation{
-			Object:   o.Generation,
-			Metadata: o.MetaGeneration,
+			Object:   m.Generation,
+			Metadata: m.MetaGeneration,
 		},
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -92,18 +92,18 @@ type FileInode struct {
 
 var _ Inode = &FileInode{}
 
-// Create a file inode for the given object in GCS. The initial lookup count is
+// Create a file inode for the given min object in GCS. The initial lookup count is
 // zero.
 //
-// REQUIRES: o != nil
-// REQUIRES: o.Generation > 0
-// REQUIRES: o.MetaGeneration > 0
-// REQUIRES: len(o.Name) > 0
-// REQUIRES: o.Name[len(o.Name)-1] != '/'
+// REQUIRES: m != nil
+// REQUIRES: m.Generation > 0
+// REQUIRES: m.MetaGeneration > 0
+// REQUIRES: len(m.Name) > 0
+// REQUIRES: m.Name[len(m.Name)-1] != '/'
 func NewFileInode(
 	id fuseops.InodeID,
 	name Name,
-	o *gcs.MinObject,
+	m *gcs.MinObject,
 	attrs fuseops.InodeAttributes,
 	bucket *gcsx.SyncerBucket,
 	localFileCache bool,
@@ -112,7 +112,7 @@ func NewFileInode(
 	localFile bool) (f *FileInode) {
 	// Set up the basic struct.
 	var minObj gcs.MinObject
-	minObjPtr := o
+	minObjPtr := m
 	if minObjPtr != nil {
 		minObj = *minObjPtr
 	}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -112,9 +112,8 @@ func NewFileInode(
 	localFile bool) (f *FileInode) {
 	// Set up the basic struct.
 	var minObj gcs.MinObject
-	minObjPtr := m
-	if minObjPtr != nil {
-		minObj = *minObjPtr
+	if m != nil {
+		minObj = *m
 	}
 	f = &FileInode{
 		bucket:         bucket,

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -103,7 +103,7 @@ var _ Inode = &FileInode{}
 func NewFileInode(
 	id fuseops.InodeID,
 	name Name,
-	o *gcs.Object,
+	o *gcs.MinObject,
 	attrs fuseops.InodeAttributes,
 	bucket *gcsx.SyncerBucket,
 	localFileCache bool,
@@ -112,7 +112,7 @@ func NewFileInode(
 	localFile bool) (f *FileInode) {
 	// Set up the basic struct.
 	var minObj gcs.MinObject
-	minObjPtr := storageutil.ConvertObjToMinObject(o)
+	minObjPtr := o
 	if minObjPtr != nil {
 		minObj = *minObjPtr
 	}

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -55,7 +55,7 @@ type FileTest struct {
 	clock  timeutil.SimulatedClock
 
 	initialContents string
-	backingObj      *gcs.Object
+	backingObj      *gcs.MinObject
 
 	in *FileInode
 }
@@ -76,11 +76,12 @@ func (t *FileTest) SetUp(ti *TestInfo) {
 	var err error
 
 	t.initialContents = "taco"
-	t.backingObj, err = storageutil.CreateObject(
+	object, err := storageutil.CreateObject(
 		t.ctx,
 		t.bucket,
 		fileName,
 		[]byte(t.initialContents))
+	t.backingObj = storageutil.ConvertObjToMinObject(object)
 
 	AssertEq(nil, err)
 

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -28,12 +28,12 @@ import (
 const SymlinkMetadataKey = "gcsfuse_symlink_target"
 
 // IsSymlink Does the supplied object represent a symlink inode?
-func IsSymlink(o *gcs.MinObject) bool {
-	if o == nil {
+func IsSymlink(m *gcs.MinObject) bool {
+	if m == nil {
 		return false
 	}
 
-	_, ok := o.Metadata[SymlinkMetadataKey]
+	_, ok := m.Metadata[SymlinkMetadataKey]
 	return ok
 }
 
@@ -66,26 +66,26 @@ var _ Inode = &SymlinkInode{}
 func NewSymlinkInode(
 	id fuseops.InodeID,
 	name Name,
-	o *gcs.MinObject,
+	m *gcs.MinObject,
 	attrs fuseops.InodeAttributes) (s *SymlinkInode) {
 	// Create the inode.
 	s = &SymlinkInode{
 		id:   id,
 		name: name,
 		sourceGeneration: Generation{
-			Object:   o.Generation,
-			Metadata: o.MetaGeneration,
+			Object:   m.Generation,
+			Metadata: m.MetaGeneration,
 		},
 		attrs: fuseops.InodeAttributes{
 			Nlink: 1,
 			Uid:   attrs.Uid,
 			Gid:   attrs.Gid,
 			Mode:  attrs.Mode,
-			Atime: o.Updated,
-			Ctime: o.Updated,
-			Mtime: o.Updated,
+			Atime: m.Updated,
+			Ctime: m.Updated,
+			Mtime: m.Updated,
 		},
-		target: o.Metadata[SymlinkMetadataKey],
+		target: m.Metadata[SymlinkMetadataKey],
 	}
 
 	// Set up lookup counting.

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -28,7 +28,7 @@ import (
 const SymlinkMetadataKey = "gcsfuse_symlink_target"
 
 // IsSymlink Does the supplied object represent a symlink inode?
-func IsSymlink(o *gcs.Object) bool {
+func IsSymlink(o *gcs.MinObject) bool {
 	if o == nil {
 		return false
 	}
@@ -66,7 +66,7 @@ var _ Inode = &SymlinkInode{}
 func NewSymlinkInode(
 	id fuseops.InodeID,
 	name Name,
-	o *gcs.Object,
+	o *gcs.MinObject,
 	attrs fuseops.InodeAttributes) (s *SymlinkInode) {
 	// Create the inode.
 	s = &SymlinkInode{

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -44,20 +44,20 @@ func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsPresent() {
 	metadata := map[string]string{
 		inode.SymlinkMetadataKey: "target",
 	}
-	o := gcs.Object{
+	m := gcs.MinObject{
 		Name:     "test",
 		Metadata: metadata,
 	}
 
-	AssertEq(true, inode.IsSymlink(&o))
+	AssertEq(true, inode.IsSymlink(&m))
 }
 
 func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsNotPresent() {
-	o := gcs.Object{
+	m := gcs.MinObject{
 		Name: "test",
 	}
 
-	AssertEq(false, inode.IsSymlink(&o))
+	AssertEq(false, inode.IsSymlink(&m))
 }
 
 func (t *SymlinkTest) TestIsSymLinkForNilObject() {


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
Change core inode implementation to store min object instead of complete object. 

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - Ran via KOKORO
