### PR TITLE
Update .codecov.yml to use the PRs base as reference

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,3 @@
-codecov:
-  strict_yaml_branch: master
 coverage:
   round: down
   precision: 2


### PR DESCRIPTION
Currently codecov uses master as the reference which doesn't really portray the right picture since the changes in master since the feature branch was cut off can lead to unrelated code coverage changes showing up.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
