### PR TITLE
disable experimental test run for presubmit test

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,6 +22,7 @@ readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
 readonly PROJECT_ID="gcs-fuse-test-ml"
 readonly BUCKET_LOCATION=us-central1
+readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 echo "Building and installing gcsfuse..."
@@ -34,4 +35,4 @@ git checkout $commitId
 
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage
-./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT
+./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,6 +22,8 @@ readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
 readonly PROJECT_ID="gcs-fuse-test-ml"
 readonly BUCKET_LOCATION=us-central1
+
+# This flag, if set true, will indicate to the underlying script, to customize for a presubmit-run.
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -23,6 +23,7 @@ readonly RUN_TEST_ON_TPC_ENDPOINT=true
 # TPC project id
 readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
+readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
@@ -57,7 +58,7 @@ gcloud config set project $PROJECT_ID
 
 set +e
 # $1 argument is refering to value of testInstalledPackage
-./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT
+./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG
 exit_code=$?
 set -e
 

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -23,6 +23,8 @@ readonly RUN_TEST_ON_TPC_ENDPOINT=true
 # TPC project id
 readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
+
+# This flag, if set true, will indicate to underlying script to customize for a presubmit run.
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -20,6 +20,7 @@ readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
 readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
 readonly BUCKET_LOCATION=us-west1
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
+readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=true
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
@@ -107,5 +108,5 @@ then
 
   echo "Running e2e tests...."
   # $1 argument is refering to value of testInstalledPackage.
-  ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT
+  ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -20,6 +20,8 @@ readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
 readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
 readonly BUCKET_LOCATION=us-west1
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
+
+# This flag, if set true, will indicate to underlying script to customize for a presubmit run.
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=true
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 	// Note: We are not testing specifically for implicit-dirs because they are covered as part of the other flags.
 	flagsSet := [][]string{}
 
