### PR TITLE
Kernel List Cache: Composite Test

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -253,6 +253,15 @@ func (t *fsTest) deleteObject(name string) error {
 	return bucket.DeleteObject(ctx, &gcs.DeleteObjectRequest{Name: name})
 }
 
+func (t *fsTest) deleteObjects(names []string) error {
+	for _, name := range names {
+		if err := t.deleteObject(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (t *fsTest) createEmptyObjects(names []string) error {
 	err := storageutil.CreateEmptyObjects(ctx, bucket, names)
 	return err

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -253,15 +253,6 @@ func (t *fsTest) deleteObject(name string) error {
 	return bucket.DeleteObject(ctx, &gcs.DeleteObjectRequest{Name: name})
 }
 
-func (t *fsTest) deleteObjects(names []string) error {
-	for _, name := range names {
-		if err := t.deleteObject(name); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (t *fsTest) createEmptyObjects(names []string) error {
 	err := storageutil.CreateEmptyObjects(ctx, bucket, names)
 	return err

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -249,6 +249,10 @@ func (t *fsTest) createObjects(in map[string]string) error {
 	return err
 }
 
+func (t *fsTest) deleteObject(name string) error {
+	return bucket.DeleteObject(ctx, &gcs.DeleteObjectRequest{Name: name})
+}
+
 func (t *fsTest) createEmptyObjects(names []string) error {
 	err := storageutil.CreateEmptyObjects(ctx, bucket, names)
 	return err

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Please refer kernel_list_cache_test.go for the documentation.
+
+package fs_test
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type KernelListCacheTestWithInfiniteTtl struct {
+	suite.Suite
+	fsTest
+	KernelListCacheTestCommon
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.MountConfig = &config.MountConfig{
+		ListConfig: config.ListConfig{
+			KernelListCacheTtlSeconds: -1,
+		},
+		MetadataCacheConfig: config.MetadataCacheConfig{
+			TtlInSeconds: 0,
+		},
+	}
+	t.serverCfg.RenameDirLimit = 10
+	t.fsTest.SetUpTestSuite()
+}
+
+func TestKernelListCacheTestInfiniteTtlSuite(t *testing.T) {
+	suite.Run(t, new(KernelListCacheTestWithInfiniteTtl))
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+
+	// No invalidation since infinite ttl.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+}

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -36,7 +36,7 @@ type KernelListCacheTestWithInfiniteTtl struct {
 func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
-		ListConfig: config.ListConfig{
+		FileSystemConfig: config.FileSystemConfig{
 			KernelListCacheTtlSeconds: -1,
 		},
 		MetadataCacheConfig: config.MetadataCacheConfig{

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -62,7 +63,7 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit(
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -81,7 +82,7 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit(
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names2))
+	require.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 }

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -106,7 +106,7 @@ type KernelListCacheTestWithPositiveTtl struct {
 func (t *KernelListCacheTestWithPositiveTtl) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
-		ListConfig: config.ListConfig{
+		FileSystemConfig: config.FileSystemConfig{
 			KernelListCacheTtlSeconds: kernelListCacheTtlSeconds,
 		},
 		MetadataCacheConfig: config.MetadataCacheConfig{

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -1,0 +1,152 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests for a file system where parallel dirops are allowed.
+// Dirops refers to readdir and lookup operations.
+
+package fs_test
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type KernelListCacheTest struct {
+	suite.Suite
+	fsTest
+}
+
+func (t *KernelListCacheTest) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.MountConfig = &config.MountConfig{
+		FileSystemConfig: config.FileSystemConfig{
+			DisableParallelDirops:     false,
+			KernelListCacheTtlSeconds: 100,
+		}}
+	t.serverCfg.RenameDirLimit = 10
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *KernelListCacheTest) SetupTest() {
+	t.createFilesAndDirStructureInBucket()
+}
+
+func (t *KernelListCacheTest) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func (t *KernelListCacheTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func TestKernelListCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(KernelListCacheTest))
+}
+
+// createFilesAndDirStructureInBucket creates the following files and directory
+// structure.
+// bucket
+//
+//	file1.txt
+//	file2.txt
+//	explicitDir1/
+//	explicitDir1/file1.txt
+//	explicitDir1/file2.txt
+//	implicitDir1/file1.txt
+func (t *KernelListCacheTest) createFilesAndDirStructureInBucket() {
+	assert.Nil(
+		t.T(),
+		t.createObjects(
+			map[string]string{
+				"file1.txt":              "abcdef",
+				"file2.txt":              "xyz",
+				"explicitDir1/":          "",
+				"explicitDir1/file1.txt": "12345",
+				"explicitDir1/file2.txt": "6789101112",
+				"implicitDir1/file1.txt": "-1234556789",
+			}))
+}
+
+func (t *KernelListCacheTest) TestKernelListCache_SimpleWorkingCase() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir1"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Create another object
+	assert.Nil(
+		t.T(),
+		t.createObjects(
+			map[string]string{
+				"explicitDir1/file3.txt": "123456",
+			}))
+
+	// First read, kernel will cache the dir response.
+	f, err = os.Open(path.Join(mntDir, "explicitDir1"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names2))
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+}
+
+func (t *KernelListCacheTest) TestKernelListCache_SimpleWorkingCase_False() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir1"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Create another object
+	assert.Nil(
+		t.T(),
+		t.createObjects(
+			map[string]string{
+				"explicitDir1/file3.txt": "123456",
+			}))
+
+	// Advance the time more than ttl, to invalidate the cache.
+	cacheClock.AdvanceTime(110 * time.Second)
+
+	// First read, kernel will cache the dir response.
+	f, err = os.Open(path.Join(mntDir, "explicitDir1"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 3, len(names2))
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+}

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -85,12 +86,10 @@ func (t *KernelListCacheTestCommon) createFilesAndDirStructureInBucket() {
 }
 
 func (t *KernelListCacheTestCommon) deleteFilesAndDirStructureInBucket() {
-	filesOrDirStructure := getFilesAndDirStructureObjects()
-	keys := make([]string, len(filesOrDirStructure))
-	for k := range filesOrDirStructure {
-		keys = append(keys, k)
+	filesAndDirStructure := getFilesAndDirStructureObjects()
+	for k := range filesAndDirStructure {
+		assert.Nil(t.T(), t.deleteObject(k))
 	}
-	assert.Nil(t.T(), t.deleteObjects(keys))
 }
 
 func (t *KernelListCacheTestCommon) deleteObjectOrFail(objectName string) {
@@ -132,7 +131,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHit() {
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -152,7 +151,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHit() {
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names2))
+	require.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 }
@@ -168,7 +167,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitWithImp
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -188,7 +187,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitWithImp
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names2))
+	require.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 }
@@ -204,7 +203,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMiss() {
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -224,7 +223,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMiss() {
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 3, len(names2))
+	require.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 	assert.Equal(t.T(), "file3.txt", names2[2])
@@ -241,7 +240,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMissWithIm
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -261,7 +260,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMissWithIm
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 3, len(names2))
+	require.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 	assert.Equal(t.T(), "file3.txt", names2[2])
@@ -280,7 +279,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -298,7 +297,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 3, len(names2))
+	require.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 	assert.Equal(t.T(), "file3.txt", names2[2])
@@ -318,7 +317,7 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	names3, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 3, len(names3))
+	require.Equal(t.T(), 3, len(names3))
 	assert.Equal(t.T(), "file1.txt", names3[0])
 	assert.Equal(t.T(), "file2.txt", names3[1])
 	assert.Equal(t.T(), "file3.txt", names3[2])

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -24,128 +24,397 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
-type KernelListCacheTest struct {
+const (
+	kernelListCacheTtlSeconds = 1000
+)
+
+// Base of the all tests:
+// How do we detect if the ReadDir() is responded from gcsfuse-filesystem or kernel?
+// By ensuring different response of same ReadDir() call from gcsfuse-filesystem.
+// So, if the current ReadDir() response is matching with previous one then
+// we can clearly say it is served from kernel cache. If not matching then served
+// from gcsfuse filesystem.
+type KernelListCacheTestWithPositiveTtl struct {
 	suite.Suite
 	fsTest
 }
 
-func (t *KernelListCacheTest) SetupSuite() {
+func (t *KernelListCacheTestWithPositiveTtl) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
 		FileSystemConfig: config.FileSystemConfig{
 			DisableParallelDirops:     false,
-			KernelListCacheTtlSeconds: 100,
+			KernelListCacheTtlSeconds: kernelListCacheTtlSeconds,
 		}}
 	t.serverCfg.RenameDirLimit = 10
 	t.fsTest.SetUpTestSuite()
 }
 
-func (t *KernelListCacheTest) SetupTest() {
+func (t *KernelListCacheTestWithPositiveTtl) SetupTest() {
 	t.createFilesAndDirStructureInBucket()
+	cacheClock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
 }
 
-func (t *KernelListCacheTest) TearDownTest() {
+func (t *KernelListCacheTestWithPositiveTtl) TearDownTest() {
+	cacheClock.AdvanceTime(util.MaxTimeDuration)
 	t.fsTest.TearDown()
+	//os.RemoveAll(path.Join(mntDir))
 }
 
-func (t *KernelListCacheTest) TearDownSuite() {
+func (t *KernelListCacheTestWithPositiveTtl) TearDownSuite() {
 	t.fsTest.TearDownTestSuite()
 }
 
 func TestKernelListCacheTestSuite(t *testing.T) {
-	suite.Run(t, new(KernelListCacheTest))
+	suite.Run(t, new(KernelListCacheTestWithPositiveTtl))
 }
 
 // createFilesAndDirStructureInBucket creates the following files and directory
 // structure.
 // bucket
 //
-//	file1.txt
-//	file2.txt
-//	explicitDir1/
-//	explicitDir1/file1.txt
-//	explicitDir1/file2.txt
-//	implicitDir1/file1.txt
-func (t *KernelListCacheTest) createFilesAndDirStructureInBucket() {
-	assert.Nil(
-		t.T(),
-		t.createObjects(
-			map[string]string{
-				"file1.txt":              "abcdef",
-				"file2.txt":              "xyz",
-				"explicitDir1/":          "",
-				"explicitDir1/file1.txt": "12345",
-				"explicitDir1/file2.txt": "6789101112",
-				"implicitDir1/file1.txt": "-1234556789",
-			}))
+//	explicitDir/
+//	explicitDir/file1.txt
+//	explicitDir/file2.txt
+//	implicitDir/file1.txt
+//	implicitDir/file2.txt
+func (t *KernelListCacheTestWithPositiveTtl) createFilesAndDirStructureInBucket() {
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/":          "",
+		"explicitDir/file1.txt": "12345",
+		"explicitDir/file2.txt": "6789101112",
+		"implicitDir/file1.txt": "-1234556789",
+		"implicitDir/file2.txt": "kdfkdj9",
+	}))
 }
 
-func (t *KernelListCacheTest) TestKernelListCache_SimpleWorkingCase() {
+// TestKernelListCache_SimpleCacheWorking:
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() within ttl will be served from kernel page cache.
+func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHit() {
 	// First read, kernel will cache the dir response.
-	f, err := os.Open(path.Join(mntDir, "explicitDir1"))
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	defer f.Close()
 
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), names1[0], "file1.txt")
+	assert.Equal(t.T(), names1[1], "file2.txt")
 
 	err = f.Close()
 	assert.Nil(t.T(), err)
 
-	// Create another object
-	assert.Nil(
-		t.T(),
-		t.createObjects(
-			map[string]string{
-				"explicitDir1/file3.txt": "123456",
-			}))
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file3.txt")
+
+	// Advancing the clock within time.
+	cacheClock.AdvanceTime(kernelListCacheTtlSeconds * time.Second / 2)
 
 	// First read, kernel will cache the dir response.
-	f, err = os.Open(path.Join(mntDir, "explicitDir1"))
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names2))
+	assert.Equal(t.T(), names1[0], names2[0])
+	assert.Equal(t.T(), names1[1], names2[1])
 
 	err = f.Close()
 	assert.Nil(t.T(), err)
 }
 
-func (t *KernelListCacheTest) TestKernelListCache_SimpleWorkingCase_False() {
+// TestKernelListCache_CacheMissOutOfTtl
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() out of ttl will also be served from GCSFuse filesystem.
+func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMiss() {
 	// First read, kernel will cache the dir response.
-	f, err := os.Open(path.Join(mntDir, "explicitDir1"))
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	defer f.Close()
 
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), names1[0], "file1.txt")
+	assert.Equal(t.T(), names1[1], "file2.txt")
 
 	err = f.Close()
 	assert.Nil(t.T(), err)
 
-	// Create another object
-	assert.Nil(
-		t.T(),
-		t.createObjects(
-			map[string]string{
-				"explicitDir1/file3.txt": "123456",
-			}))
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file3.txt")
 
-	// Advance the time more than ttl, to invalidate the cache.
-	cacheClock.AdvanceTime(110 * time.Second)
+	// Advancing the time more than ttl.
+	cacheClock.AdvanceTime(kernelListCacheTtlSeconds*time.Second + time.Second)
 
-	// First read, kernel will cache the dir response.
-	f, err = os.Open(path.Join(mntDir, "explicitDir1"))
+	// Since out of ttl, so invalidation happens and ReadDir() will be served from
+	// gcsfuse filesystem.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), names2[0], "file1.txt")
+	assert.Equal(t.T(), names2[1], "file2.txt")
+	assert.Equal(t.T(), names2[2], "file3.txt")
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+}
+
+// TestKernelListCache_CacheHitAfterInvalidation:
+// (a) First read will be served from GcsFuse filesystem.
+// (b) Second read after ttl will also be served from GCSFuse file-system.
+// (c) Third read within ttl will be served from kernel page cache.
+func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterInvalidation() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), names1[0], "file1.txt")
+	assert.Equal(t.T(), names1[1], "file2.txt")
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file3.txt")
+
+	// Advancing the time more than ttl.
+	cacheClock.AdvanceTime(kernelListCacheTtlSeconds*time.Second + time.Second)
+
+	// Since out of ttl, so invalidation happens and ReadDir() will be served from
+	// gcsfuse filesystem.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), names2[0], "file1.txt")
+	assert.Equal(t.T(), names2[1], "file2.txt")
+	assert.Equal(t.T(), names2[2], "file3.txt")
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file4.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file4.txt")
+
+	// Advancing the time within ttl.
+	cacheClock.AdvanceTime(kernelListCacheTtlSeconds * time.Second / 2)
+
+	// Within ttl, so will be served from kernel.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names3, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 3, len(names3))
+	assert.Equal(t.T(), names2[0], names3[0])
+	assert.Equal(t.T(), names2[1], names3[1])
+	assert.Equal(t.T(), names2[2], names3[2])
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+}
+
+type KernelListCacheTestWithInfiniteTtl struct {
+	suite.Suite
+	fsTest
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.MountConfig = &config.MountConfig{
+		FileSystemConfig: config.FileSystemConfig{
+			DisableParallelDirops:     false,
+			KernelListCacheTtlSeconds: -1,
+		}}
+	t.serverCfg.RenameDirLimit = 10
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) SetupTest() {
+	t.createFilesAndDirStructureInBucket()
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func TestKernelListCacheTestInfiniteTtlSuite(t *testing.T) {
+	suite.Run(t, new(KernelListCacheTestWithInfiniteTtl))
+}
+
+// TestKernelListCache_CacheMissWithZeroTtl
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheHit() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), names1[0], "file1.txt")
+	assert.Equal(t.T(), names1[1], "file2.txt")
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file3.txt")
+
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+
+	// No invalidation since infinite ttl.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names2))
+	assert.Equal(t.T(), names1[0], names2[0])
+	assert.Equal(t.T(), names1[1], names2[1])
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+}
+
+// createFilesAndDirStructureInBucket creates the following files and directory
+// structure.
+// bucket
+//
+//	explicitDir/
+//	explicitDir/file1.txt
+//	explicitDir/file2.txt
+//	implicitDir/file1.txt
+//	implicitDir/file2.txt
+func (t *KernelListCacheTestWithInfiniteTtl) createFilesAndDirStructureInBucket() {
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/":          "",
+		"explicitDir/file1.txt": "12345",
+		"explicitDir/file2.txt": "6789101112",
+		"implicitDir/file1.txt": "-1234556789",
+		"implicitDir/file2.txt": "kdfkdj9",
+	}))
+}
+
+type KernelListCacheTestWithZeroTtl struct {
+	suite.Suite
+	fsTest
+}
+
+func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.MountConfig = &config.MountConfig{
+		FileSystemConfig: config.FileSystemConfig{
+			DisableParallelDirops:     false,
+			KernelListCacheTtlSeconds: 0,
+		}}
+	t.serverCfg.RenameDirLimit = 10
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *KernelListCacheTestWithZeroTtl) SetupTest() {
+	t.createFilesAndDirStructureInBucket()
+}
+
+func (t *KernelListCacheTestWithZeroTtl) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func (t *KernelListCacheTestWithZeroTtl) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func TestKernelListCacheTestZeroTtlSuite(t *testing.T) {
+	suite.Run(t, new(KernelListCacheTestWithZeroTtl))
+}
+
+// createFilesAndDirStructureInBucket creates the following files and directory
+// structure.
+// bucket
+//
+//	explicitDir/
+//	explicitDir/file1.txt
+//	explicitDir/file2.txt
+//	implicitDir/file1.txt
+//	implicitDir/file2.txt
+func (t *KernelListCacheTestWithZeroTtl) createFilesAndDirStructureInBucket() {
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/":          "",
+		"explicitDir/file1.txt": "12345",
+		"explicitDir/file2.txt": "6789101112",
+		"implicitDir/file1.txt": "-1234556789",
+		"implicitDir/file2.txt": "kdfkdj9",
+	}))
+}
+
+// TestKernelListCache_CacheMissWithZeroTtl
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem.
+func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_CacheMiss() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), names1[0], "file1.txt")
+	assert.Equal(t.T(), names1[1], "file2.txt")
+
+	err = f.Close()
+	assert.Nil(t.T(), err)
+
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObject("explicitDir/file3.txt")
+
+	// Zero ttl, means readdir will always be served from gcsfuse.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), names2[0], "file1.txt")
+	assert.Equal(t.T(), names2[1], "file2.txt")
+	assert.Equal(t.T(), names2[2], "file3.txt")
 
 	err = f.Close()
 	assert.Nil(t.T(), err)

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// A collection of tests for a file system where parallel dirops are allowed.
-// Dirops refers to readdir and lookup operations.
+// A collection of tests which tests the kernel-list-cache feature, in which
+// directory listing 2nd time is served from kernel page-cache unless not invalidated.
+// Base of all the tests: how to detect if directory listing is served from page-cache
+// or from GCSFuse?
+// (a) GCSFuse file-system ensures different content, when listing happens on the same directory.
+// (b) If two consecutive directory listing for the same directory are same, that means
+//     2nd listing is served from kernel-page-cache.
+// (c) If not then, both 1st and 2nd listing are served from GCSFuse filesystem.
 
 package fs_test
 
