### PR TITLE
Implement code coverage checks

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,10 +1,10 @@
 codecov:
   strict_yaml_branch: master
 coverage:
-  changes: true
   round: down
   precision: 2
   status:
+    changes: true
     project:
       default:
         target: 60%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  strict_yaml_branch: master
+coverage:
+  changes: true
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 0%
+        flags:
+          - "unittest"
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        flags:
+          - "unittest"
+

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,30 @@
+name: Code Coverage
+on: [push, pull_request]
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.x
+          cache: false
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Test and coverage
+        run: CGO_ENABLED=0 go test -p 1 -covermode=atomic -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.3.1
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.3.1
+        timeout-minutes: 5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This change integrates codecov.io into gcsfuse which would keep track of coverage stats and fail presubmit checks if the code-coverage drops beyond a certain target. For code in master, we've set a minimum value of 60% and for patches, the threshold is 80%.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
