### PR TITLE
Fixing flaky OpenDirAndLookUp test

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -87,7 +87,7 @@ func (s *concurrentListingTest) Test_OpenDirAndLookUp(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	// Fails if the operation takes more than timeout.
-	timeout := 10 * time.Second
+	timeout := 40 * time.Second
 
 	// Goroutine 1: Repeatedly calls OpenDir.
 	go func() {


### PR DESCRIPTION
### Description
Increasing the timeout of OpenAndLookUp concurrent listing test, as it fails some time on smaller vm.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
