### PR TITLE
Make Logger an exported param

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	defaultLoggerFactory *loggerFactory
-	defaultLogger        *slog.Logger
+	Logger               *slog.Logger
 )
 
 // InitLogFile initializes the logger factory to create loggers that print to
@@ -95,7 +95,7 @@ func InitLogFile(legacyLogConfig config.LogConfig, newLogConfig cfg.LoggingConfi
 		level:           string(newLogConfig.Severity),
 		logRotateConfig: legacyLogConfig.LogRotateConfig,
 	}
-	defaultLogger = defaultLoggerFactory.newLogger(string(newLogConfig.Severity))
+	Logger = defaultLoggerFactory.newLogger(string(newLogConfig.Severity))
 
 	return nil
 }
@@ -108,7 +108,7 @@ func init() {
 		level:           config.INFO, // setting log level to INFO by default
 		logRotateConfig: config.DefaultLogRotateConfig(),
 	}
-	defaultLogger = defaultLoggerFactory.newLogger(config.INFO)
+	Logger = defaultLoggerFactory.newLogger(config.INFO)
 }
 
 // SetLogFormat updates the log format of default logger.
@@ -117,7 +117,7 @@ func SetLogFormat(format string) {
 		return
 	}
 	defaultLoggerFactory.format = format
-	defaultLogger = defaultLoggerFactory.newLogger(defaultLoggerFactory.level)
+	Logger = defaultLoggerFactory.newLogger(defaultLoggerFactory.level)
 }
 
 // Close closes the log file when necessary.
@@ -130,32 +130,32 @@ func Close() {
 
 // Tracef prints the message with TRACE severity in the specified format.
 func Tracef(format string, v ...interface{}) {
-	defaultLogger.Log(context.Background(), LevelTrace, fmt.Sprintf(format, v...))
+	Logger.Log(context.Background(), LevelTrace, fmt.Sprintf(format, v...))
 }
 
 // Debugf prints the message with DEBUG severity in the specified format.
 func Debugf(format string, v ...interface{}) {
-	defaultLogger.Debug(fmt.Sprintf(format, v...))
+	Logger.Debug(fmt.Sprintf(format, v...))
 }
 
 // Infof prints the message with INFO severity in the specified format.
 func Infof(format string, v ...interface{}) {
-	defaultLogger.Info(fmt.Sprintf(format, v...))
+	Logger.Info(fmt.Sprintf(format, v...))
 }
 
 // Info prints the message with info severity.
 func Info(v ...interface{}) {
-	defaultLogger.Info(fmt.Sprint(v...))
+	Logger.Info(fmt.Sprint(v...))
 }
 
 // Warnf prints the message with WARNING severity in the specified format.
 func Warnf(format string, v ...interface{}) {
-	defaultLogger.Warn(fmt.Sprintf(format, v...))
+	Logger.Warn(fmt.Sprintf(format, v...))
 }
 
 // Errorf prints the message with ERROR severity in the specified format.
 func Errorf(format string, v ...interface{}) {
-	defaultLogger.Error(fmt.Sprintf(format, v...))
+	Logger.Error(fmt.Sprintf(format, v...))
 }
 
 // Fatal prints an error log and exits with non-zero exit code.

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -55,7 +55,7 @@ func TestLoggerSuite(t *testing.T) {
 
 func redirectLogsToGivenBuffer(buf *bytes.Buffer, level string) {
 	var programLevel = new(slog.LevelVar)
-	defaultLogger = slog.New(
+	Logger = slog.New(
 		defaultLoggerFactory.createJsonOrTextHandler(buf, programLevel, "TestLogs: "),
 	)
 	setLoggingLevel(level, programLevel)
@@ -329,7 +329,7 @@ func (t *LoggerTest) TestSetLogFormatToText() {
 		SetLogFormat(test.format)
 
 		assert.NotNil(t.T(), defaultLoggerFactory)
-		assert.NotNil(t.T(), defaultLogger)
+		assert.NotNil(t.T(), Logger)
 		assert.Equal(t.T(), defaultLoggerFactory.format, test.format)
 		// Create a logger using defaultLoggerFactory that writes to buffer.
 		var buf bytes.Buffer


### PR DESCRIPTION
Currently, all the logger calls create a string out of the specified format string and values. However, this means that one cannot avail the benefit of structured logging where one can pass key - value pairs to the log which structures them as fields and values instead of encoding them all as a plain string. This structure in the logs allows for better data analysis without resorting to complex string processing. Exposing the sLog handle allows users to use the structured logging APIs.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
