### PR TITLE
Fix kokoro e2e tests

### DIFF
--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 
 	flagsSet := [][]string{
-		{"--kernel-list-cache-ttl-secs=-1", "--kernel-list-cache-ttl-secs=0"},
+		{"--kernel-list-cache-ttl-secs=-1"}, {"--kernel-list-cache-ttl-secs=0"},
 	}
 	successCode := static_mounting.RunTests(flagsSet, m)
 


### PR DESCRIPTION
### Description
Accidentally added same flag in one flagset. Fixed that.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
