### PR TITLE
Add kernel list cache tests to operations package

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -170,7 +170,7 @@ func TestMain(m *testing.M) {
 	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
 		{"--experimental-enable-json-read=true"},
-		{"--kernel-list-cache-ttl-secs=-1", "--implicit-dirs"},
+		{"--kernel-list-cache-ttl-secs -1", "--implicit-dirs"},
 	}
 
 	// gRPC tests will not run in TPC environment

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -169,7 +169,9 @@ func TestMain(m *testing.M) {
 	// Note: We are not testing specifically for implicit-dirs because they are covered as part of the other flags.
 	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
-		{"--experimental-enable-json-read=true", "--implicit-dirs=true"}}
+		{"--experimental-enable-json-read=true"},
+		{"--kernel-list-cache-ttl-secs=-1", "--implicit-dirs"},
+	}
 
 	// gRPC tests will not run in TPC environment
 	if !testing.Short() && !setup.TestOnTPCEndPoint() {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 	// Note: We are not testing specifically for implicit-dirs because they are covered as part of the other flags.
 	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
-		{"--experimental-enable-json-read=true"},
+		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
 	}
 
 	// gRPC tests will not run in TPC environment

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -148,7 +148,7 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 		},
 	}
 	filePath4 := setup.YAMLConfigFile(mountConfig4, "config4.yaml")
-	flags = append(flags, []string{"--config-file=" + filePath4})
+	flags = append(flags, []string{"--config-file=" + filePath4, "--implicit-dirs=true"})
 	return flags
 }
 
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 	// Note: We are not testing specifically for implicit-dirs because they are covered as part of the other flags.
 	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
-		{"--experimental-enable-json-read=true", "--implicit-dirs=true"},
+		{"--experimental-enable-json-read=true"},
 	}
 
 	// gRPC tests will not run in TPC environment

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -137,6 +137,18 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	filePath3 := setup.YAMLConfigFile(mountConfig3, "config3.yaml")
 	flags = append(flags, []string{"--config-file=" + filePath3})
 
+	mountConfig4 := config.MountConfig{
+		// Run with metadata caches disabled.
+		FileSystemConfig: config.FileSystemConfig{
+			KernelListCacheTtlSeconds: -1,
+		},
+		LogConfig: config.LogConfig{
+			Severity:        config.TRACE,
+			LogRotateConfig: config.DefaultLogRotateConfig(),
+		},
+	}
+	filePath4 := setup.YAMLConfigFile(mountConfig4, "config4.yaml")
+	flags = append(flags, []string{"--config-file=" + filePath4})
 	return flags
 }
 
@@ -170,7 +182,6 @@ func TestMain(m *testing.M) {
 	flagsSet := [][]string{
 		// By default, creating emptyFile is disabled.
 		{"--experimental-enable-json-read=true"},
-		{"--kernel-list-cache-ttl-secs -1", "--implicit-dirs"},
 	}
 
 	// gRPC tests will not run in TPC environment

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -44,8 +44,13 @@ mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o implicit_dirs=false
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
 
-# Run test with static mounting. (flags: --experimental-enable-json-read --implicit-dirs=true)
-gcsfuse --experimental-enable-json-read --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR
+# Run test with static mounting. (flags: --experimental-enable-json-read)
+gcsfuse --experimental-enable-json-read $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Run test with static mounting. (flags: --kernel-list-cache-ttl-secs=-1, --implicit-dirs=true)
+gcsfuse --kernel-list-cache-ttl-secs=-1 --implicit-dirs $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
 
@@ -74,8 +79,13 @@ mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o only_dir=testDir,implicit_dirs=fal
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 
-# Run tests with static mounting. (flags: --experimental-enable-json-read, --implicit-dirs=true, --only-dir testDir)
-gcsfuse --experimental-enable-json-read --only-dir testDir --implicit-dirs=true $TEST_BUCKET_NAME $MOUNT_DIR
+# Run tests with only-dir mounting. (flags: --experimental-enable-json-read, --only-dir testDir)
+gcsfuse --experimental-enable-json-read --only-dir testDir $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
+sudo umount $MOUNT_DIR
+
+# Run tests with only-dir mounting. (flags: --kernel-list-cache-ttl-secs=-1, --implicit-dirs=true, --only-dir testDir)
+gcsfuse --kernel-list-cache-ttl-secs=-1 --implicit-dirs --only-dir testDir $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME/testDir
 sudo umount $MOUNT_DIR
 


### PR DESCRIPTION
### Description
Add kernel list cache tests to operations package

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
