### PR TITLE
Bump alpine from 3.13 to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR ${GCSFUSE_REPO}
 RUN go install ./tools/build_gcsfuse
 RUN build_gcsfuse . /tmp $(git log -1 --format=format:"%H")
 
-FROM alpine:3.13
+FROM alpine:3.19
 
 RUN apk add --update --no-cache bash ca-certificates fuse
 


### PR DESCRIPTION
### Description
Bumps alpine from 3.13 to 3.19.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...

Clone of #1579  .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
