### PR TITLE
[Config CLI Parity] add squash to config structure tags to make decoding easier

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -29,37 +29,37 @@ type Config struct {
 
 	CacheDir ResolvedPath `yaml:"cache-dir"`
 
-	Debug DebugConfig `yaml:"debug"`
+	Debug DebugConfig `yaml:"debug,squash"`
 
 	EnableHns bool `yaml:"enable-hns"`
 
-	FileCache FileCacheConfig `yaml:"file-cache"`
+	FileCache FileCacheConfig `yaml:"file-cache,squash"`
 
-	FileSystem FileSystemConfig `yaml:"file-system"`
+	FileSystem FileSystemConfig `yaml:"file-system,squash"`
 
 	Foreground bool `yaml:"foreground"`
 
-	GcsAuth GcsAuthConfig `yaml:"gcs-auth"`
+	GcsAuth GcsAuthConfig `yaml:"gcs-auth,squash"`
 
-	GcsConnection GcsConnectionConfig `yaml:"gcs-connection"`
+	GcsConnection GcsConnectionConfig `yaml:"gcs-connection,squash"`
 
-	GcsRetries GcsRetriesConfig `yaml:"gcs-retries"`
+	GcsRetries GcsRetriesConfig `yaml:"gcs-retries,squash"`
 
 	ImplicitDirs bool `yaml:"implicit-dirs"`
 
-	List ListConfig `yaml:"list"`
+	List ListConfig `yaml:"list,squash"`
 
-	Logging LoggingConfig `yaml:"logging"`
+	Logging LoggingConfig `yaml:"logging,squash"`
 
-	MetadataCache MetadataCacheConfig `yaml:"metadata-cache"`
+	MetadataCache MetadataCacheConfig `yaml:"metadata-cache,squash"`
 
-	Metrics MetricsConfig `yaml:"metrics"`
+	Metrics MetricsConfig `yaml:"metrics,squash"`
 
-	Monitoring MonitoringConfig `yaml:"monitoring"`
+	Monitoring MonitoringConfig `yaml:"monitoring,squash"`
 
 	OnlyDir string `yaml:"only-dir"`
 
-	Write WriteConfig `yaml:"write"`
+	Write WriteConfig `yaml:"write,squash"`
 }
 
 type DebugConfig struct {
@@ -165,7 +165,7 @@ type LoggingConfig struct {
 
 	Format string `yaml:"format"`
 
-	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
+	LogRotate LogRotateLoggingConfig `yaml:"log-rotate,squash"`
 
 	Severity LogSeverity `yaml:"severity"`
 }
@@ -205,7 +205,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
 
-	err = viper.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access"))
+	err = viper.BindPFlag("anonymous-access", flagSet.Lookup("anonymous-access"))
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
 
-	err = viper.BindPFlag("gcs-connection.billing-project", flagSet.Lookup("billing-project"))
+	err = viper.BindPFlag("billing-project", flagSet.Lookup("billing-project"))
 	if err != nil {
 		return err
 	}
@@ -233,14 +233,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("cache-file-for-range-read", "", false, "Whether to cache file for range reads.")
 
-	err = viper.BindPFlag("file-cache.cache-file-for-range-read", flagSet.Lookup("cache-file-for-range-read"))
+	err = viper.BindPFlag("cache-file-for-range-read", flagSet.Lookup("cache-file-for-range-read"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("client-protocol", "", "http1", "The protocol used for communicating with the GCS backend. Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.")
 
-	err = viper.BindPFlag("gcs-connection.client-protocol", flagSet.Lookup("client-protocol"))
+	err = viper.BindPFlag("client-protocol", flagSet.Lookup("client-protocol"))
 	if err != nil {
 		return err
 	}
@@ -252,14 +252,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("write.create-empty-file", flagSet.Lookup("create-empty-file"))
+	err = viper.BindPFlag("create-empty-file", flagSet.Lookup("create-empty-file"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
-	err = viper.BindPFlag("gcs-connection.custom-endpoint", flagSet.Lookup("custom-endpoint"))
+	err = viper.BindPFlag("custom-endpoint", flagSet.Lookup("custom-endpoint"))
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("debug.gcs", flagSet.Lookup("debug_gcs"))
+	err = viper.BindPFlag("gcs", flagSet.Lookup("debug_gcs"))
 	if err != nil {
 		return err
 	}
@@ -306,21 +306,21 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("debug_invariants", "", false, "Exit when internal invariants are violated.")
 
-	err = viper.BindPFlag("debug.exit-on-invariant-violation", flagSet.Lookup("debug_invariants"))
+	err = viper.BindPFlag("exit-on-invariant-violation", flagSet.Lookup("debug_invariants"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("debug_mutex", "", false, "Print debug messages when a mutex is held too long.")
 
-	err = viper.BindPFlag("debug.log-mutex", flagSet.Lookup("debug_mutex"))
+	err = viper.BindPFlag("log-mutex", flagSet.Lookup("debug_mutex"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("dir-mode", "", "0755", "Permissions bits for directories, in octal.")
 
-	err = viper.BindPFlag("file-system.dir-mode", flagSet.Lookup("dir-mode"))
+	err = viper.BindPFlag("dir-mode", flagSet.Lookup("dir-mode"))
 	if err != nil {
 		return err
 	}
@@ -332,28 +332,28 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("file-system.disable-parallel-dirops", flagSet.Lookup("disable-parallel-dirops"))
+	err = viper.BindPFlag("disable-parallel-dirops", flagSet.Lookup("disable-parallel-dirops"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("download-parallelism-per-file", "", 10, "Number of concurrent download requests per file.")
 
-	err = viper.BindPFlag("file-cache.download-parallelism-per-file", flagSet.Lookup("download-parallelism-per-file"))
+	err = viper.BindPFlag("download-parallelism-per-file", flagSet.Lookup("download-parallelism-per-file"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("enable-crc-check", "", true, "Performs CRC check to ensure that file is correctly downloaded into cache.")
 
-	err = viper.BindPFlag("file-cache.enable-crc-check", flagSet.Lookup("enable-crc-check"))
+	err = viper.BindPFlag("enable-crc-check", flagSet.Lookup("enable-crc-check"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
 
-	err = viper.BindPFlag("list.enable-empty-managed-folders", flagSet.Lookup("enable-empty-managed-folders"))
+	err = viper.BindPFlag("enable-empty-managed-folders", flagSet.Lookup("enable-empty-managed-folders"))
 	if err != nil {
 		return err
 	}
@@ -367,14 +367,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	err = viper.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache"))
+	err = viper.BindPFlag("enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("enable-parallel-downloads", "", false, "Enable parallel downloads.")
 
-	err = viper.BindPFlag("file-cache.enable-parallel-downloads", flagSet.Lookup("enable-parallel-downloads"))
+	err = viper.BindPFlag("enable-parallel-downloads", flagSet.Lookup("enable-parallel-downloads"))
 	if err != nil {
 		return err
 	}
@@ -386,7 +386,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("gcs-connection.experimental-enable-json-read", flagSet.Lookup("experimental-enable-json-read"))
+	err = viper.BindPFlag("experimental-enable-json-read", flagSet.Lookup("experimental-enable-json-read"))
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size"))
+	err = viper.BindPFlag("grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size"))
 	if err != nil {
 		return err
 	}
@@ -410,7 +410,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("metadata-cache.experimental-metadata-prefetch-on-mount", flagSet.Lookup("experimental-metadata-prefetch-on-mount"))
+	err = viper.BindPFlag("experimental-metadata-prefetch-on-mount", flagSet.Lookup("experimental-metadata-prefetch-on-mount"))
 	if err != nil {
 		return err
 	}
@@ -422,21 +422,21 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("monitoring.experimental-opentelemetry-collector-address", flagSet.Lookup("experimental-opentelemetry-collector-address"))
+	err = viper.BindPFlag("experimental-opentelemetry-collector-address", flagSet.Lookup("experimental-opentelemetry-collector-address"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("file-cache-max-size-mb", "", -1, "Maximum size of the file-cache in MiBs")
 
-	err = viper.BindPFlag("file-cache.max-size-mb", flagSet.Lookup("file-cache-max-size-mb"))
+	err = viper.BindPFlag("max-size-mb", flagSet.Lookup("file-cache-max-size-mb"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
 
-	err = viper.BindPFlag("file-system.file-mode", flagSet.Lookup("file-mode"))
+	err = viper.BindPFlag("file-mode", flagSet.Lookup("file-mode"))
 	if err != nil {
 		return err
 	}
@@ -450,21 +450,21 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
-	err = viper.BindPFlag("file-system.gid", flagSet.Lookup("gid"))
+	err = viper.BindPFlag("gid", flagSet.Lookup("gid"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
 
-	err = viper.BindPFlag("gcs-connection.http-client-timeout", flagSet.Lookup("http-client-timeout"))
+	err = viper.BindPFlag("http-client-timeout", flagSet.Lookup("http-client-timeout"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("ignore-interrupts", "", false, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
 
-	err = viper.BindPFlag("file-system.ignore-interrupts", flagSet.Lookup("ignore-interrupts"))
+	err = viper.BindPFlag("ignore-interrupts", flagSet.Lookup("ignore-interrupts"))
 	if err != nil {
 		return err
 	}
@@ -478,91 +478,91 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
 
-	err = viper.BindPFlag("list.kernel-list-cache-ttl-secs", flagSet.Lookup("kernel-list-cache-ttl-secs"))
+	err = viper.BindPFlag("kernel-list-cache-ttl-secs", flagSet.Lookup("kernel-list-cache-ttl-secs"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
 
-	err = viper.BindPFlag("gcs-auth.key-file", flagSet.Lookup("key-file"))
+	err = viper.BindPFlag("key-file", flagSet.Lookup("key-file"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
 
-	err = viper.BindPFlag("gcs-connection.limit-bytes-per-sec", flagSet.Lookup("limit-bytes-per-sec"))
+	err = viper.BindPFlag("limit-bytes-per-sec", flagSet.Lookup("limit-bytes-per-sec"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.Float64P("limit-ops-per-sec", "", -1, "Operations per second limit, measured over a 30-second window (use -1 for no limit)")
 
-	err = viper.BindPFlag("gcs-connection.limit-ops-per-sec", flagSet.Lookup("limit-ops-per-sec"))
+	err = viper.BindPFlag("limit-ops-per-sec", flagSet.Lookup("limit-ops-per-sec"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("log-file", "", "", "The file for storing logs that can be parsed by fluentd. When not provided, plain text logs are printed to stdout when Cloud Storage FUSE is run  in the foreground, or to syslog when Cloud Storage FUSE is run in the  background.")
 
-	err = viper.BindPFlag("logging.file-path", flagSet.Lookup("log-file"))
+	err = viper.BindPFlag("file-path", flagSet.Lookup("log-file"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
 
-	err = viper.BindPFlag("logging.format", flagSet.Lookup("log-format"))
+	err = viper.BindPFlag("format", flagSet.Lookup("log-format"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
 
-	err = viper.BindPFlag("logging.log-rotate.backup-file-count", flagSet.Lookup("log-rotate-backup-file-count"))
+	err = viper.BindPFlag("backup-file-count", flagSet.Lookup("log-rotate-backup-file-count"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
-	err = viper.BindPFlag("logging.log-rotate.compress", flagSet.Lookup("log-rotate-compress"))
+	err = viper.BindPFlag("compress", flagSet.Lookup("log-rotate-compress"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("log-rotate-max-log-file-size-mb", "", 512, "The maximum size in megabytes that a log file can reach before it is rotated.")
 
-	err = viper.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-log-file-size-mb"))
+	err = viper.BindPFlag("max-file-size-mb", flagSet.Lookup("log-rotate-max-log-file-size-mb"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
-	err = viper.BindPFlag("logging.severity", flagSet.Lookup("log-severity"))
+	err = viper.BindPFlag("severity", flagSet.Lookup("log-severity"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
 
-	err = viper.BindPFlag("gcs-connection.max-conns-per-host", flagSet.Lookup("max-conns-per-host"))
+	err = viper.BindPFlag("max-conns-per-host", flagSet.Lookup("max-conns-per-host"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("max-download-parallelism", "", -1, "Sets an uber limit of number of concurrent file download requests that are made across all files.")
 
-	err = viper.BindPFlag("file-cache.max-download-parallelism", flagSet.Lookup("max-download-parallelism"))
+	err = viper.BindPFlag("max-download-parallelism", flagSet.Lookup("max-download-parallelism"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	err = viper.BindPFlag("gcs-connection.max-idle-conns-per-host", flagSet.Lookup("max-idle-conns-per-host"))
+	err = viper.BindPFlag("max-idle-conns-per-host", flagSet.Lookup("max-idle-conns-per-host"))
 	if err != nil {
 		return err
 	}
@@ -576,21 +576,21 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.DurationP("max-retry-sleep", "", 30000000000*time.Nanosecond, "The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry continues with this specified maximum value.")
 
-	err = viper.BindPFlag("gcs-retries.max-retry-sleep", flagSet.Lookup("max-retry-sleep"))
+	err = viper.BindPFlag("max-retry-sleep", flagSet.Lookup("max-retry-sleep"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("metadata-cache-ttl", "", 60, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.\"")
 
-	err = viper.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl"))
+	err = viper.BindPFlag("ttl-secs", flagSet.Lookup("metadata-cache-ttl"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringSliceP("o", "", []string{}, "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro")
 
-	err = viper.BindPFlag("file-system.fuse-options", flagSet.Lookup("o"))
+	err = viper.BindPFlag("fuse-options", flagSet.Lookup("o"))
 	if err != nil {
 		return err
 	}
@@ -604,42 +604,42 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("read-request-size-mb", "", 0, "Size of chunks in MiB that each concurrent request downloads.")
 
-	err = viper.BindPFlag("file-cache.read-request-size-mb", flagSet.Lookup("read-request-size-mb"))
+	err = viper.BindPFlag("read-request-size-mb", flagSet.Lookup("read-request-size-mb"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("rename-dir-limit", "", 0, "Allow rename a directory containing fewer descendants than this limit.")
 
-	err = viper.BindPFlag("file-system.rename-dir-limit", flagSet.Lookup("rename-dir-limit"))
+	err = viper.BindPFlag("rename-dir-limit", flagSet.Lookup("rename-dir-limit"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.Float64P("retry-multiplier", "", 2, "Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.")
 
-	err = viper.BindPFlag("gcs-retries.multiplier", flagSet.Lookup("retry-multiplier"))
+	err = viper.BindPFlag("multiplier", flagSet.Lookup("retry-multiplier"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.BoolP("reuse-token-from-url", "", true, "If false, the token acquired from token-url is not reused.")
 
-	err = viper.BindPFlag("gcs-auth.reuse-token-from-url", flagSet.Lookup("reuse-token-from-url"))
+	err = viper.BindPFlag("reuse-token-from-url", flagSet.Lookup("reuse-token-from-url"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("sequential-read-size-mb", "", 200, "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported")
 
-	err = viper.BindPFlag("gcs-connection.sequential-read-size-mb", flagSet.Lookup("sequential-read-size-mb"))
+	err = viper.BindPFlag("sequential-read-size-mb", flagSet.Lookup("sequential-read-size-mb"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.DurationP("stackdriver-export-interval", "", 0*time.Nanosecond, "Export metrics to stackdriver with this interval. The default value 0 indicates no exporting.")
 
-	err = viper.BindPFlag("metrics.stackdriver-export-interval", flagSet.Lookup("stackdriver-export-interval"))
+	err = viper.BindPFlag("stackdriver-export-interval", flagSet.Lookup("stackdriver-export-interval"))
 	if err != nil {
 		return err
 	}
@@ -651,14 +651,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("metadata-cache.deprecated-stat-cache-capacity", flagSet.Lookup("stat-cache-capacity"))
+	err = viper.BindPFlag("deprecated-stat-cache-capacity", flagSet.Lookup("stat-cache-capacity"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("stat-cache-max-size-mb", "", 32, "The maximum size of stat-cache in MiBs. It can also be set to -1 for no-size-limit, 0 for no cache. Values below -1 are not supported.")
 
-	err = viper.BindPFlag("metadata-cache.stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb"))
+	err = viper.BindPFlag("stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb"))
 	if err != nil {
 		return err
 	}
@@ -670,28 +670,28 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("metadata-cache.deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl"))
+	err = viper.BindPFlag("deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)\"")
 
-	err = viper.BindPFlag("file-system.temp-dir", flagSet.Lookup("temp-dir"))
+	err = viper.BindPFlag("temp-dir", flagSet.Lookup("temp-dir"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.StringP("token-url", "", "", "A url for getting an access token when the key-file is absent.")
 
-	err = viper.BindPFlag("gcs-auth.token-url", flagSet.Lookup("token-url"))
+	err = viper.BindPFlag("token-url", flagSet.Lookup("token-url"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("type-cache-max-size-mb", "", 4, "Max size of type-cache maps which are maintained at a per-directory level.")
 
-	err = viper.BindPFlag("metadata-cache.type-cache-max-size-mb", flagSet.Lookup("type-cache-max-size-mb"))
+	err = viper.BindPFlag("type-cache-max-size-mb", flagSet.Lookup("type-cache-max-size-mb"))
 	if err != nil {
 		return err
 	}
@@ -703,14 +703,14 @@ func BindFlags(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viper.BindPFlag("metadata-cache.deprecated-type-cache-ttl", flagSet.Lookup("type-cache-ttl"))
+	err = viper.BindPFlag("deprecated-type-cache-ttl", flagSet.Lookup("type-cache-ttl"))
 	if err != nil {
 		return err
 	}
 
 	flagSet.IntP("uid", "", -1, "UID owner of all inodes.")
 
-	err = viper.BindPFlag("file-system.uid", flagSet.Lookup("uid"))
+	err = viper.BindPFlag("uid", flagSet.Lookup("uid"))
 	if err != nil {
 		return err
 	}

--- a/tools/config-gen/config.tpl
+++ b/tools/config-gen/config.tpl
@@ -51,7 +51,7 @@ func BindFlags(flagSet *pflag.FlagSet) error {
   {{end}}
   {{if .HideShorthand}}flagSet.ShorthandLookup("{{ .Shorthand}}").Hidden = true{{end}}
   {{if ne .ConfigPath ""}}
-  err = viper.BindPFlag("{{ .ConfigPath}}", flagSet.Lookup("{{ .FlagName}}"))
+  err = viper.BindPFlag("{{ .ConfigName}}", flagSet.Lookup("{{ .FlagName}}"))
   if err != nil {
     return err
   }

--- a/tools/config-gen/flag_template_data_gen.go
+++ b/tools/config-gen/flag_template_data_gen.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -25,6 +26,9 @@ type flagTemplateData struct {
 	Param
 	// The pFlag function to invoke in order to add the flag.
 	Fn string
+	// The leaf config name for the flag - to be used as a key to bind cobra flag
+	// with viper config (using BindPFlag).
+	ConfigName string
 }
 
 func computeFlagTemplateData(paramsConfig []Param) ([]flagTemplateData, error) {
@@ -93,8 +97,10 @@ func computeFlagTemplateDataForParam(p Param) (flagTemplateData, error) {
 	p.DefaultValue = defaultValue
 	// Usage string safely escaped with Go syntax.
 	p.Usage = fmt.Sprintf("%q", p.Usage)
+	configParts := strings.Split(p.ConfigPath, ".")
 	return flagTemplateData{
-		Param: p,
-		Fn:    fn,
+		Param:      p,
+		Fn:         fn,
+		ConfigName: configParts[len(configParts)-1],
 	}, nil
 }

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -110,6 +110,10 @@ func computeFields(param Param) ([]fieldInfo, error) {
 			}
 
 			dt = tn + typeName
+
+			// Squash non leaf fields to make decoding possible from legacy
+			// flagStorage and mountConfig.
+			s = fmt.Sprint(s, ",squash")
 		}
 		fieldInfos = append(fieldInfos, fieldInfo{
 			TypeName:   typeName,


### PR DESCRIPTION
### Description
Add "squash" to config structure tags to make decoding easier from legacy flagStorage & mountConfig.
This is a temporary change to make transition easier to new CLI and config flags and will be reverted post transition.
Reason to revert this in future - This change doesn't allow having leaf config with conflicting names.

Reference: https://pkg.go.dev/github.com/mitchellh/mapstructure#hdr-Embedded_Structs_and_Squashing
Open issue on mapstructure library which is blocking the change: https://github.com/mitchellh/mapstructure/issues/356

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that viper configs and cobra flags are still working as intended
2. Unit tests - NA
3. Integration tests - NA
