### PR TITLE
pass environment variables to go build command of build_gcsfuse to support builds behind an HTTP proxy

### DIFF
--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -151,7 +151,8 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 		cmd.Args = append(cmd.Args, bin.goTarget)
 
 		// Set up environment.
-		cmd.Env = []string{
+		cmd.Env = append(
+			os.Environ(),
 			"GO15VENDOREXPERIMENT=1",
 			"GO111MODULE=auto",
 			fmt.Sprintf("PATH=%s", pathEnv),
@@ -159,7 +160,7 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
 			fmt.Sprintf("GOPATH=%s", gopath),
 			fmt.Sprintf("GOCACHE=%s", gocache),
 			"CGO_ENABLED=0",
-		}
+		)
 
 		// Build.
 		var output []byte


### PR DESCRIPTION
### Description

The problem I faced is described in the title, I hope this fix can be useful to someone else too.

I have a custom Dockerfile based on [the original Dockerfile in this repo](https://github.com/GoogleCloudPlatform/gcsfuse/blob/v2.0.1/Dockerfile), and my build runs behind an HTTP proxy, the build was failing. I realized it was due the following code snippet in [tools/build_gcsfuse/main.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/v2.0.1/tools/build_gcsfuse/main.go):

```
cmd := exec.Command(
	"go",
	"build",
	...
			
// Set up environment.
cmd.Env = []string{
	"GO15VENDOREXPERIMENT=1",
	"GO111MODULE=auto",
	fmt.Sprintf("PATH=%s", pathEnv),
	fmt.Sprintf("GOROOT=%s", runtime.GOROOT()),
	fmt.Sprintf("GOPATH=%s", gopath),
	fmt.Sprintf("GOCACHE=%s", gocache),
	"CGO_ENABLED=0",
}			
```

This code ignores all the current environment variables, which is IMHO unexpected as it runs inside Docker which already takes care about creating an isolated environment with fresh values of environment variables.

The particular variable important for my case was `https_proxy`, without it `go build` was failing as it was unable to access internet directly.

That variable was passed with `~/.docker/config.json` [like described in Docker docs](https://docs.docker.com/network/proxy/).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