@@ -24,7 +30,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -33,12 +38,6 @@ const (
 	kernelListCacheTtlSeconds = 1000
 )
 
-// Base of the all the tests:
-// How do we detect if the ReadDir() is responded from gcsfuse-filesystem or kernel page-cache?
-// By ensuring different consecutive response of ReadDir() for the same directory from GCSFuse filesystem.
-// So, if the current ReadDir() response is matching with previous one then
-// we can clearly say it is served from the kernel page-cache. If not matching then served
-// from gcsfuse filesystem.
 type KernelListCacheTestCommon struct {
 	suite.Suite
 	fsTest
@@ -60,8 +59,6 @@ func (t *KernelListCacheTestCommon) SetupTest() {
 }
 
 func (t *KernelListCacheTestCommon) TearDownTest() {
-	// Make sure to expire the cache for different test in the same suite.
-	cacheClock.AdvanceTime(util.MaxTimeDuration)
 	t.fsTest.TearDown()
 }
 
@@ -116,70 +113,63 @@ func TestKernelListCacheTestWithPositiveTtlSuite(t *testing.T) {
 	suite.Run(t, new(KernelListCacheTestWithPositiveTtl))
 }
 
-// TestKernelListCache_SimpleCacheWorking:
 // (a) First ReadDir() will be served from GCSFuse filesystem.
 // (b) Second ReadDir() within ttl will be served from kernel page cache.
 func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHit() {
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
-	defer f.Close()
-
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), names1[0], "file1.txt")
 	assert.Equal(t.T(), names1[1], "file2.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file3.txt": "123456",
 	}))
 	defer t.deleteObjectOrFail("explicitDir/file3.txt")
