### PR TITLE
Pass correct enable-hns flag value while creating directory inode

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -702,7 +702,8 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 			ic.Bucket,
 			fs.mtimeClock,
 			fs.cacheClock,
-			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB)
+			fs.mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB,
+			fs.mountConfig.EnableHNS)
 
 		// Implicit directories
 	case ic.FullName.IsDir():

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -44,7 +44,8 @@ func NewExplicitDirInode(
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
-	typeCacheMaxSizeMB int) (d ExplicitDirInode) {
+	typeCacheMaxSizeMB int,
+	enableHNS bool) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
 		name,
@@ -57,7 +58,7 @@ func NewExplicitDirInode(
 		mtimeClock,
 		cacheClock,
 		typeCacheMaxSizeMB,
-		false)
+		enableHNS)
 
 	d = &explicitDirInode{
 		dirInode: wrapped.(*dirInode),


### PR DESCRIPTION
### Description
Pass correct enable-hns flag value while creating directory inode

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
