### PR TITLE
Improve default logs on mounting

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	SuccessfulMountMessage = "File system has been successfully mounted."
+)
+
 ////////////////////////////////////////////////////////////////////////
 // Helpers
 ////////////////////////////////////////////////////////////////////////
@@ -239,6 +243,8 @@ func runCLIApp(c *cli.Context) (err error) {
 
 	logger.Infof("Start gcsfuse/%s for app %q using mount point: %s\n", getVersion(), flags.AppName, mountPoint)
 
+	// Log mount-config and the CLI flags in the log-file.
+	// If there is no log-file, then log these to stdout.
 	if flags.Foreground || mountConfig.FilePath == "" {
 		flagsStringified, err := util.Stringify(*flags)
 		if err != nil {
@@ -343,7 +349,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			err = fmt.Errorf("daemonize.Run: %w", err)
 			return
 		} else {
-			logger.Infof("File system has been successfully mounted.")
+			logger.Infof(SuccessfulMountMessage)
 		}
 
 		return
@@ -360,10 +366,14 @@ func runCLIApp(c *cli.Context) (err error) {
 		mfs, err = mountWithArgs(bucketName, mountPoint, flags, mountConfig)
 
 		if err == nil {
-			logger.Info("File system has been successfully mounted.")
+			// Print the success message in the log-file/stdout depending on what the logger is set to.
+			logger.Info("SuccessfulMountMessage")
+
+			// Print the success message in stdout also, if logger outputs to something other than stdout.
 			if flags.Foreground && mountConfig.FilePath != "" {
-				fmt.Println("File system has been successfully mounted.")
+				fmt.Println("SuccessfulMountMessage")
 			}
+
 			daemonize.SignalOutcome(nil)
 		} else {
 			// Printing via mountStatus will have duplicate logs on the console while

--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	// Do not log these in stdout in case of daemonized run
 	// if these are already being logged into a log-file, otherwise
 	// there will be duplicate logs for these in both places (stdout and log-file).
-	if flags.Foreground || mountConfig.FilePath == "" {
+	if flags.Foreground || mountConfig.LogConfig.FilePath == "" {
 		flagsStringified, err := util.Stringify(*flags)
 		if err != nil {
 			logger.Warnf("failed to stringify cli flags: %v", err)
@@ -373,7 +373,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			logger.Info(SuccessfulMountMessage)
 
 			// Print the success message in stdout also, if logger outputs to a log-file.
-			if mountConfig.FilePath != "" {
+			if mountConfig.LogConfig.FilePath != "" {
 				fmt.Println(SuccessfulMountMessage)
 			}
 

--- a/main.go
+++ b/main.go
@@ -239,18 +239,20 @@ func runCLIApp(c *cli.Context) (err error) {
 
 	logger.Infof("Start gcsfuse/%s for app %q using mount point: %s\n", getVersion(), flags.AppName, mountPoint)
 
-	flagsStringified, err := util.Stringify(*flags)
-	if err != nil {
-		logger.Warnf("failed to stringify cli flags: %v", err)
-	} else {
-		logger.Infof("GCSFuse mount command flags: %s", flagsStringified)
-	}
+	if flags.Foreground || mountConfig.FilePath == "" {
+		flagsStringified, err := util.Stringify(*flags)
+		if err != nil {
+			logger.Warnf("failed to stringify cli flags: %v", err)
+		} else {
+			logger.Infof("GCSFuse mount command flags: %s", flagsStringified)
+		}
 
-	mountConfigStringified, err := util.Stringify(*mountConfig)
-	if err != nil {
-		logger.Warnf("failed to stringify config-file: %v", err)
-	} else {
-		logger.Infof("GCSFuse mount config flags: %s", mountConfigStringified)
+		mountConfigStringified, err := util.Stringify(*mountConfig)
+		if err != nil {
+			logger.Warnf("failed to stringify config-file: %v", err)
+		} else {
+			logger.Infof("GCSFuse mount config flags: %s", mountConfigStringified)
+		}
 	}
 
 	// The following will not warn if the user explicitly passed the default value for StatCacheCapacity.
@@ -340,6 +342,8 @@ func runCLIApp(c *cli.Context) (err error) {
 		if err != nil {
 			err = fmt.Errorf("daemonize.Run: %w", err)
 			return
+		} else {
+			logger.Infof("File system has been successfully mounted.")
 		}
 
 		return
@@ -357,6 +361,9 @@ func runCLIApp(c *cli.Context) (err error) {
 
 		if err == nil {
 			logger.Info("File system has been successfully mounted.")
+			if flags.Foreground && mountConfig.FilePath != "" {
+				fmt.Println("File system has been successfully mounted.")
+			}
 			daemonize.SignalOutcome(nil)
 		} else {
 			// Printing via mountStatus will have duplicate logs on the console while

--- a/main.go
+++ b/main.go
@@ -372,11 +372,6 @@ func runCLIApp(c *cli.Context) (err error) {
 			// Print the success message in the log-file/stdout depending on what the logger is set to.
 			logger.Info(SuccessfulMountMessage)
 
-			// Print the success message in stdout also, if logger outputs to a log-file.
-			if mountConfig.LogConfig.FilePath != "" {
-				fmt.Println(SuccessfulMountMessage)
-			}
-
 			daemonize.SignalOutcome(nil)
 		} else {
 			// Printing via mountStatus will have duplicate logs on the console while

--- a/main.go
+++ b/main.go
@@ -370,7 +370,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			logger.Info(SuccessfulMountMessage)
 
 			// Print the success message in stdout also, if logger outputs to something other than stdout.
-			if flags.Foreground && mountConfig.FilePath != "" {
+			if mountConfig.FilePath != "" {
 				fmt.Println(SuccessfulMountMessage)
 			}
 

--- a/main.go
+++ b/main.go
@@ -245,6 +245,9 @@ func runCLIApp(c *cli.Context) (err error) {
 
 	// Log mount-config and the CLI flags in the log-file.
 	// If there is no log-file, then log these to stdout.
+	// Do not log these in stdout in case of daemonized run
+	// if these are already being logged into a log-file, otherwise
+	// there will be duplicate logs for these in both places (stdout and log-file).
 	if flags.Foreground || mountConfig.FilePath == "" {
 		flagsStringified, err := util.Stringify(*flags)
 		if err != nil {
@@ -369,7 +372,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			// Print the success message in the log-file/stdout depending on what the logger is set to.
 			logger.Info(SuccessfulMountMessage)
 
-			// Print the success message in stdout also, if logger outputs to something other than stdout.
+			// Print the success message in stdout also, if logger outputs to a log-file.
 			if mountConfig.FilePath != "" {
 				fmt.Println(SuccessfulMountMessage)
 			}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,8 @@ import (
 )
 
 const (
-	SuccessfulMountMessage = "File system has been successfully mounted."
+	SuccessfulMountMessage         = "File system has been successfully mounted."
+	UnsuccessfulMountMessagePrefix = "Error while mounting gcsfuse"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -377,8 +378,8 @@ func runCLIApp(c *cli.Context) (err error) {
 			// Printing via mountStatus will have duplicate logs on the console while
 			// mounting gcsfuse in foreground mode. But this is important to avoid
 			// losing error logs when run in the background mode.
-			logger.Errorf("Error while mounting gcsfuse: %v\n", err)
-			err = fmt.Errorf("mountWithArgs: %w", err)
+			logger.Errorf("%s: %v\n", UnsuccessfulMountMessagePrefix, err)
+			err = fmt.Errorf("%s: mountWithArgs: %w", UnsuccessfulMountMessagePrefix, err)
 			daemonize.SignalOutcome(err)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -367,11 +367,11 @@ func runCLIApp(c *cli.Context) (err error) {
 
 		if err == nil {
 			// Print the success message in the log-file/stdout depending on what the logger is set to.
-			logger.Info("SuccessfulMountMessage")
+			logger.Info(SuccessfulMountMessage)
 
 			// Print the success message in stdout also, if logger outputs to something other than stdout.
 			if flags.Foreground && mountConfig.FilePath != "" {
-				fmt.Println("SuccessfulMountMessage")
+				fmt.Println(SuccessfulMountMessage)
 			}
 
 			daemonize.SignalOutcome(nil)


### PR DESCRIPTION
### Description
The following changes in logging.

* Log `File system has been successfully mounted.` on stdout if mount succeeds, even if has specified log-file. This change is only for non-`--foreground` case.
* If log-file is specified, don't log mount-config and flags on stdout, to avoid duplication of log.
* Always prefix all mount-error logs with "Error while mounting gcsfuse: " for clarity.

More detailed log is as follows:

## Case 1 - daemonized run - succcessful mount without log-file
```
$ go run .  $bucket $mountpath
{"time":"28/02/2024 07:46:07.408051","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"}
{"time":"28/02/2024 07:46:07.408403","severity":"INFO","message":"GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":false,\"ConfigFile\":\"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPerSecond\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":60000000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":false,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"StackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"\",\"LogFormat\":\"json\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"DebugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"}
{"time":"28/02/2024 07:46:07.408492","severity":"INFO","message":"GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Format\":\"json\",\"FilePath\":\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManagedFolders\":true}"}
{"time":"28/02/2024 07:46:08.693577","severity":"INFO","message":"File system has been successfully mounted."}
```

## Case 2 - foreground run - succcessful mount without log-file
```
$ go run . --foreground  $bucket $mountpath
{"timestamp":{"seconds":1709149615,"nanos":273996882},"severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"}
{"timestamp":{"seconds":1709149615,"nanos":274290082},"severity":"INFO","message":"GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":true,\"ConfigFile\":\"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPerSecond\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":60000000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":false,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"StackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"\",\"LogFormat\":\"json\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"DebugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"}
{"timestamp":{"seconds":1709149615,"nanos":274347432},"severity":"INFO","message":"GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Format\":\"json\",\"FilePath\":\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManagedFolders\":true}"}
{"timestamp":{"seconds":1709149615,"nanos":274362882},"severity":"INFO","message":"Creating Storage handle..."}
{"timestamp":{"seconds":1709149615,"nanos":274372182},"severity":"INFO","message":"UserAgent = gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) (GPN:gcsfuse) (Cfg:0:0)\n"}
{"timestamp":{"seconds":1709149615,"nanos":274681472},"severity":"INFO","message":"Creating a mount at \"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\"\n"}
{"timestamp":{"seconds":1709149615,"nanos":274711512},"severity":"INFO","message":"Creating a new server...\n"}
{"timestamp":{"seconds":1709149615,"nanos":274735882},"severity":"INFO","message":"Set up root directory for bucket gargnitin-fuse-test-bucket1"}
{"timestamp":{"seconds":1709149616,"nanos":538466724},"severity":"INFO","message":"Mounting file system \"gargnitin-fuse-test-bucket1\"..."}
{"timestamp":{"seconds":1709149616,"nanos":541304264},"severity":"INFO","message":"File system has been successfully mounted."}
```

## Case 3 - daemonized run - succcessful mount - with log-file
```
$ go run . --log-format=text --log-file=$logfile  $bucket $mountpath

# On std-out
{"time":"28/02/2024 07:50:41.380816","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"}
{"time":"28/02/2024 07:50:42.675989","severity":"INFO","message":"File system has been successfully mounted."}

# In log-file
time="28/02/2024 07:50:41.393954" severity=INFO message="Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"
time="28/02/2024 07:50:41.394490" severity=INFO message="GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":true,\"ConfigFile\":\"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPerSecond\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":60000000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":false,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"StackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogFormat\":\"text\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"DebugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"
time="28/02/2024 07:50:41.394589" severity=INFO message="GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Format\":\"text\",\"FilePath\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManagedFolders\":true}"
time="28/02/2024 07:50:41.394607" severity=INFO message="Creating Storage handle..."
time="28/02/2024 07:50:41.394622" severity=INFO message="UserAgent = gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) (GPN:gcsfuse) (Cfg:0:0)\n"
time="28/02/2024 07:50:41.394984" severity=INFO message="Creating a mount at \"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\"\n"
time="28/02/2024 07:50:41.395020" severity=INFO message="Creating a new server...\n"
time="28/02/2024 07:50:41.395044" severity=INFO message="Set up root directory for bucket gargnitin-fuse-test-bucket1"
time="28/02/2024 07:50:42.672443" severity=INFO message="Mounting file system \"gargnitin-fuse-test-bucket1\"..."
time="28/02/2024 07:50:42.675509" severity=INFO message="File system has been successfully mounted."
```

## Case 4 - foreground run - succcessful mount - with log-file
```
$ go run . --foreground --log-format=text --log-file=$logfile  $bucket $mountpath

# On stdout

# In log-file
time="28/02/2024 07:52:51.935826" severity=INFO message="Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"
time="28/02/2024 07:52:51.936487" severity=INFO message="GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":true,\"ConfigFile\":\"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPerSecond\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":60000000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":false,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"StackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogFormat\":\"text\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"DebugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"
time="28/02/2024 07:52:51.936628" severity=INFO message="GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Format\":\"text\",\"FilePath\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManagedFolders\":true}"
time="28/02/2024 07:52:51.936652" severity=INFO message="Creating Storage handle..."
time="28/02/2024 07:52:51.936667" severity=INFO message="UserAgent = gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) (GPN:gcsfuse) (Cfg:0:0)\n"
time="28/02/2024 07:52:51.937071" severity=INFO message="Creating a mount at \"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\"\n"
time="28/02/2024 07:52:51.937119" severity=INFO message="Creating a new server...\n"
time="28/02/2024 07:52:51.937140" severity=INFO message="Set up root directory for bucket gargnitin-fuse-test-bucket1"
time="28/02/2024 07:52:53.194637" severity=INFO message="Mounting file system \"gargnitin-fuse-test-bucket1\"..."
time="28/02/2024 07:52:53.198274" severity=INFO message="File system has been successfully mounted."
```

## Case 5 - daemonized run - failed mount - with log-file
```
$ go run . --log-format=text --log-file=$logfile  a$bucket $mountpath

# On std-out
{"time":"04/03/2024 10:48:56.240802","severity":"INFO","message":"Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"}
daemonize.Run: readFromProcess: sub-process: Error while mounting gcsfuse: mountWithArgs: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: storage: bucket doesn't exist
exit status 1

# In log-file
time="04/03/2024 10:48:56.253789" severity=INFO message="Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\n"
time="04/03/2024 10:48:56.254350" severity=INFO message="GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":true,\"ConfigFile\":\"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPerSecond\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":60000000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":false,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"StackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogFormat\":\"text\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"DebugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"
time="04/03/2024 10:48:56.254421" severity=INFO message="GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Format\":\"text\",\"FilePath\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManagedFolders\":true}"
time="04/03/2024 10:48:56.254440" severity=INFO message="Creating Storage handle..."
time="04/03/2024 10:48:56.254448" severity=INFO message="UserAgent = gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:fieldtrack,boringcrypto) (GPN:gcsfuse) (Cfg:0:0)\n"
time="04/03/2024 10:48:56.254731" severity=INFO message="Creating a mount at \"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\"\n"
time="04/03/2024 10:48:56.254783" severity=INFO message="Creating a new server...\n"
time="04/03/2024 10:48:56.254814" severity=INFO message="Set up root directory for bucket agargnitin-fuse-test-bucket1"
time="04/03/2024 10:48:56.991868" severity=ERROR message="Error while mounting gcsfuse: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: storage: bucket doesn't exist\n"
```

## Case 6 - foreground run - failed mount - with log-file
```
$ go run . --foreground --log-format=text --log-file=$logfile  a$bucket $mountpath

# On stdout
Error while mounting gcsfuse: mountWithArgs: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: storage: bucket doesn't exist
exit status 1

# In log-file
time="04/03/2024 10:51:24.429381" severity=INFO message="Start gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe772469 X:f
ieldtrack,boringcrypto) for app \"\" using mount point: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/garg
nitin-fuse-test-bucket1-mount\n"
time="04/03/2024 10:51:24.429701" severity=INFO message="GCSFuse mount command flags: {\"AppName\":\"\",\"Foreground\":true,\"ConfigFile\":\
"\",\"MountOptions\":{},\"DirMode\":493,\"FileMode\":420,\"Uid\":-1,\"Gid\":-1,\"ImplicitDirs\":false,\"OnlyDir\":\"\",\"RenameDirLimit\":0,
\"CustomEndpoint\":null,\"BillingProject\":\"\",\"KeyFile\":\"\",\"TokenUrl\":\"\",\"ReuseTokenFromUrl\":true,\"EgressBandwidthLimitBytesPer
Second\":-1,\"OpRateLimitHz\":-1,\"SequentialReadSizeMb\":200,\"MaxRetrySleep\":30000000000,\"StatCacheCapacity\":12710,\"StatCacheTTL\":600
00000000,\"TypeCacheTTL\":60000000000,\"HttpClientTimeout\":0,\"MaxRetryDuration\":-1000000000,\"RetryMultiplier\":2,\"LocalFileCache\":fals
e,\"TempDir\":\"\",\"ClientProtocol\":\"http1\",\"MaxConnsPerHost\":100,\"MaxIdleConnsPerHost\":100,\"EnableNonexistentTypeCache\":false,\"S
tackdriverExportInterval\":0,\"OtelCollectorAddress\":\"\",\"LogFile\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/
test_buckets/gargnitin-fuse-test-bucket1-log.log\",\"LogFormat\":\"text\",\"ExperimentalEnableJsonRead\":false,\"DebugFuseErrors\":true,\"De
bugFuse\":false,\"DebugFS\":false,\"DebugGCS\":false,\"DebugHTTP\":false,\"DebugInvariants\":false,\"DebugMutex\":false}"
time="04/03/2024 10:51:24.429804" severity=INFO message="GCSFuse mount config flags: {\"CreateEmptyFile\":false,\"Severity\":\"INFO\",\"Form
at\":\"text\",\"FilePath\":\"/usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/test_buckets/gargnitin-fuse-test-bucket1-log
.log\",\"LogRotateConfig\":{\"MaxFileSizeMB\":512,\"BackupFileCount\":10,\"Compress\":true},\"MaxSizeMB\":-1,\"CacheFileForRangeRead\":false
,\"CacheDir\":\"\",\"TtlInSeconds\":-9223372036854775808,\"TypeCacheMaxSizeMB\":4,\"StatCacheMaxSizeMB\":-9223372036854775808,\"EnableManage
dFolders\":true}"
time="04/03/2024 10:51:24.429823" severity=INFO message="Creating Storage handle..."
time="04/03/2024 10:51:24.429835" severity=INFO message="UserAgent = gcsfuse/unknown (Go version go1.22-20240109-RC01 cl/597041403 +dcbe7724
69 X:fieldtrack,boringcrypto) (GPN:gcsfuse) (Cfg:0:0)\n"
time="04/03/2024 10:51:24.430346" severity=INFO message="Creating a mount at \"/usr/local/google/home/gargnitin/work/cloud/storage/client/gc
sfuse/test_buckets/gargnitin-fuse-test-bucket1-mount\"\n"
time="04/03/2024 10:51:24.430385" severity=INFO message="Creating a new server...\n"
time="04/03/2024 10:51:24.430403" severity=INFO message="Set up root directory for bucket agargnitin-fuse-test-bucket1"
time="04/03/2024 10:51:25.153457" severity=ERROR message="Error while mounting gcsfuse: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: storage: bucket doesn't exist\n"
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Did sanity testing (mounting, unmounting, listing)
2. Unit tests - Ran locally and passed
3. Integration tests - Ran through presubmit