-
 	// Advancing the clock within time.
 	cacheClock.AdvanceTime(kernelListCacheTtlSeconds * time.Second / 2)
 
-	// First read, kernel will cache the dir response.
+	// 2nd read, ReadDir() will be served from page-cache, that means no change in
+	// response.
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
+
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), names1[0], names2[0])
 	assert.Equal(t.T(), names1[1], names2[1])
-
-	err = f.Close()
-	assert.Nil(t.T(), err)
 }
 
-// TestKernelListCache_CacheMissOutOfTtl
 // (a) First ReadDir() will be served from GCSFuse filesystem.
 // (b) Second ReadDir() out of ttl will also be served from GCSFuse filesystem.
 func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMiss() {
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
-	defer f.Close()
-
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), names1[0], "file1.txt")
 	assert.Equal(t.T(), names1[1], "file2.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file3.txt": "123456",
 	}))
 	defer t.deleteObjectOrFail("explicitDir/file3.txt")
-
 	// Advancing the time more than ttl.
 	cacheClock.AdvanceTime(kernelListCacheTtlSeconds*time.Second + time.Second)
 
@@ -188,14 +178,12 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheMiss() {
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
+
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), names2[0], "file1.txt")
 	assert.Equal(t.T(), names2[1], "file2.txt")
 	assert.Equal(t.T(), names2[2], "file3.txt")
