### PR TITLE
 Add parallel download configuration to existing read cache e2e tests

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -144,12 +144,9 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileNameForParallelDownloadTests, true),
-	)
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -147,9 +147,9 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName+"ForReadCache", false))
-	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		false, configFileNameForParallelDownloadTests, true)})
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName, false),
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileNameForParallelDownloadTests, true),
+	)
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -141,11 +141,11 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName, false))
+	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
+		false, configFileName, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -82,6 +82,10 @@ func (s *cacheFileForRangeReadFalseTest) TestRangeReadsWithCacheMiss(t *testing.
 }
 
 func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache(t *testing.T) {
+	if isParallelDownloadsEnabled(s.flags) {
+		// This test is not valid when Parallel Downloads are enabled.
+		t.SkipNow()
+	}
 	var testFileNames [2]string
 	var expectedOutcome [2]*Expected
 	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSizeSameAsCacheCapacity, t)
@@ -145,7 +149,7 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
 		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName+"ForReadCache", false))
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
+		false, configFileNameForParallelDownloadTests, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
-	"github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,11 +107,11 @@ func (s *cacheFileForRangeReadFalseTest) TestConcurrentReads_ReadIsTreatedNonSeq
 	validate(expectedOutcome[0], structuredReadLogs[0], true, false, randomReadChunkCount, t)
 	validate(expectedOutcome[1], structuredReadLogs[1], true, false, randomReadChunkCount, t)
 	// Validate last chunk was considered non-sequential and cache hit false for first read.
-	ogletest.ExpectEq(false, structuredReadLogs[0].Chunks[randomReadChunkCount-1].IsSequential)
-	ogletest.ExpectEq(false, structuredReadLogs[0].Chunks[randomReadChunkCount-1].CacheHit)
+	assert.False(t, structuredReadLogs[0].Chunks[randomReadChunkCount-1].IsSequential)
+	assert.False(t, structuredReadLogs[0].Chunks[randomReadChunkCount-1].CacheHit)
 	// Validate last chunk was considered sequential and cache hit true for second read.
-	ogletest.ExpectEq(true, structuredReadLogs[1].Chunks[randomReadChunkCount-1].IsSequential)
-	ogletest.ExpectEq(true, structuredReadLogs[1].Chunks[randomReadChunkCount-1].CacheHit)
+	assert.True(t, structuredReadLogs[1].Chunks[randomReadChunkCount-1].IsSequential)
+	assert.True(t, structuredReadLogs[1].Chunks[randomReadChunkCount-1].CacheHit)
 
 	validateFileIsNotCached(testFileNames[0], t)
 	validateFileInCacheDirectory(testFileNames[1], fileSizeSameAsCacheCapacity, s.ctx, s.storageClient, t)
@@ -143,9 +143,9 @@ func TestCacheFileForRangeReadFalseTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName, false))
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, false, configFileName+"ForReadCache", false))
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		false, configFileName, true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -95,12 +95,9 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName, false))
-	flagsSet = append(flagsSet, []string{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		true, configFileNameForParallelDownloadTests, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -98,9 +98,9 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName, false))
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName+"ForReadCache", false))
 	flagsSet = append(flagsSet, []string{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		true, configFileName, true)})
