### PR TITLE
[CLI Config Parity] migrate key-file flag usage to new config

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -490,11 +490,6 @@ func resolvePathForTheFlagsInContext(c *cli.Context) (err error) {
 		return fmt.Errorf("resolving for log-file: %w", err)
 	}
 
-	err = resolvePathForTheFlagInContext("key-file", c)
-	if err != nil {
-		return fmt.Errorf("resolving for key-file: %w", err)
-	}
-
 	err = resolvePathForTheFlagInContext("config-file", c)
 	if err != nil {
 		return fmt.Errorf("resolving for config-file: %w", err)

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -303,17 +303,13 @@ func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 	assert.Equal(t.T(), nil, err)
 	app.Action = func(appCtx *cli.Context) {
 		resolvePathForTheFlagsInContext(appCtx)
-
 		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "test.txt"),
 			appCtx.String("log-file"))
-		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "test.txt"),
-			appCtx.String("key-file"))
 		assert.Equal(t.T(), filepath.Join(currentWorkingDir, "config.yaml"),
 			appCtx.String("config-file"))
 	}
 	// Simulate argv.
-	fullArgs := []string{"some_app", "--log-file=test.txt",
-		"--key-file=test.txt", "--config-file=config.yaml"}
+	fullArgs := []string{"some_app", "--log-file=test.txt", "--config-file=config.yaml"}
 
 	err = app.Run(fullArgs)
 

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 
@@ -49,12 +50,12 @@ func (t *MainTest) TestCreateStorageHandle() {
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
 		AppName:             "app",
-		KeyFile:             "testdata/test_creds.json",
 	}
 	mountConfig := &config.MountConfig{}
+	newConfig := &cfg.Config{GcsAuth: cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"}}
 
 	userAgent := "AppName"
-	storageHandle, err := createStorageHandle(flags, mountConfig, userAgent)
+	storageHandle, err := createStorageHandle(newConfig, flags, mountConfig, userAgent)
 
 	assert.Equal(t.T(), nil, err)
 	assert.NotEqual(t.T(), nil, storageHandle)
@@ -69,14 +70,14 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
 		AppName:             "app",
-		KeyFile:             "testdata/test_creds.json",
 	}
 	mountConfig := &config.MountConfig{
 		GCSConnection: config.GCSConnection{GRPCConnPoolSize: 1},
 	}
+	newConfig := &cfg.Config{GcsAuth: cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"}}
 
 	userAgent := "AppName"
-	storageHandle, err := createStorageHandle(flags, mountConfig, userAgent)
+	storageHandle, err := createStorageHandle(newConfig, flags, mountConfig, userAgent)
 
 	assert.Equal(t.T(), nil, err)
 	assert.NotEqual(t.T(), nil, storageHandle)

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -347,47 +347,6 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 	}
 }
 
-func TestOverrideWithFlag(t *testing.T) {
-	tests := []struct {
-		name         string
-		flag         string
-		isFlagSet    bool
-		initialValue any
-		updateValue  any
-		expected     any
-	}{
-		{
-			name:         "flagSet",
-			flag:         "log-file",
-			isFlagSet:    true,
-			initialValue: "/tmp/log.txt",
-			updateValue:  "/tmp/newLog.txt",
-			expected:     "/tmp/newLog.txt",
-		},
-		{
-			name:         "flagNotSet",
-			flag:         "ignore-interrupts",
-			isFlagSet:    false,
-			initialValue: false,
-			updateValue:  true,
-			expected:     false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			toUpdate := tc.initialValue
-			mockC := &mockCLIContext{
-				isFlagSet: map[string]bool{tc.flag: tc.isFlagSet},
-			}
-
-			overrideWithFlag(mockC, tc.flag, &toUpdate, tc.updateValue)
-
-			assert.Equal(t, tc.expected, toUpdate)
-		})
-	}
-}
-
 func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 	currentWorkingDir, err := os.Getwd()
 	require.Nil(t, err)

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -390,7 +390,7 @@ func TestOverrideWithFlag(t *testing.T) {
 
 func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 	currentWorkingDir, err := os.Getwd()
-	require.Equal(t, nil, err)
+	require.Nil(t, err)
 	var keyFileTests = []struct {
 		testName        string
 		givenKeyFile    string

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -388,49 +388,8 @@ func TestOverrideWithFlag(t *testing.T) {
 	}
 }
 
-func TestOverrideWithFlag(t *testing.T) {
-	tests := []struct {
-		name         string
-		flag         string
-		isFlagSet    bool
-		initialValue any
-		updateValue  any
-		expected     any
-	}{
-		{
-			name:         "flagSet",
-			flag:         "log-file",
-			isFlagSet:    true,
-			initialValue: "/tmp/log.txt",
-			updateValue:  "/tmp/newLog.txt",
-			expected:     "/tmp/newLog.txt",
-		},
-		{
-			name:         "flagNotSet",
-			flag:         "ignore-interrupts",
-			isFlagSet:    false,
-			initialValue: false,
-			updateValue:  true,
-			expected:     false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			toUpdate := tc.initialValue
-			mockC := &mockCLIContext{
-				isFlagSet: map[string]bool{tc.flag: tc.isFlagSet},
-			}
-
-			overrideWithFlag(mockC, tc.flag, &toUpdate, tc.updateValue)
-
-			assert.Equal(t, tc.expected, toUpdate)
-		})
-	}
-}
-
 func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
-	currentWorkdingDir, err := os.Getwd()
+	currentWorkingDir, err := os.Getwd()
 	require.Equal(t, nil, err)
 	var keyFileTests = []struct {
 		testName        string
@@ -450,7 +409,7 @@ func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 		{
 			testName:        "current working directory",
 			givenKeyFile:    "key-file.json",
-			expectedKeyFile: cfg.ResolvedPath(path.Join(currentWorkdingDir, "key-file.json")),
+			expectedKeyFile: cfg.ResolvedPath(path.Join(currentWorkingDir, "key-file.json")),
 		},
 		{
 			testName:        "empty path",
@@ -470,8 +429,9 @@ func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 
 			resolvedConfig, err := PopulateNewConfigFromLegacyFlagsAndConfig(mockCLICtx, legacyFlagStorage, legacyMountCfg)
 
-			require.Equal(t, nil, err)
-			assert.Equal(t, tc.expectedKeyFile, resolvedConfig.GcsAuth.KeyFile)
+			if assert.Equal(t, nil, err) {
+				assert.Equal(t, tc.expectedKeyFile, resolvedConfig.GcsAuth.KeyFile)
+			}
 		})
 	}
 }

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -429,7 +429,7 @@ func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 
 			resolvedConfig, err := PopulateNewConfigFromLegacyFlagsAndConfig(mockCLICtx, legacyFlagStorage, legacyMountCfg)
 
-			if assert.Equal(t, nil, err) {
+			if assert.Nil(t, err) {
 				assert.Equal(t, tc.expectedKeyFile, resolvedConfig.GcsAuth.KeyFile)
 			}
 		})


### PR DESCRIPTION
### Description
This PR is part of migration to new cobra/viper configs for CLI config parity.  
Replaced usage of `key-file` flag stored in `flagstorage.KeyFile` to `newConfig.GcsAuth.KeyFile`. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that key-file flag is working.
2. Unit tests - added
3. Integration tests - Ran via KOKORO
