### PR TITLE
Migrate experimental-metadata-prefetch-on-mount to new config.

### DIFF
--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -24,3 +24,12 @@ const (
 	ERROR   string = "ERROR"
 	OFF     string = "OFF"
 )
+
+const (
+	// ExperimentalMetadataPrefetchOnMountDisabled is the mode without metadata-prefetch.
+	ExperimentalMetadataPrefetchOnMountDisabled = "disabled"
+	// ExperimentalMetadataPrefetchOnMountSynchronous is the prefetch-mode where mounting is not marked complete until prefetch is complete.
+	ExperimentalMetadataPrefetchOnMountSynchronous = "sync"
+	// ExperimentalMetadataPrefetchOnMountAsynchronous is the prefetch-mode where mounting is marked complete once prefetch has started.
+	ExperimentalMetadataPrefetchOnMountAsynchronous = "async"
+)

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -43,9 +43,9 @@ func (o *Octal) String() string {
 type Protocol string
 
 const (
-	HTTP1 Protocol = "http1"
-	HTTP2 Protocol = "http2"
-	GRPC  Protocol = "grpc"
+	HTTP1 = "http1"
+	HTTP2 = "http2"
+	GRPC  = "grpc"
 )
 
 func (p *Protocol) UnmarshalText(text []byte) error {

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -45,5 +45,20 @@ func ValidateConfig(config *Config) error {
 		return fmt.Errorf("error parsing custom-endpoint config: %w", err)
 	}
 
+	if err = IsValidExperimentalMetadataPrefetchOnMount(config.MetadataCache.ExperimentalMetadataPrefetchOnMount); err != nil {
+		return fmt.Errorf("error parsing experimental-metadata-prefetch-on-mount: %w", err)
+	}
+
 	return nil
+}
+
+func IsValidExperimentalMetadataPrefetchOnMount(mode string) error {
+	switch mode {
+	case ExperimentalMetadataPrefetchOnMountDisabled,
+		ExperimentalMetadataPrefetchOnMountSynchronous,
+		ExperimentalMetadataPrefetchOnMountAsynchronous:
+		return nil
+	default:
+		return fmt.Errorf("unsupported metadata-prefix-mode: \"%s\"; supported values: disabled, sync, async", mode)
+	}
 }

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -40,6 +40,9 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "https://bing.com/search?q=dotnet",
 				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "disabled",
+				},
 			},
 		},
 		{
@@ -48,6 +51,36 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "https://j@ne:password@google.com",
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "disabled",
+				},
+			},
+		},
+		{
+			name: "experimental-metadata-prefetch-on-mount disabled",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "disabled",
+				},
+			},
+		},
+		{
+			name: "experimental-metadata-prefetch-on-mount async",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "async",
+				},
+			},
+		},
+		{
+			name: "experimental-metadata-prefetch-on-mount sync",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
 				},
 			},
 		},
@@ -73,6 +106,15 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "a_b://abc",
+				},
+			},
+		},
+		{
+			name: "Invalid experimental-metadata-prefetch-on-mount",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "a",
 				},
 			},
 		},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
@@ -392,7 +393,7 @@ func newApp() (app *cli.App) {
 
 			cli.StringFlag{
 				Name:  ExperimentalMetadataPrefetchOnMountFlag,
-				Value: config.DefaultExperimentalMetadataPrefetchOnMount,
+				Value: "disabled",
 				Usage: "Experimental: This indicates whether or not to prefetch the metadata (prefilling of metadata caches and creation of inodes) of the mounted bucket at the time of mounting the bucket. Supported values: \"disabled\", \"sync\" and \"async\". Any other values will return error on mounting. This is applicable only to static mounting, and not to dynamic mounting.",
 			},
 		},
@@ -667,25 +668,12 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 	return
 }
 
