### PR TITLE
Stat cache bucket changes

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -321,7 +321,7 @@ func (b *fastStatBucket) GetFolder(
 		return entry, nil
 	}
 
-	// Fetch the listing.
+	// Fetch the Folder
 	return b.wrapped.GetFolder(ctx, prefix)
 }
 

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -359,7 +359,7 @@ func (m *mockBucket) GetFolder(
 		"GetFolder",
 		file,
 		line,
-		[]interface{}{})
+		[]interface{}{ctx, prefix})
 
 	if len(retVals) != 2 {
 		panic(fmt.Sprintf("mockBucket.GetFolder: invalid return values: %v", retVals))


### PR DESCRIPTION
### Description

- This PR adds implementation for get folder in fast stat bucket.
- Next PR will contain force fetch from gcs.
- Prioritised next work for hns over adding support testify for fast stat cache bucket tests as it contains mock implementation and test method renaming which would take more time and out of scope for this PR.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - NA
