### PR TITLE
Add command to generate config file

### DIFF
--- a/cmd/genConfig.go
+++ b/cmd/genConfig.go
@@ -22,13 +22,11 @@ import (
 var cfgOutputPath string
 var genConfigCmd = &cobra.Command{
 	Use:   "genConfig",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Generate config file from the available configuration",
+	Long: `Generate the effective config file from the available configuration
+         after resolving the params passed through CLI flags and config file.
+         This config file can then be used as the sole input to GCSFuse using
+         the --config-file CLI flag to achieve the same effect.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return viper.SafeWriteConfigAs(cfgOutputPath)
 	},

--- a/cmd/genConfig.go
+++ b/cmd/genConfig.go
@@ -20,20 +20,24 @@ import (
 )
 
 var cfgOutputPath string
-var genConfigCmd = &cobra.Command{
-	Use:   "genConfig",
-	Short: "Generate config file from the available configuration",
-	Long: `Generate the effective config file from the available configuration
+
+func NewGenConfigCmd() *cobra.Command {
+	var genConfigCmd = &cobra.Command{
+		Use:   "genConfig",
+		Short: "Generate config file from the available configuration",
+		Long: `Generate the effective config file from the available configuration
          after resolving the params passed through CLI flags and config file.
          This config file can then be used as the sole input to GCSFuse using
          the --config-file CLI flag to achieve the same effect.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return viper.SafeWriteConfigAs(cfgOutputPath)
-	},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return viper.SafeWriteConfigAs(cfgOutputPath)
+		},
+	}
+	genConfigCmd.Flags().StringVar(&cfgOutputPath, "output-path", "", "Path where the output config file will be generated.")
+	genConfigCmd.MarkFlagRequired("output-path")
+	return genConfigCmd
 }
 
 func init() {
-	rootCmd.AddCommand(genConfigCmd)
-	genConfigCmd.Flags().StringVar(&cfgOutputPath, "output-path", "", "Help message for toggle")
-	genConfigCmd.MarkFlagRequired("output-path")
+	rootCmd.AddCommand(NewGenConfigCmd())
 }

--- a/cmd/genConfig.go
+++ b/cmd/genConfig.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgOutputPath string
+var genConfigCmd = &cobra.Command{
+	Use:   "genConfig",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return viper.SafeWriteConfigAs(cfgOutputPath)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genConfigCmd)
+	genConfigCmd.Flags().StringVar(&cfgOutputPath, "output-path", "", "Help message for toggle")
+	genConfigCmd.MarkFlagRequired("output-path")
+}


### PR DESCRIPTION
### Description
Add the genConfig command that can be used to generate the config file
from the available configuration.
GCS bucket names cannot contain uppercase characters. So, genConfig will not conflict/be confused with a GCS bucket.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
