### PR TITLE
Moving auth and config packages to stretchr/testify

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -19,26 +19,23 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	storagev1 "google.golang.org/api/storage/v1"
 )
 
 const tpcUniverseDomain = "apis-tpclp.goog"
-
-func TestAuth(t *testing.T) { RunTests(t) }
 
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
 type AuthTest struct {
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&AuthTest{})
-}
-
-func (t *AuthTest) SetUp(ti *TestInfo) {
+func TestAuthSuite(t *testing.T) {
+	suite.Run(t, new(AuthTest))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -47,30 +44,30 @@ func (t *AuthTest) SetUp(ti *TestInfo) {
 
 func (t *AuthTest) TestGetUniverseDomainForGoogle() {
 	contents, err := os.ReadFile("testdata/google_creds.json")
-	AssertEq(nil, err)
+	assert.NoError(t.T(), err)
 
 	domain, err := getUniverseDomain(context.Background(), contents, storagev1.DevstorageFullControlScope)
 
-	ExpectEq(nil, err)
-	ExpectEq(universeDomainDefault, domain)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), universeDomainDefault, domain)
 }
 
 func (t *AuthTest) TestGetUniverseDomainForTPC() {
 	contents, err := os.ReadFile("testdata/tpc_creds.json")
-	AssertEq(nil, err)
+	assert.NoError(t.T(), err)
 
 	domain, err := getUniverseDomain(context.Background(), contents, storagev1.DevstorageFullControlScope)
 
-	ExpectEq(nil, err)
-	ExpectEq(tpcUniverseDomain, domain)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), tpcUniverseDomain, domain)
 }
 
 func (t *AuthTest) TestGetUniverseDomainForEmptyCreds() {
 	contents, err := os.ReadFile("testdata/empty_creds.json")
-	AssertEq(nil, err)
+	assert.NoError(t.T(), err)
 
 	_, err = getUniverseDomain(context.Background(), contents, storagev1.DevstorageFullControlScope)
 
-	ExpectNe(nil, err)
-	ExpectEq("CredentialsFromJSON(): unexpected end of JSON input", err.Error())
+	assert.Error(t.T(), err)
+	assert.Equal(t.T(), "CredentialsFromJSON(): unexpected end of JSON input", err.Error())
 }

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -17,10 +17,9 @@ package config
 import (
 	"testing"
 
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
-
-func TestConfig(t *testing.T) { RunTests(t) }
 
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
@@ -36,9 +35,12 @@ type flags struct {
 	AnonymousAccess  bool
 }
 type ConfigTest struct {
+	suite.Suite
 }
 
-func init() { RegisterTestSuite(&ConfigTest{}) }
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTest))
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
@@ -64,9 +66,9 @@ func (t *ConfigTest) TestOverrideLoggingFlags_WithNonEmptyLogConfigs() {
 
 	OverrideWithLoggingFlags(mountConfig, f.LogFile, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
 
-	AssertEq(mountConfig.LogConfig.Format, "text")
-	AssertEq(mountConfig.LogConfig.FilePath, "/tmp/hello.txt")
-	AssertEq(mountConfig.LogConfig.Severity, TRACE)
+	assert.Equal(t.T(), "text", mountConfig.LogConfig.Format)
+	assert.Equal(t.T(), "/tmp/hello.txt", mountConfig.LogConfig.FilePath)
+	assert.Equal(t.T(), TRACE, mountConfig.LogConfig.Severity)
 }
 
 func (t *ConfigTest) TestOverrideLoggingFlags_WithEmptyLogConfigs() {
@@ -86,9 +88,9 @@ func (t *ConfigTest) TestOverrideLoggingFlags_WithEmptyLogConfigs() {
 
 	OverrideWithLoggingFlags(mountConfig, f.LogFile, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
 
-	AssertEq(mountConfig.LogConfig.Format, "json")
-	AssertEq(mountConfig.LogConfig.FilePath, "a.txt")
-	AssertEq(mountConfig.LogConfig.Severity, INFO)
+	assert.Equal(t.T(), "json", mountConfig.LogConfig.Format)
+	assert.Equal(t.T(), "a.txt", mountConfig.LogConfig.FilePath)
+	assert.Equal(t.T(), INFO, mountConfig.LogConfig.Severity)
 }
 
 func (t *ConfigTest) TestIsFileCacheEnabled() {
@@ -98,10 +100,10 @@ func (t *ConfigTest) TestIsFileCacheEnabled() {
 			MaxSizeMB: -1,
 		},
 	}
-	AssertEq(IsFileCacheEnabled(mountConfig), true)
+	assert.True(t.T(), IsFileCacheEnabled(mountConfig))
 
 	mountConfig1 := &MountConfig{}
-	AssertEq(IsFileCacheEnabled(mountConfig1), false)
+	assert.False(t.T(), IsFileCacheEnabled(mountConfig1))
 
 	mountConfig2 := &MountConfig{
 		CacheDir: "",
@@ -109,7 +111,7 @@ func (t *ConfigTest) TestIsFileCacheEnabled() {
 			MaxSizeMB: -1,
 		},
 	}
-	AssertEq(IsFileCacheEnabled(mountConfig2), false)
+	assert.False(t.T(), IsFileCacheEnabled(mountConfig2))
 
 	mountConfig3 := &MountConfig{
 		CacheDir: "//tmp//folder//",
@@ -117,7 +119,7 @@ func (t *ConfigTest) TestIsFileCacheEnabled() {
 			MaxSizeMB: 0,
 		},
 	}
-	AssertEq(IsFileCacheEnabled(mountConfig3), false)
+	assert.False(t.T(), IsFileCacheEnabled(mountConfig3))
 }
 
 type TestCliContext struct {
@@ -151,7 +153,7 @@ func TestOverrideWithIgnoreInterruptsFlag(t *testing.T) {
 
 			OverrideWithIgnoreInterruptsFlag(testContext, mountConfig, tt.ignoreInterruptFlagValue)
 
-			AssertEq(tt.expectedIgnoreInterrupt, mountConfig.FileSystemConfig.IgnoreInterrupts)
+			assert.Equal(t, tt.expectedIgnoreInterrupt, mountConfig.FileSystemConfig.IgnoreInterrupts)
 		})
 	}
 }
