### PR TITLE
[CLI Config Parity] migrate log-file legacy flag/config to new config 

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -485,11 +485,6 @@ func resolvePathForTheFlagInContext(flagKey string, c *cli.Context) (err error) 
 // GCSFUSE_PARENT_PROCESS_DIR. Child process is spawned when --foreground flag
 // is disabled.
 func resolvePathForTheFlagsInContext(c *cli.Context) (err error) {
-	err = resolvePathForTheFlagInContext("log-file", c)
-	if err != nil {
-		return fmt.Errorf("resolving for log-file: %w", err)
-	}
-
 	err = resolvePathForTheFlagInContext("config-file", c)
 	if err != nil {
 		return fmt.Errorf("resolving for config-file: %w", err)
@@ -500,11 +495,6 @@ func resolvePathForTheFlagsInContext(c *cli.Context) (err error) {
 
 // resolveConfigFilePaths resolves the config file paths specified in the config file.
 func resolveConfigFilePaths(mountConfig *config.MountConfig) (err error) {
-	mountConfig.LogConfig.FilePath, err = resolveFilePath(mountConfig.LogConfig.FilePath, "logging: file")
-	if err != nil {
-		return
-	}
-
 	// Resolve cache-dir path
 	resolvedPath, err := resolveFilePath(string(mountConfig.CacheDir), "cache-dir")
 	mountConfig.CacheDir = resolvedPath

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -274,23 +274,18 @@ func (t *FlagsTest) TestResolvePathForTheFlagInContext() {
 	currentWorkingDir, err := os.Getwd()
 	assert.Equal(t.T(), nil, err)
 	app.Action = func(appCtx *cli.Context) {
-		err = resolvePathForTheFlagInContext("log-file", appCtx)
-		assert.Equal(t.T(), nil, err)
 		err = resolvePathForTheFlagInContext("key-file", appCtx)
 		assert.Equal(t.T(), nil, err)
 		err = resolvePathForTheFlagInContext("config-file", appCtx)
 		assert.Equal(t.T(), nil, err)
 
 		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "test.txt"),
-			appCtx.String("log-file"))
-		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "test.txt"),
 			appCtx.String("key-file"))
 		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "config.yaml"),
 			appCtx.String("config-file"))
 	}
 	// Simulate argv.
-	fullArgs := []string{"some_app", "--log-file=test.txt",
-		"--key-file=test.txt", "--config-file=config.yaml"}
+	fullArgs := []string{"some_app", "--key-file=test.txt", "--config-file=config.yaml"}
 
 	err = app.Run(fullArgs)
 
@@ -303,13 +298,12 @@ func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 	assert.Equal(t.T(), nil, err)
 	app.Action = func(appCtx *cli.Context) {
 		resolvePathForTheFlagsInContext(appCtx)
-		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "test.txt"),
-			appCtx.String("log-file"))
+
 		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "config.yaml"),
 			appCtx.String("config-file"))
 	}
 	// Simulate argv.
-	fullArgs := []string{"some_app", "--log-file=test.txt", "--config-file=config.yaml"}
+	fullArgs := []string{"some_app", "--config-file=config.yaml"}
 
 	err = app.Run(fullArgs)
 
