### PR TITLE
Add new composite tests for parallel downloads

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -588,7 +588,7 @@ func (cht *cacheHandleTest) Test_Read_Random() {
 	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
 }
 
-func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload() {
+func (cht *cacheHandleTest) Test_Read_Random_CacheForRangeReadFalse() {
 	dst := make([]byte, ReadContentSize)
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = false
@@ -605,7 +605,7 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload() {
 	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
 }
 
-func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownloadButCacheHit() {
+func (cht *cacheHandleTest) Test_Read_Random_CacheForRangeReadFalseButCacheHit() {
 	ctx := context.Background()
 	// Download the job till util.MiB
 	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(ctx, int64(2*util.MiB), true)
@@ -878,7 +878,7 @@ func (cht *cacheHandleTest) Test_Read_Random_Parallel_Download_True() {
 	assert.ErrorContains(cht.T(), err, util.FallbackToGCSErrMsg)
 }
 
-func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload_And_ParallelDownloadsEnabled() {
+func (cht *cacheHandleTest) Test_Read_Random_CacheForRangeReadFalse_And_ParallelDownloadsEnabled() {
 	dst := make([]byte, ReadContentSize)
 	offset := int64(cht.object.Size - ReadContentSize)
 	cht.cacheHandle.isSequential = false
@@ -902,6 +902,5 @@ func (cht *cacheHandleTest) Test_Read_RandomWithNoRandomDownload_And_ParallelDow
 	assert.Less(cht.T(), jobStatus.Offset, offset)
 	assert.Equal(cht.T(), n, 0)
 	assert.False(cht.T(), cacheHit)
-	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.ErrorContains(cht.T(), err, util.FallbackToGCSErrMsg)
 }

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -17,12 +17,11 @@ package file
 import (
 	"context"
 	"crypto/rand"
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -37,15 +36,20 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 const HandlerCacheMaxSize = TestObjectSize + ObjectSizeToCauseEviction
 const ObjectSizeToCauseEviction = 20
 
-func TestCacheHandler(t *testing.T) { RunTests(t) }
+func TestCacheHandler(testSuite *testing.T) {
+	testSuite.Parallel()
+	suite.Run(testSuite, new(CacheHandlerTest))
+}
 
-type cacheHandlerTest struct {
+type cacheHandlerTestArgs struct {
 	jobManager      *downloader.JobManager
 	bucket          gcs.Bucket
 	fakeStorage     storage.FakeStorage
@@ -57,49 +61,73 @@ type cacheHandlerTest struct {
 	cacheDir        string
 }
 
-func init() { RegisterTestSuite(&cacheHandlerTest{}) }
+type CacheHandlerTest struct {
+	suite.Suite
+	cacheDir   string
+	chTestArgs *cacheHandlerTestArgs
+}
 
-func (chrT *cacheHandlerTest) SetUp(*TestInfo) {
+func (chrT *CacheHandlerTest) SetupTest() {
+	chrT.cacheDir = path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir")
+}
+
+func setupHelper(t *testing.T, fileCacheConfig *config.FileCacheConfig, cacheDir string) (chTestArgs *cacheHandlerTestArgs) {
+	t.Helper()
+	chTestArgs = &cacheHandlerTestArgs{}
 	locker.EnableInvariantsCheck()
-	chrT.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
+	chTestArgs.cacheDir = cacheDir
 
 	// Create bucket in fake storage.
-	chrT.fakeStorage = storage.NewFakeStorage()
-	storageHandle := chrT.fakeStorage.CreateStorageHandle()
-	chrT.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
+	chTestArgs.fakeStorage = storage.NewFakeStorage()
+	storageHandle := chTestArgs.fakeStorage.CreateStorageHandle()
+	chTestArgs.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
 
 	// Create test object in the bucket.
 	testObjectContent := make([]byte, TestObjectSize)
 	_, err := rand.Read(testObjectContent)
-	AssertEq(nil, err)
-	chrT.object = chrT.getMinObject(TestObjectName, testObjectContent)
+	require.NoError(t, err)
+	chTestArgs.object = createObject(t, chTestArgs.bucket, TestObjectName, testObjectContent)
 
 	// fileInfoCache with testFileInfoEntry
-	chrT.cache = lru.NewCache(HandlerCacheMaxSize)
+	chTestArgs.cache = lru.NewCache(HandlerCacheMaxSize)
 
 	// Job manager
-	chrT.jobManager = downloader.NewJobManager(chrT.cache, util.DefaultFilePerm,
-		util.DefaultDirPerm, chrT.cacheDir, DefaultSequentialReadSizeMb, &config.FileCacheConfig{
-			EnableCRC: true,
-		})
+	chTestArgs.jobManager = downloader.NewJobManager(chTestArgs.cache, util.DefaultFilePerm,
+		util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, fileCacheConfig)
 
 	// Mocked cached handler object.
-	chrT.cacheHandler = NewCacheHandler(chrT.cache, chrT.jobManager, chrT.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
+	chTestArgs.cacheHandler = NewCacheHandler(chTestArgs.cache, chTestArgs.jobManager, cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 
 	// Follow consistency, local-cache file, entry in fileInfo cache and job should exist initially.
-	chrT.fileInfoKeyName = chrT.addTestFileInfoEntryInCache(storage.TestBucketName, TestObjectName)
-	chrT.downloadPath = util.GetDownloadPath(chrT.cacheHandler.cacheDir, util.GetObjectPath(chrT.bucket.Name(), chrT.object.Name))
-	_, err = util.CreateFile(data.FileSpec{Path: chrT.downloadPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, os.O_RDONLY)
-	AssertEq(nil, err)
-	_ = chrT.getDownloadJobForTestObject()
+	chTestArgs.fileInfoKeyName = addTestFileInfoEntryInCache(t, chTestArgs, storage.TestBucketName, TestObjectName)
+	chTestArgs.downloadPath = util.GetDownloadPath(chTestArgs.cacheHandler.cacheDir, util.GetObjectPath(chTestArgs.bucket.Name(), chTestArgs.object.Name))
+	_, err = util.CreateFile(data.FileSpec{Path: chTestArgs.downloadPath, FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, os.O_RDONLY)
+	require.NoError(t, err)
+	_ = getDownloadJobForTestObject(t, chTestArgs)
+
+	t.Cleanup(func() {
+		chTestArgs.fakeStorage.ShutDown()
+		operations.RemoveDir(cacheDir)
+	})
+	return chTestArgs
 }
 
-func (chrT *cacheHandlerTest) TearDown() {
-	chrT.fakeStorage.ShutDown()
-	operations.RemoveDir(chrT.cacheDir)
+func createObject(t *testing.T, bucket gcs.Bucket, objName string, objContent []byte) *gcs.MinObject {
+	t.Helper()
+	ctx := context.Background()
+	objects := map[string][]byte{objName: objContent}
+	err := storageutil.CreateObjects(ctx, bucket, objects)
+	require.NoError(t, err)
+
+	minObject, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
+		ForceFetchFromGcs: true})
+	require.NoError(t, err)
+	require.NotNil(t, minObject)
+	return minObject
 }
 
-func (chrT *cacheHandlerTest) addTestFileInfoEntryInCache(bucketName string, objectName string) string {
+func addTestFileInfoEntryInCache(t *testing.T, chTestArgs *cacheHandlerTestArgs, bucketName string, objectName string) string {
+	t.Helper()
 	// Add an entry into
 	fileInfoKey := data.FileInfoKey{
 		BucketName: bucketName,
@@ -107,411 +135,498 @@ func (chrT *cacheHandlerTest) addTestFileInfoEntryInCache(bucketName string, obj
 	}
 	fileInfo := data.FileInfo{
 		Key:              fileInfoKey,
-		ObjectGeneration: chrT.object.Generation,
-		FileSize:         chrT.object.Size,
+		ObjectGeneration: chTestArgs.object.Generation,
+		FileSize:         chTestArgs.object.Size,
 		Offset:           0,
 	}
 
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	require.NoError(t, nil, err)
 
-	_, err = chrT.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	_, err = chTestArgs.cache.Insert(fileInfoKeyName, fileInfo)
+	require.NoError(t, nil, err)
 
 	return fileInfoKeyName
 }
 
-func (chrT *cacheHandlerTest) isEntryInFileInfoCache(objectName string, bucketName string) bool {
+func getDownloadJobForTestObject(t *testing.T, chTestArgs *cacheHandlerTestArgs) *downloader.Job {
+	t.Helper()
+	job := chTestArgs.jobManager.CreateJobIfNotExists(chTestArgs.object, chTestArgs.bucket)
+	require.NotNil(t, job)
+	return job
+}
+
+func isEntryInFileInfoCache(t *testing.T, cache *lru.Cache, objectName string, bucketName string) bool {
+	t.Helper()
 	fileInfoKey := data.FileInfoKey{
 		BucketName: bucketName,
 		ObjectName: objectName,
 	}
 
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	require.NoError(t, nil, err)
 
-	fileInfo := chrT.cache.LookUp(fileInfoKeyName)
+	fileInfo := cache.LookUp(fileInfoKeyName)
 	return fileInfo != nil
 }
 
-func (chrT *cacheHandlerTest) getDownloadJobForTestObject() *downloader.Job {
-	job := chrT.jobManager.CreateJobIfNotExists(chrT.object, chrT.bucket)
-	AssertNe(nil, job)
-	return job
-}
-
-func (chrT *cacheHandlerTest) getMinObject(objName string, objContent []byte) *gcs.MinObject {
-	ctx := context.Background()
-	objects := map[string][]byte{objName: objContent}
-	err := storageutil.CreateObjects(ctx, chrT.bucket, objects)
-	AssertEq(nil, err)
-
-	minObject, _, err := chrT.bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: objName,
-		ForceFetchFromGcs: true})
-	AssertEq(nil, err)
-	AssertNe(nil, minObject)
-	return minObject
-}
-
 // doesFileExist returns true if the file exists and false otherwise.
-// If an error occurs, the function panics.
-func doesFileExist(filePath string) bool {
+func doesFileExist(t *testing.T, filePath string) bool {
+	t.Helper()
 	_, err := os.Stat(filePath)
 
 	if err == nil {
 		return true
 	}
-
-	if os.IsNotExist(err) {
-		return false
-	}
-
-	AssertEq(nil, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
 	return false
 }
 
-func (chrT *cacheHandlerTest) Test_createLocalFileReadHandle_OnlyForRead() {
-	readFileHandle, err := chrT.cacheHandler.createLocalFileReadHandle(chrT.object.Name, chrT.bucket.Name())
+func (chrT *CacheHandlerTest) Test_createLocalFileReadHandle_OnlyForRead() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
 
-	ExpectEq(nil, err)
+	readFileHandle, err := chrT.chTestArgs.cacheHandler.createLocalFileReadHandle(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+
+	assert.NoError(chrT.T(), err)
 	_, err = readFileHandle.Write([]byte("test"))
-	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "bad file descriptor"))
+	assert.ErrorContains(chrT.T(), err, "bad file descriptor")
 }
 
-func (chrT *cacheHandlerTest) Test_cleanUpEvictedFile() {
-	fileDownloadJob := chrT.getDownloadJobForTestObject()
-	fileInfo := chrT.cache.LookUp(chrT.fileInfoKeyName)
+func (chrT *CacheHandlerTest) Test_cleanUpEvictedFile() {
+	tbl := []struct {
+		name            string
+		fileCacheConfig config.FileCacheConfig
+		cacheDir        string
+	}{
+		{
+			name:            "Non parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true},
+			cacheDir:        path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 4, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir: path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
+	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			fileDownloadJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+			fileInfo := chrT.chTestArgs.cache.LookUp(chrT.chTestArgs.fileInfoKeyName)
+			fileInfoData := fileInfo.(data.FileInfo)
+			jobStatusBefore := fileDownloadJob.GetStatus()
+			require.Equal(chrT.T(), downloader.NotStarted, jobStatusBefore.Name)
+			jobStatusBefore, err := fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
+			require.NoError(chrT.T(), err)
+			require.Equal(chrT.T(), downloader.Downloading, jobStatusBefore.Name)
+
+			err = chrT.chTestArgs.cacheHandler.cleanUpEvictedFile(&fileInfoData)
+
+			assert.NoError(chrT.T(), err)
+			jobStatusAfter := fileDownloadJob.GetStatus()
+			assert.Equal(chrT.T(), downloader.Invalid, jobStatusAfter.Name)
+			assert.False(chrT.T(), doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
+			// Job should be removed from job manager
+			assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
+		})
+	}
+}
+
+func (chrT *CacheHandlerTest) Test_cleanUpEvictedFile_WhenLocalFileNotExist() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	fileDownloadJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+	fileInfo := chrT.chTestArgs.cache.LookUp(chrT.chTestArgs.fileInfoKeyName)
 	fileInfoData := fileInfo.(data.FileInfo)
 	jobStatusBefore := fileDownloadJob.GetStatus()
-	AssertEq(jobStatusBefore.Name, downloader.NotStarted)
+	require.Equal(chrT.T(), downloader.NotStarted, jobStatusBefore.Name)
 	jobStatusBefore, err := fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
-	AssertEq(nil, err)
-	AssertEq(jobStatusBefore.Name, downloader.Downloading)
+	require.NoError(chrT.T(), err)
+	require.Equal(chrT.T(), downloader.Downloading, jobStatusBefore.Name)
+	err = os.Remove(chrT.chTestArgs.downloadPath)
+	require.NoError(chrT.T(), err)
 
-	err = chrT.cacheHandler.cleanUpEvictedFile(&fileInfoData)
+	err = chrT.chTestArgs.cacheHandler.cleanUpEvictedFile(&fileInfoData)
 
-	ExpectEq(nil, err)
+	assert.NoError(chrT.T(), err)
 	jobStatusAfter := fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusAfter.Name, downloader.Invalid)
-	ExpectFalse(doesFileExist(chrT.downloadPath))
+	assert.Equal(chrT.T(), downloader.Invalid, jobStatusAfter.Name)
+	assert.False(chrT.T(), doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
 	// Job should be removed from job manager
-	ExpectEq(nil, chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name()))
+	assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_cleanUpEvictedFile_WhenLocalFileNotExist() {
-	fileDownloadJob := chrT.getDownloadJobForTestObject()
-	fileInfo := chrT.cache.LookUp(chrT.fileInfoKeyName)
-	fileInfoData := fileInfo.(data.FileInfo)
-	jobStatusBefore := fileDownloadJob.GetStatus()
-	AssertEq(jobStatusBefore.Name, downloader.NotStarted)
-	jobStatusBefore, err := fileDownloadJob.Download(context.Background(), int64(util.MiB), false)
-	AssertEq(nil, err)
-	AssertEq(jobStatusBefore.Name, downloader.Downloading)
-	err = os.Remove(chrT.downloadPath)
-	AssertEq(nil, err)
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfAlready() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 
-	err = chrT.cacheHandler.cleanUpEvictedFile(&fileInfoData)
+	err := chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	jobStatusAfter := fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusAfter.Name, downloader.Invalid)
-	ExpectFalse(doesFileExist(chrT.downloadPath))
-	// Job should be removed from job manager
-	ExpectEq(nil, chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name()))
-}
-
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfAlready() {
-	existingJob := chrT.getDownloadJobForTestObject()
-
-	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
-
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	// File download job should also be same
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectEq(existingJob, actualJob)
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.Equal(chrT.T(), existingJob, actualJob)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_GenerationChanged() {
-	existingJob := chrT.getDownloadJobForTestObject()
-	chrT.object.Generation = chrT.object.Generation + 1
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_GenerationChanged() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+	chrT.chTestArgs.object.Generation = chrT.chTestArgs.object.Generation + 1
 
-	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+	err := chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	// File download job should be new as the file info and job should be cleaned
 	// up.
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectNe(existingJob, actualJob)
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.NotEqual(chrT.T(), existingJob, actualJob)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfNotAlready() {
-	oldJob := chrT.getDownloadJobForTestObject()
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfNotAlready() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	oldJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 	// Content of size more than 20 leads to eviction of initial TestObjectName.
 	// Here, content size is 21.
-	minObject := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
+	minObject := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1 ..."))
 	// There should be no file download job corresponding to minObject
-	existingJob := chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name())
-	AssertEq(nil, existingJob)
+	existingJob := chrT.chTestArgs.jobManager.GetJob(minObject.Name, chrT.chTestArgs.bucket.Name())
+	require.Nil(chrT.T(), existingJob)
 
 	// Insertion will happen and that leads to eviction.
-	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(minObject, chrT.bucket)
+	err := chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(minObject, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, minObject.Name, chrT.chTestArgs.bucket.Name()))
 	jobStatus := oldJob.GetStatus()
-	ExpectEq(downloader.Invalid, jobStatus.Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	assert.Equal(chrT.T(), downloader.Invalid, jobStatus.Name)
+	assert.False(chrT.T(), doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
 	// Job should be added for minObject
-	minObjectJob := chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name())
-	ExpectNe(nil, minObjectJob)
-	ExpectEq(downloader.NotStarted, minObjectJob.GetStatus().Name)
+	minObjectJob := chrT.chTestArgs.jobManager.GetJob(minObject.Name, chrT.chTestArgs.bucket.Name())
+	assert.NotNil(chrT.T(), minObjectJob)
+	assert.Equal(chrT.T(), downloader.NotStarted, minObjectJob.GetStatus().Name)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfLocalFileGetsDeleted() {
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_IfLocalFileGetsDeleted() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
 	// Delete the local cache file.
-	err := os.Remove(chrT.downloadPath)
-	AssertEq(nil, err)
+	err := os.Remove(chrT.chTestArgs.downloadPath)
+	require.NoError(chrT.T(), err)
 
 	// There is a fileInfoEntry in the fileInfoCache but the corresponding local file doesn't exist.
 	// Hence, this will return error containing util.FileNotPresentInCacheErrMsg.
-	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+	err = chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
+	assert.ErrorContains(chrT.T(), err, util.FileNotPresentInCacheErrMsg)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasCompleted() {
-	existingJob := chrT.getDownloadJobForTestObject()
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasCompleted() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 	// Make the job completed, so it's removed from job manager.
-	jobStatus, err := existingJob.Download(context.Background(), int64(chrT.object.Size), true)
-	AssertEq(nil, err)
-	AssertEq(jobStatus.Offset, chrT.object.Size)
+	jobStatus, err := existingJob.Download(context.Background(), int64(chrT.chTestArgs.object.Size), true)
+	require.NoError(chrT.T(), err)
+	require.Equal(chrT.T(), int64(chrT.chTestArgs.object.Size), jobStatus.Offset)
 	// Give time for execution of callback to remove from job manager
 	time.Sleep(time.Second)
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectEq(nil, actualJob)
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	require.Nil(chrT.T(), actualJob)
 
-	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+	err = chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	// No new job should be added to job manager
-	actualJob = chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectEq(nil, actualJob)
+	actualJob = chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.Nil(chrT.T(), actualJob)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobIsInvalidatedAndRemoved() {
-	chrT.jobManager.InvalidateAndRemoveJob(chrT.object.Name, chrT.bucket.Name())
-	existingJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectEq(nil, existingJob)
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobIsInvalidatedAndRemoved() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	chrT.chTestArgs.jobManager.InvalidateAndRemoveJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	existingJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	require.Nil(chrT.T(), existingJob)
 
 	// Because the job has been removed and file info entry is still present, new
 	// file info entry and job should be created.
-	err := chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+	err := chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	// New job should be added to job manager
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectNe(nil, actualJob)
-	ExpectEq(downloader.NotStarted, actualJob.GetStatus().Name)
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.NotNil(chrT.T(), actualJob)
+	assert.Equal(chrT.T(), downloader.NotStarted, actualJob.GetStatus().Name)
 }
 
-func (chrT *cacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasFailed() {
-	existingJob := chrT.getDownloadJobForTestObject()
+func (chrT *CacheHandlerTest) Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasFailed() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 	// Hack to fail the async job
-	correctSize := chrT.object.Size
-	chrT.object.Size = 2
+	correctSize := chrT.chTestArgs.object.Size
+	chrT.chTestArgs.object.Size = 2
 	jobStatus, err := existingJob.Download(context.Background(), 1, true)
-	AssertEq(nil, err)
-	AssertEq(downloader.Failed, jobStatus.Name)
-	chrT.object.Size = correctSize
+	require.NoError(chrT.T(), err)
+	require.Equal(chrT.T(), downloader.Failed, jobStatus.Name)
+	chrT.chTestArgs.object.Size = correctSize
 
 	// Because the job has been failed and file info entry is still present with
 	// size less than the object's size (because the async job failed), new job
 	// should be created
-	err = chrT.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.object, chrT.bucket)
+	err = chrT.chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chrT.chTestArgs.object, chrT.chTestArgs.bucket)
 
-	ExpectEq(nil, err)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	// New job should be added to job manager
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectNe(nil, actualJob)
-	ExpectEq(downloader.NotStarted, actualJob.GetStatus().Name)
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.NotNil(chrT.T(), actualJob)
+	assert.Equal(chrT.T(), downloader.NotStarted, actualJob.GetStatus().Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneration() {
-	existingJob := chrT.getDownloadJobForTestObject()
-	AssertNe(nil, existingJob)
-	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_WhenCacheHasDifferentGeneration() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+	require.NotNil(chrT.T(), existingJob)
+	require.Equal(chrT.T(), downloader.NotStarted, existingJob.GetStatus().Name)
 	// Change the version of the object, but cache still keeps old generation
-	chrT.object.Generation = chrT.object.Generation + 1
+	chrT.chTestArgs.object.Generation = chrT.chTestArgs.object.Generation + 1
 
-	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	newCacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(chrT.chTestArgs.object, chrT.chTestArgs.bucket, false, 0)
 
-	ExpectEq(nil, err)
-	ExpectEq(nil, newCacheHandle.validateCacheHandle())
+	assert.NoError(chrT.T(), err)
+	assert.Nil(chrT.T(), newCacheHandle.validateCacheHandle())
 	jobStatusOfOldJob := existingJob.GetStatus()
-	ExpectEq(jobStatusOfOldJob.Name, downloader.Invalid)
+	assert.Equal(chrT.T(), downloader.Invalid, jobStatusOfOldJob.Name)
 	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(jobStatusOfNewHandle.Name, downloader.NotStarted)
+	assert.Equal(chrT.T(), downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenAsyncDownloadJobHasFailed() {
-	existingJob := chrT.getDownloadJobForTestObject()
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_WhenAsyncDownloadJobHasFailed() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 	// Hack to fail the async job
-	correctSize := chrT.object.Size
-	chrT.object.Size = 2
+	correctSize := chrT.chTestArgs.object.Size
+	chrT.chTestArgs.object.Size = 2
 	jobStatus, err := existingJob.Download(context.Background(), 1, true)
-	AssertEq(nil, err)
-	AssertEq(downloader.Failed, jobStatus.Name)
-	chrT.object.Size = correctSize
+	require.NoError(chrT.T(), err)
+	require.Equal(chrT.T(), downloader.Failed, jobStatus.Name)
+	chrT.chTestArgs.object.Size = correctSize
 
-	newCacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	newCacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(chrT.chTestArgs.object, chrT.chTestArgs.bucket, false, 0)
 
 	// New job should be created because the earlier job has failed.
-	ExpectEq(nil, err)
-	ExpectEq(nil, newCacheHandle.validateCacheHandle())
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.Nil(chrT.T(), newCacheHandle.validateCacheHandle())
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 	jobStatusOfNewHandle := newCacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
+	assert.Equal(chrT.T(), downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreAlreadyPresent() {
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreAlreadyPresent() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
 	// File info and download job are already present for test object.
-	existingJob := chrT.getDownloadJobForTestObject()
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(chrT.chTestArgs.object, chrT.chTestArgs.bucket, false, 0)
 
-	ExpectEq(nil, err)
-	ExpectEq(nil, cacheHandle.validateCacheHandle())
+	assert.NoError(chrT.T(), err)
+	assert.Nil(chrT.T(), cacheHandle.validateCacheHandle())
 	// Job and file info are still present
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
-	ExpectEq(existingJob, cacheHandle.fileDownloadJob)
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
+	assert.Equal(chrT.T(), existingJob, cacheHandle.fileDownloadJob)
 	jobStatusOfNewHandle := cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
+	assert.Equal(chrT.T(), downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreNotPresent() {
-	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_WhenFileInfoAndJobAreNotPresent() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	minObject := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1"))
 
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
+	cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject, chrT.chTestArgs.bucket, false, 0)
 
-	ExpectEq(nil, err)
-	ExpectEq(nil, cacheHandle.validateCacheHandle())
+	assert.NoError(chrT.T(), err)
+	assert.Nil(chrT.T(), cacheHandle.validateCacheHandle())
 	// New Job and file info are created.
-	ExpectTrue(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, minObject.Name, chrT.chTestArgs.bucket.Name()))
 	jobStatusOfNewHandle := cacheHandle.fileDownloadJob.GetStatus()
-	ExpectEq(downloader.NotStarted, jobStatusOfNewHandle.Name)
+	assert.Equal(chrT.T(), downloader.NotStarted, jobStatusOfNewHandle.Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_WithEviction() {
-	// Start the existing job
-	existingJob := chrT.getDownloadJobForTestObject()
-	_, err := existingJob.Download(context.Background(), 1, false)
-	AssertEq(nil, err)
-	// Content of size more than 20 leads to eviction of initial TestObjectName.
-	// Here, content size is 21.
-	minObject := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_WithEviction() {
+	tbl := []struct {
+		name            string
+		fileCacheConfig config.FileCacheConfig
+		cacheDir        string
+	}{
+		{
+			name:            "Non parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true},
+			cacheDir:        path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 4, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir: path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
+	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			// Start the existing job
+			existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+			_, err := existingJob.Download(context.Background(), 1, false)
+			require.NoError(chrT.T(), err)
+			// Content of size more than 20 leads to eviction of initial TestObjectName.
+			// Here, content size is 21.
+			minObject := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1 ..."))
 
-	cacheHandle2, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
+			cacheHandle2, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject, chrT.chTestArgs.bucket, false, 0)
 
-	ExpectEq(nil, err)
-	ExpectEq(nil, cacheHandle2.validateCacheHandle())
-	jobStatus := existingJob.GetStatus()
-	ExpectEq(downloader.Invalid, jobStatus.Name)
-	ExpectFalse(doesFileExist(chrT.downloadPath))
+			assert.NoError(chrT.T(), err)
+			assert.Nil(chrT.T(), cacheHandle2.validateCacheHandle())
+			jobStatus := existingJob.GetStatus()
+			assert.Equal(chrT.T(), downloader.Invalid, jobStatus.Name)
+			assert.False(chrT.T(), doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
+		})
+	}
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_IfLocalFileGetsDeleted() {
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_IfLocalFileGetsDeleted() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
 	// Delete the local cache file.
-	err := os.Remove(chrT.downloadPath)
-	AssertEq(nil, err)
-	existingJob := chrT.getDownloadJobForTestObject()
+	err := os.Remove(chrT.chTestArgs.downloadPath)
+	require.NoError(chrT.T(), err)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
 
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(chrT.object, chrT.bucket, false, 0)
+	cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(chrT.chTestArgs.object, chrT.chTestArgs.bucket, false, 0)
 
-	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
-	AssertEq(nil, cacheHandle)
+	assert.ErrorContains(chrT.T(), err, util.FileNotPresentInCacheErrMsg)
+	assert.Nil(chrT.T(), cacheHandle)
 	// Check file info and download job are not removed
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
-	actualJob := chrT.jobManager.GetJob(chrT.object.Name, chrT.bucket.Name())
-	ExpectEq(existingJob, actualJob)
-	ExpectEq(downloader.NotStarted, existingJob.GetStatus().Name)
-
+	assert.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
+	actualJob := chrT.chTestArgs.jobManager.GetJob(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+	assert.Equal(chrT.T(), existingJob, actualJob)
+	assert.Equal(chrT.T(), downloader.NotStarted, existingJob.GetStatus().Name)
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_CacheForRangeRead() {
-	minObject1 := chrT.getMinObject("object_1", []byte("content of object_1 ..."))
-	cacheHandle1, err1 := chrT.cacheHandler.GetCacheHandle(minObject1, chrT.bucket, false, 0)
-	minObject2 := chrT.getMinObject("object_2", []byte("content of object_2 ..."))
-	cacheHandle2, err2 := chrT.cacheHandler.GetCacheHandle(minObject2, chrT.bucket, false, 5)
-	minObject3 := chrT.getMinObject("object_3", []byte("content of object_3 ..."))
-	cacheHandle3, err3 := chrT.cacheHandler.GetCacheHandle(minObject3, chrT.bucket, true, 0)
-	minObject4 := chrT.getMinObject("object_4", []byte("content of object_4 ..."))
-	cacheHandle4, err4 := chrT.cacheHandler.GetCacheHandle(minObject4, chrT.bucket, true, 5)
-
-	ExpectEq(nil, err1)
-	ExpectEq(nil, cacheHandle1.validateCacheHandle())
-	ExpectNe(nil, err2)
-	ExpectEq(nil, cacheHandle2)
-	ExpectTrue(strings.Contains(err2.Error(), util.CacheHandleNotRequiredForRandomReadErrMsg))
-	ExpectEq(nil, err3)
-	ExpectEq(nil, cacheHandle3.validateCacheHandle())
-	ExpectEq(nil, err4)
-	ExpectEq(nil, cacheHandle4.validateCacheHandle())
-}
-
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
-	// Check async job and file info cache not preset for object_1
-	testObjectName := "object_1"
-	existingJob := chrT.jobManager.GetJob(testObjectName, chrT.bucket.Name())
-	AssertEq(nil, existingJob)
-	wg := sync.WaitGroup{}
-	getCacheHandleTestFun := func() {
-		defer wg.Done()
-		minObj := chrT.getMinObject(testObjectName, []byte("content of object_1 ..."))
-
-		var err error
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
-
-		AssertEq(nil, err)
-		AssertEq(nil, cacheHandle.validateCacheHandle())
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_CacheForRangeRead() {
+	tbl := []struct {
+		name            string
+		fileCacheConfig config.FileCacheConfig
+		cacheDir        string
+	}{
+		{
+			name:            "Non parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true},
+			cacheDir:        path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 4, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir: path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+		},
 	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			minObject1 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1 ..."))
+			cacheHandle1, err1 := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject1, chrT.chTestArgs.bucket, false, 0)
+			minObject2 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_2", []byte("content of object_2 ..."))
+			cacheHandle2, err2 := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject2, chrT.chTestArgs.bucket, false, 5)
+			minObject3 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_3", []byte("content of object_3 ..."))
+			cacheHandle3, err3 := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject3, chrT.chTestArgs.bucket, true, 0)
+			minObject4 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_4", []byte("content of object_4 ..."))
+			cacheHandle4, err4 := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject4, chrT.chTestArgs.bucket, true, 5)
 
-	// Start concurrent GetCacheHandle()
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go getCacheHandleTestFun()
+			assert.NoError(chrT.T(), err1)
+			assert.Nil(chrT.T(), cacheHandle1.validateCacheHandle())
+			assert.ErrorContains(chrT.T(), err2, util.CacheHandleNotRequiredForRandomReadErrMsg)
+			assert.Nil(chrT.T(), cacheHandle2)
+			assert.NoError(chrT.T(), err3)
+			assert.Nil(chrT.T(), cacheHandle3.validateCacheHandle())
+			assert.NoError(chrT.T(), err4)
+			assert.Nil(chrT.T(), cacheHandle4.validateCacheHandle())
+		})
 	}
-	wg.Wait()
-
-	// Job should be added now
-	actualJob := chrT.jobManager.GetJob(testObjectName, chrT.bucket.Name())
-	jobStatus := actualJob.GetStatus()
-	ExpectEq(downloader.NotStarted, jobStatus.Name)
-	ExpectTrue(doesFileExist(util.GetDownloadPath(chrT.cacheDir, util.GetObjectPath(chrT.bucket.Name(), testObjectName))))
 }
 
-func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
-	existingJob := chrT.getDownloadJobForTestObject()
-	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_ConcurrentSameFile() {
+	tbl := []struct {
+		name                      string
+		fileCacheConfig           config.FileCacheConfig
+		cacheDir                  string
+		expectedGetCacheHandleErr error
+	}{
+		{
+			name:                      "Non parallel downloads",
+			fileCacheConfig:           config.FileCacheConfig{EnableCRC: true},
+			cacheDir:                  path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedGetCacheHandleErr: nil,
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 1, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:                  path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedGetCacheHandleErr: nil,
+		},
+	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			// Check async job and file info cache not preset for object_1
+			testObjectName := "object_1"
+			existingJob := chrT.chTestArgs.jobManager.GetJob(testObjectName, chrT.chTestArgs.bucket.Name())
+			require.Nil(chrT.T(), existingJob)
+			wg := sync.WaitGroup{}
+			getCacheHandleTestFun := func() {
+				defer wg.Done()
+				minObj := createObject(chrT.T(), chrT.chTestArgs.bucket, testObjectName, []byte("content of object_1 ..."))
+
+				var err error
+				cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObj, chrT.chTestArgs.bucket, false, 0)
+
+				assert.ErrorIs(chrT.T(), err, tc.expectedGetCacheHandleErr)
+				assert.Nil(chrT.T(), cacheHandle.validateCacheHandle())
+			}
+
+			// Start concurrent GetCacheHandle()
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go getCacheHandleTestFun()
+			}
+			wg.Wait()
+
+			// Job should be added now
+			actualJob := chrT.chTestArgs.jobManager.GetJob(testObjectName, chrT.chTestArgs.bucket.Name())
+			jobStatus := actualJob.GetStatus()
+			assert.Equal(chrT.T(), downloader.NotStarted, jobStatus.Name)
+			assert.True(chrT.T(), doesFileExist(chrT.T(), util.GetDownloadPath(chrT.cacheDir,
+				util.GetObjectPath(chrT.chTestArgs.bucket.Name(), testObjectName))))
+		})
+	}
+}
+
+func (chrT *CacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+	require.Equal(chrT.T(), downloader.NotStarted, existingJob.GetStatus().Name)
 	wg := sync.WaitGroup{}
 
 	getCacheHandleTestFun := func(index int) {
 		defer wg.Done()
 		objName := "object" + strconv.Itoa(index)
 		objContent := "object content: content#" + strconv.Itoa(index)
-		minObj := chrT.getMinObject(objName, []byte(objContent))
+		minObj := createObject(chrT.T(), chrT.chTestArgs.bucket, objName, []byte(objContent))
 
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
+		cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObj, chrT.chTestArgs.bucket, false, 0)
 
-		AssertEq(nil, err)
-		AssertEq(nil, cacheHandle.validateCacheHandle())
+		assert.NoError(chrT.T(), err)
+		assert.Nil(chrT.T(), cacheHandle.validateCacheHandle())
 	}
 
 	// Start concurrent GetCacheHandle()
@@ -522,192 +637,337 @@ func (chrT *cacheHandlerTest) Test_GetCacheHandle_ConcurrentDifferentFiles() {
 	wg.Wait()
 
 	// Existing job for default chrT object should be invalidated.
-	ExpectNe(nil, existingJob)
-	ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	assert.NotNil(chrT.T(), existingJob)
+	assert.Equal(chrT.T(), downloader.Invalid, existingJob.GetStatus().Name)
+	assert.Equal(chrT.T(), false, doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
 	// File info should also be removed.
-	ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenAlreadyInCache() {
-	existingJob := chrT.getDownloadJobForTestObject()
-	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+func (chrT *CacheHandlerTest) Test_InvalidateCache_WhenAlreadyInCache() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+	require.Equal(chrT.T(), downloader.NotStarted, existingJob.GetStatus().Name)
+	require.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 
-	err := chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
+	err := chrT.chTestArgs.cacheHandler.InvalidateCache(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
 
-	ExpectEq(nil, err)
+	assert.NoError(chrT.T(), err)
 	// Existing job for default chrT object should be invalidated.
-	ExpectNe(nil, existingJob)
-	ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
-	ExpectEq(false, doesFileExist(chrT.downloadPath))
+	assert.NotNil(chrT.T(), existingJob)
+	assert.Equal(chrT.T(), downloader.Invalid, existingJob.GetStatus().Name)
+	assert.Equal(chrT.T(), false, doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
 	// File info should also be removed.
-	ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+	assert.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_WhenEntryNotInCache() {
-	minObject := chrT.getMinObject("object_1", []byte("content of object_1"))
-	ExpectFalse(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
-	ExpectEq(nil, chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name()))
+func (chrT *CacheHandlerTest) Test_InvalidateCache_WhenEntryNotInCache() {
+	chrT.chTestArgs = setupHelper(chrT.T(), &config.FileCacheConfig{EnableCRC: true}, chrT.cacheDir)
+	minObject := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1"))
+	require.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, minObject.Name, chrT.chTestArgs.bucket.Name()))
+	require.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(minObject.Name, chrT.chTestArgs.bucket.Name()))
 
-	err := chrT.cacheHandler.InvalidateCache(minObject.Name, chrT.bucket.Name())
+	err := chrT.chTestArgs.cacheHandler.InvalidateCache(minObject.Name, chrT.chTestArgs.bucket.Name())
 
-	ExpectEq(nil, err)
-	ExpectFalse(chrT.isEntryInFileInfoCache(minObject.Name, chrT.bucket.Name()))
-	ExpectEq(nil, chrT.jobManager.GetJob(minObject.Name, chrT.bucket.Name()))
+	assert.NoError(chrT.T(), err)
+	assert.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, minObject.Name, chrT.chTestArgs.bucket.Name()))
+	assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(minObject.Name, chrT.chTestArgs.bucket.Name()))
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_Truncates() {
-	objectContent := []byte("content of object_1")
-	minObject := chrT.getMinObject("object_1", objectContent)
-	cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObject, chrT.bucket, false, 0)
-	AssertEq(nil, err)
-	buf := make([]byte, 3)
-	ctx := context.Background()
-	// Read to populate cache
-	_, cacheHit, err := cacheHandle.Read(ctx, chrT.bucket, minObject, 0, buf)
-	AssertEq(nil, err)
-	ExpectEq(false, cacheHit)
-	AssertEq(string(objectContent[:3]), string(buf))
-	AssertEq(nil, cacheHandle.Close())
-	// Open cache file before invalidation
-	objectPath := util.GetObjectPath(chrT.bucket.Name(), minObject.Name)
-	downloadPath := util.GetDownloadPath(chrT.cacheDir, objectPath)
-	file, err := os.OpenFile(downloadPath, os.O_RDONLY, 0600)
-	AssertEq(nil, err)
-	_, err = file.Read(buf)
-	AssertEq(nil, err)
-	AssertEq(string(objectContent[:3]), string(buf))
+func (chrT *CacheHandlerTest) Test_InvalidateCache_Truncates() {
+	tbl := []struct {
+		name                        string
+		fileCacheConfig             config.FileCacheConfig
+		cacheDir                    string
+		expectedCInvalidateCacheErr error
+		expectedCacheHandleReadErr  error
+		expectedCacheFileReadErr    error
+	}{
+		{
+			name:                        "Non parallel downloads",
+			fileCacheConfig:             config.FileCacheConfig{EnableCRC: true},
+			cacheDir:                    path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCInvalidateCacheErr: nil,
+			expectedCacheHandleReadErr:  nil,
+			expectedCacheFileReadErr:    io.EOF,
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 4, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:                    path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCInvalidateCacheErr: nil,
+			expectedCacheHandleReadErr:  fmt.Errorf("read via gcs"),
+			expectedCacheFileReadErr:    io.EOF,
+		},
+	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			objectContent := []byte("content of object_1")
+			minObject := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", objectContent)
+			cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject, chrT.chTestArgs.bucket, false, 0)
+			require.NoError(chrT.T(), err)
+			buf := make([]byte, 3)
+			ctx := context.Background()
+			// Read to populate cache
+			_, cacheHit, err := cacheHandle.Read(ctx, chrT.chTestArgs.bucket, minObject, 0, buf)
+			if tc.expectedCacheHandleReadErr == nil {
+				require.NoError(chrT.T(), err)
+				require.Equal(chrT.T(), string(objectContent[:3]), string(buf))
+			} else {
+				require.ErrorContains(chrT.T(), err, tc.expectedCacheHandleReadErr.Error())
+			}
+			require.Equal(chrT.T(), false, cacheHit)
+			require.Equal(chrT.T(), nil, cacheHandle.Close())
+			// Open cache file before invalidation
+			objectPath := util.GetObjectPath(chrT.chTestArgs.bucket.Name(), minObject.Name)
+			downloadPath := util.GetDownloadPath(chrT.cacheDir, objectPath)
+			file, err := os.OpenFile(downloadPath, os.O_RDONLY, 0600)
+			require.NoError(chrT.T(), err)
 
-	err = chrT.cacheHandler.InvalidateCache(minObject.Name, chrT.bucket.Name())
+			err = chrT.chTestArgs.cacheHandler.InvalidateCache(minObject.Name, chrT.chTestArgs.bucket.Name())
 
-	AssertEq(nil, err)
-	// Reading from the open file handle should fail as the file is truncated.
-	_, err = file.Read(buf)
-	AssertNe(nil, err)
-	AssertEq(io.EOF, err)
+			assert.ErrorIs(t, err, tc.expectedCInvalidateCacheErr)
+			// Reading from the open file handle should fail as the file is truncated.
+			_, err = file.Read(buf)
+			assert.ErrorIs(chrT.T(), err, tc.expectedCacheFileReadErr)
+		})
+	}
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentSameFile() {
-	existingJob := chrT.getDownloadJobForTestObject()
-	AssertEq(downloader.NotStarted, existingJob.GetStatus().Name)
-	ExpectTrue(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
-	wg := sync.WaitGroup{}
-	InvalidateCacheTestFun := func() {
-		defer wg.Done()
-
-		err := chrT.cacheHandler.InvalidateCache(chrT.object.Name, chrT.bucket.Name())
-
-		AssertEq(nil, err)
-		ExpectNe(nil, existingJob)
-		ExpectEq(downloader.Invalid, existingJob.GetStatus().Name)
-		ExpectEq(false, doesFileExist(chrT.downloadPath))
-		// File info should also be removed.
-		ExpectFalse(chrT.isEntryInFileInfoCache(chrT.object.Name, chrT.bucket.Name()))
+func (chrT *CacheHandlerTest) Test_InvalidateCache_ConcurrentSameFile() {
+	tbl := []struct {
+		name                       string
+		fileCacheConfig            config.FileCacheConfig
+		cacheDir                   string
+		expectedInvalidateCacheErr error
+	}{
+		{
+			name:                       "Non parallel downloads",
+			fileCacheConfig:            config.FileCacheConfig{EnableCRC: true},
+			cacheDir:                   path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedInvalidateCacheErr: nil,
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 1, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:                   path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedInvalidateCacheErr: nil,
+		},
 	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			existingJob := getDownloadJobForTestObject(chrT.T(), chrT.chTestArgs)
+			require.Equal(chrT.T(), downloader.NotStarted, existingJob.GetStatus().Name)
+			require.True(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
+			wg := sync.WaitGroup{}
+			InvalidateCacheTestFun := func() {
+				defer wg.Done()
 
-	// Start concurrent GetCacheHandle()
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go InvalidateCacheTestFun()
+				err := chrT.chTestArgs.cacheHandler.InvalidateCache(chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name())
+
+				assert.ErrorIs(chrT.T(), err, tc.expectedInvalidateCacheErr)
+				assert.NotNil(chrT.T(), existingJob)
+				assert.Equal(chrT.T(), downloader.Invalid, existingJob.GetStatus().Name)
+				assert.Equal(chrT.T(), false, doesFileExist(chrT.T(), chrT.chTestArgs.downloadPath))
+				// File info should also be removed.
+				assert.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, chrT.chTestArgs.object.Name, chrT.chTestArgs.bucket.Name()))
+			}
+
+			// Start concurrent GetCacheHandle()
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go InvalidateCacheTestFun()
+			}
+			wg.Wait()
+		})
 	}
-	wg.Wait()
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
-	wg := sync.WaitGroup{}
-
-	InvalidateCacheTestFun := func(index int) {
-		defer wg.Done()
-		objName := "object" + strconv.Itoa(index)
-		objContent := "object content: content#" + strconv.Itoa(index)
-		minObj := chrT.getMinObject(objName, []byte(objContent))
-
-		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
-
-		AssertEq(nil, err)
-		AssertEq(nil, chrT.jobManager.GetJob(objName, chrT.bucket.Name()))
-		AssertFalse(chrT.isEntryInFileInfoCache(objName, chrT.bucket.Name()))
+func (chrT *CacheHandlerTest) Test_InvalidateCache_ConcurrentDifferentFiles() {
+	tbl := []struct {
+		name                       string
+		fileCacheConfig            config.FileCacheConfig
+		cacheDir                   string
+		expectedInvalidateCacheErr error
+	}{
+		{
+			name:                       "Non parallel downloads",
+			fileCacheConfig:            config.FileCacheConfig{EnableCRC: true},
+			cacheDir:                   path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedInvalidateCacheErr: nil,
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 1, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:                   path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedInvalidateCacheErr: nil,
+		},
 	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			wg := sync.WaitGroup{}
+			InvalidateCacheTestFun := func(index int) {
+				defer wg.Done()
+				objName := "object" + strconv.Itoa(index)
+				objContent := "object content: content#" + strconv.Itoa(index)
+				minObj := createObject(chrT.T(), chrT.chTestArgs.bucket, objName, []byte(objContent))
 
-	// Start concurrent GetCacheHandle()
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go InvalidateCacheTestFun(i)
+				err := chrT.chTestArgs.cacheHandler.InvalidateCache(minObj.Name, chrT.chTestArgs.bucket.Name())
+
+				assert.ErrorIs(chrT.T(), err, tc.expectedInvalidateCacheErr)
+				assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(objName, chrT.chTestArgs.bucket.Name()))
+				assert.False(chrT.T(), isEntryInFileInfoCache(chrT.T(), chrT.chTestArgs.cache, objName, chrT.chTestArgs.bucket.Name()))
+			}
+
+			// Start concurrent GetCacheHandle()
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go InvalidateCacheTestFun(i)
+			}
+			wg.Wait()
+		})
 	}
-	wg.Wait()
 }
 
-func (chrT *cacheHandlerTest) Test_InvalidateCache_GetCacheHandle_Concurrent() {
-	wg := sync.WaitGroup{}
-
-	invalidateCacheTestFun := func(index int) {
-		defer wg.Done()
-		objName := "object" + strconv.Itoa(index)
-		objContent := "object content: content#" + strconv.Itoa(index)
-		minObj := chrT.getMinObject(objName, []byte(objContent))
-
-		err := chrT.cacheHandler.InvalidateCache(minObj.Name, chrT.bucket.Name())
-
-		AssertEq(nil, err)
+func (chrT *CacheHandlerTest) Test_InvalidateCache_GetCacheHandle_Concurrent() {
+	tbl := []struct {
+		name                   string
+		fileCacheConfig        config.FileCacheConfig
+		cacheDir               string
+		expectedCacheHandleErr error
+	}{
+		{
+			name:                   "Non parallel downloads",
+			fileCacheConfig:        config.FileCacheConfig{EnableCRC: true},
+			cacheDir:               path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCacheHandleErr: nil,
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 1, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:               path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCacheHandleErr: nil,
+		},
 	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			wg := sync.WaitGroup{}
+			invalidateCacheTestFun := func(index int) {
+				defer wg.Done()
+				objName := "object" + strconv.Itoa(index)
+				objContent := "object content: content#" + strconv.Itoa(index)
+				minObj := createObject(chrT.T(), chrT.chTestArgs.bucket, objName, []byte(objContent))
 
-	getCacheHandleTestFun := func(index int) {
-		defer wg.Done()
-		objName := "object" + strconv.Itoa(index)
-		objContent := "object content: content#" + strconv.Itoa(index)
-		minObj := chrT.getMinObject(objName, []byte(objContent))
+				err := chrT.chTestArgs.cacheHandler.InvalidateCache(minObj.Name, chrT.chTestArgs.bucket.Name())
 
-		cacheHandle, err := chrT.cacheHandler.GetCacheHandle(minObj, chrT.bucket, false, 0)
+				assert.NoError(chrT.T(), err)
+			}
 
-		AssertEq(nil, err)
-		AssertEq(nil, cacheHandle.validateCacheHandle())
+			getCacheHandleTestFun := func(index int) {
+				defer wg.Done()
+				objName := "object" + strconv.Itoa(index)
+				objContent := "object content: content#" + strconv.Itoa(index)
+				minObj := createObject(chrT.T(), chrT.chTestArgs.bucket, objName, []byte(objContent))
+
+				cacheHandle, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObj, chrT.chTestArgs.bucket, false, 0)
+
+				assert.ErrorIs(chrT.T(), err, tc.expectedCacheHandleErr)
+				assert.Nil(chrT.T(), cacheHandle.validateCacheHandle())
+			}
+
+			// Start concurrent GetCacheHandle()
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go invalidateCacheTestFun(i)
+				wg.Add(1)
+				go getCacheHandleTestFun(i)
+			}
+			wg.Wait()
+		})
 	}
-
-	// Start concurrent GetCacheHandle()
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go invalidateCacheTestFun(i)
-		wg.Add(1)
-		go getCacheHandleTestFun(i)
-	}
-	wg.Wait()
 }
 
-func (chrT *cacheHandlerTest) Test_Destroy() {
-	minObject1 := chrT.getMinObject("object_1", []byte("content of object_1"))
-	minObject2 := chrT.getMinObject("object_2", []byte("content of object_2"))
-	cacheHandle1, err := chrT.cacheHandler.GetCacheHandle(minObject1, chrT.bucket, true, 0)
-	AssertEq(nil, err)
-	cacheHandle2, err := chrT.cacheHandler.GetCacheHandle(minObject2, chrT.bucket, true, 0)
-	AssertEq(nil, err)
-	ctx := context.Background()
-	// Read to create and populate file in cache.
-	buf := make([]byte, 3)
-	_, cacheHit, err := cacheHandle1.Read(ctx, chrT.bucket, minObject1, 4, buf)
-	AssertEq(nil, err)
-	AssertEq(false, cacheHit)
-	_, cacheHit, err = cacheHandle2.Read(ctx, chrT.bucket, minObject2, 4, buf)
-	AssertEq(nil, err)
-	AssertEq(false, cacheHit)
-	err = cacheHandle1.Close()
-	AssertEq(nil, err)
-	err = cacheHandle2.Close()
-	AssertEq(nil, err)
+func (chrT *CacheHandlerTest) Test_Destroy() {
+	tbl := []struct {
+		name                   string
+		fileCacheConfig        config.FileCacheConfig
+		cacheDir               string
+		expectedCacheHandleErr error
+		expectedJobStatus      []string
+	}{
+		{
+			name:                   "Non parallel downloads",
+			fileCacheConfig:        config.FileCacheConfig{EnableCRC: true},
+			cacheDir:               path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCacheHandleErr: nil,
+			expectedJobStatus:      []string{string(downloader.Completed)},
+		},
+		{
+			name: "Parallel downloads",
+			fileCacheConfig: config.FileCacheConfig{EnableCRC: true, EnableParallelDownloads: true,
+				ParallelDownloadsPerFile: 4, MaxParallelDownloads: 20, DownloadChunkSizeMB: 3},
+			cacheDir:               path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir"),
+			expectedCacheHandleErr: fmt.Errorf("read via gcs"),
+			expectedJobStatus:      []string{string(downloader.Completed), string(downloader.Invalid)},
+		},
+	}
+	for _, tc := range tbl {
+		chrT.T().Run(tc.name, func(t *testing.T) {
+			chrT.chTestArgs = setupHelper(chrT.T(), &tc.fileCacheConfig, tc.cacheDir)
+			minObject1 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_1", []byte("content of object_1"))
+			minObject2 := createObject(chrT.T(), chrT.chTestArgs.bucket, "object_2", []byte("content of object_2"))
+			cacheHandle1, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject1, chrT.chTestArgs.bucket, true, 0)
+			require.NoError(chrT.T(), err)
+			cacheHandle2, err := chrT.chTestArgs.cacheHandler.GetCacheHandle(minObject2, chrT.chTestArgs.bucket, true, 0)
+			require.NoError(chrT.T(), err)
+			ctx := context.Background()
+			// Read to create and populate file in cache.
+			buf := make([]byte, 3)
+			_, cacheHit, err := cacheHandle1.Read(ctx, chrT.chTestArgs.bucket, minObject1, 4, buf)
+			if tc.expectedCacheHandleErr == nil {
+				require.NoError(chrT.T(), err)
+			} else {
+				require.ErrorContains(chrT.T(), err, tc.expectedCacheHandleErr.Error())
+			}
+			require.Equal(chrT.T(), false, cacheHit)
+			_, cacheHit, err = cacheHandle2.Read(ctx, chrT.chTestArgs.bucket, minObject2, 4, buf)
+			if tc.expectedCacheHandleErr == nil {
+				require.NoError(chrT.T(), err)
+			} else {
+				require.ErrorContains(chrT.T(), err, tc.expectedCacheHandleErr.Error())
+			}
+			require.Equal(chrT.T(), false, cacheHit)
+			err = cacheHandle1.Close()
+			require.NoError(chrT.T(), err)
+			err = cacheHandle2.Close()
+			require.NoError(chrT.T(), err)
 
-	err = chrT.cacheHandler.Destroy()
+			err = chrT.chTestArgs.cacheHandler.Destroy()
 
-	AssertEq(nil, err)
-	// Verify the cacheDir is deleted.
-	_, err = os.Stat(path.Join(chrT.cacheDir, util.FileCache))
-	AssertNe(nil, err)
-	AssertTrue(errors.Is(err, os.ErrNotExist))
-	// Verify jobs are either removed or completed and removed themselves.
-	job1 := chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name())
-	job2 := chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name())
-	AssertTrue((job1 == nil) || (job1.GetStatus().Name == downloader.Completed))
-	AssertTrue((job2 == nil) || (job2.GetStatus().Name == downloader.Completed))
-	// Job manager should no longer contain the jobs
-	AssertEq(nil, chrT.jobManager.GetJob(minObject1.Name, chrT.bucket.Name()))
-	AssertEq(nil, chrT.jobManager.GetJob(minObject2.Name, chrT.bucket.Name()))
+			assert.NoError(chrT.T(), err)
+			// Verify the cacheDir is deleted.
+			_, err = os.Stat(path.Join(chrT.cacheDir, util.FileCache))
+			assert.ErrorIs(chrT.T(), err, os.ErrNotExist)
+			// Verify jobs statuses.
+			job1 := chrT.chTestArgs.jobManager.GetJob(minObject1.Name, chrT.chTestArgs.bucket.Name())
+			job2 := chrT.chTestArgs.jobManager.GetJob(minObject1.Name, chrT.chTestArgs.bucket.Name())
+			if job1 != nil {
+				assert.Contains(chrT.T(), tc.expectedJobStatus, job1.GetStatus().Name)
+			}
+			if job2 != nil {
+				assert.Contains(chrT.T(), tc.expectedJobStatus, job2.GetStatus().Name)
+			}
+			// Job manager should no longer contain the jobs
+			assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(minObject1.Name, chrT.chTestArgs.bucket.Name()))
+			assert.Nil(chrT.T(), chrT.chTestArgs.jobManager.GetJob(minObject2.Name, chrT.chTestArgs.bucket.Name()))
+		})
+	}
 }


### PR DESCRIPTION
### Description
Add new composite tests for parallel downloads in cache_handler and cache_handle.

Changes:
1. In cache_handler_test.go, changed from jacobsa/oglestest to stretchr/testify.
2. Use table test format where possible.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - NA
