### PR TITLE
Migrate goo.gl links to TinyURL.

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -317,8 +317,8 @@ func makeRootForAllBuckets(fs *fileSystem) inode.DirInode {
 // The intuition is that we hold inode and handle locks for long-running
 // operations, and we don't want to block the entire file system on those.
 //
-// See http://goo.gl/rDxxlG for more discussion, including an informal proof
-// that a strict partial order is sufficient.
+// See https://tinyurl.com/4nh4w7u9 for more discussion, including an informal
+// proof that a strict partial order is sufficient.
 
 type fileSystem struct {
 	fuseutil.NotImplementedFileSystem

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -55,15 +55,15 @@ func init() {
 	switch runtime.GOOS {
 	case "darwin":
 		// FUSE_MAXNAMELEN is used on OS X in the kernel to limit the max length of
-		// a name that readdir needs to process (cf. https://goo.gl/eega7V).
+		// a name that readdir needs to process (https://tinyurl.com/2rr6x8mt).
 		//
 		// NOTE: I can't find where this is defined, but this appears to
 		// be its value.
 		fuseMaxNameLen = 255
 
 	case "linux":
-		// On Linux, we're looking at FUSE_NAME_MAX (https://goo.gl/qd8G0f), used
-		// in e.g. fuse_lookup_name (https://goo.gl/FHSAhy).
+		// On Linux, we're looking at FUSE_NAME_MAX (https://tinyurl.com/2fr4y7fu),
+		// used in e.g. fuse_lookup_name (https://tinyurl.com/4pacanh3).
 		fuseMaxNameLen = 1024
 
 	default:
@@ -136,7 +136,8 @@ func interestingLegalNames() (names []string) {
 	//  *  Cn (non-character and reserved), which is not included in unicode.C.
 	//  *  Co (private usage), which is large.
 	//  *  Cs (surrages), which is large.
-	//  *  U+0000, which is forbidden in paths by Go (cf. https://goo.gl/BHoO7N).
+	//  *  U+0000, which is forbidden in paths by Go
+	//     (https://tinyurl.com/mrxdwxhs).
 	//  *  U+000A and U+000D, which are forbidden by the docs.
 	//
 	for r := rune(0); r <= unicode.MaxRune; r++ {

--- a/internal/perf/memory.go
+++ b/internal/perf/memory.go
@@ -33,8 +33,8 @@ const (
 
 func HandleMemoryProfileSignals() {
 	profileOnce := func(path string) (err error) {
-		// Trigger a garbage collection to get up to date information (cf.
-		// https://goo.gl/aXVQfL).
+		// Trigger a garbage collection to get up to date information
+		// (https://tinyurl.com/93d9jh53).
 		runtime.GC()
 
 		// Open the file.

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -47,8 +47,8 @@ type Object struct {
 	Deleted         time.Time
 	Updated         time.Time
 
-	// As of 2015-06-03, the official GCS documentation for this
-	// property (https://goo.gl/GwD5Dq) says this:
+	// As of 2015-06-03, the official GCS documentation for this property
+	// (https://tinyurl.com/2zjza2cu) says this:
 	//
 	//     Newly uploaded objects have a component count of 1, and composing a
 	//     sequence of objects creates an object whose component count is equal


### PR DESCRIPTION
Google is [shutting down](https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/) `goo.gl` short link redirects (after [previously announcing](https://developers.googleblog.com/en/transitioning-google-url-shortener-to-firebase-dynamic-links/) that they'll continue to work).

Google also previously announced that you could export your links from "the `goo.gl` console", but I can't find that anywhere (the site is now just a redirect to their stupid blog post), so I had to do this by hand. There may be some errors.