### PR TITLE
[ReadCacheFunctionalTests] Setup to run read cache functional tests on an already mounted directory

### DIFF
--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -79,6 +79,7 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 	ts := &disabledCacheTTLTest{ctx: context.Background()}
 	// Create storage client before running tests.
 	closeStorageClient := createStorageClient(t, &ts.ctx, &ts.storageClient)
+	defer closeStorageClient()
 
 	// Run tests for mounted directory if the flag is set.
 	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
@@ -86,7 +87,6 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 		return
 	}
 
-	defer closeStorageClient()
 	// Define flag set to run the tests.
 	flagSet := [][]string{
 		{"--implicit-dirs=true"},

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -33,36 +33,38 @@ import (
 )
 
 const (
-	testDirName                        = "ReadCacheTest"
-	onlyDirMounted                     = "Test"
-	cacheSubDirectoryName              = "gcsfuse-file-cache"
-	smallContentSize                   = 128 * util.KiB
-	chunkSizeToRead                    = 128 * util.KiB
-	fileSize                           = 3 * util.MiB
-	fileSizeForRangeRead               = cacheCapacityForRangeReadTestInMiB * util.MiB
-	chunksRead                         = fileSize / chunkSizeToRead
-	testFileName                       = "foo"
-	cacheCapacityInMB                  = 9
-	NumberOfFilesWithinCacheLimit      = (cacheCapacityInMB * util.MiB) / fileSize
-	NumberOfFilesMoreThanCacheLimit    = (cacheCapacityInMB*util.MiB)/fileSize + 1
-	largeFileSize                      = 15 * util.MiB
-	largeFileName                      = "15MBFile"
-	largeFileChunksRead                = largeFileSize / chunkSizeToRead
-	chunksReadAfterUpdate              = 1
-	metadataCacheTTlInSec              = 10
-	testFileNameSuffixLength           = 4
-	zeroOffset                         = 0
-	randomReadOffset                   = 9 * util.MiB
-	configFileName                     = "config"
-	offsetForFirstRangeRead            = 5000
-	offsetForSecondRangeRead           = 1000
-	offsetForRangeReadWithin8MB        = 4 * util.MiB
-	offset10MiB                        = 10 * util.MiB
-	cacheCapacityForRangeReadTestInMiB = 50
-	randomReadChunkCount               = fileSizeForRangeRead / chunkSizeToRead
-	cacheCapacityForVeryLargeFileInMiB = 500
-	veryLargeFileSize                  = cacheCapacityForVeryLargeFileInMiB * util.MiB
-	offsetEndOfFile                    = veryLargeFileSize - 1*util.MiB
+	testDirName                         = "ReadCacheTest"
+	onlyDirMounted                      = "Test"
+	cacheSubDirectoryName               = "gcsfuse-file-cache"
+	smallContentSize                    = 128 * util.KiB
+	chunkSizeToRead                     = 128 * util.KiB
+	fileSize                            = 3 * util.MiB
+	fileSizeForRangeRead                = cacheCapacityForRangeReadTestInMiB * util.MiB
+	chunksRead                          = fileSize / chunkSizeToRead
+	testFileName                        = "foo"
+	cacheCapacityInMB                   = 9
+	NumberOfFilesWithinCacheLimit       = (cacheCapacityInMB * util.MiB) / fileSize
+	NumberOfFilesMoreThanCacheLimit     = (cacheCapacityInMB*util.MiB)/fileSize + 1
+	largeFileSize                       = 15 * util.MiB
+	largeFileName                       = "15MBFile"
+	largeFileChunksRead                 = largeFileSize / chunkSizeToRead
+	chunksReadAfterUpdate               = 1
+	metadataCacheTTlInSec               = 10
+	testFileNameSuffixLength            = 4
+	zeroOffset                          = 0
+	randomReadOffset                    = 9 * util.MiB
+	configFileName                      = "config"
+	offsetForFirstRangeRead             = 5000
+	offsetForSecondRangeRead            = 1000
+	offsetForRangeReadWithin8MB         = 4 * util.MiB
+	offset10MiB                         = 10 * util.MiB
+	cacheCapacityForRangeReadTestInMiB  = 50
+	randomReadChunkCount                = fileSizeForRangeRead / chunkSizeToRead
+	cacheCapacityForVeryLargeFileInMiB  = 500
+	veryLargeFileSize                   = cacheCapacityForVeryLargeFileInMiB * util.MiB
+	offsetEndOfFile                     = veryLargeFileSize - 1*util.MiB
+	cacheDirName                        = "cache-dir"
+	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_read_cache_test_logs/log.json"
 )
 
 var (
@@ -79,6 +81,14 @@ var (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
+func setupForMountedDirectoryTests() {
+	if setup.MountedDirectory() != "" {
+		cacheDirPath = path.Join(os.TempDir(), cacheDirName)
+		mountDir = setup.MountedDirectory()
+		setup.SetLogFile(logFileNameForMountedDirectoryTests)
+	}
+}
+
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client, testDirName string) {
 	mountGCSFuse(flags)
 	setup.SetMntDir(mountDir)
@@ -86,7 +96,7 @@ func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageCli
 }
 
 func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName string) string {
-	cacheDirPath = path.Join(setup.TestDir(), "cache-dir")
+	cacheDirPath = path.Join(setup.TestDir(), cacheDirName)
 
 	// Set up config file for file cache.
 	mountConfig := config.MountConfig{

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -350,7 +350,7 @@ test_cases=(
   "TestCacheFileForRangeReadFalseTest/TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
   cleanup_test_environment
@@ -359,7 +359,7 @@ done
 # cache-file-for-range-read:true read-cache test.
 read_cache_test_setup 50 true 3600
 test_case="TestCacheFileForRangeReadTrueTest/TestRangeReadsWithCacheHit"
-gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
 sudo umount "$MOUNT_DIR"
 cleanup_test_environment
@@ -368,7 +368,7 @@ cleanup_test_environment
 # Disabled cache ttl read-cache test.
 read_cache_test_setup 9 false 0
 test_case="TestDisabledCacheTTLTest/TestReadAfterObjectUpdateIsCacheMiss"
-gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
 sudo umount "$MOUNT_DIR"
 cleanup_test_environment
@@ -376,7 +376,7 @@ cleanup_test_environment
 # local modification test.
 read_cache_test_setup 9 false 3600
 test_case="TestLocalModificationTest/TestReadAfterLocalGCSFuseWriteIsCacheMiss"
-gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
 sudo umount "$MOUNT_DIR"
 cleanup_test_environment
@@ -389,7 +389,7 @@ test_cases=(
   "TestRangeReadTest/TestRangeReadsBeyondReadChunkSizeWithoutChunkDownloaded"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
   cleanup_test_environment
@@ -405,20 +405,20 @@ test_cases=(
   "TestReadOnlyTest/TestReadMultipleFilesWithinCacheLimit"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --o=ro --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --o=ro --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
   cleanup_test_environment
 done
 
 # Small cache ttl read-cache test.
-read_cache_test_setup 9 false 3600
+read_cache_test_setup 9 false 10
 test_cases=(
   "TestSmallCacheTTLTest/TestReadAfterUpdateAndCacheExpiryIsCacheMiss"
   "TestSmallCacheTTLTest/TestReadForLowMetaDataCacheTTLIsCacheHit"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
   cleanup_test_environment

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -319,7 +319,7 @@ function cleanup_test_environment() {
   # Clean up any pre-existing log files.
   rm -r /tmp/gcsfuse_read_cache_test_logs
   mkdir /tmp/gcsfuse_read_cache_test_logs
-   # Clean up cache directory.
+  # Clean up cache directory.
   rm -r /tmp/cache-dir
   mkdir /tmp/cache-dir
 }

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -304,3 +304,122 @@ echo "logging:
 gcsfuse --config-file=/tmp/gcsfuse_config.yaml $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/log_rotation/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR
 sudo umount $MOUNT_DIR
+
+# Run read cache functional tests.
+function read_cache_test_setup() {
+  cache_size_mb=$1
+  enable_range_read_cache=$2
+  cache_ttl=$3
+
+  cleanup_test_environment
+  generate_config_file "$cache_size_mb" "$enable_range_read_cache" "$cache_ttl"
+}
+
+function cleanup_test_environment() {
+  # Clean up any pre-existing log files.
+  rm -r /tmp/gcsfuse_read_cache_test_logs
+  mkdir /tmp/gcsfuse_read_cache_test_logs
+   # Clean up cache directory.
+  rm -r /tmp/cache-dir
+  mkdir /tmp/cache-dir
+}
+
+function generate_config_file() {
+  cache_size_mb=$1
+  enable_range_read_cache=$2
+  cache_ttl=$3
+
+  echo "logging:
+  file-path: /tmp/gcsfuse_read_cache_test_logs/log.json
+  format: json
+  severity: trace
+file-cache:
+  max-size-mb: $cache_size_mb
+  cache-file-for-range-read: $enable_range_read_cache
+metadata-cache:
+  stat-cache-max-size-mb: 4
+  ttl-secs: $cache_ttl
+  type-cache-max-size-mb: 32
+cache-dir: /tmp/cache-dir" > /tmp/gcsfuse_config.yaml
+}
+
+# cache-file-for-range-read:false read-cache test.
+read_cache_test_setup 50 false 3600
+test_cases=(
+  "TestCacheFileForRangeReadFalseTest/TestRangeReadsWithCacheMiss"
+  "TestCacheFileForRangeReadFalseTest/TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+  sudo umount "$MOUNT_DIR"
+  cleanup_test_environment
+done
+
+# cache-file-for-range-read:true read-cache test.
+read_cache_test_setup 50 true 3600
+test_case="TestCacheFileForRangeReadTrueTest/TestRangeReadsWithCacheHit"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+sudo umount "$MOUNT_DIR"
+cleanup_test_environment
+
+
+# Disabled cache ttl read-cache test.
+read_cache_test_setup 9 false 0
+test_case="TestDisabledCacheTTLTest/TestReadAfterObjectUpdateIsCacheMiss"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+sudo umount "$MOUNT_DIR"
+cleanup_test_environment
+
+# local modification test.
+read_cache_test_setup 9 false 3600
+test_case="TestLocalModificationTest/TestReadAfterLocalGCSFuseWriteIsCacheMiss"
+gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+sudo umount "$MOUNT_DIR"
+cleanup_test_environment
+
+# range read read-cache test.
+read_cache_test_setup 500 false 3600
+test_cases=(
+  "TestRangeReadTest/TestRangeReadsWithinReadChunkSize"
+  "TestRangeReadTest/TestRangeReadsBeyondReadChunkSizeWithChunkDownloaded"
+  "TestRangeReadTest/TestRangeReadsBeyondReadChunkSizeWithoutChunkDownloaded"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+  sudo umount "$MOUNT_DIR"
+  cleanup_test_environment
+done
+
+# Read only mount read-cache test.
+read_cache_test_setup 9 false 3600
+test_cases=(
+  "TestReadOnlyTest/TestSecondSequentialReadIsCacheHit"
+  "TestReadOnlyTest/TestReadFileSequentiallyLargerThanCacheCapacity"
+  "TestReadOnlyTest/TestReadFileRandomlyLargerThanCacheCapacity"
+  "TestReadOnlyTest/TestReadMultipleFilesMoreThanCacheLimit"
+  "TestReadOnlyTest/TestReadMultipleFilesWithinCacheLimit"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --o=ro --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+  sudo umount "$MOUNT_DIR"
+  cleanup_test_environment
+done
+
+# Small cache ttl read-cache test.
+read_cache_test_setup 9 false 3600
+test_cases=(
+  "TestSmallCacheTTLTest/TestReadAfterUpdateAndCacheExpiryIsCacheMiss"
+  "TestSmallCacheTTLTest/TestReadForLowMetaDataCacheTTLIsCacheHit"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+  sudo umount "$MOUNT_DIR"
+  cleanup_test_environment
+done

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -343,7 +343,7 @@ metadata-cache:
 cache-dir: /tmp/cache-dir" > /tmp/gcsfuse_config.yaml
 }
 
-# cache-file-for-range-read:false read-cache test.
+# Read-cache test with cache-file-for-range-read:false.
 read_cache_test_setup 50 false 3600
 test_cases=(
   "TestCacheFileForRangeReadFalseTest/TestRangeReadsWithCacheMiss"
@@ -356,7 +356,7 @@ for test_case in "${test_cases[@]}"; do
   cleanup_test_environment
 done
 
-# cache-file-for-range-read:true read-cache test.
+# Read-cache test with cache-file-for-range-read:true.
 read_cache_test_setup 50 true 3600
 test_case="TestCacheFileForRangeReadTrueTest/TestRangeReadsWithCacheHit"
 gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
@@ -365,7 +365,7 @@ sudo umount "$MOUNT_DIR"
 cleanup_test_environment
 
 
-# Disabled cache ttl read-cache test.
+# Read-cache test with disabled cache ttl.
 read_cache_test_setup 9 false 0
 test_case="TestDisabledCacheTTLTest/TestReadAfterObjectUpdateIsCacheMiss"
 gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
@@ -373,7 +373,7 @@ GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 
 sudo umount "$MOUNT_DIR"
 cleanup_test_environment
 
-# local modification test.
+# Read-cache test with local modification.
 read_cache_test_setup 9 false 3600
 test_case="TestLocalModificationTest/TestReadAfterLocalGCSFuseWriteIsCacheMiss"
 gcsfuse --config-file=/tmp/gcsfuse_config.yaml "$TEST_BUCKET_NAME" "$MOUNT_DIR" > /dev/null
@@ -381,7 +381,7 @@ GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/read_cache/... -p 1 
 sudo umount "$MOUNT_DIR"
 cleanup_test_environment
 
-# range read read-cache test.
+# Read-cache tests for range reads.
 read_cache_test_setup 500 false 3600
 test_cases=(
   "TestRangeReadTest/TestRangeReadsWithinReadChunkSize"
@@ -395,7 +395,7 @@ for test_case in "${test_cases[@]}"; do
   cleanup_test_environment
 done
 
-# Read only mount read-cache test.
+# Read cache tests on read only mount.
 read_cache_test_setup 9 false 3600
 test_cases=(
   "TestReadOnlyTest/TestSecondSequentialReadIsCacheHit"
@@ -411,7 +411,7 @@ for test_case in "${test_cases[@]}"; do
   cleanup_test_environment
 done
 
-# Small cache ttl read-cache test.
+# Read cache tests with small cache ttl.
 read_cache_test_setup 9 false 10
 test_cases=(
   "TestSmallCacheTTLTest/TestReadAfterUpdateAndCacheExpiryIsCacheMiss"


### PR DESCRIPTION
### Description
This PR includes 
* refactoring and setup to run read cache functional tests with mounted directory flag.
* Shell script to run read cache tests on an already mounted directory.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran the tests on a GCE VM.
2. Unit tests - NA
3. Integration tests - Via KOKORO
