### PR TITLE
Enabling gRPC related integration test

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -17,6 +17,8 @@
 readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
 readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
+readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
+
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
@@ -104,5 +106,5 @@ then
 
   echo "Running e2e tests...."
   # $1 argument is refering to value of testInstalledPackage.
-  ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE
+  ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -53,7 +53,7 @@ function execute_perf_test() {
   # The VM will itself exit if the gcsfuse mount fails.
   go run . $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
   # Running FIO test
-  ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
+  time ./perfmetrics/scripts/presubmit/run_load_test_on_presubmit.sh
   sudo umount gcs
 }
 

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -28,7 +28,9 @@ const DirForExplicitDirTests = "dirForExplicitDirTests"
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs=false"}}
+	flags := [][]string{
+		{"--implicit-dirs=false"},
+		{"--client-protocol=grpc", "--implicit-dirs=false"}}
 
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
 

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -28,9 +28,11 @@ const DirForExplicitDirTests = "dirForExplicitDirTests"
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{
-		{"--implicit-dirs=false"},
-		{"--client-protocol=grpc", "--implicit-dirs=false"}}
+	flags := [][]string{{"--implicit-dirs=false"}}
+
+	if !testing.Short() {
+		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=false"})
+	}
 
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
 

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -176,7 +176,8 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	commonFlags := []string{"--sequential-read-size-mb=" + fmt.Sprint(SeqReadSizeMb), "--implicit-dirs"}
-	flags := [][]string{commonFlags}
+	gRPCFlags := append(commonFlags, "--client-protocol=grpc")
+	flags := [][]string{commonFlags, gRPCFlags}
 
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -176,8 +176,12 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	commonFlags := []string{"--sequential-read-size-mb=" + fmt.Sprint(SeqReadSizeMb), "--implicit-dirs"}
-	gRPCFlags := append(commonFlags, "--client-protocol=grpc")
-	flags := [][]string{commonFlags, gRPCFlags}
+	flags := [][]string{commonFlags}
+
+	if !testing.Short() {
+		gRPCFlags := append(commonFlags, "--client-protocol=grpc")
+		flags = append(flags, gRPCFlags)
+	}
 
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -50,7 +50,9 @@ func TestMain(m *testing.M) {
 		log.Fatalf("client.CreateStorageClient: %v", err)
 	}
 
-	flags := [][]string{{"--implicit-dirs"}}
+	flags := [][]string{
+		{"--implicit-dirs"},
+		{"--client-protocol=grpc", "--implicit-dirs=true"}}
 
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
 

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -36,7 +36,10 @@ const NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs"}, {"--client-protocol=grpc", "--implicit-dirs=true"}}
+	flags := [][]string{{"--implicit-dirs"}}
+	if !testing.Short() {
+		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true"})
+	}
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
 		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -36,7 +36,7 @@ const NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs"}}
+	flags := [][]string{{"--implicit-dirs"}, {"--client-protocol=grpc", "--implicit-dirs=true"}}
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
 		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")

--- a/tools/integration_tests/local_file/local_file_test.go
+++ b/tools/integration_tests/local_file/local_file_test.go
@@ -100,7 +100,8 @@ func TestMain(m *testing.M) {
 	// Not setting config file explicitly with 'create-empty-file: false' as it is default.
 	flags := [][]string{
 		{"--implicit-dirs=true", "--rename-dir-limit=3"},
-		{"--implicit-dirs=false", "--rename-dir-limit=3"}}
+		{"--implicit-dirs=false", "--rename-dir-limit=3"},
+		{"--implicit-dirs=false", "--rename-dir-limit=3", "--client-protocol=grpc"}}
 
 	successCode := static_mounting.RunTests(flags, m)
 

