### PR TITLE
Added function to check if the directory structure in config file already exists in bucket

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -33,13 +33,13 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 
-def logmessage(message) -> None:
+def _logmessage(message) -> None:
   with open(OUTPUT_FILE, 'a') as out:
     out.write(message)
   logger.error(message)
 
 
-def check_for_config_file_inconsistency(config) -> (int):
+def _check_for_config_file_inconsistency(config) -> (int):
   """
   Checks for inconsistencies in the provided configuration.
 
@@ -50,36 +50,36 @@ def check_for_config_file_inconsistency(config) -> (int):
       0 if no inconsistencies are found, 1 otherwise.
   """
   if "name" not in config:
-    logmessage("Bucket name not specified")
+    _logmessage("Bucket name not specified")
     return 1
 
   if "folders" in config:
     if not ("num_folders" in config["folders"] or "folder_structure" in config[
       "folders"]):
-      logmessage("Key missing for nested folder")
+      _logmessage("Key missing for nested folder")
       return 1
 
     if config["folders"]["num_folders"] != len(
         config["folders"]["folder_structure"]):
-      logmessage("Inconsistency in the folder structure")
+      _logmessage("Inconsistency in the folder structure")
       return 1
 
   if "nested_folders" in config:
     if not ("folder_name" in config["nested_folders"] or
             "num_folders" in config["nested_folders"] or
             "folder_structure" in config["nested_folders"]):
-      logmessage("Key missing for nested folder")
+      _logmessage("Key missing for nested folder")
       return 1
 
     if config["nested_folders"]["num_folders"] != len(
         config["nested_folders"]["folder_structure"]):
-      logmessage("Inconsistency in the nested folder")
+      _logmessage("Inconsistency in the nested folder")
       return 1
 
   return 0
 
 
-def list_directory(path) -> list:
+def _list_directory(path) -> list:
   """Returns the list containing path of all the contents present in the current directory.
 
   Args:
@@ -94,10 +94,10 @@ def list_directory(path) -> list:
     contents_url = contents.decode('utf-8').split('\n')[:-1]
     return contents_url
   except subprocess.CalledProcessError as e:
-    logmessage(e.output.decode('utf-8'))
+    _logmessage(e.output.decode('utf-8'))
 
 
-def compare_folder_structure(folder, folder_url) -> bool:
+def _compare_folder_structure(folder, folder_url) -> bool:
   """Checks if the number of files inside folder in GCS bucket matches the
   num_files parameter for folder.
 
@@ -114,8 +114,7 @@ def compare_folder_structure(folder, folder_url) -> bool:
         "file_size": "1kb"
       }
     ]
