### PR TITLE
DontReview Call ls -R from within mount

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,10 +21,12 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/canned"
@@ -207,6 +209,24 @@ func populateArgs(c *cli.Context) (
 	return
 }
 
+func callListRecursive(mountPoint string) (err error) {
+	logger.Debugf("Started recursive listing of %s ...", mountPoint)
+	numItems := 0
+	err = filepath.WalkDir(mountPoint, func(path string, d fs.DirEntry, err error) error {
+		//logger.Infof("Walked path:%s, d=%s, isDir=%v", path, d.Name(), d.IsDir())
+		if err != nil {
+			logger.Errorf("Walked path:%s, d=%s, isDir=%v, err=%v", path, d.Name(), d.IsDir(), err)
+		}
+
+		numItems++
+		return err
+	})
+
+	logger.Debugf("... Completed recursive listing of %s. Number of items listed: %v", mountPoint, numItems)
+
+	return
+}
+
 func runCLIApp(c *cli.Context) (err error) {
 	err = resolvePathForTheFlagsInContext(c)
 	if err != nil {
@@ -365,6 +385,12 @@ func runCLIApp(c *cli.Context) (err error) {
 			return
 		} else {
 			logger.Infof(SuccessfulMountMessage)
+
+			err = callListRecursive(mountPoint)
+			if err != nil {
+				err = fmt.Errorf("daemonize.Run: %w", err)
+				return
+			}
 		}
 
 		return
@@ -384,7 +410,18 @@ func runCLIApp(c *cli.Context) (err error) {
 			// Print the success message in the log-file/stdout depending on what the logger is set to.
 			logger.Info(SuccessfulMountMessage)
 
-			daemonize.SignalOutcome(nil)
+			err = callListRecursive(mountPoint)
+			if err != nil {
+				// Printing via mountStatus will have duplicate logs on the console while
+				// mounting gcsfuse in foreground mode. But this is important to avoid
+				// losing error logs when run in the background mode.
+				logger.Errorf("%s: %v\n", UnsuccessfulMountMessagePrefix, err)
+				err = fmt.Errorf("%s: mountWithArgs: %w", UnsuccessfulMountMessagePrefix, err)
+				daemonize.SignalOutcome(err)
+				return
+			} else {
+				daemonize.SignalOutcome(nil)
+			}
 		} else {
 			// Printing via mountStatus will have duplicate logs on the console while
 			// mounting gcsfuse in foreground mode. But this is important to avoid


### PR DESCRIPTION
This call runs `ls -R` on mount-directory,
right after linux mount, and blocks
returning after mount completion to the user
until the `ls -R` completes.
The `ls -R` is simulated with filepath.WalkDir
which recursively visits each sub-directory
and takes count of all files/directories.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
