### PR TITLE
Adding function to check the consistency of config file

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/config.json
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/config.json
@@ -1,0 +1,93 @@
+{
+  "name": "hns-rename-folders-test" ,
+  "folders" : {
+    "num_folders": 3,
+    "folder_structure" : [
+      {
+        "name": "1k_files_rename_test_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "5k_files_rename_test_0" ,
+        "num_files": 5000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "10k_files_rename_test_0" ,
+        "num_files": 10000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      }
+    ]
+  },
+  "nested_folders": {
+    "folder_name": "nested_folder_rename_test",
+    "num_folders": 10,
+    "folder_structure" :  [
+      {
+        "name": "nested_folder_1_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_2_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_3_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_4_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_5_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_6_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_7_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_8_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_9_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      },
+      {
+        "name": "nested_folder_10_0" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      }
+    ]
+
+  }
+}

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -26,7 +26,7 @@ from subprocess import Popen
 OUTPUT_FILE = str(dt.now().isoformat()) + '.out'
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.ERROR,
     format='%(asctime)s [%(levelname)s] %(message)s',
     handlers=[logging.StreamHandler(sys.stdout)],
 )
@@ -36,10 +36,19 @@ logger = logging.getLogger()
 def logmessage(message) -> None:
   with open(OUTPUT_FILE, 'a') as out:
     out.write(message)
-  logger.info(message)
+  logger.error(message)
 
 
 def check_for_config_file_inconsistency(config) -> (int):
+  """
+  Checks for inconsistencies in the provided configuration.
+
+  Args:
+      config: The configuration dictionary to be checked.
+
+  Returns:
+      0 if no inconsistencies are found, 1 otherwise.
+  """
   if "name" not in config:
     logmessage("Bucket name not specified")
     return 1
@@ -90,13 +99,13 @@ if __name__ == '__main__':
 
   args = parser.parse_args(argv[1:])
 
-  # Checking that gsutil is installed:
-  logmessage('Checking whether gsutil is installed.\n')
-  process = Popen('gsutil version', shell=True)
+  # Checking that gcloud is installed:
+  logmessage('Checking whether gcloud is installed.\n')
+  process = Popen('gcloud version', shell=True)
   process.communicate()
   exit_code = process.wait()
   if exit_code != 0:
-    print('Gsutil not installed.')
+    print('gcloud not installed.')
     subprocess.call('bash', shell=True)
 
   directory_structure = json.load(open(args.config_file))

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+# limitations under the License.
+# To run the script, run in terminal :
+# python3 generate_folder_and_files.py <config-file.json>
+
+import argparse
+import json
+from datetime import datetime as dt
+import logging
+import sys
+import subprocess
+from subprocess import Popen
+
+OUTPUT_FILE = str(dt.now().isoformat()) + '.out'
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger()
+
+
+def logmessage(message) -> None:
+  with open(OUTPUT_FILE, 'a') as out:
+    out.write(message)
+  logger.info(message)
+
+
+def check_for_config_file_inconsistency(config) -> (int):
+  if "name" not in config:
+    logmessage("Bucket name not specified")
+    return 1
+
+  if "folders" in config:
+    if not ("num_folders" in config["folders"] or "folder_structure" in config[
+      "folders"]):
+      logmessage("Key missing for nested folder")
+      return 1
+
+    if config["folders"]["num_folders"] != len(
+        config["folders"]["folder_structure"]):
+      logmessage("Inconsistency in the folder structure")
+      return 1
+
+  if "nested_folders" in config:
+    if not ("folder_name" in config["nested_folders"] or
+            "num_folders" in config["nested_folders"] or
+            "folder_structure" in config["nested_folders"]):
+      logmessage("Key missing for nested folder")
+      return 1
+
+    if config["nested_folders"]["num_folders"] != len(
+        config["nested_folders"]["folder_structure"]):
+      logmessage("Inconsistency in the nested folder")
+      return 1
+
+  return 0
+
+
+if __name__ == '__main__':
+  argv = sys.argv
+  if len(argv) < 2:
+    raise TypeError('Incorrect number of arguments.\n'
+                    'Usage: '
+                    'python3 generate_files.py <config_file> [--keep_files]')
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      'config_file',
+      help='Provide path of the config file', )
+  parser.add_argument(
+      '--keep_files',
+      help='Please specify whether to keep local files/folders or not',
+      action='store_true',
+      default=False,
+      required=False)
+
+  args = parser.parse_args(argv[1:])
+
+  # Checking that gsutil is installed:
+  logmessage('Checking whether gsutil is installed.\n')
+  process = Popen('gsutil version', shell=True)
+  process.communicate()
+  exit_code = process.wait()
+  if exit_code != 0:
+    print('Gsutil not installed.')
+    subprocess.call('bash', shell=True)
+
+  directory_structure = json.load(open(args.config_file))
+
+  exit_code = check_for_config_file_inconsistency(directory_structure)
+  if exit_code != 0:
+    print('Exited with code {}'.format(exit_code))
+    subprocess.call('bash', shell=True)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -1,0 +1,109 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from generate_folders_and_files import check_for_config_file_inconsistency
+
+class TestRenameFolder(unittest.TestCase):
+  def test_missing_bucket_name(self):
+    config = {}
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 1)
+
+  def test_missing_keys_from_folder(self):
+    config = {
+        "name": "test_bucket",
+        "folders": {}
+    }
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 1)
+
+  def test_missing_keys_from_nested_folder(self):
+    config = {
+        "name": "test_bucket",
+        "nested_folders": {}
+    }
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 1)
+
+  def test_folders_num_folder_mismatch(self):
+    config = {
+        "name": "test_bucket",
+        "folders": {
+            "num_folders": 2,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 10,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 1)
+
+  def test_nested_folders_num_folder_mismatch(self):
+    config = {
+        "name": "test_bucket",
+        "nested_folders": {
+            "folder_name": "test_nested_folder",
+            "num_folders": 2,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 10,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 1)
+
+  def test_valid_config(self):
+    config = {
+        "name": "test_bucket",
+        "folders": {
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                  "name": "test_folder",
+                  "num_files": 1,
+                  "file_name_prefix": "file",
+                  "file_size": "1kb"
+                }
+            ]
+        },
+        "nested_folders": {
+            "folder_name": "nested",
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 1,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+    result = check_for_config_file_inconsistency(config)
+    self.assertEqual(result, 0)
+
+if __name__ == '__main__':
+  unittest.main()
+

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -106,4 +106,3 @@ class TestRenameFolder(unittest.TestCase):
 
 if __name__ == '__main__':
   unittest.main()
-


### PR DESCRIPTION
### Description
This script will be used to create test data in gcs bucket for hns rename folder tests.Currently, it contains the consistency checks for configuration file which contains the details of the desired folder structure.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually tested scenarios with all combinations of the required keys  missing under the folders/nested-folders section
2. Unit tests - [Unit tests](https://github.com/GoogleCloudPlatform/gcsfuse/commit/105840cbad268c2514b801c060e70f329ab48cd7#diff-9680f5049ff6a200fb5b6dfe223da1835f434911e749171d19bf7841fa36dec0) for checking consistency covering scenarios where keys are missing, mismatch in the number of folders specified and the folder structure provided, valid config file is passed ,etc . 
3. Integration tests - NA
