### PR TITLE
Change rename folder signature 

### DIFF
--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -223,14 +222,14 @@ func (b *prefixBucket) GetFolder(ctx context.Context, folderName string) (folder
 	return b.wrapped.GetFolder(ctx, mFolderName)
 }
 
+func (b *prefixBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
+	mFolderName := b.wrappedName(folderName)
+	return b.wrapped.CreateFolder(ctx, mFolderName)
+}
+
 func (b *prefixBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error) {
 	mFolderName := b.wrappedName(folderName)
 	mDestinationFolderId := b.wrappedName(destinationFolderId)
 	o, err := b.wrapped.RenameFolder(ctx, mFolderName, mDestinationFolderId)
 	return o, err
-}
-
-func (b *prefixBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
-	mFolderName := b.wrappedName(folderName)
-	return b.wrapped.CreateFolder(ctx, mFolderName)
 }

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -223,14 +223,14 @@ func (b *prefixBucket) GetFolder(ctx context.Context, folderName string) (folder
 	return b.wrapped.GetFolder(ctx, mFolderName)
 }
 
-func (b *prefixBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
-	mFolderName := b.wrappedName(folderName)
-	return b.wrapped.CreateFolder(ctx, mFolderName)
-}
-
-func (b *prefixBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*control.RenameFolderOperation, error) {
+func (b *prefixBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error) {
 	mFolderName := b.wrappedName(folderName)
 	mDestinationFolderId := b.wrappedName(destinationFolderId)
 	o, err := b.wrapped.RenameFolder(ctx, mFolderName, mDestinationFolderId)
 	return o, err
+}
+
+func (b *prefixBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
+	mFolderName := b.wrappedName(folderName)
+	return b.wrapped.CreateFolder(ctx, mFolderName)
 }

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/monitor/tags"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -217,7 +216,7 @@ func (mb *monitoringBucket) CreateFolder(ctx context.Context, folderName string)
 	return folder, err
 }
 
