### PR TITLE
small fix to read cache functional test

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -95,6 +95,7 @@ func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSeq
 	wg.Wait()
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
+	ogletest.AssertEq(2, len(structuredReadLogs))
 	// Goroutine execution order isn't guaranteed.
 	// If the object name in expected outcome doesn't align with the logs, swap
 	// the expected outcome objects and file names at positions 0 and 1.


### PR DESCRIPTION
### Description
TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache is flaky. Asserting on length of structuredReadLogs will help narrow down the problem.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
