### PR TITLE
Fix readonly --only-dir tests for GKE environment

### DIFF
--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -69,6 +69,7 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 	bucketHandle := storageClient.Bucket(bucket)
 
+	log.Println(bucket, " ", object)
 	// Loop through the file data and create/upload files
 	for _, file := range files {
 		filePath := path.Join(object, file.filePath)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -69,7 +69,6 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 	bucketHandle := storageClient.Bucket(bucket)
 
-	log.Println(bucket, " ", object)
 	// Loop through the file data and create/upload files
 	for _, file := range files {
 		filePath := path.Join(object, file.filePath)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -66,12 +66,12 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		{"This is from directory Test/b file b", TestDirForReadOnlyTest + "/Test/b/b.txt"},
 	}
 
-	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+	bucket, dirPath := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 	bucketHandle := storageClient.Bucket(bucket)
 
 	// Loop through the file data and create/upload files
 	for _, file := range files {
-		filePath := path.Join(object, file.filePath)
+		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
 		writer := object.NewWriter(ctx)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -66,13 +66,14 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		{"This is from directory Test/b file b", TestDirForReadOnlyTest + "/Test/b/b.txt"},
 	}
 
-	bucket := storageClient.Bucket(setup.TestBucket())
+	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+	bucketHandle := storageClient.Bucket(bucket)
 
 	// Loop through the file data and create/upload files
 	for _, file := range files {
-		filePath := path.Join(setup.OnlyDirMounted(),file.filePath)
+		filePath := path.Join(object, file.filePath)
 		// Create a storage writer for the destination object
-		object := bucket.Object(filePath)
+		object := bucketHandle.Object(filePath)
 		writer := object.NewWriter(ctx)
 
 		// Write the text to the object

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -66,13 +66,13 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		{"This is from directory Test/b file b", TestDirForReadOnlyTest + "/Test/b/b.txt"},
 	}
 
-	bucket, _ := setup.GetBucketAndObjectBasedOnTypeOfMount("")
-	bucketHandle := storageClient.Bucket(bucket)
+	bucket := storageClient.Bucket(setup.TestBucket())
 
 	// Loop through the file data and create/upload files
 	for _, file := range files {
+		filePath := path.Join(setup.OnlyDirMounted(),file.filePath)
 		// Create a storage writer for the destination object
-		object := bucketHandle.Object(file.filePath)
+		object := bucket.Object(filePath)
 		writer := object.NewWriter(ctx)
 
 		// Write the text to the object

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -66,12 +66,13 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		{"This is from directory Test/b file b", TestDirForReadOnlyTest + "/Test/b/b.txt"},
 	}
 
-	bucket := storageClient.Bucket(setup.TestBucket())
+	bucket, _ := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+	bucketHandle := storageClient.Bucket(bucket)
 
 	// Loop through the file data and create/upload files
 	for _, file := range files {
 		// Create a storage writer for the destination object
-		object := bucket.Object(file.filePath)
+		object := bucketHandle.Object(file.filePath)
 		writer := object.NewWriter(ctx)
 
 		// Write the text to the object

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -36,7 +36,7 @@ var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test
 var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
-var onlyDirMounted = flag.String("onlyDirMounted", "","Pass only dir name if passed during mouting.")
+
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
@@ -53,6 +53,7 @@ var (
 	testDir              string
 	mntDir               string
 	sbinFile             string
+	onlyDirMounted       string
 	dynamicBucketMounted string
 )
 
@@ -117,12 +118,12 @@ func MntDir() string {
 
 // OnlyDirMounted returns the name of the directory mounted in case of only dir mount.
 func OnlyDirMounted() string {
-	return *onlyDirMounted
+	return onlyDirMounted
 }
 
 // SetOnlyDirMounted sets the name of the directory mounted in case of only dir mount.
 func SetOnlyDirMounted(onlyDirValue string) {
-	*onlyDirMounted = onlyDirValue
+	onlyDirMounted = onlyDirValue
 }
 
 // DynamicBucketMounted returns the name of the bucket in case of dynamic mount.

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -36,7 +36,7 @@ var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test
 var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
-
+var onlyDirMounted = flag.String("onlyDirMounted", "","Pass only dir name if passed during mouting.")
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
@@ -53,7 +53,6 @@ var (
 	testDir              string
 	mntDir               string
 	sbinFile             string
-	onlyDirMounted       string
 	dynamicBucketMounted string
 )
 
@@ -118,12 +117,12 @@ func MntDir() string {
 
 // OnlyDirMounted returns the name of the directory mounted in case of only dir mount.
 func OnlyDirMounted() string {
-	return onlyDirMounted
+	return *onlyDirMounted
 }
 
 // SetOnlyDirMounted sets the name of the directory mounted in case of only dir mount.
 func SetOnlyDirMounted(onlyDirValue string) {
-	onlyDirMounted = onlyDirValue
+	*onlyDirMounted = onlyDirValue
 }
 
 // DynamicBucketMounted returns the name of the bucket in case of dynamic mount.


### PR DESCRIPTION
### Description
In scenarios where we were only mounting a directory, the test targeting that mount point failed because the "onlydir" path was not being set correctly. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested mounted directory tests
2. Unit tests - NA
3. Integration tests - Automated