-
-	err = f.Close()
-	assert.Nil(t.T(), err)
 }
 
 // TestKernelListCache_CacheHitAfterInvalidation:
@@ -206,26 +194,23 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
-	defer f.Close()
-
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), names1[0], "file1.txt")
 	assert.Equal(t.T(), names1[1], "file2.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file3.txt": "123456",
 	}))
 	defer t.deleteObjectOrFail("explicitDir/file3.txt")
-
 	// Advancing the time more than ttl.
 	cacheClock.AdvanceTime(kernelListCacheTtlSeconds*time.Second + time.Second)
-
 	// Since out of ttl, so invalidation happens and ReadDir() will be served from
 	// gcsfuse filesystem.
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
@@ -236,16 +221,13 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	assert.Equal(t.T(), names2[0], "file1.txt")
 	assert.Equal(t.T(), names2[1], "file2.txt")
 	assert.Equal(t.T(), names2[2], "file3.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file4.txt": "123456",
 	}))
 	defer t.deleteObjectOrFail("explicitDir/file4.txt")
-
 	// Advancing the time within ttl.
 	cacheClock.AdvanceTime(kernelListCacheTtlSeconds * time.Second / 2)
 
@@ -253,14 +235,12 @@ func (t *KernelListCacheTestWithPositiveTtl) TestKernelListCache_CacheHitAfterIn
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names3, err := f.Readdirnames(-1)
+
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 3, len(names3))
 	assert.Equal(t.T(), names2[0], names3[0])
 	assert.Equal(t.T(), names2[1], names3[1])
 	assert.Equal(t.T(), names2[2], names3[2])
