### PR TITLE
Experimental dashboard config to run v1 benchmark with gRPC_support1

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -31,6 +31,12 @@
       },
       "branch": "read_cache_release",
       "end_date": "2024-03-31 05:30:00+00:00"
+    },
+    {
+      "config_name": "master_benchmark_with_gRPC_changes",
+      "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
+      "branch": "gRPC_support1",
+      "end_date": "2024-03-31 05:30:00+00:00"
     }
   ]
 }


### PR DESCRIPTION
### Description
* Experimental dashboard config to run v1 benchmark with gRPC_support1

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
