### PR TITLE
Fix flaky e2e tests for managed folder

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -20,7 +20,6 @@
 package managed_folders
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path"
@@ -62,14 +61,7 @@ func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 	if s.managedFolderPermission != "nil" {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
-		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, t) {
-			fmt.Println("In sleep")
-			time.Sleep(10 * time.Second)
-		}
-		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, t) {
-			fmt.Println("In sleep")
-			time.Sleep(10 * time.Second)
-		}
+		time.Sleep(10 * time.Second)
 	}
 }
 
@@ -213,7 +205,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	setup.SetMntDir(mountDir)
 
 	// Run tests on given {Bucket permission, Managed folder permission}.
-	permissions := [][]string{{AdminPermission, "nil"}, {AdminPermission, IAMRoleForViewPermission}, {AdminPermission, IAMRoleForAdminPermission}, {ViewPermission, IAMRoleForAdminPermission}}
+	permissions := [][]string{{ViewPermission, IAMRoleForAdminPermission}}
 
 	for i := 0; i < len(permissions); i++ {
 		log.Printf("Running tests with flags, bucket have %s permission and managed folder have %s permissions: %s", permissions[i][0], permissions[i][1], flags)

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -214,6 +214,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		if ts.managedFolderPermission != "nil" {
 			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
 			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+			// Waiting for 2 minutes as it usually takes within 10 seconds for policy changes to propagate.
 			time.Sleep(10 * time.Second)
 		}
 

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -61,10 +61,10 @@ func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 	if s.managedFolderPermission != "nil" {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
-		if !checkPermissionToManagedFolder(bucket, ManagedFolder1, serviceAccount, t) {
+		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, t) {
 			time.Sleep(10 * time.Second)
 		}
-		if !checkPermissionToManagedFolder(bucket, ManagedFolder2, serviceAccount, t) {
+		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, t) {
 			time.Sleep(10 * time.Second)
 		}
 	}

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -51,7 +51,6 @@ var (
 // levels apply additively (union) throughout the resource hierarchy.
 // Hence here managed folder will have admin permission throughout all the tests.
 type managedFoldersAdminPermission struct {
-	managedFolderPermission string
 	bucketPermission        string
 }
 
@@ -210,17 +209,17 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 			creds_tests.ApplyPermissionToServiceAccount(serviceAccount, ViewPermission)
 			defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
 		}
-		ts.managedFolderPermission = permissions[i][1]
-		if ts.managedFolderPermission != "nil" {
-			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
-			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+		managedFolderPermission := permissions[i][1]
+		if managedFolderPermission != "nil" {
+			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, managedFolderPermission, t)
+			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, managedFolderPermission, t)
 			// Waiting for 2 minutes as it usually takes within 10 seconds for policy changes to propagate.
 			time.Sleep(10 * time.Second)
 		}
 
 		test_setup.RunTests(t, ts)
-		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
-		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, managedFolderPermission, t)
+		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, managedFolderPermission, t)
 	}
 	t.Cleanup(func() {
 		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -216,8 +216,11 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		}
 
 		test_setup.RunTests(t, ts)
+		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1),setup.TestBucket())
+		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2),setup.TestBucket())
 
 		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
 		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
 	}
+
 }

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -58,17 +58,10 @@ type managedFoldersAdminPermission struct {
 func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	createDirectoryStructureForNonEmptyManagedFolders(t)
-	if s.managedFolderPermission != "nil" {
-		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
-		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
-		time.Sleep(10 * time.Second)
-	}
 }
 
 func (s *managedFoldersAdminPermission) Teardown(t *testing.T) {
-	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
-	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
-	cleanup(bucket, testDir, serviceAccount, s.managedFolderPermission, t)
+	setup.CleanupDirectoryOnGCS(path.Join(bucket, testDir))
 }
 
 func (s *managedFoldersAdminPermission) TestCreateObjectInManagedFolder(t *testing.T) {
@@ -216,6 +209,15 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 			defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
 		}
 		ts.managedFolderPermission = permissions[i][1]
+		if ts.managedFolderPermission != "nil" {
+			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
+			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+			time.Sleep(10 * time.Second)
+		}
+
 		test_setup.RunTests(t, ts)
