### PR TITLE
[Temp]  Enable listing improvements in long-running tests

### DIFF
--- a/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
+++ b/perfmetrics/scripts/ml_tests/pytorch/run_model.sh
@@ -58,6 +58,8 @@ nohup /pytorch_dino/gcsfuse/gcsfuse --foreground \
         --stackdriver-export-interval=60s \
         --implicit-dirs \
         --config-file $config_filename \
+        --metadata-prefetch-on-mount=async \
+        --kernel-list-cache-ttl-secs=-1 \
       $TEST_BUCKET gcsfuse_data > "run_artifacts/gcsfuse.out" 2> "run_artifacts/gcsfuse.err" &
 
 # Update the pytorch library code to bypass the kernel-cache

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -30,6 +30,8 @@ nohup gcsfuse/gcsfuse --foreground \
       --implicit-dirs \
       --stackdriver-export-interval 60s \
       --config-file /tmp/gcsfuse_config.yaml \
+      --metadata-prefetch-on-mount=async \
+      --kernel-list-cache-ttl-secs=-1 \
       gcsfuse-ml-tf-data myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library


### PR DESCRIPTION
Add `--metadata-prefetch-on-mount=async` and
 `--kernel-list-cache-ttl-secs=-1` both to
 the cli-flags of the GCSFuse mount to all the
 long-running tests (PT dino model and TF resnet model).

It should be merged only after https://github.com/GoogleCloudPlatform/gcsfuse/pull/1897 .

This is only for a onetime run of long-running tests and should be removed after that.

### Description
Enable listing improvements in longrunning tests
    
Add `--metadata-prefetch-on-mount=async` and `--kernel-list-cache-ttl-secs=-1` both to the cli-flags of the GCSFuse mount to all the long-running tests (PT dino model and TF resnet model).

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
