### PR TITLE
Add more tests (unit, composite) tests for parallel downloads

### DIFF
--- a/internal/cache/file/downloader/parallel_downloads_job_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_test.go
@@ -18,9 +18,19 @@
 package downloader
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync/atomic"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/data"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -37,6 +47,108 @@ func init() { RegisterTestSuite(&parallelDownloaderTest{}) }
 
 func (dt *parallelDownloaderTest) SetUp(*TestInfo) {
 	dt.defaultFileCacheConfig = &config.FileCacheConfig{EnableParallelDownloads: true,
-		DownloadParallelismPerFile: 5, ReadRequestSizeMB: 2, EnableCrcCheck: true}
+		DownloadParallelismPerFile: 3, ReadRequestSizeMB: 3, EnableCrcCheck: true}
 	dt.setupHelper()
+}
+
+func (dt *parallelDownloaderTest) Test_downloadRange() {
+	// Create object in fake GCS
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 10 * util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	var callbackExecuted atomic.Bool
+	removeCallback := func() { callbackExecuted.Store(true) }
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), removeCallback)
+	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
+	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
+		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
+	AssertEq(nil, err)
+	verifyContentAtOffset := func(file *os.File, start, end int64) {
+		_, err = file.Seek(start, 0)
+		AssertEq(nil, err)
+		buf := make([]byte, end-start)
+		_, err = file.Read(buf)
+		AssertEq(nil, err)
+		// If content don't match then print start and end for easy debuggability.
+		AssertTrue(reflect.DeepEqual(objectContent[start:end], buf), fmt.Sprintf("content didn't match for start: %v and end: %v", start, end))
+	}
+
+	// Download end 1MiB of object
+	start, end := int64(9*util.MiB), int64(10*util.MiB)
+	offsetWriter := io.NewOffsetWriter(file, start)
+	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
+	AssertEq(nil, err)
+	verifyContentAtOffset(file, start, end)
+
+	// Download start 4MiB of object
+	start, end = int64(0*util.MiB), int64(4*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, start)
+	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
+	AssertEq(nil, err)
+	verifyContentAtOffset(file, start, end)
+
+	// Download middle 1B of object
+	start, end = int64(5*util.MiB), int64(5*util.MiB+1)
+	offsetWriter = io.NewOffsetWriter(file, start)
+	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
+	AssertEq(nil, err)
+	verifyContentAtOffset(file, start, end)
+
+	// Download 0B of object
+	start, end = int64(5*util.MiB), int64(5*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, start)
+	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
+	AssertEq(nil, err)
+	verifyContentAtOffset(file, start, end)
+}
+
+func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 10 * util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
+	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
+	// Add subscriber
+	subscribedOffset := int64(1 * util.MiB)
+	notificationC := dt.job.subscribe(subscribedOffset)
+	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
+		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
+	AssertEq(nil, err)
+	defer func() {
+		_ = file.Close()
+	}()
+
+	// Start download
+	err = dt.job.parallelDownloadObjectToFile(file)
+
+	AssertEq(nil, err)
+	jobStatus, ok := <-notificationC
+	AssertEq(true, ok)
+	// Check the notification is sent after subscribed offset
+	AssertGe(jobStatus.Offset, subscribedOffset)
+	dt.job.mu.Lock()
+	defer dt.job.mu.Unlock()
+	// Verify file is downloaded
+	dt.verifyFile(objectContent)
+	// Verify fileInfoCache update
+	dt.verifyFileInfoEntry(uint64(objectSize))
+}
+
+func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile_CtxCancelled() {
+	objectName := "path/in/gcs/cancel.txt"
+	objectSize := util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), func() {})
+	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
+	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
+		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
+	AssertEq(nil, err)
+	defer func() {
+		_ = file.Close()
+	}()
+
+	dt.job.cancelFunc()
+	err = dt.job.parallelDownloadObjectToFile(file)
+
+	AssertTrue(errors.Is(err, context.Canceled), fmt.Sprintf("didn't get context canceled error: %v", err))
 }


### PR DESCRIPTION
### Description
Add some tests (unit, composite & e2e) tests for parallel downloads

I tried to add to existing e2e tests but those were [failing](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/6e63e377-1c89-4ecc-b237-4c7d0a9baf9f/log), so we will address e2e tests in a separate PR.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