-    }
-  },
+    },
    "nested_folders": {
     "folder_name": "nested_folder",
     "num_folders": 1,
@@ -140,7 +139,7 @@ def compare_folder_structure(folder, folder_url) -> bool:
     false otherwise
   """
   try:
-    files_in_folder = list_directory(folder_url)
+    files_in_folder = _list_directory(folder_url)
     if len(files_in_folder) != folder["num_files"]:
       return False
   except:
@@ -151,7 +150,7 @@ def compare_folder_structure(folder, folder_url) -> bool:
   return True
 
 
-def compare_folders(folder_structure, parent_url) -> bool:
+def _compare_folders(folder_structure, parent_url) -> bool:
   """ Checks that the folder structure matches for each folder under parent_url.
 
   Args:
@@ -165,13 +164,13 @@ def compare_folders(folder_structure, parent_url) -> bool:
   """
   for folder in folder_structure:
     folder_url = '{}/{}'.format(parent_url, folder["name"])
-    match = compare_folder_structure(folder, folder_url)
+    match = _compare_folder_structure(folder, folder_url)
     if not match:
       return False
   return True
 
 
-def check_if_dir_structure_exists(directory_structure) -> bool:
+def _check_if_dir_structure_exists(directory_structure) -> bool:
   """Checks if the directory structure mentioned in the config file already
   exists in the GCS bucket.
 
@@ -187,7 +186,7 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
   bucket_url = 'gs://{}'.format(bucket_name)
 
   # Check for top level folders.
-  folders = list_directory(bucket_url)
+  folders = _list_directory(bucket_url)
   nested_folder_count = "nested_folders" in directory_structure
   if "folders" in directory_structure:
     # Note: It is already validated during input file consistency check that the
@@ -198,8 +197,8 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
       return False
 
     # For each non-nested folder , check the count of files.
-    match = compare_folders(directory_structure["folders"]["folder_structure"],
-                            bucket_url)
+    match = _compare_folders(directory_structure["folders"]["folder_structure"],
+                             bucket_url)
     if not match:
       return False
 
@@ -212,13 +211,13 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
     nested_folder_url = '{}/{}'.format(bucket_url, nested_folder)
     try:
 
-      second_level_folders = list_directory(nested_folder_url)
+      second_level_folders = _list_directory(nested_folder_url)
       if len(second_level_folders) != directory_structure["nested_folders"][
         "num_folders"]:
         return False
 
       # For each second level folder in "nested" folders, check the count of files.
-      match = compare_folders(
+      match = _compare_folders(
           directory_structure["nested_folders"]["folder_structure"],
           nested_folder_url)
       if not match:
@@ -252,7 +251,7 @@ if __name__ == '__main__':
   args = parser.parse_args(argv[1:])
 
   # Checking that gcloud is installed:
-  logmessage('Checking whether gcloud is installed.\n')
+  _logmessage('Checking whether gcloud is installed.\n')
   process = Popen('gcloud version', shell=True)
   process.communicate()
   exit_code = process.wait()
@@ -262,12 +261,11 @@ if __name__ == '__main__':
 
   directory_structure = json.load(open(args.config_file))
 
-  exit_code = check_for_config_file_inconsistency(directory_structure)
+  exit_code = _check_for_config_file_inconsistency(directory_structure)
   if exit_code != 0:
     print('Exited with code {}'.format(exit_code))
     subprocess.call('bash', shell=True)
 
   # Compare the directory structure with the JSON config file to avoid recreation of
   # same test data.
-  dir_structure_present = check_if_dir_structure_exists(directory_structure)
-  print(dir_structure_present)
+  dir_structure_present = _check_if_dir_structure_exists(directory_structure)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -169,7 +169,7 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
         if not match:
           return False
     except:
-      # Folder specified in configi fle under the nested folder structrue does
+      # Folder specified in config fle under the nested folder structrue does
       # not exist in bucket.
       return False
 
@@ -212,6 +212,6 @@ if __name__ == '__main__':
     print('Exited with code {}'.format(exit_code))
     subprocess.call('bash', shell=True)
 
-  # compare the directory structure with the config file to avoid recreation of
-  # same test data
+  # Compare the directory structure with the config file to avoid recreation of
+  # same test data.
   dir_structure_present = check_if_dir_structure_exists(directory_structure)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -98,8 +98,37 @@ def list_directory(path) -> list:
 
 
 def compare_folder_structure(folder, folder_url) -> bool:
-  """Checks if the number of files in config file under folder matches the
-  number of files in the GCS bucket.
+  """Checks if the number of files inside folder in GCS bucket matches the
+  num_files parameter for folder.
+
+  Example folder structure
+  {
+  "name": "example-folder" ,
+  "folders" : {
+    "num_folders": 1,
+    "folder_structure" : [
+      {
+        "name": "1k_files_folder" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      }
+    ]
+    }
+  },
+   "nested_folders": {
+    "folder_name": "nested_folder",
+    "num_folders": 1,
+    "folder_structure" :  [
+      {
+        "name": "1k_files_nested_folder" ,
+        "num_files": 1000 ,
+        "file_name_prefix": "file" ,
+        "file_size": "1kb"
+      }
+      ]
+    }
+  }
 
   Args:
     folder: Json Object representing the folder.
@@ -116,7 +145,7 @@ def compare_folder_structure(folder, folder_url) -> bool:
       return False
   except:
     # If the list directory fails wth url did not match object, folder
-    # specified in config file does not exist in bucket.
+    # specified in JSON folder object does not exist in bucket.
     return False
 
   return True
@@ -130,9 +159,9 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
     directory_structure: Json Object representing the directory structure.
 
   Returns:
-    true if the existing structure in GCS bucket exactly matches with teh config
-     file
-    false otherwise
+    true if the existing structure in GCS bucket exactly matches with the config
+     file.
+    false otherwise.
   """
   bucket_name = directory_structure["name"]
   bucket_url = 'gs://{}'.format(bucket_name)
@@ -141,6 +170,9 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
   folders = list_directory(bucket_url)
   nested_folder_count = "nested_folders" in directory_structure
   if "folders" in directory_structure:
+    # Note: It is already validated during input file consistency check that the
+    # keys num_folder,folder_structure is specified whenever folder section is
+    # included.
     if len(folders) != directory_structure["folders"][
       "num_folders"] + nested_folder_count:
       return False
@@ -154,6 +186,9 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
 
   # Check the number of second level folders in nested folders.
   if nested_folder_count:
+    # Note: It is already validated during input file consistency check that the
+    # keys folder_name,num_folder,folder_structure is specified whenever folder
+    # section is included.
     nested_folder = directory_structure["nested_folders"]["folder_name"]
     try:
       second_level_folders = list_directory(
@@ -169,7 +204,7 @@ def check_if_dir_structure_exists(directory_structure) -> bool:
         if not match:
           return False
     except:
-      # Folder specified in config fle under the nested folder structrue does
+      # Folder specified in JSON config file under the nested folder structrue does
       # not exist in bucket.
       return False
 
@@ -186,7 +221,7 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument(
       'config_file',
-      help='Provide path of the config file', )
+      help='Provide path of the JSON config file', )
   parser.add_argument(
       '--keep_files',
       help='Please specify whether to keep local files/folders or not',
@@ -212,6 +247,6 @@ if __name__ == '__main__':
     print('Exited with code {}'.format(exit_code))
     subprocess.call('bash', shell=True)
 
-  # Compare the directory structure with the config file to avoid recreation of
+  # Compare the directory structure with the JSON config file to avoid recreation of
   # same test data.
   dir_structure_present = check_if_dir_structure_exists(directory_structure)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -132,4 +132,5 @@ if __name__ == '__main__':
   exit_code = check_for_config_file_inconsistency(directory_structure)
   if exit_code != 0:
     print('Exited with code {}'.format(exit_code))
+<<<<<<< HEAD
     subprocess.call('bash', shell=True)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -97,7 +97,32 @@ def list_directory(path) -> list:
     logmessage(e.output.decode('utf-8'))
 
 
-def check_if_dir_structure_exists(directory_structure) -> (int):
+def compare_folder_structure(folder, folder_url) -> bool:
+  """Checks if the number of files in config file under folder matches the
+  number of files in the GCS bucket.
+
+  Args:
+    folder: Json Object representing the folder.
+    folder_url: Corresponding folder url in the GCS bucket.
+
+  Returns:
+    true if the number of files in the folder in GCS bucket matches the num_files
+    parameter of the folder JSON object.
+    false otherwise
+  """
+  try:
+    files_in_folder = list_directory(folder_url)
+    if len(files_in_folder) != folder["num_files"]:
+      return False
+  except:
+    # If the list directory fails wth url did not match object, folder
+    # specified in config file does not exist in bucket.
+    return False
+
+  return True
+
+
+def check_if_dir_structure_exists(directory_structure) -> bool:
   """Checks if the directory structure mentioned in the config file already
   exists in the GCS bucket.
 
@@ -112,26 +137,22 @@ def check_if_dir_structure_exists(directory_structure) -> (int):
   bucket_name = directory_structure["name"]
   bucket_url = 'gs://{}'.format(bucket_name)
 
-  # check for top level folders
+  # Check for top level folders.
   folders = list_directory(bucket_url)
   nested_folder_count = "nested_folders" in directory_structure
   if "folders" in directory_structure:
     if len(folders) != directory_structure["folders"][
       "num_folders"] + nested_folder_count:
-      return 0
+      return False
 
-    # for each non-nested folder , check the count of files
+    # For each non-nested folder , check the count of files.
     for folder in directory_structure["folders"]["folder_structure"]:
-      try:
-        files = list_directory('{}/{}'.format(bucket_url, folder["name"]))
-        if len(files) != folder["num_files"]:
-          return 0
-      except:
-          # if the list directory fails wth url did not match object, folder
-          # specified in config file does not exist in bucket.
-          return 0
+      folder_url = '{}/{}'.format(bucket_url, folder["name"])
+      match = compare_folder_structure(folder, folder_url)
+      if not match:
+        return False
 
-  # check the number of second level folders in nested folders
+  # Check the number of second level folders in nested folders.
   if nested_folder_count:
     nested_folder = directory_structure["nested_folders"]["folder_name"]
     try:
@@ -139,23 +160,20 @@ def check_if_dir_structure_exists(directory_structure) -> (int):
           '{}/{}'.format(bucket_url, nested_folder))
       if len(second_level_folders) != directory_structure["nested_folders"][
         "num_folders"]:
