### PR TITLE
fix gcloud install 

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -29,7 +29,7 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 # Upgrade gcloud version
 gcloud version
 wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
-sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
+sudo tar xzf gcloud.tar.gz && sudo cp -r google-cloud-sdk /usr/local && sudo rm -r google-cloud-sdk
 sudo /usr/local/google-cloud-sdk/install.sh
 export PATH=/usr/local/google-cloud-sdk/bin:$PATH
 echo 'export PATH=/usr/local/google-cloud-sdk/bin:$PATH' >> ~/.bashrc

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -57,7 +57,9 @@ gcloud config set project $PROJECT_ID
 set +e
 # $1 argument is refering to value of testInstalledPackage
 ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT
+exit_code=$?
 set -e
 
 # Activate default environment after testing.
 gcloud config configurations activate default
+exit $exit_code

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -63,4 +63,7 @@ set -e
 
 # Activate default environment after testing.
 gcloud config configurations activate default
+gcloud config unset universe_domain
+gcloud config unset api_endpoint_overrides/compute
+gcloud config unset project
 exit $exit_code

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -49,6 +49,7 @@ echo "Running e2e tests on installed package...."
 
 # Initiate PRPTST environment to establish a TPC project and associated account.
 gcloud config configurations create prptst
+gcloud config configurations activate prptst
 gcloud config set universe_domain apis-tpczero.goog
 gcloud config set api_endpoint_overrides/compute https://compute.apis-tpczero.goog/compute/v1/
 gcloud auth activate-service-account --key-file=/tmp/sa.key.json

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -83,7 +83,7 @@ function upgrade_gcloud_version() {
   # Kokoro machine's outdated gcloud version prevents the use of the "managed-folders" feature.
   gcloud version
   wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
-  sudo tar xzf gcloud.tar.gz && sudo mv google-cloud-sdk /usr/local
+  sudo tar xzf gcloud.tar.gz && sudo cp -r google-cloud-sdk /usr/local && sudo rm -r google-cloud-sdk
   sudo /usr/local/google-cloud-sdk/install.sh
   export PATH=/usr/local/google-cloud-sdk/bin:$PATH
   echo 'export PATH=/usr/local/google-cloud-sdk/bin:$PATH' >> ~/.bashrc


### PR DESCRIPTION
### Description
- The command `sudo mv google-cloud-sdk /usr/local` was causing issues(`mv: cannot move 'google-cloud-sdk' to '/usr/local/google-cloud-sdk': Directory not empty`) because it was also needed in tpc_build.sh and the e2e test script. It has been replaced with the command cp -r.
- Activating default config properly after testing.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
