### PR TITLE
[CLI Config Parity] migrate mount options

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -410,7 +410,8 @@ type flagStorage struct {
 	ConfigFile string
 
 	// File system
-	MountOptions map[string]string
+	// Deprecated: Use the param from cfg/config.go
+	MountOptions []string
 
 	// Deprecated: Use the param from cfg/config.go
 	DirMode os.FileMode
@@ -608,7 +609,7 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		ConfigFile: c.String("config-file"),
 
 		// File system
-		MountOptions:     make(map[string]string),
+		MountOptions:     c.StringSlice("o"),
 		DirMode:          os.FileMode(*c.Generic("dir-mode").(*OctalInt)),
 		FileMode:         os.FileMode(*c.Generic("file-mode").(*OctalInt)),
 		Uid:              int64(c.Int("uid")),
@@ -661,12 +662,6 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 		// Post-mount actions
 		ExperimentalMetadataPrefetchOnMount: c.String(ExperimentalMetadataPrefetchOnMountFlag),
 	}
-
-	// Handle the repeated "-o" flag.
-	for _, o := range c.StringSlice("o") {
-		mountpkg.ParseOptions(flags.MountOptions, o)
-	}
-
 	err = validateFlags(flags)
 
 	return

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -242,7 +242,7 @@ func (t *FlagsTest) TestDurations() {
 	assert.Equal(t.T(), 30*time.Second, f.MaxRetrySleep)
 }
 
-func (t *FlagsTest) TestMaps() {
+func (t *FlagsTest) TestSlice() {
 	args := []string{
 		"-o", "rw,nodev",
 		"-o", "user=jacobsa,noauto",

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/urfave/cli"
 )
@@ -249,19 +250,10 @@ func (t *FlagsTest) TestMaps() {
 
 	f := parseArgs(t, args)
 
-	var keys sort.StringSlice
-	for k := range f.MountOptions {
-		keys = append(keys, k)
-	}
-
-	sort.Sort(keys)
-	assert.ElementsMatch(t.T(),
-		keys, []string{"noauto", "nodev", "rw", "user"})
-
-	assert.Equal(t.T(), "", f.MountOptions["noauto"])
-	assert.Equal(t.T(), "", f.MountOptions["nodev"])
-	assert.Equal(t.T(), "", f.MountOptions["rw"])
-	assert.Equal(t.T(), "jacobsa", f.MountOptions["user"])
+	sort.Strings(f.MountOptions)
+	require.Equal(t.T(), 2, len(f.MountOptions))
+	assert.Equal(t.T(), "rw,nodev", f.MountOptions[0])
+	assert.Equal(t.T(), "user=jacobsa,noauto", f.MountOptions[1])
 }
 
 func (t *FlagsTest) TestResolvePathForTheFlagInContext() {

--- a/cmd/legacy_param_mapper.go
+++ b/cmd/legacy_param_mapper.go
@@ -52,9 +52,9 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 			"fuse":                        flags.DebugFuse,
 		},
 		"file-system": map[string]interface{}{
-			"dir-mode":  flags.DirMode,
-			"file-mode": flags.FileMode,
-			// Todo: "fuse-options":      nil,
+			"dir-mode":                   flags.DirMode,
+			"file-mode":                  flags.FileMode,
+			"fuse-options":               flags.MountOptions,
 			"gid":                        flags.Gid,
 			"ignore-interrupts":          flags.IgnoreInterrupts,
 			"rename-dir-limit":           flags.RenameDirLimit,
@@ -154,9 +154,11 @@ func PopulateNewConfigFromLegacyFlagsAndConfig(c cliContext, flags *flagStorage,
 	overrideWithFlag(c, "prometheus-port", &resolvedConfig.Metrics.PrometheusPort, prometheusPort)
 
 	if err := cfg.ValidateConfig(resolvedConfig); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cfg.ValidateConfig: %w", err)
 	}
-	cfg.Rationalize(resolvedConfig)
+	if err := cfg.Rationalize(resolvedConfig); err != nil {
+		return nil, fmt.Errorf("cfg.Rationalize: %w", err)
+	}
 	return resolvedConfig, nil
 }
 

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -558,7 +558,7 @@ func TestEnableEmptyManagedFoldersRationalization(t *testing.T) {
 func TestPopulateConfigFromLegacyFlags_MountOption(t *testing.T) {
 	flags := &flagStorage{
 		MountOptions:   []string{"rw,nodev", "user=jacobsa,noauto"},
-		ClientProtocol: mountpkg.HTTP2,
+		ClientProtocol: mountpkg.ClientProtocol(cfg.HTTP2),
 	}
 
 	v, err := PopulateNewConfigFromLegacyFlagsAndConfig(&mockCLIContext{}, flags, &config.MountConfig{})

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -554,3 +554,16 @@ func TestEnableEmptyManagedFoldersRationalization(t *testing.T) {
 		})
 	}
 }
+
+func TestPopulateConfigFromLegacyFlags_MountOption(t *testing.T) {
+	flags := &flagStorage{
+		MountOptions:   []string{"rw,nodev", "user=jacobsa,noauto"},
+		ClientProtocol: mountpkg.HTTP2,
+	}
+
+	v, err := PopulateNewConfigFromLegacyFlagsAndConfig(&mockCLIContext{}, flags, &config.MountConfig{})
+
+	if assert.Nil(t, err) {
+		assert.Equal(t, v.FileSystem.FuseOptions, []string{"rw,nodev", "user=jacobsa,noauto"})
+	}
+}

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFuseMountConfig_MountOptionsFormattedCorrectly(t *testing.T) {
+	fsName := "mybucket"
+	newConfig := &cfg.Config{
+		FileSystem: cfg.FileSystemConfig{
+			FuseOptions: []string{"rw,nodev", "user=jacobsa,noauto"},
+		},
+	}
+	mountConfig := &config.MountConfig{}
+
+	fuseMountCfg := getFuseMountConfig(fsName, newConfig, mountConfig)
+
+	assert.Equal(t, fsName, fuseMountCfg.FSName)
+	assert.Equal(t, "gcsfuse", fuseMountCfg.Subtype)
+	assert.Equal(t, "gcsfuse", fuseMountCfg.VolumeName)
+	assert.Equal(t, map[string]string{
+		"noauto": "",
+		"nodev":  "",
+		"rw":     "",
+		"user":   "jacobsa",
+	}, fuseMountCfg.Options)
+	assert.True(t, fuseMountCfg.EnableParallelDirOps) // Default true unless explicitly disabled
+}


### PR DESCRIPTION
### Description
Migrate mount options flag to use new config. This PR also includes some refactoring to move the parsing logic of mount options before usage.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated/added.
3. Integration tests - Via KOKORO
