### PR TITLE
Functional test with finite kernel cache ttl

### DIFF
--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -33,6 +33,10 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
+var (
+	targetDir string
+)
+
 type finiteKernelListCacheTest struct {
 	flags []string
 }

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -88,7 +88,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.Nil(t, err)

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -74,7 +74,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 	time.Sleep(2 * time.Second)
 
-	// Kernel cache will not invalidate since infinite ttl.
+	// Kernel cache will not invalidate within ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -57,9 +57,9 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
-	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
+	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
+	f2 := operations.CreateFile(path.Join(targetDir, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -59,28 +59,28 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
 	}()
 	names1, err := f.Readdirnames(-1)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(names1))
-	assert.Equal(t, "file1.txt", names1[0])
-	assert.Equal(t, "file2.txt", names1[1])
+	require.Equal(t, "file1.txt", names1[0])
+	require.Equal(t, "file2.txt", names1[1])
 	err = f.Close()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	time.Sleep(2 * time.Second)
 
-	// No invalidation since infinite ttl.
+	// Kernel cache will not invalidate since infinite ttl.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Equal(t, 2, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])
@@ -90,12 +90,10 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 
 	// The response will be served from GCSFuse after the TTL expires.
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	names3, err := f.Readdirnames(-1)
-
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	require.Equal(t, 3, len(names3))
-
 	assert.Equal(t, "file1.txt", names3[0])
 	assert.Equal(t, "file2.txt", names3[1])
 	assert.Equal(t, "file3.txt", names3[2])

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -73,7 +73,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	// Adding one object to make sure to change the ReadDir() response.
 	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join("KernelListCacheTest", "explicit_dir", "file3.txt"), "")
 	if err != nil {
-		t.Fatalf("Failed to create test directory: %v", err)
+		t.Errorf("Failed to create test directory: %v", err)
 	}
 
 	time.Sleep(2 * time.Second)

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -71,10 +71,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	err = f.Close()
 	assert.Nil(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join("KernelListCacheTest", "explicit_dir", "file3.txt"), "")
-	if err != nil {
-		t.Errorf("Failed to create test directory: %v", err)
-	}
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
 
 	time.Sleep(2 * time.Second)
 

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -72,7 +72,6 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	require.NoError(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-
 	time.Sleep(2 * time.Second)
 
 	// Kernel cache will not invalidate since infinite ttl.
@@ -84,7 +83,6 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	require.Equal(t, 2, len(names2))
 	assert.Equal(t, "file1.txt", names2[0])
 	assert.Equal(t, "file2.txt", names2[1])
-
 	// Waiting 3 more seconds to exceed the 5-second TTL for invalidating the kernel cache.
 	time.Sleep(3 * time.Second)
 
@@ -93,6 +91,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	assert.NoError(t, err)
 	names3, err := f.Readdirnames(-1)
 	assert.NoError(t, err)
+
 	require.Equal(t, 3, len(names3))
 	assert.Equal(t, "file1.txt", names3[0])
 	assert.Equal(t, "file2.txt", names3[1])

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -49,7 +49,7 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testing.T) {
+func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
 	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -96,9 +96,9 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 
 	assert.Nil(t, err)
 	require.Equal(t, 3, len(names3))
-	assert.Equal(t, "file1.txt", names2[0])
-	assert.Equal(t, "file2.txt", names2[1])
-	assert.Equal(t, "file3.txt", names2[1])
+	assert.Equal(t, "file1.txt", names3[0])
+	assert.Equal(t, "file2.txt", names3[1])
+	assert.Equal(t, "file3.txt", names3[1])
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -33,17 +33,12 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
-var (
-	targetDir string
-)
-
 type finiteKernelListCacheTest struct {
 	flags []string
 }
 
 func (s *finiteKernelListCacheTest) Setup(t *testing.T) {
 	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
-	targetDir = path.Join(testDirPath, "explicit_dir")
 }
 
 func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
@@ -55,11 +50,12 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(targetDir, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
+	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -53,9 +53,9 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f1)
+	operations.CloseFile(f1)
 	f2 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file2.txt"), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f2)
+	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
@@ -82,6 +82,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.Nil(t, err)
 	names2, err := f.Readdirnames(-1)
+	f.Close()
 
 	assert.Nil(t, err)
 	require.Equal(t, 2, len(names2))
@@ -93,12 +94,13 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *testin
 	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
 	assert.Nil(t, err)
 	names3, err := f.Readdirnames(-1)
+	f.Close()
 
 	assert.Nil(t, err)
 	require.Equal(t, 3, len(names3))
 	assert.Equal(t, "file1.txt", names3[0])
 	assert.Equal(t, "file2.txt", names3[1])
-	assert.Equal(t, "file3.txt", names3[1])
+	assert.Equal(t, "file3.txt", names3[2])
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel-list-cache/finite_kernel_list_cache_test.go
@@ -39,6 +39,7 @@ type finiteKernelListCacheTest struct {
 
 func (s *finiteKernelListCacheTest) Setup(t *testing.T) {
 	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
+	targetDir = path.Join(testDirPath, "explicit_dir")
 }
 
 func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
@@ -50,7 +51,7 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
-	operations.CreateDirectory(path.Join(testDirPath, "explicit_dir"), t)
+	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(testDirPath, "explicit_dir", "file1.txt"), setup.FilePermission_0600, t)
 	operations.CloseFile(f1)
@@ -58,7 +59,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	operations.CloseFile(f2)
 
 	// First read, kernel will cache the dir response.
-	f, err := os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err := os.Open(targetDir)
 	require.NoError(t, err)
 	defer func() {
 		assert.Nil(t, f.Close())
@@ -75,7 +76,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	time.Sleep(2 * time.Second)
 
 	// Kernel cache will not invalidate within ttl.
-	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err = os.Open(targetDir)
 	assert.NoError(t, err)
 	names2, err := f.Readdirnames(-1)
 
@@ -87,7 +88,7 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	time.Sleep(3 * time.Second)
 
 	// The response will be served from GCSFuse after the TTL expires.
-	f, err = os.Open(path.Join(testDirPath, "explicit_dir"))
+	f, err = os.Open(targetDir)
 	assert.NoError(t, err)
 	names3, err := f.Readdirnames(-1)
 	assert.NoError(t, err)

--- a/tools/integration_tests/kernel-list-cache/setup_test.go
+++ b/tools/integration_tests/kernel-list-cache/setup_test.go
@@ -37,6 +37,7 @@ const (
 
 var (
 	testDirPath string
+	targetDir   string
 	mountFunc   func([]string) error
 	// mount directory is where our tests run.
 	mountDir string

--- a/tools/integration_tests/kernel-list-cache/setup_test.go
+++ b/tools/integration_tests/kernel-list-cache/setup_test.go
@@ -37,7 +37,6 @@ const (
 
 var (
 	testDirPath string
-	targetDir   string
 	mountFunc   func([]string) error
 	// mount directory is where our tests run.
 	mountDir string


### PR DESCRIPTION
### Description
Functional test with  kernel cache ttl 5s
1. Within TTL it will be cache hit and server from kernel cache.
2. Above TTL , response will be serve from GCSFuse.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - Automated
