### PR TITLE
adds hns check in dir.go

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -272,6 +272,7 @@ func makeRootForBucket(
 		fs.mtimeClock,
 		fs.cacheClock,
 		fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB,
+		fs.mountConfig.EnableHNS,
 	)
 }
 
@@ -725,7 +726,9 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			ic.Bucket,
 			fs.mtimeClock,
 			fs.cacheClock,
-			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB)
+			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB,
+			fs.mountConfig.EnableHNS,
+		)
 
 	case inode.IsSymlink(ic.MinObject):
 		in = inode.NewSymlinkInode(

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -79,7 +79,8 @@ func (t *DirHandleTest) resetDirHandle() {
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		0)
+		0,
+		false)
 
 	t.dh = NewDirHandle(
 		dirInode,

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -118,7 +118,9 @@ func (t *DirTest) resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistent
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		typeCacheMaxSizeMB)
+		typeCacheMaxSizeMB,
+		false,
+	)
 
 	d := t.in.(*dirInode)
 	AssertNe(nil, d)

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -56,7 +56,8 @@ func NewExplicitDirInode(
 		bucket,
 		mtimeClock,
 		cacheClock,
-		typeCacheMaxSizeMB)
+		typeCacheMaxSizeMB,
+		false)
 
 	d = &explicitDirInode{
 		dirInode: wrapped.(*dirInode),


### PR DESCRIPTION
### Description

- This PR adds a parameter for HNS enable check in dir inode and its creation method.
- This is first PR for changes needed for implicit-dirs check in HNS, more changes will be in subsequent PRs.


### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - NA
