### PR TITLE
[testing-on-gke part 0.1] Add original fio/dlio load-testing code from gcs-fuse-csi-driver

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/.helmignore
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/Chart.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: data-loader
+description: A Helm chart for DLIO data loading to GCS buckets
+type: application
+version: 0.1.0

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
@@ -1,0 +1,74 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dlio-data-loader-{{ .Values.dlio.numFilesTrain }}-{{ .Values.dlio.recordLength }}
+  annotations:
+    gke-gcsfuse/volumes: "true"
+    gke-gcsfuse/cpu-limit: "0"
+    gke-gcsfuse/memory-limit: "0"
+    gke-gcsfuse/ephemeral-storage-limit: "0"
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+  containers:
+  - name: dlio-data-loader
+    image: {{ .Values.image }}
+    resources:
+      limits:
+        cpu: "100"
+        memory: 400Gi
+      requests:
+        cpu: "30"
+        memory: 300Gi
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        echo "Installing gsutil..."
+        apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        apt-get update && apt-get install -y google-cloud-cli
+
+        echo "Generating data for file number: {{ .Values.dlio.numFilesTrain }}, file size: {{ .Values.dlio.recordLength }}..."
+
+        mpirun -np 20 dlio_benchmark workload=unet3d_a100 \
+        ++workload.workflow.generate_data=True \
+        ++workload.workflow.train=False \
+        ++workload.dataset.data_folder=/data \
+        ++workload.dataset.num_files_train={{ .Values.dlio.numFilesTrain }} \
+        ++workload.dataset.record_length={{ .Values.dlio.recordLength }} \
+        ++workload.dataset.record_length_stdev=0 \
+        ++workload.dataset.record_length_resize=0
+
+        gsutil -m cp -R /data/train gs://{{ .Values.bucketName }}
+        mkdir -p /bucket/valid
+    volumeMounts:
+    - name: local-dir
+      mountPath: /data
+    - name: gcs-fuse-csi-ephemeral
+      mountPath: /bucket
+  volumes:
+  - name: local-dir
+    emptyDir: {}
+  - name: gcs-fuse-csi-ephemeral
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: {{ .Values.bucketName }}

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/values.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for data-loader.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image: jiaxun/dlio:v1.0.0
+bucketName: gke-dlio-unet3d-100kb-500k
+
+dlio:
+  numFilesTrain: 500000
+  recordLength: 102400

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json, os, pprint, subprocess
+
+import sys
+sys.path.append("../") 
+from utils.utils import get_memory, get_cpu, standard_timestamp, is_mash_installed
+
+LOCAL_LOGS_LOCATION = "../../bin/dlio-logs"
+
+record = {
+    "pod_name": "",
+    "epoch": 0,
+    "scenario": "",
+    "train_au_percentage": 0,
+    "duration": 0,
+    "train_throughput_samples_per_second": 0,
+    "train_throughput_mb_per_second": 0,
+    "throughput_over_local_ssd": 0,
+    "start": "",
+    "end": "",
+    "highest_memory": 0,
+    "lowest_memory": 0,
+    "highest_cpu": 0.0,
+    "lowest_cpu": 0.0,
+}
+
+if __name__ == "__main__":
+    bucketNames = ["gke-dlio-unet3d-100kb-500k", "gke-dlio-unet3d-150mb-5k", "gke-dlio-unet3d-3mb-100k", "gke-dlio-unet3d-500kb-1m"]
+    
+    try:
+        os.makedirs(LOCAL_LOGS_LOCATION)
+    except FileExistsError:
+        pass
+    
+    for bucketName in bucketNames:
+        print(f"Download DLIO logs from the bucket {bucketName}...")
+        result = subprocess.run(["gsutil", "-m", "cp", "-r", f"gs://{bucketName}/logs", LOCAL_LOGS_LOCATION], capture_output=False, text=True)
+        if result.returncode < 0:
+            print(f"failed to fetch DLIO logs, error: {result.stderr}")
+    
+    '''
+    "{num_files_train}-{mean_file_size}-{batch_size}":
+        "mean_file_size": str
+        "num_files_train": str
+        "batch_size": str
+        "records":
+            "local-ssd": [record1, record2, record3, record4]
+            "gcsfuse-file-cache": [record1, record2, record3, record4]
+            "gcsfuse-no-file-cache": [record1, record2, record3, record4]
+    '''
+    output = {}
+    mash_installed = is_mash_installed()
+    if not mash_installed:
+        print("Mash is not installed, will skip parsing CPU and memory usage.")
+
+    for root, _, files in os.walk(LOCAL_LOGS_LOCATION):
+        if files:
+            per_epoch_stats_file = root + "/per_epoch_stats.json"
+            summary_file = root + "/summary.json"
+            
+            with open(per_epoch_stats_file, 'r') as f:
+                per_epoch_stats_data = json.load(f)
+            with open(summary_file, 'r') as f:
+                summary_data = json.load(f)
+            
+            for i in range(summary_data["epochs"]):
+                test_name = summary_data["hostname"]
+                part_list = test_name.split("-")
+                key = "-".join(part_list[2:5])
+
+                if key not in output:
+                    output[key] = {
+                        "num_files_train": part_list[2],
+                        "mean_file_size": part_list[3],
+                        "batch_size": part_list[4],
+                        "records": {
+                            "local-ssd": [],
+                            "gcsfuse-file-cache": [],
+                            "gcsfuse-no-file-cache": [],
+                        },
+                    }
+                
+                r = record.copy()
+                r["pod_name"] = summary_data["hostname"]
+                r["epoch"] = i+1
+                r["scenario"] = "-".join(part_list[5:])
+                r["train_au_percentage"] = round(summary_data["metric"]["train_au_percentage"][i], 2)
+                r["duration"] = int(float(per_epoch_stats_data[str(i+1)]["duration"]))
+                r["train_throughput_samples_per_second"] = int(summary_data["metric"]["train_throughput_samples_per_second"][i])
+                r["train_throughput_mb_per_second"] = int(r["train_throughput_samples_per_second"] * int(output[key]["mean_file_size"]) / (1024 ** 2))
+                r["start"] = standard_timestamp(per_epoch_stats_data[str(i+1)]["start"])
+                r["end"] = standard_timestamp(per_epoch_stats_data[str(i+1)]["end"])
+                if r["scenario"] != "local-ssd" and mash_installed:
+                    r["lowest_memory"], r["highest_memory"] = get_memory(r["pod_name"], r["start"], r["end"])
+                    r["lowest_cpu"], r["highest_cpu"] = get_cpu(r["pod_name"], r["start"], r["end"])
+
+                pprint.pprint(r)
+
+                while len(output[key]["records"][r["scenario"]]) < i + 1:
+                    output[key]["records"][r["scenario"]].append({})
+                
+                output[key]["records"][r["scenario"]][i] = r
+
+    output_order = ["500000-102400-800", "500000-102400-128", "1000000-512000-800", "1000000-512000-128", "100000-3145728-200", "5000-157286400-4"]
+    scenario_order = ["local-ssd", "gcsfuse-no-file-cache", "gcsfuse-file-cache"]
+
+    output_file = open("./output.csv", "a")
+    output_file.write("File Size,File #,Total Size (GB),Batch Size,Scenario,Epoch,Duration (s),GPU Utilization (%),Throughput (sample/s),Throughput (MB/s),Throughput over Local SSD (%),GCSFuse Lowest Memory (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU (core),GCSFuse Highest CPU (core),Pod,Start,End\n")
+    
+    for key in output_order:
+        if key not in output:
+            continue
+        record_set = output[key]
+        total_size = int(int(record_set['mean_file_size']) * int(record_set['num_files_train']) / (1024 ** 3))
+
+        for scenario in scenario_order:
+            for i in range(len(record_set["records"]["local-ssd"])):
+                r = record_set["records"][scenario][i]
+                r["throughput_over_local_ssd"] = round(r["train_throughput_mb_per_second"] / record_set["records"]["local-ssd"][i]["train_throughput_mb_per_second"] * 100, 2)
+                output_file.write(f"{record_set['mean_file_size']},{record_set['num_files_train']},{total_size},{record_set['batch_size']},{scenario},")
+                output_file.write(f"{r['epoch']},{r['duration']},{r['train_au_percentage']},{r['train_throughput_samples_per_second']},{r['train_throughput_mb_per_second']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']}\n")
+
+    output_file.close()

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+def run_command(command: str):
+    result = subprocess.run(command.split(" "), capture_output=True, text=True)
+    print(result.stdout)
+    print(result.stderr)
+
+metadataCacheTtlSecs = 6048000
+bucketName_numFilesTrain_recordLength_batchSize = [
+    ("gke-dlio-unet3d-100kb-500k", 500000, 102400, 800), 
+    ("gke-dlio-unet3d-100kb-500k", 500000, 102400, 128),
+    ("gke-dlio-unet3d-500kb-1m", 1000000, 512000, 800),
+    ("gke-dlio-unet3d-500kb-1m", 1000000, 512000, 128),
+    ("gke-dlio-unet3d-3mb-100k", 100000, 3145728, 200),
+    ("gke-dlio-unet3d-150mb-5k", 5000, 157286400, 4)
+    ]
+
+scenarios = ["gcsfuse-file-cache", "gcsfuse-no-file-cache", "local-ssd"]
+
+for bucketName, numFilesTrain, recordLength, batchSize in bucketName_numFilesTrain_recordLength_batchSize:    
+    for scenario in scenarios:
+        commands = [f"helm install {bucketName}-{batchSize}-{scenario} unet3d-loading-test",
+                    f"--set bucketName={bucketName}",
+                    f"--set scenario={scenario}",
+                    f"--set dlio.numFilesTrain={numFilesTrain}",
+                    f"--set dlio.recordLength={recordLength}",
+                    f"--set dlio.batchSize={batchSize}"]
+        
+        helm_command = " ".join(commands)
+
+        run_command(helm_command)

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/.helmignore
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/Chart.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: unet3d-loading-test
+description: A Helm chart for DLIO Unet3D loading test
+type: application
+version: 0.1.0

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -1,0 +1,128 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dlio-tester-{{ .Values.dlio.numFilesTrain }}-{{ .Values.dlio.recordLength }}-{{ .Values.dlio.batchSize }}-{{ .Values.scenario }}
+  {{- if ne .Values.scenario "local-ssd" }}
+  annotations:
+    gke-gcsfuse/volumes: "true"
+    gke-gcsfuse/memory-limit: "6Gi"
+  {{- end }}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+    node.kubernetes.io/instance-type: {{ .Values.nodeType }}
+  containers:
+  - name: dlio-tester
+    image: {{ .Values.image }}
+    resources:
+      limits:
+        cpu: "100"
+        memory: 400Gi
+      requests:
+        cpu: "50"
+        memory: 300Gi
+    env:
+      - name: RDMAV_FORK_SAFE
+        value: "1"
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        # Change the source code of dlio benchmark so that page cache is cleared at every epoch
+        main_file="dlio_benchmark/main.py"
+        x=$(grep -n "for epoch in range(1, self.epochs + 1):" $main_file | cut -f1 -d ':')
+        x=$((x + 1))
+        sed -i "${x} i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ os.system(\"sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'\")" $main_file
+
+        echo "Installing gsutil..."
+        apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        apt-get update && apt-get install -y google-cloud-cli
+
+        {{ if eq .Values.scenario "local-ssd" }}
+        echo "Generating data for on Local SSD..."
+        mkdir -p /data
+
+        mpirun -np 20 dlio_benchmark workload=unet3d_a100 \
+        ++workload.workflow.generate_data=True \
+        ++workload.workflow.train=False \
+        ++workload.dataset.data_folder=/data \
+        ++workload.dataset.num_files_train={{ .Values.dlio.numFilesTrain }} \
+        ++workload.dataset.record_length={{ .Values.dlio.recordLength }} \
+        ++workload.dataset.record_length_stdev=0 \
+        ++workload.dataset.record_length_resize=0
+
+        echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
+        sleep 300
+        {{ end }}
+
+        echo "Testing {{ .Values.scenario }}"
+        mpirun -np 8 dlio_benchmark workload=unet3d_a100 \
+        ++workload.train.epochs=4 \
+        ++workload.workflow.profiling=True \
+        ++workload.profiling.profiler=iostat \
+        ++workload.profiling.iostat_devices=[md0] \
+        ++workload.dataset.data_folder=/data \
+        ++workload.dataset.num_files_train={{ .Values.dlio.numFilesTrain }} \
+        ++workload.reader.batch_size={{ .Values.dlio.batchSize }} \
+        ++workload.dataset.record_length={{ .Values.dlio.recordLength }} \
+        ++workload.reader.read_threads={{ .Values.dlio.readThreads }} \
+        ++workload.output.folder=/logs/{{ .Values.dlio.numFilesTrain }}-{{ .Values.dlio.recordLength }}-{{ .Values.dlio.batchSize }}/{{ .Values.scenario }}
+
+        gsutil -m cp -R /logs gs://{{ .Values.bucketName }}/logs/$(date +"%Y-%m-%d-%H-%M")
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+    - name: logging-vol
+      mountPath: /logs
+    - name: data-vol
+      mountPath: /data
+  volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+  - name: logging-vol
+    emptyDir: {}
+  - name: data-vol
+  {{- if eq .Values.scenario "local-ssd" }}
+    emptyDir: {}
+  {{- else if eq .Values.scenario "gcsfuse-file-cache" }}
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: {{ .Values.bucketName }}
+        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
+        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
+        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
+        fileCacheCapacity: "{{ .Values.gcsfuse.fileCacheCapacity }}"
+        fileCacheForRangeRead: "{{ .Values.gcsfuse.fileCacheForRangeRead }}"
+        gcsfuseLoggingSeverity: "debug"
+        mountOptions: implicit-dirs
+  {{- else }}
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: {{ .Values.bucketName }}
+        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
+        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
+        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
+        gcsfuseLoggingSeverity: "debug"
+        mountOptions: implicit-dirs
+  {{- end }}

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
@@ -1,0 +1,36 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for unet3d-loading-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image: jiaxun/dlio:v1.2.0
+bucketName: gke-dlio-test-data
+scenario: local-ssd
+nodeType: n2-standard-96
+
+dlio:
+  numFilesTrain: 500000
+  recordLength: 102400
+  batchSize: 800
+  readThreads: 12
+
+gcsfuse:
+  metadataCacheTTLSeconds: "360000"
+  metadataStatCacheCapacity: "-1"
+  metadataTypeCacheCapacity: "-1"
+  fileCacheCapacity: "-1"
+  fileCacheForRangeRead: "true"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/.helmignore
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/Chart.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: data-loader
+description: A Helm chart for FIO data loading to GCS buckets
+type: application
+version: 0.1.0

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
@@ -1,0 +1,95 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fio-data-loader-{{ .Values.fio.fileSize | lower }}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+  containers:
+  - name: fio-data-loader
+    image: ubuntu:24.04
+    resources:
+      limits:
+        cpu: "100"
+        memory: 400Gi
+      requests:
+        cpu: "30"
+        memory: 300Gi
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        echo "Install dependencies..."
+        apt-get update
+        apt-get install -y libaio-dev gcc make git wget
+        
+        echo "Installing gsutil..."
+        apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        apt-get update && apt-get install -y google-cloud-cli
+
+        echo "Installing fio..."
+        git clone -b fio-3.36 https://github.com/axboe/fio.git
+        cd fio
+        sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GROUP_NR 32/g' stat.h
+        ./configure && make && make install
+        cd ..
+
+        echo "Generating data for file size: {{ .Values.fio.fileSize }}, file per thread: {{ .Values.fio.filesPerThread }} ..."
+        filename=/read_cache_load_test.fio
+        {{ if eq .Values.fio.fileSize "200G" }}
+        cat > $filename << EOF
+        [global]
+        ioengine=libaio
+        direct=1
+        fadvise_hint=0
+        iodepth=64
+        invalidate=1
+        nrfiles=1
+        thread=1
+        openfiles=1
+        group_reporting=1
+        create_serialize=0
+        allrandrepeat=1
+        numjobs=1
+        filename=/data/0
+
+        [Workload]
+        bs=1M
+        filesize=200G
+        size=2G
+        rw=read
+        offset=0
+        offset_increment=1%
+        EOF
+        {{ else }}
+        wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/read_cache_release/perfmetrics/scripts/job_files/read_cache_load_test.fio
+        {{ end }}
+        
+        NUMJOBS=50 NRFILES={{ .Values.fio.filesPerThread }} FILE_SIZE={{ .Values.fio.fileSize }} BLOCK_SIZE={{ .Values.fio.blockSize }} READ_TYPE=read DIR=/data fio ${filename} --alloc-size=1048576
+
+        echo "Uploading data to bucket {{ .Values.bucketName }}..."
+        gsutil -m cp -R /data/* gs://{{ .Values.bucketName }}
+    volumeMounts:
+    - name: local-dir
+      mountPath: /data
+  volumes:
+  - name: local-dir
+    emptyDir: {}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/values.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for data-loader.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+bucketName: gke-fio-64k-1m
+
+fio:
+  fileSize: 64K
+  blockSize: 64K
+  filesPerThread: "20000"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/.helmignore
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/Chart.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: fio-loading-test
+description: A Helm chart for FIO loading test
+type: application
+version: 0.1.0

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -1,0 +1,189 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fio-tester-{{ .Values.fio.readType }}-{{ lower .Values.fio.fileSize }}-{{ lower .Values.fio.blockSize }}-{{ .Values.scenario }}
+  {{- if ne .Values.scenario "local-ssd" }}
+  annotations:
+    gke-gcsfuse/volumes: "true"
+  {{- end }}
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+    node.kubernetes.io/instance-type: {{ .Values.nodeType }}
+  containers:
+  - name: fio-tester
+    image: {{ .Values.image }}
+    securityContext: # for cache dropping in the benchmarking tests.
+      privileged: true
+    resources:
+      limits:
+        cpu: {{ .Values.resourceLimits.cpu }}
+        memory: {{ .Values.resourceLimits.memory }}
+      requests:
+        cpu: "30"
+        memory: 300Gi
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        echo "Install dependencies..."
+        apt-get update
+        apt-get install -y libaio-dev gcc make git time wget
+        
+        {{ if eq .Values.scenario "local-ssd" }}
+        echo "Installing gsutil..."
+        apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        apt-get update && apt-get install -y google-cloud-cli
+
+        gsutil -m cp -R gs://{{ .Values.bucketName }}/* /data 
+
+        echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
+        sleep 300
+        {{ end }}
+
+        # We are building fio from source because of the issue: https://github.com/axboe/fio/issues/1668.
+        # The sed command below is to address internal bug b/309563824.
+        # As recorded in this bug, fio by-default supports
+        # clat percentile values to be calculated accurately upto only
+        # 2^(FIO_IO_U_PLAT_GROUP_NR + 5) ns = 17.17 seconds.
+        # (with default value of FIO_IO_U_PLAT_GROUP_NR = 29). This change increases it upto 32, to allow
+        # latencies upto 137.44s to be calculated accurately.
+        git clone -b fio-3.36 https://github.com/axboe/fio.git
+        cd fio
+        sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GROUP_NR 32/g' stat.h
+        ./configure && make && make install
+        cd ..
+
+        echo "Preparing fio config file..."
+        filename=/read_cache_load_test.fio
+        {{ if eq .Values.fio.fileSize "200G" }}
+        cat > $filename << EOF
+        [global]
+        ioengine=libaio
+        direct=1
+        fadvise_hint=0
+        iodepth=64
+        invalidate=1
+        nrfiles=1
+        thread=1
+        openfiles=1
+        group_reporting=1
+        create_serialize=0
+        allrandrepeat=1
+        numjobs=100
+        filename=/data/0
+
+        [Workload]
+        bs=1M
+        filesize=200G
+        size=2G
+        rw={{ .Values.fio.readType }}
+        offset=0
+        offset_increment=1%
+        EOF
+        {{ else }}
+        wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/read_cache_release/perfmetrics/scripts/job_files/read_cache_load_test.fio
+        {{ end }}
+
+        echo "Setup default values..."
+        epoch=4
+        no_of_files_per_thread={{ .Values.fio.filesPerThread }}
+        read_type={{ .Values.fio.readType }}
+        pause_in_seconds=20
+        block_size={{ .Values.fio.blockSize }}
+        file_size={{ .Values.fio.fileSize }}
+        num_of_threads=50
+        workload_dir=/data
+
+        # Cleaning the pagecache, dentries and inode cache before the starting the workload.
+        echo "Drop page cache..."
+        echo 3 > /proc/sys/vm/drop_caches
+
+        # Specially for gcsfuse mounted dir: the purpose of this approach is to efficiently
+        # populate the gcsfuse metadata cache by utilizing the list call, which internally
+        # works like bulk stat call rather than making individual stat calls.
+        # And to reduce the logs redirecting the command standard-output to /dev/null.
+        echo "List workload dir..."
+        time ls -R $workload_dir 1> /dev/null
+
+        echo "Run fio tests..."
+        mkdir -p /data/fio-output/{{ .Values.scenario }}/$read_type
+        for i in $(seq $epoch); do
+
+          echo "[Epoch ${i}] start time:" `date +%s`
+          free -mh # Memory usage before workload start.
+          NUMJOBS=$num_of_threads NRFILES=$no_of_files_per_thread FILE_SIZE=$file_size BLOCK_SIZE=$block_size READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="/data/fio-output/{{ .Values.scenario }}/${read_type}/epoch${i}.json"
+          free -mh # Memory usage after workload completion.
+          echo "[Epoch ${i}] end time:" `date +%s`
+
+          # To free pagecache.
+          # Intentionally not clearing dentries and inodes: clearing them
+          # will necessitate the repopulation of the type cache in gcsfuse 2nd epoch onwards.
+          # Since we use "ls -R workload_dir" to populate the cache (sort of hack to fill the cache quickly)
+          # efficiently in the first epoch, it does not populate the negative
+          # entry for the stat cache.
+          # So just to stop the execution of  “ls -R workload_dir” command at the start
+          # of every epoch, not clearing the inodes.
+          echo 1 > /proc/sys/vm/drop_caches
+
+          sleep $pause_in_seconds
+        done
+        
+        {{ if eq .Values.scenario "local-ssd" }}
+        gsutil -m cp -R /data/fio-output/local-ssd gs://{{ .Values.bucketName }}/fio-output
+        {{ end }}
+        
+        echo "fio job completed!"
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+    - name: data-vol
+      mountPath: /data
+  volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+  - name: data-vol
+  {{- if eq .Values.scenario "local-ssd" }}
+    emptyDir: {}
+  {{- else if eq .Values.scenario "gcsfuse-file-cache" }}
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: {{ .Values.bucketName }}
+        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
+        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
+        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
+        fileCacheCapacity: "{{ .Values.gcsfuse.fileCacheCapacity }}"
+        fileCacheForRangeRead: "true"
+        gcsfuseLoggingSeverity: "debug"
+        mountOptions: implicit-dirs
+  {{- else }}
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      volumeAttributes:
+        bucketName: {{ .Values.bucketName }}
+        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
+        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
+        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
+        gcsfuseLoggingSeverity: "debug"
+        mountOptions: implicit-dirs
+  {{- end }}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -1,0 +1,40 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for unet3d-loading-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image: ubuntu:24.04
+bucketName: gke-dlio-test-data
+scenario: local-ssd
+nodeType: n2-standard-96
+
+resourceLimits:
+  cpu: 100
+  memory: 400Gi
+
+fio:
+  readType: read
+  fileSize: 64K
+  blockSize: 64K
+  filesPerThread: "20000"
+
+gcsfuse:
+  metadataCacheTTLSeconds: "6048000"
+  metadataStatCacheCapacity: "-1"
+  metadataTypeCacheCapacity: "-1"
+  fileCacheCapacity: "-1"
+  fileCacheForRangeRead: "true"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -38,3 +38,4 @@ gcsfuse:
   metadataTypeCacheCapacity: "-1"
   fileCacheCapacity: "-1"
   fileCacheForRangeRead: "true"
+

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json, os, pprint, subprocess
+
+import sys
+sys.path.append("../") 
+from utils.utils import get_memory, get_cpu, unix_to_timestamp, is_mash_installed
+
+LOCAL_LOGS_LOCATION = "../../bin/fio-logs"
+
+record = {
+    "pod_name": "",
+    "epoch": 0,
+    "scenario": "",
+    "duration": 0,
+    "IOPS": 0,
+    "throughput_mb_per_second": 0,
+    "throughput_over_local_ssd": 0,
+    "start": "",
+    "end": "",
+    "highest_memory": 0,
+    "lowest_memory": 0,
+    "highest_cpu": 0.0,
+    "lowest_cpu": 0.0,
+}
+
+if __name__ == "__main__":
+    logLocations = [("gke-fio-64k-1m", "64K"), ("gke-fio-128k-1m", "128K"), ("gke-fio-1mb-1m", "1M"), ("gke-fio-100mb-50k", "100M"), ("gke-fio-200gb-1", "200G")]
+    
+    try:
+        os.makedirs(LOCAL_LOGS_LOCATION)
+    except FileExistsError:
+        pass
+    
+    for folder, fileSize in logLocations:
+        try:
+            os.makedirs(LOCAL_LOGS_LOCATION+"/"+fileSize)
+        except FileExistsError:
+            pass
+        print(f"Download FIO output from the folder {folder}...")
+        result = subprocess.run(["gsutil", "-m", "cp", "-r", f"gs://{folder}/fio-output", LOCAL_LOGS_LOCATION+"/"+fileSize], capture_output=False, text=True)
+        if result.returncode < 0:
+            print(f"failed to fetch FIO output, error: {result.stderr}")
+    
+    '''
+    "{read_type}-{mean_file_size}":
+        "mean_file_size": str
+        "read_type": str
+        "records":
+            "local-ssd": [record1, record2, record3, record4]
+            "gcsfuse-file-cache": [record1, record2, record3, record4]
+            "gcsfuse-no-file-cache": [record1, record2, record3, record4]
+    '''
+    output = {}
+    mash_installed = is_mash_installed()
+    if not mash_installed:
+        print("Mash is not installed, will skip parsing CPU and memory usage.")
+
+    for root, _, files in os.walk(LOCAL_LOGS_LOCATION):
+        for file in files:
+            per_epoch_output = root + f"/{file}"
+            root_split = root.split("/")
+            mean_file_size = root_split[-4]
+            scenario = root_split[-2]
+            read_type = root_split[-1]
+            epoch = int(file.split(".")[0][-1])
+            
+            with open(per_epoch_output, 'r') as f:
+                per_epoch_output_data = json.load(f)
+            
+            key = "-".join([read_type, mean_file_size])
+            if key not in output:
+                output[key] = {
+                    "mean_file_size": mean_file_size,
+                    "read_type": read_type,
+                    "records": {
+                        "local-ssd": [],
+                        "gcsfuse-file-cache": [],
+                        "gcsfuse-no-file-cache": [],
+                    },
+                }
+                
+            r = record.copy()
+            bs = per_epoch_output_data["jobs"][0]["job options"]["bs"]
+            r["pod_name"] = f"fio-tester-{read_type}-{mean_file_size.lower()}-{bs.lower()}-{scenario}"
+            r["epoch"] = epoch
+            r["scenario"] = scenario
+            r["duration"] = int(per_epoch_output_data["jobs"][0]["read"]["runtime"] / 1000)
+            r["IOPS"] = int(per_epoch_output_data["jobs"][0]["read"]["iops"])
+            r["throughput_mb_per_second"] = int(per_epoch_output_data["jobs"][0]["read"]["bw_bytes"] / (1024 ** 2))
+            r["start"] = unix_to_timestamp(per_epoch_output_data["jobs"][0]["job_start"])
+            r["end"] = unix_to_timestamp(per_epoch_output_data["timestamp_ms"])
+            if r["scenario"] != "local-ssd" and mash_installed:
+                r["lowest_memory"], r["highest_memory"] = get_memory(r["pod_name"], r["start"], r["end"])
+                r["lowest_cpu"], r["highest_cpu"] = get_cpu(r["pod_name"], r["start"], r["end"])
+
+            pprint.pprint(r)
+            
+            while len(output[key]["records"][scenario]) < epoch:
+                output[key]["records"][scenario].append({})
+            
+            output[key]["records"][scenario][epoch-1] = r
+
+    output_order = ["read-64K", "read-128K", "read-1M", "read-100M", "read-200G", "randread-1M", "randread-100M", "randread-200G"]
+    scenario_order = ["local-ssd", "gcsfuse-no-file-cache", "gcsfuse-file-cache"]
+
+    output_file = open("./output.csv", "a")
+    output_file.write("File Size,Read Type,Scenario,Epoch,Duration (s),Throughput (MB/s),IOPS,Throughput over Local SSD (%),GCSFuse Lowest Memory (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU (core),GCSFuse Highest CPU (core),Pod,Start,End\n")
+    
+    for key in output_order:
+        if key not in output:
+            continue
+        record_set = output[key]
+
+        for scenario in scenario_order:
+            for i in range(len(record_set["records"][scenario])):
+                r = record_set["records"][scenario][i]
+                r["throughput_over_local_ssd"] = round(r["throughput_mb_per_second"] / record_set["records"]["local-ssd"][i]["throughput_mb_per_second"] * 100, 2)
+                output_file.write(f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mb_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']}\n")
+
+    output_file.close()

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+def run_command(command: str):
+    result = subprocess.run(command.split(" "), capture_output=True, text=True)
+    print(result.stdout)
+    print(result.stderr)
+
+bucketName_fileSize_blockSize = [
+    ("gke-fio-64k-1m", "64K", "64K"), 
+    ("gke-fio-128k-1m", "128K", "128K"),
+    ("gke-fio-1mb-1m", "1M", "256K"),
+    ("gke-fio-100mb-50k", "100M", "1M"),
+    ("gke-fio-200gb-1", "200G", "1M")
+    ]
+
+scenarios = ["gcsfuse-file-cache", "gcsfuse-no-file-cache", "local-ssd"]
+
+for bucketName, fileSize, blockSize in bucketName_fileSize_blockSize:    
+    for readType in ["read", "randread"]:
+        for scenario in scenarios:
+            if readType == "randread" and fileSize in ["64K", "128K"]:
+                continue
+            
+            commands = [f"helm install fio-loading-test-{fileSize.lower()}-{readType}-{scenario} loading-test",
+                        f"--set bucketName={bucketName}",
+                        f"--set scenario={scenario}",
+                        f"--set fio.readType={readType}",
+                        f"--set fio.fileSize={fileSize}",
+                        f"--set fio.blockSize={blockSize}"]
+            
+            if fileSize == "100M":
+                commands.append("--set fio.filesPerThread=1000")
+            
+            helm_command = " ".join(commands)
+
+            run_command(helm_command)

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess, datetime
+from typing import Tuple
+
+def is_mash_installed() -> bool:
+    try:
+        subprocess.run(["mash", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+def get_memory(pod_name: str, start: str, end: str) -> Tuple[int, int]:
+    # for some reason, the mash filter does not always work, so we fetch all the metrics for all the pods and filter later.
+    result = subprocess.run(["mash", "--namespace=cloud_prod", "--output=csv", 
+                             f"Query(Fetch(Raw('cloud.kubernetes.K8sContainer', 'kubernetes.io/container/memory/used_bytes'), {{'project': '641665282868', 'metric:memory_type': 'non-evictable'}})| Window(Align('10m'))| GroupBy(['pod_name', 'container_name'], Max()), TimeInterval('{start}', '{end}'), '5s')"], 
+                             capture_output=True, text=True)
+
+    data_points_int = []
+    data_points_by_pod_container = result.stdout.strip().split("\n")
+    for data_points in data_points_by_pod_container[1:]:
+        data_points_split = data_points.split(",")
+        pn = data_points_split[4]
+        container_name = data_points_split[5]
+        if pn == pod_name and container_name == "gke-gcsfuse-sidecar":
+            try:
+                data_points_int = [int(d) for d in data_points_split[7:]]
+            except:
+                print(f"failed to parse memory for pod {pod_name}, {start}, {end}, data {data_points_int}")
+            break
+    if not data_points_int:
+        return 0, 0
+    
+    return int(min(data_points_int) / 1024 ** 2) , int(max(data_points_int) / 1024 ** 2)
+
+def get_cpu(pod_name: str, start: str, end: str) -> Tuple[float, float]:
+    # for some reason, the mash filter does not always work, so we fetch all the metrics for all the pods and filter later.
+    result = subprocess.run(["mash", "--namespace=cloud_prod", "--output=csv", 
+                             f"Query(Fetch(Raw('cloud.kubernetes.K8sContainer', 'kubernetes.io/container/cpu/core_usage_time'), {{'project': '641665282868'}})| Window(Rate('10m'))| GroupBy(['pod_name', 'container_name'], Max()), TimeInterval('{start}', '{end}'), '5s')"], 
+                             capture_output=True, text=True)
+
+    data_points_float = []
+    data_points_by_pod_container = result.stdout.split("\n")
+    for data_points in data_points_by_pod_container[1:]:
+        data_points_split = data_points.split(",")
+        pn = data_points_split[4]
+        container_name = data_points_split[5]
+        if pn == pod_name and container_name == "gke-gcsfuse-sidecar":
+            try:
+                data_points_float = [float(d) for d in data_points_split[6:]]
+            except:
+                print(f"failed to parse CPU for pod {pod_name}, {start}, {end}, data {data_points_float}")
+            
+            break
+    
+    if not data_points_float:
+        return 0.0, 0.0
+    
+    return round(min(data_points_float), 5) , round(max(data_points_float), 5)
+
+def unix_to_timestamp(unix_timestamp: int) -> str:
+    # Convert Unix timestamp to a datetime object (aware of UTC)
+    datetime_utc = datetime.datetime.fromtimestamp(unix_timestamp / 1000, tz=datetime.timezone.utc)
+
+    # Format the datetime object as a string (if desired)
+    utc_timestamp_string = datetime_utc.strftime('%Y-%m-%d %H:%M:%S UTC')
+    
+    return utc_timestamp_string
+
+def standard_timestamp(timestamp: int) -> str:
+    return timestamp.split('.')[0].replace('T', ' ') + " UTC"

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
@@ -84,3 +84,4 @@ def unix_to_timestamp(unix_timestamp: int) -> str:
 
 def standard_timestamp(timestamp: int) -> str:
     return timestamp.split('.')[0].replace('T', ' ') + " UTC"
+


### PR DESCRIPTION
### Description
This adds relevant files from fio/, dio/ and utils/ directories from https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/tree/main/examples for planned fio/dlio testing in gcsfuse on gke.
These contain resources needed to create GKE pods for fio/dlio testing for gcsfuse mounts.

This is a first in a series of PRs. The later PRs will focus on the following
1. Adding an end-2-end script to use the above resources and scripts to run the fio/dlio tests, and according changes in these scripts themselves.
2. Adding parameters in the e2e script to control various configurable properties such as cluster/node configurations, gcsfuse mount options, workload configurations, monitoring/debugging controls etc.

This is followed up in https://github.com/GoogleCloudPlatform/gcsfuse/pull/2284 . 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - yes, tested manually, am able to use these pod resources and scripts in testing.
4. Unit tests - NA
5. Integration tests - NA
