### PR TITLE
Fix e2e tests on arm64 machine

### DIFF
--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -27,10 +27,9 @@ function upgrade_gcloud_version() {
   wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
   sudo rm -rf $(which gcloud) && sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
   # The gcloud command exists in two locations on a Kokoro ARM64 machine:
-  # /usr/bin/gcloud and /usr/snap/gcloud. Deleting both of these paths.
+  # /usr/bin/gcloud and /usr/snap/gcloud. Deleting both the paths to install latest gcloud.
   if [ ! -d $(which gcloud) ]; then
      sudo rm -rf $(which gcloud)
-     echo "Hello"
   fi
   sudo /usr/local/google-cloud-sdk/install.sh
   export PATH=$PATH:/usr/local/google-cloud-sdk/bin

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -26,6 +26,12 @@ function upgrade_gcloud_version() {
   gcloud version
   wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
   sudo rm -rf $(which gcloud) && sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
+  # The gcloud command exists in two locations on a Kokoro ARM64 machine:
+  # /usr/bin/gcloud and /usr/snap/gcloud. Deleting both of these paths.
+  if [ ! -d $(which gcloud) ]; then
+     sudo rm -rf $(which gcloud)
+     echo "Hello"
+  fi
   sudo /usr/local/google-cloud-sdk/install.sh
   export PATH=$PATH:/usr/local/google-cloud-sdk/bin
   echo 'export PATH=$PATH:/usr/local/google-cloud-sdk/bin' >> ~/.bashrc

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -25,15 +25,10 @@ readonly BUCKET_LOCATION="us-west1"
 function upgrade_gcloud_version() {
   gcloud version
   wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
-  sudo rm -rf $(which gcloud) && sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
-  # The gcloud command exists in two locations on a Kokoro ARM64 machine:
-  # /usr/bin/gcloud and /usr/snap/gcloud. Deleting both the paths to install latest gcloud.
-  if [ ! -d $(which gcloud) ]; then
-     sudo rm -rf $(which gcloud)
-  fi
+  sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
   sudo /usr/local/google-cloud-sdk/install.sh
-  export PATH=$PATH:/usr/local/google-cloud-sdk/bin
-  echo 'export PATH=$PATH:/usr/local/google-cloud-sdk/bin' >> ~/.bashrc
+  export PATH=/usr/local/google-cloud-sdk/bin:$PATH
+  echo 'export PATH=/usr/local/google-cloud-sdk/bin:$PATH' >> ~/.bashrc
   gcloud version && rm gcloud.tar.gz
   sudo /usr/local/google-cloud-sdk/bin/gcloud components update
   sudo /usr/local/google-cloud-sdk/bin/gcloud components install alpha


### PR DESCRIPTION
### Description
Issue :  The gcloud command exists in two locations on a Kokoro ARM64 machine: /usr/bin/gcloud and /usr/snap/gcloud.
Fix: added new path as prefix in PATH env variable.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - local kokoro setup
2. Unit tests - NA
3. Integration tests - Kokoro
