### PR TITLE
fix e2e test for hns bucket

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -158,7 +158,7 @@ func TestMain(m *testing.M) {
 	// Create storage client before running tests.
 	ctx := context.Background()
 	var storageClient *storage.Client
-	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*15)
+	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*40)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -233,9 +233,6 @@ function run_e2e_tests_for_hns_bucket(){
 
    echo "Running tests for HNS bucket"
    run_non_parallel_tests TEST_DIR_HNS_GROUP "$hns_bucket_name"
-   non_parallel_tests_pid_hns_group=$!
-
-   wait $non_parallel_tests_pid_hns_group
    non_parallel_tests_hns_group_exit_code=$?
 
    hns_buckets=("$hns_bucket_name")


### PR DESCRIPTION
### Description
1. Increase the timeout for the storage client, as operations tests often run for more than 15 minutes.
2. The HNS function process was running in the foreground, so we were unable to obtain a process ID and therefore couldn't get the correct exit code.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - Automated
