### PR TITLE
Pass the bucket and mountpoint into the mount fn

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -177,19 +177,19 @@ func mountWithArgs(
 	return
 }
 
-func populateArgs(c *cli.Context) (
+func populateArgs(args []string) (
 	bucketName string,
 	mountPoint string,
 	err error) {
 	// Extract arguments.
-	switch len(c.Args()) {
+	switch len(args) {
 	case 1:
 		bucketName = ""
-		mountPoint = c.Args()[0]
+		mountPoint = args[0]
 
 	case 2:
-		bucketName = c.Args()[0]
-		mountPoint = c.Args()[1]
+		bucketName = args[0]
+		mountPoint = args[1]
 
 	default:
 		err = fmt.Errorf(
@@ -284,7 +284,7 @@ func runCLIApp(c *cli.Context) (err error) {
 
 	var bucketName string
 	var mountPoint string
-	bucketName, mountPoint, err = populateArgs(c)
+	bucketName, mountPoint, err = populateArgs(c.Args())
 	if err != nil {
 		return
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,11 +45,11 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 			if cfgErr != nil {
 				return fmt.Errorf("error while parsing config: %w", cfgErr)
 			}
-			if bucket, mountpoint, err := populateArgs(args[1:]); err != nil {
-				return fmt.Errorf("error occurred while extracting the bucket and mountpoint: %w", err)
-			} else {
-				return mountFn(&configObj, bucket, mountpoint)
+			bucket, mountPoint, err := populateArgs(args[1:])
+			if err != nil {
+				return fmt.Errorf("error occurred while extracting the bucket and mountPoint: %w", err)
 			}
+			return mountFn(&configObj, bucket, mountPoint)
 		},
 	}
 	initConfig := func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewRootCmd accepts the mountFn that it executes with the parsed configuration
-func NewRootCmd(mountFn func(config cfg.Config) error) (*cobra.Command, error) {
+func NewRootCmd(mountFn func(*cfg.Config, string, string) error) (*cobra.Command, error) {
 	var (
 		configObj cfg.Config
 		cfgFile   string
@@ -45,7 +45,11 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 			if cfgErr != nil {
 				return fmt.Errorf("error while parsing config: %w", cfgErr)
 			}
-			return mountFn(configObj)
+			if bucket, mountpoint, err := populateArgs(args[1:]); err != nil {
+				return fmt.Errorf("error occurred while extracting the bucket and mountpoint: %w", err)
+			} else {
+				return mountFn(&configObj, bucket, mountpoint)
+			}
 		},
 	}
 	initConfig := func() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -159,11 +159,9 @@ func TestArgsParsing(t *testing.T) {
 
 			err = cmd.Execute()
 
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expectedBucket, bucketName)
-				if assert.Nil(t, err) {
-					assert.Equal(t, tc.expectedMountpoint, mountPoint)
-				}
+				assert.Equal(t, tc.expectedMountpoint, mountPoint)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "true" {
 		// TODO: implement the mount logic instead of simply returning nil.
-		rootCmd, err := cmd.NewRootCmd(func(config cfg.Config) error { return nil })
+		rootCmd, err := cmd.NewRootCmd(func(*cfg.Config, string, string) error { return nil })
 		if err != nil {
 			log.Fatalf("Error occurred while creating the root command: %v", err)
 		}


### PR DESCRIPTION
Pass the bucket and mountpoint into the mount fn

### Description
* Refactor the populateArgs function to take a slice of args as input instead of the cliContext.
* Invoke populateArgs in the root command so that the new config gets access to the bucket and mountpoint and can invoke the mount function with the config, bucket and mountpoint.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added the unit tests.
3. Integration tests - NA
