### PR TITLE
Added code changes to add crc check for sequential download behind flag

### DIFF
--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
@@ -80,6 +81,7 @@ func (dt *downloaderTest) waitForCrcCheckToBeCompleted() {
 			break
 		}
 		dt.job.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -74,9 +74,12 @@ func (dt *downloaderTest) waitForCrcCheckToBeCompleted() {
 	// Last notification is sent after the entire file is downloaded and before the CRC check is done.
 	// Hence, explicitly waiting till the CRC check is done.
 	for {
+		dt.job.mu.Lock()
 		if dt.job.status.Name == Completed || dt.job.status.Name == Failed {
+			dt.job.mu.Unlock()
 			break
 		}
+		dt.job.mu.Unlock()
 	}
 }
 

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -16,7 +16,6 @@ package downloader
 
 import (
 	"context"
-	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"os"
 	"path"
 	"sync"
@@ -30,6 +29,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	. "github.com/jacobsa/ogletest"
 )

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -487,7 +487,7 @@ func (job *Job) validateChecksum() (err error) {
 
 	// If the checksum doesn't match there is an error in downloading the object contents.
 	// Delete the file and corresponding key from fileInfoCache.
-	err = errors.New("checksum mismatch detected")
+	err = fmt.Errorf("checksum mismatch detected. Actual: %d, expected: %d", crc32Val, *job.object.CRC32C)
 	fileInfoKey := data.FileInfoKey{
 		BucketName: job.bucket.Name(),
 		ObjectName: job.object.Name,

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -471,6 +471,10 @@ func (job *Job) GetStatus() JobStatus {
 }
 
 func (job *Job) validateChecksum() (err error) {
+	if !job.enableCrcCheck {
+		return
+	}
+
 	crc32Val, err := cacheutil.CalculateFileCRC32(job.fileSpec.Path)
 	if err != nil {
 		return

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -398,7 +398,7 @@ func (job *Job) downloadObjectAsync() {
 					return
 				}
 			} else {
-				err = job.validateChecksum()
+				err = job.validateCRC()
 				if err != nil {
 					job.failWhileDownloading(err)
 					return
@@ -470,7 +470,9 @@ func (job *Job) GetStatus() JobStatus {
 	return job.status
 }
 
-func (job *Job) validateChecksum() (err error) {
+// Compares CRC32 of the downloaded file with the CRC32 from GCS object metadata.
+// In case of mismatch deletes the file and corresponding entry from file cache.
+func (job *Job) validateCRC() (err error) {
 	if !job.enableCrcCheck {
 		return
 	}

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -89,7 +89,6 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 }
 
 func (dt *downloaderTest) verifyFile(content []byte) {
-	fmt.Println(dt.fileSpec.Path)
 	fileStat, err := os.Stat(dt.fileSpec.Path)
 	AssertEq(nil, err)
 	AssertEq(dt.fileSpec.FilePerm, fileStat.Mode())
@@ -536,7 +535,7 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 }
 
 func (dt *downloaderTest) Test_Download_CtxCancelled() {
-	objectName := "path/in/gcs/foo.txt"
+	objectName := "path/in/gcs/cancel.txt"
 	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -783,7 +783,7 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 }
 
 func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcCheckIsTrue() {
-	objectName := "path/in/gcs/foo.txt"
+	objectName := "path/in/gcs/file1.txt"
 	objectSize := 8 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
@@ -811,7 +811,7 @@ func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcChec
 }
 
 func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcCheckIsFalse() {
-	objectName := "path/in/gcs/foo.txt"
+	objectName := "path/in/gcs/file2.txt"
 	objectSize := 1 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -436,7 +436,6 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	// Verify that jobStatus is Downloading but offset is object size
 	expectedJobStatus := JobStatus{Downloading, nil, int64(objectSize)}
 	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-
 	dt.waitForCrcCheckToBeCompleted()
 	AssertEq(Completed, dt.job.status.Name)
 
@@ -781,7 +780,7 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 	AssertEq(nil, dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcCheckIsTrue() {
+func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCrcCheckIsTrue() {
 	objectName := "path/in/gcs/file1.txt"
 	objectSize := 8 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -803,13 +802,13 @@ func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcChec
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
 	AssertEq(nil, err)
 
-	err = dt.job.validateChecksum()
+	err = dt.job.validateCRC()
 
 	AssertNe(nil, err)
 	AssertTrue(strings.Contains(err.Error(), "checksum mismatch detected"))
 }
 
-func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcCheckIsFalse() {
+func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCrcCheckIsFalse() {
 	objectName := "path/in/gcs/file2.txt"
 	objectSize := 1 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -832,7 +831,7 @@ func (dt *downloaderTest) Test_validateChecksum_ForTamperedFileWhenEnableCrcChec
 	AssertEq(nil, err)
 	dt.job.enableCrcCheck = false
 
-	err = dt.job.validateChecksum()
+	err = dt.job.validateCRC()
 
 	AssertEq(nil, err)
 	// Verify file

--- a/internal/cache/util/testdata/validfile.txt
+++ b/internal/cache/util/testdata/validfile.txt
@@ -1,0 +1,3 @@
+hi
+hello
+hello world

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -38,6 +38,7 @@ const (
 	FallbackToGCSErrMsg                       = "read via gcs"
 	FileNotPresentInCacheErrMsg               = "file is not present in cache"
 	CacheHandleNotRequiredForRandomReadErrMsg = "cacheFileForRangeRead is false, read type random read and fileInfo entry is absent"
+	BufferSizeForCrcCheck                     = 65536
 )
 
 const (
@@ -134,7 +135,7 @@ func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) err
 func calculateCRC32(reader io.Reader) (uint32, error) {
 	table := crc32.MakeTable(crc32.Castagnoli)
 	checksum := crc32.Checksum([]byte(""), table)
-	buf := make([]byte, 65536)
+	buf := make([]byte, BufferSizeForCrcCheck)
 	for {
 		switch n, err := reader.Read(buf); err {
 		case nil:

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -38,7 +38,7 @@ const (
 	FallbackToGCSErrMsg                       = "read via gcs"
 	FileNotPresentInCacheErrMsg               = "file is not present in cache"
 	CacheHandleNotRequiredForRandomReadErrMsg = "cacheFileForRangeRead is false, read type random read and fileInfo entry is absent"
-	BufferSizeForCrcCheck                     = 65536
+	BufferSizeForCRC                          = 65536
 )
 
 const (
@@ -135,7 +135,7 @@ func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) err
 func calculateCRC32(reader io.Reader) (uint32, error) {
 	table := crc32.MakeTable(crc32.Castagnoli)
 	checksum := crc32.Checksum([]byte(""), table)
-	buf := make([]byte, BufferSizeForCrcCheck)
+	buf := make([]byte, BufferSizeForCRC)
 	for {
 		switch n, err := reader.Read(buf); err {
 		case nil:

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -131,27 +131,26 @@ func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) err
 	return nil
 }
 
-func calculateCRC32(src io.Reader) (uint32, error) {
-	crc32Table := crc32.MakeTable(crc32.Castagnoli) // Pre-calculate the table
-	hasher := crc32.New(crc32Table)
-
-	fmt.Println("copying src")
-	if _, err := io.Copy(hasher, src); err != nil {
-		fmt.Println("error here")
-		return 0, fmt.Errorf("error calculating CRC-32: %w", err) // Wrap error
+func calculateCRC32(reader io.Reader) (uint32, error) {
+	table := crc32.MakeTable(crc32.Castagnoli)
+	checksum := crc32.Checksum([]byte(""), table)
+	buf := make([]byte, 65536)
+	for {
+		switch n, err := reader.Read(buf); err {
+		case nil:
+			checksum = crc32.Update(checksum, table, buf[:n])
+		case io.EOF:
+			return checksum, nil
+		default:
+			return 0, err
+		}
 	}
-
-	fmt.Println("reached here")
-	fmt.Println(hasher.Sum32())
-	return hasher.Sum32(), nil // Return checksum and nil error on success
 }
 
 // CalculateFileCRC32 calculates and returns the CRC-32 checksum of a file.
 func CalculateFileCRC32(filePath string) (uint32, error) {
 	// Open file with simplified flags and permissions
 	file, err := os.Open(filePath)
-	fmt.Println(filePath)
-	fmt.Println(err)
 	if err != nil {
 		return 0, fmt.Errorf("error opening file: %w", err)
 	}

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -246,6 +246,20 @@ func (ut *utilTest) Test_IsCacheHandleValid_False() {
 	}
 }
 
+func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnCrcForValidFile() {
+	crc, err := CalculateFileCRC32("testdata/validfile.txt")
+
+	ExpectEq(nil, err)
+	ExpectEq(515179668, crc)
+}
+
+func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist() {
+	crc, err := CalculateFileCRC32("testdata/nofile.txt")
+
+	ExpectTrue(strings.Contains(err.Error(), "no such file or directory"))
+	ExpectEq(0, crc)
+}
+
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryExists(t *testing.T) {
 	base := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirPath := path.Join(base, "/", "path/cachedir")

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -253,6 +253,13 @@ func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnCrcForValidFile() {
 	ExpectEq(515179668, crc)
 }
 
+func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnZeroForEmptyFile() {
+	crc, err := CalculateFileCRC32("testdata/emptyfile.txt")
+
+	ExpectEq(nil, err)
+	ExpectEq(0, crc)
+}
+
 func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist() {
 	crc, err := CalculateFileCRC32("testdata/nofile.txt")
 

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -1542,14 +1542,14 @@ func validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAt
 	attr2MTime, _ := time.Parse(time.RFC3339Nano, minObject2.Metadata[gcsx.MtimeMetadataKey])
 	ExpectTrue(attr1MTime.Before(attr2MTime))
 	ExpectEq(minObject1.ContentEncoding, minObject2.ContentEncoding)
+	ExpectNe(nil, minObject1.CRC32C)
+	ExpectNe(nil, minObject2.CRC32C)
 
 	// Validate Extended Object Attributes.
 	ExpectEq(extendedAttr1.ContentType, extendedAttr2.ContentType)
 	ExpectEq(extendedAttr1.ContentLanguage, extendedAttr2.ContentLanguage)
 	ExpectEq(extendedAttr1.CacheControl, extendedAttr2.CacheControl)
 	ExpectEq(extendedAttr1.Owner, extendedAttr2.Owner)
-	ExpectNe(nil, extendedAttr1.CRC32C)
-	ExpectNe(nil, extendedAttr2.CRC32C)
 	ExpectEq(extendedAttr1.MediaLink, extendedAttr2.MediaLink)
 	ExpectEq(extendedAttr1.StorageClass, extendedAttr2.StorageClass)
 	ExpectTrue(reflect.DeepEqual(extendedAttr1.Deleted, time.Time{}))

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -176,7 +176,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 	lruCache := lru.NewCache(CacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &config.FileCacheConfig{
-		EnableCrcCheck: true,
+		EnableCrcCheck: false,
 	})
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -88,6 +88,7 @@ type MinObject struct {
 	Updated         time.Time
 	Metadata        map[string]string
 	ContentEncoding string
+	CRC32C          *uint32 // Missing for CMEK buckets
 }
 
 // ExtendedObjectAttributes contains the missing attributes of Object which are not present in MinObject.
@@ -97,7 +98,6 @@ type ExtendedObjectAttributes struct {
 	CacheControl       string
 	Owner              string
 	MD5                *[md5.Size]byte // Missing for composite objects
-	CRC32C             *uint32         // Missing for CMEK buckets
 	MediaLink          string
 	StorageClass       string
 	Deleted            time.Time

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -147,6 +147,7 @@ func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 		Updated:         o.Updated,
 		Metadata:        o.Metadata,
 		ContentEncoding: o.ContentEncoding,
+		CRC32C:          o.CRC32C,
 	}
 }
 
@@ -161,7 +162,6 @@ func ConvertObjToExtendedObjectAttributes(o *gcs.Object) *gcs.ExtendedObjectAttr
 		CacheControl:       o.CacheControl,
 		Owner:              o.Owner,
 		MD5:                o.MD5,
-		CRC32C:             o.CRC32C,
 		MediaLink:          o.MediaLink,
 		StorageClass:       o.StorageClass,
 		Deleted:            o.Deleted,
@@ -192,7 +192,7 @@ func ConvertMinObjectAndExtendedObjectAttributesToObject(m *gcs.MinObject,
 		CacheControl:       e.CacheControl,
 		Owner:              e.Owner,
 		MD5:                e.MD5,
-		CRC32C:             e.CRC32C,
+		CRC32C:             m.CRC32C,
 		MediaLink:          e.MediaLink,
 		StorageClass:       e.StorageClass,
 		Deleted:            e.Deleted,

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -234,6 +234,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 	currentTime := time.Now()
 	contentEncode := "test_encoding"
 	metadata := map[string]string{"test_key": "test_value"}
+	var crc32C uint32 = 1234
 	gcsObject := gcs.Object{
 		Name:            name,
 		Size:            size,
@@ -242,6 +243,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 		Updated:         currentTime,
 		Metadata:        metadata,
 		ContentEncoding: contentEncode,
+		CRC32C:          &crc32C,
 	}
 
 	gcsMinObject := ConvertObjToMinObject(&gcsObject)
@@ -254,6 +256,7 @@ func (t objectAttrsTest) Test_ConvertObjToMinObject_WithValidObject() {
 	ExpectTrue(currentTime.Equal(gcsMinObject.Updated))
 	ExpectEq(contentEncode, gcsMinObject.ContentEncoding)
 	ExpectEq(metadata, gcsMinObject.Metadata)
+	ExpectEq(crc32C, *gcsMinObject.CRC32C)
 }
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilObject() {
@@ -266,7 +269,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNilObject
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObject() {
 	var attrMd5 *[16]byte
-	var crc32C uint32 = 0
 	timeAttr := time.Now()
 	gcsObject := gcs.Object{
 		ContentType:        "ContentType",
@@ -274,7 +276,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObje
 		CacheControl:       "CacheControl",
 		Owner:              "Owner",
 		MD5:                attrMd5,
-		CRC32C:             &crc32C,
 		MediaLink:          "MediaLink",
 		StorageClass:       "StorageClass",
 		Deleted:            timeAttr,
@@ -293,7 +294,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithValidObje
 	ExpectEq(gcsObject.CacheControl, extendedObjAttr.CacheControl)
 	ExpectEq(gcsObject.Owner, extendedObjAttr.Owner)
 	ExpectEq(gcsObject.MD5, extendedObjAttr.MD5)
-	ExpectEq(gcsObject.CRC32C, extendedObjAttr.CRC32C)
 	ExpectEq(gcsObject.MediaLink, extendedObjAttr.MediaLink)
 	ExpectEq(gcsObject.StorageClass, extendedObjAttr.StorageClass)
 	ExpectEq(0, gcsObject.Deleted.Compare(extendedObjAttr.Deleted))
@@ -338,7 +338,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMin
 
 func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMinObjectAndNonNilAttributes() {
 	var attrMd5 *[16]byte
-	var crc32C uint32 = 0
 	timeAttr := time.Now()
 	minObject := &gcs.MinObject{
 		Name:            "test",
@@ -355,7 +354,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMin
 		CacheControl:       "CacheControl",
 		Owner:              "Owner",
 		MD5:                attrMd5,
-		CRC32C:             &crc32C,
 		MediaLink:          "MediaLink",
 		StorageClass:       "StorageClass",
 		Deleted:            timeAttr,
@@ -381,7 +379,6 @@ func (t objectAttrsTest) Test_ConvertObjToExtendedObjectAttributes_WithNonNilMin
 	ExpectEq(gcsObject.CacheControl, extendedObjAttr.CacheControl)
 	ExpectEq(gcsObject.Owner, extendedObjAttr.Owner)
 	ExpectEq(gcsObject.MD5, extendedObjAttr.MD5)
-	ExpectEq(gcsObject.CRC32C, extendedObjAttr.CRC32C)
 	ExpectEq(gcsObject.MediaLink, extendedObjAttr.MediaLink)
 	ExpectEq(gcsObject.StorageClass, extendedObjAttr.StorageClass)
 	ExpectEq(0, gcsObject.Deleted.Compare(extendedObjAttr.Deleted))


### PR DESCRIPTION
### Description
CRC check will be done after the entire file is downloaded into cache based on the enableCRCCheck flag.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - No new integration tests
