### PR TITLE
Replacing panic with error message

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -160,7 +160,7 @@ func NewFileSystem(
 		var err error
 		fileCacheHandler, err = createFileCacheHandler(cfg)
 		if err != nil {
-			return nil, fmt.Errorf("while creating NewFileSystem(): %v", err)
+			return nil, err
 		}
 	}
 
@@ -236,10 +236,9 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	filePerm := util.DefaultFilePerm
 	dirPerm := util.DefaultDirPerm
 
-	// Panic in case cacheDir does not have required permissions
 	cacheDirErr := util.CreateCacheDirectoryIfNotPresentAt(cacheDir, dirPerm)
 	if cacheDirErr != nil {
-		return nil, fmt.Errorf("createFileCacheHandler: while creating file cache directory: %v", cacheDirErr)
+		return nil, fmt.Errorf("createFileCacheHandler: while creating file cache directory: %w", cacheDirErr)
 	}
 
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheDir,

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -157,7 +157,11 @@ func NewFileSystem(
 	// enabled only if cache-dir is not empty and file-cache:max-size-mb is non 0.
 	var fileCacheHandler *file.CacheHandler
 	if config.IsFileCacheEnabled(cfg.MountConfig) {
-		fileCacheHandler = createFileCacheHandler(cfg)
+		var err error
+		fileCacheHandler, err = createFileCacheHandler(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("while creating NewFileSystem(): %v", err)
+		}
 	}
 
 	// Set up the basic struct.
@@ -212,7 +216,7 @@ func NewFileSystem(
 	return fs, nil
 }
 
-func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHandler) {
+func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHandler, err error) {
 	var sizeInBytes uint64
 	// -1 means unlimited size for cache, the underlying LRU cache doesn't handle
 	// -1 explicitly, hence we pass MaxUint64 as capacity in that case.
@@ -235,7 +239,7 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	// Panic in case cacheDir does not have required permissions
 	cacheDirErr := util.CreateCacheDirectoryIfNotPresentAt(cacheDir, dirPerm)
 	if cacheDirErr != nil {
-		panic(fmt.Sprintf("createFileCacheHandler: error while creating file cache directory: %v", cacheDirErr.Error()))
+		return nil, fmt.Errorf("createFileCacheHandler: while creating file cache directory: %v", cacheDirErr)
 	}
 
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheDir,


### PR DESCRIPTION
### Description
Problem: we should not use panic statement for the user-controlled behavior. Also, we were getting generic failure while mounting.

Before the change, stdout for the mount with no permission to create cache-dir:
```
daemonize.Run: readFromProcess: Decode: EOF
```

After the change, stdout for the mount with no permission to create cache-dir:
```
daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithStorageHandle: fs.NewServer: create file system: while creating NewFileSystem(): createFileCacheHandler: while creating file cache directory: error in creating directory structure /prince/gcsfuse-file-cache: mkdir /prince: permission denied
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - checked the mount failing behavior manually.
2. Unit tests - Decided to go without unit-test for now, since we don't have straight forward way to add mount fail unit test.
3. Integration tests - 
