### PR TITLE
adds change for not waiting for download in case of sequential read w…

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -136,7 +136,15 @@ func (cht *cacheHandleTest) SetupTest() {
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
 	assert.Nil(cht.T(), err)
 
-	fileDownloadJob := downloader.NewJob(cht.object, cht.bucket, cht.cache, DefaultSequentialReadSizeMb, cht.fileSpec, func() {}, &config.FileCacheConfig{EnableCrcCheck: true})
+	fileDownloadJob := downloader.NewJob(
+		cht.object,
+		cht.bucket,
+		cht.cache,
+		DefaultSequentialReadSizeMb,
+		cht.fileSpec,
+		func() {},
+		&config.FileCacheConfig{EnableCrcCheck: true},
+	)
 
 	cht.cacheHandle = NewCacheHandle(readLocalFileHandle, fileDownloadJob, cht.cache, false, 0)
 }
@@ -818,5 +826,30 @@ func (cht *cacheHandleTest) Test_MultipleReads_CacheHitShouldBeFalseThenTrue() {
 
 	assert.Equal(cht.T(), n, ReadContentSize)
 	assert.True(cht.T(), cacheHit)
+	assert.Nil(cht.T(), err)
+}
+func (cht *cacheHandleTest) Test_Read_Sequential_Parallel_Download_True() {
+	dst := make([]byte, ReadContentSize)
+	offset := int64(cht.object.Size - ReadContentSize)
+	cht.cacheHandle.isSequential = true
+	cht.cacheHandle.cacheFileForRangeRead = true
+
+	fileDownloadJob := downloader.NewJob(
+		cht.object,
+		cht.bucket,
+		cht.cache,
+		DefaultSequentialReadSizeMb,
+		cht.fileSpec,
+		func() {},
+		&config.FileCacheConfig{EnableCrcCheck: true, EnableParallelDownloads: true},
+	)
+
+	cht.cacheHandle.fileDownloadJob = fileDownloadJob
+
+	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, offset, dst)
+
+	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
+	assert.Equal(cht.T(), downloader.Downloading, jobStatus.Name)
+	assert.False(cht.T(), cacheHit)
 	assert.Nil(cht.T(), err)
 }

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -447,7 +447,7 @@ func (job *Job) Download(ctx context.Context, offset int64, waitForDownload bool
 		return job.status, nil
 	}
 
-	if !waitForDownload {
+	if !(waitForDownload || job.fileCacheConfig.EnableParallelDownloads) {
 		defer job.mu.Unlock()
 		return job.status, nil
 	}


### PR DESCRIPTION
…hen parallel download is true

### Description
adds initial change for not waiting for download in case of sequential read when parallel download is true, this PR includes code changes for job.go and unit test, once these code changes are merged, will also add chnages for cache_handler

### Link to the issue in case of a bug fix.
b/345645002

### Testing details
1. Manual - NA
2. Unit tests - done
3. Integration tests - NA