-func validateExperimentalMetadataPrefetchOnMount(mode string) error {
-	switch mode {
-	case config.ExperimentalMetadataPrefetchOnMountDisabled:
-		fallthrough
-	case config.ExperimentalMetadataPrefetchOnMountSynchronous:
-		fallthrough
-	case config.ExperimentalMetadataPrefetchOnMountAsynchronous:
-		return nil
-	default:
-		return fmt.Errorf(config.UnsupportedMetadataPrefixModeError, mode)
-	}
-}
-
 func validateFlags(flags *flagStorage) (err error) {
 	if flags.SequentialReadSizeMb < 1 || flags.SequentialReadSizeMb > maxSequentialReadSizeMb {
 		return fmt.Errorf("SequentialReadSizeMb should be less than %d", maxSequentialReadSizeMb)
 	}
 
-	if err = validateExperimentalMetadataPrefetchOnMount(flags.ExperimentalMetadataPrefetchOnMount); err != nil {
+	if err = cfg.IsValidExperimentalMetadataPrefetchOnMount(flags.ExperimentalMetadataPrefetchOnMount); err != nil {
 		return fmt.Errorf("%s: is not valid; error = %w", ExperimentalMetadataPrefetchOnMountFlag, err)
 	}
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -530,7 +530,7 @@ type flagStorage struct {
 
 	// Post-mount actions
 
-	// ExperimentalMetadataPrefetchOnMount indicates whether or not to prefetch the metadata of the mounted bucket at the time of mounting the bucket.
+	// Deprecated: ExperimentalMetadataPrefetchOnMount indicates whether or not to prefetch the metadata of the mounted bucket at the time of mounting the bucket.
 	// Supported values: ExperimentalMetadataPrefetchOnMountDisabled, ExperimentalMetadataPrefetchOnMountSynchronous, and ExperimentalMetadataPrefetchOnMountAsynchronous.
 	// Any other values will return error on mounting.
 	// This is applicable only to single-bucket mount-points, and not to dynamic-mount points. This is because dynamic-mounts don't mount the bucket(s) at the time of

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -393,7 +393,7 @@ func newApp() (app *cli.App) {
 
 			cli.StringFlag{
 				Name:  ExperimentalMetadataPrefetchOnMountFlag,
-				Value: "disabled",
+				Value: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
 				Usage: "Experimental: This indicates whether or not to prefetch the metadata (prefilling of metadata caches and creation of inodes) of the mounted bucket at the time of mounting the bucket. Supported values: \"disabled\", \"sync\" and \"async\". Any other values will return error on mounting. This is applicable only to static mounting, and not to dynamic mounting.",
 			},
 		},
@@ -671,10 +671,6 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 func validateFlags(flags *flagStorage) (err error) {
 	if flags.SequentialReadSizeMb < 1 || flags.SequentialReadSizeMb > maxSequentialReadSizeMb {
 		return fmt.Errorf("SequentialReadSizeMb should be less than %d", maxSequentialReadSizeMb)
-	}
-
-	if err = cfg.IsValidExperimentalMetadataPrefetchOnMount(flags.ExperimentalMetadataPrefetchOnMount); err != nil {
-		return fmt.Errorf("%s: is not valid; error = %w", ExperimentalMetadataPrefetchOnMountFlag, err)
 	}
 
 	if err = config.IsTtlInSecsValid(flags.KernelListCacheTtlSeconds); err != nil {

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -350,24 +350,6 @@ func (t *FlagsTest) TestValidateFlagsForSupportedExperimentalMetadataPrefetchOnM
 	}
 }
 
-func (t *FlagsTest) TestValidateFlagsForUnsupportedExperimentalMetadataPrefetchOnMount() {
-	for _, input := range []string{
-		"", "unsupported",
-	} {
-		flags := &flagStorage{
-			// Unrelated fields, not being tested here, so set to sane values.
-			SequentialReadSizeMb: 200,
-			// The flag being tested.
-			ExperimentalMetadataPrefetchOnMount: input,
-		}
-
-		err := validateFlags(flags)
-
-		assert.NotEqual(t.T(), nil, err)
-		assert.ErrorContains(t.T(), err, fmt.Sprintf("unsupported metadata-prefix-mode: \"%s\"; supported values: disabled, sync, async", input))
-	}
-}
-
 func (t *FlagsTest) Test_resolveConfigFilePaths() {
 	mountConfig := &config.MountConfig{}
 	mountConfig.CacheDir = "~/cache-dir"

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
@@ -103,7 +104,7 @@ func (t *FlagsTest) TestDefaults() {
 	assert.False(t.T(), f.DebugInvariants)
 
 	// Post-mount actions
-	assert.Equal(t.T(), config.ExperimentalMetadataPrefetchOnMountDisabled, f.ExperimentalMetadataPrefetchOnMount)
+	assert.Equal(t.T(), cfg.ExperimentalMetadataPrefetchOnMountDisabled, f.ExperimentalMetadataPrefetchOnMount)
 
 	// Metrics
 	assert.Equal(t.T(), 0, f.PrometheusPort)
@@ -223,7 +224,7 @@ func (t *FlagsTest) TestStrings() {
 	assert.Equal(t.T(), "foobar", f.TempDir)
 	assert.Equal(t.T(), "baz", f.OnlyDir)
 	assert.Equal(t.T(), mountpkg.HTTP2, f.ClientProtocol)
-	assert.Equal(t.T(), config.ExperimentalMetadataPrefetchOnMountAsynchronous, f.ExperimentalMetadataPrefetchOnMount)
+	assert.Equal(t.T(), cfg.ExperimentalMetadataPrefetchOnMountAsynchronous, f.ExperimentalMetadataPrefetchOnMount)
 }
 
 func (t *FlagsTest) TestDurations() {
@@ -300,7 +301,7 @@ func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 func (t *FlagsTest) TestValidateFlagsForZeroSequentialReadSize() {
 	flags := &flagStorage{
 		SequentialReadSizeMb:                0,
-		ExperimentalMetadataPrefetchOnMount: config.DefaultExperimentalMetadataPrefetchOnMount,
+		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
 	}
 
 	err := validateFlags(flags)
@@ -312,7 +313,7 @@ func (t *FlagsTest) TestValidateFlagsForZeroSequentialReadSize() {
 func (t *FlagsTest) TestValidateFlagsForSequentialReadSizeGreaterThan1024() {
 	flags := &flagStorage{
 		SequentialReadSizeMb:                2048,
-		ExperimentalMetadataPrefetchOnMount: config.DefaultExperimentalMetadataPrefetchOnMount,
+		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
 	}
 
 	err := validateFlags(flags)
@@ -324,7 +325,7 @@ func (t *FlagsTest) TestValidateFlagsForSequentialReadSizeGreaterThan1024() {
 func (t *FlagsTest) TestValidateFlagsForValidSequentialReadSize() {
 	flags := &flagStorage{
 		SequentialReadSizeMb:                10,
-		ExperimentalMetadataPrefetchOnMount: config.DefaultExperimentalMetadataPrefetchOnMount,
+		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
 	}
 
 	err := validateFlags(flags)
@@ -363,7 +364,7 @@ func (t *FlagsTest) TestValidateFlagsForUnsupportedExperimentalMetadataPrefetchO
 		err := validateFlags(flags)
 
 		assert.NotEqual(t.T(), nil, err)
-		assert.ErrorContains(t.T(), err, fmt.Sprintf(config.UnsupportedMetadataPrefixModeError, input))
+		assert.ErrorContains(t.T(), err, fmt.Sprintf("unsupported metadata-prefix-mode: \"%s\"; supported values: disabled, sync, async", input))
 	}
 }
 

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -444,12 +444,12 @@ func runCLIApp(c *cli.Context) (err error) {
 		}
 		if !isDynamicMount(bucketName) {
 			switch newConfig.MetadataCache.ExperimentalMetadataPrefetchOnMount {
-			case config.ExperimentalMetadataPrefetchOnMountSynchronous:
+			case cfg.ExperimentalMetadataPrefetchOnMountSynchronous:
 				if err = callListRecursive(mountPoint); err != nil {
 					markMountFailure(err)
 					return err
 				}
-			case config.ExperimentalMetadataPrefetchOnMountAsynchronous:
+			case cfg.ExperimentalMetadataPrefetchOnMountAsynchronous:
 				go func() {
 					if err := callListRecursive(mountPoint); err != nil {
 						logger.Errorf("Metadata-prefetch failed: %v", err)

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -443,7 +443,7 @@ func runCLIApp(c *cli.Context) (err error) {
 			return err
 		}
 		if !isDynamicMount(bucketName) {
-			switch flags.ExperimentalMetadataPrefetchOnMount {
+			switch newConfig.MetadataCache.ExperimentalMetadataPrefetchOnMount {
 			case config.ExperimentalMetadataPrefetchOnMountSynchronous:
 				if err = callListRecursive(mountPoint); err != nil {
 					markMountFailure(err)

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -109,7 +109,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				DebugInvariants:                     true,
 				DebugMutex:                          true,
 				ExperimentalMetadataPrefetchOnMount: "sync",
-				ClientProtocol:                      mountpkg.HTTP1,
+				ClientProtocol:                      cfg.HTTP1,
 			},
 			mockCLICtx:        &mockCLIContext{isFlagSet: map[string]bool{}},
 			legacyMountConfig: &config.MountConfig{},
@@ -193,7 +193,8 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 		{
 			testName: "Test decode legacy config.",
 			legacyFlagStorage: &flagStorage{
-				ClientProtocol: mountpkg.GRPC,
+				ClientProtocol:                      cfg.GRPC,
+				ExperimentalMetadataPrefetchOnMount: "disabled",
 			},
 			mockCLICtx: &mockCLIContext{isFlagSet: map[string]bool{}},
 			legacyMountConfig: &config.MountConfig{
@@ -260,9 +261,10 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				},
 				CacheDir: cfg.ResolvedPath(path.Join(os.Getenv("HOME"), "cache-dir")),
 				MetadataCache: cfg.MetadataCacheConfig{
-					TtlSecs:            200,
-					TypeCacheMaxSizeMb: 7,
-					StatCacheMaxSizeMb: 4,
+					TtlSecs:                             200,
+					TypeCacheMaxSizeMb:                  7,
+					StatCacheMaxSizeMb:                  4,
+					ExperimentalMetadataPrefetchOnMount: "disabled",
 				},
 				List: cfg.ListConfig{
 					EnableEmptyManagedFolders: true,
@@ -283,13 +285,14 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 		{
 			testName: "Test overlapping flags and configs set.",
 			legacyFlagStorage: &flagStorage{
-				LogFile:                   "~/Documents/log-flag.txt",
-				LogFormat:                 "json",
-				IgnoreInterrupts:          false,
-				AnonymousAccess:           false,
-				KernelListCacheTtlSeconds: -1,
-				MaxRetryAttempts:          100,
-				ClientProtocol:            mountpkg.HTTP2,
+				LogFile:                             "~/Documents/log-flag.txt",
+				LogFormat:                           "json",
+				IgnoreInterrupts:                    false,
+				AnonymousAccess:                     false,
+				KernelListCacheTtlSeconds:           -1,
+				MaxRetryAttempts:                    100,
+				ClientProtocol:                      cfg.HTTP2,
+				ExperimentalMetadataPrefetchOnMount: "disabled",
 			},
 			mockCLICtx: &mockCLIContext{
 				isFlagSet: map[string]bool{
@@ -340,6 +343,9 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				},
 				GcsAuth: cfg.GcsAuthConfig{
 					AnonymousAccess: false,
+				},
+				MetadataCache: cfg.MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "disabled",
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
 					ClientProtocol: cfg.Protocol("http2"),
@@ -397,7 +403,7 @@ func TestPopulateConfigFromLegacyFlags_KeyFileResolution(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			mockCLICtx := &mockCLIContext{}
 			legacyFlagStorage := &flagStorage{
-				ClientProtocol: mountpkg.HTTP2,
+				ClientProtocol: cfg.HTTP2,
 				KeyFile:        tc.givenKeyFile,
 			}
 			legacyMountCfg := &config.MountConfig{}
@@ -445,7 +451,7 @@ func TestPopulateConfigFromLegacyFlags_LogFileResolution(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			mockCLICtx := &mockCLIContext{}
 			legacyFlagStorage := &flagStorage{
-				ClientProtocol: mountpkg.HTTP2,
+				ClientProtocol: cfg.HTTP2,
 				LogFile:        tc.givenLogFile,
 			}
 			legacyMountCfg := &config.MountConfig{}
@@ -463,7 +469,7 @@ func TestCustomEndpointResolutionFromFlags(t *testing.T) {
 	u, err := url.Parse("http://abc.xyz")
 	require.Nil(t, err)
 	legacyFlagStorage := &flagStorage{
-		ClientProtocol: mountpkg.HTTP2,
+		ClientProtocol: cfg.HTTP2,
 		CustomEndpoint: u,
 	}
 
@@ -558,10 +564,11 @@ func TestLogSeverityRationalization(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flags := &flagStorage{
-				ClientProtocol: mountpkg.ClientProtocol("http1"),
-				DebugFuse:      tc.debugFuse,
-				DebugGCS:       tc.debugGCS,
-				DebugMutex:     tc.debugMutex,
+				ClientProtocol:                      mountpkg.ClientProtocol("http1"),
+				ExperimentalMetadataPrefetchOnMount: "disabled",
+				DebugFuse:                           tc.debugFuse,
+				DebugGCS:                            tc.debugGCS,
+				DebugMutex:                          tc.debugMutex,
 			}
 			c := config.NewMountConfig()
 			c.Severity = tc.cfgSev
@@ -614,7 +621,8 @@ func TestEnableEmptyManagedFoldersRationalization(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			flags := &flagStorage{
-				ClientProtocol: mountpkg.ClientProtocol("http1"),
+				ClientProtocol:                      mountpkg.ClientProtocol("http1"),
+				ExperimentalMetadataPrefetchOnMount: "disabled",
 			}
 			c := config.NewMountConfig()
 			c.EnableHNS = tc.enableHns

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -229,3 +229,70 @@ func TestArgsParsing_CreateEmptyFileFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestArgParsing_ExperimentalMetadataPrefetchFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectedValue string
+		wantErr       bool
+	}{
+		{
+			name:          "set to sync",
+			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=sync", "abc", "pqr"},
+			expectedValue: "sync",
+			wantErr:       false,
+		},
+		{
+			name:          "set to async",
+			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=async", "abc", "pqr"},
+			expectedValue: "async",
+			wantErr:       false,
+		},
+		{
+			name:          "set to async, space-separated",
+			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount", "async", "abc", "pqr"},
+			expectedValue: "async",
+			wantErr:       false,
+		},
+		{
+			name:          "set to disabled",
+			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=disabled", "abc", "pqr"},
+			expectedValue: "disabled",
+			wantErr:       false,
+		},
+		{
+			name:          "Test default.",
+			args:          []string{"gcsfuse", "abc", "pqr"},
+			expectedValue: "disabled",
+			wantErr:       false,
+		},
+		{
+			name:    "Test invalid value.",
+			args:    []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=foo", "abc", "pqr"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var experimentalMetadataPrefetch string
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
+				experimentalMetadataPrefetch = cfg.MetadataCache.ExperimentalMetadataPrefetchOnMount
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(tc.args)
+
+			err = cmd.Execute()
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				if assert.NoError(t, err) {
+					assert.Equal(t, tc.expectedValue, experimentalMetadataPrefetch)
+				}
+			}
+		})
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -235,42 +235,31 @@ func TestArgParsing_ExperimentalMetadataPrefetchFlag(t *testing.T) {
 		name          string
 		args          []string
 		expectedValue string
-		wantErr       bool
 	}{
 		{
 			name:          "set to sync",
 			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=sync", "abc", "pqr"},
 			expectedValue: "sync",
-			wantErr:       false,
 		},
 		{
 			name:          "set to async",
 			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=async", "abc", "pqr"},
 			expectedValue: "async",
-			wantErr:       false,
 		},
 		{
 			name:          "set to async, space-separated",
 			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount", "async", "abc", "pqr"},
 			expectedValue: "async",
-			wantErr:       false,
 		},
 		{
 			name:          "set to disabled",
 			args:          []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=disabled", "abc", "pqr"},
 			expectedValue: "disabled",
-			wantErr:       false,
 		},
 		{
 			name:          "Test default.",
 			args:          []string{"gcsfuse", "abc", "pqr"},
 			expectedValue: "disabled",
-			wantErr:       false,
-		},
-		{
-			name:    "Test invalid value.",
-			args:    []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=foo", "abc", "pqr"},
-			wantErr: true,
 		},
 	}
 
@@ -286,13 +275,39 @@ func TestArgParsing_ExperimentalMetadataPrefetchFlag(t *testing.T) {
 
 			err = cmd.Execute()
 
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				if assert.NoError(t, err) {
-					assert.Equal(t, tc.expectedValue, experimentalMetadataPrefetch)
-				}
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedValue, experimentalMetadataPrefetch)
 			}
+		})
+	}
+}
+
+func TestArgParsing_ExperimentalMetadataPrefetchFlag_Failed(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "Test invalid value 1",
+			args: []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=foo", "abc", "pqr"},
+		},
+		{
+			name: "Test invalid value 2",
+			args: []string{"gcsfuse", "--experimental-metadata-prefetch-on-mount=123", "abc", "pqr"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(tc.args)
+
+			err = cmd.Execute()
+
+			assert.Error(t, err)
 		})
 	}
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -47,15 +47,6 @@ const (
 	DefaultIgnoreInterrupts                       = true
 	DefaultPrometheusPort                         = 0
 
-	// ExperimentalMetadataPrefetchOnMountDisabled is the mode without metadata-prefetch.
-	ExperimentalMetadataPrefetchOnMountDisabled string = "disabled"
-	// ExperimentalMetadataPrefetchOnMountSynchronous is the prefetch-mode where mounting is not marked complete until prefetch is complete.
-	ExperimentalMetadataPrefetchOnMountSynchronous string = "sync"
-	// ExperimentalMetadataPrefetchOnMountAsynchronous is the prefetch-mode where mounting is marked complete once prefetch has started.
-	ExperimentalMetadataPrefetchOnMountAsynchronous string = "async"
-	// DefaultExperimentalMetadataPrefetchOnMount is default value of metadata-prefetch i.e. if not set by user; current it is ExperimentalMetadataPrefetchOnMountDisabled.
-	DefaultExperimentalMetadataPrefetchOnMount = ExperimentalMetadataPrefetchOnMountDisabled
-
 	DefaultKernelListCacheTtlSeconds int64 = 0
 
 	DefaultEnableCRC                = false

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -35,7 +35,6 @@ const (
 	StatCacheMaxSizeMBInvalidValueError       = "the value of stat-cache-max-size-mb for metadata-cache can't be less than -1"
 	StatCacheMaxSizeMBTooHighError            = "the value of stat-cache-max-size-mb for metadata-cache is too high! Max supported: 17592186044415"
 	MaxSupportedStatCacheMaxSizeMB            = util.MaxMiBsInUint64
-	UnsupportedMetadataPrefixModeError        = "unsupported metadata-prefix-mode: \"%s\"; supported values: disabled, sync, async"
 	FileCacheMaxSizeMBInvalidValueError       = "the value of max-size-mb for file-cache can't be less than -1"
 	MaxParallelDownloadsInvalidValueError     = "the value of max-parallel-downloads for file-cache can't be less than -1"
 	ParallelDownloadsPerFileInvalidValueError = "the value of parallel-downloads-per-file for file-cache can't be less than 1"


### PR DESCRIPTION
### Description
Migrate experimental-metadata-prefetch-on-mount to new config. Validation on the flag will be added in a follow-up PR.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually that passing the flag works as intended.
2. Unit tests - NA
3. Integration tests - NA
