### PR TITLE
[CLI config parity] migrate url type to string type

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -17,7 +17,6 @@
 package cfg
 
 import (
-	"net/url"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
@@ -126,7 +125,7 @@ type GcsConnectionConfig struct {
 
 	ClientProtocol Protocol `yaml:"client-protocol"`
 
-	CustomEndpoint *url.URL `yaml:"custom-endpoint"`
+	CustomEndpoint string `yaml:"custom-endpoint"`
 
 	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
 

--- a/cfg/decode_hook.go
+++ b/cfg/decode_hook.go
@@ -15,38 +15,13 @@
 package cfg
 
 import (
-	"net/url"
-	"reflect"
-
 	"github.com/mitchellh/mapstructure"
 )
-
-func stringToURLHookFunc() mapstructure.DecodeHookFuncType {
-	return func(
-		f reflect.Type,
-		t reflect.Type,
-		data interface{},
-	) (interface{}, error) {
-		if f.Kind() != reflect.String {
-			return data, nil
-		}
-		if t != reflect.TypeOf(&url.URL{}) {
-			return data, nil
-		}
-		s := data.(string)
-		u, err := url.Parse(s)
-		if err != nil {
-			return nil, err
-		}
-		return u, nil
-	}
-}
 
 // DecodeHook will be called by Viper while constructing the config object.
 func DecodeHook() mapstructure.DecodeHookFunc {
 	return mapstructure.ComposeDecodeHookFunc(
 		mapstructure.TextUnmarshallerHookFunc(),
-		stringToURLHookFunc(),
 		mapstructure.StringToTimeDurationHookFunc(), // default hook
 		mapstructure.StringToSliceHookFunc(","),     // default hook
 	)

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -15,7 +15,6 @@
 package cfg
 
 import (
-	"net/url"
 	"os"
 	"path"
 	"testing"
@@ -37,7 +36,6 @@ func bindFlag(t *testing.T, v *viper.Viper, key string, f *flag.Flag) {
 func TestParsingSuccess(t *testing.T) {
 	type TestConfig struct {
 		OctalParam       Octal
-		URLParam         *url.URL
 		BoolParam        bool
 		StringParam      string
 		IntParam         int
@@ -51,7 +49,6 @@ func TestParsingSuccess(t *testing.T) {
 	}
 	declareFlags := func() *flag.FlagSet {
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
-		fs.String("urlParam", "", "")
 		fs.String("octalParam", "0", "")
 		fs.String("stringParam", "", "")
 		fs.Int("intParam", 0, "")
@@ -69,7 +66,6 @@ func TestParsingSuccess(t *testing.T) {
 	bindFlags := func(fs *flag.FlagSet) *viper.Viper {
 		t.Helper()
 		v := viper.New()
-		bindFlag(t, v, "URLParam", fs.Lookup("urlParam"))
 		bindFlag(t, v, "OctalParam", fs.Lookup("octalParam"))
 		bindFlag(t, v, "StringParam", fs.Lookup("stringParam"))
 		bindFlag(t, v, "IntParam", fs.Lookup("intParam"))
@@ -95,17 +91,6 @@ func TestParsingSuccess(t *testing.T) {
 			args: []string{"--octalParam=755"},
 			testFn: func(t *testing.T, c TestConfig) {
 				assert.Equal(t, Octal(0755), c.OctalParam)
-			},
-		},
-		{
-			name: "URL",
-			args: []string{"--urlParam=http://abc.xyz"},
-			testFn: func(t *testing.T, c TestConfig) {
-				u, err := url.Parse("http://abc.xyz")
-				if err != nil {
-					t.Fatalf("Error while parsing URL: %v", err)
-				}
-				assert.Equal(t, *u, *c.URLParam)
 			},
 		},
 		{
@@ -257,14 +242,12 @@ func TestParsingSuccess(t *testing.T) {
 func TestParsingError(t *testing.T) {
 	type TestConfig struct {
 		OctalParam       Octal
-		URLParam         *url.URL
 		LogSeverityParam LogSeverity
 		ProtocolParam    Protocol
 	}
 	declareFlags := func() *flag.FlagSet {
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
 		fs.String("octalParam", "0", "")
-		fs.String("urlParam", "", "")
 		fs.String("logSeverityParam", "INFO", "")
 		fs.String("protocolParam", "http1", "")
 		return fs
@@ -273,7 +256,6 @@ func TestParsingError(t *testing.T) {
 		t.Helper()
 		v := viper.New()
 		bindFlag(t, v, "OctalParam", fs.Lookup("octalParam"))
-		bindFlag(t, v, "URLParam", fs.Lookup("urlParam"))
 		bindFlag(t, v, "LogSeverityParam", fs.Lookup("logSeverityParam"))
 		bindFlag(t, v, "ProtocolParam", fs.Lookup("protocolParam"))
 		return v
@@ -287,10 +269,6 @@ func TestParsingError(t *testing.T) {
 		{
 			name: "Octal",
 			args: []string{"--octalParam=923"},
-		},
-		{
-			name: "URL",
-			args: []string{"--urlParam=a_b://abc"},
 		},
 		{
 			name:   "LogSeverity",

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -17,11 +17,12 @@ package cfg
 import "net/url"
 
 func decodeURL(u string) (string, error) {
-	decodedUrl, err := url.Parse(u)
+	// TODO: check if we can replace url.Parse with url.ParseRequestURI.
+	decodedURL, err := url.Parse(u)
 	if err != nil {
 		return "", err
 	}
-	return decodedUrl.String(), nil
+	return decodedURL.String(), nil
 }
 
 // Rationalize updates the config fields based on the values of other fields.

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -14,10 +14,28 @@
 
 package cfg
 
+import "net/url"
+
+func decodeURL(u string) (string, error) {
+	decodedUrl, err := url.Parse(u)
+	if err != nil {
+		return "", err
+	}
+	return decodedUrl.String(), nil
+}
+
 // Rationalize updates the config fields based on the values of other fields.
-func Rationalize(c *Config) {
+func Rationalize(c *Config) error {
 	// The EnableEmptyManagedFolders flag must be set to true to enforce folder prefixes for Hierarchical buckets.
 	if c.EnableHns {
 		c.List.EnableEmptyManagedFolders = true
 	}
+
+	var err error
+	c.GcsConnection.CustomEndpoint, err = decodeURL(c.GcsConnection.CustomEndpoint)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -75,7 +75,7 @@ func TestRationalizeCustomEndpointSuccessful(t *testing.T) {
 		expectedCustomEndpoint string
 	}{
 		{
-			name: "Valid Config where input and expected custom endpoint matches.",
+			name: "Valid Config where input and expected custom endpoint match.",
 			config: &Config{
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "https://bing.com/search?q=dotnet",

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -28,9 +28,9 @@ func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
 	return nil
 }
 
-func isValidURL(u string) (err error) {
-	_, err = decodeURL(u)
-	return
+func isValidURL(u string) error {
+	_, err := decodeURL(u)
+	return err
 }
 
 // ValidateConfig returns a non-nil error if the config is invalid.

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -16,6 +16,7 @@ package cfg
 
 import (
 	"fmt"
+	"net/url"
 )
 
 func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
@@ -28,10 +29,25 @@ func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
 	return nil
 }
 
+func isValidUrl(u string) (string, error) {
+	decodedUrl, err := url.Parse(u)
+	if err != nil {
+		return "", err
+	}
+	return decodedUrl.String(), nil
+}
+
 // ValidateConfig returns a non-nil error if the config is invalid.
 func ValidateConfig(config *Config) error {
-	if err := isValidLogRotateConfig(&config.Logging.LogRotate); err != nil {
+	var err error
+
+	if err = isValidLogRotateConfig(&config.Logging.LogRotate); err != nil {
 		return fmt.Errorf("error parsing log-rotate config: %w", err)
 	}
+
+	if config.GcsConnection.CustomEndpoint, err = isValidUrl(config.GcsConnection.CustomEndpoint); err != nil {
+		return fmt.Errorf("invalid config.GcsConnection.CustomEndpoint: %w", err)
+	}
+
 	return nil
 }

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -29,7 +29,7 @@ func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
 	return nil
 }
 
-func isValidUrl(u string) (string, error) {
+func isValidURL(u string) (string, error) {
 	decodedUrl, err := url.Parse(u)
 	if err != nil {
 		return "", err
@@ -45,7 +45,7 @@ func ValidateConfig(config *Config) error {
 		return fmt.Errorf("error parsing log-rotate config: %w", err)
 	}
 
-	if config.GcsConnection.CustomEndpoint, err = isValidUrl(config.GcsConnection.CustomEndpoint); err != nil {
+	if config.GcsConnection.CustomEndpoint, err = isValidURL(config.GcsConnection.CustomEndpoint); err != nil {
 		return fmt.Errorf("invalid config.GcsConnection.CustomEndpoint: %w", err)
 	}
 

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -29,12 +29,12 @@ func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
 	return nil
 }
 
-func isValidURL(u string) (string, error) {
-	decodedUrl, err := url.Parse(u)
+func isValidURL(u string) error {
+	_, err := url.Parse(u)
 	if err != nil {
-		return "", err
+		return err
 	}
-	return decodedUrl.String(), nil
+	return nil
 }
 
 // ValidateConfig returns a non-nil error if the config is invalid.
@@ -45,8 +45,8 @@ func ValidateConfig(config *Config) error {
 		return fmt.Errorf("error parsing log-rotate config: %w", err)
 	}
 
-	if config.GcsConnection.CustomEndpoint, err = isValidURL(config.GcsConnection.CustomEndpoint); err != nil {
-		return fmt.Errorf("invalid config.GcsConnection.CustomEndpoint: %w", err)
+	if err = isValidURL(config.GcsConnection.CustomEndpoint); err != nil {
+		return fmt.Errorf("error parsing custom-endpoint config: %w", err)
 	}
 
 	return nil

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -16,7 +16,6 @@ package cfg
 
 import (
 	"fmt"
-	"net/url"
 )
 
 func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
@@ -29,12 +28,9 @@ func isValidLogRotateConfig(config *LogRotateLoggingConfig) error {
 	return nil
 }
 
-func isValidURL(u string) error {
-	_, err := url.Parse(u)
-	if err != nil {
-		return err
-	}
-	return nil
+func isValidURL(u string) (err error) {
+	_, err = decodeURL(u)
+	return
 }
 
 // ValidateConfig returns a non-nil error if the config is invalid.

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -33,7 +33,7 @@ func TestValidateConfig(t *testing.T) {
 		name                   string
 		config                 *Config
 		expectedCustomEndpoint string
-		expectedErr            bool
+		wantErr                bool
 	}{
 		{
 			name: "Valid Config 1",
@@ -44,18 +44,18 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			expectedCustomEndpoint: "https://bing.com/search?q=dotnet",
-			expectedErr:            false,
+			wantErr:                false,
 		},
 		{
 			name: "Valid Config 2",
 			config: &Config{
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{
-					CustomEndpoint: "www.example.com",
+					CustomEndpoint: "https://j@ne:password@google.com",
 				},
 			},
-			expectedCustomEndpoint: "www.example.com",
-			expectedErr:            false,
+			expectedCustomEndpoint: "https://j%40ne:password@google.com",
+			wantErr:                false,
 		},
 		{
 			name: "Invalid Config",
@@ -66,17 +66,16 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			expectedCustomEndpoint: "",
-			expectedErr:            true,
+			wantErr:                true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			actualErr := ValidateConfig(tc.config)
 
 			assert.Equal(t, tc.config.GcsConnection.CustomEndpoint, tc.expectedCustomEndpoint)
-			if tc.expectedErr {
+			if tc.wantErr {
 				assert.Error(t, actualErr)
 			} else {
 				assert.NoError(t, actualErr)

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -34,7 +34,7 @@ func TestValidateConfigSuccessful(t *testing.T) {
 		config *Config
 	}{
 		{
-			name: "Valid Config where input and expected custom endpoint matches.",
+			name: "Valid Config where input and expected custom endpoint match.",
 			config: &Config{
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func validLogRotateConfig() LogRotateLoggingConfig {
+	return LogRotateLoggingConfig{
+		BackupFileCount: 0,
+		Compress:        false,
+		MaxFileSizeMb:   1,
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		config                 *Config
+		expectedCustomEndpoint string
+		expectedErr            bool
+	}{
+		{
+			name: "Valid Config 1",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsConnection: GcsConnectionConfig{
+					CustomEndpoint: "https://bing.com/search?q=dotnet",
+				},
+			},
+			expectedCustomEndpoint: "https://bing.com/search?q=dotnet",
+			expectedErr:            false,
+		},
+		{
+			name: "Valid Config 2",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsConnection: GcsConnectionConfig{
+					CustomEndpoint: "www.example.com",
+				},
+			},
+			expectedCustomEndpoint: "www.example.com",
+			expectedErr:            false,
+		},
+		{
+			name: "Invalid Config",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsConnection: GcsConnectionConfig{
+					CustomEndpoint: "a_b://abc",
+				},
+			},
+			expectedCustomEndpoint: "",
+			expectedErr:            true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			actualErr := ValidateConfig(tc.config)
+
+			assert.Equal(t, tc.config.GcsConnection.CustomEndpoint, tc.expectedCustomEndpoint)
+			if tc.expectedErr {
+				assert.Error(t, actualErr)
+			} else {
+				assert.NoError(t, actualErr)
+			}
+		})
+	}
+}

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -30,10 +30,9 @@ func validLogRotateConfig() LogRotateLoggingConfig {
 
 func TestValidateConfig(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		config                 *Config
-		expectedCustomEndpoint string
-		wantErr                bool
+		name    string
+		config  *Config
+		wantErr bool
 	}{
 		{
 			name: "Valid Config 1",
@@ -43,8 +42,7 @@ func TestValidateConfig(t *testing.T) {
 					CustomEndpoint: "https://bing.com/search?q=dotnet",
 				},
 			},
-			expectedCustomEndpoint: "https://bing.com/search?q=dotnet",
-			wantErr:                false,
+			wantErr: false,
 		},
 		{
 			name: "Valid Config 2",
@@ -54,8 +52,7 @@ func TestValidateConfig(t *testing.T) {
 					CustomEndpoint: "https://j@ne:password@google.com",
 				},
 			},
-			expectedCustomEndpoint: "https://j%40ne:password@google.com",
-			wantErr:                false,
+			wantErr: false,
 		},
 		{
 			name: "Invalid Config",
@@ -65,8 +62,7 @@ func TestValidateConfig(t *testing.T) {
 					CustomEndpoint: "a_b://abc",
 				},
 			},
-			expectedCustomEndpoint: "",
-			wantErr:                true,
+			wantErr: true,
 		},
 	}
 
@@ -74,7 +70,6 @@ func TestValidateConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actualErr := ValidateConfig(tc.config)
 
-			assert.Equal(t, tc.config.GcsConnection.CustomEndpoint, tc.expectedCustomEndpoint)
 			if tc.wantErr {
 				assert.Error(t, actualErr)
 			} else {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -28,41 +28,28 @@ func validLogRotateConfig() LogRotateLoggingConfig {
 	}
 }
 
-func TestValidateConfig(t *testing.T) {
+func TestValidateConfigSuccessful(t *testing.T) {
 	testCases := []struct {
-		name    string
-		config  *Config
-		wantErr bool
+		name   string
+		config *Config
 	}{
 		{
-			name: "Valid Config 1",
+			name: "Valid Config where input and expected custom endpoint matches.",
 			config: &Config{
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "https://bing.com/search?q=dotnet",
 				},
 			},
-			wantErr: false,
 		},
 		{
-			name: "Valid Config 2",
+			name: "Valid Config where input and expected custom endpoint differ.",
 			config: &Config{
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "https://j@ne:password@google.com",
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "Invalid Config",
-			config: &Config{
-				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
-				GcsConnection: GcsConnectionConfig{
-					CustomEndpoint: "a_b://abc",
-				},
-			},
-			wantErr: true,
 		},
 	}
 
@@ -70,11 +57,32 @@ func TestValidateConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actualErr := ValidateConfig(tc.config)
 
-			if tc.wantErr {
-				assert.Error(t, actualErr)
-			} else {
-				assert.NoError(t, actualErr)
-			}
+			assert.NoError(t, actualErr)
+		})
+	}
+}
+
+func TestValidateConfigUnsuccessful(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *Config
+	}{
+		{
+			name: "Invalid Config due to invalid custom endpoint",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsConnection: GcsConnectionConfig{
+					CustomEndpoint: "a_b://abc",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := ValidateConfig(tc.config)
+
+			assert.Error(t, actualErr)
 		})
 	}
 }

--- a/cmd/legacy_param_mapper.go
+++ b/cmd/legacy_param_mapper.go
@@ -35,7 +35,7 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 		return nil, fmt.Errorf("PopulateNewConfigFromLegacyFlagsAndConfig: unexpected nil flags or mount config")
 	}
 
-	// resolve custom endpoint url type to string.
+	// Resolve custom endpoint url type to string.
 	var customEndPoint string
 	if flags.CustomEndpoint != nil {
 		customEndPoint = flags.CustomEndpoint.String()

--- a/cmd/legacy_param_mapper.go
+++ b/cmd/legacy_param_mapper.go
@@ -35,6 +35,14 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 		return nil, fmt.Errorf("PopulateNewConfigFromLegacyFlagsAndConfig: unexpected nil flags or mount config")
 	}
 
+	// resolve custom endpoint url type to string.
+	var customEndPoint string
+	if flags.CustomEndpoint == nil {
+		customEndPoint = ""
+	} else {
+		customEndPoint = flags.CustomEndpoint.String()
+	}
+
 	resolvedConfig := &cfg.Config{}
 
 	structuredFlags := &map[string]interface{}{
@@ -66,7 +74,7 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 		"gcs-connection": map[string]interface{}{
 			"billing-project":               flags.BillingProject,
 			"client-protocol":               string(flags.ClientProtocol),
-			"custom-endpoint":               flags.CustomEndpoint,
+			"custom-endpoint":               customEndPoint,
 			"experimental-enable-json-read": flags.ExperimentalEnableJsonRead,
 			"http-client-timeout":           flags.HttpClientTimeout,
 			"limit-bytes-per-sec":           flags.EgressBandwidthLimitBytesPerSecond,

--- a/cmd/legacy_param_mapper.go
+++ b/cmd/legacy_param_mapper.go
@@ -37,9 +37,7 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 
 	// resolve custom endpoint url type to string.
 	var customEndPoint string
-	if flags.CustomEndpoint == nil {
-		customEndPoint = ""
-	} else {
+	if flags.CustomEndpoint != nil {
 		customEndPoint = flags.CustomEndpoint.String()
 	}
 

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -147,7 +147,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 					AnonymousAccess:   false,
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
-					CustomEndpoint:             nil,
+					CustomEndpoint:             "",
 					BillingProject:             "billing-project",
 					ClientProtocol:             cfg.Protocol("http1"),
 					LimitBytesPerSec:           100,
@@ -469,8 +469,8 @@ func TestCustomEndpointResolutionFromFlags(t *testing.T) {
 
 	resolvedConfig, err := PopulateNewConfigFromLegacyFlagsAndConfig(&mockCLIContext{}, legacyFlagStorage, &config.MountConfig{})
 
-	if assert.Nil(t, err) && assert.NotNil(t, resolvedConfig.GcsConnection.CustomEndpoint) {
-		assert.Equal(t, *resolvedConfig.GcsConnection.CustomEndpoint, *u)
+	if assert.Nil(t, err) && assert.NotEmpty(t, resolvedConfig.GcsConnection.CustomEndpoint) {
+		assert.Equal(t, resolvedConfig.GcsConnection.CustomEndpoint, u.String())
 	}
 }
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -52,9 +52,9 @@ type storageClient struct {
 // Return clientOpts for both gRPC client and control client.
 func createClientOptionForGRPCClient(clientConfig *storageutil.StorageClientConfig) (clientOpts []option.ClientOption, err error) {
 	// Add Custom endpoint option.
-	if clientConfig.CustomEndpoint != nil {
+	if clientConfig.CustomEndpoint != "" {
 		if clientConfig.AnonymousAccess {
-			clientOpts = append(clientOpts, option.WithEndpoint(storageutil.StripScheme(clientConfig.CustomEndpoint.String())))
+			clientOpts = append(clientOpts, option.WithEndpoint(storageutil.StripScheme(clientConfig.CustomEndpoint)))
 			// Explicitly disable auth in case of custom-endpoint, aligned with the http-client.
 			// TODO: to revisit here when supporting TPC for grpc client.
 			clientOpts = append(clientOpts, option.WithoutAuthentication())
@@ -138,8 +138,8 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 
 	// Add Custom endpoint option.
-	if clientConfig.CustomEndpoint != nil {
-		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint.String()))
+	if clientConfig.CustomEndpoint != "" {
+		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint))
 	}
 
 	return storage.NewClient(ctx, clientOpts...)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -126,7 +126,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndAut
 	url, err := url.Parse(storageutil.CustomEndpoint)
 	assert.Nil(testSuite.T(), err)
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = url
+	sc.CustomEndpoint = url.String()
 	sc.AnonymousAccess = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
@@ -139,7 +139,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndAut
 // This will fail while fetching the token-source, since key-file doesn't exist.
 func (testSuite *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilAndAuthEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = nil
+	sc.CustomEndpoint = ""
 	sc.AnonymousAccess = false
 
 	handleCreated, err := NewStorageHandle(context.Background(), sc)
@@ -254,7 +254,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithGRPCClientPro
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustomEndpointNilAndAuthEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = nil
+	sc.CustomEndpoint = ""
 	sc.AnonymousAccess = false
 	sc.ClientProtocol = cfg.GRPC
 
@@ -269,7 +269,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustom
 	url, err := url.Parse(storageutil.CustomEndpoint)
 	assert.Nil(testSuite.T(), err)
 	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.CustomEndpoint = url
+	sc.CustomEndpoint = url.String()
 	sc.AnonymousAccess = false
 	sc.ClientProtocol = cfg.GRPC
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -36,7 +35,7 @@ type StorageClientConfig struct {
 	// ClientProtocol decides the go-sdk client to create.
 	ClientProtocol    cfg.Protocol
 	UserAgent         string
-	CustomEndpoint    *url.URL
+	CustomEndpoint    string
 	KeyFile           string
 	TokenUrl          string
 	ReuseTokenFromUrl bool

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -15,7 +15,6 @@
 package storageutil
 
 import (
-	"net/url"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -36,7 +35,7 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		MaxRetryAttempts:           0,
 		RetryMultiplier:            2,
 		UserAgent:                  "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) (GCP:gcsfuse)",
-		CustomEndpoint:             &url.URL{},
+		CustomEndpoint:             "",
 		KeyFile:                    DummyKeyFile,
 		TokenUrl:                   "",
 		ReuseTokenFromUrl:          true,

--- a/tools/config-gen/flag_template_data_gen.go
+++ b/tools/config-gen/flag_template_data_gen.go
@@ -76,7 +76,7 @@ func computeFlagTemplateDataForParam(p Param) (flagTemplateData, error) {
 		}
 		defaultValue = fmt.Sprintf("%d * time.Nanosecond", dur.Nanoseconds())
 		fn = "DurationP"
-	case "octal", "url", "logSeverity", "protocol", "resolvedPath":
+	case "octal", "logSeverity", "protocol", "resolvedPath":
 		fallthrough
 	case "string":
 		defaultValue = fmt.Sprintf("%q", p.DefaultValue)

--- a/tools/config-gen/params.yaml
+++ b/tools/config-gen/params.yaml
@@ -3,7 +3,7 @@
 # flag-name: Name of the CLI flag.
 # config-path: Location of the param in the config file. A value of "gcs-auth.anonymous-access" indicates that the param will be present under the gcs-auth:anonymous-access.
 # type: data type of the param - supports the following values: ["int", "float64", "bool", "string", "duration", "octal", "[]int",
-#			"[]string", "url", "logSeverity", "protocol", "resolvedPath"]
+#			"[]string", "logSeverity", "protocol", "resolvedPath"]
 # usage: The usage doc that will appear in the helpdoc
 # default: The default value of the param.
 # deprecated: Specifies whether the param is deprecated. This will cause warnings when the user specifies the flag.
@@ -88,7 +88,7 @@
 
 - flag-name: "custom-endpoint"
   config-path: "gcs-connection.custom-endpoint"
-  type: "url"
+  type: "string"
   usage: >-
     Specifies an alternative custom endpoint for fetching data. Should only be
     used for testing.  The custom endpoint must support the equivalent resources
@@ -96,6 +96,7 @@
     https://storage.googleapis.com/storage/v1. If a custom endpoint is not
     specified,  GCSFuse uses the global GCS JSON API endpoint,
     https://storage.googleapis.com/storage/v1.
+  default: ""
 
 - flag-name: "anonymous-access"
   config-path: "gcs-auth.anonymous-access"

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -76,7 +76,7 @@ func validateParam(param Param) error {
 	// Validate the data type.
 	idx := slices.IndexFunc(
 		[]string{"int", "float64", "bool", "string", "duration", "octal", "[]int",
-			"[]string", "url", "logSeverity", "protocol", "resolvedPath"},
+			"[]string", "logSeverity", "protocol", "resolvedPath"},
 		func(dt string) bool {
 			return dt == param.Type
 		},

--- a/tools/config-gen/templates/config.tpl
+++ b/tools/config-gen/templates/config.tpl
@@ -18,7 +18,6 @@ package cfg
 
 import (
 	"time"
-	"net/url"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/spf13/pflag"

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -64,8 +64,6 @@ func getGoDataType(dt string) string {
 	switch dt {
 	case "octal":
 		return "Octal"
-	case "url":
-		return "*url.URL"
 	case "logSeverity":
 		return "LogSeverity"
 	case "protocol":


### PR DESCRIPTION
### Description
This PR includes the following changes:
- removes url type from supported new config types. This was being used by custom end point parameter.
- Refactors StorageClientConfig's CustomEndPoint to string type (from url.Url earlier) for simplification.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - Ran via KOKORO