+		true, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -100,7 +100,7 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
 		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName+"ForReadCache", false))
 	flagsSet = append(flagsSet, []string{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
-		true, configFileName+"ForReadCacheWithParallelDownload", true)})
+		true, configFileNameForParallelDownloadTests, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -98,7 +98,7 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName+"ForReadCache", false))
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName, false))
 	flagsSet = append(flagsSet, []string{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
 		true, configFileNameForParallelDownloadTests, true)})
 

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -96,11 +96,11 @@ func TestCacheFileForRangeReadTrueTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+		"--config-file="+createConfigFile(cacheCapacityForRangeReadTestInMiB, true, configFileName, false))
+	flagsSet = append(flagsSet, []string{"--config-file=" + createConfigFile(cacheCapacityForRangeReadTestInMiB,
+		true, configFileName, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -97,11 +97,13 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName,
+		false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--stat-cache-ttl=0s")
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--stat-cache-ttl=0s", "--config-file=" + createConfigFile(cacheCapacityInMB,
+		false, configFileName, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -98,12 +98,12 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName,
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache",
 		false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--stat-cache-ttl=0s")
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--stat-cache-ttl=0s", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName, true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -96,11 +96,9 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true", "--stat-cache-ttl=0s"},
+		{"--implicit-dirs", "--stat-cache-ttl=0s", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileName, false)},
+		{"--stat-cache-ttl=0s", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -96,14 +96,11 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs=true", "--stat-cache-ttl=0s"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache",
-		false))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--stat-cache-ttl=0s")
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
-	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--stat-cache-ttl=0s", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -99,7 +99,7 @@ func TestDisabledCacheTTLTest(t *testing.T) {
 		{"--implicit-dirs=true", "--stat-cache-ttl=0s"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
 		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -124,8 +124,9 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 			if filesize != (*fileInfo).Size() {
 				err = fmt.Errorf("incorrect cached file size. Expected: %d, Got %d", filesize, (*fileInfo).Size())
 				t.Logf("Incorrect cached file size, retrying %d...", attempt)
+			} else {
+				break
 			}
-			break
 		}
 		time.Sleep(retryDelay)
 	}

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/log_parser/json_parser/read_logs"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Expected is a helper struct that stores list of attributes to be validated from logs.
@@ -110,13 +112,10 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 	// Validate that the file is present in cache location.
 	expectedPathOfCachedFile := getCachedFilePath(fileName)
 	fileInfo, err := operations.StatFile(expectedPathOfCachedFile)
-	if err != nil {
-		t.Errorf("Failed to find cached file %s: %v", expectedPathOfCachedFile, err)
-	}
+	require.Nil(t, err, "Failed to find cached file %s", expectedPathOfCachedFile)
+	require.NotNil(t, fileInfo, "Received nil FileInfo %s", expectedPathOfCachedFile)
 	// Validate file size in cache directory matches actual file size.
-	if (*fileInfo).Size() != filesize {
-		t.Errorf("Incorrect cached file size. Expected %d, Got: %d", filesize, (*fileInfo).Size())
-	}
+	assert.Equal(t, filesize, (*fileInfo).Size(), "Incorrect cached file size")
 }
 
 func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -121,13 +121,16 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 
 func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
 	validateFileSizeInCacheDirectory(fileName, filesize, t)
-	// Validate CRC of cached file matches GCS CRC.
+	//Validate CRC of cached file matches GCS CRC.
 	cachedFilePath := getCachedFilePath(fileName)
 	crc32ValueOfCachedFile, err := operations.CalculateFileCRC32(cachedFilePath)
 	if err != nil {
 		t.Errorf("CalculateFileCRC32 Failed: %v", err)
 	}
-	client.ValidateCRCWithGCS(crc32ValueOfCachedFile, path.Join(testDirName, fileName), ctx, storageClient, t)
+	err = client.ValidateCRCWithGCS(crc32ValueOfCachedFile, path.Join(testDirName, fileName), ctx, storageClient)
+	if err != nil {
+		t.Errorf("Cache file CRC mismatch: %v", err)
+	}
 }
 
 func validateFileIsNotCached(fileName string, t *testing.T) {
@@ -162,7 +165,10 @@ func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage
 	if err != nil {
 		t.Errorf("CalculateCRC32 Failed: %v", err)
 	}
-	client.ValidateCRCWithGCS(gotCRC32Value, path.Join(testDirName, filename), ctx, storageClient, t)
+	err = client.ValidateCRCWithGCS(gotCRC32Value, path.Join(testDirName, filename), ctx, storageClient)
+	if err != nil {
+		t.Errorf("Content served CRC mismatch: %v", err)
+	}
 
 	return expectedOutcome
 }

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -250,12 +250,3 @@ func runTestsOnlyForDynamicMount(t *testing.T) {
 		t.SkipNow()
 	}
 }
