### PR TITLE
Create folder implementation - 3

### DIFF
--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -819,7 +819,7 @@ type CreateFolderTest struct {
 
 func init() { RegisterTestSuite(&CreateFolderTest{}) }
 
-func (t *CreateFolderTest) TestCreateFolderCallsWrappedCreateFolderWithSuccess() {
+func (t *CreateFolderTest) TestCreateFolderWhenGCSCallSucceeds() {
 	const name = "some-name"
 	folder := &gcs.Folder{
 		Name: name,
@@ -837,7 +837,7 @@ func (t *CreateFolderTest) TestCreateFolderCallsWrappedCreateFolderWithSuccess()
 	ExpectThat(result, Pointee(DeepEquals(*folder)))
 }
 
-func (t *CreateFolderTest) TestCreateFolderReturnsErrorFromWrappedCreateFolder() {
+func (t *CreateFolderTest) TestCreateFolderWhenGCSCallFails() {
 	const name = "some-name"
 	ExpectCall(t.cache, "Erase")(name).
 		WillOnce(Return())

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -813,7 +813,13 @@ func (t *DeleteFolderTest) Test_DeleteFolder_Failure() {
 	AssertNe(nil, err)
 }
 
-func (t *StatObjectTest) TestShouldCallCreateFolder() {
+type CreateFolderTest struct {
+	fastStatBucketTest
+}
+
+func init() { RegisterTestSuite(&CreateFolderTest{}) }
+
+func (t *CreateFolderTest) TestCreateFolderCallsWrappedCreateFolderWithSuccess() {
 	const name = "some-name"
 	folder := &gcs.Folder{
 		Name: name,
@@ -831,7 +837,7 @@ func (t *StatObjectTest) TestShouldCallCreateFolder() {
 	ExpectThat(result, Pointee(DeepEquals(*folder)))
 }
 
-func (t *StatObjectTest) TestCallCreateFolderWithError() {
+func (t *CreateFolderTest) TestCreateFolderReturnsErrorFromWrappedCreateFolder() {
 	const name = "some-name"
 	ExpectCall(t.cache, "Erase")(name).
 		WillOnce(Return())

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -812,3 +812,36 @@ func (t *DeleteFolderTest) Test_DeleteFolder_Failure() {
 
 	AssertNe(nil, err)
 }
+
+func (t *StatObjectTest) TestShouldCallCreateFolder() {
+	const name = "some-name"
+	folder := &gcs.Folder{
+		Name: name,
+	}
+
+	ExpectCall(t.cache, "Erase")(name).
+		WillOnce(Return())
+	ExpectCall(t.cache, "InsertFolder")(folder, Any()).
+		WillOnce(Return())
+	ExpectCall(t.wrapped, "CreateFolder")(Any(), name).
+		WillOnce(Return(folder, nil))
+
+	result, err := t.bucket.CreateFolder(context.TODO(), name)
+
+	AssertEq(nil, err)
+	ExpectThat(result, Pointee(DeepEquals(*folder)))
+}
+
+func (t *StatObjectTest) TestCallCreateFolderWithError() {
+	const name = "some-name"
+
+	ExpectCall(t.cache, "Erase")(name).
+		WillOnce(Return())
+	ExpectCall(t.wrapped, "CreateFolder")(Any(), name).
+		WillOnce(Return(nil, fmt.Errorf("mock error")))
+
+	result, err := t.bucket.CreateFolder(context.TODO(), name)
+
+	AssertNe(nil, err)
+	AssertEq(nil, result)
+}

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -818,7 +818,6 @@ func (t *StatObjectTest) TestShouldCallCreateFolder() {
 	folder := &gcs.Folder{
 		Name: name,
 	}
-
 	ExpectCall(t.cache, "Erase")(name).
 		WillOnce(Return())
 	ExpectCall(t.cache, "InsertFolder")(folder, Any()).
@@ -834,7 +833,6 @@ func (t *StatObjectTest) TestShouldCallCreateFolder() {
 
 func (t *StatObjectTest) TestCallCreateFolderWithError() {
 	const name = "some-name"
-
 	ExpectCall(t.cache, "Erase")(name).
 		WillOnce(Return())
 	ExpectCall(t.wrapped, "CreateFolder")(Any(), name).


### PR DESCRIPTION
### Description
- Fast stat bucket integration with create folder
- Insert the folder into cache after successfully created.
- Added unit tests.
- Haven't integrated stretcher testify as it will add more changes in this PR.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
