### PR TITLE
Callback getFolder in LookUpInode 

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -292,9 +292,10 @@ func (d *dirInode) lookUpChildFile(ctx context.Context, name string) (*Core, err
 
 func (d *dirInode) lookUpChildDir(ctx context.Context, name string) (*Core, error) {
 	childName := NewDirName(d.Name(), name)
-	if d.isHNSEnabled && d.bucket.BucketType() == gcs.Hierarchical {
+	if d.IsBucketHierarchical() {
 		return findExplicitFolder(ctx, d.Bucket(), childName)
 	}
+	
 	if d.implicitDirs {
 		return findDirInode(ctx, d.Bucket(), childName)
 	}
@@ -562,7 +563,7 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 		return nil, nil
 	case metadata.UnknownType:
 		b.Add(lookUpFile)
-		if d.isHNSEnabled && d.bucket.BucketType() == gcs.Hierarchical {
+		if d.IsBucketHierarchical() {
 			b.Add(lookUpHNSDir)
 		} else {
 			if d.implicitDirs {
@@ -972,4 +973,11 @@ func (d *dirInode) RenameFolder(ctx context.Context, folderName string, destinat
 func (d *dirInode) InvalidateKernelListCache() {
 	// Set prevDirListingTimeStamp to Zero time so that cache is invalidated.
 	d.prevDirListingTimeStamp = time.Time{}
+}
+
+func (d *dirInode) IsBucketHierarchical() bool {
+	if d.isHNSEnabled && d.bucket.BucketType() == gcs.Hierarchical {
+		return true
+	}
+	return false
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -292,6 +292,9 @@ func (d *dirInode) lookUpChildFile(ctx context.Context, name string) (*Core, err
 
 func (d *dirInode) lookUpChildDir(ctx context.Context, name string) (*Core, error) {
 	childName := NewDirName(d.Name(), name)
+	if d.isHNSEnabled && d.bucket.BucketType() == gcs.Hierarchical {
+		return findExplicitFolder(ctx, d.Bucket(), childName)
+	}
 	if d.implicitDirs {
 		return findDirInode(ctx, d.Bucket(), childName)
 	}

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -295,7 +295,7 @@ func (d *dirInode) lookUpChildDir(ctx context.Context, name string) (*Core, erro
 	if d.IsBucketHierarchical() {
 		return findExplicitFolder(ctx, d.Bucket(), childName)
 	}
-	
+
 	if d.implicitDirs {
 		return findDirInode(ctx, d.Bucket(), childName)
 	}

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -130,7 +130,7 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 	assert.Nil(t.T(), result)
 }
 
-func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
+func (t *HNSDirTest) TestLookUpChild_WithConflictMarkerName() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -133,7 +133,6 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"
-	// mock get folder call
 	folder := &gcs.Folder{
 		Name:           dirName,
 		MetaGeneration: int64(1),

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -130,7 +130,7 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 	assert.Nil(t.T(), result)
 }
 
-func (t *HNSDirTest) TestLookUpChild_WithConflictMarkerName() {
+func (t *HNSDirTest) TestLookUpChildWithConflictMarkerName() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -134,13 +134,10 @@ func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{
-		Name:           dirName,
-		MetaGeneration: int64(1),
+		Name: dirName,
 	}
 	statObjectRequest := gcs.StatObjectRequest{
-		Name:                           path.Join(dirInodeName, name),
-		ForceFetchFromGcs:              false,
-		ReturnExtendedObjectAttributes: false,
+		Name: path.Join(dirInodeName, name),
 	}
 	object := gcs.MinObject{Name: dirName}
 	t.mockBucket.On("GetFolder", mock.Anything, dirName).Return(folder, nil)

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -143,15 +143,17 @@ func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
 		ForceFetchFromGcs:              false,
 		ReturnExtendedObjectAttributes: false,
 	}
+	object := gcs.MinObject{Name: dirName}
 	t.mockBucket.On("GetFolder", mock.Anything, dirName).Return(folder, nil)
-	t.mockBucket.On("StatObject", mock.Anything, &statObjectRequest).Return(&gcs.MinObject{}, &gcs.ExtendedObjectAttributes{}, nil)
+	t.mockBucket.On("StatObject", mock.Anything, &statObjectRequest).Return(&object, &gcs.ExtendedObjectAttributes{}, nil)
 	t.mockBucket.On("BucketType").Return(gcs.Hierarchical)
 
 	// Look up with the proper name.
-	_, err := t.in.LookUpChild(t.ctx, name+"\n")
+	c, err := t.in.LookUpChild(t.ctx, name+"\n")
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), dirName, c.MinObject.Name)
 }
 
 func (t *HNSDirTest) TestLookUpChildShouldCheckOnlyForExplicitHNSDirectory() {

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -148,7 +148,6 @@ func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
 	t.mockBucket.On("StatObject", mock.Anything, &statObjectRequest).Return(&object, &gcs.ExtendedObjectAttributes{}, nil)
 	t.mockBucket.On("BucketType").Return(gcs.Hierarchical)
 
-	// Look up with the proper name.
 	c, err := t.in.LookUpChild(t.ctx, name+"\n")
 
 	t.mockBucket.AssertExpectations(t.T())

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -130,6 +130,31 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 	assert.Nil(t.T(), result)
 }
 
+func (t *HNSDirTest) TestLookUpChildShouldLookUpConflicting() {
+	const name = "qux"
+	dirName := path.Join(dirInodeName, name) + "/"
+	// mock get folder call
+	folder := &gcs.Folder{
+		Name:           dirName,
+		MetaGeneration: int64(1),
+	}
+	t.mockBucket.On("GetFolder", mock.Anything, dirName).Return(folder, nil)
+	t.mockBucket.On("StatObject", mock.Anything, dirName).Return(nil, gcs.NotFoundError{})
+	t.mockBucket.On("BucketType").Return(gcs.Hierarchical)
+	t.typeCache.Insert(t.fixedTime.Now().Add(time.Minute), name, metadata.ExplicitDirType)
+
+	// Look up with the proper name.
+	result, err := t.in.LookUpChild(t.ctx, name+"\n")
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
+	assert.Equal(t.T(), dirName, result.MinObject.Name)
+	assert.Equal(t.T(), int64(0), result.MinObject.Generation)
+	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
+	assert.Equal(t.T(), metadata.ExplicitDirType, t.typeCache.Get(t.fixedTime.Now(), name))
+}
+
 func (t *HNSDirTest) TestLookUpChildShouldCheckOnlyForExplicitHNSDirectory() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"


### PR DESCRIPTION
### Description
- Call Getfolder in case of LookUpConflicting function.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Automated
