### PR TITLE
fix flakiness in list large directory tests

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -176,8 +176,9 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
-	assert.Less(t, secondListTime, 100*time.Millisecond)
+	// The second directory listing should be 5 times better performant since it
+	// will be retrieved from the kernel cache.
+	assert.Less(t, 5*secondListTime, firstListTime)
 	// Clear the data after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -212,8 +213,9 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
-	assert.Less(t, secondListTime, 100*time.Millisecond)
+	// The second directory listing should be 5 times better performant since it
+	// will be retrieved from the kernel cache.
+	assert.Less(t, 5*secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -250,8 +252,9 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should take less than 100 milliseconds since it will be retrieved from the kernel cache.
-	assert.Less(t, secondListTime, 100*time.Millisecond)
+	// The second directory listing should be 5 times better performant since it
+	// will be retrieved from the kernel cache.
+	assert.Less(t, 5*secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }


### PR DESCRIPTION
### Description
On some n2-standard-16 machines, kernel list cache is taking ~130 ms thus making this test flaky. Made the logic relative to first list time to remove flakiness.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
