### PR TITLE
Kokoro tpc build fix

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -33,7 +33,7 @@ commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 ## To execute tests for a specific commitId, ensure you've checked out that commitId first.
 git checkout $commitId
 
-sudo gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
+gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 echo "Running e2e tests on installed package...."
 
 # Initiate PRPTST environment to establish a TPC project and associated account.

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -25,6 +25,9 @@ readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
+# Copy the key file for the TPC service account to use for authentication.
+gcloud alpha storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
+
 echo "Building and installing gcsfuse..."
 # Get the latest commitId of yesterday in the log file. Build gcsfuse and run
 commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
@@ -32,8 +35,6 @@ commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 
 ## To execute tests for a specific commitId, ensure you've checked out that commitId first.
 git checkout $commitId
-
-gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 echo "Running e2e tests on installed package...."
 
 # Initiate PRPTST environment to establish a TPC project and associated account.

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -25,8 +25,18 @@ readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
+
+# Upgrade gcloud version
+gcloud version
+wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
+sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
+sudo /usr/local/google-cloud-sdk/install.sh
+export PATH=/usr/local/google-cloud-sdk/bin:$PATH
+echo 'export PATH=/usr/local/google-cloud-sdk/bin:$PATH' >> ~/.bashrc
+gcloud version && rm gcloud.tar.gz
+
 # Copy the key file for the TPC service account to use for authentication.
-gcloud alpha storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
+gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 
 echo "Building and installing gcsfuse..."
 # Get the latest commitId of yesterday in the log file. Build gcsfuse and run


### PR DESCRIPTION
### Description
Kokoro TPC build is failing with 
```
ERROR: (gcloud) Invalid choice: 'storage'.
This command is available in one or more alternate release tracks.  Try:
  gcloud alpha storage
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