+
+		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
+		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
 	}
 }

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -60,7 +60,7 @@ func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 }
 
 func (s *managedFoldersAdminPermission) Teardown(t *testing.T) {
-  // The 'gsutil rm -rf' command doesn't work on managed folders.
+	// The 'gsutil rm -rf' command doesn't work on managed folders.
 	// We'll clean up the test directory but leave managed folders.
 	setup.CleanupDirectoryOnGCS(path.Join(bucket, testDir))
 }
@@ -199,7 +199,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	setup.SetMntDir(mountDir)
 
 	// Run tests on given {Bucket permission, Managed folder permission}.
-	permissions := [][]string{{ViewPermission, IAMRoleForAdminPermission}}
+	permissions := [][]string{{AdminPermission, "nil"}, {AdminPermission, IAMRoleForViewPermission}, {AdminPermission, IAMRoleForAdminPermission}, {ViewPermission, IAMRoleForAdminPermission}}
 
 	for i := 0; i < len(permissions); i++ {
 		log.Printf("Running tests with flags, bucket have %s permission and managed folder have %s permissions: %s", permissions[i][0], permissions[i][1], flags)

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -219,7 +219,11 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		}
 
 		test_setup.RunTests(t, ts)
-		defer revokePermissionAndDeleteManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
-		defer revokePermissionAndDeleteManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
+		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
 	}
+	t.Cleanup(func() {
+		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
+		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
+	})
 }

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -216,11 +216,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		}
 
 		test_setup.RunTests(t, ts)
-		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
-
-		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
-		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
+		defer revokePermissionAndDeleteManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
+		defer revokePermissionAndDeleteManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)
 	}
-
 }

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
@@ -60,6 +61,12 @@ func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 	if s.managedFolderPermission != "nil" {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
+		if !checkPermissionToManagedFolder(bucket, ManagedFolder1, serviceAccount, t) {
+			time.Sleep(10 * time.Second)
+		}
+		if !checkPermissionToManagedFolder(bucket, ManagedFolder2, serviceAccount, t) {
+			time.Sleep(10 * time.Second)
+		}
 	}
 }
 

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -213,13 +213,13 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		if managedFolderPermission != "nil" {
 			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, managedFolderPermission, t)
 			providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, managedFolderPermission, t)
-			// Waiting for 2 minutes as it usually takes within 10 seconds for policy changes to propagate.
+			// Waiting for 10 seconds as it usually takes 10 seconds for policy changes to propagate.
 			time.Sleep(10 * time.Second)
 		}
 
 		test_setup.RunTests(t, ts)
-		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, managedFolderPermission, t)
-		defer revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, managedFolderPermission, t)
+		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, managedFolderPermission, t)
+		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, managedFolderPermission, t)
 	}
 	t.Cleanup(func() {
 		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -224,6 +224,6 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
+		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
 	})
 }

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -20,6 +20,7 @@
 package managed_folders
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -62,9 +63,11 @@ func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFolderPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFolderPermission, t)
 		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, t) {
+			fmt.Println("In sleep")
 			time.Sleep(10 * time.Second)
 		}
 		for !checkPermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, t) {
+			fmt.Println("In sleep")
 			time.Sleep(10 * time.Second)
 		}
 	}

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -56,11 +56,12 @@ type managedFoldersAdminPermission struct {
 }
 
 func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
-	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	createDirectoryStructureForNonEmptyManagedFolders(t)
 }
 
 func (s *managedFoldersAdminPermission) Teardown(t *testing.T) {
+  // The 'gsutil rm -rf' command doesn't work on managed folders.
+	// We'll clean up the test directory but leave managed folders.
 	setup.CleanupDirectoryOnGCS(path.Join(bucket, testDir))
 }
 
