### PR TITLE
adds get folder method in bucket.go

### DIFF
--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -215,4 +216,9 @@ func (b *prefixBucket) DeleteObject(
 func (b *prefixBucket) DeleteFolder(ctx context.Context, folderName string) (err error) {
 	mFolderName := b.wrappedName(folderName)
 	return b.wrapped.DeleteFolder(ctx, mFolderName)
+}
+
+func (b *prefixBucket) GetFolder(ctx context.Context, folderName string) (folder *controlpb.Folder, err error) {
+	mFolderName := b.wrappedName(folderName)
+	return b.wrapped.GetFolder(ctx, mFolderName)
 }

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -396,3 +396,25 @@ func (t *PrefixBucketTest) DeleteObject() {
 	var notFoundErr *gcs.NotFoundError
 	ExpectTrue(errors.As(err, &notFoundErr))
 }
+
+func (t *PrefixBucketTest) GetFolder_Prefix() {
+	var err error
+
+	// Create a few objects.
+	err = storageutil.CreateObjects(
+		t.ctx,
+		t.wrapped,
+		map[string][]byte{
+			"something": []byte(""),
+		})
+
+	AssertEq(nil, err)
+
+	result, err := t.bucket.GetFolder(
+		t.ctx,
+		"something")
+
+	AssertEq(nil, err)
+	AssertEq("projects/_/buckets/some_bucket/folders/foo_something", result.GetName())
+
+}

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -400,7 +400,7 @@ func (t *PrefixBucketTest) DeleteObject() {
 func (t *PrefixBucketTest) GetFolder_Prefix() {
 	var err error
 
-	// Create a few objects.
+	// Replace the use of CreateObject with CreateFolder once the CreateFolder API has been successfully implemented.
 	err = storageutil.CreateObjects(
 		t.ctx,
 		t.wrapped,

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"time"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/monitor/tags"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -200,6 +201,13 @@ func (mb *monitoringBucket) DeleteFolder(ctx context.Context, folderName string)
 	err := mb.wrapped.DeleteFolder(ctx, folderName)
 	recordRequest(ctx, "DeleteFolder", startTime)
 	return err
+}
+
+func (mb *monitoringBucket) GetFolder(ctx context.Context, folderName string) (*controlpb.Folder, error) {
+	startTime := time.Now()
+	folder, err := mb.wrapped.GetFolder(ctx, folderName)
+	recordRequest(ctx, "GetFolder", startTime)
+	return folder, err
 }
 
 // recordReader increments the reader count when it's opened or closed.

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -17,6 +17,7 @@ package ratelimit
 import (
 	"io"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -195,6 +196,19 @@ func (b *throttledBucket) DeleteFolder(ctx context.Context, folderName string) (
 	err = b.wrapped.DeleteFolder(ctx, folderName)
 
 	return
+}
+
+func (b *throttledBucket) GetFolder(ctx context.Context, folderName string) (folder *controlpb.Folder, err error) {
+	// Wait for permission to call through.
+	err = b.opThrottle.Wait(ctx, 1)
+	if err != nil {
+		return
+	}
+
+	// Call through.
+	folder, err = b.wrapped.GetFolder(ctx, folderName)
+
+	return folder, err
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -513,7 +513,7 @@ func (b *bucketHandle) GetFolder(ctx context.Context, folderName string) (*contr
 	var callOptions []gax.CallOption
 
 	folder, err := b.controlClient.GetFolder(ctx, &controlpb.GetFolderRequest{
-		Name: folderName,
+		Name: "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
 	}, callOptions...)
 
 	if err != nil {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -518,10 +518,9 @@ func (b *bucketHandle) GetFolder(ctx context.Context, folderName string) (*contr
 
 	if err != nil {
 		err = fmt.Errorf("error getting metadata for folder: %s, %w", folderName, err)
-		return nil, err
 	}
 
-	return folder, nil
+	return folder, err
 }
 
 func isStorageConditionsNotEmpty(conditions storage.Conditions) bool {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -509,6 +509,21 @@ func (b *bucketHandle) getStorageLayout() (*controlpb.StorageLayout, error) {
 	return stoargeLayout, err
 }
 
+func (b *bucketHandle) GetFolder(ctx context.Context, folderName string) (*controlpb.Folder, error) {
+	var callOptions []gax.CallOption
+
+	folder, err := b.controlClient.GetFolder(ctx, &controlpb.GetFolderRequest{
+		Name: folderName,
+	}, callOptions...)
+
+	if err != nil {
+		err = fmt.Errorf("error getting metadata for folder: %s, %w", folderName, err)
+		return nil, err
+	}
+
+	return folder, nil
+}
+
 func isStorageConditionsNotEmpty(conditions storage.Conditions) bool {
 	return conditions != (storage.Conditions{})
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1316,14 +1316,14 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderExistsForHierarchicalB
 func (testSuite *BucketHandleTest) TestGetFolderWhenFolderDoesNotExistsForHierarchicalBucket() {
 	ctx := context.Background()
 	mockClient := new(MockStorageControlClient)
-	folderPath := "projects/_/buckets/" + TestBucketName + "/folders/random"
+	folderPath := "projects/_/buckets/" + TestBucketName + "/folders/" + missingObjectName
 
 	mockClient.On("GetFolder", ctx, &controlpb.GetFolderRequest{Name: folderPath}, mock.Anything).
 		Return(nil, status.Error(codes.NotFound, "folder not found"))
 	testSuite.bucketHandle.controlClient = mockClient
 	testSuite.bucketHandle.bucketType = gcs.Hierarchical
 
-	result, err := testSuite.bucketHandle.GetFolder(ctx, "random")
+	result, err := testSuite.bucketHandle.GetFolder(ctx, missingObjectName)
 
 	mockClient.AssertExpectations(testSuite.T())
 	assert.Nil(testSuite.T(), result)

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
@@ -291,6 +292,21 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 	// Put the object in cache.
 	o := storageutil.ConvertMinObjectToObject(m)
 	b.insert(o)
+
+	return
+}
+
+func (b *fastStatBucket) GetFolder(
+	ctx context.Context,
+	prefix string) (folder *controlpb.Folder, err error) {
+	// Fetch the listing.
+	folder, err = b.wrapped.GetFolder(ctx, prefix)
+	if err != nil {
+		return
+	}
+
+	// TODO: add folder metadata in stat cache
+	// b.insertFolder(folder)
 
 	return
 }

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -141,7 +141,7 @@ func (b *fastStatBucket) CreateObject(
 	// Throw away any existing record for this object.
 	b.invalidate(req.Name)
 
-	// Create the new object.
+	// TODO: create object to be replaced with create folder api once integrated
 	o, err = b.wrapped.CreateObject(ctx, req)
 	if err != nil {
 		return

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -29,4 +29,6 @@ type StorageControlClient interface {
 	DeleteFolder(ctx context.Context,
 		req *controlpb.DeleteFolderRequest,
 		opts ...gax.CallOption) error
+
+	GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error)
 }

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
@@ -236,4 +237,12 @@ func (b *debugBucket) DeleteFolder(ctx context.Context, folderName string) (err 
 
 	err = b.wrapped.DeleteFolder(ctx, folderName)
 	return err
+}
+
+func (b *debugBucket) GetFolder(ctx context.Context, folderName string) (folder *controlpb.Folder, err error) {
+	id, desc, start := b.startRequest("GetFolder(%q)", folderName)
+	defer b.finishRequest(id, desc, start, &err)
+
+	folder, err = b.wrapped.GetFolder(ctx, folderName)
+	return
 }

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -881,4 +882,11 @@ func (b *bucket) DeleteFolder(ctx context.Context, folderName string) (err error
 	b.objects = append(b.objects[:index], b.objects[index+1:]...)
 
 	return
+}
+
+func (b *bucket) GetFolder(ctx context.Context, folderPath string) (*controlpb.Folder, error) {
+	folder := controlpb.Folder{
+		Name: folderPath,
+	}
+	return &folder, nil
 }

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -884,9 +884,9 @@ func (b *bucket) DeleteFolder(ctx context.Context, folderName string) (err error
 	return
 }
 
-func (b *bucket) GetFolder(ctx context.Context, folderPath string) (*controlpb.Folder, error) {
+func (b *bucket) GetFolder(ctx context.Context, foldername string) (*controlpb.Folder, error) {
 	folder := controlpb.Folder{
-		Name: folderPath,
+		Name: "projects/_/buckets/" + b.Name() + "/folders/" + foldername,
 	}
 	return &folder, nil
 }

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -17,6 +17,7 @@ package gcs
 import (
 	"io"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"golang.org/x/net/context"
 )
 
@@ -142,4 +143,6 @@ type Bucket interface {
 		req *DeleteObjectRequest) error
 
 	DeleteFolder(ctx context.Context, folderName string) error
+
+	GetFolder(ctx context.Context, folderName string) (*controlpb.Folder, error)
 }

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -12,6 +12,7 @@ import (
 	runtime "runtime"
 	unsafe "unsafe"
 
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	oglemock "github.com/jacobsa/oglemock"
 	context "golang.org/x/net/context"
@@ -343,5 +344,28 @@ func (m *mockBucket) UpdateObject(p0 context.Context, p1 *gcs.UpdateObjectReques
 		o1 = retVals[1].(error)
 	}
 
+	return
+}
+
+func (m *mockBucket) GetFolder(
+	ctx context.Context,
+	prefix string) (folder *controlpb.Folder, err error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"GetFolder",
+		file,
+		line,
+		[]interface{}{})
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockBucket.GetFolder: invalid return values: %v", retVals))
+	}
+	// o0 string
+	if retVals[0] != nil {
+		err = retVals[0].(error)
+	}
 	return
 }

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -349,7 +349,7 @@ func (m *mockBucket) UpdateObject(p0 context.Context, p1 *gcs.UpdateObjectReques
 
 func (m *mockBucket) GetFolder(
 	ctx context.Context,
-	prefix string) (folder *controlpb.Folder, err error) {
+	prefix string) (o0 *controlpb.Folder, o1 error) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
 
@@ -360,12 +360,18 @@ func (m *mockBucket) GetFolder(
 		file,
 		line,
 		[]interface{}{})
-	if len(retVals) != 1 {
+
+	if len(retVals) != 2 {
 		panic(fmt.Sprintf("mockBucket.GetFolder: invalid return values: %v", retVals))
 	}
-	// o0 string
+
 	if retVals[0] != nil {
-		err = retVals[0].(error)
+		o0 = retVals[0].(*controlpb.Folder)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
 	}
 	return
 }

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -30,23 +30,23 @@ type MockStorageControlClient struct {
 
 // Implement the GetStorageLayout method for the mock.
 func (m *MockStorageControlClient) GetStorageLayout(ctx context.Context,
-		req *controlpb.GetStorageLayoutRequest,
-		opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
+	req *controlpb.GetStorageLayoutRequest,
+	opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
 	args := m.Called(ctx, req, opts)
 	return args.Get(0).(*controlpb.StorageLayout), args.Error(1)
 }
 
 // Implement the DeleteFolder method for the mock.
 func (m *MockStorageControlClient) DeleteFolder(ctx context.Context,
-		req *controlpb.DeleteFolderRequest,
-		opts ...gax.CallOption) error {
+	req *controlpb.DeleteFolderRequest,
+	opts ...gax.CallOption) error {
 	args := m.Called(ctx, req, opts)
 	return args.Error(0)
 }
 
 func (m *MockStorageControlClient) GetFolder(ctx context.Context,
-		req *controlpb.GetFolderRequest,
-		opts ...gax.CallOption) (*controlpb.Folder, error) {
+	req *controlpb.GetFolderRequest,
+	opts ...gax.CallOption) (*controlpb.Folder, error) {
 	args := m.Called(ctx, req, opts)
 
 	if folder, ok := args.Get(0).(*controlpb.Folder); ok {

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -49,6 +49,7 @@ func (m *MockStorageControlClient) GetFolder(ctx context.Context,
 	opts ...gax.CallOption) (*controlpb.Folder, error) {
 	args := m.Called(ctx, req, opts)
 
+	// Needed to assert folder in only those cases where folder is present
 	if folder, ok := args.Get(0).(*controlpb.Folder); ok {
 		return folder, nil
 	}

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -30,16 +30,28 @@ type MockStorageControlClient struct {
 
 // Implement the GetStorageLayout method for the mock.
 func (m *MockStorageControlClient) GetStorageLayout(ctx context.Context,
-	req *controlpb.GetStorageLayoutRequest,
-	opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
+		req *controlpb.GetStorageLayoutRequest,
+		opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
 	args := m.Called(ctx, req, opts)
 	return args.Get(0).(*controlpb.StorageLayout), args.Error(1)
 }
 
 // Implement the DeleteFolder method for the mock.
 func (m *MockStorageControlClient) DeleteFolder(ctx context.Context,
-	req *controlpb.DeleteFolderRequest,
-	opts ...gax.CallOption) error {
+		req *controlpb.DeleteFolderRequest,
+		opts ...gax.CallOption) error {
 	args := m.Called(ctx, req, opts)
 	return args.Error(0)
+}
+
+func (m *MockStorageControlClient) GetFolder(ctx context.Context,
+		req *controlpb.GetFolderRequest,
+		opts ...gax.CallOption) (*controlpb.Folder, error) {
+	args := m.Called(ctx, req, opts)
+
+	if folder, ok := args.Get(0).(*controlpb.Folder); ok {
+		return folder, nil
+	}
+
+	return nil, args.Error(1)
 }


### PR DESCRIPTION
### Description
integrates with get folder method of control client for all buckets (except fast stat bucket - next PR).
it is not called from anywhere, hence no change in existing functionality.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA
