### PR TITLE
Implement rename folder 3

### DIFF
--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -226,6 +226,7 @@ func (b *prefixBucket) GetFolder(ctx context.Context, folderName string) (folder
 
 func (b *prefixBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*control.RenameFolderOperation, error) {
 	mFolderName := b.wrappedName(folderName)
-	o, err := b.wrapped.RenameFolder(ctx, mFolderName, destinationFolderId)
+	mDestinationFolderId := b.wrappedName(destinationFolderId)
+	o, err := b.wrapped.RenameFolder(ctx, mFolderName, mDestinationFolderId)
 	return o, err
 }

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -401,24 +401,24 @@ func (t *PrefixBucketTest) DeleteObject() {
 
 func (t *PrefixBucketTest) GetFolder_Prefix() {
 	var err error
+	suffix := "something"
+	object_name := t.prefix + suffix
 
 	// Replace the use of CreateObject with CreateFolder once the CreateFolder API has been successfully implemented.
 	err = storageutil.CreateObjects(
 		t.ctx,
 		t.wrapped,
 		map[string][]byte{
-			"something": []byte(""),
+			object_name: []byte(""),
 		})
-
 	AssertEq(nil, err)
 
 	result, err := t.bucket.GetFolder(
 		t.ctx,
-		"something")
+		suffix)
 
 	AssertEq(nil, err)
-	AssertEq("projects/_/buckets/some_bucket/folders/foo_something", result.GetName())
-
+	AssertEq(object_name, result.GetName())
 }
 
 func TestDeleteFolder(t *testing.T) {
@@ -440,11 +440,9 @@ func TestDeleteFolder(t *testing.T) {
 
 	if assert.Nil(t, err) {
 		// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
-		_, _, err = wrapped.StatObject(
+		_, err = wrapped.GetFolder(
 			ctx,
-			&gcs.StatObjectRequest{
-				Name: name,
-			})
+			name)
 		var notFoundErr *gcs.NotFoundError
 		assert.ErrorAs(t, err, &notFoundErr)
 	}
@@ -463,21 +461,11 @@ func (t *PrefixBucketTest) TestRenameFolder() {
 	_, err = t.bucket.RenameFolder(t.ctx, old_suffix, new_suffix)
 	AssertEq(nil, err)
 
-	// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
-	// New Object should get created
-	_, _, err = t.wrapped.StatObject(
-		t.ctx,
-		&gcs.StatObjectRequest{
-			Name: new_suffix,
-		})
+	// New folder should get created
+	_, err = t.wrapped.GetFolder(t.ctx, new_suffix)
 	AssertEq(nil, err)
-	// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
-	// Old object should be gone.
-	_, _, err = t.wrapped.StatObject(
-		t.ctx,
-		&gcs.StatObjectRequest{
-			Name: old_suffix,
-		})
+	// Old folder should be gone.
+	_, err = t.wrapped.GetFolder(t.ctx, old_suffix)
 	var notFoundErr *gcs.NotFoundError
 	ExpectTrue(errors.As(err, &notFoundErr))
 }

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -439,7 +439,6 @@ func TestDeleteFolder(t *testing.T) {
 		objectName)
 
 	if assert.Nil(t, err) {
-		// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
 		_, err = wrapped.GetFolder(
 			ctx,
 			name)

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -449,3 +449,35 @@ func TestDeleteFolder(t *testing.T) {
 		assert.ErrorAs(t, err, &notFoundErr)
 	}
 }
+
+func (t *PrefixBucketTest) TestRenameFolder() {
+	var err error
+	old_suffix := "test"
+	name := t.prefix + old_suffix
+	new_suffix := "new_test"
+	// TODO: Replace the use of CreateObject with CreateFolder once the CreateFolder API has been successfully implemented.
+	// Create an object through the back door.
+	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte(""))
+	AssertEq(nil, err)
+
+	_, err = t.bucket.RenameFolder(t.ctx, old_suffix, new_suffix)
+	AssertEq(nil, err)
+
+	// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
+	// New Object should get created
+	_, _, err = t.wrapped.StatObject(
+		t.ctx,
+		&gcs.StatObjectRequest{
+			Name: new_suffix,
+		})
+	AssertEq(nil, err)
+	// TODO: Replace the use of StatObject with GetFolder once the GetFolder API has been successfully implemented.
+	// Old object should be gone.
+	_, _, err = t.wrapped.StatObject(
+		t.ctx,
+		&gcs.StatObjectRequest{
+			Name: old_suffix,
+		})
+	var notFoundErr *gcs.NotFoundError
+	ExpectTrue(errors.As(err, &notFoundErr))
+}

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -893,6 +893,47 @@ func (b *bucket) GetFolder(ctx context.Context, foldername string) (*controlpb.F
 }
 
 func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
-	// TODO: Implement.
+	// Check that the destination name is legal.
+	err = checkName(destinationFolderId)
+	if err != nil {
+		return
+	}
+
+	// Does the folder exist?
+	srcIndex := b.objects.find(folderName)
+	if srcIndex == len(b.objects) {
+		err = &gcs.NotFoundError{
+			Err: fmt.Errorf("Object %q not found", folderName),
+		}
+		return
+	}
+
+	// Copy it and assign a new generation number, to ensure that the generation
+	// number for the destination name is strictly increasing.
+	dst := b.objects[srcIndex]
+	dst.metadata.Name = destinationFolderId
+	dst.metadata.MediaLink = "http://localhost/download/storage/fake/" + destinationFolderId
+
+	b.prevGeneration++
+	dst.metadata.Generation = b.prevGeneration
+
+	// Insert into our array.
+	existingIndex := b.objects.find(folderName)
+	if existingIndex < len(b.objects) {
+		b.objects[existingIndex] = dst
+	} else {
+		b.objects = append(b.objects, dst)
+		sort.Sort(b.objects)
+	}
+
+	// Delete the src folder?
+	index := b.objects.find(folderName)
+	if index == len(b.objects) {
+		return
+	}
+
+	// Remove the folder.
+	b.objects = append(b.objects[:index], b.objects[index+1:]...)
+
 	return
 }


### PR DESCRIPTION
### Description
- Fake bucket implementation for rename folder
- Fix Get folder fake bucket implementation(It was not returning error if folder does not exist)
- Created rename folder test in prefix_bucket_test.
- Fix some TODOs. GetFolder API instead of statObject in prefix_bucket_tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