@@ -202,6 +203,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 
 	for i := 0; i < len(permissions); i++ {
 		log.Printf("Running tests with flags, bucket have %s permission and managed folder have %s permissions: %s", permissions[i][0], permissions[i][1], flags)
+		bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 		ts.bucketPermission = permissions[i][0]
 		if ts.bucketPermission == ViewPermission {
 			creds_tests.RevokePermission(serviceAccount, AdminPermission, setup.TestBucket())

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -216,8 +216,8 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		}
 
 		test_setup.RunTests(t, ts)
-		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1),setup.TestBucket())
-		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2),setup.TestBucket())
+		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
+		defer operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
 
 		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, ts.managedFolderPermission, t)
 		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, ts.managedFolderPermission, t)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -57,7 +57,6 @@ func checkPermissionToManagedFolder(bucket, managedFolderPath, serviceAccount st
 		t.Fatalf(fmt.Sprintf("Error in providing permission to managed folder: %v", err))
 	}
 
-	log.Println("out: ", string(out))
 	if !strings.Contains(string(out), serviceAccount) {
      return false
 	}

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -49,6 +49,22 @@ type IAMPolicy struct {
 	} `json:"bindings"`
 }
 
+func checkPermissionToManagedFolder(bucket, managedFolderPath, serviceAccount string, t *testing.T) bool{
+	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders get-iam-policy gs://%s/%s", bucket, managedFolderPath)
+	out, err := operations.ExecuteGcloudCommandf(gcloudProvidePermissionCmd)
+
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error in providing permission to managed folder: %v", err))
+	}
+
+	log.Println("out: ", string(out))
+	if !strings.Contains(string(out), serviceAccount) {
+     return false
+	}
+
+	return true
+}
+
 func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T) {
 	policy := IAMPolicy{
 		Bindings: []struct {

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -94,6 +94,11 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
+func revokePermissionAndDeleteManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T){
+	revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole, t)
+	operations.DeleteManagedFoldersInBucket(managedFolderPath, setup.TestBucket())
+}
+
 func createDirectoryStructureForNonEmptyManagedFolders(t *testing.T) {
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1/testFile

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -49,21 +49,6 @@ type IAMPolicy struct {
 	} `json:"bindings"`
 }
 
-func checkPermissionToManagedFolder(bucket, managedFolderPath, serviceAccount string, t *testing.T) bool{
-	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders get-iam-policy gs://%s/%s", bucket, managedFolderPath)
-	out, err := operations.ExecuteGcloudCommandf(gcloudProvidePermissionCmd)
-
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error in providing permission to managed folder: %v", err))
-	}
-
-	if !strings.Contains(string(out), serviceAccount) {
-     return false
-	}
-
-	return true
-}
-
 func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T) {
 	policy := IAMPolicy{
 		Bindings: []struct {

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -94,7 +94,7 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
-func revokePermissionAndDeleteManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T){
+func revokePermissionAndDeleteManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T) {
 	revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole, t)
 	operations.DeleteManagedFoldersInBucket(managedFolderPath, setup.TestBucket())
 }

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -94,11 +94,6 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
-func revokePermissionAndDeleteManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T) {
-	revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole, t)
-	operations.DeleteManagedFoldersInBucket(managedFolderPath, setup.TestBucket())
-}
-
 func createDirectoryStructureForNonEmptyManagedFolders(t *testing.T) {
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1/testFile

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -179,8 +179,6 @@ func DeleteManagedFoldersInBucket(managedFolderPath, bucket string) {
 }
 
 func CreateManagedFoldersInBucket(managedFolderPath, bucket string) {
-	// Delete if already exist.
-	DeleteManagedFoldersInBucket(managedFolderPath, bucket)
 	gcloudCreateManagedFolderCmd := fmt.Sprintf("alpha storage managed-folders create gs://%s/%s", bucket, managedFolderPath)
 
 	_, err := ExecuteGcloudCommandf(gcloudCreateManagedFolderCmd)

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -184,7 +184,7 @@ func CreateManagedFoldersInBucket(managedFolderPath, bucket string) {
 	gcloudCreateManagedFolderCmd := fmt.Sprintf("alpha storage managed-folders create gs://%s/%s", bucket, managedFolderPath)
 
 	_, err := ExecuteGcloudCommandf(gcloudCreateManagedFolderCmd)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
 		log.Fatalf(fmt.Sprintf("Error while creating managed folder: %v", err))
 	}
 }


### PR DESCRIPTION
### Description
- Added 10s sleep for policy to get propagate.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran tests for 10 times to check flaky ness on arm64 machine.
2. Unit tests - NA
3. Integration tests - NA
