### PR TITLE
[PR1] allow parallel lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.4
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
-	github.com/jacobsa/fuse v0.0.0-20231003132804-d0f3daf365c3
+	github.com/jacobsa/fuse v0.0.0-20240509083815-39f95ce809a8
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,8 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6t
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f h1:X+tnaqoCcBgAwSTJtoYW6p0qKiuPyMfofEHEFUf2kdU=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20231003132804-d0f3daf365c3 h1:NhlhxaD3w7/+ztfJzZHWJ9FeNPl3kDYQPXQ/arbXAbA=
-github.com/jacobsa/fuse v0.0.0-20231003132804-d0f3daf365c3/go.mod h1:XUKuYy1M4vamyxQjW8/WZBTxyZ0NnUiq+kkA+WWOfeI=
+github.com/jacobsa/fuse v0.0.0-20240509083815-39f95ce809a8 h1:5Meita5JExZswnw1muPoaKp1oDvSC4KbB9e8FBNTr8U=
+github.com/jacobsa/fuse v0.0.0-20240509083815-39f95ce809a8/go.mod h1:JYi9iIxdYNgxmMgLwtSHO/hmVnP2kfX1oc+mtx+XWLA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -90,7 +90,8 @@ type EnableHNS bool
 type CacheDir string
 
 type FileSystemConfig struct {
-	IgnoreInterrupts bool `yaml:"ignore-interrupts"`
+	IgnoreInterrupts      bool `yaml:"ignore-interrupts"`
+	DisableParallelDirops bool `yaml:"disable-parallel-dirops"`
 }
 
 type FileCacheConfig struct {
@@ -180,6 +181,5 @@ func NewMountConfig() *MountConfig {
 		AnonymousAccess: DefaultAnonymousAccess,
 	}
 	mountConfig.EnableHNS = DefaultEnableHNS
-
 	return mountConfig
 }

--- a/internal/config/testdata/file_system_config/invalid_disable_parallel_dirops.yaml
+++ b/internal/config/testdata/file_system_config/invalid_disable_parallel_dirops.yaml
@@ -1,0 +1,2 @@
+file-system:
+  disable-parallel-dirops: -1

--- a/internal/config/testdata/file_system_config/unset_disable_parallel_dirops.yaml
+++ b/internal/config/testdata/file_system_config/unset_disable_parallel_dirops.yaml
@@ -1,0 +1,2 @@
+write:
+  create-empty-file: true

--- a/internal/config/testdata/valid_config.yaml
+++ b/internal/config/testdata/valid_config.yaml
@@ -25,3 +25,4 @@ grpc:
 enable-hns: true
 file-system:
   ignore-interrupts: true
+  disable-parallel-dirops: true

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -47,6 +47,7 @@ func validateDefaultConfig(t *testing.T, mountConfig *MountConfig) {
 	assert.False(t, mountConfig.AuthConfig.AnonymousAccess)
 	assert.False(t, bool(mountConfig.EnableHNS))
 	assert.False(t, mountConfig.FileSystemConfig.IgnoreInterrupts)
+	assert.False(t, mountConfig.FileSystemConfig.DisableParallelDirops)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -126,6 +127,7 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 
 	// file-system config
 	assert.True(t.T(), mountConfig.FileSystemConfig.IgnoreInterrupts)
+	assert.True(t.T(), mountConfig.FileSystemConfig.DisableParallelDirops)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_InvalidLogConfig() {
@@ -246,4 +248,18 @@ func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_UnsetAnonymousAcces
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
 	assert.False(t.T(), mountConfig.AuthConfig.AnonymousAccess)
+}
+
+func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_InvalidDisableParallelDirops() {
+	_, err := ParseConfigFile("testdata/file_system_config/invalid_disable_parallel_dirops.yaml")
+
+	assert.ErrorContains(t.T(), err, "error parsing config file: yaml: unmarshal errors:\n  line 2: cannot unmarshal !!int `-1` into bool")
+}
+
+func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_UnsetDisableParallelDirops() {
+	mountConfig, err := ParseConfigFile("testdata/file_system_config/unset_disable_parallel_dirops.yaml")
+
+	assert.NoError(t.T(), err)
+	assert.NotNil(t.T(), mountConfig)
+	assert.False(t.T(), mountConfig.FileSystemConfig.DisableParallelDirops)
 }

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -92,6 +92,18 @@ func (d *baseDirInode) Unlock() {
 	d.mu.Unlock()
 }
 
+// LockForChildLookup takes exclusive lock on inode when the inode's child is
+// looked up. It is different from non-base dir inode because during lookup of
+// child in base directory inode, the buckets map is modified and hence should
+// be guarded by exclusive lock.
+func (d *baseDirInode) LockForChildLookup() {
+	d.mu.Lock()
+}
+
+func (d *baseDirInode) UnlockForChildLookup() {
+	d.mu.Unlock()
+}
+
 func (d *baseDirInode) ID() fuseops.InodeID {
 	return d.id
 }

--- a/main_test.go
+++ b/main_test.go
@@ -176,7 +176,7 @@ func (t *MainTest) TestStringifyShouldReturnAllFlagsPassedInMountConfigAsMarshal
 	actual, err := util.Stringify(mountConfig)
 	AssertEq(nil, err)
 
-	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxSizeMB\":0,\"StatCacheMaxSizeMB\":0,\"EnableEmptyManagedFolders\":false,\"ConnPoolSize\":0,\"AnonymousAccess\":false,\"EnableHNS\":true,\"IgnoreInterrupts\":false}"
+	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"TRACE\",\"Format\":\"\",\"FilePath\":\"\\\"path\\\"to\\\"file\\\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":2,\"BackupFileCount\":2,\"Compress\":true},\"MaxSizeMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxSizeMB\":0,\"StatCacheMaxSizeMB\":0,\"EnableEmptyManagedFolders\":false,\"ConnPoolSize\":0,\"AnonymousAccess\":false,\"EnableHNS\":true,\"IgnoreInterrupts\":false,\"DisableParallelDirops\":false}"
 	AssertEq(expected, actual)
 }
 
