### PR TITLE
Fix flaky list large dir e2e test

### DIFF
--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -36,9 +36,9 @@ const NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs"}}
+	flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0"}}
 	if !testing.Short() {
-		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true"})
+		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0"})
 	}
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {


### PR DESCRIPTION
### Description
This change is necessary because there is a test failures due to delays in updating the stat-cache.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
