### PR TITLE
Add setup for kernel list cache E2E tests

### DIFF
--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_list_cache
+
+import (
+	"log"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type disabledKernelListCacheTest struct {
+	flags []string
+}
+
+func (s *disabledKernelListCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
+}
+
+func (s *disabledKernelListCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+// TODO: Add test scenarios here.
+func (s *disabledKernelListCacheTest) TestMock(t *testing.T) {
+	t.Log("running mock test")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestDisabledKernelListCacheTest(t *testing.T) {
+	ts := &disabledKernelListCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--kernel-list-cache-ttl-secs=0"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_list_cache
+
+import (
+	"log"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type finiteKernelListCacheTest struct {
+	flags []string
+}
+
+func (s *finiteKernelListCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
+}
+
+func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+// TODO: Add test scenarios here.
+func (s *finiteKernelListCacheTest) TestMock(t *testing.T) {
+	t.Log("running mock test")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestFiniteKernelListCacheTest(t *testing.T) {
+	ts := &finiteKernelListCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--kernel-list-cache-ttl-secs=5"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_list_cache
+
+import (
+	"log"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type infiniteKernelListCacheTest struct {
+	flags []string
+}
+
+func (s *infiniteKernelListCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
+}
+
+func (s *infiniteKernelListCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+// TODO: Add test scenarios here.
+func (s *infiniteKernelListCacheTest) TestMock(t *testing.T) {
+	t.Log("running mock test")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestInfiniteKernelListCacheTest(t *testing.T) {
+	ts := &infiniteKernelListCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--kernel-list-cache-ttl-secs=-1"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/kernel-list-cache/setup_test.go
+++ b/tools/integration_tests/kernel-list-cache/setup_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_list_cache
+
+import (
+	"context"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName    = "KernelListCacheTest"
+	onlyDirMounted = "OnlyDirMountKernelListCache"
+)
+
+var (
+	testDirPath string
+	mountFunc   func([]string) error
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir       string
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client, testDirName string) {
+	// When tests are running in GKE environment, use the mounted directory provided as test flag.
+	if setup.MountedDirectory() != "" {
+		mountDir = setup.MountedDirectory()
+	}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	setup.SetMntDir(mountDir)
+	testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+}
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	// Create common storage client to be used in test.
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithTimeOut(&ctx, &storageClient, time.Minute*15)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// If Mounted Directory flag is set, run tests for mounted directory.
+	setup.RunTestsForMountedDirectoryFlag(m)
+	// Else run tests for testBucket.
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	// Save mount and root directory variables.
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+
+	if successCode == 0 {
+		log.Println("Running dynamic mounting tests...")
+		// Save mount directory variable to have path of bucket to run tests.
+		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		successCode = m.Run()
+	}
+
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(onlyDirMounted + "/")
+		mountDir = rootDir
+		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		successCode = m.Run()
+		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+	}
+
+	// Clean up test directory created.
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -63,6 +63,7 @@ TEST_DIR_PARALLEL=(
   "interrupt"
   "operations"
   "log_content"
+  "kernel_list_cache"
 )
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL=(

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -466,17 +466,23 @@ func MountGCSFuseWithGivenMountFunc(flags []string, mountFunc func([]string) err
 }
 
 func UnmountGCSFuseAndDeleteLogFile(rootDir string) {
+	UnmountGCSFuse(rootDir)
+	// delete log file created
+	if *mountedDirectory != "" {
+		err := os.Remove(LogFile())
+		if err != nil {
+			LogAndExit(fmt.Sprintf("Error in deleting log file: %v", err))
+		}
+	}
+}
+
+func UnmountGCSFuse(rootDir string) {
 	SetMntDir(rootDir)
 	if *mountedDirectory == "" {
 		// Unmount GCSFuse only when tests are not running on mounted directory.
 		err := UnMount()
 		if err != nil {
 			LogAndExit(fmt.Sprintf("Error in unmounting bucket: %v", err))
-		}
-		// delete log file created
-		err = os.Remove(LogFile())
-		if err != nil {
-			LogAndExit(fmt.Sprintf("Error in deleting log file: %v", err))
 		}
 	}
 }


### PR DESCRIPTION
### Description
Add setup for kernel list cache E2E tests

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
