### PR TITLE
Adding experimental config to benchmark grpc performance

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/build.sh
@@ -82,7 +82,8 @@ fi
 # Executing perf tests
 LOG_FILE_FIO_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs${EXPERIMENT_NUMBER}.txt"
 GCSFUSE_FIO_FLAGS="$GCSFUSE_FLAGS --log-file $LOG_FILE_FIO_TESTS --log-format \"text\" --stackdriver-export-interval=30s"
-BUCKET_NAME="experimental-periodic-perf-tests-${EXPERIMENT_NUMBER}"
+# Adding `golang-grpc-test` prefix to allow list bucket for grpc client so that we can also run workload with grpc-client in addition to http one.
+BUCKET_NAME="golang-grpc-test-experimental-periodic-perf-tests-${EXPERIMENT_NUMBER}"
 ./run_load_test_and_fetch_metrics.sh "$GCSFUSE_FIO_FLAGS" "$UPLOAD_FLAGS" "$BUCKET_NAME"
 
 # ls_metrics test. This test does gcsfuse mount with the passed flags first and then does the testing.

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -36,7 +36,7 @@
       "config_name": "master_benchmark_with_gRPC_changes_enabled",
       "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100 --client-protocol grpc --debug_fuse --debug_gcs",
       "branch": "master",
-      "end_date": "2024-09-31 05:30:00+00:00"
+      "end_date": "2024-09-30 05:30:00+00:00"
     }
   ]
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/periodic_experiments/experiments_configuration.json
@@ -33,10 +33,10 @@
       "end_date": "2024-03-31 05:30:00+00:00"
     },
     {
-      "config_name": "master_benchmark_with_gRPC_changes",
-      "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs",
-      "branch": "gRPC_support1",
-      "end_date": "2024-03-31 05:30:00+00:00"
+      "config_name": "master_benchmark_with_gRPC_changes_enabled",
+      "gcsfuse_flags": "--implicit-dirs --max-conns-per-host 100 --client-protocol grpc --debug_fuse --debug_gcs",
+      "branch": "master",
+      "end_date": "2024-09-31 05:30:00+00:00"
     }
   ]
 }


### PR DESCRIPTION
### Description
- Changes to support gRPC flow in the experimental dashboard script (renaming the bucket name, also ensured same region of GCP vm and bucket for direct path).
- Modified the existing `gRPC disabled` dashboard config with `gRPC enabled` config.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
