### PR TITLE
Add crc check to read cache functional tests

### DIFF
--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -132,7 +132,8 @@ func getCRCOfFile(filePath string) (crc32Value uint32) {
 	// Closing file at the end.
 	defer operations.CloseFile(file)
 
-	hasher := crc32.NewIEEE() // Use the standard CRC-32 IEEE polynomial
+	var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+	hasher := crc32.New(crc32cTable)
 	_, err = io.Copy(hasher, file)
 	if err != nil {
 		fmt.Println("Error calculating CRC-32:", err)

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -119,16 +119,6 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 	}
 }
 
-func ValidateCRCWithGCS(gotCRC32Value uint32, objectName string, ctx context.Context, storageClient *storage.Client, t *testing.T) {
-	attr, err := client.StatObject(ctx, storageClient, path.Join(testDirName, objectName))
-	if err != nil {
-		t.Errorf("Failed to fetch object attributes: %v", err)
-	}
-	if attr.CRC32C != gotCRC32Value {
-		t.Errorf("CRC32 mismatch. Expected %d, Got %d", attr.CRC32C, gotCRC32Value)
-	}
-}
-
 func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
 	validateFileSizeInCacheDirectory(fileName, filesize, t)
 	// Validate CRC of cached file matches GCS CRC.
@@ -137,7 +127,7 @@ func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.C
 	if err != nil {
 		t.Errorf("CalculateFileCRC32 Failed: %v", err)
 	}
-	ValidateCRCWithGCS(crc32ValueOfCachedFile, fileName, ctx, storageClient, t)
+	client.ValidateCRCWithGCS(crc32ValueOfCachedFile, path.Join(testDirName, fileName), ctx, storageClient, t)
 }
 
 func validateFileIsNotCached(fileName string, t *testing.T) {
@@ -190,7 +180,7 @@ func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage
 	if err != nil {
 		t.Errorf("CalculateCRC32 Failed: %v", err)
 	}
-	ValidateCRCWithGCS(gotCRC32Value, filename, ctx, storageClient, t)
+	client.ValidateCRCWithGCS(gotCRC32Value, path.Join(testDirName, filename), ctx, storageClient, t)
 
 	return expectedOutcome
 }

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -91,6 +91,7 @@ func ValidateObjectChunkFromGCS(ctx context.Context, storageClient *storage.Clie
 		t.Fatalf("GCS file %s content mismatch. Got file size: %d, Expected "+
 			"file size: %d ", fileName, len(gotContent), len(expectedContent))
 	}
+
 }
 
 func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *storage.Client,

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -91,7 +91,6 @@ func ValidateObjectChunkFromGCS(ctx context.Context, storageClient *storage.Clie
 		t.Fatalf("GCS file %s content mismatch. Got file size: %d, Expected "+
 			"file size: %d ", fileName, len(gotContent), len(expectedContent))
 	}
-
 }
 
 func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *storage.Client,

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -154,3 +154,13 @@ func CreateNFilesInDir(ctx context.Context, storageClient *storage.Client, numFi
 	}
 	return fileNames
 }
+
+func ValidateCRCWithGCS(gotCRC32Value uint32, objectPath string, ctx context.Context, storageClient *storage.Client, t *testing.T) {
+	attr, err := StatObject(ctx, storageClient, objectPath)
+	if err != nil {
+		t.Errorf("Failed to fetch object attributes: %v", err)
+	}
+	if attr.CRC32C != gotCRC32Value {
+		t.Errorf("CRC32 mismatch. Expected %d, Got %d", attr.CRC32C, gotCRC32Value)
+	}
+}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -638,3 +638,15 @@ func CalculateCRC32(src io.Reader) (uint32, error) {
 
 	return hasher.Sum32(), nil // Return checksum and nil error on success
 }
+
+// CalculateFileCRC32 calculates and returns the CRC-32 checksum of a file.
+func CalculateFileCRC32(filePath string) (uint32, error) {
+	// Open file with simplified flags and permissions
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0, fmt.Errorf("error opening file: %w", err)
+	}
+	defer file.Close() // Ensure file closure
+
+	return CalculateCRC32(file)
+}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"io/fs"
 	"log"
@@ -624,4 +625,16 @@ func CreateFileOfSize(fileSize int64, filePath string, t *testing.T) {
 		t.Errorf("operations.GenerateRandomData: %v", err)
 	}
 	CreateFileWithContent(filePath, FilePermission_0600, string(randomData), t)
+}
+
+// CalculateCRC32 calculates and returns the CRC-32 checksum of the data from the provided Reader.
+func CalculateCRC32(src io.Reader) (uint32, error) {
+	crc32Table := crc32.MakeTable(crc32.Castagnoli) // Pre-calculate the table
+	hasher := crc32.New(crc32Table)
+
+	if _, err := io.Copy(hasher, src); err != nil {
+		return 0, fmt.Errorf("error calculating CRC-32: %w", err) // Wrap error
+	}
+
+	return hasher.Sum32(), nil // Return checksum and nil error on success
 }


### PR DESCRIPTION
### Description

Instead of comparing content read with GCS and cached file with GCS, calculate CRC of the file and validate that it matches the CRC values on GCS.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran mounted directory tests.
2. Unit tests - NA
3. Integration tests - Ran via KOKORO
