### PR TITLE
Adding negative entry after in delete object flow

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -273,8 +273,13 @@ func (b *fastStatBucket) UpdateObject(
 func (b *fastStatBucket) DeleteObject(
 	ctx context.Context,
 	req *gcs.DeleteObjectRequest) (err error) {
-	b.invalidate(req.Name)
 	err = b.wrapped.DeleteObject(ctx, req)
+	if err != nil {
+		b.invalidate(req.Name)
+	} else {
+		b.addNegativeEntry(req.Name)
+	}
+
 	return
 }
 

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -714,8 +714,8 @@ func (t *DeleteObjectTest) WrappedSucceeds() {
 	const name = ""
 	var err error
 
-	// Erase
-	ExpectCall(t.cache, "Erase")(Any())
+	// AddNegativeEntry
+	ExpectCall(t.cache, "AddNegativeEntry")(Any(), Any())
 
 	// Wrapped
 	ExpectCall(t.wrapped, "DeleteObject")(Any(), Any()).


### PR DESCRIPTION
### Description
- Correcting the order of deletion of object from metadata cache and actual deletion in GCS. Initially, we used to delete from the cache before the actual delete. Ideally, it should be done after the actual deletion in GCS. - Need to think here more - the implication of these changes.
- Adding negative entry in metadata cache once object is deleted successfully.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