-func (mb *monitoringBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
+func (mb *monitoringBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
 	startTime := time.Now()
 	o, err = mb.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
 	recordRequest(ctx, "RenameFolder", startTime)

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -17,7 +17,6 @@ package ratelimit
 import (
 	"io"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -198,7 +197,7 @@ func (b *throttledBucket) DeleteFolder(ctx context.Context, folderName string) (
 	return
 }
 
-func (b *throttledBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
+func (b *throttledBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
 	// Wait for permission to call through.
 	err = b.opThrottle.Wait(ctx, 1)
 	if err != nil {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -477,14 +477,20 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 	return err
 }
 
-func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (resp *control.RenameFolderOperation, err error) {
+func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
 	req := &controlpb.RenameFolderRequest{
 		Name:                "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
 		DestinationFolderId: destinationFolderId,
 	}
-	resp, err = b.controlClient.RenameFolder(ctx, req)
+	resp, err := b.controlClient.RenameFolder(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("longrunning operation: %w", err)
+	}
 
-	return resp, err
+	controlFolder, err := resp.Wait(ctx)
+	folder = gcs.GCSFolder(b.bucketName, controlFolder)
+
+	return folder, err
 }
 
 // TODO: Consider adding this method to the bucket interface if additional

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -471,7 +471,7 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 	var callOptions []gax.CallOption
 
 	err = b.controlClient.DeleteFolder(ctx, &controlpb.DeleteFolderRequest{
-		Name: "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
+		Name: fmt.Sprintf("projects/_/buckets/%s/folders/%s", b.bucketName, folderName),
 	}, callOptions...)
 
 	return err
@@ -479,12 +479,11 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 
 func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
 	var controlFolder *controlpb.Folder
-	var resp RenameFolderOperationInterface
 	req := &controlpb.RenameFolderRequest{
-		Name:                "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
+		Name:                fmt.Sprintf("projects/_/buckets/%s/folders/%s", b.bucketName, folderName),
 		DestinationFolderId: destinationFolderId,
 	}
-	resp, err = b.controlClient.RenameFolder(ctx, req)
+	resp, err := b.controlClient.RenameFolder(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +501,7 @@ func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, dest
 func (b *bucketHandle) getStorageLayout() (*controlpb.StorageLayout, error) {
 	var callOptions []gax.CallOption
 	stoargeLayout, err := b.controlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
-		Name:      "projects/_/buckets/" + b.bucketName + "/storageLayout",
+		Name:      fmt.Sprintf("projects/_/buckets/%s/storageLayout", b.bucketName),
 		Prefix:    "",
 		RequestId: "",
 	}, callOptions...)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -486,7 +486,7 @@ func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, dest
 	}
 	resp, err = b.controlClient.RenameFolder(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("longrunning operation: %w", err)
+		return nil, err
 	}
 
 	// Wait blocks until the long-running operation is completed,

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -479,11 +479,12 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 
 func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
 	var controlFolder *controlpb.Folder
+	var resp RenameFolderOperationInterface
 	req := &controlpb.RenameFolderRequest{
 		Name:                "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
 		DestinationFolderId: destinationFolderId,
 	}
-	resp, err := b.controlClient.RenameFolder(ctx, req)
+	resp, err = b.controlClient.RenameFolder(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("longrunning operation: %w", err)
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -37,6 +37,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+const FullFolderPathHNS = "projects/_/buckets/%s/folders/%s"
+
 type bucketHandle struct {
 	gcs.Bucket
 	bucket        *storage.BucketHandle
@@ -471,7 +473,7 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 	var callOptions []gax.CallOption
 
 	err = b.controlClient.DeleteFolder(ctx, &controlpb.DeleteFolderRequest{
-		Name: fmt.Sprintf("projects/_/buckets/%s/folders/%s", b.bucketName, folderName),
+		Name: fmt.Sprintf(FullFolderPathHNS, b.bucketName, folderName),
 	}, callOptions...)
 
 	return err
@@ -480,7 +482,7 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
 	var controlFolder *controlpb.Folder
 	req := &controlpb.RenameFolderRequest{
-		Name:                fmt.Sprintf("projects/_/buckets/%s/folders/%s", b.bucketName, folderName),
+		Name:                fmt.Sprintf(FullFolderPathHNS, b.bucketName, folderName),
 		DestinationFolderId: destinationFolderId,
 	}
 	resp, err := b.controlClient.RenameFolder(ctx, req)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -478,6 +478,7 @@ func (b *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err
 }
 
 func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
+	var controlFolder *controlpb.Folder
 	req := &controlpb.RenameFolderRequest{
 		Name:                "projects/_/buckets/" + b.bucketName + "/folders/" + folderName,
 		DestinationFolderId: destinationFolderId,
@@ -487,7 +488,9 @@ func (b *bucketHandle) RenameFolder(ctx context.Context, folderName string, dest
 		return nil, fmt.Errorf("longrunning operation: %w", err)
 	}
 
-	controlFolder, err := resp.Wait(ctx)
+	// Wait blocks until the long-running operation is completed,
+	// returning the response and any errors encountered.
+	controlFolder, err = resp.Wait(ctx)
 	folder = gcs.GCSFolder(b.bucketName, controlFolder)
 
 	return folder, err

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1299,6 +1299,24 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderExistsForHierarchicalB
 	assert.Equal(testSuite.T(), TestObjectName, result.Name)
 }
 
+func (testSuite *BucketHandleTest) TestRenameFolder() {
+	mockFolder := controlpb.Folder{Name: TestObjectName}
+	mockClient := new(MockStorageControlClient)
+	mockClientOnRenameOperation := new(MockRenameFolderOperation)
+	mockClientOnRenameOperation.On("Wait", context.Background()).Return(mockFolder)
+	mockClient.On("RenameFolder", mock.Anything, &controlpb.RenameFolderRequest{Name: "projects/_/buckets/" + TestBucketName + "/folders/" + TestObjectName, DestinationFolderId: TestRenameFolder}, mock.Anything).
+		Return(mockClientOnRenameOperation, nil)
+	testSuite.bucketHandle.controlClient = mockClient
+	testSuite.bucketHandle.bucketType = gcs.Hierarchical
+
+	o, err := testSuite.bucketHandle.RenameFolder(context.Background(), TestObjectName, TestRenameFolder)
+
+	mockClient.AssertExpectations(testSuite.T())
+	mockClientOnRenameOperation.AssertExpectations(testSuite.T())
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), o)
+}
+
 func (testSuite *BucketHandleTest) TestGetFolderWhenFolderDoesNotExistsForHierarchicalBucket() {
 	ctx := context.Background()
 	mockClient := new(MockStorageControlClient)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1316,21 +1316,6 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderDoesNotExistsForHierar
 	assert.ErrorContains(testSuite.T(), err, "folder not found")
 }
 
-func (testSuite *BucketHandleTest) TestRenameFolder() {
-	ctx := context.Background()
-	mockClient := new(MockStorageControlClient)
-	mockClient.On("RenameFolder", mock.Anything, &controlpb.RenameFolderRequest{Name: "projects/_/buckets/" + TestBucketName + "/folders/" + TestObjectName, DestinationFolderId: TestRenameFolder}, mock.Anything).
-		Return(&gcs.Folder{Name: TestRenameFolder}, nil)
-	testSuite.bucketHandle.controlClient = mockClient
-	testSuite.bucketHandle.bucketType = gcs.Hierarchical
-
-	o, err := testSuite.bucketHandle.RenameFolder(ctx, TestObjectName, TestRenameFolder)
-
-	mockClient.AssertExpectations(testSuite.T())
-	assert.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), o.Name, TestRenameFolder)
-}
-
 func (testSuite *BucketHandleTest) TestRenameFolderWithError() {
 	ctx := context.Background()
 	mockClient := new(MockStorageControlClient)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1299,26 +1299,6 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderExistsForHierarchicalB
 	assert.Equal(testSuite.T(), TestObjectName, result.Name)
 }
 
-func (testSuite *BucketHandleTest) TestRenameFolder() {
-	mockFolder := controlpb.Folder{Name: TestObjectName}
-	mockClient := new(MockStorageControlClient)
-	mockClientOnRenameOperation := new(MockRenameFolderOperation)
-	mockClientOnRenameOperation.On("Wait", context.Background()).Return(mockFolder)
-	var r RenameFolderOperationInterface
-	r = mockClientOnRenameOperation
-	mockClient.On("RenameFolder", mock.Anything, &controlpb.RenameFolderRequest{Name: "projects/_/buckets/" + TestBucketName + "/folders/" + TestObjectName, DestinationFolderId: TestRenameFolder}, mock.Anything).
-		Return(r, nil)
-	testSuite.bucketHandle.controlClient = mockClient
-	testSuite.bucketHandle.bucketType = gcs.Hierarchical
-
-	o, err := testSuite.bucketHandle.RenameFolder(context.Background(), TestObjectName, TestRenameFolder)
-
-	mockClient.AssertExpectations(testSuite.T())
-	mockClientOnRenameOperation.AssertExpectations(testSuite.T())
-	assert.Nil(testSuite.T(), err)
-	assert.NotNil(testSuite.T(), o)
-}
-
 func (testSuite *BucketHandleTest) TestGetFolderWhenFolderDoesNotExistsForHierarchicalBucket() {
 	ctx := context.Background()
 	mockClient := new(MockStorageControlClient)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1304,8 +1304,10 @@ func (testSuite *BucketHandleTest) TestRenameFolder() {
 	mockClient := new(MockStorageControlClient)
 	mockClientOnRenameOperation := new(MockRenameFolderOperation)
 	mockClientOnRenameOperation.On("Wait", context.Background()).Return(mockFolder)
+	var r RenameFolderOperationInterface
+	r = mockClientOnRenameOperation
 	mockClient.On("RenameFolder", mock.Anything, &controlpb.RenameFolderRequest{Name: "projects/_/buckets/" + TestBucketName + "/folders/" + TestObjectName, DestinationFolderId: TestRenameFolder}, mock.Anything).
-		Return(mockClientOnRenameOperation, nil)
+		Return(r, nil)
 	testSuite.bucketHandle.controlClient = mockClient
 	testSuite.bucketHandle.bucketType = gcs.Hierarchical
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1320,7 +1320,7 @@ func (testSuite *BucketHandleTest) TestRenameFolder() {
 	ctx := context.Background()
 	mockClient := new(MockStorageControlClient)
 	mockClient.On("RenameFolder", mock.Anything, &controlpb.RenameFolderRequest{Name: "projects/_/buckets/" + TestBucketName + "/folders/" + TestObjectName, DestinationFolderId: TestRenameFolder}, mock.Anything).
-		Return(&control.RenameFolderOperation{}, nil)
+		Return(&gcs.Folder{Name: TestRenameFolder}, nil)
 	testSuite.bucketHandle.controlClient = mockClient
 	testSuite.bucketHandle.bucketType = gcs.Hierarchical
 
@@ -1328,7 +1328,7 @@ func (testSuite *BucketHandleTest) TestRenameFolder() {
 
 	mockClient.AssertExpectations(testSuite.T())
 	assert.Nil(testSuite.T(), err)
-	assert.NotNil(testSuite.T(), o)
+	assert.Equal(testSuite.T(), o.Name, TestRenameFolder)
 }
 
 func (testSuite *BucketHandleTest) TestRenameFolderWithError() {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
@@ -325,18 +324,18 @@ func (b *fastStatBucket) GetFolder(
 	return b.wrapped.GetFolder(ctx, prefix)
 }
 
-func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
-	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
-
-	// TODO: Invalidate cache
-
-	return o, err
-}
-
 func (b *fastStatBucket) CreateFolder(ctx context.Context, folderName string) (o *gcs.Folder, err error) {
 	o, err = b.wrapped.CreateFolder(ctx, folderName)
 
 	// TODO: Insert folder in the cache
 
 	return
+}
+
+func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
+	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
+
+	// TODO: Invalidate cache
+
+	return o, err
 }

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -325,18 +325,18 @@ func (b *fastStatBucket) GetFolder(
 	return b.wrapped.GetFolder(ctx, prefix)
 }
 
+func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
+	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
+
+	// TODO: Invalidate cache
+
+	return o, err
+}
+
 func (b *fastStatBucket) CreateFolder(ctx context.Context, folderName string) (o *gcs.Folder, err error) {
 	o, err = b.wrapped.CreateFolder(ctx, folderName)
 
 	// TODO: Insert folder in the cache
 
 	return
-}
-
-func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
-	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
-
-	// TODO: Invalidate cache
-
-	return o, err
 }

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -37,7 +37,3 @@ type StorageControlClient interface {
 
 	CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error)
 }
-
-type RenameFolderOperationInterface interface {
-	Wait(ctx context.Context, opts ...gax.CallOption) (*controlpb.Folder, error)
-}

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -37,3 +37,7 @@ type StorageControlClient interface {
 
 	CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error)
 }