--- a/tools/integration_tests/local_file/local_file_test.go
+++ b/tools/integration_tests/local_file/local_file_test.go
@@ -98,23 +98,22 @@ func TestMain(m *testing.M) {
 
 	// Set up flags to run tests on.
 	// Not setting config file explicitly with 'create-empty-file: false' as it is default.
-	flags := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true", "--rename-dir-limit=3"},
 		{"--implicit-dirs=false", "--rename-dir-limit=3"}}
 
 	if !testing.Short() {
-		flags = append(flags, []string{"--implicit-dirs=false", "--rename-dir-limit=3", "--client-protocol=grpc"})
-		flags = append(flags, []string{"--implicit-dirs=true", "--rename-dir-limit=3", "--client-protocol=grpc"})
+		setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--client-protocol=grpc")
 	}
 
-	successCode := static_mounting.RunTests(flags, m)
+	successCode := static_mounting.RunTests(flagsSet, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, m)
+		successCode = only_dir_mounting.RunTests(flagsSet, m)
 	}
 
 	if successCode == 0 {
-		successCode = dynamic_mounting.RunTests(flags, m)
+		successCode = dynamic_mounting.RunTests(flagsSet, m)
 	}
 
 	// Close storage client and release resources.

--- a/tools/integration_tests/local_file/local_file_test.go
+++ b/tools/integration_tests/local_file/local_file_test.go
@@ -100,8 +100,12 @@ func TestMain(m *testing.M) {
 	// Not setting config file explicitly with 'create-empty-file: false' as it is default.
 	flags := [][]string{
 		{"--implicit-dirs=true", "--rename-dir-limit=3"},
-		{"--implicit-dirs=false", "--rename-dir-limit=3"},
-		{"--implicit-dirs=false", "--rename-dir-limit=3", "--client-protocol=grpc"}}
+		{"--implicit-dirs=false", "--rename-dir-limit=3"}}
+
+	if !testing.Short() {
+		flags = append(flags, []string{"--implicit-dirs=false", "--rename-dir-limit=3", "--client-protocol=grpc"})
+		flags = append(flags, []string{"--implicit-dirs=true", "--rename-dir-limit=3", "--client-protocol=grpc"})
+	}
 
 	successCode := static_mounting.RunTests(flags, m)
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -135,7 +135,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 	// Set up flags to run tests on.
 	// Note: GRPC related tests will work only if you have allow-list bucket.
-	flags := [][]string{
+	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
@@ -143,29 +143,29 @@ func TestMain(m *testing.M) {
 		{"--client-protocol=grpc", "--implicit-dirs=true"}}
 
 	if !testing.Short() {
-		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=false"})
+		flagsSet = append(flagsSet, []string{"--client-protocol=grpc", "--implicit-dirs=false"})
 	}
 
 	mountConfigFlags := createMountConfigsAndEquivalentFlags()
-	flags = append(flags, mountConfigFlags...)
+	flagsSet = append(flagsSet, mountConfigFlags...)
 
-	successCode := static_mounting.RunTests(flags, m)
+	successCode := static_mounting.RunTests(flagsSet, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, m)
+		successCode = only_dir_mounting.RunTests(flagsSet, m)
 	}
 
 	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flags, m)
+		successCode = persistent_mounting.RunTests(flagsSet, m)
 	}
 
 	if successCode == 0 {
-		successCode = dynamic_mounting.RunTests(flags, m)
+		successCode = dynamic_mounting.RunTests(flagsSet, m)
 	}
 
 	if successCode == 0 {
 		// Test for admin permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectAdmin", m)
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flagsSet, "objectAdmin", m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -140,7 +140,12 @@ func TestMain(m *testing.M) {
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
-		{"--client-protocol=grpc", "--implicit-dirs=false"}}
+		{"--client-protocol=grpc", "--implicit-dirs=true"}}
+
+	if !testing.Short() {
+		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=false"})
+	}
+
 	mountConfigFlags := createMountConfigsAndEquivalentFlags()
 	flags = append(flags, mountConfigFlags...)
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -134,11 +134,13 @@ func TestMain(m *testing.M) {
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()
 	// Set up flags to run tests on.
+	// Note: GRPC related tests will work only if you have allow-list bucket.
 	flags := [][]string{
 		// By default, creating emptyFile is disabled.
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
-		{"--experimental-enable-json-read=true", "--implicit-dirs=true"}}
+		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
+		{"--client-protocol=grpc", "--implicit-dirs=false"}}
 	mountConfigFlags := createMountConfigsAndEquivalentFlags()
 	flags = append(flags, mountConfigFlags...)
 

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -136,16 +136,16 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet,
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
 		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -94,16 +94,16 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet,
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
 		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -95,16 +95,16 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
