### PR TITLE
Fix default for experimental-grpc-conn-pool-size

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -399,7 +399,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("experimental-grpc-conn-pool-size", "", 0, "The number of gRPC channel in grpc client.")
+	flagSet.IntP("experimental-grpc-conn-pool-size", "", 1, "The number of gRPC channel in grpc client.")
 
 	err = flagSet.MarkDeprecated("experimental-grpc-conn-pool-size", "Experimental flag: can be removed in a minor release.")
 	if err != nil {

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -481,7 +481,7 @@
   config-path: "gcs-connection.grpc-conn-pool-size"
   type: "int"
   usage: "The number of gRPC channel in grpc client."
-  default: "0"
+  default: "1"
   deprecated: true
   deprecation-warning: "Experimental flag: can be removed in a minor release."
 


### PR DESCRIPTION
### Description
Change the default for experimental-grpc-conn-pool-size in the new config to 1.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Will be added in a follow-up PR
3. Integration tests - NA