+
+type RenameFolderOperationInterface interface {
+	Wait(ctx context.Context, opts ...gax.CallOption) (*controlpb.Folder, error)
+}

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
@@ -247,18 +246,18 @@ func (b *debugBucket) GetFolder(ctx context.Context, folderName string) (folder 
 	return
 }
 
-func (b *debugBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
-	id, desc, start := b.startRequest("RenameFolder(%q)", folderName)
-	defer b.finishRequest(id, desc, start, &err)
-
-	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
-	return o, err
-}
-
 func (b *debugBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
 	id, desc, start := b.startRequest("CreateFolder(%q)", folderName)
 	defer b.finishRequest(id, desc, start, &err)
 
 	folder, err = b.wrapped.CreateFolder(ctx, folderName)
 	return
+}
+
+func (b *debugBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
+	id, desc, start := b.startRequest("RenameFolder(%q)", folderName)
+	defer b.finishRequest(id, desc, start, &err)
+
+	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
+	return o, err
 }

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -247,18 +247,18 @@ func (b *debugBucket) GetFolder(ctx context.Context, folderName string) (folder 
 	return
 }
 
+func (b *debugBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
+	id, desc, start := b.startRequest("RenameFolder(%q)", folderName)
+	defer b.finishRequest(id, desc, start, &err)
+
+	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
+	return o, err
+}
+
 func (b *debugBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
 	id, desc, start := b.startRequest("CreateFolder(%q)", folderName)
 	defer b.finishRequest(id, desc, start, &err)
 
 	folder, err = b.wrapped.CreateFolder(ctx, folderName)
 	return
-}
-
-func (b *debugBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
-	id, desc, start := b.startRequest("RenameFolder(%q)", folderName)
-	defer b.finishRequest(id, desc, start, &err)
-
-	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
-	return o, err
 }

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -900,11 +900,6 @@ func (b *bucket) GetFolder(ctx context.Context, foldername string) (*gcs.Folder,
 	return &gcs.Folder{Name: foldername}, nil
 }
 
