### PR TITLE
Adding helper function for rename folder test

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -79,6 +79,25 @@ def check_for_config_file_inconsistency(config) -> (int):
   return 0
 
 
+def list_directory(path) -> list:
+  """Returns the list containing path of all the contents present in the current directory.
+
+  Args:
+    path: Path of the directory.
+
+  Returns:
+    A list containing path of all contents present in the input path.
+  """
+  try:
+    contents = subprocess.check_output(
+        'gcloud storage ls {}'.format(path), shell=True)
+    contents_url = contents.decode('utf-8').split('\n')[:-1]
+    return contents_url
+  except subprocess.CalledProcessError as e:
+    logmessage(e.output.decode('utf-8'))
+    subprocess.call('bash', shell=True)
+
+
 if __name__ == '__main__':
   argv = sys.argv
   if len(argv) < 2:


### PR DESCRIPTION
### Description
Added helper function and its unit tests for listing directories which will be further used as a check to create directory structure if it does not exist already.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested that recursive listing does not happen.
2. Unit tests - Unit tests for [successful execution](https://github.com/GoogleCloudPlatform/gcsfuse/blob/5a29bdf591af09b3e3f847b6bdcd91df6f181148/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py#L135) and [thrown exception](https://github.com/GoogleCloudPlatform/gcsfuse/blob/5a29bdf591af09b3e3f847b6bdcd91df6f181148/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py#L121) 
3. Integration tests - NA
