### PR TITLE
Minor changes for stat cache for HNS

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -248,16 +248,15 @@ func (sc *statCacheBucketView) LookUpFolder(
 	// Look up in the LRU cache.
 	hit, entry := sc.sharedCacheLookup(folderName, now)
 
-	if hit {
-		// Adds scenario to check folder as well even if object with same name is already present
-		if entry.f == nil {
-			return false, nil
-		}
-
-		return true, entry.f
+	if !hit {
+		return false, nil
+	}
+	// Adds scenario to check folder as well even if object with same name is already present
+	if entry.f == nil {
+		return false, nil
 	}
 
-	return false, nil
+	return true, entry.f
 }
 
 func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (bool, *entry) {

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -252,6 +252,7 @@ func (sc *statCacheBucketView) LookUpFolder(
 		return false, nil
 	}
 	// Adds scenario to check folder as well even if object with same name is already present
+	// TODO: should be removed once integration for lookup is completed
 	if entry.f == nil {
 		return false, nil
 	}

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -335,7 +335,15 @@ func (b *fastStatBucket) GetFolder(
 	}
 
 	// Fetch the Folder
-	return b.wrapped.GetFolder(ctx, prefix)
+	folder, error := b.wrapped.GetFolder(ctx, prefix)
+
+	if error != nil {
+		return nil, error
+	}
+
+	// Record the new folder.
+	b.cache.InsertFolder(folder, b.clock.Now().Add(b.ttl))
+	return folder, nil
 }
 
 func (b *fastStatBucket) CreateFolder(ctx context.Context, folderName string) (f *gcs.Folder, err error) {

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -761,6 +761,8 @@ func (t *StatObjectTest) TestShouldCallGetFolderWhenEntryIsNotPresent() {
 
 	ExpectCall(t.cache, "LookUpFolder")(name, Any()).
 		WillOnce(Return(false, nil))
+	ExpectCall(t.cache, "InsertFolder")(folder, Any()).
+		WillOnce(Return())
 	ExpectCall(t.wrapped, "GetFolder")(Any(), name).
 		WillOnce(Return(folder, nil))
 
@@ -768,6 +770,21 @@ func (t *StatObjectTest) TestShouldCallGetFolderWhenEntryIsNotPresent() {
 
 	AssertEq(nil, err)
 	ExpectThat(result, Pointee(DeepEquals(*folder)))
+}
+
+func (t *StatObjectTest) TestShouldReturnNilWhenErrorIsReturnedFromGetFolder() {
+	const name = "some-name"
+	error := errors.New("connection error")
+
+	ExpectCall(t.cache, "LookUpFolder")(name, Any()).
+		WillOnce(Return(false, nil))
+	ExpectCall(t.wrapped, "GetFolder")(Any(), name).
+		WillOnce(Return(nil, error))
+
+	folder, result := t.bucket.GetFolder(context.TODO(), name)
+
+	AssertEq(nil, folder)
+	AssertEq(error, result)
 }
 
 func (t *StatObjectTest) TestRenameFolder() {


### PR DESCRIPTION
### Description

- Minor refactoring to simplify if condition for lookup folder.
- Inserts folder in stat cache if get folder was  successful.
- Negative stat cache scenario will be added in next PR, as some discussion is going on for it.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - Done