-func (b *bucket) CreateFolder(ctx context.Context, foldername string) (o *gcs.Folder, err error) {
-	// TODO: Implement
-	return
-}
-
 func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
 	// Check that the destination name is legal.
 	err = checkName(destinationFolderId)
@@ -948,5 +943,10 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 	// Remove the folder.
 	b.objects = append(b.objects[:index], b.objects[index+1:]...)
 
+	return
+}
+
+func (b *bucket) CreateFolder(ctx context.Context, foldername string) (o *gcs.Folder, err error) {
+	// TODO: Implement
 	return
 }

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -900,7 +899,12 @@ func (b *bucket) GetFolder(ctx context.Context, foldername string) (*gcs.Folder,
 	return &gcs.Folder{Name: foldername}, nil
 }
 
-func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *control.RenameFolderOperation, err error) {
+func (b *bucket) CreateFolder(ctx context.Context, foldername string) (o *gcs.Folder, err error) {
+	// TODO: Implement
+	return
+}
+
+func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
 	// Check that the destination name is legal.
 	err = checkName(destinationFolderId)
 	if err != nil {
@@ -943,10 +947,5 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 	// Remove the folder.
 	b.objects = append(b.objects[:index], b.objects[index+1:]...)
 
-	return
-}
-
-func (b *bucket) CreateFolder(ctx context.Context, foldername string) (o *gcs.Folder, err error) {
-	// TODO: Implement
 	return
 }

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -17,7 +17,6 @@ package gcs
 import (
 	"io"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"golang.org/x/net/context"
 )
 
@@ -147,7 +146,7 @@ type Bucket interface {
 	GetFolder(ctx context.Context, folderName string) (*Folder, error)
 
 	// Atomically rename folder for Hierarchical bucket.
-	RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*control.RenameFolderOperation, error)
+	RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*Folder, error)
 
 	CreateFolder(ctx context.Context, folderName string) (*Folder, error)
 }

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -376,6 +376,32 @@ func (m *mockBucket) GetFolder(
 	return
 }
 