@@ -417,9 +411,6 @@ func (t *FlagsTest) TestValidateFlagsForUnsupportedExperimentalMetadataPrefetchO
 
 func (t *FlagsTest) Test_resolveConfigFilePaths() {
 	mountConfig := &config.MountConfig{}
-	mountConfig.LogConfig = config.LogConfig{
-		FilePath: "~/test.txt",
-	}
 	mountConfig.CacheDir = "~/cache-dir"
 
 	err := resolveConfigFilePaths(mountConfig)
@@ -427,7 +418,6 @@ func (t *FlagsTest) Test_resolveConfigFilePaths() {
 	assert.Equal(t.T(), nil, err)
 	homeDir, err := os.UserHomeDir()
 	assert.Equal(t.T(), nil, err)
-	assert.Equal(t.T(), filepath.Join(homeDir, "test.txt"), mountConfig.LogConfig.FilePath)
 	assert.EqualValues(t.T(), filepath.Join(homeDir, "cache-dir"), mountConfig.CacheDir)
 }
 
@@ -437,7 +427,6 @@ func (t *FlagsTest) Test_resolveConfigFilePaths_WithoutSettingPaths() {
 	err := resolveConfigFilePaths(mountConfig)
 
 	assert.Equal(t.T(), nil, err)
-	assert.Equal(t.T(), "", mountConfig.LogConfig.FilePath)
 	assert.EqualValues(t.T(), "", mountConfig.CacheDir)
 }
 

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -258,7 +258,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		return fmt.Errorf("error resolving flags and configs: %w", err)
 	}
 
