### PR TITLE
Fix e2e tests

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -16,7 +16,6 @@
 package operations_test
 
 import (
-	"log"
 	"os"
 	"path"
 	"testing"
@@ -128,7 +127,6 @@ func TestMain(m *testing.M) {
 	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as operations tests validates content from the bucket.
 	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		log.Print("Please pass --onlyDirMounted <dirName> flag if you are running tests with only-dir mount.")
 		setup.RunTestsForMountedDirectoryFlag(m)
 	}
 

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -56,32 +56,32 @@ sudo umount $MOUNT_DIR
 
 # Run tests with static mounting. (flags: --implicit-dirs=true, --only-dir testDir)
 gcsfuse --only-dir testDir --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with persistent mounting. (flags: --implicit-dirs=true, --only-dir=testDir)
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=true
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME --onlyDirMounted testDir
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with static mounting. (flags: --implicit-dirs=false, --only-dir testDir)
 gcsfuse --only-dir testDir --implicit-dirs=false $TEST_BUCKET_NAME $MOUNT_DIR
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME --onlyDirMounted testDir
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with persistent mounting. (flags: --implicit-dirs=false, --only-dir=testDir)
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=false
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME --onlyDirMounted testDir
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with static mounting. (flags: --experimental-enable-json-read, --implicit-dirs=true, --only-dir testDir)
 gcsfuse --experimental-enable-json-read --only-dir testDir --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME --onlyDirMounted testDir
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with persistent mounting. (flags: --experimental-enable-json-read, --implicit-dirs=true, --only-dir=testDir)
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=true,experimental_enable_json_read=true
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME --onlyDirMounted testDir
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
 # Run tests with config "create-empty-file: true".

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -181,10 +181,7 @@ func DeleteAllObjectsWithPrefix(ctx context.Context, client *storage.Client, pre
 }
 
 func StatObject(ctx context.Context, client *storage.Client, object string) (*storage.ObjectAttrs, error) {
-	fmt.Println("before change: ", object)
-
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
-	fmt.Println(bucket, object)
 
 	attrs, err := client.Bucket(bucket).Object(object).Attrs(ctx)
 	if err != nil {

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -181,7 +181,10 @@ func DeleteAllObjectsWithPrefix(ctx context.Context, client *storage.Client, pre
 }
 
 func StatObject(ctx context.Context, client *storage.Client, object string) (*storage.ObjectAttrs, error) {
+	fmt.Println("before change: ", object)
+
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
+	fmt.Println(bucket, object)
 
 	attrs, err := client.Bucket(bucket).Object(object).Attrs(ctx)
 	if err != nil {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -36,7 +36,6 @@ var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test
 var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
-var onlyDirMounted = flag.String("onlyDirMounted", "", "To be used in mounted directory tests, when only-dir flag is used.")
 
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
@@ -53,6 +52,7 @@ var (
 	testDir              string
 	mntDir               string
 	sbinFile             string
+	onlyDirMounted       string
 	dynamicBucketMounted string
 )
 
@@ -117,12 +117,12 @@ func MntDir() string {
 
 // OnlyDirMounted returns the name of the directory mounted in case of only dir mount.
 func OnlyDirMounted() string {
-	return *onlyDirMounted
+	return onlyDirMounted
 }
 
 // SetOnlyDirMounted sets the name of the directory mounted in case of only dir mount.
 func SetOnlyDirMounted(onlyDirValue string) {
-	*onlyDirMounted = onlyDirValue
+	onlyDirMounted = onlyDirValue
 }
 
 // DynamicBucketMounted returns the name of the bucket in case of dynamic mount.
@@ -407,7 +407,7 @@ func GetBucketAndObjectBasedOnTypeOfMount(object string) (string, string) {
 	if strings.Contains(TestBucket(), "/") {
 		// This case arises when we run tests on mounted directory and pass
 		// bucket/directory in testbucket flag.
-		separateBucketAndObjectName(bucket, object)
+		bucket, object = separateBucketAndObjectName(bucket, object)
 	}
 	if dynamicBucketMounted != "" {
 		bucket = dynamicBucketMounted


### PR DESCRIPTION
### Description
E2E tests started failing with mounted directory flag because we were not setting the bucket and object properly after refactoring changes https://github.com/GoogleCloudPlatform/gcsfuse/pull/1771. 
Also reverted the changes to expose onlyirMounted flag as GKE team is not using it.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran the script on GCE VM.
2. Unit tests - NA
3. Integration tests - Ran via KOKORO
