### PR TITLE
Code-gen URL params as pointer

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -126,7 +126,7 @@ type GcsConnectionConfig struct {
 
 	ClientProtocol Protocol `yaml:"client-protocol"`
 
-	CustomEndpoint url.URL `yaml:"custom-endpoint"`
+	CustomEndpoint *url.URL `yaml:"custom-endpoint"`
 
 	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
 

--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -30,7 +30,7 @@ func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
-		if t != reflect.TypeOf(url.URL{}) {
+		if t != reflect.TypeOf(&url.URL{}) {
 			return data, nil
 		}
 		s := data.(string)
@@ -38,7 +38,7 @@ func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
 		if err != nil {
 			return nil, err
 		}
-		return *u, nil
+		return u, nil
 	}
 }
 

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -37,7 +37,7 @@ func bindFlag(t *testing.T, v *viper.Viper, key string, f *flag.Flag) {
 func TestParsingSuccess(t *testing.T) {
 	type TestConfig struct {
 		OctalParam       Octal
-		URLParam         url.URL
+		URLParam         *url.URL
 		BoolParam        bool
 		StringParam      string
 		IntParam         int
@@ -105,7 +105,7 @@ func TestParsingSuccess(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error while parsing URL: %v", err)
 				}
-				assert.Equal(t, *u, c.URLParam)
+				assert.Equal(t, *u, *c.URLParam)
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestParsingSuccess(t *testing.T) {
 func TestParsingError(t *testing.T) {
 	type TestConfig struct {
 		OctalParam       Octal
-		URLParam         url.URL
+		URLParam         *url.URL
 		LogSeverityParam LogSeverity
 		ProtocolParam    Protocol
 	}

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -439,7 +439,7 @@ func TestPopulateConfigFromLegacyFlags_LogFileResolution(t *testing.T) {
 	}
 }
 
-func TestURLResolutionFromFlags(t *testing.T) {
+func TestCustomEndpointResolutionFromFlags(t *testing.T) {
 	u, err := url.Parse("http://abc.xyz")
 	require.Nil(t, err)
 	legacyFlagStorage := &flagStorage{

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -147,7 +147,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 					AnonymousAccess:   false,
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
-					CustomEndpoint:             url.URL{},
+					CustomEndpoint:             nil,
 					BillingProject:             "billing-project",
 					ClientProtocol:             cfg.Protocol("http1"),
 					LimitBytesPerSec:           100,
@@ -436,5 +436,20 @@ func TestPopulateConfigFromLegacyFlags_LogFileResolution(t *testing.T) {
 				assert.Equal(t, tc.expectedLogFile, resolvedConfig.Logging.FilePath)
 			}
 		})
+	}
+}
+
+func TestURLResolutionFromFlags(t *testing.T) {
+	u, err := url.Parse("http://abc.xyz")
+	require.Nil(t, err)
+	legacyFlagStorage := &flagStorage{
+		ClientProtocol: mountpkg.HTTP2,
+		CustomEndpoint: u,
+	}
+
+	resolvedConfig, err := PopulateNewConfigFromLegacyFlagsAndConfig(&mockCLIContext{}, legacyFlagStorage, &config.MountConfig{})
+
+	if assert.Nil(t, err) && assert.NotNil(t, resolvedConfig.GcsConnection.CustomEndpoint) {
+		assert.Equal(t, *resolvedConfig.GcsConnection.CustomEndpoint, *u)
 	}
 }

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -65,7 +65,7 @@ func getGoDataType(dt string) string {
 	case "octal":
 		return "Octal"
 	case "url":
-		return "url.URL"
+		return "*url.URL"
 	case "logSeverity":
 		return "LogSeverity"
 	case "protocol":


### PR DESCRIPTION
Code-gen URL params as pointer types. This is in line with the URL params in the legacy config.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
