### PR TITLE
Fix only dir mounting e2e test

### DIFF
--- a/tools/integration_tests/local_file/local_file_test.go
+++ b/tools/integration_tests/local_file/local_file_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	testDirName = "LocalFileTest"
+	testDirName                 = "LocalFileTest"
+	testDirOnlyDirForLocalFiles = "testDirOnlyDirForLocalFiles"
 )
 
 var (
@@ -109,7 +110,7 @@ func TestMain(m *testing.M) {
 	successCode := static_mounting.RunTests(flagsSet, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flagsSet, m)
+		successCode = only_dir_mounting.RunTests(flagsSet, testDirOnlyDirForLocalFiles, m)
 	}
 
 	if successCode == 0 {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -85,6 +85,7 @@ const PrefixFileInDirThreeInCreateThreeLevelDirTest = "fileInDirThreeInCreateThr
 const FileInDirThreeInCreateThreeLevelDirTest = "fileInDirThreeInCreateThreeLevelDirTest1"
 const ContentInFileInDirThreeInCreateThreeLevelDirTest = "Hello world!!"
 const Content = "line 1\nline 2\n"
+const testDirOnlyDirForOperations = "testDirOnlyDirForOperations"
 
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
@@ -154,7 +155,7 @@ func TestMain(m *testing.M) {
 	successCode := static_mounting.RunTests(flagsSet, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flagsSet, m)
+		successCode = only_dir_mounting.RunTests(flagsSet, testDirOnlyDirForOperations, m)
 	}
 
 	if successCode == 0 {

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	testDirName                         = "ReadCacheTest"
-	onlyDirMounted                      = "Test"
+	onlyDirMounted                      = "onlyDirReadCache"
 	cacheSubDirectoryName               = "gcsfuse-file-cache"
 	smallContentSize                    = 128 * util.KiB
 	chunkSizeToRead                     = 128 * util.KiB

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -36,6 +36,7 @@ const EmptySubDirectory = "emptySubDirectory"
 const NonEmptySubDirectory = "nonEmptySubDirectory"
 const RenamedDirectory = "renamedDirectory"
 const PrefixTempFile = "temp"
+const testDirOnlyDirForRenameDirLimit = "testDirOnlyDirForRenameDirLimit"
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
@@ -58,7 +59,7 @@ func TestMain(m *testing.M) {
 	successCode := static_mounting.RunTests(flags, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, m)
+		successCode = only_dir_mounting.RunTests(flags, testDirOnlyDirForRenameDirLimit, m)
 	}
 
 	if successCode == 0 {

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -56,10 +56,10 @@ func mountGcsFuseForFlagsAndExecuteTests(flags [][]string, m *testing.M) (succes
 	return
 }
 
-func executeTestsForOnlyDirMounting(flags [][]string, m *testing.M) (successCode int) {
+func executeTestsForOnlyDirMounting(flags [][]string, onlyDir string, m *testing.M) (successCode int) {
 	// Set onlyDirMounted value to the directory being mounted.
-	setup.SetOnlyDirMounted(DirectoryInTestBucket)
-	mountDirInBucket := path.Join(setup.TestBucket(), DirectoryInTestBucket)
+	setup.SetOnlyDirMounted(onlyDir)
+	mountDirInBucket := path.Join(setup.TestBucket(), onlyDir)
 	// Clean the bucket.
 
 	setup.RunScriptForTestData("../util/mounting/only_dir_mounting/testdata/delete_objects.sh", mountDirInBucket)
@@ -84,10 +84,10 @@ func executeTestsForOnlyDirMounting(flags [][]string, m *testing.M) (successCode
 	return
 }
 
-func RunTests(flags [][]string, m *testing.M) (successCode int) {
+func RunTests(flags [][]string, onlyDir string, m *testing.M) (successCode int) {
 	log.Println("Running only dir mounting tests...")
 
-	successCode = executeTestsForOnlyDirMounting(flags, m)
+	successCode = executeTestsForOnlyDirMounting(flags, onlyDir, m)
 
 	log.Printf("Test log: %s\n", setup.LogFile())
 


### PR DESCRIPTION
### Description
Parallel package execution was causing directory mounting tests to fail due to the deletion of directories with the same name.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
