### PR TITLE
Fix race in test

### DIFF
--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -127,6 +127,7 @@ func TestParallelDownloads(t *testing.T) {
 	}
 	for _, tc := range tbl {
 		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
 			t.Parallel()
 			cache, cacheDir := configureCache(t, 2*tc.objectSize)
 			storageHandle := configureFakeStorage(t)


### PR DESCRIPTION
Shadow the tc variable so that different subtests refer to their corresponding tc.

It's have been fine had the subtests ran sequentially but in a parallel run, different tests sharing the same tc variable can lead to race.