### PR TITLE
Fixing error in listing for duplicate files

### DIFF
--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -137,9 +137,9 @@ func fixConflictingNames(entries []fuseutil.Dirent, localEntries map[string]fuse
 
 		if eIsDir == prevIsDir {
 			if _, ok := localEntries[e.Name]; ok && !eIsDir {
-				// if we find same entry in GCS vs local file entries, i.e, the entry is
-				// uploaded to GCS but not yet deleted from local entries. Hence,
-				// don't return it as part of list response.
+				// We have found same entry in GCS and local file entries, i.e, the
+				// entry is uploaded to GCS but not yet deleted from local entries.
+				// Do not return the duplicate entry as part of list response.
 				continue
 			} else {
 				err = fmt.Errorf(

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -106,7 +106,7 @@ func (dh *DirHandle) checkInvariants() {
 // GCS object names, to conflicting file names.
 //
 // Input must be sorted by name.
-func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
+func fixConflictingNames(entries []fuseutil.Dirent, localEntries map[string]fuseutil.Dirent) (output []fuseutil.Dirent, err error) {
 	// Sanity check.
 	if !sort.IsSorted(sortedDirents(entries)) {
 		err = fmt.Errorf("expected sorted input")
@@ -119,13 +119,15 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 
 		// Find the previous entry.
 		if i == 0 {
+			output = append(output, *e)
 			continue
 		}
 
-		prev := &entries[i-1]
+		prev := &output[len(output)-1]
 
 		// Does the pair have matching names?
 		if e.Name != prev.Name {
+			output = append(output, *e)
 			continue
 		}
 
@@ -134,13 +136,19 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 		prevIsDir := prev.Type == fuseutil.DT_Directory
 
 		if eIsDir == prevIsDir {
-			err = fmt.Errorf(
-				"weird dirent type pair for name %q: %v, %v",
-				e.Name,
-				e.Type,
-				prev.Type)
-
-			return
+			if _, ok := localEntries[e.Name]; ok && !eIsDir {
+				// if we find same entry in GCS vs local file entries, i.e, the entry is
+				// uploaded to GCS but not yet deleted from local entries. Hence,
+				// don't return it as part of list response.
+				continue
+			} else {
+				err = fmt.Errorf(
+					"weird dirent type pair for name %q: %v, %v",
+					e.Name,
+					e.Type,
+					prev.Type)
+				return
+			}
 		}
 
 		// Repair whichever is not the directory.
@@ -149,6 +157,8 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 		} else {
 			e.Name += inode.ConflictingFileNameSuffix
 		}
+
+		output = append(output, *e)
 	}
 
 	return
@@ -161,7 +171,7 @@ func fixConflictingNames(entries []fuseutil.Dirent) (err error) {
 func readAllEntries(
 	ctx context.Context,
 	in inode.DirInode,
-	localEntries []fuseutil.Dirent) (entries []fuseutil.Dirent, err error) {
+	localEntries map[string]fuseutil.Dirent) (entries []fuseutil.Dirent, err error) {
 	// Read entries from GCS.
 	// Read one batch at a time.
 	var tok string
@@ -185,7 +195,9 @@ func readAllEntries(
 	}
 
 	// Append local file entries (not synced to GCS).
-	entries = append(entries, localEntries...)
+	for _, localEntry := range localEntries {
+		entries = append(entries, localEntry)
+	}
 
 	// Ensure that the entries are sorted, for use in fixConflictingNames
 	// below.
@@ -194,16 +206,9 @@ func readAllEntries(
 	// Fix name conflicts.
 	// When a local file is synced to GCS but not removed from the local file map,
 	// the entries list will have two duplicate entries.
-	// To handle this scenario, we had 2 options:
-	// Option 1: [Selected]
-	// Throw an error while fixing conflicting names. The error will be fixed in
-	// subsequent ls calls assuming that entry will be removed from localFileInodes.
-	// Option 2: [Not Selected]
-	// Restrict fixConflictingNames to only GCS entries and show duplicate
-	// entries when ReadDir is called. In this case, a local file can have
-	// same name as directory and LookUpInode call will fetch directory details
-	// for both of them.
-	err = fixConflictingNames(entries)
+	// To handle this scenario, we are removing the duplicate entry before
+	// returning the response to kernel.
+	entries, err = fixConflictingNames(entries, localEntries)
 	if err != nil {
 		err = fmt.Errorf("fixConflictingNames: %w", err)
 		return
@@ -236,7 +241,7 @@ func readAllEntries(
 
 // LOCKS_REQUIRED(dh.Mu)
 // LOCKS_EXCLUDED(dh.in)
-func (dh *DirHandle) ensureEntries(ctx context.Context, localFileEntries []fuseutil.Dirent) (err error) {
+func (dh *DirHandle) ensureEntries(ctx context.Context, localFileEntries map[string]fuseutil.Dirent) (err error) {
 	dh.in.Lock()
 	defer dh.in.Unlock()
 
@@ -270,7 +275,7 @@ func (dh *DirHandle) ensureEntries(ctx context.Context, localFileEntries []fuseu
 func (dh *DirHandle) ReadDir(
 	ctx context.Context,
 	op *fuseops.ReadDirOp,
-	localFileEntries []fuseutil.Dirent) (err error) {
+	localFileEntries map[string]fuseutil.Dirent) (err error) {
 	// If the request is for offset zero, we assume that either this is the first
 	// call or rewinddir has been called. Reset state.
 	if op.Offset == 0 {

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -225,3 +225,50 @@ func (t *DirHandleTest) EnsureEntriesWithSameNameLocalFileAndGCSDirectory() {
 	t.validateEntry(t.dh.entries[0], localFileName, fuseutil.DT_Directory)
 	t.validateEntry(t.dh.entries[1], localFileName+inode.ConflictingFileNameSuffix, fuseutil.DT_File)
 }
+
+func (t *DirHandleTest) EnsureEntriesWithNoFiles() {
+	// Setup localFileEntries.
+	localFileEntries := map[string]fuseutil.Dirent{}
+
+	// Ensure entries.
+	err := t.dh.ensureEntries(t.ctx, localFileEntries)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(0, len(t.dh.entries))
+}
+
+func (t *DirHandleTest) EnsureEntriesWithOneGCSFile() {
+	var err error
+	// Set up empty GCS objects.
+	// DirHandle holds a DirInode pointing to "testDir".
+	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject1", nil)
+	AssertEq(nil, err)
+	// Setup empty localFileEntries.
+	var localFileEntries map[string]fuseutil.Dirent
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(1, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], "gcsObject1", fuseutil.DT_File)
+}
+
+func (t *DirHandleTest) EnsureEntriesWithOneLocalFile() {
+	var err error
+	localFileName1 := "localFile1"
+	// Setup localFileEntries.
+	localFileEntries := map[string]fuseutil.Dirent{
+		localFileName1: {Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
+	}
+
+	// Ensure entries.
+	err = t.dh.ensureEntries(t.ctx, localFileEntries)
+
+	// Validations
+	AssertEq(nil, err)
+	AssertEq(1, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], localFileName1, fuseutil.DT_File)
+}

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -16,7 +16,6 @@ package handle
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -126,9 +125,9 @@ func (t *DirHandleTest) EnsureEntriesWithLocalAndGCSFiles() {
 	localFileName1 := "localFile1"
 	localFileName2 := "localFile2"
 	// Setup localFileEntries.
-	localFileEntries := []fuseutil.Dirent{
-		{Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
-		{Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
+	localFileEntries := map[string]fuseutil.Dirent{
+		localFileName1: {Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
+		localFileName2: {Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
@@ -152,7 +151,7 @@ func (t *DirHandleTest) EnsureEntriesWithOnlyGCSFiles() {
 	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
 	AssertEq(nil, err)
 	// Setup empty localFileEntries.
-	var localFileEntries []fuseutil.Dirent
+	var localFileEntries map[string]fuseutil.Dirent
 
 	// Ensure entries.
 	err = t.dh.ensureEntries(t.ctx, localFileEntries)
@@ -169,9 +168,9 @@ func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
 	localFileName1 := "localFile1"
 	localFileName2 := "localFile2"
 	// Setup localFileEntries.
-	localFileEntries := []fuseutil.Dirent{
-		{Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
-		{Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
+	localFileEntries := map[string]fuseutil.Dirent{
+		localFileName1: {Offset: 0, Inode: 10, Name: localFileName1, Type: fuseutil.DT_File},
+		localFileName2: {Offset: 0, Inode: 20, Name: localFileName2, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
@@ -192,16 +191,17 @@ func (t *DirHandleTest) EnsureEntriesWithSameNameLocalAndGCSFile() {
 	AssertEq(nil, err)
 	localFileName := "file1"
 	// Setup localFileEntries.
-	localFileEntries := []fuseutil.Dirent{
-		{Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
+	localFileEntries := map[string]fuseutil.Dirent{
+		localFileName: {Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.
 	err = t.dh.ensureEntries(t.ctx, localFileEntries)
 
 	// Validations
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "readAllEntries: fixConflictingNames: "))
+	AssertEq(nil, err)
+	AssertEq(1, len(t.dh.entries))
+	t.validateEntry(t.dh.entries[0], localFileName, fuseutil.DT_File)
 }
 
 func (t *DirHandleTest) EnsureEntriesWithSameNameLocalFileAndGCSDirectory() {
@@ -212,8 +212,8 @@ func (t *DirHandleTest) EnsureEntriesWithSameNameLocalFileAndGCSDirectory() {
 	AssertEq(nil, err)
 	localFileName := "file1"
 	// Setup localFileEntries.
-	localFileEntries := []fuseutil.Dirent{
-		{Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
+	localFileEntries := map[string]fuseutil.Dirent{
+		localFileName: {Offset: 0, Inode: 10, Name: localFileName, Type: fuseutil.DT_File},
 	}
 
 	// Ensure entries.

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -232,7 +232,7 @@ func (d *baseDirInode) DeleteChildDir(
 	return
 }
 
-func (d *baseDirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEntries []fuseutil.Dirent) {
+func (d *baseDirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEntries map[string]fuseutil.Dirent) {
 	// Base directory can not contain local files.
 	return nil
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -16,7 +16,6 @@ package inode
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"sort"
@@ -1481,7 +1480,6 @@ func (t *DirTest) LocalFileEntriesWithUnlinkedLocalChildFiles() {
 	}
 
 	entries := t.in.LocalFileEntries(localFileInodes)
-	fmt.Println(entries)
 
 	// Validate entries contains only linked child files.
 	AssertEq(1, len(entries))

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -16,6 +16,7 @@ package inode
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"sort"
@@ -185,6 +186,10 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		&t.clock,
 		true) //localFile
 	return
+}
+
+func (t *DirTest) getLocalDirentKey(in Inode) string {
+	return path.Base(in.Name().LocalName())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1443,10 +1448,8 @@ func (t *DirTest) LocalFileEntriesWith2LocalChildFiles() {
 	entries := t.in.LocalFileEntries(localFileInodes)
 
 	AssertEq(2, len(entries))
-	entryNames := []string{entries[0].Name, entries[1].Name}
-	sort.Strings(entryNames)
-	AssertEq(entryNames[0], "1_localChildInode")
-	AssertEq(entryNames[1], "2_localChildInode")
+	AssertEq(entries[t.getLocalDirentKey(in1)].Name, "1_localChildInode")
+	AssertEq(entries[t.getLocalDirentKey(in2)].Name, "2_localChildInode")
 }
 
 func (t *DirTest) LocalFileEntriesWithNoLocalChildFiles() {
@@ -1478,10 +1481,11 @@ func (t *DirTest) LocalFileEntriesWithUnlinkedLocalChildFiles() {
 	}
 
 	entries := t.in.LocalFileEntries(localFileInodes)
+	fmt.Println(entries)
 
 	// Validate entries contains only linked child files.
 	AssertEq(1, len(entries))
-	AssertEq(entries[0].Name, "1_localChildInode")
+	AssertEq(entries[t.getLocalDirentKey(in1)].Name, "1_localChildInode")
 }
 
 func (t *DirTest) Test_ShouldInvalidateKernelListCache_ListingNotHappenedYet() {

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -26,7 +26,6 @@ package fs_test
 import (
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -225,10 +224,7 @@ func (t *KernelListCacheTestWithPositiveTtl) Test_Parallel_ReadDirAndFileOperati
 			assert.Nil(t.T(), err)
 
 			_, err = f.Readdirnames(-1)
-			if err != nil {
-				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
-				assert.True(t.T(), strings.Contains(err.Error(), "input/output error"))
-			}
+			assert.Nil(t.T(), err)
 
 			err = f.Close()
 			assert.Nil(t.T(), err)

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -239,10 +238,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileOperations(t *testin
 			assert.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			if err != nil {
-				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
-				assert.True(t, strings.Contains(err.Error(), "input/output error"))
-			}
+			assert.Nil(t, err)
 
 			err = f.Close()
 			assert.Nil(t, err)
@@ -361,15 +357,6 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileEdit(t *testing.T) {
 	wg.Add(2)
 	timeout := 400 * time.Second
 
-	// Pre-creating files for go-routine 2, this to avoid expected input/output error.
-	for i := 0; i < iterationsForHeavyOperations; i++ {
-		filePath := path.Join(targetDir, fmt.Sprintf("test_file_%d.txt", i))
-		file, err := os.Create(filePath)
-		require.Nil(t, err)
-		err = file.Close()
-		require.Nil(t, err)
-	}
-
 	// Goroutine 1: Repeatedly calls Readdir
 	go func() {
 		defer wg.Done()
@@ -439,10 +426,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 			assert.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			if err != nil {
-				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
-				assert.True(t, strings.Contains(err.Error(), "input/output error"))
-			}
+			assert.Nil(t, err)
 
 			err = f.Close()
 			assert.Nil(t, err)
@@ -545,10 +529,7 @@ func (s *concurrentListingTest) Test_ListWithMoveFile(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = f.Readdirnames(-1)
-			if err != nil {
-				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
-				assert.True(t, strings.Contains(err.Error(), "input/output error"))
-			}
+			assert.Nil(t, err)
 
 			assert.NoError(t, f.Close())
 		}
@@ -605,10 +586,7 @@ func (s *concurrentListingTest) Test_ListWithMoveDir(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = f.Readdirnames(-1)
-			if err != nil {
-				// This is expected, see the documentation for fixConflictingNames() call in dir_handle.go.
-				assert.True(t, strings.Contains(err.Error(), "input/output error"))
-			}
+			assert.Nil(t, err)
 
 			assert.NoError(t, f.Close())
 		}

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -168,8 +167,8 @@ func TestReadDirWithSameNameLocalAndGCSFile(t *testing.T) {
 
 	// Attempt to list testDir.
 	_, err := os.ReadDir(testDirPath)
-	if err == nil || !strings.Contains(err.Error(), "input/output error") {
-		t.Fatalf("Expected error: %s, Got error: %v", "input/output error", err)
+	if err != nil {
+		t.Fatalf("ReadDir err: %v", err)
 	}
 
 	// Close the local file.


### PR DESCRIPTION
When there is local file synced to GCS but not deleted from localFileInodes, listing fails with input/output error. This is because it detects duplicate entries with the same name.
Fix: Remove the duplicate entry when GCS entry matches with local file inode.

Issue link: https://github.com/GoogleCloudPlatform/gcsfuse/issues/2220

### Testing details
1. Manual - Done
2. Unit tests - Added as required
3. Integration tests - Existing tests are sufficient
