### PR TITLE
Printing logs at the end

### DIFF
--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -166,8 +166,6 @@ function print_test_logs() {
       echo "=== Log for ${test_log_file} ==="
       cat "$log_file"
       echo "========================================="
-      # Remove the log file
-      rm "$log_file"
     fi
   done
 }


### PR DESCRIPTION
### Description
Our test logs are currently unorganized, with output from different packages intermixed. This makes it extremely difficult to troubleshoot failures because we can't easily isolate logs from specific tests.

Create a temporary file to store log file names from a background process. Create an array from it and print logs from the given log files, then delete them.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