-
-	err = f.Close()
-	assert.Nil(t.T(), err)
 }
 
 type KernelListCacheTestWithInfiniteTtl struct {
@@ -283,30 +263,27 @@ func TestKernelListCacheTestInfiniteTtlSuite(t *testing.T) {
 	suite.Run(t, new(KernelListCacheTestWithInfiniteTtl))
 }
 
-// TestKernelListCache_CacheMissWithZeroTtl
 // (a) First ReadDir() will be served from GCSFuse filesystem.
 // (b) Second ReadDir() will also be served from GCSFuse filesystem.
-func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheHit() {
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit() {
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
-	defer f.Close()
-
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), names1[0], "file1.txt")
 	assert.Equal(t.T(), names1[1], "file2.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file3.txt": "123456",
 	}))
 	defer t.deleteObjectOrFail("explicitDir/file3.txt")
-
 	// Advancing time by 5 years (157800000 seconds).
 	cacheClock.AdvanceTime(157800000 * time.Second)
 
@@ -314,13 +291,11 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheHit() {
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
+
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), names1[0], names2[0])
 	assert.Equal(t.T(), names1[1], names2[1])
-
-	err = f.Close()
-	assert.Nil(t.T(), err)
 }
 
 type KernelListCacheTestWithZeroTtl struct {
@@ -343,24 +318,22 @@ func TestKernelListCacheTestZeroTtlSuite(t *testing.T) {
 	suite.Run(t, new(KernelListCacheTestWithZeroTtl))
 }
 
-// TestKernelListCache_AlwaysCacheMiss
 // (a) First ReadDir() will be served from GCSFuse filesystem.
 // (b) Second ReadDir() will also be served from GCSFuse filesystem.
 func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_AlwaysCacheMiss() {
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
-	defer f.Close()
-
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), names1[0], "file1.txt")
 	assert.Equal(t.T(), names1[1], "file2.txt")
