### PR TITLE
Add a test to ensure that the version is correctly printed in the gcsfuse binary

### DIFF
--- a/tools/build_gcsfuse/main_test.go
+++ b/tools/build_gcsfuse/main_test.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "gcsfuse-test")
+	if err != nil {
+		t.Fatalf("Error while creating temporary directory: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	err = buildBinaries(dir, "../../", "99.88.77", nil)
+	if err != nil {
+		t.Fatalf("Error while building binary: %v", err)
+	}
+
+	cmd := exec.Command(path.Join(dir, "bin/gcsfuse"), "--version")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error while running the gcsfuse binary: %v", err)
+	}
+	assert.Contains(t, string(output), "gcsfuse version 99.88.77")
+}


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
