### PR TITLE
Fixing custom-endpoint issue in grpc

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -484,7 +484,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		customEndpoint = nil
 	} else {
 		customEndpoint, err = url.Parse(customEndpointStr)
-		if err != nil {
+		if customEndpoint.String() == "" || err != nil {
 			err = fmt.Errorf("could not parse custom-endpoint: %w", err)
 			return
 		}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,16 +57,17 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 
 	var clientOpts []option.ClientOption
-	tokenSrc, err := storageutil.CreateTokenSource(clientConfig)
-	if err != nil {
-		err = fmt.Errorf("while fetching tokenSource: %w", err)
-		return
-	}
-	clientOpts = append(clientOpts, option.WithTokenSource(tokenSrc))
 
 	// Add Custom endpoint option.
 	if clientConfig.CustomEndpoint != nil {
 		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint.String()))
+	} else {
+		tokenSrc, tokenCreationErr := storageutil.CreateTokenSource(clientConfig)
+		if tokenCreationErr != nil {
+			err = fmt.Errorf("while fetching tokenSource: %w", tokenCreationErr)
+			return
+		}
+		clientOpts = append(clientOpts, option.WithTokenSource(tokenSrc))
 	}
 
 	clientOpts = append(clientOpts, option.WithGRPCConnectionPool(clientConfig.GrpcConnPoolSize))

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -61,7 +61,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Add Custom endpoint option.
 	if clientConfig.CustomEndpoint != nil {
 		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint.String()))
-		// Explicitly disable no-auth in case of custom-endpoint, aligned with the http-client.
+		// Explicitly disable auth in case of custom-endpoint, aligned with the http-client.
 		// TODO: to revisit here when supporting TPC for grpc client.
 		clientOpts = append(clientOpts, option.WithoutAuthentication())
 	} else {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -61,6 +61,9 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Add Custom endpoint option.
 	if clientConfig.CustomEndpoint != nil {
 		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint.String()))
+		// Explicitly disable no-auth in case of custom-endpoint, aligned with the http-client.
+		// TODO: to revisit here when supporting TPC for grpc client.
+		clientOpts = append(clientOpts, option.WithoutAuthentication())
 	} else {
 		tokenSrc, tokenCreationErr := storageutil.CreateTokenSource(clientConfig)
 		if tokenCreationErr != nil {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -19,14 +19,15 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
-
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"golang.org/x/net/context"
 	option "google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	// Side effect to run grpc client with direct-path on gcp machine.
 	_ "google.golang.org/grpc/balancer/rls"
@@ -60,10 +61,11 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// Add Custom endpoint option.
 	if clientConfig.CustomEndpoint != nil {
-		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint.String()))
+		clientOpts = append(clientOpts, option.WithEndpoint(storageutil.StripScheme(clientConfig.CustomEndpoint.String())))
 		// Explicitly disable auth in case of custom-endpoint, aligned with the http-client.
 		// TODO: to revisit here when supporting TPC for grpc client.
 		clientOpts = append(clientOpts, option.WithoutAuthentication())
+		clientOpts = append(clientOpts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	} else {
 		tokenSrc, tokenCreationErr := storageutil.CreateTokenSource(clientConfig)
 		if tokenCreationErr != nil {

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const urlSchemaSeparator = "://"
+
 type StorageClientConfig struct {
 	/** Common client parameters. */
 
@@ -111,8 +113,8 @@ func CreateTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth
 
 // StripScheme strips the scheme from a host if it contains.
 func StripScheme(url string) string {
-	if strings.Contains(url, "://") {
-		url = strings.SplitN(url, "://", 2)[1]
+	if strings.Contains(url, urlSchemaSeparator) {
+		url = strings.SplitN(url, urlSchemaSeparator, 2)[1]
 	}
 	return url
 }

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const urlSchemaSeparator = "://"
+const urlSchemeSeparator = "://"
 
 type StorageClientConfig struct {
 	/** Common client parameters. */
@@ -111,10 +111,10 @@ func CreateTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth
 	}
 }
 
-// StripScheme strips the scheme from a host if it contains.
+// StripScheme strips the scheme part of given url.
 func StripScheme(url string) string {
-	if strings.Contains(url, urlSchemaSeparator) {
-		url = strings.SplitN(url, urlSchemaSeparator, 2)[1]
+	if strings.Contains(url, urlSchemeSeparator) {
+		url = strings.SplitN(url, urlSchemeSeparator, 2)[1]
 	}
 	return url
 }

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/auth"
@@ -106,4 +107,12 @@ func CreateTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth
 	} else {
 		return oauth2.StaticTokenSource(&oauth2.Token{}), nil
 	}
+}
+
+// StripScheme strips the scheme from a host if it contains.
+func StripScheme(url string) string {
+	if strings.Contains(url, "://") {
+		url = strings.SplitN(url, "://", 2)[1]
+	}
+	return url
 }

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -96,3 +96,31 @@ func (t *clientTest) TestCreateHttpClientWithHttp2() {
 	t.validateProxyInTransport(httpClient)
 	ExpectEq(sc.HttpClientTimeout, httpClient.Timeout)
 }
+
+func (t *clientTest) TestStripScheme() {
+	for _, tc := range []struct {
+		input          string
+		expectedOutput string
+	}{
+		{
+			input:          "",
+			expectedOutput: "",
+		},
+		{
+			input:          "localhost:8080",
+			expectedOutput: "localhost:8080",
+		},
+		{
+			input:          "http://localhost:8888",
+			expectedOutput: "localhost:8888",
+		},
+		{
+			input:          "cp://localhost:8888",
+			expectedOutput: "localhost:8888",
+		},
+	} {
+		output := StripScheme(tc.input)
+
+		AssertEq(tc.expectedOutput, output)
+	}
+}

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -115,7 +115,7 @@ func (t *clientTest) TestStripScheme() {
 			expectedOutput: "localhost:8888",
 		},
 		{
-			input:          "cp://localhost:8888",
+			input:          "bad://localhost:8888",
 			expectedOutput: "localhost:8888",
 		},
 	} {

--- a/internal/storage/storageutil/client_test.go
+++ b/internal/storage/storageutil/client_test.go
@@ -115,8 +115,12 @@ func (t *clientTest) TestStripScheme() {
 			expectedOutput: "localhost:8888",
 		},
 		{
-			input:          "bad://localhost:8888",
+			input:          "cp://localhost:8888",
 			expectedOutput: "localhost:8888",
+		},
+		{
+			input:          "bad://http://localhost:888://",
+			expectedOutput: "http://localhost:888://",
 		},
 	} {
 		output := StripScheme(tc.input)


### PR DESCRIPTION
### Description
`STORAGE_EMULATOR_HOST_GRPC` was not working with grpc client, as internally [go-sdk](https://github.com/googleapis/google-cloud-go/blob/67d353beefe3b607c08c891876fbd95ab89e5fe3/storage/grpc_client.go#L97) sets option.WithoutAuthentication when this environment variable is set. As we are setting the creds everytime hence it fails because of [this](https://github.com/googleapis/google-api-go-client/blob/3daccecaae7b1bcd1371a44cb2d25b2fec4f34f2/internal/settings.go#L109) check.

```
Error while mounting gcsfuse: Failed to create storage handle using createStorageHandle: go storage client creation failed: options.WithoutAuthentication is incompatible with any option that provides credentials
```

Simulating the same behaviour for custom-endpoint as for setting `STORAGE_EMULATOR_HOST_GRPC` environment varible. Also, we are  not passing the creds when custom-endpoint is non-nil.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested manually working fine.
2. Unit tests - NA
3. Integration tests - NA
