### PR TITLE
Add max-download-parallelism validation

### DIFF
--- a/internal/config/testdata/file_cache_config/invalid_zero_max_download_parallelism.yaml
+++ b/internal/config/testdata/file_cache_config/invalid_zero_max_download_parallelism.yaml
@@ -1,0 +1,3 @@
+file-cache:
+  enable-parallel-downloads: true
+  max-download-parallelism: 0

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -81,12 +81,16 @@ func (fileCacheConfig *FileCacheConfig) validate() error {
 	if fileCacheConfig.MaxDownloadParallelism < -1 {
 		return fmt.Errorf(MaxDownloadParallelismInvalidValueError)
 	}
+	if fileCacheConfig.EnableParallelDownloads && fileCacheConfig.MaxDownloadParallelism == 0 {
+		return fmt.Errorf("the value of max-download-parallelism for file-cache must not be 0 when enable-parallel-downloads is true")
+	}
 	if fileCacheConfig.DownloadParallelismPerFile < 1 {
 		return fmt.Errorf(DownloadParallelismPerFileInvalidValueError)
 	}
 	if fileCacheConfig.ReadRequestSizeMB < 1 {
 		return fmt.Errorf(ReadRequestSizeMBInvalidValueError)
 	}
+
 	return nil
 }
 

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -174,6 +174,12 @@ func (t *YamlParserTest) TestReadConfigFile_InvalidMaxDownloadParallelismConfig(
 	assert.ErrorContains(t.T(), err, MaxDownloadParallelismInvalidValueError)
 }
 
+func (t *YamlParserTest) TestReadConfigFile_InvalidZeroMaxDownloadParallelismConfig() {
+	_, err := ParseConfigFile("testdata/file_cache_config/invalid_zero_max_download_parallelism.yaml")
+
+	assert.ErrorContains(t.T(), err, "the value of max-download-parallelism for file-cache can't be 0 when enable-parallel-downloads is true")
+}
+
 func (t *YamlParserTest) TestReadConfigFile_InvalidDownloadParallelismPerFileConfig() {
 	_, err := ParseConfigFile("testdata/file_cache_config/invalid_download_parallelism_per_file.yaml")
 

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -177,7 +177,7 @@ func (t *YamlParserTest) TestReadConfigFile_InvalidMaxDownloadParallelismConfig(
 func (t *YamlParserTest) TestReadConfigFile_InvalidZeroMaxDownloadParallelismConfig() {
 	_, err := ParseConfigFile("testdata/file_cache_config/invalid_zero_max_download_parallelism.yaml")
 
-	assert.ErrorContains(t.T(), err, "the value of max-download-parallelism for file-cache can't be 0 when enable-parallel-downloads is true")
+	assert.ErrorContains(t.T(), err, "the value of max-download-parallelism for file-cache must not be 0 when enable-parallel-downloads is true")
 }
 
 func (t *YamlParserTest) TestReadConfigFile_InvalidDownloadParallelismPerFileConfig() {


### PR DESCRIPTION
Reject 0 max-download-parallelism when parallel downloads enabled

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