-        return 0
+        return False
 
-      # for each second level folder in "nested" folders, check the count of files
+      # For each second level folder in "nested" folders, check the count of files.
       for folder in directory_structure["nested_folders"]["folder_structure"]:
-        try:
-          files_nested_folder = list_directory(
-              '{}/{}/{}'.format(bucket_url, nested_folder, folder["name"]))
-          if len(files_nested_folder) != folder["num_files"]:
-            return 0
-        except:
-            # second level nested folder specified in config file does not exist
-            return 0
+        folder_url= '{}/{}/{}'.format(bucket_url,nested_folder,folder["name"])
+        match= compare_folder_structure(folder,folder_url)
+        if not match:
+          return False
     except:
-      # folder specified in the nested folder structrue does not exist in bucket
-      return 0
+      # Folder specified in configi fle under the nested folder structrue does
+      # not exist in bucket.
+      return False
 
-  return 1
+  return True
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -95,7 +95,6 @@ def list_directory(path) -> list:
     return contents_url
   except subprocess.CalledProcessError as e:
     logmessage(e.output.decode('utf-8'))
-    subprocess.call('bash', shell=True)
 
 
 def check_if_dir_structure_exists(directory_structure) -> (int):
@@ -123,25 +122,38 @@ def check_if_dir_structure_exists(directory_structure) -> (int):
 
     # for each non-nested folder , check the count of files
     for folder in directory_structure["folders"]["folder_structure"]:
-      files = list_directory('{}/{}'.format(bucket_url, folder["name"]))
-      if len(files) != folder["num_files"]:
-        return 0
+      try:
+        files = list_directory('{}/{}'.format(bucket_url, folder["name"]))
+        if len(files) != folder["num_files"]:
+          return 0
+      except:
+          # if the list directory fails wth url did not match object, folder
+          # specified in config file does not exist in bucket.
+          return 0
 
   # check the number of second level folders in nested folders
   if nested_folder_count:
     nested_folder = directory_structure["nested_folders"]["folder_name"]
-    second_level_folders = list_directory(
-        '{}/{}'.format(bucket_url, nested_folder))
-    if len(second_level_folders) != directory_structure["nested_folders"][
-      "num_folders"]:
-      return 0
-
-    # for each second level folder in "nested" folders, check the count of files
-    for folder in directory_structure["nested_folders"]["folder_structure"]:
-      files_nested_folder = list_directory(
-          '{}/{}/{}'.format(bucket_url, nested_folder, folder["name"]))
-      if len(files_nested_folder) != folder["num_files"]:
+    try:
+      second_level_folders = list_directory(
+          '{}/{}'.format(bucket_url, nested_folder))
+      if len(second_level_folders) != directory_structure["nested_folders"][
+        "num_folders"]:
         return 0
