### PR TITLE
Add support for post-processing configuration

### DIFF
--- a/cfg/vet.go
+++ b/cfg/vet.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg
+
+func VetConfig(c *Config) {
+	// The EnableEmptyManagedFolders flag must be set to true to enforce folder prefixes for Hierarchical buckets.
+	if c.EnableHns {
+		c.List.EnableEmptyManagedFolders = true
+	}
+}

--- a/cmd/config_vetting_test.go
+++ b/cmd/config_vetting_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnableEmptyManagedFoldersResolution(t *testing.T) {
+	testcases := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "enable-hns set to true",
+			args:     []string{"--enable-hns"},
+			expected: true,
+		},
+		{
+			name:     "enable-hns set to true but enable-empty-managed-folders set to false",
+			args:     []string{"--enable-hns", "--enable-empty-managed-folders=false"},
+			expected: true,
+		},
+		{
+			name:     "enable-hns not true but enable-empty-managed-folders set to true",
+			args:     []string{"--enable-hns=false", "--enable-empty-managed-folders=true"},
+			expected: true,
+		},
+		{
+			name:     "both enable-hns and enable-empty-managed-folders not true",
+			args:     []string{"--enable-hns=false", "--enable-empty-managed-folders=false"},
+			expected: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := getConfigObject(t, tc.args)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expected, c.List.EnableEmptyManagedFolders)
+			}
+		})
+	}
+}

--- a/cmd/legacy_param_mapper.go
+++ b/cmd/legacy_param_mapper.go
@@ -150,6 +150,7 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 	if err := cfg.ValidateConfig(resolvedConfig); err != nil {
 		return nil, err
 	}
+	cfg.VetConfig(resolvedConfig)
 	return resolvedConfig, nil
 }
 

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -504,3 +504,53 @@ func TestInvalidClientProtocol(t *testing.T) {
 
 	assert.NotNil(t, err)
 }
+
+func TestEnableEmptyManagedFoldersVetting(t *testing.T) {
+	testcases := []struct {
+		name                              string
+		enableHns                         bool
+		enableEmptyManagedFolders         bool
+		expectedEnableEmptyManagedFolders bool
+	}{
+		{
+			name:                              "both enable-hns and enable-empty-managed-folders set to true",
+			enableHns:                         true,
+			enableEmptyManagedFolders:         true,
+			expectedEnableEmptyManagedFolders: true,
+		},
+		{
+			name:                              "enable-hns set to true",
+			enableHns:                         true,
+			enableEmptyManagedFolders:         false,
+			expectedEnableEmptyManagedFolders: true,
+		},
+		{
+			name:                              "enable-hns not true but enable-empty-managed-folders set to true",
+			enableHns:                         false,
+			enableEmptyManagedFolders:         true,
+			expectedEnableEmptyManagedFolders: true,
+		},
+		{
+			name:                              "both enable-hns and enable-empty-managed-folders not true",
+			enableHns:                         false,
+			enableEmptyManagedFolders:         false,
+			expectedEnableEmptyManagedFolders: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := &flagStorage{
+				ClientProtocol: mountpkg.ClientProtocol("http1"),
+			}
+			c := config.NewMountConfig()
+			c.EnableHNS = tc.enableHns
+			c.ListConfig.EnableEmptyManagedFolders = tc.enableEmptyManagedFolders
+
+			resolvedConfig, err := PopulateNewConfigFromLegacyFlagsAndConfig(&mockCLIContext{}, flags, c)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedEnableEmptyManagedFolders, resolvedConfig.List.EnableEmptyManagedFolders)
+			}
+		})
+	}
+}

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -288,7 +288,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				IgnoreInterrupts:          false,
 				AnonymousAccess:           false,
 				KernelListCacheTtlSeconds: -1,
-				MaxRetryAttempts:          100,
+				MaxRetryAttempts:          15,
 				ClientProtocol:            mountpkg.HTTP2,
 			},
 			mockCLICtx: &mockCLIContext{
@@ -345,7 +345,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 					ClientProtocol: cfg.Protocol("http2"),
 				},
 				GcsRetries: cfg.GcsRetriesConfig{
-					MaxRetryAttempts: 100,
+					MaxRetryAttempts: 15,
 				},
 			},
 			expectedErr: nil,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,10 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		); cfgErr != nil {
 			return
 		}
-		cfgErr = cfg.ValidateConfig(&configObj)
+		if cfgErr = cfg.ValidateConfig(&configObj); cfgErr != nil {
+			return
+		}
+		cfg.VetConfig(&configObj)
 	}
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", "", "The path to the config file where all gcsfuse related config needs to be specified. "+


### PR DESCRIPTION
### Description
Add a function to post-process config-params.
Currently it only caters to List.EnableEmptyManagedFolders but it will be expanded to handle MetadataCache attributes in the future.
I haven't removed the similar vetting config in mount_config since EnableEmptyManagedFolders has not yet been migrated to the new config.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
