### PR TITLE
Fix semantic doc for implicit dirs

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -202,9 +202,7 @@ The above example was based on greenfield deployments which assumes starting fre
 
 However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
 
-So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using
-
-`gsutil cp -r`
+So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using `gsutil cp -r` command)
 - A/1.txt
 - A/B/2.txt
 - C/3.txt

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -202,7 +202,8 @@ The above example was based on greenfield deployments which assumes starting fre
 
 However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
 
-If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command. - A/1.txt
+If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command.
+- A/1.txt
 - A/B/2.txt
 - C/3.txt
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -207,7 +207,7 @@ If a user has the following objects in their Cloud Storage buckets, for example 
 - C/3.txt
 
 then mounting the bucket and running ```ls``` to see its content will not show any files until placeholder directory objects A/, A/B/, and C/ are created in the GCS bucket. These placeholder directory objects can be created by running `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C` on GCSFuse mounted directory.
-At which point they will correctly see:
+At which point the user will correctly see:
 - A/
 - A/1.txt
 - A/B/

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,5 +1,3 @@
-
-
 # Read/Writes
 
 **Reads**

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -200,19 +200,23 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
-However, If a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the Cloud Storage bucket using Cloud Storage FUSE, then those directories (and the sub-directories and objects under them) will not be visible. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching Cloud Storage object ending in a slash exists.
+However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
 
-**Note**: These backing objects for directories are special 0-byte objects, which are placeholders for directories, and can only be created either with Cloud Storage Fuse using mkdir command or other Cloud clients e.g. Google Cloud Console. These backing objects are not created by the Cloud Storage CLI tools such as `gcloud` and `gsutil`.
+So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using
 
