### PR TITLE
Add all config-params to params.yaml

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -285,7 +285,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("debug_gcs", "", false, "This flag is unused. Debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
+	flagSet.BoolP("debug_gcs", "", false, "This flag is unused. Debug GCS logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 
 	err = flagSet.MarkDeprecated("debug_gcs", "This flag is currently unused.")
 	if err != nil {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -24,13 +24,37 @@ import (
 type Config struct {
 	AppName string `yaml:"app-name"`
 
+	CacheDir ResolvedPath `yaml:"cache-dir"`
+
 	Debug DebugConfig `yaml:"debug"`
+
+	EnableHns bool `yaml:"enable-hns"`
+
+	FileCache FileCacheConfig `yaml:"file-cache"`
 
 	FileSystem FileSystemConfig `yaml:"file-system"`
 
+	Foreground bool `yaml:"foreground"`
+
+	GcsAuth GcsAuthConfig `yaml:"gcs-auth"`
+
 	GcsConnection GcsConnectionConfig `yaml:"gcs-connection"`
 
+	GcsRetries GcsRetriesConfig `yaml:"gcs-retries"`
+
+	ImplicitDirs bool `yaml:"implicit-dirs"`
+
+	List ListConfig `yaml:"list"`
+
 	Logging LoggingConfig `yaml:"logging"`
+
+	MetadataCache MetadataCacheConfig `yaml:"metadata-cache"`
+
+	Metrics MetricsConfig `yaml:"metrics"`
+
+	OnlyDir string `yaml:"only-dir"`
+
+	Write WriteConfig `yaml:"write"`
 }
 
 type DebugConfig struct {
@@ -39,28 +63,150 @@ type DebugConfig struct {
 	LogMutex bool `yaml:"log-mutex"`
 }
 
+type FileCacheConfig struct {
+	CacheFileForRangeRead bool `yaml:"cache-file-for-range-read"`
+
+	MaxSizeMb int `yaml:"max-size-mb"`
+}
+
 type FileSystemConfig struct {
+	DirMode Octal `yaml:"dir-mode"`
+
 	FileMode Octal `yaml:"file-mode"`
+
+	FuseOptions []string `yaml:"fuse-options"`
+
+	Gid int `yaml:"gid"`
+
+	IgnoreInterrupts bool `yaml:"ignore-interrupts"`
+
+	RenameDirLimit int `yaml:"rename-dir-limit"`
+
+	TempDir string `yaml:"temp-dir"`
 
 	Uid int `yaml:"uid"`
 }
 
+type GcsAuthConfig struct {
+	AnonymousAccess bool `yaml:"anonymous-access"`
+
+	KeyFile string `yaml:"key-file"`
+
+	ReuseTokenFromUrl bool `yaml:"reuse-token-from-url"`
+
+	TokenUrl string `yaml:"token-url"`
+}
+
 type GcsConnectionConfig struct {
+	BillingProject string `yaml:"billing-project"`
+
 	ClientProtocol Protocol `yaml:"client-protocol"`
+
+	CustomEndpoint string `yaml:"custom-endpoint"`
+
+	GrpcConnPoolSize int `yaml:"grpc-conn-pool-size"`
+
+	HttpClientTimeout time.Duration `yaml:"http-client-timeout"`
+
+	LimitBytesPerSec float64 `yaml:"limit-bytes-per-sec"`
+
+	LimitOpsPerSec float64 `yaml:"limit-ops-per-sec"`
+
+	MaxConnsPerHost int `yaml:"max-conns-per-host"`
+
+	MaxIdleConnsPerHost int `yaml:"max-idle-conns-per-host"`
+
+	RetryMultiplier float64 `yaml:"retry-multiplier"`
+
+	SequentialReadSizeMb int `yaml:"sequential-read-size-mb"`
+}
+
+type GcsRetriesConfig struct {
+	MaxRetrySleep time.Duration `yaml:"max-retry-sleep"`
+}
+
+type ListConfig struct {
+	EnableEmptyManagedFolders bool `yaml:"enable-empty-managed-folders"`
+
+	KernelListCacheTtlSecs int `yaml:"kernel-list-cache-ttl-secs"`
+}
+
+type LogRotateLoggingConfig struct {
+	BackupFileCount int `yaml:"backup-file-count"`
+
+	Compress bool `yaml:"compress"`
+
+	MaxFileSizeMb int `yaml:"max-file-size-mb"`
 }
 
 type LoggingConfig struct {
 	FilePath ResolvedPath `yaml:"file-path"`
 
+	Format string `yaml:"format"`
+
+	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
+
 	Severity LogSeverity `yaml:"severity"`
+}
+
+type MetadataCacheConfig struct {
+	DeprecatedStatCacheCapacity int `yaml:"deprecated-stat-cache-capacity"`
+
+	DeprecatedStatCacheTtl time.Duration `yaml:"deprecated-stat-cache-ttl"`
+
+	DeprecatedTypeCacheTtl time.Duration `yaml:"deprecated-type-cache-ttl"`
+
+	EnableNonexistentTypeCache bool `yaml:"enable-nonexistent-type-cache"`
+
+	StatCacheMaxSizeMb int `yaml:"stat-cache-max-size-mb"`
+
+	TtlSecs int `yaml:"ttl-secs"`
+
+	TypeCacheMaxSizeMb int `yaml:"type-cache-max-size-mb"`
+}
+
+type MetricsConfig struct {
+	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
+}
+
+type WriteConfig struct {
+	CreateEmptyFile bool `yaml:"create-empty-file"`
 }
 
 func BindFlags(flagSet *pflag.FlagSet) error {
 	var err error
 
+	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
+
+	err = viper.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access"))
+	if err != nil {
+		return err
+	}
+
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
 
 	err = viper.BindPFlag("app-name", flagSet.Lookup("app-name"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
+
+	err = viper.BindPFlag("gcs-connection.billing-project", flagSet.Lookup("billing-project"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("cache-dir", "", "", "Enables file-caching. Specifies the directory to use for file-cache.")
+
+	err = viper.BindPFlag("cache-dir", flagSet.Lookup("cache-dir"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("cache-file-for-range-read", "", false, "Whether to cache file for range reads.")
+
+	err = viper.BindPFlag("file-cache.cache-file-for-range-read", flagSet.Lookup("cache-file-for-range-read"))
 	if err != nil {
 		return err
 	}
@@ -72,7 +218,33 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("debug_fuse", "", true, "This flag is currently unused.")
+	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
+
+	err = flagSet.MarkDeprecated("create-empty-file", "This flag will be deleted soon.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("write.create-empty-file", flagSet.Lookup("create-empty-file"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
+
+	err = viper.BindPFlag("gcs-connection.custom-endpoint", flagSet.Lookup("custom-endpoint"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("debug_fs", "", false, "This flag is currently unused.")
+
+	err = flagSet.MarkDeprecated("debug_fs", "This flag is currently unused.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("debug_fuse", "", false, "This flag is currently unused.")
 
 	err = flagSet.MarkDeprecated("debug_fuse", "This flag is currently unused.")
 	if err != nil {
@@ -82,6 +254,20 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("debug_fuse_errors", "", true, "This flag is currently unused.")
 
 	err = flagSet.MarkDeprecated("debug_fuse_errors", "This flag is currently unused.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("debug_gcs", "", false, "This flag is currently unused.")
+
+	err = flagSet.MarkDeprecated("debug_gcs", "This flag is currently unused.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("debug_http", "", false, "This flag is currently unused.")
+
+	err = flagSet.MarkDeprecated("debug_http", "This flag is currently unused.")
 	if err != nil {
 		return err
 	}
@@ -100,9 +286,140 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.StringP("dir-mode", "", "0755", "Permissions bits for directories, in octal.")
+
+	err = viper.BindPFlag("file-system.dir-mode", flagSet.Lookup("dir-mode"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
+
+	err = viper.BindPFlag("list.enable-empty-managed-folders", flagSet.Lookup("enable-empty-managed-folders"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-hns", "", false, "Enables support for HNS buckets")
+
+	err = viper.BindPFlag("enable-hns", flagSet.Lookup("enable-hns"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
+
+	err = viper.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("experimental-enable-json-read", "", false, "By default, GCSFuse uses the GCS XML API to get and read objects. When this flag is specified, GCSFuse uses the GCS JSON API instead.\"")
+
+	err = flagSet.MarkDeprecated("experimental-enable-json-read", "Experimental flag: could be dropped even in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("experimental-metadata-prefetch-on-mount", "", "disabled", "Experimental: This indicates whether or not to prefetch the metadata (prefilling of metadata caches and creation of inodes) of the mounted bucket at the time of mounting the bucket. Supported values: \"disabled\", \"sync\" and \"async\". Any other values will return error on mounting. This is applicable only to static mounting, and not to dynamic mounting.")
+
+	err = flagSet.MarkDeprecated("experimental-metadata-prefetch-on-mount", "Experimental flag: could be removed even in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("experimental-opentelemetry-collector-address", "", "", "Experimental: Export metrics to the OpenTelemetry collector at this address.")
+
+	err = flagSet.MarkDeprecated("experimental-opentelemetry-collector-address", "Experimental flag: could be dropped even in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("file-cache-max-size-mb", "", -1, "Maximum size of the file-cache in MiBs")
+
+	err = viper.BindPFlag("file-cache.max-size-mb", flagSet.Lookup("file-cache-max-size-mb"))
+	if err != nil {
+		return err
+	}
+
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
 
 	err = viper.BindPFlag("file-system.file-mode", flagSet.Lookup("file-mode"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("foreground", "", false, "Stay in the foreground after mounting.")
+
+	err = viper.BindPFlag("foreground", flagSet.Lookup("foreground"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
+
+	err = viper.BindPFlag("file-system.gid", flagSet.Lookup("gid"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("grpc-conn-pool-size", "", 0, "The number of gRPC channel in grpc client.")
+
+	err = flagSet.MarkDeprecated("grpc-conn-pool-size", "Experimental flag: can be removed in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("grpc-conn-pool-size"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
+
+	err = viper.BindPFlag("gcs-connection.http-client-timeout", flagSet.Lookup("http-client-timeout"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("ignore-interrupts", "", false, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
+
+	err = viper.BindPFlag("file-system.ignore-interrupts", flagSet.Lookup("ignore-interrupts"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("implicit-dirs", "", false, "Implicitly define directories based on content. See files and directories in docs/semantics for more information")
+
+	err = viper.BindPFlag("implicit-dirs", flagSet.Lookup("implicit-dirs"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
+
+	err = viper.BindPFlag("list.kernel-list-cache-ttl-secs", flagSet.Lookup("kernel-list-cache-ttl-secs"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
+
+	err = viper.BindPFlag("gcs-auth.key-file", flagSet.Lookup("key-file"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
+
+	err = viper.BindPFlag("gcs-connection.limit-bytes-per-sec", flagSet.Lookup("limit-bytes-per-sec"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.Float64P("limit-ops-per-sec", "", -1, "Operations per second limit, measured over a 30-second window (use -1 for no limit)")
+
+	err = viper.BindPFlag("gcs-connection.limit-ops-per-sec", flagSet.Lookup("limit-ops-per-sec"))
 	if err != nil {
 		return err
 	}
@@ -114,9 +431,185 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
+
+	err = viper.BindPFlag("logging.format", flagSet.Lookup("log-format"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
+
+	err = viper.BindPFlag("logging.log-rotate.backup-file-count", flagSet.Lookup("log-rotate-backup-file-count"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("log-rotate-compress", "", true, "Whether the rotated log files should be gzipped.")
+
+	err = viper.BindPFlag("logging.log-rotate.compress", flagSet.Lookup("log-rotate-compress"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("log-rotate-max-log-file-size-mb", "", 512, "the maximum size in megabytes that a log file can reach before it is rotated.")
+
+	err = viper.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-log-file-size-mb"))
+	if err != nil {
+		return err
+	}
+
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
 	err = viper.BindPFlag("logging.severity", flagSet.Lookup("log-severity"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
+
+	err = viper.BindPFlag("gcs-connection.max-conns-per-host", flagSet.Lookup("max-conns-per-host"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
+
+	err = viper.BindPFlag("gcs-connection.max-idle-conns-per-host", flagSet.Lookup("max-idle-conns-per-host"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
+
+	err = flagSet.MarkDeprecated("max-retry-duration", "This is currently unused.")
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("max-retry-sleep", "", 30000000000*time.Nanosecond, "The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry continues with this specified maximum value.")
+
+	err = viper.BindPFlag("gcs-retries.max-retry-sleep", flagSet.Lookup("max-retry-sleep"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("metadata-cache-ttl", "", math.MinInt64, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.\"")
+
+	err = viper.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringSliceP("o", "", []string{}, "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro")
+
+	err = viper.BindPFlag("file-system.fuse-options", flagSet.Lookup("o"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("only-dir", "", "", "Mount only a specific directory within the bucket. See docs/mounting for more information")
+
+	err = viper.BindPFlag("only-dir", flagSet.Lookup("only-dir"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("rename-dir-limit", "", 0, "Allow rename a directory containing fewer descendants than this limit.")
+
+	err = viper.BindPFlag("file-system.rename-dir-limit", flagSet.Lookup("rename-dir-limit"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.Float64P("retry-multiplier", "", 2, "Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.")
+
+	err = viper.BindPFlag("gcs-connection.retry-multiplier", flagSet.Lookup("retry-multiplier"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("reuse-token-from-url", "", true, "If false, the token acquired from token-url is not reused.")
+
+	err = viper.BindPFlag("gcs-auth.reuse-token-from-url", flagSet.Lookup("reuse-token-from-url"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("sequential-read-size-mb", "", 200, "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported")
+
+	err = viper.BindPFlag("gcs-connection.sequential-read-size-mb", flagSet.Lookup("sequential-read-size-mb"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("stackdriver-export-interval", "", 0*time.Nanosecond, "Export metrics to stackdriver with this interval. The default value 0 indicates no exporting.")
+
+	err = viper.BindPFlag("metrics.stackdriver-export-interval", flagSet.Lookup("stackdriver-export-interval"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("stat-cache-capacity", "", 20460, "How many entries can the stat-cache hold (impacts memory consumption). This flag has been deprecated (starting v2.0) and in favor of stat-cache-max-size-mb. For now, the value of stat-cache-capacity will be translated to the next higher corresponding value of stat-cache-max-size-mb (assuming stat-cache entry-size ~= 1640 bytes, including 1400 for positive entry and 240 for corresponding negative entry), if stat-cache-max-size-mb is not set.\"")
+
+	err = flagSet.MarkDeprecated("stat-cache-capacity", "This flag has been deprecated (starting v2.0) in favor of stat-cache-max-size-mb.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("metadata-cache.deprecated-stat-cache-capacity", flagSet.Lookup("stat-cache-capacity"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("stat-cache-max-size-mb", "", math.MinInt64, "The maximum size of stat-cache in MiBs. It can also be set to -1 for no-size-limit, 0 for no cache. Values below -1 are not supported.")
+
+	err = viper.BindPFlag("metadata-cache.stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("stat-cache-ttl", "", 60000000000*time.Nanosecond, "How long to cache StatObject results and inode attributes. This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second is used as ttl for both stat-cache and type-cache, when metadata-cache-ttl-secs is not set.")
+
+	err = flagSet.MarkDeprecated("stat-cache-ttl", "This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("metadata-cache.deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)\"")
+
+	err = viper.BindPFlag("file-system.temp-dir", flagSet.Lookup("temp-dir"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.StringP("token-url", "", "", "A url for getting an access token when the key-file is absent.")
+
+	err = viper.BindPFlag("gcs-auth.token-url", flagSet.Lookup("token-url"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.IntP("type-cache-max-size-mb", "", 4, "Max size of type-cache maps which are maintained at a per-directory level.")
+
+	err = viper.BindPFlag("metadata-cache.type-cache-max-size-mb", flagSet.Lookup("type-cache-max-size-mb"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.DurationP("type-cache-ttl", "", 60000000000*time.Nanosecond, "Usage: How long to cache StatObject results and inode attributes. This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second is used as ttl for both stat-cache and type-cache, when metadata-cache-ttl-secs is not set.")
+
+	err = flagSet.MarkDeprecated("type-cache-ttl", "This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("metadata-cache.deprecated-type-cache-ttl", flagSet.Lookup("type-cache-ttl"))
 	if err != nil {
 		return err
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -89,6 +89,8 @@ type FileCacheConfig struct {
 type FileSystemConfig struct {
 	DirMode Octal `yaml:"dir-mode"`
 
+	DisableParallelDirops bool `yaml:"disable-parallel-dirops"`
+
 	FileMode Octal `yaml:"file-mode"`
 
 	FuseOptions []string `yaml:"fuse-options"`
@@ -262,14 +264,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("debug_fs", "", false, "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
+	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 
 	err = flagSet.MarkDeprecated("debug_fs", "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 	if err != nil {
 		return err
 	}
 
-	flagSet.BoolP("debug_fuse", "", false, "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
+	flagSet.BoolP("debug_fuse", "", false, "This flag is unused. Debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 
 	err = flagSet.MarkDeprecated("debug_fuse", "debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 	if err != nil {
@@ -283,7 +285,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("debug_gcs", "", false, "This flag is currently unused.")
+	flagSet.BoolP("debug_gcs", "", false, "This flag is unused. Debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 
 	err = flagSet.MarkDeprecated("debug_gcs", "This flag is currently unused.")
 	if err != nil {
@@ -319,6 +321,18 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 	flagSet.StringP("dir-mode", "", "0755", "Permissions bits for directories, in octal.")
 
 	err = viper.BindPFlag("file-system.dir-mode", flagSet.Lookup("dir-mode"))
+	if err != nil {
+		return err
+	}
+
+	flagSet.BoolP("disable-parallel-dirops", "", false, "Specifies whether to allow parallel dir operations (lookups and readers)")
+
+	err = flagSet.MarkHidden("disable-parallel-dirops")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("file-system.disable-parallel-dirops", flagSet.Lookup("disable-parallel-dirops"))
 	if err != nil {
 		return err
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -17,6 +17,9 @@
 package cfg
 
 import (
+	"math"
+	"time"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -90,7 +93,7 @@ type FileSystemConfig struct {
 type GcsAuthConfig struct {
 	AnonymousAccess bool `yaml:"anonymous-access"`
 
-	KeyFile string `yaml:"key-file"`
+	KeyFile ResolvedPath `yaml:"key-file"`
 
 	ReuseTokenFromUrl bool `yaml:"reuse-token-from-url"`
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -107,7 +107,9 @@ type GcsConnectionConfig struct {
 
 	ClientProtocol Protocol `yaml:"client-protocol"`
 
-	CustomEndpoint string `yaml:"custom-endpoint"`
+	CustomEndpoint url.URL `yaml:"custom-endpoint"`
+
+	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
 
 	GrpcConnPoolSize int `yaml:"grpc-conn-pool-size"`
 
@@ -328,6 +330,11 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("experimental-enable-json-read", "", false, "By default, GCSFuse uses the GCS XML API to get and read objects. When this flag is specified, GCSFuse uses the GCS JSON API instead.\"")
 
 	err = flagSet.MarkDeprecated("experimental-enable-json-read", "Experimental flag: could be dropped even in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("gcs-connection.experimental-enable-json-read", flagSet.Lookup("experimental-enable-json-read"))
 	if err != nil {
 		return err
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -17,7 +17,6 @@
 package cfg
 
 import (
-	"math"
 	"net/url"
 	"time"
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -18,6 +18,7 @@ package cfg
 
 import (
 	"math"
+	"net/url"
 	"time"
 
 	"github.com/spf13/pflag"

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -55,6 +55,8 @@ type Config struct {
 
 	Metrics MetricsConfig `yaml:"metrics"`
 
+	Monitoring MonitoringConfig `yaml:"monitoring"`
+
 	OnlyDir string `yaml:"only-dir"`
 
 	Write WriteConfig `yaml:"write"`
@@ -161,6 +163,8 @@ type MetadataCacheConfig struct {
 
 	EnableNonexistentTypeCache bool `yaml:"enable-nonexistent-type-cache"`
 
+	ExperimentalMetadataPrefetchOnMount string `yaml:"experimental-metadata-prefetch-on-mount"`
+
 	StatCacheMaxSizeMb int `yaml:"stat-cache-max-size-mb"`
 
 	TtlSecs int `yaml:"ttl-secs"`
@@ -170,6 +174,10 @@ type MetadataCacheConfig struct {
 
 type MetricsConfig struct {
 	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
+}
+
+type MonitoringConfig struct {
+	ExperimentalOpentelemetryCollectorAddress string `yaml:"experimental-opentelemetry-collector-address"`
 }
 
 type WriteConfig struct {
@@ -331,9 +339,19 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	err = viper.BindPFlag("metadata-cache.experimental-metadata-prefetch-on-mount", flagSet.Lookup("experimental-metadata-prefetch-on-mount"))
+	if err != nil {
+		return err
+	}
+
 	flagSet.StringP("experimental-opentelemetry-collector-address", "", "", "Experimental: Export metrics to the OpenTelemetry collector at this address.")
 
 	err = flagSet.MarkDeprecated("experimental-opentelemetry-collector-address", "Experimental flag: could be dropped even in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("monitoring.experimental-opentelemetry-collector-address", flagSet.Lookup("experimental-opentelemetry-collector-address"))
 	if err != nil {
 		return err
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -71,7 +71,7 @@ type DebugConfig struct {
 type FileCacheConfig struct {
 	CacheFileForRangeRead bool `yaml:"cache-file-for-range-read"`
 
-	MaxSizeMb int `yaml:"max-size-mb"`
+	MaxSizeMb int64 `yaml:"max-size-mb"`
 }
 
 type FileSystemConfig struct {
@@ -81,15 +81,15 @@ type FileSystemConfig struct {
 
 	FuseOptions []string `yaml:"fuse-options"`
 
-	Gid int `yaml:"gid"`
+	Gid int64 `yaml:"gid"`
 
 	IgnoreInterrupts bool `yaml:"ignore-interrupts"`
 
-	RenameDirLimit int `yaml:"rename-dir-limit"`
+	RenameDirLimit int64 `yaml:"rename-dir-limit"`
 
 	TempDir string `yaml:"temp-dir"`
 
-	Uid int `yaml:"uid"`
+	Uid int64 `yaml:"uid"`
 }
 
 type GcsAuthConfig struct {
@@ -111,7 +111,7 @@ type GcsConnectionConfig struct {
 
 	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
 
-	GrpcConnPoolSize int `yaml:"grpc-conn-pool-size"`
+	GrpcConnPoolSize int64 `yaml:"grpc-conn-pool-size"`
 
 	HttpClientTimeout time.Duration `yaml:"http-client-timeout"`
 
@@ -119,11 +119,11 @@ type GcsConnectionConfig struct {
 
 	LimitOpsPerSec float64 `yaml:"limit-ops-per-sec"`
 
-	MaxConnsPerHost int `yaml:"max-conns-per-host"`
+	MaxConnsPerHost int64 `yaml:"max-conns-per-host"`
 
-	MaxIdleConnsPerHost int `yaml:"max-idle-conns-per-host"`
+	MaxIdleConnsPerHost int64 `yaml:"max-idle-conns-per-host"`
 
-	SequentialReadSizeMb int `yaml:"sequential-read-size-mb"`
+	SequentialReadSizeMb int64 `yaml:"sequential-read-size-mb"`
 }
 
 type GcsRetriesConfig struct {
@@ -135,15 +135,15 @@ type GcsRetriesConfig struct {
 type ListConfig struct {
 	EnableEmptyManagedFolders bool `yaml:"enable-empty-managed-folders"`
 
-	KernelListCacheTtlSecs int `yaml:"kernel-list-cache-ttl-secs"`
+	KernelListCacheTtlSecs int64 `yaml:"kernel-list-cache-ttl-secs"`
 }
 
 type LogRotateLoggingConfig struct {
-	BackupFileCount int `yaml:"backup-file-count"`
+	BackupFileCount int64 `yaml:"backup-file-count"`
 
 	Compress bool `yaml:"compress"`
 
-	MaxFileSizeMb int `yaml:"max-file-size-mb"`
+	MaxFileSizeMb int64 `yaml:"max-file-size-mb"`
 }
 
 type LoggingConfig struct {
@@ -157,7 +157,7 @@ type LoggingConfig struct {
 }
 
 type MetadataCacheConfig struct {
-	DeprecatedStatCacheCapacity int `yaml:"deprecated-stat-cache-capacity"`
+	DeprecatedStatCacheCapacity int64 `yaml:"deprecated-stat-cache-capacity"`
 
 	DeprecatedStatCacheTtl time.Duration `yaml:"deprecated-stat-cache-ttl"`
 
@@ -167,11 +167,11 @@ type MetadataCacheConfig struct {
 
 	ExperimentalMetadataPrefetchOnMount string `yaml:"experimental-metadata-prefetch-on-mount"`
 
-	StatCacheMaxSizeMb int `yaml:"stat-cache-max-size-mb"`
+	StatCacheMaxSizeMb int64 `yaml:"stat-cache-max-size-mb"`
 
-	TtlSecs int `yaml:"ttl-secs"`
+	TtlSecs int64 `yaml:"ttl-secs"`
 
-	TypeCacheMaxSizeMb int `yaml:"type-cache-max-size-mb"`
+	TypeCacheMaxSizeMb int64 `yaml:"type-cache-max-size-mb"`
 }
 
 type MetricsConfig struct {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -121,13 +121,13 @@ type GcsConnectionConfig struct {
 
 	MaxIdleConnsPerHost int `yaml:"max-idle-conns-per-host"`
 
-	RetryMultiplier float64 `yaml:"retry-multiplier"`
-
 	SequentialReadSizeMb int `yaml:"sequential-read-size-mb"`
 }
 
 type GcsRetriesConfig struct {
 	MaxRetrySleep time.Duration `yaml:"max-retry-sleep"`
+
+	Multiplier float64 `yaml:"multiplier"`
 }
 
 type ListConfig struct {
@@ -545,7 +545,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.Float64P("retry-multiplier", "", 2, "Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.")
 
-	err = viper.BindPFlag("gcs-connection.retry-multiplier", flagSet.Lookup("retry-multiplier"))
+	err = viper.BindPFlag("gcs-retries.multiplier", flagSet.Lookup("retry-multiplier"))
 	if err != nil {
 		return err
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -263,16 +263,16 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("debug_fs", "", false, "This flag is currently unused.")
+	flagSet.BoolP("debug_fs", "", false, "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 
-	err = flagSet.MarkDeprecated("debug_fs", "This flag is currently unused.")
+	err = flagSet.MarkDeprecated("debug_fs", "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 	if err != nil {
 		return err
 	}
 
-	flagSet.BoolP("debug_fuse", "", false, "This flag is currently unused.")
+	flagSet.BoolP("debug_fuse", "", false, "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 
-	err = flagSet.MarkDeprecated("debug_fuse", "This flag is currently unused.")
+	err = flagSet.MarkDeprecated("debug_fuse", "debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs.")
 	if err != nil {
 		return err
 	}
@@ -378,6 +378,18 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.IntP("experimental-grpc-conn-pool-size", "", 0, "The number of gRPC channel in grpc client.")
+
+	err = flagSet.MarkDeprecated("experimental-grpc-conn-pool-size", "Experimental flag: can be removed in a minor release.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size"))
+	if err != nil {
+		return err
+	}
+
 	flagSet.StringP("experimental-metadata-prefetch-on-mount", "", "disabled", "Experimental: This indicates whether or not to prefetch the metadata (prefilling of metadata caches and creation of inodes) of the mounted bucket at the time of mounting the bucket. Supported values: \"disabled\", \"sync\" and \"async\". Any other values will return error on mounting. This is applicable only to static mounting, and not to dynamic mounting.")
 
 	err = flagSet.MarkDeprecated("experimental-metadata-prefetch-on-mount", "Experimental flag: could be removed even in a minor release.")
@@ -426,18 +438,6 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
 	err = viper.BindPFlag("file-system.gid", flagSet.Lookup("gid"))
-	if err != nil {
-		return err
-	}
-
-	flagSet.IntP("grpc-conn-pool-size", "", 0, "The number of gRPC channel in grpc client.")
-
-	err = flagSet.MarkDeprecated("grpc-conn-pool-size", "Experimental flag: can be removed in a minor release.")
-	if err != nil {
-		return err
-	}
-
-	err = viper.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("grpc-conn-pool-size"))
 	if err != nil {
 		return err
 	}
@@ -512,14 +512,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("log-rotate-compress", "", true, "Whether the rotated log files should be gzipped.")
+	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
 	err = viper.BindPFlag("logging.log-rotate.compress", flagSet.Lookup("log-rotate-compress"))
 	if err != nil {
 		return err
 	}
 
-	flagSet.IntP("log-rotate-max-log-file-size-mb", "", 512, "the maximum size in megabytes that a log file can reach before it is rotated.")
+	flagSet.IntP("log-rotate-max-log-file-size-mb", "", 512, "The maximum size in megabytes that a log file can reach before it is rotated.")
 
 	err = viper.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-log-file-size-mb"))
 	if err != nil {
@@ -568,7 +568,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("metadata-cache-ttl", "", math.MinInt64, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.\"")
+	flagSet.IntP("metadata-cache-ttl", "", 60, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.\"")
 
 	err = viper.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl"))
 	if err != nil {
@@ -643,7 +643,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("stat-cache-max-size-mb", "", math.MinInt64, "The maximum size of stat-cache in MiBs. It can also be set to -1 for no-size-limit, 0 for no cache. Values below -1 are not supported.")
+	flagSet.IntP("stat-cache-max-size-mb", "", 32, "The maximum size of stat-cache in MiBs. It can also be set to -1 for no-size-limit, 0 for no cache. Values below -1 are not supported.")
 
 	err = viper.BindPFlag("metadata-cache.stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb"))
 	if err != nil {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -65,6 +65,8 @@ type Config struct {
 type DebugConfig struct {
 	ExitOnInvariantViolation bool `yaml:"exit-on-invariant-violation"`
 
+	Gcs bool `yaml:"gcs"`
+
 	LogMutex bool `yaml:"log-mutex"`
 }
 
@@ -274,6 +276,11 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("debug_gcs", "", false, "This flag is currently unused.")
 
 	err = flagSet.MarkDeprecated("debug_gcs", "This flag is currently unused.")
+	if err != nil {
+		return err
+	}
+
+	err = viper.BindPFlag("debug.gcs", flagSet.Lookup("debug_gcs"))
 	if err != nil {
 		return err
 	}

--- a/tools/config-gen/config.tpl
+++ b/tools/config-gen/config.tpl
@@ -17,7 +17,6 @@
 package cfg
 
 import (
-	"math"
 	"time"
 	"net/url"
 

--- a/tools/config-gen/config.tpl
+++ b/tools/config-gen/config.tpl
@@ -19,6 +19,7 @@ package cfg
 import (
 	"math"
 	"time"
+	"net/url"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"

--- a/tools/config-gen/config.tpl
+++ b/tools/config-gen/config.tpl
@@ -17,6 +17,9 @@
 package cfg
 
 import (
+	"math"
+	"time"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -385,6 +385,34 @@
   type: "bool"
   usage: "Whether to cache file for range reads."
 
+- flag-name: "enable-crc-check"
+  config-path: "file-cache.enable-crc-check"
+  type: "bool"
+  usage: "Performs CRC check to ensure that file is correctly downloaded into cache."
+  default: true
+
+- flag-name: "enable-parallel-downloads"
+  config-path: "file-cache.enable-parallel-downloads"
+  type: "bool"
+  usage: "Enable parallel downloads."
+
+- flag-name: "download-parallelism-per-file"
+  config-path: "file-cache.download-parallelism-per-file"
+  type: "int"
+  usage: "Number of concurrent download requests per file."
+  default: "10"
+
+- flag-name: "max-download-parallelism"
+  config-path: "file-cache.max-download-parallelism"
+  type: "int"
+  usage: "Sets an uber limit of number of concurrent file download requests that are made across all files."
+  default: "-1"
+
+- flag-name: "read-request-size-mb"
+  config-path: "file-cache.read-request-size-mb"
+  type: "int"
+  usage: "Size of chunks in MiB that each concurrent request downloads."
+
 - flag-name: "cache-dir"
   config-path: "cache-dir"
   type: "resolvedPath"

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -66,6 +66,13 @@
     inflight operations.
   default: false
 
+- flag-name: "disable-parallel-dirops"
+  config-path: "file-system.disable-parallel-dirops"
+  type: "bool"
+  usage: "Specifies whether to allow parallel dir operations (lookups and readers)"
+  default: false
+  hide-flag: true
+
 - flag-name: "custom-endpoint"
   config-path: "gcs-connection.custom-endpoint"
   type: "url"

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -275,6 +275,7 @@
   default: "0s"
 
 - flag-name: "experimental-opentelemetry-collector-address"
+  config-path: "monitoring.experimental-opentelemetry-collector-address"
   type: "string"
   usage: "Experimental: Export metrics to the OpenTelemetry collector at this address."
   deprecated: true
@@ -345,6 +346,7 @@
   usage: "Print debug messages when a mutex is held too long."
 
 - flag-name: "experimental-metadata-prefetch-on-mount"
+  config-path: "metadata-cache.experimental-metadata-prefetch-on-mount"
   type: "string"
   usage: >-
     Experimental: This indicates whether or not to prefetch the metadata

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -2,11 +2,13 @@
   config-path: "app-name"
   type: "string"
   usage: "The application name of this mount."
+  default: ""
 
 - flag-name: "foreground"
   config-path: "foreground"
   type: "bool"
   usage: "Stay in the foreground after mounting."
+  default: false
 
 - flag-name: "o"
   config-path: "file-system.fuse-options"
@@ -41,16 +43,19 @@
   config-path: "implicit-dirs"
   type: "bool"
   usage: "Implicitly define directories based on content. See files and directories in docs/semantics for more information"
+  default: false
 
 - flag-name: "only-dir"
   config-path: "only-dir"
   type: "string"
   usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
+  default: ""
 
 - flag-name: "rename-dir-limit"
   config-path: "file-system.rename-dir-limit"
   type: "int"
   usage: "Allow rename a directory containing fewer descendants than this limit."
+  default: "0"
 
 - flag-name: "ignore-interrupts"
   config-path: "file-system.ignore-interrupts"
@@ -59,6 +64,7 @@
     Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered
     by Ctrl+C). This prevents those signals from immediately terminating gcsfuse
     inflight operations.
+  default: false
 
 - flag-name: "custom-endpoint"
   config-path: "gcs-connection.custom-endpoint"
@@ -75,6 +81,7 @@
   config-path: "gcs-auth.anonymous-access"
   type: "bool"
   usage: "Authentication is enabled by default. This flag disables authentication"
+  default: false
 
 - flag-name: "billing-project"
   config-path: "gcs-connection.billing-project"
@@ -82,6 +89,7 @@
   usage: >-
     Project to use for billing when accessing a bucket enabled with "Requester
     Pays". (The default is none)
+  default: ""
 
 - flag-name: "key-file"
   config-path: "gcs-auth.key-file"
@@ -92,6 +100,7 @@
   config-path: "gcs-auth.token-url"
   type: "string"
   usage: "A url for getting an access token when the key-file is absent."
+  default: ""
 
 - flag-name: "reuse-token-from-url"
   config-path: "gcs-auth.reuse-token-from-url"
@@ -132,7 +141,7 @@
   usage: >-
     The maximum size of stat-cache in MiBs. It can also be set to -1 for
     no-size-limit, 0 for no cache. Values below -1 are not supported.
-  default: "math.MinInt64"
+  default: "32"
 
 - flag-name: "type-cache-max-size-mb"
   config-path: "metadata-cache.type-cache-max-size-mb"
@@ -147,7 +156,7 @@
     The ttl value in seconds to be used for expiring items in metadata-cache. It
     can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled
     metadata-cache. Any value set below -1 will throw an error."
-  default: "math.MinInt64"
+  default: "60"
 
 - flag-name: "stat-cache-capacity"
   config-path: "metadata-cache.deprecated-stat-cache-capacity"
@@ -206,6 +215,7 @@
     next opendir (comes in the start, as part of next listing) call. 0 means no
     caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1
     will throw error.
+  default: "0"
 
 - flag-name: "http-client-timeout"
   config-path: "gcs-connection.http-client-timeout"
@@ -213,10 +223,12 @@
   usage: >-
     The time duration that http client will wait to get response from the
     server. The default value 0 indicates no timeout.
+  default: "0s"
 
 - flag-name: "max-retry-duration"
   type: "duration"
   usage: "This is currently unused."
+  default: "0s"
   deprecated: true
   deprecation-warning: "This is currently unused."
 
@@ -232,6 +244,7 @@
   usage: >-
     Path to the temporary directory where writes are staged prior to upload to
     Cloud Storage. (default: system default, likely /tmp)"
+  default: ""
 
 - flag-name: "client-protocol"
   config-path: "gcs-connection.client-protocol"
@@ -265,6 +278,7 @@
     not be seen. For example, if this flag is set, and metadata-cache-ttl-secs
     is set, then if we create the same file/node in the meantime using the same
     mount, since we are not refreshing the cache, it will still return nil.
+  default: false
 
 - flag-name: "stackdriver-export-interval"
   config-path: "metrics.stackdriver-export-interval"
@@ -278,6 +292,7 @@
   config-path: "monitoring.experimental-opentelemetry-collector-address"
   type: "string"
   usage: "Experimental: Export metrics to the OpenTelemetry collector at this address."
+  default: ""
   deprecated: true
   deprecation-warning: "Experimental flag: could be dropped even in a minor release."
 
@@ -302,6 +317,7 @@
   usage: >-
     By default, GCSFuse uses the GCS XML API to get and read objects. When this
     flag is specified, GCSFuse uses the GCS JSON API instead."
+  default: false
   deprecated: true
   deprecation-warning: "Experimental flag: could be dropped even in a minor release."
 
@@ -314,26 +330,30 @@
 
 - flag-name: "debug_fuse"
   type: "bool"
-  usage: "This flag is currently unused."
+  usage: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
+  default: false
   deprecated: true
-  deprecation-warning: "This flag is currently unused."
+  deprecation-warning: "debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
 
 - flag-name: "debug_fs"
   type: "bool"
-  usage: "This flag is currently unused."
+  usage: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
+  default: false
   deprecated: true
-  deprecation-warning: "This flag is currently unused."
+  deprecation-warning: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
 
 - flag-name: "debug_gcs"
   config-path: "debug.gcs"
   type: "bool"
   usage: "This flag is currently unused."
+  default: false
   deprecated: true
   deprecation-warning: "This flag is currently unused."
 
 - flag-name: "debug_http"
   type: "bool"
   usage: "This flag is currently unused."
+  default: false
   deprecated: true
   deprecation-warning: "This flag is currently unused."
 
@@ -341,11 +361,13 @@
   config-path: "debug.exit-on-invariant-violation"
   type: "bool"
   usage: "Exit when internal invariants are violated."
+  default: false
 
 - flag-name: "debug_mutex"
   config-path: "debug.log-mutex"
   type: "bool"
   usage: "Print debug messages when a mutex is held too long."
+  default: false
 
 - flag-name: "experimental-metadata-prefetch-on-mount"
   config-path: "metadata-cache.experimental-metadata-prefetch-on-mount"
@@ -365,6 +387,7 @@
   type: "bool"
   usage: "For a new file, it creates an empty file in Cloud Storage bucket as a
   hold."
+  default: false
   deprecated: true
   deprecation-warning: "This flag will be deleted soon."
 
@@ -384,6 +407,7 @@
   config-path: "file-cache.cache-file-for-range-read"
   type: "bool"
   usage: "Whether to cache file for range reads."
+  default: false
 
 - flag-name: "enable-crc-check"
   config-path: "file-cache.enable-crc-check"
@@ -395,6 +419,7 @@
   config-path: "file-cache.enable-parallel-downloads"
   type: "bool"
   usage: "Enable parallel downloads."
+  default: false
 
 - flag-name: "download-parallelism-per-file"
   config-path: "file-cache.download-parallelism-per-file"
@@ -412,6 +437,7 @@
   config-path: "file-cache.read-request-size-mb"
   type: "int"
   usage: "Size of chunks in MiB that each concurrent request downloads."
+  default: "0"
 
 - flag-name: "cache-dir"
   config-path: "cache-dir"
@@ -428,11 +454,13 @@
     (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases.
     (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case.
     (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.
+  default: false
 
-- flag-name: "grpc-conn-pool-size"
+- flag-name: "experimental-grpc-conn-pool-size"
   config-path: "gcs-connection.grpc-conn-pool-size"
   type: "int"
   usage: "The number of gRPC channel in grpc client."
+  default: "0"
   deprecated: true
   deprecation-warning: "Experimental flag: can be removed in a minor release."
 
@@ -440,24 +468,25 @@
   config-path: "enable-hns"
   type: "bool"
   usage: "Enables support for HNS buckets"
+  default: false
 
 - flag-name: "log-rotate-max-log-file-size-mb"
   config-path: "logging.log-rotate.max-file-size-mb"
   type: "int"
+  usage: "The maximum size in megabytes that a log file can reach before it is rotated."
   default: "512"
-  usage: "the maximum size in megabytes that a log file can reach before it is rotated."
 
 - flag-name: "log-rotate-backup-file-count"
   config-path: "logging.log-rotate.backup-file-count"
   type: "int"
-  default: "10"
   usage: >-
     The maximum number of backup log files to retain after they have been
     rotated. The default value is 10. When value is set to 0, all backup files are
     retained.
+  default: "10"
 
 - flag-name: "log-rotate-compress"
   config-path: "logging.log-rotate.compress"
   type: "bool"
+  usage: "Controls whether the rotated log files should be compressed using gzip."
   default: "true"
-  usage: "Whether the rotated log files should be gzipped."

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -325,6 +325,7 @@
   deprecation-warning: "This flag is currently unused."
 
 - flag-name: "debug_gcs"
+  config-path: "debug.gcs"
   type: "bool"
   usage: "This flag is currently unused."
   deprecated: true

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -221,7 +221,7 @@
   deprecation-warning: "This is currently unused."
 
 - flag-name: "retry-multiplier"
-  config-path: "gcs-connection.retry-multiplier"
+  config-path: "gcs-retries.multiplier"
   type: "float64"
   usage: Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.
   default: 2

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -85,7 +85,7 @@
 
 - flag-name: "key-file"
   config-path: "gcs-auth.key-file"
-  type: "string"
+  type: "resolvedPath"
   usage: "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)"
 
 - flag-name: "token-url"

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -62,7 +62,7 @@
 
 - flag-name: "custom-endpoint"
   config-path: "gcs-connection.custom-endpoint"
-  type: "string"
+  type: "url"
   usage: >-
     Specifies an alternative custom endpoint for fetching data. Should only be
     used for testing.  The custom endpoint must support the equivalent resources
@@ -297,6 +297,7 @@
   default: "json"
 
 - flag-name: "experimental-enable-json-read"
+  config-path: "gcs-connection.experimental-enable-json-read"
   type: "bool"
   usage: >-
     By default, GCSFuse uses the GCS XML API to get and read objects. When this

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -330,14 +330,14 @@
 
 - flag-name: "debug_fuse"
   type: "bool"
-  usage: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
+  usage: "This flag is unused. Debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
   default: false
   deprecated: true
   deprecation-warning: "debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
 
 - flag-name: "debug_fs"
   type: "bool"
-  usage: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
+  usage: "This flag is unused."
   default: false
   deprecated: true
   deprecation-warning: "This flag is  unused. debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
@@ -345,7 +345,7 @@
 - flag-name: "debug_gcs"
   config-path: "debug.gcs"
   type: "bool"
-  usage: "This flag is currently unused."
+  usage: "This flag is unused. Debug fuse logs are now controlled by log-severity flag, please use log-severity trace to view the logs."
   default: false
   deprecated: true
   deprecation-warning: "This flag is currently unused."

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -3,6 +3,22 @@
   type: "string"
   usage: "The application name of this mount."
 
+- flag-name: "foreground"
+  config-path: "foreground"
+  type: "bool"
+  usage: "Stay in the foreground after mounting."
+
+- flag-name: "o"
+  config-path: "file-system.fuse-options"
+  type: "[]string"
+  usage: "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro"
+
+- flag-name: "dir-mode"
+  config-path: "file-system.dir-mode"
+  type: "octal"
+  usage: "Permissions bits for directories, in octal."
+  default: "0755"
+
 - flag-name: "file-mode"
   config-path: "file-system.file-mode"
   type: "octal"
@@ -15,16 +31,305 @@
   default: -1
   usage: "UID owner of all inodes."
 
+- flag-name: "gid"
+  config-path: "file-system.gid"
+  type: "int"
+  default: -1
+  usage: "GID owner of all inodes."
+
+- flag-name: "implicit-dirs"
+  config-path: "implicit-dirs"
+  type: "bool"
+  usage: "Implicitly define directories based on content. See files and directories in docs/semantics for more information"
+
+- flag-name: "only-dir"
+  config-path: "only-dir"
+  type: "string"
+  usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
+
+- flag-name: "rename-dir-limit"
+  config-path: "file-system.rename-dir-limit"
+  type: "int"
+  usage: "Allow rename a directory containing fewer descendants than this limit."
+
+- flag-name: "ignore-interrupts"
+  config-path: "file-system.ignore-interrupts"
+  type: "bool"
+  usage: >-
+    Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered
+    by Ctrl+C). This prevents those signals from immediately terminating gcsfuse
+    inflight operations.
+
+- flag-name: "custom-endpoint"
+  config-path: "gcs-connection.custom-endpoint"
+  type: "string"
+  usage: >-
+    Specifies an alternative custom endpoint for fetching data. Should only be
+    used for testing.  The custom endpoint must support the equivalent resources
+    and operations as the GCS  JSON endpoint,
+    https://storage.googleapis.com/storage/v1. If a custom endpoint is not
+    specified,  GCSFuse uses the global GCS JSON API endpoint,
+    https://storage.googleapis.com/storage/v1.
+
+- flag-name: "anonymous-access"
+  config-path: "gcs-auth.anonymous-access"
+  type: "bool"
+  usage: "Authentication is enabled by default. This flag disables authentication"
+
+- flag-name: "billing-project"
+  config-path: "gcs-connection.billing-project"
+  type: "string"
+  usage: >-
+    Project to use for billing when accessing a bucket enabled with "Requester
+    Pays". (The default is none)
+
+- flag-name: "key-file"
+  config-path: "gcs-auth.key-file"
+  type: "string"
+  usage: "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)"
+
+- flag-name: "token-url"
+  config-path: "gcs-auth.token-url"
+  type: "string"
+  usage: "A url for getting an access token when the key-file is absent."
+
+- flag-name: "reuse-token-from-url"
+  config-path: "gcs-auth.reuse-token-from-url"
+  type: "bool"
+  usage: "If false, the token acquired from token-url is not reused."
+  default: "true"
+
+- flag-name: "limit-bytes-per-sec"
+  config-path: "gcs-connection.limit-bytes-per-sec"
+  type: "float64"
+  usage: "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)"
+  default: "-1"
+
+- flag-name: "limit-ops-per-sec"
+  config-path: "gcs-connection.limit-ops-per-sec"
+  type: "float64"
+  usage: "Operations per second limit, measured over a 30-second window (use -1 for no limit)"
+  default: "-1"
+
+- flag-name: "sequential-read-size-mb"
+  config-path: "gcs-connection.sequential-read-size-mb"
+  type: "int"
+  usage: "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported"
+  default: "200"
+
+- flag-name: "max-retry-sleep"
+  config-path: "gcs-retries.max-retry-sleep"
+  type: "duration"
+  usage: >-
+    The maximum duration allowed to sleep in a retry loop with exponential
+    backoff for failed requests to GCS backend. Once the backoff duration
+    exceeds this limit, the retry continues with this specified maximum value.
+  default: "30s"
+
+- flag-name: "stat-cache-max-size-mb"
+  config-path: "metadata-cache.stat-cache-max-size-mb"
+  type: "int"
+  usage: >-
+    The maximum size of stat-cache in MiBs. It can also be set to -1 for
+    no-size-limit, 0 for no cache. Values below -1 are not supported.
+  default: "math.MinInt64"
+
+- flag-name: "type-cache-max-size-mb"
+  config-path: "metadata-cache.type-cache-max-size-mb"
+  type: "int"
+  usage: "Max size of type-cache maps which are maintained at a per-directory level."
+  default: "4"
+
+- flag-name: "metadata-cache-ttl"
+  config-path: "metadata-cache.ttl-secs"
+  type: "int"
+  usage: >-
+    The ttl value in seconds to be used for expiring items in metadata-cache. It
+    can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled
+    metadata-cache. Any value set below -1 will throw an error."
+  default: "math.MinInt64"
+
+- flag-name: "stat-cache-capacity"
+  config-path: "metadata-cache.deprecated-stat-cache-capacity"
+  type: "int"
+  usage: >-
+    How many entries can the stat-cache hold (impacts memory consumption). This
+    flag has been deprecated (starting v2.0) and in favor of
+    stat-cache-max-size-mb. For now, the value of stat-cache-capacity will be
+    translated to the next higher corresponding value of stat-cache-max-size-mb
+    (assuming stat-cache entry-size ~= 1640 bytes, including 1400 for positive
+    entry and 240 for corresponding negative entry), if stat-cache-max-size-mb
+    is not set."
+  deprecated: true
+  deprecation-warning: >-
+    This flag has been deprecated (starting v2.0) in favor of
+    stat-cache-max-size-mb.
+  default: "20460"
+
+- flag-name: "stat-cache-ttl"
+  config-path: "metadata-cache.deprecated-stat-cache-ttl"
+  type: "duration"
+  usage: >-
+    How long to cache StatObject results and inode attributes. This flag
+    has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For
+    now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to
+    the next higher multiple of a second is used as ttl for both stat-cache and
+    type-cache, when metadata-cache-ttl-secs is not set.
+  default: "60s"
+  deprecated: true
+  deprecation-warning: >-
+    This flag has been deprecated (starting v2.0) in favor of
+    metadata-cache-ttl-secs.
+
+- flag-name: "type-cache-ttl"
+  config-path: "metadata-cache.deprecated-type-cache-ttl"
+  type: "duration"
+  usage: >-
+    Usage: How long to cache StatObject results and inode attributes. This flag
+    has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For
+    now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to
+    the next higher multiple of a second is used as ttl for both stat-cache and
+    type-cache, when metadata-cache-ttl-secs is not set.
+  default: "60s"
+  deprecated: true
+  deprecation-warning: >-
+    This flag has been deprecated (starting v2.0) in favor of
+    metadata-cache-ttl-secs.
+
+- flag-name: "kernel-list-cache-ttl-secs"
+  config-path: "list.kernel-list-cache-ttl-secs"
+  type: "int"
+  usage: >-
+    How long the directory listing (output of ls <dir>) should be cached in the
+    kernel page cache. If a particular directory cache entry is kept by kernel
+    for longer than TTL, then it will be sent for invalidation by gcsfuse on
+    next opendir (comes in the start, as part of next listing) call. 0 means no
+    caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1
+    will throw error.
+
+- flag-name: "http-client-timeout"
+  config-path: "gcs-connection.http-client-timeout"
+  type: "duration"
+  usage: >-
+    The time duration that http client will wait to get response from the
+    server. The default value 0 indicates no timeout.
+
+- flag-name: "max-retry-duration"
+  type: "duration"
+  usage: "This is currently unused."
+  deprecated: true
+  deprecation-warning: "This is currently unused."
+
+- flag-name: "retry-multiplier"
+  config-path: "gcs-connection.retry-multiplier"
+  type: "float64"
+  usage: Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.
+  default: 2
+
+- flag-name: "temp-dir"
+  config-path: "file-system.temp-dir"
+  type: "string"
+  usage: >-
+    Path to the temporary directory where writes are staged prior to upload to
+    Cloud Storage. (default: system default, likely /tmp)"
+
+- flag-name: "client-protocol"
+  config-path: "gcs-connection.client-protocol"
+  type: "protocol"
+  usage: >-
+    The protocol used for communicating with the GCS backend.
+    Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.
+  default: "http1"
+
+- flag-name: "max-conns-per-host"
+  config-path: "gcs-connection.max-conns-per-host"
+  type: "int"
+  usage: >-
+    The max number of TCP connections allowed per server. This is effective when
+    client-protocol is set to 'http1'. The default value 0 indicates no limit on
+    TCP connections (limited by the machine specifications).
+  default: "0"
+  
+- flag-name: "max-idle-conns-per-host"
+  config-path: "gcs-connection.max-idle-conns-per-host"
+  type: "int"
+  usage: "The number of maximum idle connections allowed per server."
+  default: "100"
+
+- flag-name: "enable-nonexistent-type-cache"
+  config-path: "metadata-cache.enable-nonexistent-type-cache"
+  type: "bool"
+  usage: >-
+    Once set, if an inode is not found in GCS, a type cache entry with type
+    NonexistentType will be created. This also means new file/dir created might
+    not be seen. For example, if this flag is set, and metadata-cache-ttl-secs
+    is set, then if we create the same file/node in the meantime using the same
+    mount, since we are not refreshing the cache, it will still return nil.
+
+- flag-name: "stackdriver-export-interval"
+  config-path: "metrics.stackdriver-export-interval"
+  type: "duration"
+  usage: >-
+    Export metrics to stackdriver with this interval. The default value 0
+    indicates no exporting.
+  default: "0s"
+
+- flag-name: "experimental-opentelemetry-collector-address"
+  type: "string"
+  usage: "Experimental: Export metrics to the OpenTelemetry collector at this address."
+  deprecated: true
+  deprecation-warning: "Experimental flag: could be dropped even in a minor release."
+
+- flag-name: "log-file"
+  config-path: "logging.file-path"
+  type: "resolvedPath"
+  usage: >-
+    The file for storing logs that can be parsed by fluentd. When not provided,
+    plain text logs are printed to stdout when Cloud Storage FUSE is run 
+    in the foreground, or to syslog when Cloud Storage FUSE is run in the 
+    background.
+
+- flag-name: "log-format"
+  config-path: "logging.format"
+  type: "string"
+  usage: "The format of the log file: 'text' or 'json'."
+  default: "json"
+
+- flag-name: "experimental-enable-json-read"
+  type: "bool"
+  usage: >-
+    By default, GCSFuse uses the GCS XML API to get and read objects. When this
+    flag is specified, GCSFuse uses the GCS JSON API instead."
+  deprecated: true
+  deprecation-warning: "Experimental flag: could be dropped even in a minor release."
+
 - flag-name: "debug_fuse_errors"
   type: "bool"
-  default: "true"
   usage: "This flag is currently unused."
+  default: "true"
   deprecated: true
   deprecation-warning: "This flag is currently unused."
 
 - flag-name: "debug_fuse"
   type: "bool"
-  default: "true"
+  usage: "This flag is currently unused."
+  deprecated: true
+  deprecation-warning: "This flag is currently unused."
+
+- flag-name: "debug_fs"
+  type: "bool"
+  usage: "This flag is currently unused."
+  deprecated: true
+  deprecation-warning: "This flag is currently unused."
+
+- flag-name: "debug_gcs"
+  type: "bool"
+  usage: "This flag is currently unused."
+  deprecated: true
+  deprecation-warning: "This flag is currently unused."
+
+- flag-name: "debug_http"
+  type: "bool"
   usage: "This flag is currently unused."
   deprecated: true
   deprecation-warning: "This flag is currently unused."
@@ -39,25 +344,88 @@
   type: "bool"
   usage: "Print debug messages when a mutex is held too long."
 
-- flag-name: "log-file"
-  config-path: "logging.file-path"
-  type: "resolvedPath"
+- flag-name: "experimental-metadata-prefetch-on-mount"
+  type: "string"
   usage: >-
-    The file for storing logs that can be parsed by fluentd. When not provided,
-    plain text logs are printed to stdout when Cloud Storage FUSE is run 
-    in the foreground, or to syslog when Cloud Storage FUSE is run in the 
-    background.
+    Experimental: This indicates whether or not to prefetch the metadata
+    (prefilling of metadata caches and creation of inodes) of the mounted bucket
+    at the time of mounting the bucket. Supported values: "disabled", "sync" and
+    "async". Any other values will return error on mounting. This is applicable
+    only to static mounting, and not to dynamic mounting.
+  default: "disabled"
+  deprecated: true
+  deprecation-warning: "Experimental flag: could be removed even in a minor release."
+
+- flag-name: "create-empty-file"
+  config-path: "write.create-empty-file"
+  type: "bool"
+  usage: "For a new file, it creates an empty file in Cloud Storage bucket as a
+  hold."
+  deprecated: true
+  deprecation-warning: "This flag will be deleted soon."
 
 - flag-name: "log-severity"
   config-path: "logging.severity"
   type: "logSeverity"
-  default: "info"
   usage: "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]"
+  default: "info"
 
-- flag-name: "client-protocol"
-  config-path: "gcs-connection.client-protocol"
-  type: "protocol"
-  default: "http1"
+- flag-name: "file-cache-max-size-mb"
+  config-path: "file-cache.max-size-mb"
+  type: "int"
+  usage: "Maximum size of the file-cache in MiBs"
+  default: "-1"
+
+- flag-name: "cache-file-for-range-read"
+  config-path: "file-cache.cache-file-for-range-read"
+  type: "bool"
+  usage: "Whether to cache file for range reads."
+
+- flag-name: "cache-dir"
+  config-path: "cache-dir"
+  type: "resolvedPath"
+  usage: "Enables file-caching. Specifies the directory to use for file-cache."
+
+- flag-name: "enable-empty-managed-folders"
+  config-path: "list.enable-empty-managed-folders"
+  type: "bool"
   usage: >-
-    The protocol used for communicating with the GCS backend.
-    Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.
+    This handles the corner case in listing managed folders.
+    There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object.
+    This flag always works in conjunction with --implicit-dirs flag.
+    (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases.
+    (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case.
+    (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.
+
+- flag-name: "grpc-conn-pool-size"
+  config-path: "gcs-connection.grpc-conn-pool-size"
+  type: "int"
+  usage: "The number of gRPC channel in grpc client."
+  deprecated: true
+  deprecation-warning: "Experimental flag: can be removed in a minor release."
+
+- flag-name: "enable-hns"
+  config-path: "enable-hns"
+  type: "bool"
+  usage: "Enables support for HNS buckets"
+
+- flag-name: "log-rotate-max-log-file-size-mb"
+  config-path: "logging.log-rotate.max-file-size-mb"
+  type: "int"
+  default: "512"
+  usage: "the maximum size in megabytes that a log file can reach before it is rotated."
+
+- flag-name: "log-rotate-backup-file-count"
+  config-path: "logging.log-rotate.backup-file-count"
+  type: "int"
+  default: "10"
+  usage: >-
+    The maximum number of backup log files to retain after they have been
+    rotated. The default value is 10. When value is set to 0, all backup files are
+    retained.
+
+- flag-name: "log-rotate-compress"
+  config-path: "logging.log-rotate.compress"
+  type: "bool"
+  default: "true"
+  usage: "Whether the rotated log files should be gzipped."

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -74,6 +74,10 @@ func getGoDataType(dt string) string {
 		return "ResolvedPath"
 	case "duration":
 		return "time.Duration"
+	case "int":
+		return "int64"
+	case "[]int":
+		return "[]int64"
 	default:
 		return dt
 	}


### PR DESCRIPTION
### Description
* All all currently used params to params.yaml.
* Generate int flags with type as int64 as opposed to platform-dependent int.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
