### PR TITLE
Fix prefix bucket implementation for get folder

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -373,7 +373,7 @@ func findExplicitFolder(ctx context.Context, bucket *gcsx.SyncerBucket, name Nam
 		return nil, fmt.Errorf("error in get folder for lookup : %w", folderErr)
 	}
 
-	folderObject := folderResult.ConvertFolderToMinObject(name.objectName)
+	folderObject := folderResult.ConvertFolderToMinObject()
 
 	return &Core{
 		Bucket:    bucket,

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -205,7 +205,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeIsRegularF
 	fileName := path.Join(dirInodeName, name)
 	// mock stat object call
 	minObject := &gcs.MinObject{
-		Name:           name,
+		Name:           fileName,
 		MetaGeneration: int64(1),
 		Generation:     int64(2),
 	}
@@ -222,7 +222,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeIsRegularF
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), fileName, result.FullName.GcsObjectName())
-	assert.Equal(t.T(), name, result.MinObject.Name)
+	assert.Equal(t.T(), fileName, result.MinObject.Name)
 	assert.Equal(t.T(), int64(2), result.MinObject.Generation)
 	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
 	assert.Equal(t.T(), metadata.RegularFileType, t.typeCache.Get(t.fixedTime.Now(), name))
@@ -233,7 +233,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeIsSymlinkT
 	fileName := path.Join(dirInodeName, name)
 	// mock stat object call
 	minObject := &gcs.MinObject{
-		Name:           name,
+		Name:           fileName,
 		MetaGeneration: int64(1),
 		Generation:     int64(2),
 		Metadata:       map[string]string{"gcsfuse_symlink_target": "link"},
@@ -251,7 +251,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeIsSymlinkT
 
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), fileName, result.FullName.GcsObjectName())
-	assert.Equal(t.T(), name, result.MinObject.Name)
+	assert.Equal(t.T(), fileName, result.MinObject.Name)
 	assert.Equal(t.T(), int64(2), result.MinObject.Generation)
 	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
 	assert.Equal(t.T(), metadata.SymlinkType, t.typeCache.Get(t.fixedTime.Now(), name))

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -219,7 +219,15 @@ func (b *prefixBucket) DeleteFolder(ctx context.Context, folderName string) (err
 
 func (b *prefixBucket) GetFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {
 	mFolderName := b.wrappedName(folderName)
-	return b.wrapped.GetFolder(ctx, mFolderName)
+
+	f, err := b.wrapped.GetFolder(ctx, mFolderName)
+
+	// Modify the returned folder.
+	if f != nil {
+		f.Name = b.localName(f.Name)
+	}
+
+	return f, err
 }
 
 func (b *prefixBucket) CreateFolder(ctx context.Context, folderName string) (folder *gcs.Folder, err error) {

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -415,7 +415,7 @@ func TestGetFolder_Prefix(t *testing.T) {
 		folderName)
 
 	assert.Nil(nil, err)
-	assert.Equal(t, name, result.Name)
+	assert.Equal(t, folderName, result.Name)
 }
 
 func TestDeleteFolder(t *testing.T) {

--- a/internal/storage/gcs/folder.go
+++ b/internal/storage/gcs/folder.go
@@ -47,10 +47,10 @@ func getFolderName(bucketName string, fullPath string) string {
 	return folderName
 }
 
-func (f *Folder) ConvertFolderToMinObject(name string) *MinObject {
+func (f *Folder) ConvertFolderToMinObject() *MinObject {
 
 	return &MinObject{
-		Name:           name,
+		Name:           f.Name,
 		MetaGeneration: f.MetaGeneration,
 		Updated:        f.UpdateTime,
 	}

--- a/internal/storage/gcs/folder_test.go
+++ b/internal/storage/gcs/folder_test.go
@@ -64,9 +64,9 @@ func TestConvertFolderToMinObject(t *testing.T) {
 		UpdateTime:     timestamp.AsTime(),
 	}
 
-	result := folder.ConvertFolderToMinObject("object-name")
+	result := folder.ConvertFolderToMinObject()
 
-	assert.Equal(t, result.Name, "object-name")
+	assert.Equal(t, result.Name, TestFolderName)
 	assert.Equal(t, result.MetaGeneration, int64(10))
 	assert.Equal(t, result.Updated, timestamp.AsTime())
 }


### PR DESCRIPTION
### Description
- Fixed prefix_bucket implementation for the GetFolder API. This addresses a previous issue where the prefix was not being removed from the response, resulting in absolute paths instead of relative paths when mounting directories.
- Refactored the ConvertFolderToMinObject function to remove unnecessary arguments, streamlining its implementation.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