+
+      # for each second level folder in "nested" folders, check the count of files
+      for folder in directory_structure["nested_folders"]["folder_structure"]:
+        try:
+          files_nested_folder = list_directory(
+              '{}/{}/{}'.format(bucket_url, nested_folder, folder["name"]))
+          if len(files_nested_folder) != folder["num_files"]:
+            return 0
+        except:
+            # second level nested folder specified in config file does not exist
+            return 0
+    except:
+      # folder specified in the nested folder structrue does not exist in bucket
+      return 0
 
   return 1
 
@@ -180,7 +192,6 @@ if __name__ == '__main__':
   exit_code = check_for_config_file_inconsistency(directory_structure)
   if exit_code != 0:
     print('Exited with code {}'.format(exit_code))
-<<<<<<< HEAD
     subprocess.call('bash', shell=True)
 
   # compare the directory structure with the config file to avoid recreation of

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -116,10 +116,8 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
 class TestListDirectory(unittest.TestCase):
 
   @patch('subprocess.check_output')
-  @patch('subprocess.call')
   @patch('generate_folders_and_files.logmessage')
-  def test_listing_at_non_existent_path(self, mock_logmessage,
-      mock_subprocess_call, mock_check_output):
+  def test_listing_at_non_existent_path(self, mock_logmessage,mock_check_output):
     mock_check_output.side_effect = subprocess.CalledProcessError(
         returncode=1,
         cmd="gcloud storage ls gs://fake_bkt",
@@ -129,7 +127,6 @@ class TestListDirectory(unittest.TestCase):
 
     self.assertEqual(dir_list, None)
     mock_logmessage.assert_called_once_with('Error while listing')
-    mock_subprocess_call.assert_called_once_with('bash', shell=True)
 
   @patch('subprocess.check_output')
   def test_listing_directory(self, mock_check_output):

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -20,7 +20,7 @@ from mock import patch, call
 class TestCheckForConfigFileInconsistency(unittest.TestCase):
   def test_missing_bucket_name(self):
     config = {}
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 1)
 
@@ -29,7 +29,7 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
         "name": "test_bucket",
         "folders": {}
     }
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 1)
 
@@ -38,7 +38,7 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
         "name": "test_bucket",
         "nested_folders": {}
     }
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 1)
 
@@ -57,7 +57,7 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
             ]
         }
     }
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 1)
 
@@ -77,7 +77,7 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
             ]
         }
     }
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 1)
 
@@ -108,7 +108,7 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
             ]
         }
     }
-    result = generate_folders_and_files.check_for_config_file_inconsistency(
+    result = generate_folders_and_files._check_for_config_file_inconsistency(
         config)
     self.assertEqual(result, 0)
 
@@ -116,14 +116,14 @@ class TestCheckForConfigFileInconsistency(unittest.TestCase):
 class TestListDirectory(unittest.TestCase):
 
   @patch('subprocess.check_output')
-  @patch('generate_folders_and_files.logmessage')
+  @patch('generate_folders_and_files._logmessage')
   def test_listing_at_non_existent_path(self, mock_logmessage,mock_check_output):
     mock_check_output.side_effect = subprocess.CalledProcessError(
         returncode=1,
         cmd="gcloud storage ls gs://fake_bkt",
         output=b'Error while listing')
 
-    dir_list = generate_folders_and_files.list_directory("gs://fake_bkt")
+    dir_list = generate_folders_and_files._list_directory("gs://fake_bkt")
 
     self.assertEqual(dir_list, None)
     mock_logmessage.assert_called_once_with('Error while listing')
@@ -137,14 +137,14 @@ class TestListDirectory(unittest.TestCase):
                          "gs://fake_bkt/fake_folder_1/",
                          "gs://fake_bkt/nested_fake_folder/"]
 
-    dir_list = generate_folders_and_files.list_directory("gs://fake_bkt")
+    dir_list = generate_folders_and_files._list_directory("gs://fake_bkt")
 
     self.assertEqual(dir_list, expected_dir_list)
 
 
 class TestCompareFolderStructure(unittest.TestCase):
 