@@ -188,7 +188,7 @@ func (t *MainTest) TestEnableHNSFlagFalse() {
 	actual, err := util.Stringify(mountConfig)
 	AssertEq(nil, err)
 
-	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"\",\"Format\":\"\",\"FilePath\":\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":0,\"BackupFileCount\":0,\"Compress\":false},\"MaxSizeMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxSizeMB\":0,\"StatCacheMaxSizeMB\":0,\"EnableEmptyManagedFolders\":false,\"ConnPoolSize\":0,\"AnonymousAccess\":false,\"EnableHNS\":false,\"IgnoreInterrupts\":false}"
+	expected := "{\"CreateEmptyFile\":false,\"Severity\":\"\",\"Format\":\"\",\"FilePath\":\"\",\"LogRotateConfig\":{\"MaxFileSizeMB\":0,\"BackupFileCount\":0,\"Compress\":false},\"MaxSizeMB\":0,\"CacheFileForRangeRead\":false,\"CacheDir\":\"\",\"TtlInSeconds\":0,\"TypeCacheMaxSizeMB\":0,\"StatCacheMaxSizeMB\":0,\"EnableEmptyManagedFolders\":false,\"ConnPoolSize\":0,\"AnonymousAccess\":false,\"EnableHNS\":false,\"IgnoreInterrupts\":false,\"DisableParallelDirops\":false}"
 	AssertEq(expected, actual)
 }
 

--- a/mount.go
+++ b/mount.go
@@ -145,6 +145,15 @@ be interacting with the file system.`)
 		Subtype:    "gcsfuse",
 		VolumeName: "gcsfuse",
 		Options:    flags.MountOptions,
+		// Allows parallel LookUpInode & ReadDir calls from Kernel's FUSE driver.
+		// GCSFuse takes exclusive lock on directory inodes during ReadDir call,
+		// hence there is no effect of parallelization of incoming ReadDir calls
+		// from FUSE driver for user of GCSFuse. However, in case of LookUpInode
+		// calls, GCSFuse takes read only lock during LookUpInode call which helps
+		// users experience the performance gains. E.g. if a user workload tries to
+		// access two files under same directory parallely, then the lookups also
+		// happen parallely.
+		EnableParallelDirOps: !(mountConfig.FileSystemConfig.DisableParallelDirops),
 	}
 
 	mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse: ")


### PR DESCRIPTION
### Description
Allow parallel lookups by 
(a) passing FUSE_PARALLEL_DIROPS option which allows parallel dirops (readdir and lookup calls) from FUSE driver. In my experiments i noticed that with this flag, readdir becomes parallel for same directory and lookup becomes parallel for files under same mount. Also, the even without this option, the lookup calls are parallel on repeat lookups of same files. GCSFuse takes locks on dir inode during readdir operations hence with this option. for user only the lookups are parallelized.
(b) take readonly lock on dir inode instead of exclusive lock while doing lookup.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added in https://github.com/GoogleCloudPlatform/gcsfuse/pull/1906
3. Integration tests - [Run1](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/649ee2d0-d588-4f1b-8f44-d60de68c6310/log), [Run2](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/30414bd3-fd53-4a8a-9304-d622a3c78c54/log), [Run3](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/8cb49318-7df0-472f-befd-1a70fa9ce7b9/log), [Run 4](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/f51a77a2-f43d-42ed-b09c-add738dc250e/log), [Run 5](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/c4906f58-c77e-4a0c-ac71-df7dad51765f) (More e2e tests to be added in next PR: https://github.com/GoogleCloudPlatform/gcsfuse/pull/1907)
4. Perf test (Run 4)
![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/c09d800c-0e16-4cf4-8e15-93c177b9c544)