-	// Enable experimental-enable-json-read=true case for non-presubmit runs.
+	// Enable experimental-enable-json-read=true case, but for non-presubmit runs only.
 	if !setup.IsPresubmitRun() {
 		flagsSet = append(flagsSet, []string{
 			// By default, creating emptyFile is disabled.

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -179,9 +179,13 @@ func TestMain(m *testing.M) {
 	// Set up flags to run tests on.
 	// Note: GRPC related tests will work only if you have allow-list bucket.
 	// Note: We are not testing specifically for implicit-dirs because they are covered as part of the other flags.
-	flagsSet := [][]string{
-		// By default, creating emptyFile is disabled.
-		{"--experimental-enable-json-read=true"},
+	flagsSet := [][]string{}
+
+	// Enable experimental-enable-json-read=true case for non-presubmit runs.
+	if !setup.IsPresubmitRun() {
+		flagsSet = append(flagsSet, []string{
+			// By default, creating emptyFile is disabled.
+			"--experimental-enable-json-read=true"})
 	}
 
 	// gRPC tests will not run in TPC environment

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -31,9 +31,7 @@ RUN_TEST_ON_TPC_ENDPOINT=false
 if [ $4 != "" ]; then
   RUN_TEST_ON_TPC_ENDPOINT=$4
 fi
-
 INTEGRATION_TEST_TIMEOUT_IN_MINS=70
-
 
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 if [ $# -ge 5 ] ; then

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -31,7 +31,9 @@ RUN_TEST_ON_TPC_ENDPOINT=false
 if [ $4 != "" ]; then
   RUN_TEST_ON_TPC_ENDPOINT=$4
 fi
-INTEGRATION_TEST_TIMEOUT=70m
+
+INTEGRATION_TEST_TIMEOUT_IN_MINS=70
+
 
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 if [ $# -ge 5 ] ; then
@@ -48,21 +50,18 @@ fi
 if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   GO_TEST_SHORT_FLAG="-short"
   echo "Setting the flag to skip few un-important integration tests."
-  INTEGRATION_TEST_TIMEOUT=50m
-  echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
+  INTEGRATION_TEST_TIMEOUT_IN_MINS=$((INTEGRATION_TEST_TIMEOUT_IN_MINS-20))
 fi
 
 # Pass flag "-presubmit" to 'go test' command and lower timeout for presubmit runs.
 if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
+  echo "This is a presubmit-run, which skips some tests."
   PRESUBMIT_RUN_FLAG="-presubmit"
-  if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
-    INTEGRATION_TEST_TIMEOUT=40m
-  else
-    INTEGRATION_TEST_TIMEOUT=60m
-  fi
-  echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
-  echo "This is a presubmit-run."
+  INTEGRATION_TEST_TIMEOUT_IN_MINS=$((INTEGRATION_TEST_TIMEOUT_IN_MINS-10))
 fi
+
+INTEGRATION_TEST_TIMEOUT=""${INTEGRATION_TEST_TIMEOUT_IN_MINS}"m"
+echo "Setting the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
 
 readonly RANDOM_STRING_LENGTH=5
 # Test directory arrays

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -53,6 +53,9 @@ fi
 
 if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
   GO_TEST_PRESUBMIT_FLAG="-presubmit"
+  if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
+    INTEGRATION_TEST_TIMEOUT=40m
+  fi
   echo "Setting the flag to mark run as presubmit-run."
 fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -52,7 +52,7 @@ if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
 fi
 
 if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
-  GO_TEST_PRESUBMIT_FLAG="-presubmit"
+  PRESUBMIT_RUN_FLAG="-presubmit"
   if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
     INTEGRATION_TEST_TIMEOUT=40m
     echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
@@ -159,7 +159,7 @@ function run_non_parallel_tests() {
     echo $log_file >> $TEST_LOGS_FILE
 
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -183,7 +183,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done
@@ -272,7 +272,7 @@ function run_e2e_tests_for_tpc() {
   gcloud storage rm -r gs://gcsfuse-e2e-tests-tpc/**
 
   # Run Operations e2e tests in TPC to validate all the functionality.
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG -p 1 --integrationTest -v --testbucket=gcsfuse-e2e-tests-tpc --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG -p 1 --integrationTest -v --testbucket=gcsfuse-e2e-tests-tpc --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
   exit_code=$?
 
   set -e

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -55,8 +55,10 @@ if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
   PRESUBMIT_RUN_FLAG="-presubmit"
   if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
     INTEGRATION_TEST_TIMEOUT=40m
-    echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
+  else
+    INTEGRATION_TEST_TIMEOUT=60m
   fi
+  echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
   echo "Setting the flag to mark run as presubmit-run."
 fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -34,7 +34,7 @@ fi
 INTEGRATION_TEST_TIMEOUT=70m
 
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
-if [ $# -ge 5 ]
+if [ $# -ge 5 ] ; then
   RUN_TESTS_WITH_PRESUBMIT_FLAG=$5
 fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -33,6 +33,11 @@ if [ $4 != "" ]; then
 fi
 INTEGRATION_TEST_TIMEOUT=70m
 
+RUN_TESTS_WITH_PRESUBMIT_FLAG=false
+if [ $# -ge 5 ]
+  RUN_TESTS_WITH_PRESUBMIT_FLAG=$5
+fi
+
 if [ "$#" -lt 3 ]
 then
   echo "Incorrect number of arguments passed, please refer to the script and pass the three arguments required..."
@@ -44,6 +49,11 @@ if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   echo "Setting the flag to skip few un-important integration tests."
   INTEGRATION_TEST_TIMEOUT=50m
   echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
+fi
+
+if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
+  GO_TEST_PRESUBMIT_FLAG="-presubmit"
+  echo "Setting the flag to mark run as presubmit-run."
 fi
 
 readonly RANDOM_STRING_LENGTH=5
@@ -145,7 +155,7 @@ function run_non_parallel_tests() {
     echo $log_file >> $TEST_LOGS_FILE
 
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG --integrationTest -v --testbucket=$bucket_name_non_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -169,7 +179,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done
@@ -258,7 +268,7 @@ function run_e2e_tests_for_tpc() {
   gcloud storage rm -r gs://gcsfuse-e2e-tests-tpc/**
 
   # Run Operations e2e tests in TPC to validate all the functionality.
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG -p 1 --integrationTest -v --testbucket=gcsfuse-e2e-tests-tpc --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $GO_TEST_PRESUBMIT_FLAG -p 1 --integrationTest -v --testbucket=gcsfuse-e2e-tests-tpc --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
   exit_code=$?
 
   set -e

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -35,6 +35,7 @@ INTEGRATION_TEST_TIMEOUT=70m
 
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 if [ $# -ge 5 ] ; then
+  # This parameter is set to true by caller, only for presubmit runs.
   RUN_TESTS_WITH_PRESUBMIT_FLAG=$5
 fi
 
@@ -51,6 +52,7 @@ if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
 fi
 
+# Pass flag "-presubmit" to 'go test' command and lower timeout for presubmit runs.
 if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
   PRESUBMIT_RUN_FLAG="-presubmit"
   if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
@@ -59,7 +61,7 @@ if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
     INTEGRATION_TEST_TIMEOUT=60m
   fi
   echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
-  echo "Setting the flag to mark run as presubmit-run."
+  echo "This is a presubmit-run."
 fi
 
 readonly RANDOM_STRING_LENGTH=5

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -31,7 +31,7 @@ RUN_TEST_ON_TPC_ENDPOINT=false
 if [ $4 != "" ]; then
   RUN_TEST_ON_TPC_ENDPOINT=$4
 fi
-INTEGRATION_TEST_TIMEOUT=60m
+INTEGRATION_TEST_TIMEOUT=70m
 
 if [ "$#" -lt 3 ]
 then
@@ -42,7 +42,7 @@ fi
 if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
   GO_TEST_SHORT_FLAG="-short"
   echo "Setting the flag to skip few un-important integration tests."
-  INTEGRATION_TEST_TIMEOUT=40m
+  INTEGRATION_TEST_TIMEOUT=50m
   echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
 fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -55,6 +55,7 @@ if [ "$RUN_TESTS_WITH_PRESUBMIT_FLAG" == true ]; then
   GO_TEST_PRESUBMIT_FLAG="-presubmit"
   if [ "$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE" == true ]; then
     INTEGRATION_TEST_TIMEOUT=40m
+    echo "Changing the integration test timeout to: $INTEGRATION_TEST_TIMEOUT"
   fi
   echo "Setting the flag to mark run as presubmit-run."
 fi

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+var isPresubmitRun = flag.Bool("presubmit", false, "Boolean flag to indicate if test-run is a presubmit run.")
 var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
 var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
@@ -70,6 +71,10 @@ func RunScriptForTestData(args ...string) {
 		log.Printf("Error: %s", out)
 		panic(err)
 	}
+}
+
+func IsPresubmitRun() bool {
+	return *isPresubmitRun
 }
 
 func TestBucket() string {


### PR DESCRIPTION
### Description
This change 
* increases e2e test runs by 10 minutes for scenarios which run the experimental-feature test.
* Removes e2e test corresponding to https://github.com/GoogleCloudPlatform/gcsfuse/blob/deb9ba8e40ba4fb3ea82844a70a54132d2cdcb28/tools/integration_tests/operations/operations_test.go#L184 from presubmit tests run (though still kept in the periodic e2e test runs).

This addresses internal bug id 353629055.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - In presubmit integration tests, it prints the following logs
   ```
   Setting the flag to skip few un-important integration tests.
   This is a presubmit-run, which skips some tests.
   Setting the integration test timeout to: 40m
   ```
3. Unit tests - NA
4. Integration tests - presubmit runs