-  @patch('generate_folders_and_files.list_directory')
+  @patch('generate_folders_and_files._list_directory')
   def test_folder_structure_matches(self,mock_listdir):
     mock_listdir.return_value=['test_file_1.txt']
     test_folder={
@@ -155,11 +155,11 @@ class TestCompareFolderStructure(unittest.TestCase):
     }
     test_folder_url='gs://temp_folder_url'
 
-    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+    match = generate_folders_and_files._compare_folder_structure(test_folder, test_folder_url)
 
     self.assertEqual(match,True)
 
-  @patch('generate_folders_and_files.list_directory')
+  @patch('generate_folders_and_files._list_directory')
   def test_folder_structure_mismatches(self,mock_listdir):
     mock_listdir.return_value=['test_file_1.txt']
     test_folder={
@@ -170,11 +170,11 @@ class TestCompareFolderStructure(unittest.TestCase):
     }
     test_folder_url='gs://temp_folder_url'
 
-    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+    match = generate_folders_and_files._compare_folder_structure(test_folder, test_folder_url)
 
     self.assertEqual(match,False)
 
-  @patch('generate_folders_and_files.list_directory')
+  @patch('generate_folders_and_files._list_directory')
   def test_folder_does_not_exist_in_gcs_bucket(self,mock_listdir):
     mock_listdir.side_effect=subprocess.CalledProcessError(
         returncode=1,
@@ -188,7 +188,7 @@ class TestCompareFolderStructure(unittest.TestCase):
     }
     test_folder_url='gs://fake_bkt/folder_does_not_exist'
 
-    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+    match = generate_folders_and_files._compare_folder_structure(test_folder, test_folder_url)
 
     self.assertEqual(match,False)
     self.assertRaises(subprocess.CalledProcessError)
@@ -196,7 +196,7 @@ class TestCompareFolderStructure(unittest.TestCase):
 
 class TestCheckIfDirStructureExists(unittest.TestCase):
 
-  @patch("generate_folders_and_files.list_directory")
+  @patch("generate_folders_and_files._list_directory")
   def test_dir_already_exists_in_gcs_bucket(self, mock_list_directory):
     mock_list_directory.side_effect = [
         ["gs://test_bucket/test_folder/", "gs://test_bucket/nested/"],
@@ -231,12 +231,12 @@ class TestCheckIfDirStructureExists(unittest.TestCase):
         }
     }
 
-    dir_present = generate_folders_and_files.check_if_dir_structure_exists(
+    dir_present = generate_folders_and_files._check_if_dir_structure_exists(
       dir_config)
 
     self.assertEqual(dir_present, 1)
 
-  @patch("generate_folders_and_files.list_directory")
+  @patch("generate_folders_and_files._list_directory")
   def test_dir_does_not_exist_in_gcs_bucket(self, mock_list_directory):
     mock_list_directory.side_effect = [
         ["gs://test_bucket/test_folder/", "gs://test_bucket/nested/"],
@@ -272,7 +272,7 @@ class TestCheckIfDirStructureExists(unittest.TestCase):
         }
     }
 