-Lets take an example. The user creates the following objects by uploading a local directory using `gcloud cp -r` command (learn more [here](https://cloud.google.com/storage/docs/objects#command-line)). Since gcloud creates [simulated folders](https://cloud.google.com/storage/docs/objects#simulated-folders) the following hierarchy may get created:
-- A/ (no backing object on Cloud Storage bucket)
+`gsutil cp -r`
 - A/1.txt
-- A/B/ (no backing object on Cloud Storage bucket)
 - A/B/2.txt
-- C/ (no backing object on Cloud Storage bucket)
 - C/3.txt
 
-Then, mounting the bucket and running ```ls``` to see its content will not show any files until either the directories A/, A/B/, and C/ get their backing Cloud Storage objects or `--implicit-dirs` flag is set in Cloud Storage Fuse mount command.
+then mounting the bucket and running ```ls``` to see its content will not show any files until the directories A/, A/B/, and C/ are created on the local filesystem using the `mkdir` command (or create these from the WebUI). A user would have to run `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C`
+At which point they will correctly see:
+- A/
+- A/1.txt
+- A/B/
+- A/B/2.txt
+- C/
+- C/3.txt
 
 **Using ```--implicit-dirs``` flag:**
 
@@ -225,7 +229,6 @@ However, implicit directories does have drawbacks:
 - With the example above, it will appear as if there is a directory called "A/" containing a file called "1.txt". But when the user runs ‘rm A/1.txt’, it will appear as if the file system is completely empty. This is contrary to expectations, since the user hasn't run ```rmdir A/```.
 - Cloud Storage FUSE sends a single Objects.list request to Cloud Storage, and treats the directory as being implicitly defined if the results are non-empty. In rare cases (notably when many objects have recently been deleted) Objects.list may return an arbitrary number of empty responses with continuation tokens, even for a non-empty name range. In order to bound the number of requests, Cloud Storage FUSE simply ignores this subtlety. Therefore in rare cases an implicitly defined directory will fail to appear.
 
-**Note:** `--implicit-dirs` flag is detrimental to performance, so it should be avoided unless necessary. To avoid it, you can mount using `--implicit-dirs` flag once, then create the directories on the mounted filesystem using the ```mkdir``` command, which will create the Cloud Storage objects backing the directories, and then mount without `--implicit-dirs` flag from the next time onwards.
 Alternatively, users can create a script which lists the buckets and creates the appropriate objects for the directories so that the ```--implicit-dirs``` flag is not used.
 
 # Generations

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -202,7 +202,7 @@ The above example was based on greenfield deployments which assumes starting fre
 
 However, If a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the Cloud Storage bucket using Cloud Storage FUSE, then those directories (and the sub-directories and objects under them) will not be visible, which do not have backing Cloud Storage objects. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching Cloud Storage object ending in a slash exists.
 
-**Note**: These backing objects for directories are special 0-byte objects, which are placeholders for directories, and can only be created either with Cloud Storage Fuse using mkdir command or other Cloud clients e.g. Cloud Web UI.
+**Note**: These backing objects for directories are special 0-byte objects, which are placeholders for directories, and can only be created either with Cloud Storage Fuse using mkdir command or other Cloud clients e.g. Cloud Web UI. These backing objects are not created by the Cloud Storage CLI tools such as `gcloud` and `gsutil`.
 
 Let us assume the user has the following objects in their Cloud Storage bucket (for example created by uploading a local directory using ``` gsutil cp -r``` command),
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -200,13 +200,12 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
 However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects which are placeholders for directories. Note that these can also be created via the WebUI and Cloud Storage SDKs, but not by the Cloud Storage CLI tools such as gcloud or gsutil.
-
 If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command.
 - A/1.txt
 - A/B/2.txt
 - C/3.txt
 
-then mounting the bucket and running ```ls``` to see its content will not show any files until the directories A/, A/B/, and C/ are created on the local filesystem using the `mkdir` command (or create these from the WebUI). A user would have to run `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C`.
+then mounting the bucket and running ```ls``` to see its content will not show any files until placeholder directory objects A/, A/B/, and C/ are created in the GCS bucket. These placeholder directory objects can be created by running `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C` on GCSFuse mounted directory.
 At which point they will correctly see:
 - A/
 - A/1.txt

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -200,6 +200,7 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
 However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects which are placeholders for directories. Note that these can also be created via the WebUI and Cloud Storage SDKs, but not by the Cloud Storage CLI tools such as gcloud or gsutil.
+
 If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command.
 - A/1.txt
 - A/B/2.txt

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -1,4 +1,5 @@
 
+
 # Read/Writes
 
 **Reads**
@@ -200,7 +201,7 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
-However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
+However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects which are placeholders for directories. Note that these can also be created via the WebUI and Cloud Storage SDKs, but not by the Cloud Storage CLI tools such as gcloud or gsutil.
 
 If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command.
 - A/1.txt

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -202,12 +202,12 @@ The above example was based on greenfield deployments which assumes starting fre
 
 However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
 
-So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using `gsutil cp -r` command)
+So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using `gsutil cp -r` command).
 - A/1.txt
 - A/B/2.txt
 - C/3.txt
 
-then mounting the bucket and running ```ls``` to see its content will not show any files until the directories A/, A/B/, and C/ are created on the local filesystem using the `mkdir` command (or create these from the WebUI). A user would have to run `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C`
+then mounting the bucket and running ```ls``` to see its content will not show any files until the directories A/, A/B/, and C/ are created on the local filesystem using the `mkdir` command (or create these from the WebUI). A user would have to run `mkdir ./A`, `mkdir ./A/B` and `mkdir ./C`.
 At which point they will correctly see:
 - A/
 - A/1.txt

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -200,10 +200,9 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
-However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
+However, if a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the bucket using Cloud Storage FUSE, the directories and objects under the directories will not be visible until a user manually creates the directory, with the same name, using mkdir on the local instance (or by creating the folder in the WebUI). This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching object ending in a slash exists.  These backing objects for directories are special 0-byte objects, which are placeholders for directories and are not created by the Cloud Storage CLI tools such as gcloud or gsutil.
 
-So if a user has the following objects in their Cloud Storage buckets, that were not originally created via Cloud Storage FUSE (for example created by uploading a local directory using `gsutil cp -r` command).
-- A/1.txt
+If a user has the following objects in their Cloud Storage buckets, for example created by uploading a local directory using `gsutil cp -r` command. - A/1.txt
 - A/B/2.txt
 - C/3.txt
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -200,12 +200,11 @@ Even though A/, A/B/, and C/ are directories in the filesystem, a 0-byte object 
 
 The above example was based on greenfield deployments which assumes starting fresh, where the directories are created from Cloud Storage FUSE. If a user unmounts this Cloud Storage FUSE bucket, and then re-mounts it to a different path, the user will see the directory structure correctly in the filesystem because it was originally created by Cloud Storage FUSE.
 
