### PR TITLE
Close the reader of async job in file cache to have the closing debug logs

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -362,6 +362,10 @@ func (job *Job) downloadObjectAsync() {
 				}
 				start += maxRead
 				if start == newReaderLimit {
+					err = newReader.Close()
+					if err != nil {
+						logger.Errorf("Job:%p (%s:/%s) error while closing reader: %v", job, job.bucket.Name(), job.object.Name, err)
+					}
 					newReader = nil
 				}
 


### PR DESCRIPTION
### Description
Close the reader of async job in file cache to have the closing logs

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Checked with and without changes. With changes the closing logs appear.
2. Unit tests - NA
3. Integration tests -[link](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/6e27566c-42a6-4de7-ad43-01c1db7877f5/log)
