### PR TITLE
Resolve metadata-cache-ttl in new config

### DIFF
--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -26,11 +26,11 @@ func VetConfig(v *viper.Viper, config *Config) {
 		config.List.EnableEmptyManagedFolders = true
 	}
 	// Handle metadatacache ttl
-	ResolveMetadataCacheTTL(v, config)
+	resolveMetadataCacheTTL(v, config)
 }
 
-// ResolveMetadataCacheTTL returns the ttl to be used for stat/type cache based on the user flags/configs.
-func ResolveMetadataCacheTTL(v *viper.Viper, config *Config) {
+// RresolveMetadataCacheTTL returns the ttl to be used for stat/type cache based on the user flags/configs.
+func resolveMetadataCacheTTL(v *viper.Viper, config *Config) {
 	// If metadata-cache:ttl-secs has been set in config-file, then
 	// it overrides both stat-cache-ttl and type-cache-tll.
 	if v.IsSet("metadata-cache.ttl-secs") {

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg
+
+import (
+	"math"
+
+	"github.com/spf13/viper"
+)
+
+func VetConfig(v *viper.Viper, config *Config) {
+	// The EnableEmptyManagedFolders flag must be set to true to enforce folder prefixes for Hierarchical buckets.
+	if config.EnableHns {
+		config.List.EnableEmptyManagedFolders = true
+	}
+	// Handle metadatacache ttl
+	ResolveMetadataCacheTTL(v, config)
+}
+
+// ResolveMetadataCacheTTL returns the ttl to be used for stat/type cache based on the user flags/configs.
+func ResolveMetadataCacheTTL(v *viper.Viper, config *Config) {
+	// If metadata-cache:ttl-secs has been set in config-file, then
+	// it overrides both stat-cache-ttl and type-cache-tll.
+	if v.IsSet("metadata-cache.ttl-secs") {
+		// if ttl-secs is set to -1, set StatOrTypeCacheTTL to the max possible duration.
+		if config.MetadataCache.TtlSecs == -1 {
+			config.MetadataCache.TtlSecs = math.MaxInt64
+		}
+		return
+	}
+	config.MetadataCache.TtlSecs = int64(math.Ceil(math.Min(config.MetadataCache.DeprecatedStatCacheTtl.Seconds(),
+		config.MetadataCache.DeprecatedTypeCacheTtl.Seconds())))
+}

--- a/cmd/config_vetting_test.go
+++ b/cmd/config_vetting_test.go
@@ -1,0 +1,150 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getConfigObject(t *testing.T, args []string) (*cfg.Config, error) {
+	t.Helper()
+	var c cfg.Config
+	cmd, err := NewRootCmd(func(config cfg.Config) error {
+		c = config
+		return nil
+	})
+	require.Nil(t, err)
+	cmdArgs := append([]string{"gcsfuse"}, args...)
+	cmdArgs = append(cmdArgs, "a")
+	cmd.SetArgs(cmdArgs)
+	if err = cmd.Execute(); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+func TestMetadataCacheTTLResolution(t *testing.T) {
+	testcases := []struct {
+		name            string
+		args            []string
+		expectedTTLSecs int64
+	}{
+		{
+			name:            "Most common scenario, when user doesn't set any of the TTL config parameters.",
+			args:            []string{},
+			expectedTTLSecs: 60,
+		},
+		{
+			name:            "user sets only metadata-cache:ttl-secs and sets it to -1",
+			args:            []string{"--metadata-cache-ttl=-1"},
+			expectedTTLSecs: math.MaxInt64,
+		},
+		{
+			name:            "user sets only metadata-cache:ttl-secs and sets it to 0.",
+			args:            []string{"--metadata-cache-ttl=0"},
+			expectedTTLSecs: 0,
+		},
+		{
+			name:            "user sets only metadata-cache:ttl-secs and sets it to a positive value.",
+			args:            []string{"--metadata-cache-ttl=30"},
+			expectedTTLSecs: 30,
+		},
+		{
+			name:            "user sets only metadata-cache:ttl-secs and sets it to its highest supported value.",
+			args:            []string{fmt.Sprintf("--metadata-cache-ttl=%d", config.MaxSupportedTtlInSeconds)},
+			expectedTTLSecs: config.MaxSupportedTtlInSeconds,
+		},
+		{
+			name:            "user sets both the old flags and the metadata-cache:ttl-secs. Here ttl-secs overrides both flags.",
+			args:            []string{"--stat-cache-ttl=5m", "--type-cache-ttl=1h", "--metadata-cache-ttl=10800"},
+			expectedTTLSecs: 10800,
+		},
+		{
+			name:            "user sets only stat/type-cache-ttl flag(s), and not metadata-cache:ttl-secs.",
+			args:            []string{"--stat-cache-ttl=0s", "--type-cache-ttl=0s"},
+			expectedTTLSecs: 0,
+		},
+		{
+			name:            "stat-cache enabled, but not type-cache.",
+			args:            []string{"--stat-cache-ttl=1h", "--type-cache-ttl=0s"},
+			expectedTTLSecs: 0,
+		},
+		{
+			name:            "type-cache enabled, but not stat-cache.",
+			args:            []string{"--type-cache-ttl=1h", "--stat-cache-ttl=0s"},
+			expectedTTLSecs: 0,
+		},
+		{
+			name:            "both type-cache and stat-cache enabled.",
+			args:            []string{"--type-cache-ttl=1h", "--stat-cache-ttl=30s"},
+			expectedTTLSecs: 30,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := getConfigObject(t, tc.args)
+
+			if assert.Nil(t, err) {
+				config.MetadataCache.TtlSecs = tc.expectedTTLSecs
+			}
+		})
+	}
+}
+
+func TestEnableEmptyManagedFoldersResolution(t *testing.T) {
+	testcases := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "enable-hns set to true",
+			args:     []string{"--enable-hns"},
+			expected: true,
+		},
+		{
+			name:     "enable-hns set to true but enable-empty-managed-folders set to false",
+			args:     []string{"--enable-hns", "--enable-empty-managed-folders=false"},
+			expected: true,
+		},
+		{
+			name:     "enable-hns not true but enable-empty-managed-folders set to true",
+			args:     []string{"--enable-hns=false", "--enable-empty-managed-folders=true"},
+			expected: true,
+		},
+		{
+			name:     "both enable-hns and enable-empty-managed-folders not true",
+			args:     []string{"--enable-hns=false", "--enable-empty-managed-folders=false"},
+			expected: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := getConfigObject(t, tc.args)
+
+			if assert.Nil(t, err) {
+				config.List.EnableEmptyManagedFolders = tc.expected
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
@@ -52,12 +51,14 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		if cfgFile != "" {
 			cfgFile, err := util.GetResolvedPath(cfgFile)
 			if err != nil {
-				logger.Fatal("error while resolving config-file path[%s]: %v", cfgFile, err)
+				cfgErr = fmt.Errorf("error while resolving config-file path[%s]: %w", cfgFile, err)
+				return
 			}
 			v.SetConfigFile(cfgFile)
 			v.SetConfigType("yaml")
 			if err := v.ReadInConfig(); err != nil {
-				logger.Fatal("error while reading the config: %v", err)
+				cfgErr = fmt.Errorf("error while reading the config: %w", err)
+				return
 			}
 		}
 
@@ -68,6 +69,9 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 			decoderConfig.ErrorUnused = true
 		},
 		)
+		if cfgErr == nil {
+			cfg.VetConfig(v, &configObj)
+		}
 	}
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", "", "The path to the config file where all gcsfuse related config needs to be specified. "+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
@@ -51,14 +52,12 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		if cfgFile != "" {
 			cfgFile, err := util.GetResolvedPath(cfgFile)
 			if err != nil {
-				cfgErr = fmt.Errorf("error while resolving config-file path[%s]: %w", cfgFile, err)
-				return
+				logger.Fatal("error while resolving config-file path[%s]: %v", cfgFile, err)
 			}
 			v.SetConfigFile(cfgFile)
 			v.SetConfigType("yaml")
 			if err := v.ReadInConfig(); err != nil {
-				cfgErr = fmt.Errorf("error while reading the config: %w", err)
-				return
+				logger.Fatal("error while reading the config: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Resolve metadata-cache-ttl in new config

### Description
* We want to use the metadata-cache.ttl-secs field to represent the metadata-cache ttl and resolve it upfront as opposed to resolving it when needed. We'll follow up with a similar change for the old config too which will allow us to use the old and new configs interchangeably.
* Make change to set the enable-empty-managed-folders whenever enable-hns is set.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added the required unit tests in cmd/ in order to avoid cyclic dependency.
3. Integration tests - NA
