### PR TITLE
Remove default limit on max tcp connections by setting max-conns-per-host to 0

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -268,7 +268,8 @@ func newApp() (app *cli.App) {
 				Name:  "max-conns-per-host",
 				Value: 0,
 				Usage: "The max number of TCP connections allowed per server. This is " +
-					"effective when --client-protocol is set to 'http1'.",
+					"effective when --client-protocol is set to 'http1'. The default value" +
+					" 0 indicates no limit on TCP connections (limited by the machine specifications)",
 			},
 
 			cli.IntFlag{

--- a/flags.go
+++ b/flags.go
@@ -266,7 +266,7 @@ func newApp() (app *cli.App) {
 
 			cli.IntFlag{
 				Name:  "max-conns-per-host",
-				Value: 100,
+				Value: 0,
 				Usage: "The max number of TCP connections allowed per server. This is " +
 					"effective when --client-protocol is set to 'http1'.",
 			},

--- a/flags_test.go
+++ b/flags_test.go
@@ -93,6 +93,7 @@ func (t *FlagsTest) Defaults() {
 	ExpectEq("", f.TempDir)
 	ExpectEq(2, f.RetryMultiplier)
 	ExpectFalse(f.EnableNonexistentTypeCache)
+	ExpectEq(0, f.MaxConnsPerHost)
 
 	// Logging
 	ExpectTrue(f.DebugFuseErrors)

--- a/perfmetrics/scripts/README.md
+++ b/perfmetrics/scripts/README.md
@@ -24,7 +24,7 @@ cd gcsfuse/perfmetrics/scripts
 ```
 4. Create a directory and mount your GCS bucket into it using GCSFuse:
 ```bash
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100 --client-protocol http1"
+GCSFUSE_FLAGS="--implicit-dirs --client-protocol http1"
 BUCKET_NAME=your-bucket-name
 mkdir -p your-directory-name
 MOUNT_POINT=your-directory-name

--- a/perfmetrics/scripts/compare_fuse_types_using_fio.py
+++ b/perfmetrics/scripts/compare_fuse_types_using_fio.py
@@ -33,7 +33,7 @@ from fio import fio_metrics
 from absl import app
 
 GCSFUSE_REPO = 'https://github.com/GoogleCloudPlatform/gcsfuse'
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+GCSFUSE_FLAGS = "--implicit-dirs"
 
 
 def _install_gcsfuse(version, gcs_bucket, gcsfuse_flags) -> None:

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -39,7 +39,7 @@ then
   UPLOAD_FLAGS="--upload_gs"
 fi
 
-GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100  --debug_fuse --debug_gcs --log-format \"text\" "
+GCSFUSE_FLAGS="--implicit-dirs  --debug_fuse --debug_gcs --log-format \"text\" "
 LOG_FILE_FIO_TESTS=${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs.txt
 GCSFUSE_FIO_FLAGS="$GCSFUSE_FLAGS --log-file $LOG_FILE_FIO_TESTS --stackdriver-export-interval=30s"
 BUCKET_NAME="periodic-perf-tests"

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
@@ -593,21 +593,22 @@ class ListingBenchmarkTest(unittest.TestCase):
 
   @patch('listing_benchmark.subprocess.call', return_value=0)
   def test_mount_gcs_bucket(self, mock_subprocess_call):
-    directory_name = listing_benchmark._mount_gcs_bucket('fake_bucket', '--implicit-dirs --max-conns-per-host 100')
+    directory_name = listing_benchmark._mount_gcs_bucket('fake_bucket',
+                                                         '--implicit-dirs')
     self.assertEqual(directory_name, 'fake_bucket')
     self.assertEqual(mock_subprocess_call.call_count, 2)
     self.assertEqual(mock_subprocess_call.call_args_list, [
         call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs --max-conns-per-host 100 fake_bucket fake_bucket', shell=True)
+        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True)
     ])
 
   @patch('listing_benchmark.subprocess.call', return_value=1)
   def test_mount_gcs_bucket_error(self, mock_subprocess_call):
-    listing_benchmark._mount_gcs_bucket('fake_bucket', '--implicit-dirs --max-conns-per-host 100')
+    listing_benchmark._mount_gcs_bucket('fake_bucket', '--implicit-dirs')
     self.assertEqual(mock_subprocess_call.call_count, 3)
     self.assertEqual(mock_subprocess_call.call_args_list, [
         call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs --max-conns-per-host 100 fake_bucket fake_bucket', shell=True),
+        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True),
         call('bash', shell=True)
     ])
 

--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -57,7 +57,6 @@ echo "Mounting GCSFuse..."
 nohup /pytorch_dino/gcsfuse/gcsfuse --foreground \
         --stackdriver-export-interval=60s \
         --implicit-dirs \
-        --max-conns-per-host=100 \
         --config-file $config_filename \
       $TEST_BUCKET gcsfuse_data > "run_artifacts/gcsfuse.out" 2> "run_artifacts/gcsfuse.err" &
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -28,7 +28,6 @@ echo "logging:
        " > /tmp/gcsfuse_config.yaml
 nohup gcsfuse/gcsfuse --foreground \
       --implicit-dirs \
-      --max-conns-per-host 100 \
       --stackdriver-export-interval 60s \
       --config-file /tmp/gcsfuse_config.yaml \
       gcsfuse-ml-tf-data myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -49,7 +49,7 @@ git fetch origin -q
 
 function execute_perf_test() {
   mkdir -p gcs
-  GCSFUSE_FLAGS="--implicit-dirs --max-conns-per-host 100"
+  GCSFUSE_FLAGS="--implicit-dirs"
   BUCKET_NAME=presubmit-perf-tests
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.


### PR DESCRIPTION
### Description
change default value of max-conns-per-host to 0 [unlimited].

### Link to the issue in case of a bug fix.
b/329816962

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
4. Perf tests - (2 runs)
[
![4ZRBxYnyn7WZSTV](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/76d35552-338d-41a1-aeee-bdc2bda28f14)
![5joHVkBWtwGfmiM](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/f23377d9-66c1-46c2-93ab-05d74164e02e)
](url)