### PR TITLE
Rename folder unit tests with mock bucket in dir handle

### DIFF
--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1526,49 +1526,6 @@ func (t *DirTest) Test_ShouldInvalidateKernelListCache_ZeroTtl() {
 	AssertEq(true, shouldInvalidate)
 }
 
-func (t *DirTest) TestRenameFolderWithGivenName() {
-	const (
-		dirName       = "qux"
-		renameDirName = "rename"
-	)
-	folderName := path.Join(dirInodeName, dirName) + "/"
-	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
-	// Create the original folder.
-	_, err := t.bucket.CreateFolder(t.ctx, folderName)
-	AssertEq(nil, err)
-
-	// Attempt to rename the folder.
-	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
-
-	AssertEq(nil, err)
-	// Verify the original folder no longer exists.
-	_, err = t.bucket.GetFolder(t.ctx, folderName)
-	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
-	// Verify the renamed folder exists.
-	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
-	AssertEq(nil, err)
-	AssertEq(renameFolderName, f.Name)
-}
-
-func (t *DirTest) TestRenameFolderWithNonExistentSourceFolder() {
-	const (
-		dirName       = "qux"
-		renameDirName = "rename"
-	)
-	folderName := path.Join(dirInodeName, dirName) + "/"
-	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
-
-	// Attempt to rename the folder.
-	_, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
-
-	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
-	// Verify the renamed folder does not exist.
-	_, err = t.bucket.GetFolder(t.ctx, renameFolderName)
-	ExpectTrue(errors.As(err, &notFoundErr))
-}
-
 func (t *DirTest) Test_InvalidateKernelListCache() {
 	d := t.in.(*dirInode)
 	d.prevDirListingTimeStamp = d.cacheClock.Now()

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -245,3 +245,40 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeIsNonExist
 	assert.Nil(t.T(), result)
 	t.mockBucket.AssertExpectations(t.T())
 }
+
+func (t *HNSDirTest) TestRenameFolderWithGivenName() {
+	const (
+		dirName       = "qux"
+		renameDirName = "rename"
+	)
+	folderName := path.Join(dirInodeName, dirName) + "/"
+	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
+	renameFolder := gcs.Folder{Name: renameFolderName}
+	t.mockBucket.On("RenameFolder", t.ctx, folderName, renameFolderName).Return(&renameFolder, nil)
+
+	// Attempt to rename the folder.
+	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.NoError(t.T(), err)
+	// Verify the renamed folder exists.
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), renameFolderName, f.Name)
+}
+
+func (t *HNSDirTest) TestRenameFolderWithNonExistentSourceFolder() {
+	var notFoundErr *gcs.NotFoundError
+	const (
+		dirName       = "qux"
+		renameDirName = "rename"
+	)
+	folderName := path.Join(dirInodeName, dirName) + "/"
+	renameFolderName := path.Join(dirInodeName, renameDirName) + "/"
+	t.mockBucket.On("RenameFolder", t.ctx, folderName, renameFolderName).Return(nil, &gcs.NotFoundError{})
+
+	// Attempt to rename the folder.
+	_, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.True(t.T(), errors.As(err, &notFoundErr))
+}

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -277,8 +277,9 @@ func (t *HNSDirTest) TestRenameFolderWithNonExistentSourceFolder() {
 	t.mockBucket.On("RenameFolder", t.ctx, folderName, renameFolderName).Return(nil, &gcs.NotFoundError{})
 
 	// Attempt to rename the folder.
-	_, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
+	f, err := t.in.RenameFolder(t.ctx, folderName, renameFolderName)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.True(t.T(), errors.As(err, &notFoundErr))
+	assert.Nil(t.T(), f)
 }

--- a/internal/storage/testify_mock_bucket.go
+++ b/internal/storage/testify_mock_bucket.go
@@ -95,7 +95,10 @@ func (m *TestifyMockBucket) GetFolder(ctx context.Context, folderName string) (*
 
 func (m *TestifyMockBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error) {
 	args := m.Called(ctx, folderName, destinationFolderId)
-	return args.Get(0).(*gcs.Folder), args.Error(1)
+	if args.Get(0) != nil {
+		return args.Get(0).(*gcs.Folder), nil
+	}
+	return nil, args.Error(1)
 }
 
 func (m *TestifyMockBucket) CreateFolder(ctx context.Context, folderName string) (*gcs.Folder, error) {


### PR DESCRIPTION
### Description
- Moved rename dir tests to hns dir test as they are part of hns scenarios and needed to use mock bucket instead of fake bucket which can mock atomic rename behaviour without adding complex logic in fake bucket.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
