### PR TITLE
Change Go version to match 1.N.P syntax.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0


### PR DESCRIPTION
This fixes the CodeQL warning about incorrect Go Toolchain version.

### Description
![image](https://github.com/GoogleCloudPlatform/gcsfuse/assets/2505471/4c5fe2a0-b623-4894-86ff-7e85cf6bdf22)


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
