### PR TITLE
Disable the "changes" feature of codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,7 +2,6 @@ coverage:
   round: down
   precision: 2
   status:
-    changes: true
     project:
       default:
         target: 60%


### PR DESCRIPTION
The "changes" feature detects unrelated code coverage changes. It's been noisy for gcsfuse. Disabling it.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