+func (m *mockBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o0 *gcs.Folder, o1 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"RenameFolder",
+		file,
+		line,
+		[]interface{}{})
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockBucket.RenameFolder: invalid return values: %v", retVals))
+	}
+	// o0 string
+	if retVals[0] != nil {
+		o0 = retVals[0].(*control.RenameFolderOperation)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
+	}
+	return
+}
+
 func (m *mockBucket) CreateFolder(ctx context.Context, prefix string) (o0 *gcs.Folder, o1 error) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
@@ -394,32 +420,6 @@ func (m *mockBucket) CreateFolder(ctx context.Context, prefix string) (o0 *gcs.F
 
 	if retVals[0] != nil {
 		o0 = retVals[0].(*gcs.Folder)
-	}
-
-	// o1 error
-	if retVals[1] != nil {
-		o1 = retVals[1].(error)
-	}
-	return
-}
-
-func (m *mockBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o0 *control.RenameFolderOperation, o1 error) {
-	// Get a file name and line number for the caller.
-	_, file, line, _ := runtime.Caller(1)
-
-	// Hand the call off to the controller, which does most of the work.
-	retVals := m.controller.HandleMethodCall(
-		m,
-		"RenameFolder",
-		file,
-		line,
-		[]interface{}{})
-	if len(retVals) != 1 {
-		panic(fmt.Sprintf("mockBucket.RenameFolder: invalid return values: %v", retVals))
-	}
-	// o0 string
-	if retVals[0] != nil {
-		o0 = retVals[0].(*control.RenameFolderOperation)
 	}
 
 	// o1 error

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -12,7 +12,6 @@ import (
 	runtime "runtime"
 	unsafe "unsafe"
 
-	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	oglemock "github.com/jacobsa/oglemock"
 	context "golang.org/x/net/context"
@@ -376,32 +375,6 @@ func (m *mockBucket) GetFolder(
 	return
 }
 
-func (m *mockBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o0 *gcs.Folder, o1 error) {
-	// Get a file name and line number for the caller.
-	_, file, line, _ := runtime.Caller(1)
-
-	// Hand the call off to the controller, which does most of the work.
-	retVals := m.controller.HandleMethodCall(
-		m,
-		"RenameFolder",
-		file,
-		line,
-		[]interface{}{})
-	if len(retVals) != 1 {
-		panic(fmt.Sprintf("mockBucket.RenameFolder: invalid return values: %v", retVals))
-	}
-	// o0 string
-	if retVals[0] != nil {
-		o0 = retVals[0].(*control.RenameFolderOperation)
-	}
-
-	// o1 error
-	if retVals[1] != nil {
-		o1 = retVals[1].(error)
-	}
-	return
-}
-
 func (m *mockBucket) CreateFolder(ctx context.Context, prefix string) (o0 *gcs.Folder, o1 error) {
 	// Get a file name and line number for the caller.
 	_, file, line, _ := runtime.Caller(1)
@@ -418,6 +391,32 @@ func (m *mockBucket) CreateFolder(ctx context.Context, prefix string) (o0 *gcs.F
 		panic(fmt.Sprintf("mockBucket.GetFolder: invalid return values: %v", retVals))
 	}
 
+	if retVals[0] != nil {
+		o0 = retVals[0].(*gcs.Folder)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
+	}
+	return
+}
+
+func (m *mockBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o0 *gcs.Folder, o1 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"RenameFolder",
+		file,
+		line,
+		[]interface{}{})
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockBucket.RenameFolder: invalid return values: %v", retVals))
+	}
+	// o0 string
 	if retVals[0] != nil {
 		o0 = retVals[0].(*gcs.Folder)
 	}

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -29,6 +29,11 @@ type MockStorageControlClient struct {
 	mock.Mock
 }
 
+type MockRenameFolderOperation struct {
+	RenameFolderOperationInterface
+	mock.Mock
+}
+
 // Implement the GetStorageLayout method for the mock.
 func (m *MockStorageControlClient) GetStorageLayout(ctx context.Context,
 	req *controlpb.GetStorageLayoutRequest,
@@ -75,6 +80,16 @@ func (m *MockStorageControlClient) RenameFolder(ctx context.Context, req *contro
 	args := m.Called(ctx, req, opts)
 
 	if folderOp, ok := args.Get(0).(*control.RenameFolderOperation); ok {
+		return folderOp, nil
+	}
+
+	return nil, args.Error(1)
+}
+
+func (m *MockRenameFolderOperation) Wait(ctx context.Context, opts ...gax.CallOption) (*controlpb.Folder, error) {
+	args := m.Called(ctx, opts)
+
+	if folderOp, ok := args.Get(0).(*controlpb.Folder); ok {
 		return folderOp, nil
 	}
 

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -29,11 +29,6 @@ type MockStorageControlClient struct {
 	mock.Mock
 }
 
-type MockRenameFolderOperation struct {
-	RenameFolderOperationInterface
-	mock.Mock
-}
-
 // Implement the GetStorageLayout method for the mock.
 func (m *MockStorageControlClient) GetStorageLayout(ctx context.Context,
 	req *controlpb.GetStorageLayoutRequest,
@@ -80,16 +75,6 @@ func (m *MockStorageControlClient) RenameFolder(ctx context.Context, req *contro
 	args := m.Called(ctx, req, opts)
 
 	if folderOp, ok := args.Get(0).(*control.RenameFolderOperation); ok {
-		return folderOp, nil
-	}
-
-	return nil, args.Error(1)
-}
-
-func (m *MockRenameFolderOperation) Wait(ctx context.Context, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	args := m.Called(ctx, opts)
-
-	if folderOp, ok := args.Get(0).(*controlpb.Folder); ok {
 		return folderOp, nil
 	}
 

--- a/internal/storage/mock_control_client.go
+++ b/internal/storage/mock_control_client.go
@@ -74,8 +74,8 @@ func (m *MockStorageControlClient) CreateFolder(ctx context.Context, req *contro
 func (m *MockStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
 	args := m.Called(ctx, req, opts)
 
-	if folder, ok := args.Get(0).(*control.RenameFolderOperation); ok {
-		return folder, nil
+	if folderOp, ok := args.Get(0).(*control.RenameFolderOperation); ok {
+		return folderOp, nil
 	}
 
 	return nil, args.Error(1)


### PR DESCRIPTION
### Description
- The signature of the RenameFolder function has been modified.
- We previously returned control.RenameFolderOperation, but to keep the control client integration within the bucket handle, we now return gcs.Folder.
- Unit testing a successful rename is not possible because the control client's rename folder operation returns a control.RenameFolderOperation response containing private data that we cannot access externally so we can not mock it in our unit tests.
- We've added a wait call directly within the bucket handle to block until the long-running operation completes successfully.(Previously we thought to add this call from where we call RenameFolder API)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
