### PR TITLE
Increase the wait time to 15 minutes for VM setup in ML tests.

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -156,8 +156,8 @@ then
   sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "mkdir github; cd github; git clone https://github.com/GoogleCloudPlatform/gcsfuse.git; cd gcsfuse; git checkout master;"
   echo "Trigger the build script on test VM"
   sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "bash \$HOME/$TEST_SCRIPT_PATH 1> \$HOME/build.out 2> \$HOME/build.err &"
-  echo "Wait for 10 minutes for test VM to setup for test and to change the status from START to RUNNING."
-  sleep 600s
+  echo "Wait for 15 minutes for test VM to setup for test and to change the status from START to RUNNING."
+  sleep 900s
 
   # If the model is still not running after waiting, then the build should fail.
   if [ $(get_run_status) != "RUNNING" ];


### PR DESCRIPTION
### Description
Increase the wait time to 15 minutes for VM to setup as the pytorch v2 takes more than 10 minutes and fails every 7 days when the model starts.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