-
-func isParallelDownloadsEnabled(flags []string) bool {
-	for _, flag := range flags {
-		if flag == "--config-file="+path.Join(setup.TestDir(), configFileNameForParallelDownloadTests) {
-			return true
-		}
-	}
-	return false
-}

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -119,13 +119,13 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 		// Validate that the file is present in cache location.
 		var fileInfo *fs.FileInfo
 		fileInfo, err = operations.StatFile(expectedPathOfCachedFile)
-		if fileInfo == nil {
-			err = fmt.Errorf("received nil FileInfo %s", expectedPathOfCachedFile)
-		}
 		// Validate file size in cache directory matches actual file size.
-		if err == nil && filesize != (*fileInfo).Size() {
-			err = fmt.Errorf("incorrect cached file size. Expected: %d, Got %d", filesize, (*fileInfo).Size())
-			t.Logf("Incorrect cached file size, retrying %d...", attempt)
+		if err == nil && fileInfo != nil {
+			if filesize != (*fileInfo).Size() {
+				err = fmt.Errorf("incorrect cached file size. Expected: %d, Got %d", filesize, (*fileInfo).Size())
+				t.Logf("Incorrect cached file size, retrying %d...", attempt)
+			}
+			break
 		}
 		time.Sleep(retryDelay)
 	}

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -100,11 +100,13 @@ func TestLocalModificationTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true", "--config-file=" + createConfigFile(cacheCapacityInMB,
-			false, configFileName+"ForReadCache", false)},
-		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
-			false, configFileNameForParallelDownloadTests, true)},
+		{"--implicit-dirs"},
 	}
+
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true),
+	)
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -100,13 +100,9 @@ func TestLocalModificationTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs"},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
-
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true),
-	)
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -101,9 +101,11 @@ func TestLocalModificationTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false,
+		configFileName, false))
+	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
+		false, configFileName, true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -103,9 +103,9 @@ func TestLocalModificationTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false,
-		configFileName, false))
+		configFileName+"ForReadCache", false))
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName, true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -100,12 +100,11 @@ func TestLocalModificationTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs=true", "--config-file=" + createConfigFile(cacheCapacityInMB,
+			false, configFileName+"ForReadCache", false)},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
+			false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false,
-		configFileName+"ForReadCache", false))
-	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -101,11 +101,9 @@ func TestRangeReadTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(largeFileCacheCapacity, false, configFileName+"1", false)},
+		{"--config-file=" + createConfigFile(largeFileCacheCapacity, true, configFileName+"2", false)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet,
-		"--config-file="+createConfigFile(largeFileCacheCapacity, false, configFileName+"1", false),
-		"--config-file="+createConfigFile(largeFileCacheCapacity, true, configFileName+"2", false))
 
 	// Run tests.
 	for _, flags := range flagSet {

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -55,7 +55,7 @@ func (s *rangeReadTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
-	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, veryLargeFileSize, t)
+	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, largeFileSize, t)
 
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offsetForRangeReadWithin8MB, t)
@@ -66,7 +66,7 @@ func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
 }
 
 func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithChunkDownloaded(t *testing.T) {
-	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, veryLargeFileSize, t)
+	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, largeFileSize, t)
 
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
 	time.Sleep(2 * time.Second)
