### PR TITLE
Run test and not just subtests parallely

### DIFF
--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -90,6 +90,7 @@ func TestParsingSuccess(t *testing.T) {
 		setupFn func()
 		testFn  func(*testing.T, TestConfig)
 	}{
+		t.Parallel()
 		{
 			name: "Octal",
 			args: []string{"--octalParam=755"},
@@ -230,6 +231,7 @@ func TestParsingSuccess(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if tc.setupFn != nil {
@@ -304,8 +306,8 @@ func TestParsingError(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			fs := declareFlags()
 			v := bindFlags(fs)
 			c := TestConfig{}

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -91,6 +91,7 @@ func createObjectInStoreAndInitCache(t *testing.T, cache *lru.Cache, bucket gcs.
 }
 
 func TestParallelDownloads(t *testing.T) {
+	t.Parallel()
 	tbl := []struct {
 		name                     string
 		objectSize               int64
@@ -126,8 +127,8 @@ func TestParallelDownloads(t *testing.T) {
 		},
 	}
 	for _, tc := range tbl {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 			cache, cacheDir := configureCache(t, 2*tc.objectSize)
 			storageHandle := configureFakeStorage(t)


### PR DESCRIPTION
### Description
Calling t.Parallel() in the subtests just invokes the subtest concurrently with each other but those subtests will not be interleaved with other tests in the same package. Fix that to run subtests parallely with other tests in the same package.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
