### PR TITLE
Clean generated code as part of "clean" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean-gen:
 	rm -rf cfg/config.go
 
 clean: clean-gen
-	go clean && rm -rf cfg/config.go
+	go clean
 
 clean-all: clean-gen
 	go clean -i ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 
-.PHONY: generate fmt vet build buildTest install test clean clean-all
+.PHONY: generate fmt vet build buildTest install test clean-gen clean clean-all
 
 generate:
 	go generate ./...
@@ -23,8 +23,11 @@ install: fmt
 test: fmt
 	CGO_ENABLED=0 go test -count 1 -v `go list ./... | grep -v internal/cache/...` && CGO_ENABLED=0 go test -p 1 -count 1 -v ./internal/cache/...
 
-clean:
-	go clean
+clean-gen:
+	rm -rf cfg/config.go
 
-clean-all:
+clean: clean-gen
+	go clean && rm -rf cfg/config.go
+
+clean-all: clean-gen
 	go clean -i ./...


### PR DESCRIPTION
### Description
The "clean-gen" target deletes the auto-generated code i.e. "config.go". It's a dependency of "clean" and "clean-all" targets so that the generated code gets cleaned up too.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Yes - tested the the generated code was getting deleted.
2. Unit tests - NA
3. Integration tests - NA
