### PR TITLE
Fix test in GKE environment

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -411,7 +411,7 @@ func AddHNSFlagForHierarchicalBucket(ctx context.Context, storageClient *storage
 	if err != nil {
 		return nil, fmt.Errorf("Error in getting bucket attrs: %w", err)
 	}
-	if !attrs.HierarchicalNamespace.Enabled {
+	if attrs.HierarchicalNamespace != nil && !attrs.HierarchicalNamespace.Enabled {
 		return nil, fmt.Errorf("Bucket is not Hierarchical")
 	}
 


### PR DESCRIPTION
### Description
I've implemented a check for HierarchicalNamespace.Enabled to incorporate the HNS flag in end-to-end tests. Older buckets lack this attribute, potentially leading to nil pointer exceptions. To mitigate this, I've added a fix to verify the presence of HierarchicalNamespace.

Alternatively, the GKE team could create a new bucket where the `HierarchicalNamespace` attribute already defined.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated and Ran mounted directory script
