### PR TITLE
Added mount/unmount functions for rename benchmark

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -362,9 +362,11 @@ def _parse_and_generate_directory_structure(dir_str) -> int:
     _logmessage('Deleting the temporary directory.\n',LOG_INFO)
     subprocess.call(['rm', '-r', TEMPORARY_DIRECTORY])
 
-    return 0
+  return 0
 
 
+=======
+>>>>>>> 55d7dea4a (Adding function to check the consistency of config file)
 if __name__ == '__main__':
   argv = sys.argv
   if len(argv) < 2:

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -365,8 +365,6 @@ def _parse_and_generate_directory_structure(dir_str) -> int:
   return 0
 
 
-=======
->>>>>>> 55d7dea4a (Adding function to check the consistency of config file)
 if __name__ == '__main__':
   argv = sys.argv
   if len(argv) < 2:

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -362,7 +362,7 @@ def _parse_and_generate_directory_structure(dir_str) -> int:
     _logmessage('Deleting the temporary directory.\n',LOG_INFO)
     subprocess.call(['rm', '-r', TEMPORARY_DIRECTORY])
 
-  return 0
+    return 0
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -138,7 +138,7 @@ class TestListDirectory(unittest.TestCase):
                          "gs://fake_bkt/fake_folder_1/",
                          "gs://fake_bkt/nested_fake_folder/"]
 
-    dir_list = generate_folders_and_files._list_directory("gs://fake_bkt")
+    dir_list = generate_folders_and_files.list_directory("gs://fake_bkt")
 
     self.assertEqual(dir_list, expected_dir_list)
 

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -527,5 +527,69 @@ class TestParseAndGenerateDirStructure(unittest.TestCase):
     mock_generate.assert_has_calls(expected_generate_and_upload_calls)
 
 