@@ -179,7 +181,7 @@ func TestOverrideWithAnonymousAccessFlag(t *testing.T) {
 
 			OverrideWithAnonymousAccessFlag(testContext, mountConfig, tt.anonymousAccessFlagValue)
 
-			AssertEq(tt.expectedAnonymousAccess, mountConfig.AuthConfig.AnonymousAccess)
+			assert.Equal(t, tt.expectedAnonymousAccess, mountConfig.AuthConfig.AnonymousAccess)
 		})
 	}
 }

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -45,7 +45,7 @@ func validateDefaultConfig(t *testing.T, mountConfig *MountConfig) {
 	assert.False(t, mountConfig.FileCacheConfig.CacheFileForRangeRead)
 	assert.Equal(t, 1, mountConfig.GrpcClientConfig.ConnPoolSize)
 	assert.False(t, mountConfig.AuthConfig.AnonymousAccess)
-	assert.Equal(t, false, bool(mountConfig.EnableHNS))
+	assert.False(t, bool(mountConfig.EnableHNS))
 	assert.False(t, mountConfig.FileSystemConfig.IgnoreInterrupts)
 }
 
@@ -122,7 +122,7 @@ func (t *YamlParserTest) TestReadConfigFile_ValidConfig() {
 	assert.True(t.T(), mountConfig.AuthConfig.AnonymousAccess)
 
 	// enable-hns
-	assert.Equal(t.T(), true, bool(mountConfig.EnableHNS))
+	assert.True(t.T(), bool(mountConfig.EnableHNS))
 
 	// file-system config
 	assert.True(t.T(), mountConfig.FileSystemConfig.IgnoreInterrupts)
@@ -245,5 +245,5 @@ func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_UnsetAnonymousAcces
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), false, mountConfig.AuthConfig.AnonymousAccess)
+	assert.False(t.T(), mountConfig.AuthConfig.AnonymousAccess)
 }


### PR DESCRIPTION
### Description
Moving auth and config packages to stretchr/testify

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
