### PR TITLE
Update semantics for MinObject in stat-cache in march_2024_release

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -79,9 +79,13 @@ The behavior of stat cache is controlled by the following flags/config parameter
    This has been deprecated (starting v2.0) and is ignored if the user sets `metadata-cache:stat-cache-max-size-mb` .
    This can be set to 0 for disabling stat-cache and > 0 for setting a finite stat-cache size.
 
-   If neither of these two is set, then a size of 32MB is used, which is equivalent to about 12710 stat-cache entries (assuming just as many negative stat-cache entries).
+   If neither of these two is set, then a size of 32MB is used, which is
+   equivalent to about 20460 stat-cache entries (assuming just as many negative
+   stat-cache entries).
 
-   If you have more objects (folders or files) than that in your bucket that you want to access, then you may want to increase this, otherwise the caching will not function properly when listing that folder's contents:
+   If you have more objects (folders or files) than that in your bucket that you
+   want to access, then you may want to increase this, otherwise the caching
+   will not function properly when listing that folder's contents:
     - ListObjects will return information on the items within the folder. Each item's data is cached
     - Because there are more objects than cache capacity, the earliest entries will be evicted
     - The linux kernel then asks for a little more information on each file.


### PR DESCRIPTION
### Description
This updates the semantics.md for the changes
related to replacement of gcs.Object with MinObject in stat-cache and in other places.

This is a cherry-pick from [this](https://github.com/GoogleCloudPlatform/gcsfuse/pull/1752/files#diff-fb497abe2ee21cd857a4434d6fa6aa054e45cfa22e73808db344344ea8d492e9) .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