+class TestParseAndGenerateDirStructure(unittest.TestCase):
+
+  @patch('generate_folders_and_files.logmessage')
+  def test_no_dir_structure_passed(self,mock_logmessage):
+    dir_str={}
+
+    exit_code=generate_folders_and_files.parse_and_generate_directory_structure(dir_str)
+
+    self.assertEqual(exit_code,-1)
+    mock_logmessage.assert_called_once_with("Directory structure not specified via config file.","error")
+
+
+  @patch('generate_folders_and_files.TEMPORARY_DIRECTORY', './tmp/data_gen')
+  @patch('subprocess.call')
+  @patch('generate_folders_and_files.logmessage')
+  @patch('generate_folders_and_files.generate_files_and_upload_to_gcs_bucket')
+  def test_valid_dir_str_with_folders(self, mock_generate, mock_log, mock_subprocess):
+    dir_str = {
+        "name": "test_bucket",
+        "folders": {
+            "num_folders":1,
+            "folder_structure": [
+                {
+                    "name": "test_folder",
+                    "num_files": 2,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        },
+        "nested_folders": {
+            "folder_name": "test_nested",
+            "num_folders": 1,
+            "folder_structure": [
+                {
+                    "name": "test_nested_folder1",
+                    "num_files": 2,
+                    "file_name_prefix": "file",
+                    "file_size": "1kb"
+                }
+            ]
+        }
+    }
+
+    exit_code = generate_folders_and_files.parse_and_generate_directory_structure(dir_str)
+
+    self.assertEqual(exit_code, 0)
+    # Verify subprocess calls
+    expected_subprocess_calls = [
+        call(['mkdir', '-p', generate_folders_and_files.TEMPORARY_DIRECTORY]),
+        call(['rm', '-r', generate_folders_and_files.TEMPORARY_DIRECTORY])
+    ]
+    mock_subprocess.assert_has_calls(expected_subprocess_calls)
+    # Verify log messages
+    mock_log.assert_any_call('Making a temporary directory.\n', "info")
+    mock_log.assert_any_call('Deleting the temporary directory.\n', "info")
+    # Verify generate_files_and_upload_to_gcs_bucket call
+    expected_generate_and_upload_calls = [
+        call( 'gs://test_bucket/test_folder/',2,'kb',1,'file'),
+        call('gs://test_bucket/test_nested/test_nested_folder1/',2,'kb',1,'file')
+    ]
+    mock_generate.assert_has_calls(expected_generate_and_upload_calls)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files_test.py
@@ -138,7 +138,7 @@ class TestListDirectory(unittest.TestCase):
                          "gs://fake_bkt/fake_folder_1/",
                          "gs://fake_bkt/nested_fake_folder/"]
 
-    dir_list = generate_folders_and_files.list_directory("gs://fake_bkt")
+    dir_list = generate_folders_and_files._list_directory("gs://fake_bkt")
 
     self.assertEqual(dir_list, expected_dir_list)
 

--- a/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark.py
@@ -1,0 +1,148 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Python script for benchmarking renaming operation.
+
+This python script benchmarks and compares the latency of rename folder operations
+using existing renamedir API vs hns supported rename folder API.
+
+Note: This python script is dependent on generate_folders_and_files.py.
+"""
+
+import argparse
+import sys
+import json
+import logging
+import subprocess
+import generate_folders_and_files
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger()
+
+
+def _check_dependencies(packages) -> None:
+  """Check whether the dependencies are installed or not.
+
+  Args:
+    packages: List containing the names of the dependencies to be checked.
+
+  Raises:
+    Aborts the execution if a particular dependency is not found.
+  """
+
+  for curr_package in packages:
+    log.info('Checking whether %s is installed.\n', curr_package)
+    exit_code = subprocess.call(
+        '{} --version'.format(curr_package), shell=True)
+    if exit_code != 0:
+      log.error(
+          '%s not installed. Please install. Aborting!\n', curr_package)
+      subprocess.call('bash', shell=True)
+
+  return
+
+
+def _unmount_gcs_bucket(gcs_bucket) -> None:
+  """Unmounts the GCS bucket.
+
+  Args:
+    gcs_bucket: Name of the directory to which GCS bucket is mounted to.
+
+  Raises:
+    An error if the GCS bucket could not be umnounted and aborts the program.
+  """
+  log.info('Unmounting the GCS Bucket.\n')
+  exit_code = subprocess.call('umount -l {}'.format(gcs_bucket), shell=True)
+  if exit_code != 0:
+    log.error('Error encountered in umounting the bucket. Aborting!\n')
+    subprocess.call('bash', shell=True)
+  else:
+    subprocess.call('rm -rf {}'.format(gcs_bucket), shell=True)
+    log.info(
+        'Successfully unmounted the bucket and deleted %s directory.\n',
+        gcs_bucket)
+
+
+def _mount_gcs_bucket(bucket_name, gcsfuse_flags) -> str:
+  """Mounts the GCS bucket into the gcs_bucket directory.
+  For testing renameFolder API,we mount using config-file flag which contains
+  enable-hns set to true
+  For testing renameDir API, we mount using implicit-dirs flag.
+
+  Args:
+    bucket_name: Name of the bucket to be mounted.
+    gcsfuse_flags: Set of flags for which bucket_name will be mounted
+
+  Returns:
+    A string which contains the name of the directory to which the bucket
+    is mounted.
+
+  Raises:
+    Aborts the program if error is encountered while mounting the bucket.
+  """
+  log.info('Started mounting the GCS Bucket using GCSFuse.\n')
+  gcs_bucket = bucket_name
+  subprocess.call('mkdir {}'.format(gcs_bucket), shell=True)
+
+  exit_code = subprocess.call(
+      'gcsfuse {} {} {}'.format(
+          gcsfuse_flags, bucket_name, gcs_bucket), shell=True)
+  if exit_code != 0:
+    log.error('Cannot mount the GCS bucket due to exit code %s.\n', exit_code)
+    subprocess.call('bash', shell=True)
+  else:
+    return gcs_bucket
+
+
+if __name__ == '__main__':
+  argv = sys.argv
+  if len(argv) < 2:
+    raise TypeError('Incorrect number of arguments.\n'
+                    'Usage: '
+                    'python3 renaming_benchmark.py <config_file> [--keep_files]')
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      'dir_config',
+      help='Provide path of the directory structure config file', )
+  parser.add_argument(
+      '--num_samples',
+      help='Number of samples to collect of each test.',
+      action='store',
+      nargs=1,
+      default=[10],
+      required=False,
+  )
+
+  args = parser.parse_args(argv[1:])
+
+  _check_dependencies(['gcloud', 'gcsfuse'])
+
+  directory_structure=json.load(open(args.dir_config))
+
+  # Consistency checks for the input JSON file.
+  if generate_folders_and_files.check_for_config_file_inconsistency(directory_structure):
+    log.error("Inconsistency exists in the input JSON file.")
+    subprocess.call('bash',shell=True)
+
+  # Ensure directory structure exists in the bucket before running tests.
+  # In case of mistmatch, run generate_folders_and_files.py script with the
+  # input config file to get the desired structure.
+  if not generate_folders_and_files.check_if_dir_structure_exists(directory_structure):
+    log.error("Mismatch exists between passed dir structure json file and existing"
+              "structure in the GCS bucket.")
+    subprocess.call('bash',shell=True)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark_test.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+import unittest
+import renaming_benchmark
+from mock import patch,call,mock_open
+
+class TestMountAndUmount(unittest.TestCase):
+  @patch('renaming_benchmark.subprocess.call', return_value=0)
+  def test_unmount_gcs_bucket(self, mock_subprocess_call):
+    renaming_benchmark._unmount_gcs_bucket('fake_bucket')
+    self.assertEqual(mock_subprocess_call.call_count, 2)
+    self.assertEqual(mock_subprocess_call.call_args_list[0], call(
+        'umount -l fake_bucket', shell=True))
+    self.assertEqual(mock_subprocess_call.call_args_list[1], call(
+        'rm -rf fake_bucket', shell=True))
+
+  @patch('renaming_benchmark.subprocess.call', return_value=1)
+  def test_unmount_gcs_bucket_error(self, mock_subprocess_call):
+    renaming_benchmark._unmount_gcs_bucket('fake_bucket')
+    self.assertEqual(mock_subprocess_call.call_count, 2)
+    self.assertEqual(mock_subprocess_call.call_args_list[0], call(
+        'umount -l fake_bucket', shell=True))
+    self.assertEqual(
+        mock_subprocess_call.call_args_list[1], call('bash', shell=True))
+
+  @patch('renaming_benchmark.subprocess.call', return_value=0)
+  def test_mount_gcs_bucket(self, mock_subprocess_call):
+    directory_name = renaming_benchmark._mount_gcs_bucket('fake_bucket',
+                                                         '--implicit-dirs')
+    self.assertEqual(directory_name, 'fake_bucket')
+    self.assertEqual(mock_subprocess_call.call_count, 2)
+    self.assertEqual(mock_subprocess_call.call_args_list, [
+        call('mkdir fake_bucket', shell=True),
+        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True)
+    ])
+
+  @patch('renaming_benchmark.subprocess.call', return_value=1)
+  def test_mount_gcs_bucket_error(self, mock_subprocess_call):
+    renaming_benchmark._mount_gcs_bucket('fake_bucket', '--implicit-dirs')
+    self.assertEqual(mock_subprocess_call.call_count, 3)
+    self.assertEqual(mock_subprocess_call.call_args_list, [
+        call('mkdir fake_bucket', shell=True),
+        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True),
+        call('bash', shell=True)
+    ])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
@@ -573,45 +573,6 @@ class ListingBenchmarkTest(unittest.TestCase):
         'fake_bucket/', DIRECTORY_STRUCTURE3)
     self.assertFalse(result)
 
-  @patch('listing_benchmark.subprocess.call', return_value=0)
-  def test_unmount_gcs_bucket(self, mock_subprocess_call):
-    listing_benchmark._unmount_gcs_bucket('fake_bucket')
-    self.assertEqual(mock_subprocess_call.call_count, 2)
-    self.assertEqual(mock_subprocess_call.call_args_list[0], call(
-        'umount -l fake_bucket', shell=True))
-    self.assertEqual(mock_subprocess_call.call_args_list[1], call(
-        'rm -rf fake_bucket', shell=True))
-
-  @patch('listing_benchmark.subprocess.call', return_value=1)
-  def test_unmount_gcs_bucket_error(self, mock_subprocess_call):
-    listing_benchmark._unmount_gcs_bucket('fake_bucket')
-    self.assertEqual(mock_subprocess_call.call_count, 2)
-    self.assertEqual(mock_subprocess_call.call_args_list[0], call(
-        'umount -l fake_bucket', shell=True))
-    self.assertEqual(
-        mock_subprocess_call.call_args_list[1], call('bash', shell=True))
-
-  @patch('listing_benchmark.subprocess.call', return_value=0)
-  def test_mount_gcs_bucket(self, mock_subprocess_call):
-    directory_name = listing_benchmark._mount_gcs_bucket('fake_bucket',
-                                                         '--implicit-dirs')
-    self.assertEqual(directory_name, 'fake_bucket')
-    self.assertEqual(mock_subprocess_call.call_count, 2)
-    self.assertEqual(mock_subprocess_call.call_args_list, [
-        call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True)
-    ])
-
-  @patch('listing_benchmark.subprocess.call', return_value=1)
-  def test_mount_gcs_bucket_error(self, mock_subprocess_call):
-    listing_benchmark._mount_gcs_bucket('fake_bucket', '--implicit-dirs')
-    self.assertEqual(mock_subprocess_call.call_count, 3)
-    self.assertEqual(mock_subprocess_call.call_args_list, [
-        call('mkdir fake_bucket', shell=True),
-        call('gcsfuse --implicit-dirs fake_bucket fake_bucket', shell=True),
-        call('bash', shell=True)
-    ])
-
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
### Description
For the rename benchmark tests, we need to mount the GCS bucket differently for comparing performance of new and old API.Hence, created mount and unmount functions for the same.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests -[ Failure and success case scenarios for both mount and unmount operations](https://github.com/GoogleCloudPlatform/gcsfuse/blob/ddbff8bf5222758d51051be492b6212295c9f88a/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark_test.py#L19)
3. Integration tests - NA
