### PR TITLE
Use truncate and remove function while eviction from job during CRC check

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -489,8 +489,8 @@ func (job *Job) validateCRC() (err error) {
 	}
 
 	job.fileInfoCache.Erase(fileInfoKeyName)
-	removeErr := os.Remove(job.fileSpec.Path)
-	if removeErr != nil {
+	removeErr := cacheutil.TruncateAndRemoveFile(job.fileSpec.Path)
+	if removeErr != nil && !os.IsNotExist(removeErr) {
 		err = errors.Join(err, removeErr)
 	}
 

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -165,3 +165,19 @@ func CalculateFileCRC32(ctx context.Context, filePath string) (uint32, error) {
 
 	return calculateCRC32(ctx, file)
 }
+
+// TruncateAndRemoveFile first truncates the file to 0 and then remove (delete)
+// the file at given path.
+func TruncateAndRemoveFile(filePath string) error {
+	// Truncate the file to 0 size, so that even if there are open file handles
+	// and linux doesn't delete the file, the file will not take space.
+	err := os.Truncate(filePath, 0)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(filePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -332,6 +332,7 @@ func (ut *utilTest) Test_TruncateAndRemoveFile_OpenedFileDeleted() {
 	ExpectEq(nil, err)
 	// The size of open file should be 0.
 	fileInfo, err = file.Stat()
+	ExpectEq(nil, err)
 	ExpectEq(0, fileInfo.Size())
 }
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -318,7 +318,9 @@ func (ut *utilTest) Test_TruncateAndRemoveFile_OpenedFileDeleted() {
 	AssertEq(nil, err)
 	// Open the file again
 	file, err = os.Open(fileName)
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	AssertEq(nil, err)
 	fileInfo, err := file.Stat()
 	AssertEq(nil, err)

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -278,6 +278,61 @@ func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorWhenContextIsCancel
 	ExpectEq(0, crc)
 }
 
+func (ut *utilTest) Test_TruncateAndRemoveFile_FileExists() {
+	// Create a file to be deleted.
+	fileName := "temp.txt"
+	file, err := os.Create(fileName)
+	AssertEq(nil, err)
+	_, err = file.WriteString("Writing some data")
+	AssertEq(nil, err)
+	err = file.Close()
+	AssertEq(nil, err)
+
+	err = TruncateAndRemoveFile(fileName)
+
+	ExpectEq(nil, err)
+	// Check the file is deleted.
+	_, err = os.Stat(fileName)
+	ExpectTrue(os.IsNotExist(err), fmt.Sprintf("expected not exist error but got error: %v", err))
+}
+
+func (ut *utilTest) Test_TruncateAndRemoveFile_FileDoesNotExist() {
+	// Create a file to be deleted.
+	fileName := "temp.txt"
+
+	err := TruncateAndRemoveFile(fileName)
+
+	ExpectTrue(os.IsNotExist(err), fmt.Sprintf("expected not exist error but got error: %v", err))
+}
+
+func (ut *utilTest) Test_TruncateAndRemoveFile_OpenedFileDeleted() {
+	// Create a file to be deleted.
+	fileName := "temp.txt"
+	file, err := os.Create(fileName)
+	AssertEq(nil, err)
+	fileString := "Writing some data"
+	_, err = file.WriteString(fileString)
+	AssertEq(nil, err)
+	// Close the file to get the contents synced.
+	err = file.Close()
+	AssertEq(nil, err)
+	// Open the file again
+	file, err = os.Open(fileName)
+	defer file.Close()
+	AssertEq(nil, err)
+	fileInfo, err := file.Stat()
+	AssertEq(nil, err)
+	AssertEq(len(fileString), fileInfo.Size())
+
+	// File is not closed and call TruncateAndRemoveFile
+	err = TruncateAndRemoveFile(fileName)
+
+	ExpectEq(nil, err)
+	// The size of open file should be 0.
+	fileInfo, err = file.Stat()
+	ExpectEq(0, fileInfo.Size())
+}
+
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryExists(t *testing.T) {
 	base := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirPath := path.Join(base, "/", "path/cachedir")


### PR DESCRIPTION
### Description
Use truncate and remove function while eviction from job during CRC check.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - added integration test tag. 
