### PR TITLE
Use struct to bundle function parameters

### DIFF
--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -78,8 +79,9 @@ func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
 
 	// Job manager
 	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm,
-		util.DefaultDirPerm, chrT.cacheDir, DefaultSequentialReadSizeMb, false,
-		0, 0, 0, true)
+		util.DefaultDirPerm, chrT.cacheDir, DefaultSequentialReadSizeMb, &config.FileCacheConfig{
+			EnableCrcCheck: true,
+		})
 
 	// Mocked cached handler object.
 	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/data"
@@ -59,8 +60,9 @@ func (dt *downloaderTest) SetUp(*TestInfo) {
 	dt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
-	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, false,
-		0, 0, 0, true)
+	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, &config.FileCacheConfig{
+		EnableCrcCheck: true,
+	})
 }
 
 func (dt *downloaderTest) TearDown() {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -244,9 +244,7 @@ func createFileCacheHandler(cfg *ServerConfig) (fileCacheHandler *file.CacheHand
 	}
 
 	jobManager := downloader.NewJobManager(fileInfoCache, filePerm, dirPerm, cacheDir,
-		cfg.SequentialReadSizeMb, cfg.MountConfig.FileCacheConfig.EnableParallelDownloads,
-		cfg.MountConfig.FileCacheConfig.DownloadParallelismPerFile, cfg.MountConfig.MaxDownloadParallelism,
-		cfg.MountConfig.FileCacheConfig.ReadRequestSizeMB, cfg.MountConfig.EnableCrcCheck)
+		cfg.SequentialReadSizeMb, &cfg.MountConfig.FileCacheConfig)
 	fileCacheHandler = file.NewCacheHandler(fileInfoCache, jobManager,
 		cacheDir, filePerm, dirPerm)
 	return

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
@@ -174,7 +175,9 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 
 	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
 	lruCache := lru.NewCache(CacheMaxSize)
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, false, 0, 0, 0, true)
+	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &config.FileCacheConfig{
+		EnableCrcCheck: true,
+	})
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 
 	// Set up the reader.


### PR DESCRIPTION
Instead of passing file-cache related arguments individually, using the FileCacheConfig struct to make code more readable.

### Description

### Link to the issue in case of a bug fix.
b/345646639

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
