### PR TITLE
refactor run_e2e_tests script | add hns tests

### DIFF
--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -253,7 +253,7 @@ function main(){
   run_e2e_tests_for_flat_bucket &
   e2e_tests_flat_bucket_pid=$!
 
-  run_e2e_tests_for_hns_bucket &
+  run_e2e_tests_for_hns_bucket
   e2e_tests_hns_bucket_pid=$!
 
   wait $e2e_tests_flat_bucket_pid

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -15,42 +15,45 @@
 
 # This will stop execution when any command will have non-zero status.
 
-set -e
-
 # true or false to run e2e tests on installedPackage
 RUN_E2E_TESTS_ON_PACKAGE=$1
 readonly INTEGRATION_TEST_TIMEOUT=40m
-readonly PROJECT_ID="gcs-fuse-test-ml"
 readonly BUCKET_LOCATION="us-west1"
-
 # Test directory arrays
 TEST_DIR_PARALLEL=(
-  "local_file"
-  "log_rotation"
-  "mounting"
-  "read_cache"
-  "gzip"
-  "write_large_files"
-)
-
+    "local_file"
+    "log_rotation"
+    "mounting"
+    "read_cache"
+    "gzip"
+    "write_large_files"
+  )
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL_GROUP_1=(
-  "readonly"
-  "managed_folders"
-)
+    "readonly"
+    "managed_folders"
+  )
 
 # These test packages can be configured to run in parallel once they achieve
 # directory independence.
 TEST_DIR_NON_PARALLEL_GROUP_2=(
-  "explicit_dir"
-  "implicit_dir"
-  "list_large_dir"
-  "operations"
-  "read_large_files"
-  "rename_dir_limit"
-)
+    "explicit_dir"
+    "implicit_dir"
+    "list_large_dir"
+    "operations"
+    "read_large_files"
+    "rename_dir_limit"
+  )
+
+TEST_DIR_HNS_GROUP=(
+    "implicit_dir"
+    "operations"
+  )
 
 function upgrade_gcloud_version() {
+  sudo apt-get update
+  # Upgrade gcloud version.
+  # Kokoro machine's outdated gcloud version prevents the use of the "managed-folders" feature.
   gcloud version
   wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
   sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
@@ -62,7 +65,6 @@ function upgrade_gcloud_version() {
   sudo /usr/local/google-cloud-sdk/bin/gcloud components install alpha
 }
 
-# Install packages
 function install_packages() {
   # e.g. architecture=arm64 or amd64
   architecture=$(dpkg --print-architecture)
@@ -77,20 +79,29 @@ function install_packages() {
   sudo apt install -y python3-crcmod
 }
 
-# Create bucket for integration tests.
 function create_bucket() {
   bucket_prefix=$1
+  readonly project_id="gcs-fuse-test-ml"
   # The length of the random string
   length=5
   # Generate the random string
   random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
   bucket_name=$bucket_prefix$random_string
   # We are using gcloud alpha because gcloud storage is giving issues running on Kokoro
-  gcloud alpha storage buckets create gs://$bucket_name --project=$PROJECT_ID --location=$BUCKET_LOCATION --uniform-bucket-level-access
+  gcloud alpha storage buckets create gs://$bucket_name --project=$project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access
   echo $bucket_name
 }
 
-# Non parallel execution of integration tests located within specified test directories.
+function create_hns_bucket() {
+  readonly hns_project_id="gcs-fuse-test"
+  length=5
+  # Generate the random string
+  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
+  bucket_name="gcsfuse-e2e-tests-hns-"$random_string
+  gcloud alpha storage buckets create gs://$bucket_name --project=$hns_project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access --enable-hierarchical-namespace
+  echo "$bucket_name"
+}
+
 function run_non_parallel_tests() {
   local exit_code=0
   local -n test_array=$1
@@ -110,12 +121,11 @@ function run_non_parallel_tests() {
   return $exit_code
 }
 
-# Parallel execution of integration tests located within specified test directories.
-# It aims to improve testing speed by running tests concurrently, while providing basic error reporting.
 function run_parallel_tests() {
   local exit_code=0
   local -n test_array=$1
   local bucket_name_parallel=$2
+  local pids=()
 
   for test_dir_p in "${test_array[@]}"
   do
@@ -138,69 +148,144 @@ function run_parallel_tests() {
   return $exit_code
 }
 
-sudo apt-get update
-# Upgrade gcloud version.
-# Kokoro machine's outdated gcloud version prevents the use of the "managed-folders" feature.
-upgrade_gcloud_version
-install_packages
+function create_flat_buckets() {
+  # Test setup
+  # Create Bucket for non parallel e2e tests
+  # The bucket prefix for the random string
+  bucketPrefix="gcsfuse-non-parallel-e2e-tests-group-1-"
+  BUCKET_NAME_NON_PARALLEL_GROUP_1=$(create_bucket $bucketPrefix)
+  echo "Bucket name for non parallel tests group - 1: "$BUCKET_NAME_NON_PARALLEL_GROUP_1
 
-# Test setup
-# Create Bucket for non parallel e2e tests
-# The bucket prefix for the random string
-bucket_prefix="gcsfuse-non-parallel-e2e-tests-group-1-"
-bucket_name_non_parallel_group_1=$(create_bucket $bucket_prefix)
-echo "Bucket name for non parallel tests group - 1: "$bucket_name_non_parallel_group_1
+  # Test setup
+  # Create Bucket for non parallel e2e tests
+  # The bucket prefix for the random string
+  bucketPrefix="gcsfuse-non-parallel-e2e-tests-group-2-"
+  BUCKET_NAME_NON_PARALLEL_GROUP_2=$(create_bucket $bucketPrefix)
+  echo "Bucket name for non parallel tests group - 2 : "$BUCKET_NAME_NON_PARALLEL_GROUP_2
 
-# Test setup
-# Create Bucket for non parallel e2e tests
-# The bucket prefix for the random string
-bucket_prefix="gcsfuse-non-parallel-e2e-tests-group-2-"
-bucket_name_non_parallel_group_2=$(create_bucket $bucket_prefix)
-echo "Bucket name for non parallel tests group - 2 : "$bucket_name_non_parallel_group_2
+  # Create Bucket for parallel e2e tests
+  # The bucket prefix for the random string
+  bucketPrefix="gcsfuse-parallel-e2e-tests-"
+  BUCKET_NAME_PARALLEL=$(create_bucket $bucketPrefix)
+  echo "Bucket name for parallel tests: "$BUCKET_NAME_PARALLEL
+}
 
-# Create Bucket for parallel e2e tests
-# The bucket prefix for the random string
-bucket_prefix="gcsfuse-parallel-e2e-tests-"
-bucket_name_parallel=$(create_bucket $bucket_prefix)
-echo "Bucket name for parallel tests: "$bucket_name_parallel
+function run_e2e_tests_for_flat_bucket() {
+ # Parallel execution of integration tests located within specified test directories.
+ # It aims to improve testing speed by running tests concurrently, while providing basic error reporting.
+  echo "Running parallel tests..."
+  # Run parallel tests
+  run_parallel_tests TEST_DIR_PARALLEL $BUCKET_NAME_PARALLEL &
+  parallel_tests_pid=$!
 
-# Run tests
-set +e
-echo "Running parallel tests..."
-# Run parallel tests
-run_parallel_tests TEST_DIR_PARALLEL $bucket_name_parallel &
-parallel_tests_pid=$!
+ # Non parallel execution of integration tests located within specified test directories.
+ echo "Running non parallel tests group-1..."
+ run_non_parallel_tests TEST_DIR_NON_PARALLEL_GROUP_1 $BUCKET_NAME_NON_PARALLEL_GROUP_1 &
+ non_parallel_tests_pid_group_1=$!
+ echo "Running non parallel tests group-2..."
+ run_non_parallel_tests TEST_DIR_NON_PARALLEL_GROUP_2 $BUCKET_NAME_NON_PARALLEL_GROUP_2 &
+ non_parallel_tests_pid_group_2=$!
 
-# Run non parallel tests
-echo "Running non parallel tests group-1..."
-run_non_parallel_tests TEST_DIR_NON_PARALLEL_GROUP_1 $bucket_name_non_parallel_group_1 &
-non_parallel_tests_pid_group_1=$!
-echo "Running non parallel tests group-2..."
-run_non_parallel_tests TEST_DIR_NON_PARALLEL_GROUP_2 $bucket_name_non_parallel_group_2 &
-non_parallel_tests_pid_group_2=$!
+ # Wait for all tests to complete.
+ wait $parallel_tests_pid
+ parallel_tests_exit_code=$?
+ wait $non_parallel_tests_pid_group_1
+ non_parallel_tests_exit_code_group_1=$?
+ wait $non_parallel_tests_pid_group_2
+ non_parallel_tests_exit_code_group_2=$?
 
-# Wait for all tests to complete.
-wait $parallel_tests_pid
-parallel_tests_exit_code=$?
-wait $non_parallel_tests_pid_group_1
-non_parallel_tests_exit_code_group_1=$?
-wait $non_parallel_tests_pid_group_2
-non_parallel_tests_exit_code_group_2=$?
-set -e
 
-# Cleanup
-# Delete bucket after testing.
-gcloud alpha storage rm --recursive gs://$bucket_name_parallel/
-gcloud alpha storage rm --recursive gs://$bucket_name_non_parallel_group_1/
-gcloud alpha storage rm --recursive gs://$bucket_name_non_parallel_group_2/
+ if [ $non_parallel_tests_exit_code_group_1 != 0 ] || [ $non_parallel_tests_exit_code_group_2 != 0 ] || [ $parallel_tests_exit_code != 0 ];
+ then
+   exit 1
+ fi
+}
 
-# Removing bin file after testing.
-if [ $RUN_E2E_TESTS_ON_PACKAGE != true ];
-then
-  sudo rm /usr/local/bin/gcsfuse
-fi
-if [ $non_parallel_tests_exit_code_group_1 != 0 ] || [ $non_parallel_tests_exit_code_group_2 != 0 ] || [ $parallel_tests_exit_code != 0 ];
-then
-  echo "The tests failed."
-  exit 1
-fi
+function run_e2e_tests_for_hns_bucket(){
+   echo "Running tests for HNS bucket"
+   run_non_parallel_tests TEST_DIR_HNS_GROUP "$HNS_BUCKET_NAME"
+   non_parallel_tests_pid_hns_group=$!
+
+   wait $non_parallel_tests_pid_hns_group
+   non_parallel_tests_hns_group_exit_code=$?
+
+   if [ $non_parallel_tests_hns_group_exit_code != 0 ];
+   then
+     exit 1
+   fi
+}
+
+#commenting it so cleanup and failure check happens for both
+#set -e
+
+function clean_up() {
+  # Cleanup
+  # Delete bucket after testing.
+  local -n buckets=$1
+  for bucket in "${buckets[@]}"
+    do
+      gcloud alpha storage rm --recursive gs://$bucket
+    done
+}
+
+function clean_up_buckets(){
+  flat_buckets=("$BUCKET_NAME_PARALLEL" "$BUCKET_NAME_NON_PARALLEL_GROUP_1" "$BUCKET_NAME_NON_PARALLEL_GROUP_2")
+  hns_buckets=("$HNS_BUCKET_NAME")
+
+  clean_up flat_buckets
+  clean_up hns_buckets
+}
+
+function main(){
+  set -e
+
+  upgrade_gcloud_version
+
+  install_packages
+
+  create_flat_buckets
+  HNS_BUCKET_NAME=$(create_hns_bucket)
+  echo "Hns Bucket Created: "$HNS_BUCKET_NAME
+
+  set +e
+
+  #run integration tests
+  run_e2e_tests_for_flat_bucket &
+  e2e_tests_flat_bucket_pid=$!
+
+  run_e2e_tests_for_hns_bucket &
+  e2e_tests_hns_bucket_pid=$!
+
+  wait $e2e_tests_flat_bucket_pid
+  e2e_tests_flat_bucket_status=$?
+
+  wait $e2e_tests_hns_bucket_pid
+  e2e_tests_hns_bucket_status=$?
+
+    # Cleanup
+    # Delete bucket after testing.
+  clean_up_buckets
+
+  set -e
+
+  if [ $e2e_tests_flat_bucket_status != 0 ];
+  then
+    echo "The e2e tests for flat bucket failed.."
+    exit 1
+  fi
+
+  if [ $e2e_tests_hns_bucket_status != 0 ];
+  then
+    echo "The e2e tests for hns bucket failed.."
+    exit 1
+  fi
+
+  # Removing bin file after testing.
+  if [ $RUN_E2E_TESTS_ON_PACKAGE != true ];
+  then
+    sudo rm /usr/local/bin/gcsfuse
+  fi
+}
+
+#Main method to run script
+main

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -19,7 +19,7 @@
 RUN_E2E_TESTS_ON_PACKAGE=$1
 readonly INTEGRATION_TEST_TIMEOUT=40m
 readonly BUCKET_LOCATION="us-west1"
-RANDOM_STRING_LENGTH=5
+readonly RANDOM_STRING_LENGTH=5
 # Test directory arrays
 TEST_DIR_PARALLEL=(
   "local_file"
@@ -82,7 +82,7 @@ function install_packages() {
 
 function create_bucket() {
   bucket_prefix=$1
-  readonly project_id="gcs-fuse-test-ml"
+  local -r project_id="gcs-fuse-test-ml"
   # Generate bucket name with random string
   bucket_name=$bucket_prefix$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   # We are using gcloud alpha because gcloud storage is giving issues running on Kokoro
@@ -91,7 +91,7 @@ function create_bucket() {
 }
 
 function create_hns_bucket() {
-  readonly hns_project_id="gcs-fuse-test"
+  local -r hns_project_id="gcs-fuse-test"
   # Generate bucket name with random string
   bucket_name="gcsfuse-e2e-tests-hns-"$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   gcloud alpha storage buckets create gs://$bucket_name --project=$hns_project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access --enable-hierarchical-namespace

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -201,7 +201,6 @@ function run_e2e_tests_for_hns_bucket(){
    non_parallel_tests_hns_group_exit_code=$?
 
    hns_buckets=("$hns_bucket_name")
-
    clean_up hns_buckets
 
    if [ $non_parallel_tests_hns_group_exit_code != 0 ];

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -250,9 +250,9 @@ function main(){
   set +e
 
   #run integration tests
-  run_e2e_tests_for_hns_bucket
+  run_e2e_tests_for_hns_bucket &
   e2e_tests_hns_bucket_pid=$!
-  
+
   run_e2e_tests_for_flat_bucket &
   e2e_tests_flat_bucket_pid=$!
 

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -250,11 +250,11 @@ function main(){
   set +e
 
   #run integration tests
-  run_e2e_tests_for_flat_bucket &
-  e2e_tests_flat_bucket_pid=$!
-
   run_e2e_tests_for_hns_bucket
   e2e_tests_hns_bucket_pid=$!
+  
+  run_e2e_tests_for_flat_bucket &
+  e2e_tests_flat_bucket_pid=$!
 
   wait $e2e_tests_flat_bucket_pid
   e2e_tests_flat_bucket_status=$?

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -19,6 +19,7 @@
 RUN_E2E_TESTS_ON_PACKAGE=$1
 readonly INTEGRATION_TEST_TIMEOUT=40m
 readonly BUCKET_LOCATION="us-west1"
+RANDOM_STRING_LENGTH=5
 # Test directory arrays
 TEST_DIR_PARALLEL=(
     "local_file"
@@ -82,11 +83,8 @@ function install_packages() {
 function create_bucket() {
   bucket_prefix=$1
   readonly project_id="gcs-fuse-test-ml"
-  # The length of the random string
-  length=5
-  # Generate the random string
-  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
-  bucket_name=$bucket_prefix$random_string
+  # Generate bucket name with random string
+  bucket_name=$bucket_prefix$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   # We are using gcloud alpha because gcloud storage is giving issues running on Kokoro
   gcloud alpha storage buckets create gs://$bucket_name --project=$project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access
   echo $bucket_name
@@ -94,10 +92,8 @@ function create_bucket() {
 
 function create_hns_bucket() {
   readonly hns_project_id="gcs-fuse-test"
-  length=5
-  # Generate the random string
-  random_string=$(tr -dc 'a-z0-9' < /dev/urandom | head -c $length)
-  bucket_name="gcsfuse-e2e-tests-hns-"$random_string
+  # Generate bucket name with random string
+  bucket_name="gcsfuse-e2e-tests-hns-"$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   gcloud alpha storage buckets create gs://$bucket_name --project=$hns_project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access --enable-hierarchical-namespace
   echo "$bucket_name"
 }

--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -22,34 +22,34 @@ readonly BUCKET_LOCATION="us-west1"
 RANDOM_STRING_LENGTH=5
 # Test directory arrays
 TEST_DIR_PARALLEL=(
-    "local_file"
-    "log_rotation"
-    "mounting"
-    "read_cache"
-    "gzip"
-    "write_large_files"
-  )
+  "local_file"
+  "log_rotation"
+  "mounting"
+  "read_cache"
+  "gzip"
+  "write_large_files"
+)
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL_GROUP_1=(
-    "readonly"
-    "managed_folders"
-  )
+  "readonly"
+  "managed_folders"
+)
 
 # These test packages can be configured to run in parallel once they achieve
 # directory independence.
 TEST_DIR_NON_PARALLEL_GROUP_2=(
-    "explicit_dir"
-    "implicit_dir"
-    "list_large_dir"
-    "operations"
-    "read_large_files"
-    "rename_dir_limit"
-  )
+  "explicit_dir"
+  "implicit_dir"
+  "list_large_dir"
+  "operations"
+  "read_large_files"
+  "rename_dir_limit"
+)
 
 TEST_DIR_HNS_GROUP=(
-    "implicit_dir"
-    "operations"
-  )
+  "implicit_dir"
+  "operations"
+)
 
 function upgrade_gcloud_version() {
   sudo apt-get update

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # Here $1 refers to the testBucket argument
-echo "This is from directory fileInImplicitDir1 file implicitDirectory" >> fileInImplicitDir1
+echo "This is from directory fileInImplicitDir1 file implicitDirectory" > fileInImplicitDir1
 # bucket/implicitDirectory/fileInImplicitDir1
-gsutil mv fileInImplicitDir1 gs://$1/implicitDirectory/
-echo "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2" >> fileInImplicitDir2
+gsutil cp fileInImplicitDir1 gs://$1/implicitDirectory/
+echo "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2" > fileInImplicitDir2
 # bucket/implicitDirectory/implicitSubDirectory/fileInImplicitDir2
-gsutil mv fileInImplicitDir2 gs://$1/implicitDirectory/implicitSubDirectory/
+gsutil cp fileInImplicitDir2 gs://$1/implicitDirectory/implicitSubDirectory/


### PR DESCRIPTION
Description
create a main method for all execution steps to be orchestrated at one place

extracted bucket creation and cleanup to a method | add hns bucket creation and clean up

run operations and implicit package tests for hns bucket

adds create_hns_buckets to create bucket for hns

seggregated check for hns test failures

reafctor variable names to lower case to make it consistent and more readable ([ref](https://stackoverflow.com/questions/673055/correct-bash-and-shell-script-variable-capitalization#:~:text=If%20it%27s%20your%20variable%2C%20lowercase%20it.%20If%20you%20export%20it%2C%20uppercase%20it.))

fix echo statement for hns bucket name

refactoring move actual test calls into functions for flat and hns bu…

adds bucket for hns in allow list project

Link to the issue in case of a bug fix.
b/328727379

Testing details
Manual - Done
Unit tests - NA
Integration tests - Done