### PR TITLE
Upgrading go version to 1.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.22.1-alpine as builder
+FROM golang:1.22.2-alpine as builder
 
 RUN apk add git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse/v2
 
-go 1.22.1
+go 1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -18,7 +18,7 @@ NUM_EPOCHS=80
 TEST_BUCKET="gcsfuse-ml-data"
 
 # Install golang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Installs go1.22.1 on the container, builds gcsfuse using log_rotation file
+# Installs go1.22.2 on the container, builds gcsfuse using log_rotation file
 # and installs tf-models-official v2.13.2, makes update to include clear_kernel_cache
 # and epochs functionality, and runs the model
 
 # Install go lang
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -36,8 +36,8 @@ set -e
 sudo apt-get update
 echo Installing git
 sudo apt-get install git
-echo Installing go-lang  1.22.1
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-amd64.tar.gz -q
+echo Installing go-lang  1.22.2
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export CGO_ENABLED=0

--- a/perfmetrics/scripts/read_cache/setup.sh
+++ b/perfmetrics/scripts/read_cache/setup.sh
@@ -64,7 +64,7 @@ sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GRO
 cd -
 
 # Install and validate go.
-version=1.22.1
+version=1.22.2
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go
 tar -xzf go_tar.tar.gz && sudo mv go /usr/local

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.22.2.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.22.1 as gcsfuse-package
+FROM golang:1.22.2 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -83,8 +83,8 @@ function upgrade_gcloud_version() {
 function install_packages() {
   # e.g. architecture=arm64 or amd64
   architecture=$(dpkg --print-architecture)
-  echo "Installing go-lang 1.22.1..."
-  wget -O go_tar.tar.gz https://go.dev/dl/go1.22.1.linux-${architecture}.tar.gz -q
+  echo "Installing go-lang 1.22.2..."
+  wget -O go_tar.tar.gz https://go.dev/dl/go1.22.2.linux-${architecture}.tar.gz -q
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
   # install python3-setuptools tools.

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -17,7 +17,7 @@
 # Copy the gcsfuse packages to the host:
 #   > docker run -it -v /tmp:/output gcsfuse-release cp -r /packages /output
 
-FROM golang:1.22.1 as builder
+FROM golang:1.22.2 as builder
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
 


### PR DESCRIPTION
### Description
Upgrading go's minor version from 1.22.1 to 1.22.2

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Presubmits
3. Integration tests - Presubmits
4. Per tests - below:

![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/26776982/f901cba5-24e4-46cc-a505-a7d14bdd9f0d)

