### PR TITLE
Kernel cache list tests in list large directory e2e tests

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -92,7 +92,7 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFiles(objs, t)
 	firstListTime := endTime.Sub(startTime)
-	// List Directory second time, this time response should come through kernel cache.
+	// Listing the directory a second time should retrieve the response from the kernel cache.
 	startTime = time.Now()
 	objs, err = os.ReadDir(dirPath)
 	if err != nil {
@@ -102,7 +102,7 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 	validateDirectoryWithTwelveThousandFiles(objs, t)
 	secondListTime := endTime.Sub(startTime)
 
-	// Second time response will get fetch from kernel, so it will take less time to get response.
+	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
 
 	// Clear the data after testing.
@@ -156,7 +156,7 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFilesAndHundredExplicitDirectory(objs, t)
 	firstListTime := endTime.Sub(startTime)
-	// List Directory second time, this time response should come through kernel cache.
+	// Listing the directory a second time should retrieve the response from the kernel cache.
 	startTime = time.Now()
 	objs, err = os.ReadDir(dirPath)
 	if err != nil {
@@ -166,7 +166,7 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 	validateDirectoryWithTwelveThousandFilesAndHundredExplicitDirectory(objs, t)
 	secondListTime := endTime.Sub(startTime)
 
-	// Second time response will get fetch from kernel, so it will take less time to get response.
+	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
@@ -228,7 +228,7 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFilesHundredExplicitDirAndHundredImplicitDir(objs, t)
 	firstListTime := endTime.Sub(startTime)
-	// List Directory second time, this time response should come through kernel cache.
+	// Listing the directory a second time should retrieve the response from the kernel cache.
 	startTime = time.Now()
 	objs, err = os.ReadDir(dirPath)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 	validateDirectoryWithTwelveThousandFilesHundredExplicitDirAndHundredImplicitDir(objs, t)
 	secondListTime := endTime.Sub(startTime)
 
-	// Second time response will get fetch from kernel, so it will take less time to get response.
+	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -176,7 +176,8 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-
+	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
+	assert.Less(t, secondListTime, 100*time.Millisecond)
 	// Clear the data after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -211,6 +212,8 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
+	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
+	assert.Less(t, secondListTime, 100*time.Millisecond)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -247,6 +250,8 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
+	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
+	assert.Less(t, secondListTime, 100*time.Millisecond)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -30,37 +30,6 @@ import (
 // //////////////////////////////////////////////////////////////////////
 // Helpers
 // //////////////////////////////////////////////////////////////////////
-func checkIfObjNameIsCorrect(objName string, prefix string, maxNumber int, t *testing.T) {
-	// Extracting object number.
-	objNumberStr := strings.ReplaceAll(objName, prefix, "")
-	objNumber, err := strconv.Atoi(objNumberStr)
-	if err != nil {
-		t.Errorf("Error in extracting file number.")
-	}
-	if objNumber < 1 || objNumber > maxNumber {
-		t.Errorf("Correct object does not exist.")
-	}
-}
-
-func createTwelveThousandFilesAndUploadOnTestBucket(t *testing.T) {
-	// Creating twelve thousand files in DirectoryWithTwelveThousandFiles directory to upload them on a bucket for testing.
-	localDirPath := path.Join(os.Getenv("HOME"), DirectoryWithTwelveThousandFiles)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, PrefixFileInDirectoryWithTwelveThousandFiles, t)
-
-	// Uploading twelve thousand files to directoryWithTwelveThousandFiles in testBucket.
-	dirPath := path.Join(setup.TestBucket(), DirectoryForListLargeFileTests, DirectoryWithTwelveThousandFiles)
-	setup.RunScriptForTestData("testdata/upload_files_to_bucket.sh", dirPath, DirectoryWithTwelveThousandFiles, PrefixFileInDirectoryWithTwelveThousandFiles)
-}
-
-// Create a hundred explicit directories.
-func createHundredExplicitDir(dirPath string, t *testing.T) {
-	// Create hundred explicit directories.
-	for i := 1; i <= NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles; i++ {
-		subDirPath := path.Join(dirPath, PrefixExplicitDirInLargeDirListTest+strconv.Itoa(i))
-		operations.CreateDirectoryWithNFiles(0, subDirPath, "", t)
-	}
-}
-
 func validateDirectoryWithTwelveThousandFiles(objs []os.DirEntry, t *testing.T) {
 	// number of objs - 12000
 	if len(objs) != NumberOfFilesInDirectoryWithTwelveThousandFiles {
@@ -144,8 +113,39 @@ func validateDirectoryWithTwelveThousandFilesAndHundredExplicitDirectory(objs []
 	}
 }
 
+func checkIfObjNameIsCorrect(objName string, prefix string, maxNumber int, t *testing.T) {
+	// Extracting object number.
+	objNumberStr := strings.ReplaceAll(objName, prefix, "")
+	objNumber, err := strconv.Atoi(objNumberStr)
+	if err != nil {
+		t.Errorf("Error in extracting file number.")
+	}
+	if objNumber < 1 || objNumber > maxNumber {
+		t.Errorf("Correct object does not exist.")
+	}
+}
+
+func createTwelveThousandFilesAndUploadOnTestBucket(t *testing.T) {
+	// Creating twelve thousand files in DirectoryWithTwelveThousandFiles directory to upload them on a bucket for testing.
+	localDirPath := path.Join(os.Getenv("HOME"), DirectoryWithTwelveThousandFiles)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, PrefixFileInDirectoryWithTwelveThousandFiles, t)
+
+	// Uploading twelve thousand files to directoryWithTwelveThousandFiles in testBucket.
+	dirPath := path.Join(setup.TestBucket(), DirectoryForListLargeFileTests, DirectoryWithTwelveThousandFiles)
+	setup.RunScriptForTestData("testdata/upload_files_to_bucket.sh", dirPath, DirectoryWithTwelveThousandFiles, PrefixFileInDirectoryWithTwelveThousandFiles)
+}
+
+// Create a hundred explicit directories.
+func createHundredExplicitDir(dirPath string, t *testing.T) {
+	// Create hundred explicit directories.
+	for i := 1; i <= NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles; i++ {
+		subDirPath := path.Join(dirPath, PrefixExplicitDirInLargeDirListTest+strconv.Itoa(i))
+		operations.CreateDirectoryWithNFiles(0, subDirPath, "", t)
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////
-// Test Function (Runs once before all tests)
+// Tests
 ////////////////////////////////////////////////////////////////////////
 
 // Test with a bucket with twelve thousand files.

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -36,7 +36,7 @@ const NumberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0"}}
+	flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"}}
 	if !testing.Short() {
 		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0"})
 	}

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -63,7 +63,7 @@ TEST_DIR_PARALLEL=(
   "interrupt"
   "operations"
   "log_content"
-  "kernel_list_cache"
+  "kernel-list-cache"
 )
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL=(

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -244,7 +244,7 @@ sudo umount $MOUNT_DIR
 
 # package list_large_dir
 # Run tests with static mounting. (flags: --implicit-dirs)
-gcsfuse --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
+gcsfuse --implicit-dirs --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1 $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/list_large_dir/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -468,7 +468,7 @@ func MountGCSFuseWithGivenMountFunc(flags []string, mountFunc func([]string) err
 func UnmountGCSFuseAndDeleteLogFile(rootDir string) {
 	UnmountGCSFuse(rootDir)
 	// delete log file created
-	if *mountedDirectory != "" {
+	if *mountedDirectory == "" {
 		err := os.Remove(LogFile())
 		if err != nil {
 			LogAndExit(fmt.Sprintf("Error in deleting log file: %v", err))


### PR DESCRIPTION
### Description
1. Added the `--kernel-list-cache-ttl-secs=-1` flag to the "list_large_directory" end-to-end tests.
2. Since we are running the list operation twice, created a separate validator function for each test.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual 
Manually checked the list time for all the tests. Second list is much faster than first.
```
=== RUN   TestListDirectoryWithTwelveThousandFiles
2024/07/11 08:31:04 First List Time:  612.80212ms   Second List Time: 49.783908ms
--- PASS: TestListDirectoryWithTwelveThousandFiles (71.26s)
=== RUN   TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir
2024/07/11 08:32:28 First List Time: 687.169932ms   Second List Time: 51.786384ms
--- PASS: TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir (84.28s)
=== RUN   TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir
2024/07/11 08:36:42 First List Time: 690.750416ms   Second List Time: 52.545325ms
--- PASS: TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir (252.02s)
```
3. Unit tests - NA
4. Integration tests - Automated 
