### PR TITLE
Remove operations e2e tests for metadata-prefetch

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -132,16 +132,6 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	filePath3 := setup.YAMLConfigFile(mountConfig3, "config3.yaml")
 	flags = append(flags, []string{"--config-file=" + filePath3})
 
-	// Set up config file testing experimental-metadata-prefetch-on-mount: "async".
-	mountConfig4 := config.MountConfig{
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
-	}
-	filePath4 := setup.YAMLConfigFile(mountConfig4, "config4.yaml")
-	flags = append(flags, []string{"--config-file=" + filePath4, "--experimental-metadata-prefetch-on-mount=async"})
-
 	return flags
 }
 


### PR DESCRIPTION
### Description
Removing these tests as these are failing in some cases in periodic e2e tests.
This is only an experimental feature right now, so its failing integration tests should not block
periodic e2e tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
