### PR TITLE
fix ignore interrupt integration tests

### DIFF
--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -18,6 +18,7 @@
 package interrupt
 
 import (
+	"log"
 	"path"
 	"testing"
 
@@ -77,6 +78,18 @@ func gitAdd(filePath string) ([]byte, error) {
 func nonEmptyCommit() ([]byte, error) {
 	repositoryPath := path.Join(testDirPath, repoName)
 	return operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "commit -m \"test\"")
+}
+
+func setGithubUserConfig() {
+	repositoryPath := path.Join(testDirPath, repoName)
+	output, err := operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "git config --global user.email \"abc@def.com\"")
+	if err != nil {
+		log.Printf("Error setting git user.email: %s: %v", string(output), err)
+	}
+	output, err = operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "git config --global user.name \"abc\"")
+	if err != nil {
+		log.Printf("Error setting git user.name: %s: %v", string(output), err)
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -142,5 +155,6 @@ func (s *ignoreInterruptsTest) TestGitCommitWithChanges(t *testing.T) {
 
 func TestIgnoreInterrupts(t *testing.T) {
 	ts := &ignoreInterruptsTest{}
+	setGithubUserConfig()
 	test_setup.RunTests(t, ts)
 }

--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -81,11 +81,11 @@ func nonEmptyCommit() ([]byte, error) {
 }
 
 func setGithubUserConfig() {
-	output, err := operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config user.email \"abc@def.com\"")
+	output, err := operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config --global user.email \"abc@def.com\"")
 	if err != nil {
 		log.Printf("Error setting git user.email: %s: %v", string(output), err)
 	}
-	output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config user.name \"abc\"")
+	output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config --global user.name \"abc\"")
 	if err != nil {
 		log.Printf("Error setting git user.name: %s: %v", string(output), err)
 	}

--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -81,11 +81,12 @@ func nonEmptyCommit() ([]byte, error) {
 }
 
 func setGithubUserConfig() {
-	output, err := operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config --global user.email \"abc@def.com\"")
+	repositoryPath := path.Join(testDirPath, repoName)
+	output, err := operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "config user.email \"abc@def.com\"")
 	if err != nil {
 		log.Printf("Error setting git user.email: %s: %v", string(output), err)
 	}
-	output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config --global user.name \"abc\"")
+	output, err = operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "config user.name \"abc\"")
 	if err != nil {
 		log.Printf("Error setting git user.name: %s: %v", string(output), err)
 	}
@@ -121,6 +122,7 @@ func (s *ignoreInterruptsTest) TestGitEmptyCommit(t *testing.T) {
 	if err != nil {
 		t.Errorf("cloneRepository() failed: %v", err)
 	}
+	setGithubUserConfig()
 
 	output, err := emptyCommit()
 
@@ -134,6 +136,7 @@ func (s *ignoreInterruptsTest) TestGitCommitWithChanges(t *testing.T) {
 	if err != nil {
 		t.Errorf("cloneRepository() failed: %v", err)
 	}
+	setGithubUserConfig()
 
 	filePath := path.Join(testDirPath, repoName, testFileName)
 	operations.CreateFileOfSize(util.MiB, filePath, t)
@@ -154,6 +157,5 @@ func (s *ignoreInterruptsTest) TestGitCommitWithChanges(t *testing.T) {
 
 func TestIgnoreInterrupts(t *testing.T) {
 	ts := &ignoreInterruptsTest{}
-	setGithubUserConfig()
 	test_setup.RunTests(t, ts)
 }

--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -81,12 +81,11 @@ func nonEmptyCommit() ([]byte, error) {
 }
 
 func setGithubUserConfig() {
-	repositoryPath := path.Join(testDirPath, repoName)
-	output, err := operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "git config --global user.email \"abc@def.com\"")
+	output, err := operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config user.email \"abc@def.com\"")
 	if err != nil {
 		log.Printf("Error setting git user.email: %s: %v", string(output), err)
 	}
-	output, err = operations.ExecuteToolCommandfInDirectory(repositoryPath, tool, "git config --global user.name \"abc\"")
+	output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "config user.name \"abc\"")
 	if err != nil {
 		log.Printf("Error setting git user.name: %s: %v", string(output), err)
 	}


### PR DESCRIPTION
### Description
The tests were failing on CD pipeline with the following error:
```
git_clone_test.go:116: Git empty commit failed: : failed command '/bin/bash -c git commit --allow-empty -m " empty commit"': exit status 128, Author identity unknown
        
        *** Please tell me who you are.
        
        Run
        
          git config --global user.email "you@example.com"
          git config --global user.name "Your Name"
        
        to set your account's default identity.
```

Fixed by setting the user config before running the tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran on debian 11 and centos 7 VM to verify the fix.
![4Xm7BAfLESVRzHh](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/10f631b6-7e51-4f3b-a45c-217222947338)
![78EwQPAwjcuxMkY](https://github.com/GoogleCloudPlatform/gcsfuse/assets/57195160/421e4708-1e79-4466-a435-3098dfedb072)

3. Unit tests - NA
4. Integration tests - Ran on KOKORO
