### PR TITLE
Add constraints on number of args

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func NewRootCmd(mountFn func(config cfg.Config) error) (*cobra.Command, error) {
 and access Cloud Storage buckets as local file systems. For a technical overview
 of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		Version: getVersion(),
-		Args:    cobra.RangeArgs(1, 2),
+		Args:    cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfgErr != nil {
 				return fmt.Errorf("error while parsing config: %w", cfgErr)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func NewRootCmd(mountFn func(config cfg.Config) error) (*cobra.Command, error) {
 and access Cloud Storage buckets as local file systems. For a technical overview
 of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		Version: getVersion(),
+		Args:    cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfgErr != nil {
 				return fmt.Errorf("error while parsing config: %w", cfgErr)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidConfig(t *testing.T) {
@@ -55,22 +56,22 @@ func TestTooManyCobraArgs(t *testing.T) {
 	}{
 		{
 			name:        "Too many args",
-			args:        []string{"abc", "pqr", "xyz"},
+			args:        []string{"gcsfuse", "abc", "pqr", "xyz"},
 			expectError: true,
 		},
 		{
 			name:        "Too few args",
-			args:        []string{},
+			args:        []string{"gcsfuse"},
 			expectError: true,
 		},
 		{
-			name:        "One arg is okay",
-			args:        []string{"abc"},
+			name:        "Two args is okay",
+			args:        []string{"gcsfuse", "abc"},
 			expectError: false,
 		},
 		{
-			name:        "Two args is okay",
-			args:        []string{"abc", "pqr"},
+			name:        "Three args is okay",
+			args:        []string{"gcsfuse", "abc", "pqr"},
 			expectError: false,
 		},
 	}
@@ -78,9 +79,7 @@ func TestTooManyCobraArgs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd, err := NewRootCmd(func(config cfg.Config) error { return nil })
-			if err != nil {
-				t.Fatalf("Error while creating the root command: %v", err)
-			}
+			require.Nil(t, err)
 			cmd.SetArgs(tc.args)
 
 			err = cmd.Execute()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -46,3 +46,50 @@ func TestValidConfig(t *testing.T) {
 
 	assert.Nil(t, cmd.Execute())
 }
+
+func TestTooManyCobraArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name:        "Too many args",
+			args:        []string{"abc", "pqr", "xyz"},
+			expectError: true,
+		},
+		{
+			name:        "Too few args",
+			args:        []string{},
+			expectError: true,
+		},
+		{
+			name:        "One arg is okay",
+			args:        []string{"abc"},
+			expectError: false,
+		},
+		{
+			name:        "Two args is okay",
+			args:        []string{"abc", "pqr"},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, err := NewRootCmd(func(config cfg.Config) error { return nil })
+			if err != nil {
+				t.Fatalf("Error while creating the root command: %v", err)
+			}
+			cmd.SetArgs(tc.args)
+
+			err = cmd.Execute()
+
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Limit the number of arguments that the root command can receive to the range [1, 2]
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests.
3. Integration tests - NA