@@ -75,7 +75,7 @@ func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithChunkDownloaded(t *
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
 	validate(expectedOutcome1, structuredReadLogs[0], true, false, 1, t)
 	validate(expectedOutcome2, structuredReadLogs[1], false, true, 1, t)
-	validateCacheSizeWithinLimit(cacheCapacityForVeryLargeFileInMiB, t)
+	validateCacheSizeWithinLimit(largeFileCacheCapacity, t)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -99,16 +99,13 @@ func TestRangeReadTest(t *testing.T) {
 		return
 	}
 
-	setup.RunTestsOnlyForStaticMount(mountDir, t)
 	// Define flag set to run the tests.
 	flagSet := [][]string{
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet,
-		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, false, configFileName+"1", false),
-		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, true, configFileName+"2", false))
-	flagSet = append(flagSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForVeryLargeFileInMiB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
+		"--config-file="+createConfigFile(largeFileCacheCapacity, false, configFileName+"1", false),
+		"--config-file="+createConfigFile(largeFileCacheCapacity, true, configFileName+"2", false))
 
 	// Run tests.
 	for _, flags := range flagSet {

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -108,7 +108,7 @@ func TestRangeReadTest(t *testing.T) {
 		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, false, configFileName+"1", false),
 		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, true, configFileName+"2", false))
 	flagSet = append(flagSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForVeryLargeFileInMiB,
-		false, configFileName+"3", true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagSet {

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -34,9 +34,10 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 type rangeReadTest struct {
-	flags         []string
-	storageClient *storage.Client
-	ctx           context.Context
+	flags                      []string
+	storageClient              *storage.Client
+	ctx                        context.Context
+	isParallelDownloadsEnabled bool
 }
 
 func (s *rangeReadTest) Setup(t *testing.T) {
@@ -55,6 +56,12 @@ func (s *rangeReadTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
+	if s.isParallelDownloadsEnabled {
+		// This test verifies that the reads are all cache hit within a downloaded chunk.
+		// However, with parallel downloads, we cannot guarantee this behavior, so
+		// we skip this test when parallel downloads are enabled.
+		t.SkipNow()
+	}
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, largeFileSize, t)
 
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
@@ -65,11 +72,11 @@ func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize(t *testing.T) {
 	validate(expectedOutcome2, structuredReadLogs[1], false, true, 1, t)
 }
 
-func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithChunkDownloaded(t *testing.T) {
+func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithFileCached(t *testing.T) {
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, largeFileSize, t)
 
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, t)
-	time.Sleep(2 * time.Second)
+	validateFileInCacheDirectory(testFileName, largeFileSize, ctx, s.storageClient, t)
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset10MiB, t)
 
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), t)
@@ -99,15 +106,23 @@ func TestRangeReadTest(t *testing.T) {
 		return
 	}
 
-	// Define flag set to run the tests.
-	flagSet := [][]string{
+	// Run tests with parallel downloads disabled.
+	flagsSet := [][]string{
 		{"--implicit-dirs", "--config-file=" + createConfigFile(largeFileCacheCapacity, false, configFileName+"1", false)},
-		{"--config-file=" + createConfigFile(largeFileCacheCapacity, true, configFileName+"2", false)},
+	}
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
 	}
 
-	// Run tests.
-	for _, flags := range flagSet {
+	// Run tests with parallel downloads enabled.
+	flagsSet = [][]string{
+		{"--config-file=" + createConfigFile(largeFileCacheCapacity, true, configFileName+"2", false)},
+	}
+	for _, flags := range flagsSet {
 		ts.flags = flags
+		ts.isParallelDownloadsEnabled = true
 		log.Printf("Running tests with flags: %s", ts.flags)
 		test_setup.RunTests(t, ts)
 	}

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -103,12 +103,12 @@ func TestRangeReadTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet,
-		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, false, configFileName+"1"),
-		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, true, configFileName+"2"))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagSet, "--o=ro", "")
+		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, false, configFileName+"1", false),
+		"--config-file="+createConfigFile(cacheCapacityForVeryLargeFileInMiB, true, configFileName+"2", false))
+	flagSet = append(flagSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityForVeryLargeFileInMiB,
+		false, configFileName+"3", true)})
 
 	// Run tests.
 	for _, flags := range flagSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -165,9 +165,10 @@ func TestReadOnlyTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs", "--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB, true, configFileName, false)},
