### PR TITLE
fix kokoro e2e tests

### DIFF
--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -29,7 +29,8 @@ function upgrade_gcloud_version() {
   sudo /usr/local/google-cloud-sdk/install.sh
   export PATH=$PATH:/usr/local/google-cloud-sdk/bin
   echo 'export PATH=$PATH:/usr/local/google-cloud-sdk/bin' >> ~/.bashrc
-  gcloud version && rm gcloud.tar.gz && gcloud components update
+  gcloud version && rm gcloud.tar.gz
+  sudo /usr/local/google-cloud-sdk/bin/gcloud components update
   sudo /usr/local/google-cloud-sdk/bin/gcloud components install alpha
 }
 


### PR DESCRIPTION
### Description
Kokoro e2e tests are failing on arm64 machine with
```
Beginning update. This process may take several minutes.
ERROR: (gcloud.components.update) You cannot perform this action because this Google Cloud CLI installation is managed by an external package manager.
Please consider using a separate installation of the Google Cloud CLI created through the default mechanism described at: https://cloud.google.com/sdk/
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested on local kokoro setup
2. Unit tests - NA
3. Integration tests - NA
