### PR TITLE
Migrate a few flags to the new config

### DIFF
--- a/cfg/types.go
+++ b/cfg/types.go
@@ -42,6 +42,12 @@ func (o *Octal) String() string {
 // Protocol is the datatype that specifies the type of connection: http1/http2/grpc.
 type Protocol string
 
+const (
+	HTTP1 Protocol = "http1"
+	HTTP2 Protocol = "http2"
+	GRPC  Protocol = "grpc"
+)
+
 func (p *Protocol) UnmarshalText(text []byte) error {
 	txtStr := string(text)
 	protocol := strings.ToLower(txtStr)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -390,57 +390,92 @@ func newApp() (app *cli.App) {
 }
 
 type flagStorage struct {
-	AppName    string
+	// Deprecated: Use the param from cfg/config.go
+	AppName string
+	// Deprecated: Use the param from cfg/config.go
 	Foreground bool
 	ConfigFile string
 
 	// File system
-	MountOptions     map[string]string
-	DirMode          os.FileMode
-	FileMode         os.FileMode
-	Uid              int64
-	Gid              int64
-	ImplicitDirs     bool
-	OnlyDir          string
+	MountOptions map[string]string
+
+	// Deprecated: Use the param from cfg/config.go
+	DirMode os.FileMode
+
+	// Deprecated: Use the param from cfg/config.go
+	FileMode os.FileMode
+
+	// Deprecated: Use the param from cfg/config.go
+	Uid int64
+
+	// Deprecated: Use the param from cfg/config.go
+	Gid          int64
+	ImplicitDirs bool
+	OnlyDir      string
+
+	// Deprecated: Use the param from cfg/config.go
 	RenameDirLimit   int64
 	IgnoreInterrupts bool
 
 	// GCS
-	CustomEndpoint                     *url.URL
-	BillingProject                     string
-	KeyFile                            string
-	TokenUrl                           string
-	ReuseTokenFromUrl                  bool
+	CustomEndpoint *url.URL
+
+	// Deprecated: Use the param from cfg/config.go
+	BillingProject string
+
+	// Deprecated: Use the param from cfg/config.go
+	KeyFile string
+
+	// Deprecated: Use the param from cfg/config.go
+	TokenUrl string
+
+	// Deprecated: Use the param from cfg/config.go
+	ReuseTokenFromUrl bool
+
+	// Deprecated: Use the param from cfg/config.go
 	EgressBandwidthLimitBytesPerSecond float64
-	OpRateLimitHz                      float64
-	SequentialReadSizeMb               int32
-	AnonymousAccess                    bool
+
+	// Deprecated: Use the param from cfg/config.go
+	OpRateLimitHz        float64
+	SequentialReadSizeMb int32
+	AnonymousAccess      bool
 
 	// Tuning
-	MaxRetrySleep              time.Duration
-	StatCacheCapacity          int
-	StatCacheTTL               time.Duration
-	TypeCacheTTL               time.Duration
-	KernelListCacheTtlSeconds  int64
-	HttpClientTimeout          time.Duration
-	MaxRetryDuration           time.Duration
-	RetryMultiplier            float64
-	LocalFileCache             bool
-	TempDir                    string
-	ClientProtocol             mountpkg.ClientProtocol
-	MaxConnsPerHost            int
-	MaxIdleConnsPerHost        int
+	MaxRetrySleep             time.Duration
+	StatCacheCapacity         int
+	StatCacheTTL              time.Duration
+	TypeCacheTTL              time.Duration
+	KernelListCacheTtlSeconds int64
+	HttpClientTimeout         time.Duration
+	MaxRetryDuration          time.Duration
+	RetryMultiplier           float64
+	LocalFileCache            bool
+
+	// Deprecated: Use the param from cfg/config.go
+	TempDir             string
+	ClientProtocol      mountpkg.ClientProtocol
+	MaxConnsPerHost     int
+	MaxIdleConnsPerHost int
+
+	// Deprecated: Use the param from cfg/config.go
 	EnableNonexistentTypeCache bool
 
 	// Monitoring & Logging
-	StackdriverExportInterval  time.Duration
-	OtelCollectorAddress       string
-	LogFile                    string
-	LogFormat                  string
+	// Deprecated: Use the param from cfg/config.go
+	StackdriverExportInterval time.Duration
+
+	// Deprecated: Use the param from cfg/config.go
+	OtelCollectorAddress string
+	LogFile              string
+	LogFormat            string
+
+	// Deprecated: Use the param from cfg/config.go
 	ExperimentalEnableJsonRead bool
 	DebugFuseErrors            bool
 
 	// Debugging
+
+	// Deprecated: Use the param from cfg/config.go
 	DebugFuse       bool
 	DebugFS         bool
 	DebugGCS        bool

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -289,7 +289,7 @@ func runCLIApp(c *cli.Context) (err error) {
 		return
 	}
 
-	logger.Infof("Start gcsfuse/%s for app %q using mount point: %s\n", getVersion(), flags.AppName, mountPoint)
+	logger.Infof("Start gcsfuse/%s for app %q using mount point: %s\n", getVersion(), newConfig.AppName, mountPoint)
 
 	// Log mount-config and the CLI flags in the log-file.
 	// If there is no log-file, then log these to stdout.

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -43,16 +43,18 @@ type MainTest struct {
 
 func (t *MainTest) TestCreateStorageHandle() {
 	flags := &flagStorage{
-		ClientProtocol:      mountpkg.HTTP1,
 		MaxConnsPerHost:     5,
 		MaxIdleConnsPerHost: 100,
 		HttpClientTimeout:   5,
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
 		AppName:             "app",
+		KeyFile:             "testdata/test_creds.json",
 	}
 	mountConfig := &config.MountConfig{}
-	newConfig := &cfg.Config{GcsAuth: cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"}}
+	newConfig := &cfg.Config{
+		GcsConnection: cfg.GcsConnectionConfig{ClientProtocol: cfg.HTTP1},
+		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"}}
 
 	userAgent := "AppName"
 	storageHandle, err := createStorageHandle(newConfig, flags, mountConfig, userAgent)
@@ -63,7 +65,6 @@ func (t *MainTest) TestCreateStorageHandle() {
 
 func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 	flags := &flagStorage{
-		ClientProtocol:      mountpkg.GRPC,
 		MaxConnsPerHost:     5,
 		MaxIdleConnsPerHost: 100,
 		HttpClientTimeout:   5,
@@ -74,7 +75,10 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 	mountConfig := &config.MountConfig{
 		GCSConnection: config.GCSConnection{GRPCConnPoolSize: 1},
 	}
-	newConfig := &cfg.Config{GcsAuth: cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"}}
+	newConfig := &cfg.Config{
+		GcsConnection: cfg.GcsConnectionConfig{ClientProtocol: cfg.GRPC},
+		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
+	}
 
 	userAgent := "AppName"
 	storageHandle, err := createStorageHandle(newConfig, flags, mountConfig, userAgent)

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -48,7 +48,6 @@ func (t *MainTest) TestCreateStorageHandle() {
 		HttpClientTimeout:   5,
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
-		AppName:             "app",
 	}
 	mountConfig := &config.MountConfig{}
 	newConfig := &cfg.Config{
@@ -69,7 +68,6 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 		HttpClientTimeout:   5,
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
-		AppName:             "app",
 	}
 	mountConfig := &config.MountConfig{
 		GCSConnection: config.GCSConnection{GRPCConnPoolSize: 1},

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -49,7 +49,6 @@ func (t *MainTest) TestCreateStorageHandle() {
 		MaxRetrySleep:       7,
 		RetryMultiplier:     2,
 		AppName:             "app",
-		KeyFile:             "testdata/test_creds.json",
 	}
 	mountConfig := &config.MountConfig{}
 	newConfig := &cfg.Config{

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -47,7 +47,7 @@ func mountWithStorageHandle(
 	// currently. This gives a better user experience than harder to debug EIO
 	// errors when reading files in the future.
 	if newConfig.FileSystem.TempDir != "" {
-		logger.Infof("Creating a temporary directory at %q\n", flags.TempDir)
+		logger.Infof("Creating a temporary directory at %q\n", newConfig.FileSystem.TempDir)
 		var f *os.File
 		f, err = fsutil.AnonymousFile(string(newConfig.FileSystem.TempDir))
 		f.Close()
@@ -70,7 +70,7 @@ func mountWithStorageHandle(
 		return
 	}
 
-	if newConfig.FileSystem.Uid == 0 && newConfig.FileSystem.Uid < 0 {
+	if uid == 0 && newConfig.FileSystem.Uid < 0 {
 		fmt.Fprintln(os.Stdout, `
 WARNING: gcsfuse invoked as root. This will cause all files to be owned by
 root. If this is not what you intended, invoke gcsfuse as the user that will
@@ -99,7 +99,7 @@ be interacting with the file system.`)
 		OpRateLimitHz:                      newConfig.GcsConnection.LimitOpsPerSec,
 		StatCacheMaxSizeMB:                 statCacheMaxSizeMB,
 		StatCacheTTL:                       metadataCacheTTL,
-		EnableMonitoring:                   flags.StackdriverExportInterval > 0,
+		EnableMonitoring:                   newConfig.Metrics.StackdriverExportInterval > 0,
 		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
 		DebugGCS:                           flags.DebugGCS,

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -27,9 +27,12 @@ import (
 type ClientProtocol string
 
 const (
+	// Deprecated: Use the constant from cfg package
 	HTTP1 ClientProtocol = "http1"
+	// Deprecated: Use the constant from cfg package
 	HTTP2 ClientProtocol = "http2"
-	GRPC  ClientProtocol = "grpc"
+	// Deprecated: Use the constant from cfg package
+	GRPC ClientProtocol = "grpc"
 	// DefaultStatOrTypeCacheTTL is the default value used for
 	// stat-cache-ttl or type-cache-ttl if they have not been set
 	// by the user.

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -22,8 +22,8 @@ import (
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
-	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"golang.org/x/net/context"
 	option "google.golang.org/api/option"
@@ -84,7 +84,7 @@ func createClientOptionForGRPCClient(clientConfig *storageutil.StorageClientConf
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
 func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig) (sc *storage.Client, err error) {
-	if clientConfig.ClientProtocol != mountpkg.GRPC {
+	if clientConfig.ClientProtocol != cfg.GRPC {
 		return nil, fmt.Errorf("client-protocol requested is not GRPC: %s", clientConfig.ClientProtocol)
 	}
 
@@ -115,7 +115,7 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	var clientOpts []option.ClientOption
 
 	// Add WithHttpClient option.
-	if clientConfig.ClientProtocol == mountpkg.HTTP1 || clientConfig.ClientProtocol == mountpkg.HTTP2 {
+	if clientConfig.ClientProtocol == cfg.HTTP1 || clientConfig.ClientProtocol == cfg.HTTP2 {
 		var httpClient *http.Client
 		httpClient, err = storageutil.CreateHttpClient(clientConfig)
 		if err != nil {
@@ -154,9 +154,9 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	// The default protocol for the Go Storage control client's folders API is gRPC.
 	// gcsfuse will initially mirror this behavior due to the client's lack of HTTP support.
 	var controlClient *control.StorageControlClient
-	if clientConfig.ClientProtocol == mountpkg.GRPC {
+	if clientConfig.ClientProtocol == cfg.GRPC {
 		sc, err = createGRPCClientHandle(ctx, &clientConfig)
-	} else if clientConfig.ClientProtocol == mountpkg.HTTP1 || clientConfig.ClientProtocol == mountpkg.HTTP2 {
+	} else if clientConfig.ClientProtocol == cfg.HTTP1 || clientConfig.ClientProtocol == cfg.HTTP2 {
 		sc, err = createHTTPClientHandle(ctx, &clientConfig)
 	} else {
 		err = fmt.Errorf("invalid client-protocol requested: %s", clientConfig.ClientProtocol)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -20,7 +20,7 @@ import (
 	"net/url"
 	"testing"
 
-	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
@@ -92,7 +92,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2EnabledAndAuthEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.ClientProtocol = mountpkg.HTTP2
+	sc.ClientProtocol = cfg.HTTP2
 	sc.AnonymousAccess = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
@@ -203,7 +203,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.ClientProtocol = mountpkg.GRPC
+	sc.ClientProtocol = cfg.GRPC
 
 	storageClient, err := createGRPCClientHandle(context.Background(), &sc)
 
@@ -222,7 +222,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle() {
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientProtocol() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.ClientProtocol = mountpkg.GRPC
+	sc.ClientProtocol = cfg.GRPC
 
 	storageClient, err := NewStorageHandle(context.Background(), sc)
 
@@ -232,31 +232,31 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientProtocol()
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_WithHTTPClientProtocol() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.ClientProtocol = mountpkg.HTTP1
+	sc.ClientProtocol = cfg.HTTP1
 
 	storageClient, err := createGRPCClientHandle(context.Background(), &sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), storageClient)
-	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not GRPC: %s", mountpkg.HTTP1))
+	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not GRPC: %s", cfg.HTTP1))
 }
 
 func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithGRPCClientProtocol() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.ClientProtocol = mountpkg.GRPC
+	sc.ClientProtocol = cfg.GRPC
 
 	storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), storageClient)
-	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not HTTP1 or HTTP2: %s", mountpkg.GRPC))
+	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not HTTP1 or HTTP2: %s", cfg.GRPC))
 }
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustomEndpointNilAndAuthEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = nil
 	sc.AnonymousAccess = false
-	sc.ClientProtocol = mountpkg.GRPC
+	sc.ClientProtocol = cfg.GRPC
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 
@@ -271,7 +271,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustom
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.CustomEndpoint = url
 	sc.AnonymousAccess = false
-	sc.ClientProtocol = mountpkg.GRPC
+	sc.ClientProtocol = cfg.GRPC
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/auth"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
-	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
@@ -35,7 +35,7 @@ type StorageClientConfig struct {
 	/** Common client parameters. */
 
 	// ClientProtocol decides the go-sdk client to create.
-	ClientProtocol    mountpkg.ClientProtocol
+	ClientProtocol    cfg.Protocol
 	UserAgent         string
 	CustomEndpoint    *url.URL
 	KeyFile           string
@@ -61,7 +61,7 @@ type StorageClientConfig struct {
 func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *http.Client, err error) {
 	var transport *http.Transport
 	// Using http1 makes the client more performant.
-	if storageClientConfig.ClientProtocol == mountpkg.HTTP1 {
+	if storageClientConfig.ClientProtocol == cfg.HTTP1 {
 		transport = &http.Transport{
 			Proxy:               http.ProxyFromEnvironment,
 			MaxConnsPerHost:     storageClientConfig.MaxConnsPerHost,

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -18,7 +18,7 @@ import (
 	"net/url"
 	"time"
 
-	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 )
 
 const CustomEndpoint = "https://localhost:9000"
@@ -28,7 +28,7 @@ const CustomTokenUrl = "http://custom-token-url"
 // GetDefaultStorageClientConfig is only for test.
 func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 	return StorageClientConfig{
-		ClientProtocol:             mountpkg.HTTP1,
+		ClientProtocol:             cfg.HTTP1,
 		MaxConnsPerHost:            10,
 		MaxIdleConnsPerHost:        100,
 		HttpClientTimeout:          800 * time.Millisecond,


### PR DESCRIPTION
### Description
Migrate the following flags to the new config:
* app-name
* foreground
* rename-dir-limit
* billing-project
* limit-bytes-per-sec
* limit-ops-per-sec
* stackdriver-export-interval
* experimental-opentelemetry-collector-address
* experimental-enable-json-read
* temp-dir
* enable-nonexistent-type-cache
* file-mode
* dir-mode
* uid
* gid

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually to see that the flags are correctly being reflected.
2. Unit tests - Existing unit-tests in legacy_param_mapper.go should already cover it.
3. Integration tests - NA
