### PR TITLE
Functional test for kernel-cache-ttl=0

### DIFF
--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -70,10 +70,7 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir", "file3.txt"), "")
-	if err != nil {
-		t.Errorf("Failed to create test directory: %v", err)
-	}
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	// Zero ttl, means readdir will always be served from gcsfuse.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
@@ -69,8 +70,10 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	f3 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file3.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f3)
+	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirPath, "explicit_dir", "file3.txt"), "")
+	if err != nil {
+		t.Errorf("Failed to create test directory: %v", err)
+	}
 
 	// Zero ttl, means readdir will always be served from gcsfuse.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -49,15 +49,15 @@ func (s *disabledKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *testing.T) {
-	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
+	operations.CreateDirectory(targetDir, t)
 	// Create test data
-	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
+	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
+	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
-	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err := os.Open(targetDir)
 	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
@@ -73,7 +73,7 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	// Zero ttl, means readdir will always be served from gcsfuse.
-	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err = os.Open(targetDir)
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 	assert.NoError(t, err)

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -58,26 +58,26 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
 	}()
 	names1, err := f.Readdirnames(-1)
 	assert.Nil(t, err)
 	require.Equal(t, 2, len(names1))
-	assert.Equal(t, "file1.txt", names1[0])
-	assert.Equal(t, "file2.txt", names1[1])
+	require.Equal(t, "file1.txt", names1[0])
+	require.Equal(t, "file2.txt", names1[1])
 	err = f.Close()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	// Zero ttl, means readdir will always be served from gcsfuse.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Equal(t, 3, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -70,7 +70,7 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirPath, "explicit_dir", "file3.txt"), "")
+	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir", "file3.txt"), "")
 	if err != nil {
 		t.Errorf("Failed to create test directory: %v", err)
 	}

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -49,6 +49,7 @@ func (s *disabledKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -47,14 +47,13 @@ func (s *disabledKernelListCacheTest) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-// TODO: Add test scenarios here.
 func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *testing.T) {
-	operations.CreateDirectory(path.Join(testDirPath, "explicitDir"), t)
+	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
 	// Adding one object to make sure to change the ReadDir() response.
-	f1 := operations.CreateFile(path.Join(testDirPath, "explicitDir", "file1.txt"), setup.FilePermission_0600, t)
+	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f1)
 	// Adding one object to make sure to change the ReadDir() response.
-	f2 := operations.CreateFile(path.Join(testDirPath, "explicitDir", "file2.txt"), setup.FilePermission_0600, t)
+	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
@@ -71,11 +70,11 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	f3 := operations.CreateFile(path.Join(testDirPath, "explicitDir", "file3.txt"), setup.FilePermission_0600, t)
+	f3 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file3.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f3)
 
 	// Zero ttl, means readdir will always be served from gcsfuse.
-	f, err = os.Open(path.Join(testDirPath, "explicitDir"))
+	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.Nil(t, err)
 	names2, err := f.Readdirnames(-1)
 

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -76,8 +76,8 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
-
 	assert.NoError(t, err)
+
 	require.Equal(t, 3, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -52,9 +52,9 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f1)
+	operations.CloseFile(f1)
 	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f2)
+	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))

--- a/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/disabled_kernel_list_cache_test.go
@@ -49,10 +49,9 @@ func (s *disabledKernelListCacheTest) Teardown(t *testing.T) {
 
 func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *testing.T) {
 	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
-	// Adding one object to make sure to change the ReadDir() response.
+	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f1)
-	// Adding one object to make sure to change the ReadDir() response.
 	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f2)
 

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -26,6 +26,10 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
+var (
+	targetDir string
+)
+
 type finiteKernelListCacheTest struct {
 	flags []string
 }

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -26,10 +26,6 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
-var (
-	targetDir string
-)
-
 type finiteKernelListCacheTest struct {
 	flags []string
 }


### PR DESCRIPTION
### Description
- Functional test for kernel-cache-ttl=0 
(a) First ReadDir() will be served from GCSFuse filesystem.
(b) Second ReadDir() will also be served from GCSFuse filesystem.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