-
 	err = f.Close()
 	assert.Nil(t.T(), err)
-
 	// Adding one object to make sure to change the ReadDir() response.
 	assert.Nil(t.T(), t.createObjects(map[string]string{
 		"explicitDir/file3.txt": "123456",
@@ -371,12 +344,10 @@ func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_AlwaysCacheMiss() {
 	f, err = os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)
 	names2, err := f.Readdirnames(-1)
+
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), names2[0], "file1.txt")
 	assert.Equal(t.T(), names2[1], "file2.txt")
 	assert.Equal(t.T(), names2[2], "file3.txt")
-
-	err = f.Close()
-	assert.Nil(t.T(), err)
 }

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -61,7 +62,7 @@ func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_AlwaysCacheMiss() {
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 2, len(names1))
+	require.Equal(t.T(), 2, len(names1))
 	assert.Equal(t.T(), "file1.txt", names1[0])
 	assert.Equal(t.T(), "file2.txt", names1[1])
 	err = f.Close()
@@ -78,7 +79,7 @@ func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_AlwaysCacheMiss() {
 	names2, err := f.Readdirnames(-1)
 
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), 3, len(names2))
+	require.Equal(t.T(), 3, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 	assert.Equal(t.T(), "file3.txt", names2[2])

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Please refer kernel_list_cache_test.go for the documentation.
+
+package fs_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type KernelListCacheTestWithZeroTtl struct {
+	suite.Suite
+	fsTest
+	KernelListCacheTestCommon
+}
+
+func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.MountConfig = &config.MountConfig{
+		ListConfig: config.ListConfig{
+			KernelListCacheTtlSeconds: 0,
+		},
+		MetadataCacheConfig: config.MetadataCacheConfig{
+			TtlInSeconds: 0,
+		},
+	}
+	t.serverCfg.RenameDirLimit = 10
+	t.fsTest.SetUpTestSuite()
+}
+
+func TestKernelListCacheTestZeroTtlSuite(t *testing.T) {
+	suite.Run(t, new(KernelListCacheTestWithZeroTtl))
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem.
+func (t *KernelListCacheTestWithZeroTtl) TestKernelListCache_AlwaysCacheMiss() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+
+	// Zero ttl, means readdir will always be served from gcsfuse.
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+	assert.Equal(t.T(), "file3.txt", names2[2])
+}

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -35,7 +35,7 @@ type KernelListCacheTestWithZeroTtl struct {
 func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.MountConfig = &config.MountConfig{
-		ListConfig: config.ListConfig{
+		FileSystemConfig: config.FileSystemConfig{
 			KernelListCacheTtlSeconds: 0,
 		},
 		MetadataCacheConfig: config.MetadataCacheConfig{


### PR DESCRIPTION
### Description
- Added basic composite test to make sure kernel-list-cache is working fine.
- I'll add more tests in another PR - like creation or deletion of file inside a directory invalidates the cache.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
