### PR TITLE
Allow Dockerfiles to clone from commit-hash too

### DIFF
--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -45,10 +45,12 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git clone --branch ${BRANCH_NAME} --depth 1 ${GCSFUSE_REPO}
+RUN git clone ${GCSFUSE_REPO}
 
 ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
+
+RUN git checkout ${BRANCH_NAME}
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -28,10 +28,10 @@ ENV GO111MODULE=auto
 ARG GCSFUSE_VERSION
 ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
 ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
-RUN git clone --branch ${BRANCH_NAME} --depth 1 ${GCSFUSE_REPO}
-
+RUN git clone ${GCSFUSE_REPO} 
 ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
+RUN git checkout ${BRANCH_NAME}
 
 ARG DEBEMAIL="gcs-fuse-maintainers@google.com"
 ARG DEBFULLNAME="GCSFuse Team"


### PR DESCRIPTION
### Description

Switch `git clone --depth 1 BRANCH_NAME` to
`git clone && git checkout BRANCH_NAME` to
extend support for BRANCH_NAME to be commit-hash
apart from branch-name or tag.

This is of course slower than `git clone --depth 1`, but is compatible with commit IDs too.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
