### PR TITLE
[bug fix] Kernel list cache remove directory operation fails when files are created on GCS 

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1832,9 +1832,12 @@ func (fs *fileSystem) RmDir(
 			err = fmt.Errorf("ReadEntries: %w", err)
 			return err
 		}
-		//Clear kernel list cache after removing a directory. This ensures remote
-		//GCS files are included in future directory listings for unlinking.
-		childDir.InvalidateKernelListCache()
+
+		if fs.kernelListCacheTTL > 0 {
+			// Clear kernel list cache after removing a directory. This ensures remote
+			// GCS files are included in future directory listings for unlinking.
+			childDir.InvalidateKernelListCache()
+		}
 
 		// Are there any entries?
 		if len(entries) != 0 {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1832,6 +1832,9 @@ func (fs *fileSystem) RmDir(
 			err = fmt.Errorf("ReadEntries: %w", err)
 			return err
 		}
+		//Clear kernel list cache after removing a directory. This ensures remote
+		//GCS files are included in future directory listings for unlinking.
+		childDir.InvalidateKernelListCache()
 
 		// Are there any entries?
 		if len(entries) != 0 {

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -243,6 +243,11 @@ func (d *baseDirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	return true
 }
 
+func (d *baseDirInode) InvalidateKernelListCache() {
+	// Kernel list cache is not supported for baseDirInode.
+	return
+}
+
 func (d *baseDirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (op *gcs.Folder, err error) {
 	err = fuse.ENOSYS
 	return

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -243,7 +243,7 @@ func (d *baseDirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	return true
 }
 
-// Kernel list cache is not supported for baseDirInode.
+// List operation is not supported for baseDirInode.
 func (d *baseDirInode) InvalidateKernelListCache() {}
 
 func (d *baseDirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (op *gcs.Folder, err error) {

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -243,10 +243,8 @@ func (d *baseDirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	return true
 }
 
-func (d *baseDirInode) InvalidateKernelListCache() {
-	// Kernel list cache is not supported for baseDirInode.
-	return
-}
+// Kernel list cache is not supported for baseDirInode.
+func (d *baseDirInode) InvalidateKernelListCache() {}
 
 func (d *baseDirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (op *gcs.Folder, err error) {
 	err = fuse.ENOSYS

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -147,6 +147,10 @@ type DirInode interface {
 	// should be invalidated or not.
 	ShouldInvalidateKernelListCache(ttl time.Duration) bool
 
+	//InvalidateKernelListCache sets the prevDirListingTimeStamp to zero so that
+	//cache is invalidated for next list call.
+	InvalidateKernelListCache()
+
 	// RLock readonly lock.
 	RLock()
 
@@ -956,4 +960,9 @@ func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinat
 	d.cache.Insert(d.cacheClock.Now(), destinationFolderName, metadata.ExplicitDirType)
 
 	return folder, nil
+}
+
+func (d *dirInode) InvalidateKernelListCache() {
+	// Set prevDirListingTimeStamp to Zero time so that cache is invalidated.
+	d.prevDirListingTimeStamp = time.Time{}
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -147,8 +147,8 @@ type DirInode interface {
 	// should be invalidated or not.
 	ShouldInvalidateKernelListCache(ttl time.Duration) bool
 
-	//InvalidateKernelListCache sets the prevDirListingTimeStamp to zero so that
-	//cache is invalidated for next list call.
+	// InvalidateKernelListCache guarantees that the subsequent list call will be
+	// served from GCSFuse.
 	InvalidateKernelListCache()
 
 	// RLock readonly lock.

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1568,3 +1568,12 @@ func (t *DirTest) TestRenameFolderWithNonExistentSourceFolder() {
 	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
 	ExpectTrue(errors.As(err, &notFoundErr))
 }
+
+func (t *DirTest) Test_InvalidateKernelListCache() {
+	d := t.in.(*dirInode)
+	d.prevDirListingTimeStamp = d.cacheClock.Now()
+
+	t.in.InvalidateKernelListCache()
+
+	AssertTrue(d.prevDirListingTimeStamp.IsZero())
+}

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1572,6 +1572,7 @@ func (t *DirTest) TestRenameFolderWithNonExistentSourceFolder() {
 func (t *DirTest) Test_InvalidateKernelListCache() {
 	d := t.in.(*dirInode)
 	d.prevDirListingTimeStamp = d.cacheClock.Now()
+	AssertFalse(d.prevDirListingTimeStamp.IsZero())
 
 	t.in.InvalidateKernelListCache()
 

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -17,6 +17,7 @@
 package fs_test
 
 import (
+	"errors"
 	"os"
 	"path"
 	"testing"
@@ -85,4 +86,64 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit(
 	require.Equal(t.T(), 2, len(names2))
 	assert.Equal(t.T(), "file1.txt", names2[0])
 	assert.Equal(t.T(), "file2.txt", names2[1])
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterListCachedWorks() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+
+	// os.RemoveDir should delete all files and invalidate cache.
+	err = os.RemoveAll(path.Join(mntDir, "explicitDir"))
+	assert.NoError(t.T(), err)
+
+	_, err = os.ReadDir(path.Join(mntDir, "explicitDir"))
+	var pathError *os.PathError
+	assert.True(t.T(), errors.As(err, &pathError))
+}
+
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterListCacheInvalidatesCache() {
+	// First read, kernel will cache the dir response.
+	f, err := os.Open(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+	names1, err := f.Readdirnames(-1)
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 2, len(names1))
+	assert.Equal(t.T(), "file1.txt", names1[0])
+	assert.Equal(t.T(), "file2.txt", names1[1])
+	err = f.Close()
+	assert.Nil(t.T(), err)
+	// Adding one object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file3.txt": "123456",
+	}))
+	// Advancing time by 5 years (157800000 seconds).
+	cacheClock.AdvanceTime(157800000 * time.Second)
+	// os.RemoveDir should delete all files and invalidate cache.
+	err = os.RemoveAll(path.Join(mntDir, "explicitDir"))
+	assert.NoError(t.T(), err)
+
+	// Adding one more object to make sure to change the ReadDir() response.
+	assert.Nil(t.T(), t.createObjects(map[string]string{
+		"explicitDir/file4.txt": "123456",
+	}))
+	names2, err := os.ReadDir(path.Join(mntDir, "explicitDir"))
+	assert.Nil(t.T(), err)
+
+	assert.Nil(t.T(), err)
+	require.Equal(t.T(), 1, len(names2))
+	assert.Equal(t.T(), "file4.txt", names2[0].Name())
 }

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -147,3 +147,35 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterL
 	require.Equal(t.T(), 1, len(names2))
 	assert.Equal(t.T(), "file4.txt", names2[0].Name())
 }
+
+//func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirWorksWhenNoLocalCachedFiles() {
+//	err := os.Mkdir(path.Join(mntDir, "newDir"), os.FileMode(0777))
+//	// First read, kernel will cache the dir response.
+//	f, err := os.Open(path.Join(mntDir, "newDir"))
+//	assert.Nil(t.T(), err)
+//	names1, err := f.Readdirnames(-1)
+//	assert.Nil(t.T(), err)
+//	require.Equal(t.T(), 0, len(names1))
+//	err = f.Close()
+//	assert.Nil(t.T(), err)
+//	// Adding one object to make sure to change the ReadDir() response.
+//	assert.Nil(t.T(), t.createObjects(map[string]string{
+//		"newDir/file1.txt": "123456",
+//	}))
+//
+//	// os.RemoveAll should delete all files and invalidate cache.
+//	err = os.RemoveAll(path.Join(mntDir, "newDir"))
+//	assert.NoError(t.T(), err)
+//
+//	//assert.NotNil(t.T(), err)
+//
+//	//err = os.RemoveAll(path.Join(mntDir, "newDir"))
+//	//assert.NoError(t.T(), err)
+//
+//	//names2, err := os.ReadDir(path.Join(mntDir, "newDir"))
+//	//assert.NoError(t.T(), err)
+//	//require.Equal(t.T(), 1, len(names2))
+//	//assert.Equal(t.T(), "file1.txt", names2[0].Name())
+//	//var pathError *os.PathError
+//	//assert.True(t.T(), errors.As(err, &pathError))
+//}

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -147,35 +147,3 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterL
 	require.Equal(t.T(), 1, len(names2))
 	assert.Equal(t.T(), "file4.txt", names2[0].Name())
 }
-
-//func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirWorksWhenNoLocalCachedFiles() {
-//	err := os.Mkdir(path.Join(mntDir, "newDir"), os.FileMode(0777))
-//	// First read, kernel will cache the dir response.
-//	f, err := os.Open(path.Join(mntDir, "newDir"))
-//	assert.Nil(t.T(), err)
-//	names1, err := f.Readdirnames(-1)
-//	assert.Nil(t.T(), err)
-//	require.Equal(t.T(), 0, len(names1))
-//	err = f.Close()
-//	assert.Nil(t.T(), err)
-//	// Adding one object to make sure to change the ReadDir() response.
-//	assert.Nil(t.T(), t.createObjects(map[string]string{
-//		"newDir/file1.txt": "123456",
-//	}))
-//
-//	// os.RemoveAll should delete all files and invalidate cache.
-//	err = os.RemoveAll(path.Join(mntDir, "newDir"))
-//	assert.NoError(t.T(), err)
-//
-//	//assert.NotNil(t.T(), err)
-//
-//	//err = os.RemoveAll(path.Join(mntDir, "newDir"))
-//	//assert.NoError(t.T(), err)
-//
-//	//names2, err := os.ReadDir(path.Join(mntDir, "newDir"))
-//	//assert.NoError(t.T(), err)
-//	//require.Equal(t.T(), 1, len(names2))
-//	//assert.Equal(t.T(), "file1.txt", names2[0].Name())
-//	//var pathError *os.PathError
-//	//assert.True(t.T(), errors.As(err, &pathError))
-//}

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -88,7 +88,7 @@ func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_AlwaysCacheHit(
 	assert.Equal(t.T(), "file2.txt", names2[1])
 }
 
-func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterListCachedWorks() {
+func (t *KernelListCacheTestWithInfiniteTtl) TestKernelListCache_RemoveDirAfterListIsCachedWorks() {
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(path.Join(mntDir, "explicitDir"))
 	assert.Nil(t.T(), err)

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -228,33 +228,6 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnFileRename(
 	assert.Equal(t, "renamed_file2.txt", names2[2])
 }
 
-func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
-	targetDir := path.Join(testDirPath, "explicit_dir")
-	operations.CreateDirectory(targetDir, t)
-	// Create test data
-	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
-
-	// (a) First read served from GCS, kernel will cache the dir response.
-	f, err := os.Open(targetDir)
-	assert.NoError(t, err)
-	names1, err := f.Readdirnames(-1)
-	assert.NoError(t, err)
-	require.Equal(t, 2, len(names1))
-	require.Equal(t, "file1.txt", names1[0])
-	require.Equal(t, "file2.txt", names1[1])
-	err = f.Close()
-	assert.NoError(t, err)
-
-	// Adding one object to make sure to change the ReadDir() response.
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-
-	err = os.RemoveAll(targetDir)
-	require.NoError(t, err)
-}
-
 // explicit_dir/file1.txt
 // explicit_dir/sub_dir/file2.txt
 // explicit_dir/sub_dir/file3.txt
@@ -501,9 +474,8 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory
 	assert.NoError(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-	// Error is expected in first delete directory operation due to internal bug b/352688554.
 	err = os.RemoveAll(targetDir)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// Unlink calls triggered due to os.RemoveAll will invalidate the cache so
 	// fresh response from GCS is expected containing the uncached file.

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -228,9 +228,6 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnFileRename(
 	assert.Equal(t, "renamed_file2.txt", names2[2])
 }
 
-// (a) First ReadDir() will be served from GCSFuse filesystem.
-// (b) Second RmDIr() will also be served from GCSFuse filesystem, but it will cache the response.
-// (c) Third ReadDir() will serve the read request from cache.
 func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -258,38 +258,6 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory
 	require.NoError(t, err)
 }
 
-//func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectoryContainingOnlyGCSFiles(t *testing.T) {
-//	targetDir := path.Join(testDirPath, "explicit_dir")
-//	operations.CreateDirectory(targetDir, t)
-//
-//	// (a) First read served from GCS, kernel will cache the dir response.
-//	f, err := os.Open(targetDir)
-//	assert.NoError(t, err)
-//	names1, err := f.Readdirnames(-1)
-//	assert.NoError(t, err)
-//	require.Equal(t, 0, len(names1))
-//	err = f.Close()
-//	assert.NoError(t, err)
-//
-//	// Adding one object to make sure to change the ReadDir() response.
-//	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-//
-//	err = os.RemoveAll(targetDir)
-//	assert.NoError(t, err)
-//
-//	err = os.RemoveAll(targetDir)
-//	assert.NoError(t, err)
-//
-//	f, err = os.Open(targetDir)
-//	assert.NoError(t, err)
-//	names2, err := f.Readdirnames(-1)
-//	assert.NoError(t, err)
-//	require.Equal(t, 1, len(names2))
-//	err = f.Close()
-//	assert.NoError(t, err)
-//}
-//
-
 // explicit_dir/file1.txt
 // explicit_dir/sub_dir/file2.txt
 // explicit_dir/sub_dir/file3.txt

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -258,6 +258,38 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory
 	require.NoError(t, err)
 }
 
+//func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectoryContainingOnlyGCSFiles(t *testing.T) {
+//	targetDir := path.Join(testDirPath, "explicit_dir")
+//	operations.CreateDirectory(targetDir, t)
+//
+//	// (a) First read served from GCS, kernel will cache the dir response.
+//	f, err := os.Open(targetDir)
+//	assert.NoError(t, err)
+//	names1, err := f.Readdirnames(-1)
+//	assert.NoError(t, err)
+//	require.Equal(t, 0, len(names1))
+//	err = f.Close()
+//	assert.NoError(t, err)
+//
+//	// Adding one object to make sure to change the ReadDir() response.
+//	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
+//
+//	err = os.RemoveAll(targetDir)
+//	assert.NoError(t, err)
+//
+//	err = os.RemoveAll(targetDir)
+//	assert.NoError(t, err)
+//
+//	f, err = os.Open(targetDir)
+//	assert.NoError(t, err)
+//	names2, err := f.Readdirnames(-1)
+//	assert.NoError(t, err)
+//	require.Equal(t, 1, len(names2))
+//	err = f.Close()
+//	assert.NoError(t, err)
+//}
+//
+
 // explicit_dir/file1.txt
 // explicit_dir/sub_dir/file2.txt
 // explicit_dir/sub_dir/file3.txt

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -473,23 +473,11 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory
 	err = f.Close()
 	assert.NoError(t, err)
 	// Adding one object to make sure to change the ReadDir() response.
+	// All files including file3.txt will be deleted by os.RemoveAll
 	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-	err = os.RemoveAll(targetDir)
-	assert.NoError(t, err)
 
-	// Unlink calls triggered due to os.RemoveAll will invalidate the cache so
-	// fresh response from GCS is expected containing the uncached file.
-	f, err = os.Open(targetDir)
-	assert.NoError(t, err)
-	names2, err := f.Readdirnames(-1)
-	assert.NoError(t, err)
-	require.Equal(t, 1, len(names2))
-	assert.Equal(t, "file3.txt", names2[0])
-	err = f.Close()
-	assert.NoError(t, err)
-
-	// 2nd RemoveAll call will succeed.
 	err = os.RemoveAll(targetDir)
+
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
### Description
Scenario:
1. Read directory (listing) with kernel list cache enabled
2. List response is cached in kernel.
3. Create a file on the same GCS bucket inside the same directory outside of the GCSFuse mount via another tool like pantheon, gsutil.
4. call os.RemoveAll on the same directory in GCS Fuse.
5. Kernel will use the list cache response to list & delete the files and the newly created file (outside GCSFuse mount) won't be deleted.
6. os.RemoveAll will fail with directory not empty error when trying to delete the parent directory.

Fix: 
1. As part of the RmDir call, we will invalidate the cache by setting the previous directory listing timestamp to 0. 
2. This will make the open dir call to invalidate the cache so os.RemoveAll will start working.

Note: even after this fix, rm -r from terminal continues to fail as there in that case, we don't get first RmDir call (which invalidates the cache). Ref: https://github.com/GoogleCloudPlatform/gcsfuse/blob/8d72ea9205d148739f9bf2d20dda7dda7f72eb47/internal/fs/fs.go#L1752

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Added