-	config.OverrideWithLoggingFlags(mountConfig, flags.LogFile, flags.LogFormat,
+	config.OverrideWithLoggingFlags(mountConfig, flags.LogFormat,
 		flags.DebugFuse, flags.DebugGCS, flags.DebugMutex)
 	config.OverrideWithIgnoreInterruptsFlag(c, mountConfig, flags.IgnoreInterrupts)
 	config.OverrideWithAnonymousAccessFlag(c, mountConfig, flags.AnonymousAccess)
@@ -296,7 +296,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	// Do not log these in stdout in case of daemonized run
 	// if these are already being logged into a log-file, otherwise
 	// there will be duplicate logs for these in both places (stdout and log-file).
-	if flags.Foreground || mountConfig.LogConfig.FilePath == "" {
+	if flags.Foreground || newConfig.Logging.FilePath == "" {
 		flagsStringified, err := util.Stringify(*flags)
 		if err != nil {
 			logger.Warnf("failed to stringify cli flags: %v", err)

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -276,7 +276,7 @@ func runCLIApp(c *cli.Context) (err error) {
 	}
 
 	if flags.Foreground {
-		err = logger.InitLogFile(mountConfig.LogConfig)
+		err = logger.InitLogFile(mountConfig.LogConfig, newConfig.Logging)
 		if err != nil {
 			return fmt.Errorf("init log file: %w", err)
 		}

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -39,6 +39,7 @@ func (m *mockCLIContext) IsSet(name string) bool {
 }
 
 func TestPopulateConfigFromLegacyFlags(t *testing.T) {
+	currentWorkingDir, _ := os.Getwd()
 	var populateConfigFromLegacyFlags = []struct {
 		testName          string
 		legacyFlagStorage *flagStorage
@@ -201,7 +202,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				LogConfig: config.LogConfig{
 					Severity: "info",
 					Format:   "text",
-					FilePath: "~/Documents/log-file.txt",
+					FilePath: "log-file.txt",
 					LogRotateConfig: config.LogRotateConfig{
 						MaxFileSizeMB:   20,
 						BackupFileCount: 2,
@@ -240,7 +241,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				Logging: cfg.LoggingConfig{
 					Severity: "INFO",
 					Format:   "text",
-					FilePath: cfg.ResolvedPath(path.Join(os.Getenv("HOME"), "Documents/log-file.txt")),
+					FilePath: cfg.ResolvedPath(path.Join(currentWorkingDir, "log-file.txt")),
 					LogRotate: cfg.LogRotateLoggingConfig{
 						MaxFileSizeMb:   20,
 						BackupFileCount: 2,

--- a/internal/config/config_util.go
+++ b/internal/config/config_util.go
@@ -34,12 +34,8 @@ const (
 
 // OverrideWithLoggingFlags overwrites the configs with the flag values if the
 // config values are empty.
-func OverrideWithLoggingFlags(mountConfig *MountConfig, logFile string, logFormat string,
+func OverrideWithLoggingFlags(mountConfig *MountConfig, logFormat string,
 	debugFuse bool, debugGCS bool, debugMutex bool) {
-	// If log file is not set in config file, override it with flag value.
-	if mountConfig.LogConfig.FilePath == "" {
-		mountConfig.LogConfig.FilePath = logFile
-	}
 	// If log format is not set in config file, override it with flag value.
 	if mountConfig.LogConfig.Format == "" {
 		mountConfig.LogConfig.Format = logFormat

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -59,17 +59,15 @@ func (t *ConfigTest) TestOverrideLoggingFlags_WithNonEmptyLogConfigs() {
 	mountConfig := &MountConfig{}
 	mountConfig.LogConfig = LogConfig{
 		Severity: ERROR,
-		FilePath: "/tmp/hello.txt",
 		Format:   "text",
 	}
 	mountConfig.WriteConfig = WriteConfig{
 		CreateEmptyFile: true,
 	}
 
-	OverrideWithLoggingFlags(mountConfig, f.LogFile, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
+	OverrideWithLoggingFlags(mountConfig, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
 
 	assert.Equal(t.T(), "text", mountConfig.LogConfig.Format)
-	assert.Equal(t.T(), "/tmp/hello.txt", mountConfig.LogConfig.FilePath)
 	assert.Equal(t.T(), TRACE, mountConfig.LogConfig.Severity)
 }
 
@@ -81,17 +79,15 @@ func (t *ConfigTest) TestOverrideLoggingFlags_WithEmptyLogConfigs() {
 	mountConfig := &MountConfig{}
 	mountConfig.LogConfig = LogConfig{
 		Severity: INFO,
-		FilePath: "",
 		Format:   "",
 	}
 	mountConfig.WriteConfig = WriteConfig{
 		CreateEmptyFile: true,
 	}
 
-	OverrideWithLoggingFlags(mountConfig, f.LogFile, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
+	OverrideWithLoggingFlags(mountConfig, f.LogFormat, f.DebugFuse, f.DebugGCS, f.DebugMutex)
 
 	assert.Equal(t.T(), "json", mountConfig.LogConfig.Format)
-	assert.Equal(t.T(), "a.txt", mountConfig.LogConfig.FilePath)
 	assert.Equal(t.T(), INFO, mountConfig.LogConfig.Severity)
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -274,18 +275,18 @@ func (t *LoggerTest) TestInitLogFile() {
 	filePath += "/log.txt"
 	fileSize := 100
 	backupFileCount := 2
-	logConfig := config.LogConfig{
+	legacyLogConfig := config.LogConfig{
 		Severity: config.DEBUG,
 		Format:   format,
-		FilePath: filePath,
 		LogRotateConfig: config.LogRotateConfig{
 			MaxFileSizeMB:   fileSize,
 			BackupFileCount: backupFileCount,
 			Compress:        true,
 		},
 	}
+	newLogConfig := cfg.LoggingConfig{FilePath: cfg.ResolvedPath(filePath)}
 
-	err := InitLogFile(logConfig)
+	err := InitLogFile(legacyLogConfig, newLogConfig)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), filePath, defaultLoggerFactory.file.Name())

--- a/tools/integration_tests/log_rotation/log_rotation_test.go
+++ b/tools/integration_tests/log_rotation/log_rotation_test.go
@@ -94,6 +94,7 @@ func TestMain(m *testing.M) {
 	// Set up directory for logs.
 	logDirPath = setup.SetUpLogDirForTestDirTests(logDirName)
 	logFilePath = path.Join(logDirPath, logFileName)
+	setup.SetLogFile(logFilePath)
 
 	// Set up config files.
 	// TODO: add tests for backupLogFileCount = 0.


### PR DESCRIPTION
### Description
This PR is part of migration to new cobra/viper configs for CLI config parity.
Replaced usage of `log-file` flag stored in `flagstorage.LogFile` and `mountConfig.LogConfig.FilePath` to `newConfig.Logging.FilePath`.

Note: Post merging this PR, log-file flag will start taking precedence when both flag and config is set.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that the new flag is working
2. Unit tests - Updated
3. Integration tests - Ran via KOKORO