-However, If a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the Cloud Storage bucket using Cloud Storage FUSE, then those directories (and the sub-directories and objects under them) will not be visible, which do not have backing Cloud Storage objects. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching Cloud Storage object ending in a slash exists.
+However, If a user already has objects with prefixes to simulate a directory structure in their buckets that did not originate from Cloud Storage FUSE, and mounts the Cloud Storage bucket using Cloud Storage FUSE, then those directories (and the sub-directories and objects under them) will not be visible. This is because with Cloud Storage FUSE, directories are by default not implicitly defined; they exist only if a matching Cloud Storage object ending in a slash exists.
 
-**Note**: These backing objects for directories are special 0-byte objects, which are placeholders for directories, and can only be created either with Cloud Storage Fuse using mkdir command or other Cloud clients e.g. Cloud Web UI. These backing objects are not created by the Cloud Storage CLI tools such as `gcloud` and `gsutil`.
+**Note**: These backing objects for directories are special 0-byte objects, which are placeholders for directories, and can only be created either with Cloud Storage Fuse using mkdir command or other Cloud clients e.g. Google Cloud Console. These backing objects are not created by the Cloud Storage CLI tools such as `gcloud` and `gsutil`.
 
-Let us assume the user has the following objects in their Cloud Storage bucket (for example created by uploading a local directory using ``` gsutil cp -r``` command),
-
+Lets take an example. The user creates the following objects by uploading a local directory using `gcloud cp -r` command (learn more [here](https://cloud.google.com/storage/docs/objects#command-line)). Since gcloud creates [simulated folders](https://cloud.google.com/storage/docs/objects#simulated-folders) the following hierarchy may get created:
 - A/ (no backing object on Cloud Storage bucket)
 - A/1.txt
 - A/B/ (no backing object on Cloud Storage bucket)
@@ -226,9 +225,8 @@ However, implicit directories does have drawbacks:
 - With the example above, it will appear as if there is a directory called "A/" containing a file called "1.txt". But when the user runs ‘rm A/1.txt’, it will appear as if the file system is completely empty. This is contrary to expectations, since the user hasn't run ```rmdir A/```.
 - Cloud Storage FUSE sends a single Objects.list request to Cloud Storage, and treats the directory as being implicitly defined if the results are non-empty. In rare cases (notably when many objects have recently been deleted) Objects.list may return an arbitrary number of empty responses with continuation tokens, even for a non-empty name range. In order to bound the number of requests, Cloud Storage FUSE simply ignores this subtlety. Therefore in rare cases an implicitly defined directory will fail to appear.
 
-Alternatively, users can create a script which lists the buckets and creates the appropriate objects for the directories so that the ```--implicit-dirs``` flag is not used. 
-
-**Note:** `--implicit-dirs` flag is detrimental to performance, so it should be avoided unless necessary. To avoid it, you can mount using `--implicit-dirs` flag once, then create the directories on the mounted filesystem using the ```mkdir``` command, which will create the Cloud  Storage objects backing the directories, and then mount without --implicit-dirs  flag from the next time onwards.
+**Note:** `--implicit-dirs` flag is detrimental to performance, so it should be avoided unless necessary. To avoid it, you can mount using `--implicit-dirs` flag once, then create the directories on the mounted filesystem using the ```mkdir``` command, which will create the Cloud Storage objects backing the directories, and then mount without `--implicit-dirs` flag from the next time onwards.
+Alternatively, users can create a script which lists the buckets and creates the appropriate objects for the directories so that the ```--implicit-dirs``` flag is not used.
 
 # Generations
 


### PR DESCRIPTION
### Description
The documentation is misleading because it fails to mention that Pantheon's "create folder" action also creates a 0-byte object, making it visible even without the implicit-dir flag.

Our documentation currently states that using the mkdir command in the filesystem is necessary, which is misleading.

Corrected the documentation to clarify it clearly.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
