### PR TITLE
PR3: GRPC - Add support of `grpc` value as client-protocol flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -251,7 +251,7 @@ func newApp() (app *cli.App) {
 				Name:  "client-protocol",
 				Value: string(mountpkg.HTTP1),
 				Usage: "The protocol used for communicating with the GCS backend. " +
-					"Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2).",
+					"Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2) or grpc.",
 			},
 
 			cli.IntFlag{
@@ -400,8 +400,8 @@ type flagStorage struct {
 	OtelCollectorAddress       string
 	LogFile                    string
 	LogFormat                  string
-	ExperimentalEnableJsonRead  bool
-	DebugFuseErrors             bool
+	ExperimentalEnableJsonRead bool
+	DebugFuseErrors            bool
 
 	// Debugging
 	DebugFuse       bool

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -55,7 +55,7 @@ const (
 
 func (cp ClientProtocol) IsValid() bool {
 	switch cp {
-	case HTTP1, HTTP2:
+	case HTTP1, HTTP2, GRPC:
 		return true
 	}
 	return false

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func getConfigForUserAgent(mountConfig *config.MountConfig) string {
 	}
 	return fmt.Sprintf("%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled)
 }
-func createStorageHandle(flags *flagStorage, userAgent string) (storageHandle storage.StorageHandle, err error) {
+func createStorageHandle(flags *flagStorage, mountConfig *config.MountConfig, userAgent string) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{
 		ClientProtocol:             flags.ClientProtocol,
 		MaxConnsPerHost:            flags.MaxConnsPerHost,
@@ -113,6 +113,7 @@ func createStorageHandle(flags *flagStorage, userAgent string) (storageHandle st
 		TokenUrl:                   flags.TokenUrl,
 		ReuseTokenFromUrl:          flags.ReuseTokenFromUrl,
 		ExperimentalEnableJsonRead: flags.ExperimentalEnableJsonRead,
+		GrpcConnPoolSize:           mountConfig.GrpcClientConfig.ConnPoolSize,
 	}
 	logger.Infof("UserAgent = %s\n", storageClientConfig.UserAgent)
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)
@@ -145,7 +146,7 @@ func mountWithArgs(
 	if bucketName != canned.FakeBucketName {
 		userAgent := getUserAgent(flags.AppName, getConfigForUserAgent(mountConfig))
 		logger.Info("Creating Storage handle...")
-		storageHandle, err = createStorageHandle(flags, userAgent)
+		storageHandle, err = createStorageHandle(flags, mountConfig, userAgent)
 		if err != nil {
 			err = fmt.Errorf("Failed to create storage handle using createStorageHandle: %w", err)
 			return

--- a/main_test.go
+++ b/main_test.go
@@ -35,9 +35,32 @@ func (t *MainTest) TestCreateStorageHandle() {
 		AppName:             "app",
 		KeyFile:             "testdata/test_creds.json",
 	}
+	mountConfig := &config.MountConfig{}
 
 	userAgent := "AppName"
-	storageHandle, err := createStorageHandle(flags, userAgent)
+	storageHandle, err := createStorageHandle(flags, mountConfig, userAgent)
+
+	AssertEq(nil, err)
+	AssertNe(nil, storageHandle)
+}
+
+func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
+	flags := &flagStorage{
+		ClientProtocol:      mountpkg.GRPC,
+		MaxConnsPerHost:     5,
+		MaxIdleConnsPerHost: 100,
+		HttpClientTimeout:   5,
+		MaxRetrySleep:       7,
+		RetryMultiplier:     2,
+		AppName:             "app",
+		KeyFile:             "testdata/test_creds.json",
+	}
+	mountConfig := &config.MountConfig{
+		GrpcClientConfig: config.GrpcClientConfig{ConnPoolSize: 1},
+	}
+
+	userAgent := "AppName"
+	storageHandle, err := createStorageHandle(flags, mountConfig, userAgent)
 
 	AssertEq(nil, err)
 	AssertNe(nil, storageHandle)


### PR DESCRIPTION
### Description
Adding one more candidate value `grpc` as part of client-protocol flag. This will enable gcsfuse to communicate with cloud-storage using grpc client.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Checked grpc integration is working fine.
2. Unit tests - Automation
3. Integration tests - Automation
