### PR TITLE
Adding GRPC client configuration in Mount configuration

### DIFF
--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -47,6 +47,7 @@ const (
 
 	DefaultFileCacheMaxSizeMB               int64 = -1
 	DefaultEnableEmptyManagedFoldersListing       = false
+	DefaultGrpcConnectionPoolSize                 = 1
 )
 
 type WriteConfig struct {
@@ -69,6 +70,11 @@ type ListConfig struct {
 	// (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above mentioned corner case.
 	// (c) If ImplicitDirectories is false then no managed folders are listed irrespective of EnableEmptyManagedFolders flag.
 	EnableEmptyManagedFolders bool `yaml:"enable-empty-managed-folders"`
+}
+
+type GrpcClientConfig struct {
+	// ConnectionPoolSize configures the number of gRPC channel in grpc client.
+	ConnectionPoolSize int `yaml:"conn-pool-size,omitempty"`
 }
 
 type CacheDir string
@@ -105,6 +111,7 @@ type MountConfig struct {
 	CacheDir            `yaml:"cache-dir"`
 	MetadataCacheConfig `yaml:"metadata-cache"`
 	ListConfig          `yaml:"list"`
+	GrpcClientConfig    `yaml:"grpc-client"`
 }
 
 // LogRotateConfig defines the parameters for log rotation. It consists of three
@@ -148,6 +155,9 @@ func NewMountConfig() *MountConfig {
 	}
 	mountConfig.ListConfig = ListConfig{
 		EnableEmptyManagedFolders: DefaultEnableEmptyManagedFoldersListing,
+	}
+	mountConfig.GrpcClientConfig = GrpcClientConfig{
+		ConnectionPoolSize: DefaultGrpcConnectionPoolSize,
 	}
 	return mountConfig
 }

--- a/internal/config/testdata/grpc_client_config/invalid_conn_pool_size.yaml
+++ b/internal/config/testdata/grpc_client_config/invalid_conn_pool_size.yaml
@@ -1,0 +1,3 @@
+grpc-client:
+  conn-pool-size: 0
+

--- a/internal/config/testdata/grpc_client_config/unset_conn_pool_size.yaml
+++ b/internal/config/testdata/grpc_client_config/unset_conn_pool_size.yaml
@@ -1,0 +1,3 @@
+write:
+  create-empty-file: true
+

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -18,3 +18,5 @@ metadata-cache:
   stat-cache-max-size-mb: 3
 list:
   enable-empty-managed-folders: true
+grpc-client:
+  conn-pool-size: 4

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -100,6 +100,13 @@ func (metadataCacheConfig *MetadataCacheConfig) validate() error {
 	return nil
 }
 
+func (grpcClientConfig *GrpcClientConfig) validate() error {
+	if grpcClientConfig.ConnectionPoolSize < 1 {
+		return fmt.Errorf("the value of connection-pool-size can't be less than 1")
+	}
+	return nil
+}
+
 func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 	mountConfig = NewMountConfig()
 
@@ -143,6 +150,10 @@ func ParseConfigFile(fileName string) (mountConfig *MountConfig, err error) {
 
 	if err = mountConfig.MetadataCacheConfig.validate(); err != nil {
 		return mountConfig, fmt.Errorf("error parsing metadata-cache configs: %w", err)
+	}
+
+	if err = mountConfig.GrpcClientConfig.validate(); err != nil {
+		return mountConfig, fmt.Errorf("error parsing grpc-client-config: %w", err)
 	}
 	return
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -43,6 +43,7 @@ func validateDefaultConfig(mountConfig *MountConfig) {
 	ExpectEq("", mountConfig.CacheDir)
 	ExpectEq(-1, mountConfig.FileCacheConfig.MaxSizeMB)
 	ExpectEq(false, mountConfig.FileCacheConfig.CacheFileForRangeRead)
+	ExpectEq(1, mountConfig.GrpcClientConfig.ConnectionPoolSize)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -207,4 +208,19 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_StatCacheSizeToo
 
 	AssertNe(nil, err)
 	AssertThat(err, oglematchers.Error(oglematchers.HasSubstr(StatCacheMaxSizeMBTooHighError)))
+}
+
+func (t *YamlParserTest) TestReadConfigFile_GrpcClientConfig_invalidConnectionPoolSize() {
+	_, err := ParseConfigFile("testdata/grpc_client_config/invalid_conn_pool_size.yaml")
+
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "error parsing grpc-client-config: the value of connection-pool-size can't be less than 1"))
+}
+
+func (t *YamlParserTest) TestReadConfigFile_GrpcClientConfig_unsetConnectionPoolSize() {
+	mountConfig, err := ParseConfigFile("testdata/grpc_client_config/unset_conn_pool_size.yaml")
+
+	AssertEq(nil, err)
+	AssertNe(nil, mountConfig)
+	AssertEq(DefaultGrpcConnectionPoolSize, mountConfig.GrpcClientConfig.ConnectionPoolSize)
 }


### PR DESCRIPTION
### Description
Adding conn-pool-size as part of grpc client config.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
