### PR TITLE
Making read large files test package parallell

### DIFF
--- a/perfmetrics/scripts/run_e2e_tests.sh
+++ b/perfmetrics/scripts/run_e2e_tests.sh
@@ -29,6 +29,7 @@ TEST_DIR_PARALLEL=(
   "gzip"
   "write_large_files"
   "list_large_dir"
+  "read_large_files"
 )
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL_GROUP_1=(
@@ -43,7 +44,6 @@ TEST_DIR_NON_PARALLEL_GROUP_2=(
   "explicit_dir"
   "implicit_dir"
   "operations"
-  "read_large_files"
   "rename_dir_limit"
 )
 

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -62,7 +62,7 @@ func TestReadFilesConcurrently(t *testing.T) {
 		fileInLocalDisk := path.Join(os.Getenv("HOME"), filesInLocalDisk[i])
 		filesPathInLocalDisk = append(filesPathInLocalDisk, fileInLocalDisk)
 
-		file := path.Join(setup.MntDir(), filesInLocalDisk[i])
+		file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, filesInLocalDisk[i])
 		filesPathInMntDir = append(filesPathInMntDir, file)
 
 		createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -84,7 +84,4 @@ func TestReadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-
-	// Cleanup
-	setup.CleanUpDir(testDir)
 }

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -51,6 +51,8 @@ func readFile(fileInLocalDisk string, fileInMntDir string) error {
 }
 
 func TestReadFilesConcurrently(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
+
 	filesInLocalDisk := [NumberOfFilesInLocalDiskForConcurrentRead]string{FileOne, FileTwo, FileThree}
 	var filesPathInLocalDisk []string
 	var filesPathInMntDir []string
@@ -59,7 +61,7 @@ func TestReadFilesConcurrently(t *testing.T) {
 		fileInLocalDisk := path.Join(os.Getenv("HOME"), filesInLocalDisk[i])
 		filesPathInLocalDisk = append(filesPathInLocalDisk, fileInLocalDisk)
 
-		file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, filesInLocalDisk[i])
+		file := path.Join(testDir, filesInLocalDisk[i])
 		filesPathInMntDir = append(filesPathInMntDir, file)
 
 		createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -51,7 +51,7 @@ func readFile(fileInLocalDisk string, fileInMntDir string) error {
 }
 
 func TestReadFilesConcurrently(t *testing.T) {
-	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
 
 	filesInLocalDisk := [NumberOfFilesInLocalDiskForConcurrentRead]string{FileOne, FileTwo, FileThree}
 	var filesPathInLocalDisk []string

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -51,7 +51,7 @@ func readFile(fileInLocalDisk string, fileInMntDir string) error {
 }
 
 func TestReadFilesConcurrently(t *testing.T) {
-	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
 
 	filesInLocalDisk := [NumberOfFilesInLocalDiskForConcurrentRead]string{FileOne, FileTwo, FileThree}
 	var filesPathInLocalDisk []string

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -84,4 +84,7 @@ func TestReadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
+
+	// Cleanup
+	setup.CleanUpDir(testDir)
 }

--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -51,9 +51,6 @@ func readFile(fileInLocalDisk string, fileInMntDir string) error {
 }
 
 func TestReadFilesConcurrently(t *testing.T) {
-	// Clean the mountedDirectory before running test.
-	setup.CleanMntDir()
-
 	filesInLocalDisk := [NumberOfFilesInLocalDiskForConcurrentRead]string{FileOne, FileTwo, FileThree}
 	var filesPathInLocalDisk []string
 	var filesPathInMntDir []string

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 func TestReadLargeFileRandomly(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
-	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)
+	file := path.Join(testDir, FiveHundredMBFile)
 	// Create and copy the local file in mountedDirectory.
 	createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)
 

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -54,6 +54,4 @@ func TestReadLargeFileRandomly(t *testing.T) {
 
 	// Removing file after testing.
 	operations.RemoveFile(fileInLocalDisk)
-	// Cleanup
-	setup.CleanUpDir(testDir)
 }

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestReadLargeFileRandomly(t *testing.T) {
-	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(testDir, FiveHundredMBFile)
 	// Create and copy the local file in mountedDirectory.

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestReadLargeFileRandomly(t *testing.T) {
-	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(testDir, FiveHundredMBFile)
 	// Create and copy the local file in mountedDirectory.

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -30,7 +30,7 @@ func TestReadLargeFileRandomly(t *testing.T) {
 	setup.CleanMntDir()
 
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
-	file := path.Join(setup.MntDir(), FiveHundredMBFile)
+	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)
 	// Create and copy the local file in mountedDirectory.
 	createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)
 

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -54,4 +54,6 @@ func TestReadLargeFileRandomly(t *testing.T) {
 
 	// Removing file after testing.
 	operations.RemoveFile(fileInLocalDisk)
+	// Cleanup
+	setup.CleanUpDir(testDir)
 }

--- a/tools/integration_tests/read_large_files/random_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/random_read_large_file_test.go
@@ -26,9 +26,6 @@ import (
 )
 
 func TestReadLargeFileRandomly(t *testing.T) {
-	// Clean the mountedDirectory before running test.
-	setup.CleanMntDir()
-
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)
 	// Create and copy the local file in mountedDirectory.

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -37,6 +37,10 @@ const MinReadableByteFromFile = 0
 const MaxReadableByteFromFile = 500 * OneMB
 const DirForReadLargeFilesTests = "dirForReadLargeFilesTests"
 
+var (
+	testDir string
+)
+
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
 

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -35,6 +35,7 @@ const ChunkSize = 200 * OneMB
 const NumberOfRandomReadCalls = 200
 const MinReadableByteFromFile = 0
 const MaxReadableByteFromFile = 500 * OneMB
+const DirForReadLargeFilesTests = "dirForReadLargeFilesTests"
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -37,8 +37,6 @@ const MinReadableByteFromFile = 0
 const MaxReadableByteFromFile = 500 * OneMB
 const DirForReadLargeFilesTests = "dirForReadLargeFilesTests"
 
-var testDir string
-
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
 

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -37,9 +37,7 @@ const MinReadableByteFromFile = 0
 const MaxReadableByteFromFile = 500 * OneMB
 const DirForReadLargeFilesTests = "dirForReadLargeFilesTests"
 
-var (
-	testDir string
-)
+var testDir string
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -98,8 +98,6 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 
 	successCode := static_mounting.RunTests(flags, m)
-	// Cleanup
-	setup.CleanUpDir(testDir)
 	os.Exit(successCode)
 }
 

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -98,6 +98,8 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 
 	successCode := static_mounting.RunTests(flags, m)
+	// Cleanup
+	setup.CleanUpDir(testDir)
 	os.Exit(successCode)
 }
 

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -25,9 +25,10 @@ import (
 )
 
 func TestReadLargeFileSequentially(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	// Create file of 500 MB with random data in local disk and copy it in mntDir.
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
-	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)
+	file := path.Join(testDir, FiveHundredMBFile)
 	createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)
 
 	// Sequentially read the data from file.

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -25,9 +25,6 @@ import (
 )
 
 func TestReadLargeFileSequentially(t *testing.T) {
-	// Clean the mountedDirectory before running test.
-	setup.CleanMntDir()
-
 	// Create file of 500 MB with random data in local disk and copy it in mntDir.
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -50,4 +50,6 @@ func TestReadLargeFileSequentially(t *testing.T) {
 
 	// Removing file after testing.
 	operations.RemoveFile(fileInLocalDisk)
+	// Cleanup
+	setup.CleanUpDir(testDir)
 }

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestReadLargeFileSequentially(t *testing.T) {
-	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	// Create file of 500 MB with random data in local disk and copy it in mntDir.
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(testDir, FiveHundredMBFile)

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -30,7 +30,7 @@ func TestReadLargeFileSequentially(t *testing.T) {
 
 	// Create file of 500 MB with random data in local disk and copy it in mntDir.
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
-	file := path.Join(setup.MntDir(), FiveHundredMBFile)
+	file := path.Join(setup.MntDir(), DirForReadLargeFilesTests, FiveHundredMBFile)
 	createFileOnDiskAndCopyToMntDir(fileInLocalDisk, file, FiveHundredMB, t)
 
 	// Sequentially read the data from file.

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestReadLargeFileSequentially(t *testing.T) {
-	testDir := setup.SetupTestDirectory(DirForReadLargeFilesTests)
+	testDir = setup.SetupTestDirectory(DirForReadLargeFilesTests)
 	// Create file of 500 MB with random data in local disk and copy it in mntDir.
 	fileInLocalDisk := path.Join(os.Getenv("HOME"), FiveHundredMBFile)
 	file := path.Join(testDir, FiveHundredMBFile)

--- a/tools/integration_tests/read_large_files/seq_read_large_file_test.go
+++ b/tools/integration_tests/read_large_files/seq_read_large_file_test.go
@@ -50,6 +50,4 @@ func TestReadLargeFileSequentially(t *testing.T) {
 
 	// Removing file after testing.
 	operations.RemoveFile(fileInLocalDisk)
-	// Cleanup
-	setup.CleanUpDir(testDir)
 }


### PR DESCRIPTION
### Description
Made read large files package independent, to make it parallel run with other packages.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
