### PR TITLE
Remove metageneration argument from folder struct

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -280,15 +280,6 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time) {
 	name := sc.key(f.Name)
 
-	// Return if there is already a better entry?
-	existing := sc.sharedCache.LookUp(name)
-	if existing != nil && existing.(entry).f != nil {
-		existingFolder := existing.(entry).f
-		if f.MetaGeneration != existingFolder.MetaGeneration && f.MetaGeneration < existingFolder.MetaGeneration {
-			return
-		}
-	}
-
 	e := entry{
 		f:          f,
 		expiration: expiration,

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -421,7 +421,7 @@ func (t *MultiBucketStatCacheTest) Test_ExpiresLeastRecentlyUsed() {
 func (t *StatCacheTest) Test_InsertFolderCreateEntryWhenNoEntryIsPresent() {
 	const name = "key1"
 	newEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -434,11 +434,11 @@ func (t *StatCacheTest) Test_InsertFolderCreateEntryWhenNoEntryIsPresent() {
 func (t *StatCacheTest) Test_InsertFolderOverrideEntryOldEntryIsAlreadyPresent() {
 	const name = "key1"
 	existingEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 	newEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -451,7 +451,7 @@ func (t *StatCacheTest) Test_InsertFolderOverrideEntryOldEntryIsAlreadyPresent()
 func (t *StatCacheTest) Test_LookupReturnFalseIfExpirationIsPassed() {
 	const name = "key1"
 	entry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 	t.statCache.InsertFolder(entry, expiration)
 
@@ -473,11 +473,11 @@ func (t *StatCacheTest) Test_LookupReturnFalseWhenIsNotPresent() {
 func (t *StatCacheTest) Test_InsertFolderShouldNotOverrideEntryIfMetagenerationIsOld() {
 	const name = "key1"
 	existingEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 	newEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -490,7 +490,7 @@ func (t *StatCacheTest) Test_InsertFolderShouldNotOverrideEntryIfMetagenerationI
 func (t *StatCacheTest) Test_AddNegativeEntryForFolderShouldAddNegativeEntryForFolder() {
 	const name = "key1"
 	existingEntry := &gcs.Folder{
-		Name:           name,
+		Name: name,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 
@@ -521,7 +521,7 @@ func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize()
 	objectEntry1 := &gcs.MinObject{Name: "1"}
 	objectEntry2 := &gcs.MinObject{Name: "2"}
 	folderEntry := &gcs.Folder{
-		Name:           "3",
+		Name: "3",
 	}
 	t.statCache.Insert(objectEntry1, expiration) // adds size of 1428
 	t.statCache.Insert(objectEntry2, expiration) // adds size of 1428
@@ -552,16 +552,16 @@ func (t *StatCacheTest) Test_ShouldEvictAllEntriesWithPrefixFolder() {
 	localCache := lru.NewCache(uint64(10000))
 	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
 	folderEntry1 := &gcs.Folder{
-		Name:           "a",
+		Name: "a",
 	}
 	objectEntry1 := &gcs.MinObject{Name: "a/b"}
 	objectEntry2 := &gcs.MinObject{Name: "a/b/c"}
 	objectEntry3 := &gcs.MinObject{Name: "d"}
 	folderEntry2 := &gcs.Folder{
-		Name:           "a/d",
+		Name: "a/d",
 	}
 	folderEntry3 := &gcs.Folder{
-		Name:           "b",
+		Name: "b",
 	}
 	t.statCache.InsertFolder(folderEntry1, expiration) //adds size of 220 and exceeds capacity
 	t.statCache.Insert(objectEntry1, expiration)       // adds size of 1428

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -422,7 +422,6 @@ func (t *StatCacheTest) Test_InsertFolderCreateEntryWhenNoEntryIsPresent() {
 	const name = "key1"
 	newEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 1,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -430,19 +429,16 @@ func (t *StatCacheTest) Test_InsertFolderCreateEntryWhenNoEntryIsPresent() {
 	hit, entry := t.statCache.LookUpFolder(name, someTime)
 	assert.True(t.T(), hit)
 	assert.Equal(t.T(), "key1", entry.Name)
-	assert.Equal(t.T(), int64(1), entry.MetaGeneration)
 }
 
 func (t *StatCacheTest) Test_InsertFolderOverrideEntryOldEntryIsAlreadyPresent() {
 	const name = "key1"
 	existingEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 1,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 	newEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 2,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -450,14 +446,12 @@ func (t *StatCacheTest) Test_InsertFolderOverrideEntryOldEntryIsAlreadyPresent()
 	hit, entry := t.statCache.LookUpFolder(name, someTime)
 	assert.True(t.T(), hit)
 	assert.Equal(t.T(), "key1", entry.Name)
-	assert.Equal(t.T(), int64(2), entry.MetaGeneration)
 }
 
 func (t *StatCacheTest) Test_LookupReturnFalseIfExpirationIsPassed() {
 	const name = "key1"
 	entry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 1,
 	}
 	t.statCache.InsertFolder(entry, expiration)
 
@@ -480,12 +474,10 @@ func (t *StatCacheTest) Test_InsertFolderShouldNotOverrideEntryIfMetagenerationI
 	const name = "key1"
 	existingEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 2,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 	newEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 1,
 	}
 
 	t.statCache.InsertFolder(newEntry, expiration)
@@ -493,14 +485,12 @@ func (t *StatCacheTest) Test_InsertFolderShouldNotOverrideEntryIfMetagenerationI
 	hit, entry := t.statCache.LookUpFolder(name, someTime)
 	assert.True(t.T(), hit)
 	assert.Equal(t.T(), "key1", entry.Name)
-	assert.Equal(t.T(), int64(2), entry.MetaGeneration)
 }
 
 func (t *StatCacheTest) Test_AddNegativeEntryForFolderShouldAddNegativeEntryForFolder() {
 	const name = "key1"
 	existingEntry := &gcs.Folder{
 		Name:           name,
-		MetaGeneration: 2,
 	}
 	t.statCache.InsertFolder(existingEntry, expiration)
 
@@ -532,7 +522,6 @@ func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize()
 	objectEntry2 := &gcs.MinObject{Name: "2"}
 	folderEntry := &gcs.Folder{
 		Name:           "3",
-		MetaGeneration: 1,
 	}
 	t.statCache.Insert(objectEntry1, expiration) // adds size of 1428
 	t.statCache.Insert(objectEntry2, expiration) // adds size of 1428
@@ -564,18 +553,15 @@ func (t *StatCacheTest) Test_ShouldEvictAllEntriesWithPrefixFolder() {
 	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
 	folderEntry1 := &gcs.Folder{
 		Name:           "a",
-		MetaGeneration: 1,
 	}
 	objectEntry1 := &gcs.MinObject{Name: "a/b"}
 	objectEntry2 := &gcs.MinObject{Name: "a/b/c"}
 	objectEntry3 := &gcs.MinObject{Name: "d"}
 	folderEntry2 := &gcs.Folder{
 		Name:           "a/d",
-		MetaGeneration: 1,
 	}
 	folderEntry3 := &gcs.Folder{
 		Name:           "b",
-		MetaGeneration: 1,
 	}
 	t.statCache.InsertFolder(folderEntry1, expiration) //adds size of 220 and exceeds capacity
 	t.statCache.Insert(objectEntry1, expiration)       // adds size of 1428

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -114,8 +114,6 @@ func (t *HNSDirTest) TestShouldFindExplicitHNSFolder() {
 	assert.NotEqual(t.T(), nil, result.MinObject)
 	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
 	assert.Equal(t.T(), dirName, result.MinObject.Name)
-	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
-
 }
 
 func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
@@ -170,7 +168,6 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckOnlyForExplicitHNSDirectory() {
 	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
 	assert.Equal(t.T(), dirName, result.MinObject.Name)
 	assert.Equal(t.T(), int64(0), result.MinObject.Generation)
-	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
 	assert.Equal(t.T(), metadata.ExplicitDirType, t.typeCache.Get(t.fixedTime.Now(), name))
 }
 
@@ -194,7 +191,6 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeNotPresent
 	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
 	assert.Equal(t.T(), dirName, result.MinObject.Name)
 	assert.Equal(t.T(), int64(0), result.MinObject.Generation)
-	assert.Equal(t.T(), int64(1), result.MinObject.MetaGeneration)
 	assert.Equal(t.T(), metadata.ExplicitDirType, t.typeCache.Get(t.fixedTime.Now(), name))
 }
 

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -102,7 +102,7 @@ func (t *HNSDirTest) TestShouldFindExplicitHNSFolder() {
 	const name = "qux"
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{
-		Name:           dirName,
+		Name: dirName,
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 
@@ -154,7 +154,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckOnlyForExplicitHNSDirectory() {
 	dirName := path.Join(dirInodeName, name) + "/"
 	// mock get folder call
 	folder := &gcs.Folder{
-		Name:           dirName,
+		Name: dirName,
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	t.mockBucket.On("BucketType").Return(gcs.Hierarchical)
@@ -176,7 +176,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeNotPresent
 	dirName := path.Join(dirInodeName, name) + "/"
 	// mock get folder call
 	folder := &gcs.Folder{
-		Name:           dirName,
+		Name: dirName,
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("storage: object doesn't exist")}

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -103,7 +103,6 @@ func (t *HNSDirTest) TestShouldFindExplicitHNSFolder() {
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{
 		Name:           dirName,
-		MetaGeneration: int64(1),
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 
@@ -158,7 +157,6 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckOnlyForExplicitHNSDirectory() {
 	// mock get folder call
 	folder := &gcs.Folder{
 		Name:           dirName,
-		MetaGeneration: int64(1),
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	t.mockBucket.On("BucketType").Return(gcs.Hierarchical)
@@ -182,7 +180,6 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeNotPresent
 	// mock get folder call
 	folder := &gcs.Folder{
 		Name:           dirName,
-		MetaGeneration: int64(1),
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("storage: object doesn't exist")}

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -269,7 +269,6 @@ func (b *bucket) mintObject(
 func (b *bucket) mintFolder(folderName string) (f gcs.Folder) {
 	f = gcs.Folder{
 		Name:           folderName,
-		MetaGeneration: 1,
 		UpdateTime:     b.clock.Now(),
 	}
 
@@ -947,7 +946,7 @@ func (b *bucket) GetFolder(ctx context.Context, foldername string) (*gcs.Folder,
 		return nil, err
 	}
 
-	return &gcs.Folder{Name: foldername, MetaGeneration: b.folders[index].MetaGeneration}, nil
+	return &gcs.Folder{Name: foldername}, nil
 }
 
 func (b *bucket) CreateFolder(ctx context.Context, folderName string) (*gcs.Folder, error) {
@@ -1007,7 +1006,6 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 
 	folder := &gcs.Folder{
 		Name:           destinationFolderId,
-		MetaGeneration: 1,
 		UpdateTime:     time.Now()}
 
 	// Delete the src folder?

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -268,8 +268,8 @@ func (b *bucket) mintObject(
 // LOCKS_REQUIRED(b.mu)
 func (b *bucket) mintFolder(folderName string) (f gcs.Folder) {
 	f = gcs.Folder{
-		Name:           folderName,
-		UpdateTime:     b.clock.Now(),
+		Name:       folderName,
+		UpdateTime: b.clock.Now(),
 	}
 
 	return
@@ -1005,8 +1005,8 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 	}
 
 	folder := &gcs.Folder{
-		Name:           destinationFolderId,
-		UpdateTime:     time.Now()}
+		Name:       destinationFolderId,
+		UpdateTime: time.Now()}
 
 	// Delete the src folder?
 	index := b.folders.find(folderName)

--- a/internal/storage/gcs/folder.go
+++ b/internal/storage/gcs/folder.go
@@ -22,15 +22,15 @@ import (
 )
 
 type Folder struct {
-	Name           string
-	UpdateTime     time.Time
+	Name       string
+	UpdateTime time.Time
 }
 
 func GCSFolder(bucketName string, attrs *controlpb.Folder) *Folder {
 	// Setting the parameters in Folder and doing conversions as necessary.
 	return &Folder{
-		Name:           getFolderName(bucketName, attrs.Name),
-		UpdateTime:     attrs.GetUpdateTime().AsTime(),
+		Name:       getFolderName(bucketName, attrs.Name),
+		UpdateTime: attrs.GetUpdateTime().AsTime(),
 	}
 }
 
@@ -47,7 +47,7 @@ func getFolderName(bucketName string, fullPath string) string {
 
 func (f *Folder) ConvertFolderToMinObject() *MinObject {
 	return &MinObject{
-		Name:           f.Name,
-		Updated:        f.UpdateTime,
+		Name:    f.Name,
+		Updated: f.UpdateTime,
 	}
 }

--- a/internal/storage/gcs/folder.go
+++ b/internal/storage/gcs/folder.go
@@ -23,7 +23,6 @@ import (
 
 type Folder struct {
 	Name           string
-	MetaGeneration int64
 	UpdateTime     time.Time
 }
 
@@ -31,7 +30,6 @@ func GCSFolder(bucketName string, attrs *controlpb.Folder) *Folder {
 	// Setting the parameters in Folder and doing conversions as necessary.
 	return &Folder{
 		Name:           getFolderName(bucketName, attrs.Name),
-		MetaGeneration: attrs.Metageneration,
 		UpdateTime:     attrs.GetUpdateTime().AsTime(),
 	}
 }
@@ -48,10 +46,8 @@ func getFolderName(bucketName string, fullPath string) string {
 }
 
 func (f *Folder) ConvertFolderToMinObject() *MinObject {
-
 	return &MinObject{
 		Name:           f.Name,
-		MetaGeneration: f.MetaGeneration,
 		Updated:        f.UpdateTime,
 	}
 }

--- a/internal/storage/gcs/folder_test.go
+++ b/internal/storage/gcs/folder_test.go
@@ -65,6 +65,5 @@ func TestConvertFolderToMinObject(t *testing.T) {
 	result := folder.ConvertFolderToMinObject()
 
 	assert.Equal(t, result.Name, TestFolderName)
-	assert.Equal(t, result.MetaGeneration, int64(10))
 	assert.Equal(t, result.Updated, timestamp.AsTime())
 }

--- a/internal/storage/gcs/folder_test.go
+++ b/internal/storage/gcs/folder_test.go
@@ -48,7 +48,6 @@ func TestGCSFolder(t *testing.T) {
 	gcsFolder := GCSFolder(TestBucketName, &attrs)
 
 	assert.Equal(t, attrs.Name, gcsFolder.Name)
-	assert.Equal(t, attrs.Metageneration, gcsFolder.MetaGeneration)
 	assert.Equal(t, attrs.UpdateTime.AsTime(), gcsFolder.UpdateTime)
 }
 
@@ -59,9 +58,8 @@ func TestConvertFolderToMinObject(t *testing.T) {
 	}
 
 	folder := Folder{
-		Name:           TestFolderName,
-		MetaGeneration: 10,
-		UpdateTime:     timestamp.AsTime(),
+		Name:       TestFolderName,
+		UpdateTime: timestamp.AsTime(),
 	}
 
 	result := folder.ConvertFolderToMinObject()


### PR DESCRIPTION
### Description
Remove the meteGeneration field from the folder struct since its value remains constant throughout all operations

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
