### PR TITLE
[PR-6] changes to account for min object size instead of object size

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -71,9 +71,13 @@ The behavior of stat cache is controlled by the following flags/config parameter
    This has been deprecated (starting v2.0) and is ignored if the user sets `metadata-cache:stat-cache-max-size-mb` .
    This can be set to 0 for disabling stat-cache and > 0 for setting a finite stat-cache size.
 
-   If neither of these two is set, then a size of 32MB is used, which is equivalent to about 12710 stat-cache entries (assuming just as many negative stat-cache entries).
+   If neither of these two is set, then a size of 32MB is used, which is
+   equivalent to about 20460 stat-cache entries (assuming just as many negative
+   stat-cache entries).
 
-   If you have more objects (folders or files) than that in your bucket that you want to access, then you may want to increase this, otherwise the caching will not function properly when listing that folder's contents:
+   If you have more objects (folders or files) than that in your bucket that you
+   want to access, then you may want to increase this, otherwise the caching
+   will not function properly when listing that folder's contents:
     - ListObjects will return information on the items within the folder. Each item's data is cached
     - Because there are more objects than cache capacity, the earliest entries will be evicted
     - The linux kernel then asks for a little more information on each file.

--- a/flags.go
+++ b/flags.go
@@ -208,7 +208,7 @@ func newApp() (app *cli.App) {
 			cli.IntFlag{
 				Name:  "stat-cache-capacity",
 				Value: mount.DefaultStatCacheCapacity,
-				Usage: "How many entries can the stat-cache hold (impacts memory consumption). This flag has been deprecated (starting v2.0) and in its place only metadata-cache:stat-cache-max-size-mb in the gcsfuse config-file will be supported. For now, the value of stat-cache-capacity will be translated to the next higher corresponding value of metadata-cache:stat-cache-max-size-mb (assuming stat-cache entry-size ~= 2640 bytes, including 2400 for positive entry and 240 for corresponding negative entry), when metadata-cache:stat-cache-max-size-mb is not set.",
+				Usage: "How many entries can the stat-cache hold (impacts memory consumption). This flag has been deprecated (starting v2.0) and in its place only metadata-cache:stat-cache-max-size-mb in the gcsfuse config-file will be supported. For now, the value of stat-cache-capacity will be translated to the next higher corresponding value of metadata-cache:stat-cache-max-size-mb (assuming stat-cache entry-size ~= 1640 bytes, including 1400 for positive entry and 240 for corresponding negative entry), when metadata-cache:stat-cache-max-size-mb is not set.",
 			},
 
 			cli.DurationFlag{

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -88,7 +88,7 @@ type entry struct {
 // The size calculated by the unsafe.Sizeof calls, and
 // NestedSizeOfGcsMinObject etc. does not account for
 // hidden members in data structures like maps, slices, linked-lists etc.
-// To account for those, we are adding a fixed constant of 553 bytes (deduced from
+// To account for those, we are adding a fixed constant of 515 bytes (deduced from
 // benchmark runs) to heap-size per positive stat-cache entry
 // to calculate a size closer to the actual memory utilization.
 func (e entry) Size() (size uint64) {
@@ -97,7 +97,7 @@ func (e entry) Size() (size uint64) {
 	// struct stored in the cache map and in the cache linked-list.
 	size = uint64(util.UnsafeSizeOf(&e) + len(e.key) + 2*util.UnsafeSizeOf(&e.key) + util.NestedSizeOfGcsMinObject(e.m))
 	if e.m != nil {
-		size += 553
+		size += 515
 	}
 
 	// Convert heap-size to RSS (resident set size).

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -108,14 +108,14 @@ func init() {
 }
 
 func (t *StatCacheTest) SetUp(ti *TestInfo) {
-	cache := lru.NewCache(uint64(mount.AverageSizeOfPositiveStatCacheEntry * capacity))
+	cache := lru.NewCache(uint64((mount.AverageSizeOfPositiveStatCacheEntry + mount.AverageSizeOfNegativeStatCacheEntry) * capacity))
 	t.cache.wrapped = metadata.NewStatCacheBucketView(cache, "") // this demonstrates
 	// that if you are using a cache for a single bucket, then
 	// its prepending bucketName can be left empty("") without any problem.
 }
 
 func (t *MultiBucketStatCacheTest) SetUp(ti *TestInfo) {
-	sharedCache := lru.NewCache(uint64(mount.AverageSizeOfPositiveStatCacheEntry * capacity))
+	sharedCache := lru.NewCache(uint64((mount.AverageSizeOfPositiveStatCacheEntry + mount.AverageSizeOfNegativeStatCacheEntry) * capacity))
 	t.multiBucketCache.fruits = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "fruits")}
 	t.multiBucketCache.spices = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "spices")}
 }
@@ -152,18 +152,18 @@ func (t *StatCacheTest) KeysPresentButEverythingIsExpired() {
 }
 
 func (t *StatCacheTest) FillUpToCapacity() {
-	AssertEq(3, capacity) // maxSize = 3 * 2400 = 7200 bytes
+	AssertEq(3, capacity) // maxSize = 3 * 1640 = 4920 bytes
 
 	m0 := &gcs.MinObject{Name: "burrito"}
 	m1 := &gcs.MinObject{Name: "taco"}
 	m2 := &gcs.MinObject{Name: "quesadilla"}
 
-	//TODO: to update the sizes in comments.
-	t.cache.Insert(m0, expiration)                    // size = 1886 bytes
-	t.cache.Insert(m1, expiration)                    // size = 1874 bytes (cumulative = 3760 bytes)
-	t.cache.AddNegativeEntry("enchilada", expiration) // size = 178 bytes (cumulative = 3938 bytes)
-	t.cache.Insert(m2, expiration)                    // size = 1898 bytes (cumulative = 5836 bytes)
-	t.cache.AddNegativeEntry("fajita", expiration)    // size = 172 bytes (cumulative = 6008 bytes)
+	t.cache.Insert(m0, expiration)                    // size = 1394 bytes
+	t.cache.Insert(m1, expiration)                    // size = 1382 bytes (cumulative = 2776 bytes)
+	t.cache.AddNegativeEntry("enchilada", expiration) // size = 178 bytes (cumulative = 2954 bytes)
+	t.cache.Insert(m2, expiration)                    // size = 1406 bytes (cumulative = 4360 bytes)
+	t.cache.AddNegativeEntry("fajita", expiration)    // size = 172 bytes (cumulative = 4532 bytes)
+	t.cache.AddNegativeEntry("salsa", expiration)     // size = 170 bytes (cumulative = 4702 bytes)
 
 	// Before expiration
 	justBefore := expiration.Add(-time.Nanosecond)
@@ -172,13 +172,15 @@ func (t *StatCacheTest) FillUpToCapacity() {
 	ExpectTrue(t.cache.NegativeEntry("enchilada", justBefore))
 	ExpectEq(m2, t.cache.LookUpOrNil("quesadilla", justBefore))
 	ExpectTrue(t.cache.NegativeEntry("fajita", justBefore))
+	ExpectTrue(t.cache.NegativeEntry("salsa", justBefore))
 
 	// At expiration
 	ExpectEq(m0, t.cache.LookUpOrNil("burrito", expiration))
 	ExpectEq(m1, t.cache.LookUpOrNil("taco", expiration))
-	ExpectTrue(t.cache.NegativeEntry("enchilada", justBefore))
-	ExpectEq(m2, t.cache.LookUpOrNil("quesadilla", justBefore))
-	ExpectTrue(t.cache.NegativeEntry("fajita", justBefore))
+	ExpectTrue(t.cache.NegativeEntry("enchilada", expiration))
+	ExpectEq(m2, t.cache.LookUpOrNil("quesadilla", expiration))
+	ExpectTrue(t.cache.NegativeEntry("fajita", expiration))
+	ExpectTrue(t.cache.NegativeEntry("salsa", expiration))
 
 	// After expiration
 	justAfter := expiration.Add(time.Nanosecond)
@@ -187,34 +189,34 @@ func (t *StatCacheTest) FillUpToCapacity() {
 	ExpectFalse(t.cache.Hit("enchilada", justAfter))
 	ExpectFalse(t.cache.Hit("quesadilla", justAfter))
 	ExpectFalse(t.cache.Hit("fajita", justAfter))
+	ExpectFalse(t.cache.Hit("salsa", justAfter))
 }
 
-// TODO: Uncomment this test after finding average size of min object entry.
-//func (t *StatCacheTest) ExpiresLeastRecentlyUsed() {
-//	AssertEq(3, capacity) // maxSize = 3 * 2400 = 7200 bytes
-//
-//	o0 := &gcs.MinObject{Name: "burrito"}
-//	o1 := &gcs.MinObject{Name: "taco"}
-//	o2 := &gcs.MinObject{Name: "quesadilla"}
-//
-//	t.cache.Insert(o0, expiration)                         // size = 1886 bytes
-//	t.cache.Insert(o1, expiration)                         // Least recent, size = 1874 bytes (cumulative = 3760 bytes)
-//	t.cache.AddNegativeEntry("enchilada", expiration)      // Third most recent, size = 178 bytes (cumulative = 3938 bytes)
-//	t.cache.Insert(o2, expiration)                         // Second most recent, size = 1898 bytes (cumulative = 5836 bytes)
-//	AssertEq(o0, t.cache.LookUpOrNil("burrito", someTime)) // Most recent
-//
-//	// Insert another.
-//	o3 := &gcs.MinObject{Name: "queso"}
-//	t.cache.Insert(o3, expiration) // size = 1878 bytes (cumulative = 7714 bytes)
-//	// This would evict the least recent entry i.e o1/"taco".
-//
-//	// See what's left.
-//	ExpectFalse(t.cache.Hit("taco", someTime))
-//	ExpectEq(o0, t.cache.LookUpOrNil("burrito", someTime))
-//	ExpectTrue(t.cache.NegativeEntry("enchilada", someTime))
-//	ExpectEq(o2, t.cache.LookUpOrNil("quesadilla", someTime))
-//	ExpectEq(o3, t.cache.LookUpOrNil("queso", someTime))
-//}
+func (t *StatCacheTest) ExpiresLeastRecentlyUsed() {
+	AssertEq(3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+
+	o0 := &gcs.MinObject{Name: "burrito"}
+	o1 := &gcs.MinObject{Name: "taco"}
+	o2 := &gcs.MinObject{Name: "quesadilla"}
+
+	t.cache.Insert(o0, expiration)                         // size = 1394 bytes
+	t.cache.Insert(o1, expiration)                         // Least recent, size = 1382 bytes (cumulative = 2776 bytes)
+	t.cache.AddNegativeEntry("enchilada", expiration)      // Third most recent, size = 178 bytes (cumulative = 2954 bytes)
+	t.cache.Insert(o2, expiration)                         // Second most recent, size = 1406 bytes (cumulative = 4360 bytes)
+	AssertEq(o0, t.cache.LookUpOrNil("burrito", someTime)) // Most recent
+
+	// Insert another.
+	o3 := &gcs.MinObject{Name: "queso"}
+	t.cache.Insert(o3, expiration) // size = 1386 bytes (cumulative = 5746 bytes)
+	// This would evict the least recent entry i.e o1/"taco".
+
+	// See what's left.
+	ExpectFalse(t.cache.Hit("taco", someTime))
+	ExpectEq(o0, t.cache.LookUpOrNil("burrito", someTime))
+	ExpectTrue(t.cache.NegativeEntry("enchilada", someTime))
+	ExpectEq(o2, t.cache.LookUpOrNil("quesadilla", someTime))
+	ExpectEq(o3, t.cache.LookUpOrNil("queso", someTime))
+}
 
 func (t *StatCacheTest) Overwrite_NewerGeneration() {
 	m0 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5}
@@ -342,18 +344,18 @@ func (t *MultiBucketStatCacheTest) CreateEntriesWithSameNameInDifferentBuckets()
 }
 
 func (t *MultiBucketStatCacheTest) FillUpToCapacity() {
-	AssertEq(3, capacity) // maxSize = 3 * 2400 = 7200 bytes
+	AssertEq(3, capacity) // maxSize = 3 * 1640 = 4920 bytes
 
 	cache := &t.multiBucketCache
 	fruits := &cache.fruits
 	spices := &cache.spices
 
-	fruits.Insert(apple, expiration)               // size = 1892 bytes
-	fruits.Insert(orange, expiration)              // size = 1896 bytes (cumulative = 3788 bytes)
-	spices.Insert(cardamom, expiration)            // size = 1904 bytes (cumulative = 5692 bytes)
-	fruits.AddNegativeEntry("papaya", expiration)  // size = 186 bytes (cumulative = 5878 bytes)
-	spices.AddNegativeEntry("saffron", expiration) // size = 188 bytes (cumulative = 6066 bytes)
-	spices.AddNegativeEntry("pepper", expiration)  // size = 186 bytes (cumulative = 6252 bytes)
+	fruits.Insert(apple, expiration)               // size = 1400 bytes
+	fruits.Insert(orange, expiration)              // size = 1404 bytes (cumulative = 2804 bytes)
+	spices.Insert(cardamom, expiration)            // size = 1412 bytes (cumulative = 4216 bytes)
+	fruits.AddNegativeEntry("papaya", expiration)  // size = 186 bytes (cumulative = 4402 bytes)
+	spices.AddNegativeEntry("saffron", expiration) // size = 188 bytes (cumulative = 4590 bytes)
+	spices.AddNegativeEntry("pepper", expiration)  // size = 186 bytes (cumulative = 4776 bytes)
 
 	// Before expiration
 	justBefore := expiration.Add(-time.Nanosecond)
@@ -367,10 +369,10 @@ func (t *MultiBucketStatCacheTest) FillUpToCapacity() {
 	// At expiration
 	ExpectEq(apple, fruits.LookUpOrNil("apple", expiration))
 	ExpectEq(orange, fruits.LookUpOrNil("orange", expiration))
-	ExpectEq(cardamom, spices.LookUpOrNil("cardamom", justBefore))
-	ExpectTrue(fruits.NegativeEntry("papaya", justBefore))
-	ExpectTrue(spices.NegativeEntry("saffron", justBefore))
-	ExpectTrue(spices.NegativeEntry("pepper", justBefore))
+	ExpectEq(cardamom, spices.LookUpOrNil("cardamom", expiration))
+	ExpectTrue(fruits.NegativeEntry("papaya", expiration))
+	ExpectTrue(spices.NegativeEntry("saffron", expiration))
+	ExpectTrue(spices.NegativeEntry("pepper", expiration))
 
 	// After expiration
 	justAfter := expiration.Add(time.Nanosecond)
@@ -382,27 +384,26 @@ func (t *MultiBucketStatCacheTest) FillUpToCapacity() {
 	ExpectFalse(spices.Hit("pepper", justAfter))
 }
 
-// TODO: Uncomment this test after finding average size of min object entry.
-//func (t *MultiBucketStatCacheTest) ExpiresLeastRecentlyUsed() {
-//	AssertEq(3, capacity) // maxSize = 3 * 2400 = 7200 bytes
-//
-//	cache := &t.multiBucketCache
-//	fruits := &cache.fruits
-//	spices := &cache.spices
-//
-//	fruits.Insert(apple, expiration)                       // size = 1892 bytes
-//	fruits.Insert(orange, expiration)                      // Least recent, size = 1896 bytes (cumulative = 3788 bytes)
-//	spices.Insert(cardamom, expiration)                    // Second most recent, size = 1904 bytes (cumulative = 5692 bytes)
-//	AssertEq(apple, fruits.LookUpOrNil("apple", someTime)) // Most recent
-//
-//	// Insert another.
-//	saffron := &gcs.MinObject{Name: "saffron"}
-//	spices.Insert(saffron, expiration) // size = 1900 bytes (cumulative = 7592 bytes)
-//	// This will evict the least recent entry, i.e. orange.
-//
-//	// See what's left.
-//	ExpectFalse(fruits.Hit("orange", someTime))
-//	ExpectEq(apple, fruits.LookUpOrNil("apple", someTime))
-//	ExpectEq(cardamom, spices.LookUpOrNil("cardamom", someTime))
-//	ExpectEq(saffron, spices.LookUpOrNil("saffron", someTime))
-//}
+func (t *MultiBucketStatCacheTest) ExpiresLeastRecentlyUsed() {
+	AssertEq(3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+
+	cache := &t.multiBucketCache
+	fruits := &cache.fruits
+	spices := &cache.spices
+
+	fruits.Insert(apple, expiration)                       // size = 1400 bytes
+	fruits.Insert(orange, expiration)                      // Least recent, size = 1404 bytes (cumulative = 2804 bytes)
+	spices.Insert(cardamom, expiration)                    // Second most recent, size = 1412 bytes (cumulative = 4216 bytes)
+	AssertEq(apple, fruits.LookUpOrNil("apple", someTime)) // Most recent
+
+	// Insert another.
+	saffron := &gcs.MinObject{Name: "saffron"}
+	spices.Insert(saffron, expiration) // size = 1408 bytes (cumulative = 5624 bytes)
+	// This will evict the least recent entry, i.e. orange.
+
+	// See what's left.
+	ExpectFalse(fruits.Hit("orange", someTime))
+	ExpectEq(apple, fruits.LookUpOrNil("apple", someTime))
+	ExpectEq(cardamom, spices.LookUpOrNil("cardamom", someTime))
+	ExpectEq(saffron, spices.LookUpOrNil("saffron", someTime))
+}

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -35,7 +35,7 @@ const (
 	DefaultStatOrTypeCacheTTL time.Duration = time.Minute
 	// DefaultStatCacheCapacity is the default value for stat-cache-capacity.
 	// This is equivalent of setting metadata-cache: stat-cache-max-size-mb.
-	DefaultStatCacheCapacity = 12710
+	DefaultStatCacheCapacity = 20460
 	// DefaultStatCacheMaxSizeMB is the default for stat-cache-max-size-mb
 	// and is to be used when neither stat-cache-max-size-mb nor
 	// stat-cache-capacity is set.
@@ -44,7 +44,7 @@ const (
 	// meant for two purposes.
 	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
 	// 2. internal testing.
-	AverageSizeOfPositiveStatCacheEntry uint64 = 2400
+	AverageSizeOfPositiveStatCacheEntry uint64 = 1400
 	// AverageSizeOfNegativeStatCacheEntry is the assumed size of each negative stat-cache-entry,
 	// meant for two purposes..
 	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.

--- a/internal/mount/flag_test.go
+++ b/internal/mount/flag_test.go
@@ -208,7 +208,7 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 			// Old-scenario where user sets only stat-cache-capacity flag(s), and not metadata-cache:stat-cache-max-size-mb. Case 2: stat-cache-capacity is non-zero.
 			flagStatCacheCapacity:         10000,
 			mountConfigStatCacheMaxSizeMB: config.StatCacheMaxSizeMBUnsetSentinel,
-			expectedStatCacheMaxSizeMB:    26, // 26 MiB = MiB-ceiling (10k entries * (AssumedSizeOfPositiveStatCacheEntry + AssumedSizeOfNegativeStatCacheEntry) /entry)
+			expectedStatCacheMaxSizeMB:    16, // 16 MiB = MiB ceiling (10k entries * 1640 bytes (AssumedSizeOfPositiveStatCacheEntry + AssumedSizeOfNegativeStatCacheEntry))
 		},
 	} {
 		statCacheMaxSizeMB, err := ResolveStatCacheMaxSizeMB(input.mountConfigStatCacheMaxSizeMB, input.flagStatCacheCapacity)


### PR DESCRIPTION
### Description
This PR includes the following changes:
* Changed AverageSizeOfPositiveStatCacheEntry to 1400 bytes (from 2400 bytes) based on listing benchmarks done when stat cache stores gcs.MinObject instead of entire gcs.Object. 
* Accordingly DefaultStatCacheCapacity is increased to 20460 entries (default stat cache size divided by size of each entry = `32*1024*1024/1640`)
* The delta factor between computed gcs.MinObject and RSS reduced to 515.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - updated
3. Integration tests - via KOKORO