-    dir_present = generate_folders_and_files.check_if_dir_structure_exists(
+    dir_present = generate_folders_and_files._check_if_dir_structure_exists(
       dir_config)
 
     self.assertEqual(dir_present, 0)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -145,5 +145,89 @@ class TestListDirectory(unittest.TestCase):
     self.assertEqual(dir_list, expected_dir_list)
 
 
+class TestCheckIfDirStructureExists(unittest.TestCase):
+
+  @patch("generate_folders_and_files.list_directory")
+  def test_dir_already_exists_in_gcs_bucket(self, mock_list_directory):
+    mock_list_directory.side_effect = [
+        ["gs://test_bucket/test_folder/", "gs://test_bucket/nested/"],
+        ["gs://test_bucket/test_folder/file_1.txt"],
+        ["gs://test_bucket/nested/test_folder/"],
+        ["gs://test_bucket/nested/test_folder/file_1.txt"]
+    ]
+    dir_config = {
+        "name": "test_bucket",
+        "folders": {
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 1,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        },
+        "nested_folders": {
+            "folder_name": "nested",
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 1,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+
+    dir_present = generate_folders_and_files.check_if_dir_structure_exists(
+      dir_config)
+
+    self.assertEqual(dir_present, 1)
+
+  @patch("generate_folders_and_files.list_directory")
+  def test_dir_does_not_exist_in_gcs_bucket(self, mock_list_directory):
+    mock_list_directory.side_effect = [
+        ["gs://test_bucket/test_folder/", "gs://test_bucket/nested/"],
+        ["gs://test_bucket/test_folder/file_1.txt",
+         "gs://test_bucket/test_folder/file_1.txt"],
+        ["gs://test_bucket/nested/test_folder/"],
+        ["gs://test_bucket/nested/test_folder/file_1.txt"]
+    ]
+    dir_config = {
+        "name": "test_bucket",
+        "folders": {
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 1,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        },
+        "nested_folders": {
+            "folder_name": "nested",
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 1,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+
+    dir_present = generate_folders_and_files.check_if_dir_structure_exists(
+      dir_config)
+
+    self.assertEqual(dir_present, 0)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -142,6 +142,58 @@ class TestListDirectory(unittest.TestCase):
     self.assertEqual(dir_list, expected_dir_list)
 
 
+class TestCompareFolderStructure(unittest.TestCase):
+
+  @patch('generate_folders_and_files.list_directory')
+  def test_folder_structure_matches(self,mock_listdir):
+    mock_listdir.return_value=['test_file_1.txt']
+    test_folder={
+        "name": "test_folder",
+        "num_files": 1,
+        "file_name_prefix": "test_file",
+        "file_size": "1kb"
+    }
+    test_folder_url='gs://temp_folder_url'
+
+    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+
+    self.assertEqual(match,True)
+
+  @patch('generate_folders_and_files.list_directory')
+  def test_folder_structure_mismatches(self,mock_listdir):
+    mock_listdir.return_value=['test_file_1.txt']
+    test_folder={
+        "name": "test_folder",
+        "num_files": 2,
+        "file_name_prefix": "test_file",
+        "file_size": "1kb"
+    }
+    test_folder_url='gs://temp_folder_url'
+
+    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+
+    self.assertEqual(match,False)
+
+  @patch('generate_folders_and_files.list_directory')
+  def test_folder_does_not_exist_in_gcs_bucket(self,mock_listdir):
+    mock_listdir.side_effect=subprocess.CalledProcessError(
+        returncode=1,
+        cmd="gcloud storage ls gs://fake_bkt/folder_does_not_exist",
+        output=b'Error while listing')
+    test_folder={
+        "name": "test_folder",
+        "num_files": 1,
+        "file_name_prefix": "test_file",
+        "file_size": "1kb"
+    }
+    test_folder_url='gs://fake_bkt/folder_does_not_exist'
+
+    match = generate_folders_and_files.compare_folder_structure(test_folder,test_folder_url)
+
+    self.assertEqual(match,False)
+    self.assertRaises(subprocess.CalledProcessError)
+
+
 class TestCheckIfDirStructureExists(unittest.TestCase):
 
   @patch("generate_folders_and_files.list_directory")


### PR DESCRIPTION
### Description
Added the check_if_dir_structure_exists function in order to prevent recreation of existing test data in the bucket for rename folder tests.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - checked scenarios when number of directories is same but name differs on both top and second level folders .
2. Unit tests - wrote unit tests for [existing directory](https://github.com/GoogleCloudPlatform/gcsfuse/blob/ccb4bccca45e47803a1ecb590e0d9a0ce5d6898d/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py#L148) and [directory not existing](https://github.com/GoogleCloudPlatform/gcsfuse/blob/ccb4bccca45e47803a1ecb590e0d9a0ce5d6898d/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py#L188) scenarios 
3. Integration tests - NA
