### PR TITLE
Upgrade to go 1.22.1 (with fix for dockerfiles)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   linux-tests:
     strategy:
       matrix:
-        go: [ 1.21.x ]
+        go: [ 1.22.x ]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
 
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.21"
+        go-version: "1.22"
     - name: checkout code
       uses: actions/checkout@v3
     - name: golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.21.7-alpine as builder
+FROM golang:1.22.0-alpine as builder
 
 RUN apk add git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.22.0-alpine as builder
+FROM golang:1.22.1-alpine as builder
 
 RUN apk add git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse
 
-go 1.21
+go 1.22.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse
 
-go 1.22.0
+go 1.22.1
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -18,7 +18,7 @@ NUM_EPOCHS=80
 TEST_BUCKET="gcsfuse-ml-data"
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.7.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -18,7 +18,7 @@ NUM_EPOCHS=80
 TEST_BUCKET="gcsfuse-ml-data"
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Installs go1.21 on the container, builds gcsfuse using log_rotation file
+# Installs go1.22 on the container, builds gcsfuse using log_rotation file
 # and installs tf-models-official v2.13.2, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.7.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Installs go1.22 on the container, builds gcsfuse using log_rotation file
+# Installs go1.22.1 on the container, builds gcsfuse using log_rotation file
 # and installs tf-models-official v2.13.2, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -34,8 +34,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.21.7
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.7.linux-amd64.tar.gz -q
+echo Installing go-lang  1.22.0
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -34,8 +34,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.22.0
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -q
+echo Installing go-lang  1.22.1
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/read_cache/setup.sh
+++ b/perfmetrics/scripts/read_cache/setup.sh
@@ -64,7 +64,7 @@ sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GRO
 cd -
 
 # Install and validate go.
-version=1.21.7
+version=1.22.0
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go
 tar -xzf go_tar.tar.gz && sudo mv go /usr/local

--- a/perfmetrics/scripts/read_cache/setup.sh
+++ b/perfmetrics/scripts/read_cache/setup.sh
@@ -64,7 +64,7 @@ sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GRO
 cd -
 
 # Install and validate go.
-version=1.22.0
+version=1.22.1
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go
 tar -xzf go_tar.tar.gz && sudo mv go /usr/local

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -43,8 +43,8 @@ upgrade_gcloud_version
 
 # e.g. architecture=arm64 or amd64
 architecture=$(dpkg --print-architecture)
-echo "Installing go-lang 1.22.0..."
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-${architecture}.tar.gz -q
+echo "Installing go-lang 1.22.1..."
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 # install python3-setuptools tools.

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -43,8 +43,8 @@ upgrade_gcloud_version
 
 # e.g. architecture=arm64 or amd64
 architecture=$(dpkg --print-architecture)
-echo "Installing go-lang 1.21.7..."
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.7.linux-${architecture}.tar.gz -q
+echo "Installing go-lang 1.22.0..."
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 # install python3-setuptools tools.

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.21.7.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.0.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -47,7 +47,7 @@ ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
 RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
 
-ARG GCSFUSE_PATH=/go/gcsfuse
+ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
 
 # Install fpm package using bundle

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -36,6 +36,11 @@ ARG OS_NAME
 # Image with gcsfuse installed and its package (.deb)
 FROM golang:1.22.0 as gcsfuse-package
 
+# Directory for creating a go module
+RUN mkdir containerized_gcsfuse
+WORKDIR $PWD/containerized_gcsfuse
+RUN go mod init containerized_gcsfuse
+
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 
 ENV CGO_ENABLED=0
@@ -43,21 +48,17 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
-ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
-ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
-RUN go get -d ${GCSFUSE_REPO}
-
-WORKDIR ${GCSFUSE_PATH}
-# Branch name for building through a particular branch.
-ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
+ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse"
+ENV GCSFUSE_PATH "$GOPATH/pkg/mod/$GCSFUSE_REPO@v${GCSFUSE_VERSION}"
+RUN go get ${GCSFUSE_REPO}@v${GCSFUSE_VERSION}
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
 
 ARG GCSFUSE_BIN="/gcsfuse"
 WORKDIR ${GOPATH}
-RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse
+# The following can be optimizing by building from local code.
+RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse@v${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
@@ -73,7 +74,7 @@ RUN fpm \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
     --vendor "" \
-    --url "https://$GCSFUSE_REPO" \
+    --url "https://$GCSFUSE_REPO/" \
     --description "A user-space file system for Google Cloud Storage."
 
 # distroless image with gcsfuse installed.

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -36,11 +36,6 @@ ARG OS_NAME
 # Image with gcsfuse installed and its package (.deb)
 FROM golang:1.22.0 as gcsfuse-package
 
-# Directory for creating a go module
-RUN mkdir containerized_gcsfuse
-WORKDIR $PWD/containerized_gcsfuse
-RUN go mod init containerized_gcsfuse
-
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 
 ENV CGO_ENABLED=0
@@ -48,17 +43,21 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
-ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse"
-ENV GCSFUSE_PATH "$GOPATH/pkg/mod/$GCSFUSE_REPO@v${GCSFUSE_VERSION}"
-RUN go get ${GCSFUSE_REPO}@v${GCSFUSE_VERSION}
+ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
+
+ARG GCSFUSE_PATH=/go/gcsfuse
+WORKDIR ${GCSFUSE_PATH}
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
 
 ARG GCSFUSE_BIN="/gcsfuse"
 WORKDIR ${GOPATH}
-# The following can be optimizing by building from local code.
-RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse@v${GCSFUSE_VERSION}
+
+WORKDIR ${GCSFUSE_PATH}/tools/build_gcsfuse
+RUN go install
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
@@ -74,7 +73,7 @@ RUN fpm \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
     --vendor "" \
-    --url "https://$GCSFUSE_REPO/" \
+    --url "https://$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."
 
 # distroless image with gcsfuse installed.

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.21.7 as gcsfuse-package
+FROM golang:1.22.0 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.22.0 as gcsfuse-package
+FROM golang:1.22.1 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -45,7 +45,7 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
+RUN git clone --branch ${BRANCH_NAME} --depth 1 ${GCSFUSE_REPO}
 
 ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -19,11 +19,6 @@
 
 FROM golang:1.22.0 as builder
 
-# Directory for creating a go module
-RUN mkdir package_gcsfuse
-WORKDIR $PWD/package_gcsfuse
-RUN go mod init package_gcsfuse
-
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 
 ENV CGO_ENABLED=0
@@ -31,11 +26,13 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
-ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse"
-ENV GCSFUSE_PATH "$GOPATH/pkg/mod/$GCSFUSE_REPO@v${GCSFUSE_VERSION}"
-RUN go get ${GCSFUSE_REPO}@v${GCSFUSE_VERSION}
+ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
 
+ARG GCSFUSE_PATH=/go/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
+
 ARG DEBEMAIL="gcs-fuse-maintainers@google.com"
 ARG DEBFULLNAME="GCSFuse Team"
 
@@ -49,8 +46,8 @@ RUN if [ "${ARCHITECTURE}" != "amd64" ] && [ "${ARCHITECTURE}" != "arm64" ]; the
 fi
 ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_${ARCHITECTURE}"
 ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
-WORKDIR ${GOPATH}
-RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse@v${GCSFUSE_VERSION}
+WORKDIR ${GCSFUSE_PATH}/tools/build_gcsfuse
+RUN go install
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
@@ -90,5 +87,5 @@ RUN fpm \
     --rpm-digest sha256 \
     --license Apache-2.0 \
     --vendor "" \
-    --url "https://$GCSFUSE_REPO/" \
+    --url "https://$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -30,7 +30,7 @@ ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
 RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
 
-ARG GCSFUSE_PATH=/go/gcsfuse
+ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
 
 ARG DEBEMAIL="gcs-fuse-maintainers@google.com"

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.21.7 as builder
+FROM golang:1.22.0 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -19,6 +19,11 @@
 
 FROM golang:1.22.0 as builder
 
+# Directory for creating a go module
+RUN mkdir package_gcsfuse
+WORKDIR $PWD/package_gcsfuse
+RUN go mod init package_gcsfuse
+
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 
 ENV CGO_ENABLED=0
@@ -26,18 +31,13 @@ ENV GOOS=linux
 ENV GO111MODULE=auto
 
 ARG GCSFUSE_VERSION
-ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse/"
-ENV GCSFUSE_PATH "$GOPATH/src/$GCSFUSE_REPO"
-RUN go get -d ${GCSFUSE_REPO}
+ARG GCSFUSE_REPO="github.com/googlecloudplatform/gcsfuse"
+ENV GCSFUSE_PATH "$GOPATH/pkg/mod/$GCSFUSE_REPO@v${GCSFUSE_VERSION}"
+RUN go get ${GCSFUSE_REPO}@v${GCSFUSE_VERSION}
 
 WORKDIR ${GCSFUSE_PATH}
 ARG DEBEMAIL="gcs-fuse-maintainers@google.com"
 ARG DEBFULLNAME="GCSFuse Team"
-
-# Build Arg for building through a particular branch/commit. By default, it uses
-# the tag corresponding to passed GCSFUSE VERSION
-ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git checkout "${BRANCH_NAME}"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
@@ -50,13 +50,13 @@ fi
 ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_${ARCHITECTURE}"
 ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
 WORKDIR ${GOPATH}
-RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse
+RUN go install ${GCSFUSE_REPO}/tools/build_gcsfuse@v${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}
 RUN build_gcsfuse ${GCSFUSE_PATH} ${GCSFUSE_BIN} ${GCSFUSE_VERSION}
 RUN mkdir -p ${GCSFUSE_BIN}/usr && mv ${GCSFUSE_BIN}/bin ${GCSFUSE_BIN}/usr/bin
 
 # Creating structure for debian package as we are using 'dpkg-deb --build' to create debian package
-RUN mkdir -p ${GCSFUSE_BIN}/DEBIAN && cp $GOPATH/src/$GCSFUSE_REPO/DEBIAN/* ${GCSFUSE_BIN}/DEBIAN/
+RUN mkdir -p ${GCSFUSE_BIN}/DEBIAN && cp ${GCSFUSE_PATH}/DEBIAN/* ${GCSFUSE_BIN}/DEBIAN/
 RUN mkdir -p ${GCSFUSE_DOC}
 RUN mv ${GCSFUSE_BIN}/DEBIAN/copyright ${GCSFUSE_DOC} &&  \
     mv ${GCSFUSE_BIN}/DEBIAN/changelog ${GCSFUSE_DOC} && \
@@ -90,5 +90,5 @@ RUN fpm \
     --rpm-digest sha256 \
     --license Apache-2.0 \
     --vendor "" \
-    --url "https://$GCSFUSE_REPO" \
+    --url "https://$GCSFUSE_REPO/" \
     --description "A user-space file system for Google Cloud Storage."

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.22.0 as builder
+FROM golang:1.22.1 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -28,7 +28,7 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git clone --branch ${BRANCH_NAME} ${GCSFUSE_REPO}
+RUN git clone --branch ${BRANCH_NAME} --depth 1 ${GCSFUSE_REPO}
 
 ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}


### PR DESCRIPTION
### Description
* Reapply "Upgrade to golang 1.22 (#1753)" (#1766)
    This reverts commit a63a46fdbecbcfa58591e76a9bf49af6239ae7f1.
* Fixes dockerfiles which failed with go 1.22, because of `go get` error, by switching to `git clone` (in the docker container).
* Upgrade to 1.22.1

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Sanity testing
2. Unit tests - NA
3. Integration tests - [Passed](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/a557edef-b441-4b82-a37a-06757750634a).
4. Perf tests
```
+--------+------------+--------------+------------+--------------+--------------+
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
+--------+------------+--------------+------------+--------------+--------------+
| Master |  0.25MiB   | 536.37MiB/s  | 1.26MiB/s  |  77.95MiB/s  |  1.08MiB/s   |
|   PR   |  0.25MiB   | 518.86MiB/s  |  1.3MiB/s  |  70.12MiB/s  |  1.31MiB/s   |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 4645.71MiB/s | 80.55MiB/s | 1238.05MiB/s |  79.37MiB/s  |
|   PR   | 48.828MiB  | 4477.76MiB/s | 79.18MiB/s | 1277.78MiB/s |  80.71MiB/s  |
|        |            |              |            |              |              |
| Master | 976.562MiB | 4406.04MiB/s | 33.37MiB/s | 477.44MiB/s  |  32.95MiB/s  |
|   PR   | 976.562MiB | 4423.47MiB/s | 33.91MiB/s | 608.93MiB/s  |  31.9MiB/s   |
|        |            |              |            |              |              |
+--------+------------+--------------+------------+--------------+--------------+
```