-	appendFlags(&flagSet, "--stat-cache-ttl=0s")
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--stat-cache-ttl=0s")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -99,14 +99,14 @@ func TestLocalModificationTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -116,10 +116,10 @@ func TestRangeReadTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet,
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet,
 		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, false, configFileName+"1"),
 		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, true, configFileName+"2"))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet, "--o=ro", "")
 
 	// Run tests.
 	for _, flags := range flagSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -164,17 +164,17 @@ func TestReadOnlyTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet,
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
 		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1"),
 		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2"))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -131,12 +131,12 @@ func TestRemountTest(t *testing.T) {
 		t.SkipNow()
 	}
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}
@@ -149,7 +149,7 @@ func TestRemountTest(t *testing.T) {
 	}()
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -116,20 +115,6 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 	}
 	filePath := setup.YAMLConfigFile(mountConfig, fileName)
 	return filePath
-}
-
-func appendFlags(flagSet *[][]string, newFlags ...string) {
-	var resultFlagSet [][]string
-	for _, flag := range *flagSet {
-		for _, newFlag := range newFlags {
-			f := flag
-			if strings.Compare(newFlag, "") != 0 {
-				f = append(flag, newFlag)
-			}
-			resultFlagSet = append(resultFlagSet, f)
-		}
-	}
-	*flagSet = resultFlagSet
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -120,16 +120,16 @@ func TestSmallCacheTTLTest(t *testing.T) {
 	}
 
 	// Define flag set to run the tests.
-	flagSet := [][]string{
+	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 		{"--implicit-dirs=false"},
 	}
-	appendFlags(&flagSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
-	appendFlags(&flagSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
-	appendFlags(&flagSet, "--o=ro", "")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
-	for _, flags := range flagSet {
+	for _, flags := range flagsSet {
 		ts.flags = flags
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -78,6 +78,10 @@ func TestMain(m *testing.M) {
 
 	flags := [][]string{{"--o=ro", "--implicit-dirs=true"}, {"--file-mode=544", "--dir-mode=544", "--implicit-dirs=true"}}
 
+	if !testing.Short() {
+		flags = append(flags, []string{"--client-protocol=grpc", "--o=ro", "--implicit-dirs=true"})
+	}
+
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -20,13 +20,7 @@ RUN_E2E_TESTS_ON_PACKAGE=$1
 
 # By default, this shell script runs all the integration tests, but few tests
 # can be skipped by passing the 2nd argument as `true`.
-if [ $# -gt 1 ]; then
-  RUN_ONLY_IMPORTANT_TESTS=$2
-else
-  RUN_ONLY_IMPORTANT_TESTS=false
-fi
-
-if [ "$RUN_ONLY_IMPORTANT_TESTS" == true ]; then
+if [ "$2" == true ]; then
   GO_TEST_SHORT_FLAG="-short"
   echo "Setting the flag to skip few un-important integration tests..."
 fi

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -17,7 +17,7 @@
 
 # true or false to run e2e tests on installedPackage
 RUN_E2E_TESTS_ON_PACKAGE=$1
-readonly INTEGRATION_TEST_TIMEOUT=80m
+readonly INTEGRATION_TEST_TIMEOUT=60m
 readonly BUCKET_LOCATION="us-west1"
 readonly RANDOM_STRING_LENGTH=5
 # Test directory arrays
@@ -117,7 +117,7 @@ function run_non_parallel_tests() {
     local log_file="/tmp/${test_dir_np}_${bucket_name_non_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 -short --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -141,7 +141,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel -short -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -17,7 +17,7 @@
 
 # true or false to run e2e tests on installedPackage
 RUN_E2E_TESTS_ON_PACKAGE=$1
-readonly INTEGRATION_TEST_TIMEOUT=40m
+readonly INTEGRATION_TEST_TIMEOUT=80m
 readonly BUCKET_LOCATION="us-west1"
 readonly RANDOM_STRING_LENGTH=5
 # Test directory arrays
@@ -171,15 +171,17 @@ function print_test_logs() {
 }
 
 function run_e2e_tests_for_flat_bucket() {
-  bucketPrefix="gcsfuse-non-parallel-e2e-tests-group-1-"
+  # Adding prefix `golang-grpc-test` to white list the bucket for grpc so that
+  # we can run grpc related e2e tests.
+  bucketPrefix="golang-grpc-test-gcsfuse-non-parallel-e2e-tests-group-1-"
   bucket_name_non_parallel_group_1=$(create_bucket $bucketPrefix)
   echo "Bucket name for non parallel tests group - 1: "$bucket_name_non_parallel_group_1
 
-  bucketPrefix="gcsfuse-non-parallel-e2e-tests-group-2-"
+  bucketPrefix="golang-grpc-test-gcsfuse-non-parallel-e2e-tests-group-2-"
   bucket_name_non_parallel_group_2=$(create_bucket $bucketPrefix)
   echo "Bucket name for non parallel tests group - 2 : "$bucket_name_non_parallel_group_2
 
-  bucketPrefix="gcsfuse-parallel-e2e-tests-"
+  bucketPrefix="golang-grpc-test-gcsfuse-parallel-e2e-tests-"
   bucket_name_parallel=$(create_bucket $bucketPrefix)
   echo "Bucket name for parallel tests: "$bucket_name_parallel
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -17,6 +17,20 @@
 
 # true or false to run e2e tests on installedPackage
 RUN_E2E_TESTS_ON_PACKAGE=$1
+
+# By default, this shell script runs all the integration tests, but few tests
+# can be skipped by passing the 2nd argument as `true`.
+if [ $# -gt 1 ]; then
+  RUN_ONLY_IMPORTANT_TESTS=$2
+else
+  RUN_ONLY_IMPORTANT_TESTS=false
+fi
+
+if [ "$RUN_ONLY_IMPORTANT_TESTS" == true ]; then
+  GO_TEST_SHORT_FLAG="-short"
+  echo "Setting the flag to skip few un-important integration tests..."
+fi
+
 readonly INTEGRATION_TEST_TIMEOUT=60m
 readonly BUCKET_LOCATION="us-west1"
 readonly RANDOM_STRING_LENGTH=5
@@ -116,8 +130,9 @@ function run_non_parallel_tests() {
     # convention to include the bucket name as a suffix (e.g., package_name_bucket_name).
     local log_file="/tmp/${test_dir_np}_${bucket_name_non_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
+
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 -short --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -141,7 +156,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel -short -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -128,7 +128,7 @@ function run_non_parallel_tests() {
     echo $log_file >> $TEST_LOGS_FILE
 
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -152,7 +152,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -96,8 +96,10 @@ function create_bucket() {
 
 function create_hns_bucket() {
   local -r hns_project_id="gcs-fuse-test"
-  # Generate bucket name with random string
-  bucket_name="gcsfuse-e2e-tests-hns-"$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
+  # Generate bucket name with random string.
+  # Adding prefix `golang-grpc-test` to white list the bucket for grpc
+  # so that we can run grpc related e2e tests.
+  bucket_name="golang-grpc-test-gcsfuse-e2e-tests-hns-"$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   gcloud alpha storage buckets create gs://$bucket_name --project=$hns_project_id --location=$BUCKET_LOCATION --uniform-bucket-level-access --enable-hierarchical-namespace
   echo "$bucket_name"
 }

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -18,9 +18,11 @@
 # true or false to run e2e tests on installedPackage
 RUN_E2E_TESTS_ON_PACKAGE=$1
 
-# By default, this shell script runs all the integration tests, but few tests
-# can be skipped by passing the 2nd argument as `true`.
-if [ "$2" == true ]; then
+# Pass "true" to skip few non-essential tests.
+# By default, this script runs all the integration tests.
+SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=$2
+
+if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   GO_TEST_SHORT_FLAG="-short"
   echo "Setting the flag to skip few un-important integration tests..."
 fi

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -22,12 +22,15 @@ RUN_E2E_TESTS_ON_PACKAGE=$1
 # By default, this script runs all the integration tests.
 SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=$2
 
+INTEGRATION_TEST_TIMEOUT=60m
+
 if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   GO_TEST_SHORT_FLAG="-short"
-  echo "Setting the flag to skip few un-important integration tests..."
+  echo "Setting the flag to skip few un-important integration tests."
+  INTEGRATION_TEST_TIMEOUT=40m
+  echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
 fi
 
-readonly INTEGRATION_TEST_TIMEOUT=60m
 readonly BUCKET_LOCATION="us-west1"
 readonly RANDOM_STRING_LENGTH=5
 # Test directory arrays

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -450,3 +450,39 @@ sudo umount $MOUNT_DIR
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs -o config_file=/tmp/gcsfuse_config.yaml
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/managed_folders/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME -run TestEnableEmptyManagedFoldersTrue
 sudo umount $MOUNT_DIR
+
+# For GRPC: running only core integration tests.
+
+# Test packages: operations
+# Run test with static mounting. (flags: --client-protocol=grpc --implicit-dirs=true)
+gcsfuse --client-protocol=grpc --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Run test with persistent mounting. (flags: --client-protocol=grpc --implicit-dirs=true)
+mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=true,client_protocol=grpc
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Test package: implicit_dir
+# Run tests with static mounting.  (flags: --client-protocol=grpc --implicit-dirs=true)
+gcsfuse --implicit-dirs=true --client-protocol=grpc $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Run test with persistent mounting.  (flags: --client-protocol=grpc --implicit-dirs=true)
+mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=true,client_protocol=grpc
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# package list_large_dir
+# Run tests with static mounting. (flags: --client-protocol=grpc --implicit-dirs)
+gcsfuse --client-protocol=grpc --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/list_large_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Run test with persistent mounting.  (flags: --client-protocol=grpc --implicit-dirs=true)
+mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=true,client_protocol=grpc
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/list_large_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -474,15 +474,3 @@ sudo umount $MOUNT_DIR
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=true,client_protocol=grpc
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/implicit_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
-
-# package list_large_dir
-# Run tests with static mounting. (flags: --client-protocol=grpc --implicit-dirs)
-gcsfuse --client-protocol=grpc --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/list_large_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
-sudo umount $MOUNT_DIR
-
-# Run test with persistent mounting.  (flags: --client-protocol=grpc --implicit-dirs=true)
-mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=true,client_protocol=grpc
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/list_large_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
-sudo umount $MOUNT_DIR
-

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -26,7 +26,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-const PrefixBucketForDynamicMountingTest = "gcsfuse-dynamic-mounting-test-"
+// Adding prefix `golang-grpc-test` to white list the bucket for grpc so that
+// we can run the grpc related e2e test.
+const PrefixBucketForDynamicMountingTest = "golang-grpc-test-gcsfuse-dynamic-mounting-test-"
 
 var testBucketForDynamicMounting = PrefixBucketForDynamicMountingTest + setup.GenerateRandomString(5)
 

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -69,22 +69,22 @@ func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
 	return err
 }
 
-func executeTestsForPersistentMounting(flags [][]string, m *testing.M) (successCode int) {
+func executeTestsForPersistentMounting(flagsSet [][]string, m *testing.M) (successCode int) {
 	var err error
 
-	for i := 0; i < len(flags); i++ {
-		if err = mountGcsfuseWithPersistentMounting(flags[i]); err != nil {
+	for i := 0; i < len(flagsSet); i++ {
+		if err = mountGcsfuseWithPersistentMounting(flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
-		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
+		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
 	}
 	return
 }
 
-func RunTests(flags [][]string, m *testing.M) (successCode int) {
+func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running persistent mounting tests...")
 
-	successCode = executeTestsForPersistentMounting(flags, m)
+	successCode = executeTestsForPersistentMounting(flagsSet, m)
 
 	log.Printf("Test log: %s\n", setup.LogFile())
 

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -41,22 +41,22 @@ func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	return err
 }
 
-func executeTestsForStaticMounting(flags [][]string, m *testing.M) (successCode int) {
+func executeTestsForStaticMounting(flagsSet [][]string, m *testing.M) (successCode int) {
 	var err error
 
-	for i := 0; i < len(flags); i++ {
-		if err = MountGcsfuseWithStaticMounting(flags[i]); err != nil {
+	for i := 0; i < len(flagsSet); i++ {
+		if err = MountGcsfuseWithStaticMounting(flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
-		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
+		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
 	}
 	return
 }
 
-func RunTests(flags [][]string, m *testing.M) (successCode int) {
+func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running static mounting tests...")
 
-	successCode = executeTestsForStaticMounting(flags, m)
+	successCode = executeTestsForStaticMounting(flagsSet, m)
 
 	log.Printf("Test log: %s\n", setup.LogFile())
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -461,10 +461,11 @@ func RunTestsOnlyForStaticMount(mountDir string, t *testing.T) {
 	}
 }
 
-// AppendFlagsToAllFlagsInTheFlagsSet appends the newFlags in all the command in the
+// AppendFlagsToAllFlagsInTheFlagsSet appends the newFlags in every flags present in the
 // flagsSet.
-// Here, flags represent to one mounting command.
-// flagsSet represent to set of mounting commands.
+// Input flagsSet: [][]string{{"--x", "--y"}, {"--x", "--z"}}
+// Input newFlags: "--a", "--b"
+// Output modified flagsSet: [][]string{{"--x", "--y", "--a", "--b"}, {"--x", "--z", "--a", "--b"}}
 func AppendFlagsToAllFlagsInTheFlagsSet(flagsSet *[][]string, newFlags ...string) {
 	var resultFlagsSet [][]string
 	for _, flags := range *flagsSet {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -461,11 +461,11 @@ func RunTestsOnlyForStaticMount(mountDir string, t *testing.T) {
 	}
 }
 
-// AppendFlagsToAllFlagsInTheFlagsSet appends the newFlags in every flags present in the
+// AppendFlagsToAllFlagsInTheFlagsSet appends each flag in newFlags to every flags present in the
 // flagsSet.
 // Input flagsSet: [][]string{{"--x", "--y"}, {"--x", "--z"}}
-// Input newFlags: "--a", "--b"
-// Output modified flagsSet: [][]string{{"--x", "--y", "--a", "--b"}, {"--x", "--z", "--a", "--b"}}
+// Input newFlags: {"--a", "--b", ""}
+// Output modified flagsSet: [][]string{{"--x", "--y", "--a"}, {"--x", "--z", "--a"},{"--x", "--y", "--b"},{"--x", "--z", "--b"},{"--x", "--y"}, {"--x", "--z"}}
 func AppendFlagsToAllFlagsInTheFlagsSet(flagsSet *[][]string, newFlags ...string) {
 	var resultFlagsSet [][]string
 	for _, flags := range *flagsSet {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -460,3 +460,21 @@ func RunTestsOnlyForStaticMount(mountDir string, t *testing.T) {
 		t.SkipNow()
 	}
 }
+
+// AppendFlagsToAllFlagsInTheFlagsSet appends the newFlags in all the command in the
+// flagsSet.
+// Here, flags represent to one mounting command.
+// flagsSet represent to set of mounting commands.
+func AppendFlagsToAllFlagsInTheFlagsSet(flagsSet *[][]string, newFlags ...string) {
+	var resultFlagsSet [][]string
+	for _, flags := range *flagsSet {
+		for _, newFlag := range newFlags {
+			f := flags
+			if strings.Compare(newFlag, "") != 0 {
+				f = append(flags, newFlag)
+			}
+			resultFlagsSet = append(resultFlagsSet, f)
+		}
+	}
+	*flagsSet = resultFlagsSet
+}


### PR DESCRIPTION
### Description
- Enabling e2e test for gRPC changes.
- Added support of -short flag while running the integration test, this will skip few tests inside test package. 
- Enabling only important tests (operations) for gRPC as part presubmit test. But exhaustive test will be run as part of e2e test.

Currently time taken by pre-submit test - 34m.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
