### PR TITLE
Use default MaxDownloadParallelism based on number of CPU cores

### DIFF
--- a/internal/config/config_util.go
+++ b/internal/config/config_util.go
@@ -114,6 +114,6 @@ func ListCacheTtlSecsToDuration(secs int64) time.Duration {
 	return time.Duration(secs * int64(time.Second))
 }
 
-func DefaultMaxDownloadParallelism() int {
+func DefaultMaxParallelDownloads() int {
 	return max(16, 2*runtime.NumCPU())
 }

--- a/internal/config/config_util.go
+++ b/internal/config/config_util.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"runtime"
 	"time"
 )
 
@@ -111,4 +112,8 @@ func ListCacheTtlSecsToDuration(secs int64) time.Duration {
 	}
 
 	return time.Duration(secs * int64(time.Second))
+}
+
+func DefaultMaxDownloadParallelism() int {
+	return max(16, 2*runtime.NumCPU())
 }

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -267,3 +267,7 @@ func Test_ListCacheTtlSecsToDuration_InvalidCall(t *testing.T) {
 	// Calling with invalid argument to trigger panic.
 	ListCacheTtlSecsToDuration(-3)
 }
+
+func Test_DefaultMaxDownloadParallelism(t *testing.T) {
+	assert.GreaterOrEqual(t, DefaultMaxDownloadParallelism(), 16)
+}

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -268,6 +268,6 @@ func Test_ListCacheTtlSecsToDuration_InvalidCall(t *testing.T) {
 	ListCacheTtlSecsToDuration(-3)
 }
 
-func Test_DefaultMaxDownloadParallelism(t *testing.T) {
-	assert.GreaterOrEqual(t, DefaultMaxDownloadParallelism(), 16)
+func Test_DefaultMaxParallelDownloads(t *testing.T) {
+	assert.GreaterOrEqual(t, DefaultMaxParallelDownloads(), 16)
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -187,7 +187,7 @@ func NewMountConfig() *MountConfig {
 		MaxSizeMB:                DefaultFileCacheMaxSizeMB,
 		EnableParallelDownloads:  DefaultEnableParallelDownloads,
 		ParallelDownloadsPerFile: DefaultParallelDownloadsPerFile,
-		MaxParallelDownloads:     DefaultMaxDownloadParallelism(),
+		MaxParallelDownloads:     DefaultMaxParallelDownloads(),
 		DownloadChunkSizeMB:      DefaultDownloadChunkSizeMB,
 		EnableCRC:                DefaultEnableCRC,
 	}

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -63,7 +63,6 @@ const (
 	DefaultEnableParallelDownloads  = false
 	DefaultDownloadChunkSizeMB      = 25
 	DefaultParallelDownloadsPerFile = 10
-	DefaultMaxParallelDownloads     = -1
 )
 
 type WriteConfig struct {
@@ -188,7 +187,7 @@ func NewMountConfig() *MountConfig {
 		MaxSizeMB:                DefaultFileCacheMaxSizeMB,
 		EnableParallelDownloads:  DefaultEnableParallelDownloads,
 		ParallelDownloadsPerFile: DefaultParallelDownloadsPerFile,
-		MaxParallelDownloads:     DefaultMaxParallelDownloads,
+		MaxParallelDownloads:     DefaultMaxDownloadParallelism(),
 		DownloadChunkSizeMB:      DefaultDownloadChunkSizeMB,
 		EnableCRC:                DefaultEnableCRC,
 	}

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -44,7 +44,7 @@ func validateDefaultConfig(t *testing.T, mountConfig *MountConfig) {
 	assert.False(t, mountConfig.FileCacheConfig.CacheFileForRangeRead)
 	assert.False(t, mountConfig.FileCacheConfig.EnableParallelDownloads)
 	assert.Equal(t, 10, mountConfig.FileCacheConfig.ParallelDownloadsPerFile)
-	assert.Equal(t, -1, mountConfig.FileCacheConfig.MaxParallelDownloads)
+	assert.GreaterOrEqual(t, mountConfig.FileCacheConfig.MaxParallelDownloads, 16)
 	assert.Equal(t, 25, mountConfig.FileCacheConfig.DownloadChunkSizeMB)
 	assert.True(t, mountConfig.FileCacheConfig.EnableCRC)
 	assert.Equal(t, 1, mountConfig.GCSConnection.GRPCConnPoolSize)


### PR DESCRIPTION
### Description
Use default MaxDownloadParallelism based on number of CPU cores. Also set a minimum value of 16 in case the cores of CPU is less (2 or 4).

Using default 2 * number of cores as with the testing so far with a workload, this value looks good.

And couple of more things to tell upfront :
1. This is based on CPU cores count of machine, so on GKE this will translate to machine's CPU cores and not on the CPU limit on pod. We are fine here because pod limit <= machine CPU cores. So, we are just assigning higher value to max parallel downloads there.
2. It's possible to mount multiple GCSFuse mounts on single GCE VM/GKE node. In that case, one GCSFuse default is not affected by the other.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
