### PR TITLE
Implement rename folder function in dir Inode interface

### DIFF
--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -242,3 +242,8 @@ func (d *baseDirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	// for baseDirInode.
 	return true
 }
+
+func (d *baseDirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (op *gcs.Folder, err error) {
+	err = fuse.ENOSYS
+	return
+}

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -943,7 +943,6 @@ func (d *dirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 }
 
 func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
-
 	folder, err = d.bucket.RenameFolder(ctx, folderName, destinationFolderId)
 	if err != nil {
 		return nil, err

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -64,6 +64,8 @@ type DirInode interface {
 	// true.
 	LookUpChild(ctx context.Context, name string) (*Core, error)
 
+	RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error)
+
 	// Read the children objects of this dir, recursively. The result count
 	// is capped at the given limit. Internal caches are not refreshed from this
 	// call.
@@ -938,4 +940,16 @@ func (d *dirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 
 	cachedDuration := d.cacheClock.Now().Sub(d.prevDirListingTimeStamp)
 	return cachedDuration >= ttl
+}
+
+func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
+
+	folder, err = d.bucket.RenameFolder(ctx, folderName, destinationFolderId)
+	if err != nil {
+		return nil, err
+	}
+
+	d.cache.Erase(folderName)
+
+	return
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -943,16 +943,17 @@ func (d *dirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	return cachedDuration >= ttl
 }
 
-func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
-	folder, err = d.bucket.RenameFolder(ctx, folderName, destinationFolderId)
+func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinationFolderName string) (*gcs.Folder, error) {
+	folder, err := d.bucket.RenameFolder(ctx, folderName, destinationFolderName)
 	if err != nil {
 		return nil, err
 	}
 
+	// TODO: Cache updates won't be necessary once type cache usage is removed from HNS.
 	// Remove old entry from type cache.
 	d.cache.Erase(folderName)
 	// Add new renamed folder in type cache.
-	d.cache.Insert(d.cacheClock.Now(), destinationFolderId, metadata.ExplicitDirType)
+	d.cache.Insert(d.cacheClock.Now(), destinationFolderName, metadata.ExplicitDirType)
 
-	return
+	return folder, nil
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -64,6 +64,7 @@ type DirInode interface {
 	// true.
 	LookUpChild(ctx context.Context, name string) (*Core, error)
 
+	// Rename the directiory/folder.
 	RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error)
 
 	// Read the children objects of this dir, recursively. The result count

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -949,7 +949,10 @@ func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinat
 		return nil, err
 	}
 
+	// Remove old entry from type cache.
 	d.cache.Erase(folderName)
+	// Add new renamed folder in type cache.
+	d.cache.Insert(d.cacheClock.Now(), destinationFolderId, metadata.ExplicitDirType)
 
 	return
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1566,21 +1566,26 @@ func (t *DirTest) TestShouldReturnNilWhenGCSFolderNotFound() {
 	AssertEq(nil, result)
 }
 
-func (t *DirTest) Test_ShouldRenameFolder() {
-	const dirName = "qux"
-	const renameDirName = "rename"
+func (t *DirTest) TestShouldRenameFolder() {
+	const (
+		dirName       = "qux"
+		renameDirName = "rename"
+	)
 	folderName := path.Join(dirInodeName, dirName) + "/"
 	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
+	// Create the original folder.
 	_, err := t.bucket.CreateFolder(t.ctx, folderName)
 	AssertEq(nil, err)
 
+	// Attempt to rename the folder.
 	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
 	AssertEq(nil, err)
 
-	// Check the bucket.
+	// Verify the original folder no longer exists.
 	_, err = t.bucket.GetFolder(t.ctx, folderName)
 	var notFoundErr *gcs.NotFoundError
 	ExpectTrue(errors.As(err, &notFoundErr))
+	// Verify the renamed folder exists.
 	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
 	AssertEq(nil, err)
 	AssertEq(renameFolderName, f.Name)

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1565,3 +1565,23 @@ func (t *DirTest) TestShouldReturnNilWhenGCSFolderNotFound() {
 	AssertEq(nil, err)
 	AssertEq(nil, result)
 }
+
+func (t *DirTest) Test_ShouldRenameFolder() {
+	const dirName = "qux"
+	const renameDirName = "rename"
+	folderName := path.Join(dirInodeName, dirName) + "/"
+	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
+	_, err := t.bucket.CreateFolder(t.ctx, folderName)
+	AssertEq(nil, err)
+
+	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
+	AssertEq(nil, err)
+
+	// Check the bucket.
+	_, err = t.bucket.GetFolder(t.ctx, folderName)
+	var notFoundErr *gcs.NotFoundError
+	ExpectTrue(errors.As(err, &notFoundErr))
+	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
+	AssertEq(nil, err)
+	AssertEq(renameFolderName, f.Name)
+}

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1579,8 +1579,8 @@ func (t *DirTest) TestShouldRenameFolder() {
 
 	// Attempt to rename the folder.
 	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
-	AssertEq(nil, err)
 
+	AssertEq(nil, err)
 	// Verify the original folder no longer exists.
 	_, err = t.bucket.GetFolder(t.ctx, folderName)
 	var notFoundErr *gcs.NotFoundError
@@ -1589,4 +1589,21 @@ func (t *DirTest) TestShouldRenameFolder() {
 	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
 	AssertEq(nil, err)
 	AssertEq(renameFolderName, f.Name)
+}
+
+func (t *DirTest) TestShouldRenameFolderWithError() {
+	const (
+		dirName       = "qux"
+		renameDirName = "rename"
+	)
+	folderName := path.Join(dirInodeName, dirName) + "/"
+	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
+
+	// Attempt to rename the folder.
+	_, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
+
+	AssertNe(nil, err)
+	// Verify the renamed folder does not exist.
+	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
+	AssertNe(nil, err)
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1591,7 +1591,7 @@ func (t *DirTest) TestShouldRenameFolder() {
 	AssertEq(renameFolderName, f.Name)
 }
 
-func (t *DirTest) TestShouldRenameFolderWithError() {
+func (t *DirTest) TestShouldRenameFolderWithSrcFolderDoesNotExist() {
 	const (
 		dirName       = "qux"
 		renameDirName = "rename"
@@ -1602,7 +1602,8 @@ func (t *DirTest) TestShouldRenameFolderWithError() {
 	// Attempt to rename the folder.
 	_, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
 
-	AssertNe(nil, err)
+	var notFoundErr *gcs.NotFoundError
+	ExpectTrue(errors.As(err, &notFoundErr))
 	// Verify the renamed folder does not exist.
 	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
 	AssertNe(nil, err)

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1606,5 +1606,5 @@ func (t *DirTest) TestShouldRenameFolderWithSrcFolderDoesNotExist() {
 	ExpectTrue(errors.As(err, &notFoundErr))
 	// Verify the renamed folder does not exist.
 	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
-	AssertNe(nil, err)
+	ExpectTrue(errors.As(err, &notFoundErr))
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1566,7 +1566,7 @@ func (t *DirTest) TestShouldReturnNilWhenGCSFolderNotFound() {
 	AssertEq(nil, result)
 }
 
-func (t *DirTest) TestShouldRenameFolder() {
+func (t *DirTest) TestRenameFolderWithGivenName() {
 	const (
 		dirName       = "qux"
 		renameDirName = "rename"
@@ -1591,7 +1591,7 @@ func (t *DirTest) TestShouldRenameFolder() {
 	AssertEq(renameFolderName, f.Name)
 }
 
-func (t *DirTest) TestShouldRenameFolderWithSrcFolderDoesNotExist() {
+func (t *DirTest) TestRenameFolderWithNonExistentSourceFolder() {
 	const (
 		dirName       = "qux"
 		renameDirName = "rename"


### PR DESCRIPTION
### Description
- RenameFolder function in DirInode interface. We will call this function further from fs.go whenever renameDir call will make for HNS. Currently this function is not being called from anywhere.
- Unit test

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
