### PR TITLE
Fix exit code in e2e tests

### DIFF
--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -65,14 +65,14 @@ func runTestsOnGivenMountedTestBucket(bucketName string, flags [][]string, rootM
 		log.Printf("Running dynamic mounting tests with flags: %s", flags[i])
 		// Running tests on flags.
 		successCode = setup.ExecuteTest(m)
-		if successCode != 0 {
-			return
-		}
 
 		// Currently mntDir is mntDir/bucketName.
 		// Unmounting can happen on rootMntDir. Changing mntDir to rootMntDir for unmounting.
 		setup.SetMntDir(rootMntDir)
 		setup.UnMountAndThrowErrorInFailure(flags[i], successCode)
+		if successCode != 0 {
+			return
+		}
 	}
 	return
 }

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -65,7 +65,7 @@ func runTestsOnGivenMountedTestBucket(bucketName string, flags [][]string, rootM
 		log.Printf("Running dynamic mounting tests with flags: %s", flags[i])
 		// Running tests on flags.
 		successCode = setup.ExecuteTest(m)
-		if successCode != 0{
+		if successCode != 0 {
 			return
 		}
 

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -65,6 +65,9 @@ func runTestsOnGivenMountedTestBucket(bucketName string, flags [][]string, rootM
 		log.Printf("Running dynamic mounting tests with flags: %s", flags[i])
 		// Running tests on flags.
 		successCode = setup.ExecuteTest(m)
+		if successCode != 0{
+			return
+		}
 
 		// Currently mntDir is mntDir/bucketName.
 		// Unmounting can happen on rootMntDir. Changing mntDir to rootMntDir for unmounting.

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -52,7 +52,7 @@ func mountGcsFuseForFlagsAndExecuteTests(flags [][]string, m *testing.M) (succes
 		}
 		log.Printf("Running only dir mounting tests with flags: %s", flags[i])
 		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
-		if successCode != 0{
+		if successCode != 0 {
 			return
 		}
 	}

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -52,6 +52,9 @@ func mountGcsFuseForFlagsAndExecuteTests(flags [][]string, m *testing.M) (succes
 		}
 		log.Printf("Running only dir mounting tests with flags: %s", flags[i])
 		successCode = setup.ExecuteTestForFlagsSet(flags[i], m)
+		if successCode != 0{
+			return
+		}
 	}
 	return
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -76,7 +76,7 @@ func executeTestsForPersistentMounting(flagsSet [][]string, m *testing.M) (succe
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])
 		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
-		if successCode != 0{
+		if successCode != 0 {
 			return
 		}
 	}

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -76,6 +76,9 @@ func executeTestsForPersistentMounting(flagsSet [][]string, m *testing.M) (succe
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])
 		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
+		if successCode != 0{
+			return
+		}
 	}
 	return
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -55,7 +55,7 @@ func executeTestsForStaticMounting(flagsSet [][]string, m *testing.M) (successCo
 		}
 		log.Printf("Running static mounting tests with flags: %s", flagsSet[i])
 		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
-		if successCode != 0{
+		if successCode != 0 {
 			return
 		}
 	}

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -55,6 +55,9 @@ func executeTestsForStaticMounting(flagsSet [][]string, m *testing.M) (successCo
 		}
 		log.Printf("Running static mounting tests with flags: %s", flagsSet[i])
 		successCode = setup.ExecuteTestForFlagsSet(flagsSet[i], m)
+		if successCode != 0{
+			return
+		}
 	}
 	return
 }


### PR DESCRIPTION
### Description
Previously, if tests passed on one flag suite but failed on another, the overall test run was not considered a failure.  This issue needs to be addressed by immediately returning a non-zero exit code whenever any tests fail.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
