### PR TITLE
Use 1.22 as the min Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse/v2
 
-go 1.22.4
+go 1.22
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0


### PR DESCRIPTION
The "go" line in go.mod specifies the minimum Go version that's required by the current module. While building, go automatically picks up the installed go version if it's same or more recent than the specified go version in go.mod. Since GCSFuse is compatible with go v1.22, we can declare the same in go.mod and let Go decide the right toolchain to build.

### Description

### Link to the issue in case of a bug fix.
b/346695794

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
