### PR TITLE
Kernel list cache CT - 2: cache eviction on creation or deletion of files or folder

### DIFF
--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -86,3 +86,264 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit(
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
 }
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// addition of new file.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnAdditionOfFile() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	fNew, err := os.Create(path.Join(mntDir, "explicitDir/file4.txt"))
+	require.Nil(t.T(), err)
+	assert.NotNil(t.T(), fNew)
+	defer func() {
+		assert.Nil(t.T(), fNew.Close())
+		assert.Nil(t.T(), os.Remove(path.Join(mntDir, "explicitDir/file4.txt")))
+	}()
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 4, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+	assert.Equal(t.T(), "file3.txt", names2[2])
+	assert.Equal(t.T(), "file4.txt", names2[3])
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// deletion of new file.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnDeletionOfFile() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	err = os.Remove(path.Join(mntDir, "explicitDir/file2.txt"))
+	require.Nil(t.T(), err)
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file3.txt", names2[1]) // file2.txt deleted, hence file3.txt
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// file rename.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnFileRename() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	err = os.Rename(path.Join(mntDir, "explicitDir/file2.txt"), path.Join(mntDir, "explicitDir/renamed_file2.txt"))
+	require.Nil(t.T(), err)
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file3.txt", names2[1])
+	assert.Equal(t.T(), "renamed_file2.txt", names2[2])
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// addition of new directory.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnAdditionOfDirectory() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	err = os.Mkdir(path.Join(mntDir, "explicitDir/sub_dir"), dirPerms)
+	require.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), os.Remove(path.Join(mntDir, "explicitDir/sub_dir")))
+	}()
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 4, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+	assert.Equal(t.T(), "file3.txt", names2[2])
+	assert.Equal(t.T(), "sub_dir", names2[3])
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// deletion of directory.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnDeletionOfDirectory() {
+	// Creating a directory in the start.
+	err := os.Mkdir(path.Join(mntDir, "explicitDir/sub_dir"), dirPerms)
+	assert.Nil(t.T(), err)
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 3, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	assert.Equal(t.T(), "sub_dir", names1[2])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	err = os.Remove(path.Join(mntDir, "explicitDir/sub_dir"))
+	require.Nil(t.T(), err)
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	require.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 3, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+	assert.Equal(t.T(), "file3.txt", names2[2])
+}
+
+// (a) First ReadDir() will be served from GCSFuse filesystem.
+// (b) Second ReadDir() will also be served from GCSFuse filesystem, because of
+// directory rename.
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_CacheMissOnDirectoryRename() {
+	// Creating a directory in the start.
+	err := os.Mkdir(path.Join(mntDir, "explicitDir/sub_dir"), dirPerms)
+	assert.Nil(t.T(), err)
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), f.Close())
+	}()
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 3, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	assert.Equal(t.T(), "sub_dir", names1[2])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	defer t.deleteObjectOrFail("explicitDir/file3.txt")
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// Ideally no invalidation since infinite ttl, but creation of a new file inside
+	// directory evicts the list cache for that directory.
+	err = os.Rename(path.Join(mntDir, "explicitDir/sub_dir"), path.Join(mntDir, "explicitDir/renamed_sub_dir"))
+	require.Nil(t.T(), err)
+	defer func() {
+		assert.Nil(t.T(), os.Remove(path.Join(mntDir, "explicitDir/renamed_sub_dir")))
+	}()
+
+	f, err = os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names2, err := f.Readdirnames(-1)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 4, len(names2))
+	assert.Equal(t.T(), "file1.txt", names2[0])
+	assert.Equal(t.T(), "file2.txt", names2[1])
+	assert.Equal(t.T(), "file3.txt", names2[2])
+	assert.Equal(t.T(), "renamed_sub_dir", names2[3])
+}


### PR DESCRIPTION
### Description
- Composite test containing cache eviction scenario - happens once a file/folder is added and deleted from a directory.
- Will add the nested directory scenario in the next PR.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
