### PR TITLE
fix flaky modification time check in integration tests

### DIFF
--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
-	"github.com/jacobsa/fuse/fusetesting"
-	"github.com/jacobsa/ogletest"
 )
 
 const DirAttrTest = "dirAttrTest"
@@ -42,8 +40,11 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if objName != statObjName {
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}
-	ogletest.ExpectThat(oStat, fusetesting.MtimeIsWithin(preCreateTime, operations.TimeSlop))
-	ogletest.ExpectThat(oStat, fusetesting.MtimeIsWithin(postCreateTime, operations.TimeSlop))
+
+	statModTime := oStat.ModTime()
+	if (preCreateTime.After(statModTime)) || (postCreateTime.Before(statModTime)) {
+		t.Errorf("File modification time not in the expected time-range")
+	}
 
 	if oStat.Size() != byteSize {
 		t.Errorf("File size is not %v bytes, found size: %d bytes", BytesWrittenInFile, oStat.Size())
@@ -53,10 +54,13 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 func TestFileAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so using
+	// operations.TimeSlop to adjust pre and post create time.
+	// Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Add(-operations.TimeSlop)
 	fileName := path.Join(testDir, tempFileName)
 	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Add(+operations.TimeSlop)
 
 	// The file size in createTempFile() is BytesWrittenInFile bytes
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
@@ -66,10 +70,13 @@ func TestFileAttributes(t *testing.T) {
 func TestEmptyDirAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so using
+	// operations.TimeSlop to adjust pre and post create time.
+	// Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Add(-operations.TimeSlop)
 	dirName := path.Join(testDir, DirAttrTest)
 	operations.CreateDirectoryWithNFiles(0, dirName, "", t)
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Add(operations.TimeSlop)
 
 	checkIfObjectAttrIsCorrect(path.Join(testDir, DirAttrTest), preCreateTime, postCreateTime, 0, t)
 }
@@ -77,10 +84,13 @@ func TestEmptyDirAttributes(t *testing.T) {
 func TestNonEmptyDirAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	preCreateTime := time.Now()
+	// kernel time can be slightly out of sync of time.Now(), so using
+	// operations.TimeSlop to adjust pre and post create time.
+	// Ref: https://github.com/golang/go/issues/33510
+	preCreateTime := time.Now().Add(-operations.TimeSlop)
 	dirName := path.Join(testDir, DirAttrTest)
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
-	postCreateTime := time.Now()
+	postCreateTime := time.Now().Add(operations.TimeSlop)
 
 	checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
 }

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 const (
@@ -36,6 +37,11 @@ const (
 	OneMiB = OneKiB * OneKiB
 	// ChunkSizeForContentComparison is currently set to 1 MiB.
 	ChunkSizeForContentComparison int = OneMiB
+
+	// TimeSlop The radius we use for "expect mtime is within"-style assertions as kernel
+	// time can be slightly out of sync of time.Now().
+	// Ref: https://github.com/golang/go/issues/33510
+	TimeSlop = 25 * time.Millisecond
 )
 
 func copyFile(srcFileName, dstFileName string, allowOverwrite bool) (err error) {


### PR DESCRIPTION
### Description
This PR fixes flaky file and directory attributes tests. 

**Cause:** The tests were flaky because kernel clock can be out of sync of time.Now() Ref: https://github.com/golang/go/issues/33510
To handle this case, we were rounding off the times to nearest second for comparison but sometimes, edge condition can happen where pre-create time gets rounded up while the actual modification time gets rounded down.

**New Fix:** We will use time slop of 25 milli seconds to move pre and post create times so that file modification time lies between the range of preCreate and postCreate time.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran on VM and via KOKORO