-		{"--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB, true, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -166,12 +166,13 @@ func TestReadOnlyTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1"),
-		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2"))
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB,
+		false, configFileName+"3", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -165,14 +165,12 @@ func TestReadOnlyTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs=true", "--o=ro"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
-	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
+		//"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
+		//"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -172,7 +172,7 @@ func TestReadOnlyTest(t *testing.T) {
 		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"3", true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -168,8 +168,7 @@ func TestReadOnlyTest(t *testing.T) {
 		{"--implicit-dirs=true", "--o=ro"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName, false),
 		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -165,11 +165,9 @@ func TestReadOnlyTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true", "--o=ro"},
+		{"--implicit-dirs", "--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB, true, configFileName, false)},
+		{"--o=ro", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -168,8 +168,8 @@ func TestReadOnlyTest(t *testing.T) {
 		{"--implicit-dirs=true", "--o=ro"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		//"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
-		//"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"1", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, true, configFileName+"2", false),
 		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Run tests.

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -134,10 +134,9 @@ func TestRemountTest(t *testing.T) {
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
-	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -134,10 +134,10 @@ func TestRemountTest(t *testing.T) {
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName, true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -133,10 +133,11 @@ func TestRemountTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+	flagsSet = append(flagsSet, []string{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB,
+		false, configFileName, true)})
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -135,7 +135,7 @@ func TestRemountTest(t *testing.T) {
 		{"--implicit-dirs=true"},
 	}
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName+"ForReadCache", false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
 		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Create storage client before running tests.

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -132,11 +132,9 @@ func TestRemountTest(t *testing.T) {
 	}
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs=true", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 
 	// Create storage client before running tests.
 	ts := &remountTest{ctx: context.Background()}

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -65,9 +65,9 @@ const (
 	offsetEndOfFile                     = veryLargeFileSize - 1*util.MiB
 	cacheDirName                        = "cache-dir"
 	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_read_cache_test_logs/log.json"
-	downloadParallelismPerFile          = 4
-	maxDownloadParallelism              = -1
-	readRequestSizeMB                   = 2
+	parallelDownloadsPerFile            = 4
+	maxParallelDownloads                = -1
+	downloadChunkSizeMB                 = 2
 	enableCrcCheck                      = true
 )
 
@@ -112,10 +112,10 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 			MaxSizeMB:                cacheSize,
 			CacheFileForRangeRead:    cacheFileForRangeRead,
 			EnableParallelDownloads:  enableParallelDownloads,
-			ParallelDownloadsPerFile: downloadParallelismPerFile,
-			MaxDownloadParallelism:   maxDownloadParallelism,
-			ReadRequestSizeMB:        readRequestSizeMB,
-			EnableCrcCheck:           enableCrcCheck,
+			ParallelDownloadsPerFile: parallelDownloadsPerFile,
+			MaxParallelDownloads:     maxParallelDownloads,
+			DownloadChunkSizeMB:      downloadChunkSizeMB,
+			EnableCRC:                enableCrcCheck,
 		},
 		CacheDir: cacheDirPath,
 		LogConfig: config.LogConfig{

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*25)
+	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*15)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -66,7 +66,7 @@ const (
 	logFileNameForMountedDirectoryTests    = "/tmp/gcsfuse_read_cache_test_logs/log.json"
 	parallelDownloadsPerFile               = 4
 	maxParallelDownloads                   = -1
-	downloadChunkSizeMB                    = 2
+	downloadChunkSizeMB                    = 3
 	enableCrcCheck                         = true
 )
 

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*20)
+	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*25)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -86,15 +86,6 @@ var (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-func isParallelDownloadsEnabled(flags []string) bool {
-	for _, flag := range flags {
-		if flag == "--config-file="+path.Join(setup.TestDir(), configFileNameForParallelDownloadTests) {
-			return true
-		}
-	}
-	return false
-}
-
 func setupForMountedDirectoryTests() {
 	if setup.MountedDirectory() != "" {
 		cacheDirPath = path.Join(os.TempDir(), cacheDirName)

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -142,10 +142,6 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 ////////////////////////////////////////////////////////////////////////
 
 func TestMain(m *testing.M) {
-	//out, err := operations.CalculateFileCRC32("/tmp/gcsfuse_readwrite_test_545011229/cache-dir/gcsfuse-file-cache/ashmeenbkt/ReadCacheTest/ReadCacheTestomyh")
-	//fmt.Println(out, " ", err)
-	//return
-
 	setup.ParseSetUpFlags()
 
 	ctx = context.Background()

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -145,7 +145,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*15)
+	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*20)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -33,42 +33,41 @@ import (
 )
 
 const (
-	testDirName                         = "ReadCacheTest"
-	onlyDirMounted                      = "OnlyDirMountReadCache"
-	cacheSubDirectoryName               = "gcsfuse-file-cache"
-	smallContentSize                    = 128 * util.KiB
-	chunkSizeToRead                     = 128 * util.KiB
-	fileSize                            = 3 * util.MiB
-	fileSizeSameAsCacheCapacity         = cacheCapacityForRangeReadTestInMiB * util.MiB
-	fileSizeForRangeRead                = 8 * util.MiB
-	chunksRead                          = fileSize / chunkSizeToRead
-	testFileName                        = "foo"
-	cacheCapacityInMB                   = 9
-	NumberOfFilesWithinCacheLimit       = (cacheCapacityInMB * util.MiB) / fileSize
-	NumberOfFilesMoreThanCacheLimit     = (cacheCapacityInMB*util.MiB)/fileSize + 1
-	largeFileSize                       = 15 * util.MiB
-	largeFileName                       = "15MBFile"
-	largeFileChunksRead                 = largeFileSize / chunkSizeToRead
-	chunksReadAfterUpdate               = 1
-	metadataCacheTTlInSec               = 10
-	testFileNameSuffixLength            = 4
-	zeroOffset                          = 0
-	randomReadOffset                    = 9 * util.MiB
-	configFileName                      = "config"
-	offset5000                          = 5000
-	offset1000                          = 1000
-	offsetForRangeReadWithin8MB         = 4 * util.MiB
-	offset10MiB                         = 10 * util.MiB
-	cacheCapacityForRangeReadTestInMiB  = 50
-	cacheCapacityForVeryLargeFileInMiB  = 500
-	veryLargeFileSize                   = cacheCapacityForVeryLargeFileInMiB * util.MiB
-	offsetEndOfFile                     = veryLargeFileSize - 1*util.MiB
-	cacheDirName                        = "cache-dir"
-	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_read_cache_test_logs/log.json"
-	parallelDownloadsPerFile            = 4
-	maxParallelDownloads                = -1
-	downloadChunkSizeMB                 = 2
-	enableCrcCheck                      = true
+	testDirName                            = "ReadCacheTest"
+	onlyDirMounted                         = "OnlyDirMountReadCache"
+	cacheSubDirectoryName                  = "gcsfuse-file-cache"
+	smallContentSize                       = 128 * util.KiB
+	chunkSizeToRead                        = 128 * util.KiB
+	fileSize                               = 3 * util.MiB
+	fileSizeSameAsCacheCapacity            = cacheCapacityForRangeReadTestInMiB * util.MiB
+	fileSizeForRangeRead                   = 8 * util.MiB
+	chunksRead                             = fileSize / chunkSizeToRead
+	testFileName                           = "foo"
+	cacheCapacityInMB                      = 9
+	NumberOfFilesWithinCacheLimit          = (cacheCapacityInMB * util.MiB) / fileSize
+	NumberOfFilesMoreThanCacheLimit        = (cacheCapacityInMB*util.MiB)/fileSize + 1
+	largeFileSize                          = 15 * util.MiB
+	largeFileCacheCapacity                 = 15
+	largeFileName                          = "15MBFile"
+	largeFileChunksRead                    = largeFileSize / chunkSizeToRead
+	chunksReadAfterUpdate                  = 1
+	metadataCacheTTlInSec                  = 10
+	testFileNameSuffixLength               = 4
+	zeroOffset                             = 0
+	randomReadOffset                       = 9 * util.MiB
+	configFileName                         = "config"
+	configFileNameForParallelDownloadTests = "configForReadCacheWithParallelDownload"
+	offset5000                             = 5000
+	offset1000                             = 1000
+	offsetForRangeReadWithin8MB            = 4 * util.MiB
+	offset10MiB                            = 10 * util.MiB
+	cacheCapacityForRangeReadTestInMiB     = 50
+	cacheDirName                           = "cache-dir"
+	logFileNameForMountedDirectoryTests    = "/tmp/gcsfuse_read_cache_test_logs/log.json"
+	parallelDownloadsPerFile               = 4
+	maxParallelDownloads                   = -1
+	downloadChunkSizeMB                    = 2
+	enableCrcCheck                         = true
 )
 
 var (
@@ -86,6 +85,15 @@ var (
 ////////////////////////////////////////////////////////////////////////
 // Helpers
 ////////////////////////////////////////////////////////////////////////
+
+func isParallelDownloadsEnabled(flags []string) bool {
+	for _, flag := range flags {
+		if flag == "--config-file="+path.Join(setup.TestDir(), configFileNameForParallelDownloadTests) {
+			return true
+		}
+	}
+	return false
+}
 
 func setupForMountedDirectoryTests() {
 	if setup.MountedDirectory() != "" {
@@ -134,6 +142,10 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 ////////////////////////////////////////////////////////////////////////
 
 func TestMain(m *testing.M) {
+	//out, err := operations.CalculateFileCRC32("/tmp/gcsfuse_readwrite_test_545011229/cache-dir/gcsfuse-file-cache/ashmeenbkt/ReadCacheTest/ReadCacheTestomyh")
+	//fmt.Println(out, " ", err)
+	//return
+
 	setup.ParseSetUpFlags()
 
 	ctx = context.Background()

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -65,6 +65,10 @@ const (
 	offsetEndOfFile                     = veryLargeFileSize - 1*util.MiB
 	cacheDirName                        = "cache-dir"
 	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_read_cache_test_logs/log.json"
+	downloadParallelismPerFile          = 4
+	maxDownloadParallelism              = -1
+	readRequestSizeMB                   = 2
+	enableCrcCheck                      = true
 )
 
 var (
@@ -97,7 +101,7 @@ func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageCli
 	testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
-func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName string) string {
+func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName string, enableParallelDownloads bool) string {
 	cacheDirPath = path.Join(setup.TestDir(), cacheDirName)
 
 	// Set up config file for file cache.
@@ -105,8 +109,13 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as low because the operations are performed on small
 			// files
-			MaxSizeMB:             cacheSize,
-			CacheFileForRangeRead: cacheFileForRangeRead,
+			MaxSizeMB:                  cacheSize,
+			CacheFileForRangeRead:      cacheFileForRangeRead,
+			EnableParallelDownloads:    enableParallelDownloads,
+			DownloadParallelismPerFile: downloadParallelismPerFile,
+			MaxDownloadParallelism:     maxDownloadParallelism,
+			ReadRequestSizeMB:          readRequestSizeMB,
+			EnableCrcCheck:             enableCrcCheck,
 		},
 		CacheDir: cacheDirPath,
 		LogConfig: config.LogConfig{

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -109,13 +109,13 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 		FileCacheConfig: config.FileCacheConfig{
 			// Keeping the size as low because the operations are performed on small
 			// files
-			MaxSizeMB:                  cacheSize,
-			CacheFileForRangeRead:      cacheFileForRangeRead,
-			EnableParallelDownloads:    enableParallelDownloads,
-			DownloadParallelismPerFile: downloadParallelismPerFile,
-			MaxDownloadParallelism:     maxDownloadParallelism,
-			ReadRequestSizeMB:          readRequestSizeMB,
-			EnableCrcCheck:             enableCrcCheck,
+			MaxSizeMB:                cacheSize,
+			CacheFileForRangeRead:    cacheFileForRangeRead,
+			EnableParallelDownloads:  enableParallelDownloads,
+			ParallelDownloadsPerFile: downloadParallelismPerFile,
+			MaxDownloadParallelism:   maxDownloadParallelism,
+			ReadRequestSizeMB:        readRequestSizeMB,
+			EnableCrcCheck:           enableCrcCheck,
 		},
 		CacheDir: cacheDirPath,
 		LogConfig: config.LogConfig{

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -123,12 +123,10 @@ func TestSmallCacheTTLTest(t *testing.T) {
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false,
-		configFileName, false))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
+		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
-	flagsSet = append(flagsSet, []string{fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec), "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -128,7 +128,7 @@ func TestSmallCacheTTLTest(t *testing.T) {
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
 	flagsSet = append(flagsSet, []string{fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec), "--config-file=" + createConfigFile(cacheCapacityInMB,
-		false, configFileName+"3", true)})
+		false, configFileName+"ForReadCacheWithParallelDownload", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -122,11 +122,13 @@ func TestSmallCacheTTLTest(t *testing.T) {
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--implicit-dirs=true"},
-		{"--implicit-dirs=false"},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName))
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--config-file="+createConfigFile(cacheCapacityInMB, false,
+		configFileName, false))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--o=ro", "")
+	flagsSet = append(flagsSet, []string{fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec), "--config-file=" + createConfigFile(cacheCapacityInMB,
+		false, configFileName+"3", true)})
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -121,11 +121,9 @@ func TestSmallCacheTTLTest(t *testing.T) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--implicit-dirs=true"},
+		{"--implicit-dirs", "--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileName, false)},
+		{"--config-file=" + createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true)},
 	}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet,
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileName, false),
-		"--config-file="+createConfigFile(cacheCapacityInMB, false, configFileNameForParallelDownloadTests, true))
 	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, fmt.Sprintf("--stat-cache-ttl=%ds", metadataCacheTTlInSec))
 
 	// Run tests.

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -155,12 +156,13 @@ func CreateNFilesInDir(ctx context.Context, storageClient *storage.Client, numFi
 	return fileNames
 }
 
-func ValidateCRCWithGCS(gotCRC32Value uint32, objectPath string, ctx context.Context, storageClient *storage.Client, t *testing.T) {
+func ValidateCRCWithGCS(gotCRC32Value uint32, objectPath string, ctx context.Context, storageClient *storage.Client) error {
 	attr, err := StatObject(ctx, storageClient, objectPath)
 	if err != nil {
-		t.Errorf("Failed to fetch object attributes: %v", err)
+		return fmt.Errorf("Failed to fetch object attributes: %v", err)
 	}
 	if attr.CRC32C != gotCRC32Value {
-		t.Errorf("CRC32 mismatch. Expected %d, Got %d", attr.CRC32C, gotCRC32Value)
+		return fmt.Errorf("CRC32 mismatch. Expected %d, Got %d", attr.CRC32C, gotCRC32Value)
 	}
+	return nil
 }

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -158,8 +158,8 @@ func CreateNFilesInDir(ctx context.Context, storageClient *storage.Client, numFi
 
 func ValidateCRCWithGCS(gotCRC32Value uint32, objectPath string, ctx context.Context, storageClient *storage.Client) error {
 	attr, err := StatObject(ctx, storageClient, objectPath)
-	if err != nil {
-		return fmt.Errorf("Failed to fetch object attributes: %v", err)
+	if err != nil || attr == nil {
+		return fmt.Errorf("failed to fetch object attributes: %v", err)
 	}
 	if attr.CRC32C != gotCRC32Value {
 		return fmt.Errorf("CRC32 mismatch. Expected %d, Got %d", attr.CRC32C, gotCRC32Value)


### PR DESCRIPTION
### Description

This PR adds parallel download configuration to existing read cache e2e tests.
Changes involved:
- Parallel download config added to the existing tests.
- It is possible that cache file is not fully downloaded after the read is served, so retry for 5 seconds until the file is cached before matching CRC with GCS.
- Some miscellaneous changes to return error / use stretchr testify to make the test more debuggable.
- Reduce file size for tools/integration_tests/read_cache/range_read_test.go file so that the test executes faster. Parallel download tests are not added for this file as it is not predictable that the file will be cached for a chunk in this case. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran multiple times manually to confirm that the test is not flaky.
2. Unit tests - NA
3. Integration tests - Ran via KOKORO.
