### PR TITLE
Functional test infinite kernel cache ttl - 1

### DIFF
--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -72,8 +72,8 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	// Adding one object to make sure to change the ReadDir() response.
 	f3 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file3.txt"), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f3)
-	// Advancing time by 5 years (157800000 seconds).
-	time.Sleep(157800000 * time.Second)
+
+	time.Sleep(5 * time.Second)
 
 	// No invalidation since infinite ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -50,15 +50,16 @@ func (s *infiniteKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testing.T) {
-	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	operations.CreateDirectory(targetDir, t)
 	// Create test data
-	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
+	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
+	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
-	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err := os.Open(targetDir)
 	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
@@ -77,7 +78,7 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	time.Sleep(5 * time.Second)
 
 	// Kernel cache will not invalidate since infinite ttl.
-	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err = os.Open(targetDir)
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 	assert.NoError(t, err)

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
@@ -70,8 +71,10 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	f3 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file3.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f3)
+	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirPath, "explicit_dir", "file3.txt"), "")
+	if err != nil {
+		log.Printf("Failed to create test directory: %v", err)
+	}
 
 	time.Sleep(5 * time.Second)
 

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -70,11 +70,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	assert.Equal(t, "file2.txt", names1[1])
 	err = f.Close()
 	assert.Nil(t, err)
+
 	// Adding one object to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir", "file3.txt"), "")
-	if err != nil {
-		t.Errorf("Failed to create test directory: %v", err)
-	}
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	// Waiting for 5 seconds to see if the kernel cache expires.
 	time.Sleep(5 * time.Second)

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -73,9 +73,10 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	// Adding one object to make sure to change the ReadDir() response.
 	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirPath, "explicit_dir", "file3.txt"), "")
 	if err != nil {
-		log.Printf("Failed to create test directory: %v", err)
+		t.Errorf("Failed to create test directory: %v", err)
 	}
 
+	// Waiting for 5 seconds to see if the kernel cache expires.
 	time.Sleep(5 * time.Second)
 
 	// No invalidation since infinite ttl.

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -53,9 +53,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f1)
+	operations.CloseFile(f1)
 	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f2)
+	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -59,17 +59,17 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
 	}()
 	names1, err := f.Readdirnames(-1)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(names1))
-	assert.Equal(t, "file1.txt", names1[0])
-	assert.Equal(t, "file2.txt", names1[1])
+	require.Equal(t, "file1.txt", names1[0])
+	require.Equal(t, "file2.txt", names1[1])
 	err = f.Close()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
@@ -79,10 +79,10 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 
 	// No invalidation since infinite ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Equal(t, 2, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -75,8 +75,8 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 	// Waiting for 5 seconds to see if the kernel cache expires.
 	time.Sleep(5 * time.Second)
-	
-	// No invalidation since infinite ttl.
+
+	// Kernel cache will not invalidate since infinite ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -71,7 +71,7 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirPath, "explicit_dir", "file3.txt"), "")
+	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir", "file3.txt"), "")
 	if err != nil {
 		t.Errorf("Failed to create test directory: %v", err)
 	}

--- a/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/infinite_kernel_list_cache_test.go
@@ -73,16 +73,15 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-
 	// Waiting for 5 seconds to see if the kernel cache expires.
 	time.Sleep(5 * time.Second)
-
+	
 	// No invalidation since infinite ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
-
 	assert.NoError(t, err)
+
 	require.Equal(t, 2, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])


### PR DESCRIPTION
### Description
Functional test for kernel-cache-ttl=-1
(a) First ReadDir() will be served from GCSFuse filesystem.
(b) Second ReadDir() will also be served from Kernel cache.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
