### PR TITLE
Decode empty string as nil for URL

### DIFF
--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -34,6 +34,9 @@ func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
 			return data, nil
 		}
 		s := data.(string)
+		if s == "" {
+			return nil, nil
+		}
 		u, err := url.Parse(s)
 		if err != nil {
 			return nil, err
@@ -46,8 +49,8 @@ func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
 func DecodeHook() mapstructure.DecodeHookFunc {
 	return mapstructure.ComposeDecodeHookFunc(
 		mapstructure.TextUnmarshallerHookFunc(),
-		stringToURLHookFunc(),
 		mapstructure.StringToTimeDurationHookFunc(), // default hook
 		mapstructure.StringToSliceHookFunc(","),     // default hook
+		stringToURLHookFunc(),
 	)
 }

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -109,6 +109,13 @@ func TestParsingSuccess(t *testing.T) {
 			},
 		},
 		{
+			name: "Empty URL",
+			args: []string{""},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Nil(t, c.URLParam)
+			},
+		},
+		{
 			name: "Bool1",
 			args: []string{"--boolParam"},
 			testFn: func(t *testing.T, c TestConfig) {


### PR DESCRIPTION
Instead of unmarshalling/decoding empty string as a pointer pointing to an empty url.URL{} object, decode it as nil.

### Description
Moving stringToURLFunc() to the last in the list of decode hooks since the other decoders like `StringToTimeDurationHookFunc()` and `mapstructure.StringToSliceHookFunc`  are unable to handle nils.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests
3. Integration tests - NA
