### PR TITLE
fix flaky TestRangeReadsWithCacheHit test by reducing the file size

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -85,6 +85,7 @@ func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSeq
 	var expectedOutcome [2]*Expected
 	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeSameAsCacheCapacity, t)
 	testFileNames[1] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeSameAsCacheCapacity, t)
+	randomReadChunkCount := fileSizeSameAsCacheCapacity / chunkSizeToRead
 
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -70,9 +70,9 @@ func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
 	// Do a random read on file and validate from gcs.
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForFirstRangeRead, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset5000, t)
 	// Read file again from offset 1000 and validate from gcs.
-	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForSecondRangeRead, t)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset1000, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
 	validate(expectedOutcome1, structuredReadLogs[0], false, false, 1, t)
@@ -83,8 +83,8 @@ func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.
 func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache(t *testing.T) {
 	var testFileNames [2]string
 	var expectedOutcome [2]*Expected
-	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
-	testFileNames[1] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
+	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeSameAsCacheCapacity, t)
+	testFileNames[1] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeSameAsCacheCapacity, t)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {
@@ -111,7 +111,7 @@ func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSeq
 	ogletest.ExpectEq(true, structuredReadLogs[1].Chunks[randomReadChunkCount-1].CacheHit)
 
 	validateFileIsNotCached(testFileNames[0], t)
-	validateFileInCacheDirectory(testFileNames[1], fileSizeForRangeRead, s.ctx, s.storageClient, t)
+	validateFileInCacheDirectory(testFileNames[1], fileSizeSameAsCacheCapacity, s.ctx, s.storageClient, t)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -57,11 +57,11 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeForRangeRead, t)
 
 	// Do a random read on file and validate from gcs.
-	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForFirstRangeRead, t)
+	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset5000, t)
 	// Wait for the cache to propagate the updates before proceeding to get cache hit.
 	time.Sleep(2 * time.Second)
 	// Read file again from zeroOffset 1000 and validate from gcs.
-	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForSecondRangeRead, t)
+	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset1000, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
 	validate(expectedOutcome1, structuredReadLogs[0], false, false, 1, t)

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -59,7 +59,6 @@ const (
 	offsetForRangeReadWithin8MB         = 4 * util.MiB
 	offset10MiB                         = 10 * util.MiB
 	cacheCapacityForRangeReadTestInMiB  = 50
-	randomReadChunkCount                = fileSizeForRangeRead / chunkSizeToRead
 	cacheCapacityForVeryLargeFileInMiB  = 500
 	veryLargeFileSize                   = cacheCapacityForVeryLargeFileInMiB * util.MiB
 	offsetEndOfFile                     = veryLargeFileSize - 1*util.MiB

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -38,7 +38,8 @@ const (
 	smallContentSize                    = 128 * util.KiB
 	chunkSizeToRead                     = 128 * util.KiB
 	fileSize                            = 3 * util.MiB
-	fileSizeForRangeRead                = cacheCapacityForRangeReadTestInMiB * util.MiB
+	fileSizeSameAsCacheCapacity         = cacheCapacityForRangeReadTestInMiB * util.MiB
+	fileSizeForRangeRead                = 8 * util.MiB
 	chunksRead                          = fileSize / chunkSizeToRead
 	testFileName                        = "foo"
 	cacheCapacityInMB                   = 9
@@ -53,8 +54,8 @@ const (
 	zeroOffset                          = 0
 	randomReadOffset                    = 9 * util.MiB
 	configFileName                      = "config"
-	offsetForFirstRangeRead             = 5000
-	offsetForSecondRangeRead            = 1000
+	offset5000                          = 5000
+	offset1000                          = 1000
 	offsetForRangeReadWithin8MB         = 4 * util.MiB
 	offset10MiB                         = 10 * util.MiB
 	cacheCapacityForRangeReadTestInMiB  = 50


### PR DESCRIPTION
### Description
TestRangeReadsWithCacheHit was sometimes failing with the following error:
```
2024/05/20 04:36:31 Running tests with flags: [--implicit-dirs=true --config-file=/tmp/gcsfuse_readwrite_test_2956740480/config --o=ro]
=== RUN   TestCacheFileForRangeReadTrueTest/TestRangeReadsWithCacheHit
    helpers_test.go:118: Incorrect cached file size. Expected 52428800, Got: 20044413
    gcs_helper.go:164: CRC32 mismatch. Expected 583443541, Got 3098506051
```
Fix: Reduced the file size to 8 MiB to ensure that complete file gets cached within time limit.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran on louhi - the test did not fail in any of the runs
2. Unit tests - NA
3. Integration tests - via KOKORO (The test did not fail in any of the KOKORO runs)
