### PR TITLE
Making compute crc method context cancellable

### DIFF
--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -76,7 +76,7 @@ func (dt *downloaderTest) waitForCrcCheckToBeCompleted() {
 	// Hence, explicitly waiting till the CRC check is done.
 	for {
 		dt.job.mu.Lock()
-		if dt.job.status.Name == Completed || dt.job.status.Name == Failed {
+		if dt.job.status.Name == Completed || dt.job.status.Name == Failed || dt.job.status.Name == Invalid {
 			dt.job.mu.Unlock()
 			break
 		}

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -483,7 +483,7 @@ func (job *Job) validateCRC() (err error) {
 		return
 	}
 
-	crc32Val, err := cacheutil.CalculateFileCRC32(job.fileSpec.Path)
+	crc32Val, err := cacheutil.CalculateFileCRC32(job.cancelCtx, job.fileSpec.Path)
 	if err != nil {
 		return
 	}

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -509,7 +509,6 @@ func (job *Job) handleError(err error) {
 	}
 
 	job.failWhileDownloading(err)
-	return
 }
 
 // Sets the status as invalid and notifies the subscribers.

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -807,6 +807,7 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCrcCheckIsTr
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
 	AssertEq(nil, err)
 
+	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
 	AssertNe(nil, err)
@@ -840,6 +841,7 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCrcCheckIsFa
 	AssertEq(nil, err)
 	dt.job.fileCacheConfig.EnableCrcCheck = false
 
+	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
 	AssertEq(nil, err)

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -141,7 +140,7 @@ func calculateCRC32(ctx context.Context, reader io.Reader) (uint32, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return 0, errors.New("CRC computation is cancelled")
+			return 0, fmt.Errorf("CRC computation is cancelled: %w", ctx.Err())
 		default:
 			switch n, err := reader.Read(buf); err {
 			case nil:

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -132,24 +134,29 @@ func CreateCacheDirectoryIfNotPresentAt(dirPath string, dirPerm os.FileMode) err
 	return nil
 }
 
-func calculateCRC32(reader io.Reader) (uint32, error) {
+func calculateCRC32(ctx context.Context, reader io.Reader) (uint32, error) {
 	table := crc32.MakeTable(crc32.Castagnoli)
 	checksum := crc32.Checksum([]byte(""), table)
 	buf := make([]byte, BufferSizeForCRC)
 	for {
-		switch n, err := reader.Read(buf); err {
-		case nil:
-			checksum = crc32.Update(checksum, table, buf[:n])
-		case io.EOF:
-			return checksum, nil
+		select {
+		case <-ctx.Done():
+			return 0, errors.New("CRC computation is cancelled")
 		default:
-			return 0, err
+			switch n, err := reader.Read(buf); err {
+			case nil:
+				checksum = crc32.Update(checksum, table, buf[:n])
+			case io.EOF:
+				return checksum, nil
+			default:
+				return 0, err
+			}
 		}
 	}
 }
 
 // CalculateFileCRC32 calculates and returns the CRC-32 checksum of a file.
-func CalculateFileCRC32(filePath string) (uint32, error) {
+func CalculateFileCRC32(ctx context.Context, filePath string) (uint32, error) {
 	// Open file with simplified flags and permissions
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -157,5 +164,5 @@ func CalculateFileCRC32(filePath string) (uint32, error) {
 	}
 	defer file.Close() // Ensure file closure
 
-	return calculateCRC32(file)
+	return calculateCRC32(ctx, file)
 }

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -29,6 +28,7 @@ import (
 	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	. "github.com/jacobsa/ogletest"
+	"golang.org/x/net/context"
 )
 
 func TestUtil(t *testing.T) { RunTests(t) }
@@ -271,9 +271,9 @@ func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist() {
 func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorWhenContextIsCancelled() {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
-
 	crc, err := CalculateFileCRC32(ctx, "testdata/validfile.txt")
 
+	ExpectTrue(errors.Is(err, context.Canceled))
 	ExpectTrue(strings.Contains(err.Error(), "CRC computation is cancelled"))
 	ExpectEq(0, crc)
 }

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -247,23 +248,33 @@ func (ut *utilTest) Test_IsCacheHandleValid_False() {
 }
 
 func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnCrcForValidFile() {
-	crc, err := CalculateFileCRC32("testdata/validfile.txt")
+	crc, err := CalculateFileCRC32(context.Background(), "testdata/validfile.txt")
 
 	ExpectEq(nil, err)
 	ExpectEq(515179668, crc)
 }
 
 func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnZeroForEmptyFile() {
-	crc, err := CalculateFileCRC32("testdata/emptyfile.txt")
+	crc, err := CalculateFileCRC32(context.Background(), "testdata/emptyfile.txt")
 
 	ExpectEq(nil, err)
 	ExpectEq(0, crc)
 }
 
 func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist() {
-	crc, err := CalculateFileCRC32("testdata/nofile.txt")
+	crc, err := CalculateFileCRC32(context.Background(), "testdata/nofile.txt")
 
 	ExpectTrue(strings.Contains(err.Error(), "no such file or directory"))
+	ExpectEq(0, crc)
+}
+
+func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorWhenContextIsCancelled() {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+
+	crc, err := CalculateFileCRC32(ctx, "testdata/validfile.txt")
+
+	ExpectTrue(strings.Contains(err.Error(), "CRC computation is cancelled"))
 	ExpectEq(0, crc)
 }
 


### PR DESCRIPTION
### Description
Making compute crc method context cancellable, so it can be cancelled as part of job cancellation

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA
