### PR TITLE
Adding e2e test for kernel-list-cache concurrency test 

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -15,10 +15,18 @@
 package concurrent_operations
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -33,20 +41,363 @@ func (s *concurrentListingTest) Setup(t *testing.T) {
 
 func (s *concurrentListingTest) Teardown(t *testing.T) {}
 
+// Create initial directory structure for kernel-list-cache test.
+// bucket
+//
+//		file1.txt
+//		file2.txt
+//	 explicitDir/
+//		explicitDir/file1.txt
+//		explicitDir/file2.txt
+func createDirectoryStructure(t *testing.T) {
+	// Create explicitDir structure
+	explicitDir := path.Join(testDirPath, "explicitDir")
+	operations.CreateDirectory(explicitDir, t)
+	operations.CreateFileOfSize(5, path.Join(explicitDir, "file1.txt"), t)
+	operations.CreateFileOfSize(10, path.Join(explicitDir, "file2.txt"), t)
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-// TODO: Add test scenarios here.
-func (s *concurrentListingTest) TestMock1(t *testing.T) {
-	t.Log("running mock test 1")
+// Test_OpenDirAndLookUp helps in detecting the deadlock when
+// OpenDir() and LookUpInode() request for same directory comes in parallel.
+func (s *concurrentListingTest) Test_OpenDirAndLookUp(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Fail if the operation takes more than timeout.
+	timeout := 5 * time.Second
+	iterationsPerGoroutine := 100
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			f, err := os.Open(path.Join(testDirPath, "explicitDir"))
+			assert.Nil(t, err)
+
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			_, err := os.Stat(path.Join(testDirPath, "explicitDir"))
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Wait for goroutines or timeout.
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+	select {
+	case <-done:
+		// Operation completed successfully before timeout.
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock")
+	}
+}
+
+// Test_Parallel_ReadDirAndDirOperations tests for potential deadlocks or race conditions when
+// ReadDir() is called concurrently with directory creation and deletion operations.
+func (s *concurrentListingTest) Test_Parallel_ReadDirAndLookUp(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	timeout := 200 * time.Second
+	iterationsPerGoroutine := 40
+
+	parentDir := path.Join(testDirPath, "explicitDir")
+
+	// Goroutine 1: Repeatedly calls Readdir
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			f, err := os.Open(parentDir)
+			assert.Nil(t, err)
+
+			_, err = f.Readdirnames(0)
+			assert.Nil(t, err)
+
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Goroutine 2: Creates and deletes directories
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			_, err := os.Stat(path.Join(testDirPath, "explicitDir"))
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Wait for goroutines or timeout
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success: Both operations finished before timeout
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock or race condition detected during Readdir and directory operations")
+	}
+}
+
+// Test_Concurrent_ReadDir tests for potential deadlocks or race conditions
+// when multiple goroutines call Readdir() concurrently on the same directory.
+func (s *concurrentListingTest) Test_ReadDir(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	goroutineCount := 10          // Number of concurrent goroutines
+	iterationsPerGoroutine := 100 // Number of iterations per goroutine
+
+	wg.Add(goroutineCount)
+	timeout := 50 * time.Second
+
+	dirPath := path.Join(testDirPath, "explicitDir")
+
+	for i := 0; i < goroutineCount; i++ {
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < iterationsPerGoroutine; j++ {
+				f, err := os.Open(dirPath)
+				assert.Nil(t, err)
+
+				_, err = f.Readdirnames(-1) // Read all directory entries
+				assert.Nil(t, err)
+
+				err = f.Close()
+				assert.Nil(t, err)
+			}
+		}()
+	}
+
+	// Wait for goroutines or timeout
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success: All Readdir operations finished before timeout
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock or race condition detected during concurrent Readdir calls")
+	}
+}
+
+// Test_Parallel_ReadDirAndFileOperations detects race conditions and deadlocks when one goroutine
+// performs Readdir() while another concurrently creates and deletes files in the same directory.
+func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileOperations(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	timeout := 200 * time.Second // Adjust timeout as needed
+	iterationsPerGoroutine := 40
+
+	dirPath := path.Join(testDirPath, "explicitDir")
+
+	// Goroutine 1: Repeatedly calls Readdir
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ { // Adjust iteration count if needed
+			f, err := os.Open(dirPath)
+			assert.Nil(t, err)
+
+			_, err = f.Readdirnames(-1)
+			if err != nil {
+				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
+				assert.True(t, strings.Contains(err.Error(), "input/output error"))
+			}
+
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Goroutine 2: Creates and deletes files
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ { // Adjust iteration count if needed
+			filePath := path.Join(dirPath, "tmp_file.txt")
+			renamedFilePath := path.Join(dirPath, "renamed_tmp_file.txt")
+
+			// Create
+			f, err := os.Create(filePath)
+			assert.Nil(t, err)
+
+			err = f.Close()
+			assert.Nil(t, err)
+
+			// Rename
+			err = os.Rename(filePath, renamedFilePath)
+			assert.Nil(t, err)
+
+			// Delete
+			err = os.Remove(renamedFilePath)
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Wait for goroutines or timeout
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success: Both operations finished before timeout
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock or race condition detected")
+	}
+}
+
+// Test_Parallel_ReadDirAndDirOperations tests for potential deadlocks or race conditions when
+// ReadDir() is called concurrently with directory creation and deletion operations.
+func (s *concurrentListingTest) Test_Parallel_ReadDirAndDirOperations(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	timeout := 200 * time.Second
+	iterationsPerGoroutine := 40
+
+	parentDir := path.Join(testDirPath, "explicitDir")
+
+	// Goroutine 1: Repeatedly calls Readdir
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			f, err := os.Open(parentDir)
+			assert.Nil(t, err)
+
+			_, err = f.Readdirnames(0)
+			assert.Nil(t, err)
+
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Goroutine 2: Creates and deletes directories
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			dirPath := path.Join(parentDir, "test_dir")
+			renamedDirPath := path.Join(parentDir, "renamed_test_dir")
+
+			// Create
+			err := os.Mkdir(dirPath, 0755)
+			assert.Nil(t, err)
+
+			// Rename
+			err = os.Rename(dirPath, renamedDirPath)
+			assert.Nil(t, err)
+
+			// Delete
+			err = os.Remove(renamedDirPath)
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Wait for goroutines or timeout
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success: Both operations finished before timeout
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock or race condition detected during Readdir and directory operations")
+	}
+}
+
+func (s *concurrentListingTest) Test_Parallel_ListDirAndFileEdit(t *testing.T) {
+	createDirectoryStructure(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	timeout := 200 * time.Second
+	iterationsPerGoroutine := 40
+
+	parentDir := path.Join(testDirPath, "explicitDir")
+
+	// Goroutine 1: Repeatedly calls Readdir
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			f, err := os.Open(parentDir)
+			assert.Nil(t, err)
+
+			_, err = f.Readdirnames(0)
+			assert.Nil(t, err)
+
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Goroutine 2: Create and edit files
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterationsPerGoroutine; i++ {
+			filePath := path.Join(parentDir, fmt.Sprintf("test_file_%d.txt", i))
+
+			// Create file
+			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
+			assert.Nil(t, err)
+
+			// Edit file (append some data)
+			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, setup.FilePermission_0600)
+			assert.Nil(t, err)
+			_, err = f.Write([]byte(" This is an edit."))
+			assert.Nil(t, err)
+			err = f.Close()
+			assert.Nil(t, err)
+		}
+	}()
+
+	// Wait for goroutines or timeout
+	done := make(chan bool, 1)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success: Both operations finished before timeout
+	case <-time.After(timeout):
+		assert.FailNow(t, "Possible deadlock or race condition detected during Readdir and directory operations")
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestInfiniteKernelListCacheTest(t *testing.T) {
+func TestConcurrentListing(t *testing.T) {
 	ts := &concurrentListingTest{}
 	test_setup.RunTests(t, ts)
 }

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -483,7 +483,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 	// Goroutine 4: Repeatedly stats
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterationsForMediumOperations; i++ {
+		for i := 0; i < iterationsForLightOperations; i++ {
 			_, err := os.Stat(targetDir)
 			assert.Nil(t, err)
 		}

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
@@ -69,10 +68,6 @@ func TestMain(m *testing.M) {
 
 	if successCode == 0 {
 		successCode = only_dir_mounting.RunTests(flagsSet, onlyDirMounted, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flagsSet, m)
 	}
 
 	if successCode == 0 {

--- a/tools/integration_tests/kernel-list-cache/setup_test.go
+++ b/tools/integration_tests/kernel-list-cache/setup_test.go
@@ -24,6 +24,8 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
@@ -89,22 +91,22 @@ func TestMain(m *testing.M) {
 	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
 	successCode := m.Run()
 
-	//if successCode == 0 {
-	//	log.Println("Running dynamic mounting tests...")
-	//	// Save mount directory variable to have path of bucket to run tests.
-	//	mountDir = path.Join(setup.MntDir(), setup.TestBucket())
-	//	mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
-	//	successCode = m.Run()
-	//}
-	//
-	//if successCode == 0 {
-	//	log.Println("Running only dir mounting tests...")
-	//	setup.SetOnlyDirMounted(onlyDirMounted + "/")
-	//	mountDir = rootDir
-	//	mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
-	//	successCode = m.Run()
-	//	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
-	//}
+	if successCode == 0 {
+		log.Println("Running dynamic mounting tests...")
+		// Save mount directory variable to have path of bucket to run tests.
+		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		successCode = m.Run()
+	}
+
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(onlyDirMounted + "/")
+		mountDir = rootDir
+		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		successCode = m.Run()
+		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+	}
 
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/kernel-list-cache/setup_test.go
+++ b/tools/integration_tests/kernel-list-cache/setup_test.go
@@ -24,8 +24,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
@@ -91,22 +89,22 @@ func TestMain(m *testing.M) {
 	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
 	successCode := m.Run()
 
-	if successCode == 0 {
-		log.Println("Running dynamic mounting tests...")
-		// Save mount directory variable to have path of bucket to run tests.
-		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
-		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
-		successCode = m.Run()
-	}
-
-	if successCode == 0 {
-		log.Println("Running only dir mounting tests...")
-		setup.SetOnlyDirMounted(onlyDirMounted + "/")
-		mountDir = rootDir
-		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
-		successCode = m.Run()
-		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
-	}
+	//if successCode == 0 {
+	//	log.Println("Running dynamic mounting tests...")
+	//	// Save mount directory variable to have path of bucket to run tests.
+	//	mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+	//	mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+	//	successCode = m.Run()
+	//}
+	//
+	//if successCode == 0 {
+	//	log.Println("Running only dir mounting tests...")
+	//	setup.SetOnlyDirMounted(onlyDirMounted + "/")
+	//	mountDir = rootDir
+	//	mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+	//	successCode = m.Run()
+	//	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+	//}
 
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -64,6 +64,7 @@ TEST_DIR_PARALLEL=(
   "operations"
   "log_content"
   "kernel-list-cache"
+  "concurrent_operations"
 )
 # These tests never become parallel as it is changing bucket permissions.
 TEST_DIR_NON_PARALLEL=(


### PR DESCRIPTION
### Description
**Test case added**
(a) Added test for parellel OpenDir and LookUp concurrently.
(b) Added test for parallel ReadDir and LookUp concurrently.
(c) Added test for parallel ReadDir by 10 go routines.
(d) Added test for concurrent ReadDir and delete/create/rename on file underneath.
(e) Added test for concurrent ReadDir and delete/create/rename folder underneath.
(f) Added test for concurrent ReadDir and FileEdit underneath.
(g) Added a kitchen task to run multiple operations concurrently.

**Parallelize the test within test-suite**
Test time got  reduced from 300s to 170s (on n2-std-96 vm). Ref: https://stackoverflow.com/questions/24375966/does-go-test-run-unit-tests-concurrently

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested on n2-std-96 vm.
2. Unit tests - NA
3. Integration tests - NA
