### PR TITLE
Using PATH env variable instead of copying gcsfuse package for integration tests 

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -23,9 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/persistent_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
@@ -151,15 +149,15 @@ func TestMain(m *testing.M) {
 	mountConfigFlags := createMountConfigsAndEquivalentFlags()
 	flagsSet = append(flagsSet, mountConfigFlags...)
 
-	successCode := static_mounting.RunTests(flagsSet, m)
+	//successCode := static_mounting.RunTests(flagsSet, m)
+	//
+	//if successCode == 0 {
+	//	successCode = only_dir_mounting.RunTests(flagsSet, m)
+	//}
 
-	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flagsSet, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flagsSet, m)
-	}
+	//if successCode == 0 {
+	successCode := persistent_mounting.RunTests(flagsSet, m)
+	//}
 
 	if successCode == 0 {
 		successCode = dynamic_mounting.RunTests(flagsSet, m)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/persistent_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
@@ -149,15 +151,15 @@ func TestMain(m *testing.M) {
 	mountConfigFlags := createMountConfigsAndEquivalentFlags()
 	flagsSet = append(flagsSet, mountConfigFlags...)
 
-	//successCode := static_mounting.RunTests(flagsSet, m)
-	//
-	//if successCode == 0 {
-	//	successCode = only_dir_mounting.RunTests(flagsSet, m)
-	//}
+	successCode := static_mounting.RunTests(flagsSet, m)
 
-	//if successCode == 0 {
-	successCode := persistent_mounting.RunTests(flagsSet, m)
-	//}
+	if successCode == 0 {
+		successCode = only_dir_mounting.RunTests(flagsSet, m)
+	}
+
+	if successCode == 0 {
+		successCode = persistent_mounting.RunTests(flagsSet, m)
+	}
 
 	if successCode == 0 {
 		successCode = dynamic_mounting.RunTests(flagsSet, m)

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -298,12 +298,6 @@ function main(){
     echo "The e2e tests for hns bucket failed.."
     exit 1
   fi
-
-  # Removing bin file after testing.
-  if [ $RUN_E2E_TESTS_ON_PACKAGE != true ];
-  then
-    sudo rm /usr/local/bin/gcsfuse
-  fi
 }
 
 #Main method to run script

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -185,17 +185,6 @@ func SetUpTestDir() error {
 	return nil
 }
 
-// Removing bin file after testing.
-func RemoveBinFileCopiedForTesting() {
-	if !TestInstalledPackage() {
-		cmd := exec.Command("sudo", "rm", "/usr/local/bin/gcsfuse")
-		err := cmd.Run()
-		if err != nil {
-			log.Printf("Error in removing file:%v", err)
-		}
-	}
-}
-
 func UnMount() error {
 	fusermount, err := exec.LookPath("fusermount")
 	if err != nil {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -167,7 +167,7 @@ func SetUpTestDir() error {
 		//if err != nil {
 		//	log.Printf("Error in copying bin file:%v", err)
 		//}
-		err := os.Setenv("PATH", TestDir()+":"+os.Getenv("PATH"))
+		err := os.Setenv("PATH", TestDir()+"/bin:"+os.Getenv("PATH"))
 		if err != nil {
 			log.Printf(err.Error())
 		}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -160,13 +160,13 @@ func SetUpTestDir() error {
 		binFile = path.Join(TestDir(), "bin/gcsfuse")
 		sbinFile = path.Join(TestDir(), "sbin/mount.gcsfuse")
 
-		// mount.gcsfuse will find gcsfuse executable in mentioned locations.
-		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
-		// Copying the executable to /usr/local/bin
-		err := operations.CopyDirWithRootPermission(binFile, "/usr/local/bin")
-		if err != nil {
-			log.Printf("Error in copying bin file:%v", err)
-		}
+		//// mount.gcsfuse will find gcsfuse executable in mentioned locations.
+		//// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
+		//// Copying the executable to /usr/local/bin
+		//err := operations.CopyDirWithRootPermission(binFile, "/usr/local/bin")
+		//if err != nil {
+		//	log.Printf("Error in copying bin file:%v", err)
+		//}
 	} else {
 		// when testInstalledPackage flag is set, gcsfuse is preinstalled on the
 		// machine. Hence, here we are overwriting binFile to gcsfuse.

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"testing"
@@ -43,6 +44,7 @@ const (
 	FilePermission_0600 = 0600
 	DirPermission_0755  = 0755
 	Charset             = "abcdefghijklmnopqrstuvwxyz0123456789"
+	PathEnvVariable     = "PATH"
 )
 
 var (
@@ -160,16 +162,12 @@ func SetUpTestDir() error {
 		binFile = path.Join(TestDir(), "bin/gcsfuse")
 		sbinFile = path.Join(TestDir(), "sbin/mount.gcsfuse")
 
-		//// mount.gcsfuse will find gcsfuse executable in mentioned locations.
-		//// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
-		//// Copying the executable to /usr/local/bin
-		//err := operations.CopyDirWithRootPermission(binFile, "/usr/local/bin")
-		//if err != nil {
-		//	log.Printf("Error in copying bin file:%v", err)
-		//}
-		err := os.Setenv("PATH", TestDir()+"/bin:"+os.Getenv("PATH"))
+		// mount.gcsfuse will find gcsfuse executable in mentioned locations.
+		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/find.go#L59
+		// Setting PATH so that executable is found in test directory.
+		err := os.Setenv(PathEnvVariable, path.Join(TestDir(), "bin")+string(filepath.ListSeparator)+os.Getenv(PathEnvVariable))
 		if err != nil {
-			log.Printf(err.Error())
+			log.Printf("Error in setting PATH environment variable: %v", err.Error())
 		}
 	} else {
 		// when testInstalledPackage flag is set, gcsfuse is preinstalled on the

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -167,6 +167,10 @@ func SetUpTestDir() error {
 		//if err != nil {
 		//	log.Printf("Error in copying bin file:%v", err)
 		//}
+		err := os.Setenv("PATH", TestDir()+":"+os.Getenv("PATH"))
+		if err != nil {
+			log.Printf(err.Error())
+		}
 	} else {
 		// when testInstalledPackage flag is set, gcsfuse is preinstalled on the
 		// machine. Hence, here we are overwriting binFile to gcsfuse.


### PR DESCRIPTION
### Description
Repeatedly copying bin file was throwing warnings. Using PATH env variable instead to keep the test logs clean.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Via KOKORO
