### PR TITLE
Convert Golang compliant flags to POSIX compliant

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,11 +38,12 @@ func logPanic() {
 
 // convertToPosixArgs converts a slice of commandline args and transforms them
 // into POSIX compliant args. All it does is that it converts flags specified
-// using a single-hyphen to double-hyphens.
+// using a single-hyphen to double-hyphens. We are excluding "-v" because it's
+// reserved for showing version in Cobra.
 func convertToPosixArgs(args []string) []string {
 	pArgs := make([]string, 0, len(args))
 	for _, a := range args {
-		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") {
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") && a != "-v" {
 			pArgs = append(pArgs, "-"+a)
 		} else {
 			pArgs = append(pArgs, a)

--- a/main.go
+++ b/main.go
@@ -36,6 +36,21 @@ func logPanic() {
 	}
 }
 
+// convertToPosixArgs converts a slice of commandline args and transforms them
+// into POSIX compliant args. All it does is that it converts flags specified
+// using a single-hyphen to double-hyphens.
+func convertToPosixArgs(args []string) []string {
+	pArgs := make([]string, 0, len(args))
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") {
+			pArgs = append(pArgs, "-"+a)
+		} else {
+			pArgs = append(pArgs, a)
+		}
+	}
+	return args
+}
+
 // Don't remove the comment below. It's used to generate config.go file
 // which is used for flag and config file parsing.
 // Refer https://go.dev/blog/generate for details.
@@ -47,6 +62,7 @@ func main() {
 	// Make logging output better.
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "true" {
+		os.Args = convertToPosixArgs(os.Args)
 		cmd.Execute()
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func convertToPosixArgs(args []string) []string {
 			pArgs = append(pArgs, a)
 		}
 	}
-	return args
+	return pArgs
 }
 
 // Don't remove the comment below. It's used to generate config.go file

--- a/main_test.go
+++ b/main_test.go
@@ -46,6 +46,11 @@ func TestPosixFlagsConversion(t *testing.T) {
 			input:    []string{"abc", "--flag=\"-test\""},
 			expected: []string{"abc", "--flag=\"-test\""},
 		},
+		{
+			name:     "Version shorthand stays unchanged.",
+			input:    []string{"abc", "-v"},
+			expected: []string{"abc", "-v"},
+		},
 	}
 	for _, tc := range data {
 		t.Run(tc.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPosixFlagsConversion(t *testing.T) {
+	data := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Single hyphen converted to double",
+			input:    []string{"abc", "-flag"},
+			expected: []string{"abc", "--flag"},
+		},
+		{
+			name:     "Double-hyphens remain unchanged",
+			input:    []string{"abc", "--flag"},
+			expected: []string{"abc", "--flag"},
+		},
+		{
+			name:     "Single hyphen converted to double for flags with values",
+			input:    []string{"abc", "-flag=\"test\""},
+			expected: []string{"abc", "--flag=\"test\""},
+		},
+		{
+			name:     "Values with hyphen stay unchanged",
+			input:    []string{"abc", "--flag=\"-test\""},
+			expected: []string{"abc", "--flag=\"-test\""},
+		},
+	}
+	for _, tc := range data {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, convertToPosixArgs(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
Golang flags don't distinguish between single-hyphen and double-hyphen flags. POSIX compliant flags that are supported by pflag and Cobra however require flags to be prefixed with double hyphens. So, augment the flags in os.Args by converting the single-hyphen flags to double-hyphen ones so that they can be consumed by Cobra and Viper.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
