### PR TITLE
Ignore EOF as error while recording bytes read.

### DIFF
--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -248,7 +248,7 @@ type monitoringReadCloser struct {
 
 func (mrc *monitoringReadCloser) Read(p []byte) (n int, err error) {
 	n, err = mrc.wrapped.Read(p)
-	if err == nil {
+	if err == nil || err == io.EOF {
 		stats.Record(mrc.ctx, readBytesCount.M(int64(n)))
 	}
 	return


### PR DESCRIPTION
EOF is not a real error; it just signifies that it has reached the end of file. Ignore it while recording metrics otherwise metrics won't be recorded correctly.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
