### PR TITLE
[Config-CLI Parity][Fix] Populate config object when config file is not provided

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,14 +58,14 @@ func init() {
 }
 
 func initConfig() {
-	if cfgFile == "" {
-		return
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+		viper.SetConfigType("yaml")
+		if err := viper.ReadInConfig(); err != nil {
+			logger.Fatal("error while reading the config: %v", err)
+		}
 	}
-	viper.SetConfigFile(cfgFile)
-	viper.SetConfigType("yaml")
-	if err := viper.ReadInConfig(); err != nil {
-		logger.Fatal("error while reading the config: %v", err)
-	}
+
 	err := viper.Unmarshal(&configObj, viper.DecodeHook(cfg.DecodeHook()), func(decoderConfig *mapstructure.DecoderConfig) {
 		// By default, viper supports mapstructure tags for unmarshalling. Override that to support yaml tag.
 		decoderConfig.TagName = "yaml"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -59,6 +60,10 @@ func init() {
 
 func initConfig() {
 	if cfgFile != "" {
+		cfgFile, err := util.GetResolvedPath(cfgFile)
+		if err != nil {
+			logger.Fatal("error while resolving config-file path[%s]: %v", cfgFile, err)
+		}
 		viper.SetConfigFile(cfgFile)
 		viper.SetConfigType("yaml")
 		if err := viper.ReadInConfig(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,8 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", "", "Absolute path to the config file.")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", "", "The path to the config file where all gcsfuse related config needs to be specified."+
+		"Refer to 'https://cloud.google.com/storage/docs/gcsfuse-cli#config-file' for possible configurations.")
 
 	// Add all the other flags.
 	if err := cfg.BindFlags(rootCmd.PersistentFlags()); err != nil {


### PR DESCRIPTION
### Description
Config object should be populated with only CLI flags in cases where config file is not provided.
Also resolves the config file path before usage.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually and printed the config object to confirm it is working as intended
2. Unit tests - NA
3. Integration tests - NA
