### PR TITLE
Make Wait for Download false for all read scenarios when parallel downloads is true

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -185,6 +185,10 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 
 		fch.prevOffset = offset
 
+		if fch.fileDownloadJob.IsParallelDownloadsEnabled() {
+			waitForDownload = false
+		}
+
 		jobStatus, err = fch.fileDownloadJob.Download(ctx, requiredOffset, waitForDownload)
 		if err != nil {
 			n = 0

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -136,7 +136,7 @@ func (cht *cacheHandleTest) SetupTest() {
 	readLocalFileHandle, err := util.CreateFile(cht.fileSpec, os.O_RDONLY)
 	assert.Nil(cht.T(), err)
 
-	fileDownloadJob := downloader.NewJob(cht.object, cht.bucket, cht.cache, DefaultSequentialReadSizeMb, cht.fileSpec, func() {}, &config.FileCacheConfig{EnableCrcCheck: true})
+	fileDownloadJob := downloader.NewJob(cht.object, cht.bucket, cht.cache, DefaultSequentialReadSizeMb, cht.fileSpec, func() {}, &config.FileCacheConfig{EnableCrcCheck: true, EnableParallelDownloads: false})
 
 	cht.cacheHandle = NewCacheHandle(readLocalFileHandle, fileDownloadJob, cht.cache, false, 0)
 }

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -515,3 +515,10 @@ func (job *Job) validateCRC() (err error) {
 
 	return
 }
+
+func (job *Job) IsParallelDownloadsEnabled() bool {
+	if job.fileCacheConfig != nil && job.fileCacheConfig.EnableParallelDownloads {
+		return true
+	}
+	return false
+}

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -848,3 +848,29 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCrcCheckIsFa
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
+
+func (dt *downloaderTest) Test_When_Parallel_Download_Is_Enabled() {
+	//Arrange - initJobTest is being called in setup of downloader.go
+	dt.job.fileCacheConfig.EnableParallelDownloads = true
+
+	result := dt.job.IsParallelDownloadsEnabled()
+
+	AssertTrue(result)
+}
+
+func (dt *downloaderTest) Test_When_Parallel_Download_Is_Disabled() {
+	//Arrange - initJobTest is being called in setup of downloader.go
+	dt.job.fileCacheConfig.EnableParallelDownloads = false
+
+	result := dt.job.IsParallelDownloadsEnabled()
+
+	AssertFalse(result)
+}
+
+func (dt *downloaderTest) Test_When_Parallel_Download_Is_Not_Explicitly_Set_In_Config() {
+	//Arrange - initJobTest is being called in setup of downloader.go
+
+	result := dt.job.IsParallelDownloadsEnabled()
+
+	AssertFalse(result)
+}

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -980,11 +980,3 @@ func (dt *downloaderTest) Test_When_Parallel_Download_Is_Disabled() {
 
 	AssertFalse(result)
 }
-
-func (dt *downloaderTest) Test_When_Parallel_Download_Is_Not_Explicitly_Set_In_Config() {
-	//Arrange - initJobTest is being called in setup of downloader.go
-
-	result := dt.job.IsParallelDownloadsEnabled()
-
-	AssertFalse(result)
-}


### PR DESCRIPTION
### Description
Make Wait for Download false for all read scenarios when parallel downloads is true

### Link to the issue in case of a bug fix.
b/345645002

### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - NA
