### PR TITLE
Add handling for custom types in Config object.

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -65,7 +65,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("client-protocol", "", "http1", "The protocol used for communicating with the GCS backend. Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2) or grpc.")
+	flagSet.StringP("client-protocol", "", "http1", "The protocol used for communicating with the GCS backend. Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.")
 
 	err = viper.BindPFlag("gcs-connection.client-protocol", flagSet.Lookup("client-protocol"))
 	if err != nil {
@@ -107,14 +107,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("log-file", "", "", "The file for storing logs that can be parsed by fluentd. When not provided, plain text logs are printed to stdout.")
+	flagSet.StringP("log-file", "", "", "The file for storing logs that can be parsed by fluentd. When not provided, plain text logs are printed to stdout when Cloud Storage FUSE is run  in the foreground, or to syslog when Cloud Storage FUSE is run in the  background.")
 
 	err = viper.BindPFlag("logging.file-path", flagSet.Lookup("log-file"))
 	if err != nil {
 		return err
 	}
 
-	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity")
+	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
 	err = viper.BindPFlag("logging.severity", flagSet.Lookup("log-severity"))
 	if err != nil {

--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -15,18 +15,13 @@
 package cfg
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
-	"slices"
-	"strconv"
-	"strings"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/mitchellh/mapstructure"
 )
 
-func customTypeDecodeHook() mapstructure.DecodeHookFuncType {
+func decodeURLHook() mapstructure.DecodeHookFuncType {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
@@ -35,33 +30,15 @@ func customTypeDecodeHook() mapstructure.DecodeHookFuncType {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
-		s := data.(string)
-		switch t {
-		case reflect.TypeOf(Octal(0)):
-			return strconv.ParseInt(s, 8, 32)
-		case reflect.TypeOf(url.URL{}):
-			u, err := url.Parse(s)
-			if err != nil {
-				return nil, err
-			}
-			return *u, nil
-		case reflect.TypeOf(LogSeverity("")):
-			level := strings.ToUpper(s)
-			if !slices.Contains([]string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "OFF"}, level) {
-				return nil, fmt.Errorf("invalid logseverity: %s", s)
-			}
-			return level, nil
-		case reflect.TypeOf(Protocol("")):
-			protocol := strings.ToLower(s)
-			if !slices.Contains([]string{"http1", "http2", "grpc"}, protocol) {
-				return nil, fmt.Errorf("invalid protocol: %s", s)
-			}
-			return protocol, nil
-		case reflect.TypeOf(ResolvedPath("")):
-			return util.GetResolvedPath(s)
-		default:
+		if t != reflect.TypeOf(url.URL{}) {
 			return data, nil
 		}
+		s := data.(string)
+		u, err := url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+		return *u, nil
 	}
 }
 
@@ -69,7 +46,7 @@ func customTypeDecodeHook() mapstructure.DecodeHookFuncType {
 func DecodeHook() mapstructure.DecodeHookFunc {
 	return mapstructure.ComposeDecodeHookFunc(
 		mapstructure.TextUnmarshallerHookFunc(),
-		customTypeDecodeHook(),
+		decodeURLHook(),
 		mapstructure.StringToTimeDurationHookFunc(), // default hook
 		mapstructure.StringToSliceHookFunc(","),     // default hook
 	)

--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-func decodeURLHook() mapstructure.DecodeHookFuncType {
+func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
@@ -46,7 +46,7 @@ func decodeURLHook() mapstructure.DecodeHookFuncType {
 func DecodeHook() mapstructure.DecodeHookFunc {
 	return mapstructure.ComposeDecodeHookFunc(
 		mapstructure.TextUnmarshallerHookFunc(),
-		decodeURLHook(),
+		stringToURLHookFunc(),
 		mapstructure.StringToTimeDurationHookFunc(), // default hook
 		mapstructure.StringToSliceHookFunc(","),     // default hook
 	)

--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+	"github.com/mitchellh/mapstructure"
+)
+
+func customTypeDecodeHook() mapstructure.DecodeHookFuncType {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		s := data.(string)
+		switch t {
+		case reflect.TypeOf(Octal(0)):
+			return strconv.ParseInt(s, 8, 32)
+		case reflect.TypeOf(url.URL{}):
+			u, err := url.Parse(s)
+			if err != nil {
+				return nil, err
+			}
+			return *u, nil
+		case reflect.TypeOf(LogSeverity("")):
+			level := strings.ToUpper(s)
+			if !slices.Contains([]string{"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "OFF"}, level) {
+				return nil, fmt.Errorf("invalid logseverity: %s", s)
+			}
+			return level, nil
+		case reflect.TypeOf(Protocol("")):
+			protocol := strings.ToLower(s)
+			if !slices.Contains([]string{"http1", "http2", "grpc"}, protocol) {
+				return nil, fmt.Errorf("invalid protocol: %s", s)
+			}
+			return protocol, nil
+		case reflect.TypeOf(ResolvedPath("")):
+			return util.GetResolvedPath(s)
+		default:
+			return data, nil
+		}
+	}
+}
+
+// DecodeHook will be called by Viper while constructing the config object.
+func DecodeHook() mapstructure.DecodeHookFunc {
+	return mapstructure.ComposeDecodeHookFunc(
+		mapstructure.TextUnmarshallerHookFunc(),
+		customTypeDecodeHook(),
+		mapstructure.StringToTimeDurationHookFunc(), // default hook
+		mapstructure.StringToSliceHookFunc(","),     // default hook
+	)
+}

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -229,17 +229,17 @@ func TestParsingSuccess(t *testing.T) {
 		},
 	}
 
-	for _, k := range tests {
-		t.Run(k.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if k.setupFn != nil {
-				k.setupFn()
+			if tc.setupFn != nil {
+				tc.setupFn()
 			}
 			c := TestConfig{}
 			fs := declareFlags()
 			v := bindFlags(fs)
 			args := []string{"test"}
-			args = append(args, k.args...)
+			args = append(args, tc.args...)
 			err := fs.Parse(args)
 			if err != nil {
 				t.Fatalf("Flag parsing failed: %v", err)
@@ -248,7 +248,7 @@ func TestParsingSuccess(t *testing.T) {
 			err = v.Unmarshal(&c, viper.DecodeHook(DecodeHook()))
 
 			if assert.Nil(t, err) {
-				k.testFn(t, c)
+				tc.testFn(t, c)
 			}
 		})
 	}

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -1,0 +1,307 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg
+
+import (
+	"net/url"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func bindFlag(t *testing.T, v *viper.Viper, key string, f *flag.Flag) {
+	t.Helper()
+	err := v.BindPFlag(key, f)
+	if err != nil {
+		t.Fatalf("Error occured while binding key: %s to flag: %v", key, err)
+	}
+}
+
+func TestParsingSuccess(t *testing.T) {
+	type TestConfig struct {
+		OctalParam       Octal
+		URLParam         url.URL
+		BoolParam        bool
+		StringParam      string
+		IntParam         int
+		FloatParam       float64
+		DurationParam    time.Duration
+		StringSliceParam []string
+		IntSliceParam    []int
+		LogSeverityParam LogSeverity
+		ProtocolParam    Protocol
+		PathParam        ResolvedPath
+	}
+	declareFlags := func() *flag.FlagSet {
+		fs := flag.NewFlagSet("test", flag.ExitOnError)
+		fs.String("urlParam", "", "")
+		fs.String("octalParam", "0", "")
+		fs.String("stringParam", "", "")
+		fs.Int("intParam", 0, "")
+		fs.Float64("floatParam", 0.0, "")
+		fs.Duration("durationParam", 0*time.Nanosecond, "")
+		fs.StringSlice("stringSliceParam", []string{}, "")
+		fs.IntSlice("intSliceParam", []int{}, "")
+		fs.Bool("boolParam", false, "")
+		fs.String("logSeverityParam", "INFO", "")
+		fs.String("protocolParam", "http1", "")
+		fs.String("pathParam", "", "")
+		return fs
+	}
+
+	bindFlags := func(fs *flag.FlagSet) *viper.Viper {
+		t.Helper()
+		v := viper.New()
+		bindFlag(t, v, "URLParam", fs.Lookup("urlParam"))
+		bindFlag(t, v, "OctalParam", fs.Lookup("octalParam"))
+		bindFlag(t, v, "StringParam", fs.Lookup("stringParam"))
+		bindFlag(t, v, "IntParam", fs.Lookup("intParam"))
+		bindFlag(t, v, "FloatParam", fs.Lookup("floatParam"))
+		bindFlag(t, v, "DurationParam", fs.Lookup("durationParam"))
+		bindFlag(t, v, "StringSliceParam", fs.Lookup("stringSliceParam"))
+		bindFlag(t, v, "IntSliceParam", fs.Lookup("intSliceParam"))
+		bindFlag(t, v, "BoolParam", fs.Lookup("boolParam"))
+		bindFlag(t, v, "LogSeverityParam", fs.Lookup("logSeverityParam"))
+		bindFlag(t, v, "ProtocolParam", fs.Lookup("protocolParam"))
+		bindFlag(t, v, "PathParam", fs.Lookup("pathParam"))
+		return v
+	}
+	tests := []struct {
+		name    string
+		args    []string
+		param   string
+		setupFn func()
+		testFn  func(*testing.T, TestConfig)
+	}{
+		{
+			name: "Octal",
+			args: []string{"--octalParam=755"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, Octal(0755), c.OctalParam)
+			},
+		},
+		{
+			name: "URL",
+			args: []string{"--urlParam=http://abc.xyz"},
+			testFn: func(t *testing.T, c TestConfig) {
+				u, err := url.Parse("http://abc.xyz")
+				if err != nil {
+					t.Fatalf("Error while parsing URL: %v", err)
+				}
+				assert.Equal(t, *u, c.URLParam)
+			},
+		},
+		{
+			name: "Bool1",
+			args: []string{"--boolParam"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.True(t, c.BoolParam)
+			},
+		},
+		{
+			name: "Bool2",
+			args: []string{"--boolParam=true"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.True(t, c.BoolParam)
+			},
+		},
+		{
+			name: "Bool3",
+			args: []string{"--boolParam=false"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.False(t, c.BoolParam)
+			},
+		},
+		{
+			name: "String",
+			args: []string{"--stringParam=abc"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, "abc", c.StringParam)
+			},
+		},
+		{
+			name: "Int",
+			args: []string{"--intParam=23"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, 23, c.IntParam)
+			},
+		},
+		{
+			name: "Float",
+			args: []string{"--floatParam=2.5"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, 2.5, c.FloatParam)
+			},
+		},
+		{
+			name: "Duration",
+			args: []string{"--durationParam=30s"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, 30*time.Second, c.DurationParam)
+			},
+		},
+		{
+			name: "StringSlice1",
+			args: []string{"--stringSliceParam=a,b"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.ElementsMatch(t, []string{"a", "b"}, c.StringSliceParam)
+			},
+		},
+		{
+			name: "StringSlice2",
+			args: []string{"--stringSliceParam=a", "--stringSliceParam=b"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.ElementsMatch(t, []string{"a", "b"}, c.StringSliceParam)
+			},
+		},
+		{
+			name: "IntSlice1",
+			args: []string{"--intSliceParam=2,-11"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.ElementsMatch(t, []int{2, -11}, c.IntSliceParam)
+			},
+		},
+		{
+			name: "IntSlice2",
+			args: []string{"--intSliceParam=3", "--intSliceParam=5"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.ElementsMatch(t, []int{3, 5}, c.IntSliceParam)
+			},
+		},
+		{
+			name: "LogSeverity",
+			args: []string{"--logSeverityParam=WARNING"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, LogSeverity("WARNING"), c.LogSeverityParam)
+			},
+		},
+		{
+			name: "ResolvedPath1",
+			args: []string{"--pathParam=~/test.txt"},
+			testFn: func(t *testing.T, c TestConfig) {
+				h, err := os.UserHomeDir()
+				if assert.Nil(t, err) {
+					assert.Equal(t, path.Join(h, "test.txt"), string(c.PathParam))
+				}
+			},
+		},
+		{
+			name: "ResolvedPath2",
+			setupFn: func() {
+				os.Setenv("gcsfuse-parent-process-dir", "/a")
+				t.Cleanup(func() { os.Unsetenv("gcsfuse-parent-process-dir") })
+			},
+			args: []string{"--pathParam=./test.txt"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, "/a/test.txt", string(c.PathParam))
+			},
+		},
+	}
+
+	for _, k := range tests {
+		t.Run(k.name, func(t *testing.T) {
+			t.Parallel()
+			if k.setupFn != nil {
+				k.setupFn()
+			}
+			c := TestConfig{}
+			fs := declareFlags()
+			v := bindFlags(fs)
+			args := []string{"test"}
+			args = append(args, k.args...)
+			err := fs.Parse(args)
+			if err != nil {
+				t.Fatalf("Flag parsing failed: %v", err)
+			}
+
+			err = v.Unmarshal(&c, viper.DecodeHook(DecodeHook()))
+
+			if assert.Nil(t, err) {
+				k.testFn(t, c)
+			}
+		})
+	}
+}
+
+func TestParsingError(t *testing.T) {
+	type TestConfig struct {
+		OctalParam       Octal
+		URLParam         url.URL
+		LogSeverityParam LogSeverity
+		ProtocolParam    Protocol
+	}
+	declareFlags := func() *flag.FlagSet {
+		fs := flag.NewFlagSet("test", flag.ExitOnError)
+		fs.String("octalParam", "0", "")
+		fs.String("urlParam", "", "")
+		fs.String("logSeverityParam", "INFO", "")
+		fs.String("protocolParam", "http1", "")
+		return fs
+	}
+	bindFlags := func(fs *flag.FlagSet) *viper.Viper {
+		t.Helper()
+		v := viper.New()
+		bindFlag(t, v, "OctalParam", fs.Lookup("octalParam"))
+		bindFlag(t, v, "URLParam", fs.Lookup("urlParam"))
+		bindFlag(t, v, "LogSeverityParam", fs.Lookup("logSeverityParam"))
+		bindFlag(t, v, "ProtocolParam", fs.Lookup("protocolParam"))
+		return v
+	}
+	tests := []struct {
+		name  string
+		args  []string
+		param string
+	}{
+		{
+			name: "Octal",
+			args: []string{"--octalParam=923"},
+		},
+		{
+			name: "URL",
+			args: []string{"--urlParam=a_b://abc"},
+		},
+		{
+			name: "LogSeverity",
+			args: []string{"--logSeverityParam=abc"},
+		},
+		{
+			name: "Protocol",
+			args: []string{"--protocolParam=pqr"},
+		},
+	}
+	for _, k := range tests {
+		t.Run(k.name, func(t *testing.T) {
+			t.Parallel()
+			fs := declareFlags()
+			v := bindFlags(fs)
+			c := TestConfig{}
+			args := []string{"test"}
+			args = append(args, k.args...)
+			err := fs.Parse(args)
+			if err != nil {
+				t.Fatalf("Flag parsing failed: %v", err)
+			}
+
+			err = v.Unmarshal(&c, viper.DecodeHook(DecodeHook()))
+
+			assert.NotNil(t, err)
+		})
+	}
+}

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -18,8 +18,21 @@ import (
 	"fmt"
 )
 
+// Octal is the datatype for params such as file-mode and dir-mode which accept a base-8 value.
 type Octal int
 
 func (oi Octal) String() string {
 	return fmt.Sprintf("%o", oi)
 }
+
+// Protocol is the datatype that specifies the type of connection: http1/http2/grpc.
+type Protocol string
+
+// LogSeverity represents the logging severity and can accept the following values
+// "TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "OFF"
+type LogSeverity string
+
+// ResolvedPath represents a file-path which could be the absolute or relative
+// path or could be resolved based on the value of GCSFUSE_PARENT_PROCESS_DIR
+// env var.
+type ResolvedPath string

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -68,9 +68,8 @@ func (l *LogSeverity) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// ResolvedPath represents a file-path which could be the absolute or relative
-// path or could be resolved based on the value of GCSFUSE_PARENT_PROCESS_DIR
-// env var.
+// ResolvedPath represents a file-path which is an absolute path and is resolved
+// based on the value of GCSFUSE_PARENT_PROCESS_DIR env var.
 type ResolvedPath string
 
 func (p *ResolvedPath) UnmarshalText(text []byte) error {

--- a/tools/config-gen/flag_template_data_gen.go
+++ b/tools/config-gen/flag_template_data_gen.go
@@ -50,13 +50,6 @@ func computeFlagTemplateDataForParam(p Param) (flagTemplateData, error) {
 			defaultValue = p.DefaultValue
 		}
 		fn = "IntP"
-	case "octal":
-		if p.DefaultValue == "" {
-			defaultValue = "0"
-		} else {
-			defaultValue = p.DefaultValue
-		}
-		fn = "IntP"
 	case "float64":
 		if p.DefaultValue == "" {
 			defaultValue = "0.0"
@@ -83,6 +76,16 @@ func computeFlagTemplateDataForParam(p Param) (flagTemplateData, error) {
 		}
 		defaultValue = fmt.Sprintf("%d * time.Nanosecond", dur.Nanoseconds())
 		fn = "DurationP"
+	case "octal":
+		fallthrough
+	case "url":
+		fallthrough
+	case "logSeverity":
+		fallthrough
+	case "protocol":
+		fallthrough
+	case "resolvedPath":
+		fallthrough
 	case "string":
 		defaultValue = fmt.Sprintf("%q", p.DefaultValue)
 		fn = "StringP"

--- a/tools/config-gen/flag_template_data_gen.go
+++ b/tools/config-gen/flag_template_data_gen.go
@@ -76,15 +76,7 @@ func computeFlagTemplateDataForParam(p Param) (flagTemplateData, error) {
 		}
 		defaultValue = fmt.Sprintf("%d * time.Nanosecond", dur.Nanoseconds())
 		fn = "DurationP"
-	case "octal":
-		fallthrough
-	case "url":
-		fallthrough
-	case "logSeverity":
-		fallthrough
-	case "protocol":
-		fallthrough
-	case "resolvedPath":
+	case "octal", "url", "logSeverity", "protocol", "resolvedPath":
 		fallthrough
 	case "string":
 		defaultValue = fmt.Sprintf("%q", p.DefaultValue)

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -44,13 +44,15 @@
   type: "resolvedPath"
   usage: >-
     The file for storing logs that can be parsed by fluentd. When not provided,
-    plain text logs are printed to stdout.
+    plain text logs are printed to stdout when Cloud Storage FUSE is run 
+    in the foreground, or to syslog when Cloud Storage FUSE is run in the 
+    background.
 
 - flag-name: "log-severity"
   config-path: "logging.severity"
   type: "logSeverity"
   default: "info"
-  usage: "Specifies the logging severity expressed as one of [trace, debug, info, warning, error]"
+  usage: "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]"
 
 - flag-name: "client-protocol"
   config-path: "gcs-connection.client-protocol"
@@ -58,4 +60,4 @@
   default: "http1"
   usage: >-
     The protocol used for communicating with the GCS backend.
-    Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2) or grpc.
+    Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -50,7 +50,7 @@
   config-path: "logging.severity"
   type: "logSeverity"
   default: "info"
-  usage: "Specifies the logging severity"
+  usage: "Specifies the logging severity expressed as one of [trace, debug, info, warning, error]"
 
 - flag-name: "client-protocol"
   config-path: "gcs-connection.client-protocol"

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -7,6 +7,7 @@
   config-path: "file-system.file-mode"
   type: "octal"
   usage: "Permissions bits for files, in octal."
+  default: "0644"
 
 - flag-name: "uid"
   config-path: "file-system.uid"
@@ -37,3 +38,24 @@
   config-path: "debug.log-mutex"
   type: "bool"
   usage: "Print debug messages when a mutex is held too long."
+
+- flag-name: "log-file"
+  config-path: "logging.file-path"
+  type: "resolvedPath"
+  usage: >-
+    The file for storing logs that can be parsed by fluentd. When not provided,
+    plain text logs are printed to stdout.
+
+- flag-name: "log-severity"
+  config-path: "logging.severity"
+  type: "logSeverity"
+  default: "info"
+  usage: "Specifies the logging severity"
+
+- flag-name: "client-protocol"
+  config-path: "gcs-connection.client-protocol"
+  type: "protocol"
+  default: "http1"
+  usage: >-
+    The protocol used for communicating with the GCS backend.
+    Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2) or grpc.

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -75,7 +75,7 @@ func validateParam(param Param) error {
 	// Validate the data type.
 	idx := slices.IndexFunc(
 		[]string{"int", "float64", "bool", "string", "duration", "octal", "[]int",
-			"[]string", "url", "logSeverity", "protocol", "resolvedPath", "nonNegativeOrMinusOne"},
+			"[]string", "url", "logSeverity", "protocol", "resolvedPath"},
 		func(dt string) bool {
 			return dt == param.Type
 		},

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -74,7 +74,8 @@ func validateParam(param Param) error {
 
 	// Validate the data type.
 	idx := slices.IndexFunc(
-		[]string{"int", "float64", "bool", "string", "duration", "octal", "[]int", "[]string"},
+		[]string{"int", "float64", "bool", "string", "duration", "octal", "[]int",
+			"[]string", "url", "logSeverity", "protocol", "resolvedPath", "nonNegativeOrMinusOne"},
 		func(dt string) bool {
 			return dt == param.Type
 		},

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -64,6 +64,16 @@ func getGoDataType(dt string) string {
 	switch dt {
 	case "octal":
 		return "Octal"
+	case "url":
+		return "url.URL"
+	case "logSeverity":
+		return "LogSeverity"
+	case "protocol":
+		return "Protocol"
+	case "resolvedPath":
+		return "ResolvedPath"
+	case "nonNegativeOrMinusOne":
+		return "NonNegativeOrMinusOne"
 	case "duration":
 		return "time.Duration"
 	default:

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -72,8 +72,6 @@ func getGoDataType(dt string) string {
 		return "Protocol"
 	case "resolvedPath":
 		return "ResolvedPath"
-	case "nonNegativeOrMinusOne":
-		return "NonNegativeOrMinusOne"
 	case "duration":
 		return "time.Duration"
 	default:


### PR DESCRIPTION
We have added support to declare and decode the following types:
* LogSeverity
* ResolvedPath
* Octal
* Protocol

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
