### PR TITLE
Don't change "-h" shorthand to "--h"

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,9 +44,14 @@ func logPanic() {
 func convertToPosixArgs(args []string) []string {
 	pArgs := make([]string, 0, len(args))
 	for _, a := range args {
-		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") && a != "-v" {
+		switch {
+		case a == "--v", a == "-v":
+			pArgs = append(pArgs, "-v")
+		case a == "--h", a == "-h":
+			pArgs = append(pArgs, "-h")
+		case strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--"):
 			pArgs = append(pArgs, "-"+a)
-		} else {
+		default:
 			pArgs = append(pArgs, a)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -47,11 +47,6 @@ func TestPosixFlagsConversion(t *testing.T) {
 			expected: []string{"abc", "--flag=\"-test\""},
 		},
 		{
-			name:     "Version shorthand stays unchanged.",
-			input:    []string{"abc", "-v"},
-			expected: []string{"abc", "-v"},
-		},
-		{
 			name:     "Help shorthand stays unchanged.",
 			input:    []string{"abc", "-h"},
 			expected: []string{"abc", "-h"},

--- a/main_test.go
+++ b/main_test.go
@@ -51,6 +51,26 @@ func TestPosixFlagsConversion(t *testing.T) {
 			input:    []string{"abc", "-v"},
 			expected: []string{"abc", "-v"},
 		},
+		{
+			name:     "Help shorthand stays unchanged.",
+			input:    []string{"abc", "-h"},
+			expected: []string{"abc", "-h"},
+		},
+		{
+			name:     "Version shorthand stays unchanged.",
+			input:    []string{"abc", "-v"},
+			expected: []string{"abc", "-v"},
+		},
+		{
+			name:     "Help flag becomes help shorthand.",
+			input:    []string{"abc", "--h"},
+			expected: []string{"abc", "-h"},
+		},
+		{
+			name:     "Version flag becomes version shorthand.",
+			input:    []string{"abc", "--v"},
+			expected: []string{"abc", "-v"},
+		},
 	}
 	for _, tc := range data {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
urfave/cli uses the golang flags library which treats the "-flagName" and "--flagName" as equivalent, however Cobra, which uses the pFlags (POSIX flag standard), treats single-hyphen-prefixed flags as shorthands while doubly-hyphen-prefixed as flags. In order to be backward compatible, we prefix the flags that have been specified with a single hyphen with another hyphen. This however causes problems for certain shorthand flags such as "-v" and "-h" which have special meaning to Cobra. Prefixing them with another hyphen causes errors since to Cobra, Cobra only knows about "v" and "h" shorthands not flags.
As part of this PR we address the following:
* Don't modify "-h" to "--h"
* Convert "--h" and "--v" to "-h" and "-v" respectively.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA
