### PR TITLE
[testing-on-gke part 1.2] Support generic workloads in gke load test-run scripts

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -15,10 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This program takes in a json test-config file, finds out valid
+"""Generates and deploys helm charts for DLIO workloads.
 
+This program takes in a json test-config file, finds out valid
 DLIO workloads from it and generates and deploys a helm chart for
-each DLIO workload.
+each valid DLIO workload.
 """
 
 import argparse
@@ -33,8 +34,8 @@ def run_command(command: str):
   print(result.stderr)
 
 
-def createHelmInstallCommands(dlioWorkloads: set):
-  """Create helm install commands for the given set of dlioWorkload objects."""
+def createHelmInstallCommands(dlioWorkloads: set) -> list:
+  """Create helm install commands for the given dlioWorkload objects."""
   helm_commands = []
   for dlioWorkload in dlioWorkloads:
     for batchSize in dlioWorkload.batchSizes:

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -15,43 +15,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""This program takes in a json dlio test-config file and generates and deploys helm charts."""
+
+import argparse
+from collections.abc import Sequence
+import os
 import subprocess
+
+from absl import app
+import dlio_workload
 
 
 def run_command(command: str):
-  result = subprocess.run(command.split(" "), capture_output=True, text=True)
+  result = subprocess.run(command.split(' '), capture_output=True, text=True)
   print(result.stdout)
   print(result.stderr)
 
 
-metadataCacheTtlSecs = 6048000
-bucketName_numFilesTrain_recordLength_batchSize = [
-    ("gke-dlio-unet3d-100kb-500k", 500000, 102400, 800),
-    ("gke-dlio-unet3d-100kb-500k", 500000, 102400, 128),
-    ("gke-dlio-unet3d-500kb-1m", 1000000, 512000, 800),
-    ("gke-dlio-unet3d-500kb-1m", 1000000, 512000, 128),
-    ("gke-dlio-unet3d-3mb-100k", 100000, 3145728, 200),
-    ("gke-dlio-unet3d-150mb-5k", 5000, 157286400, 4),
-]
+def createHelmInstallCommands(dlioWorkloads):
+  helm_commands = []
+  for dlioWorkload in dlioWorkloads:
+    for batchSize in dlioWorkload.batchSizes:
+      commands = [
+          (
+              'helm install'
+              f' {dlioWorkload.bucket}-{batchSize}-{dlioWorkload.scenario} unet3d-loading-test'
+          ),
+          f'--set bucketName={dlioWorkload.bucket}',
+          f'--set scenario={dlioWorkload.scenario}',
+          f'--set dlio.numFilesTrain={dlioWorkload.numFilesTrain}',
+          f'--set dlio.recordLength={dlioWorkload.recordLength}',
+          f'--set dlio.batchSize={batchSize}',
+      ]
 
-scenarios = ["gcsfuse-file-cache", "gcsfuse-no-file-cache", "local-ssd"]
+      helm_command = ' '.join(commands)
+      helm_commands.append(helm_command)
+  return helm_commands
 
-for (
-    bucketName,
-    numFilesTrain,
-    recordLength,
-    batchSize,
-) in bucketName_numFilesTrain_recordLength_batchSize:
-  for scenario in scenarios:
-    commands = [
-        f"helm install {bucketName}-{batchSize}-{scenario} unet3d-loading-test",
-        f"--set bucketName={bucketName}",
-        f"--set scenario={scenario}",
-        f"--set dlio.numFilesTrain={numFilesTrain}",
-        f"--set dlio.recordLength={recordLength}",
-        f"--set dlio.batchSize={batchSize}",
-    ]
 
-    helm_command = " ".join(commands)
+def main(args) -> None:
+  dlioWorkloads = dlio_workload.ParseTestConfigForDlioWorkloads(
+      args.workload_config
+  )
+  helmInstallCommands = createHelmInstallCommands(dlioWorkloads)
+  for helmInstallCommand in helmInstallCommands:
+    print(f'{helmInstallCommand}')
+    run_command(helmInstallCommand)
 
-    run_command(helm_command)
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+      prog='DLIO test runner',
+      description=(
+          'This program takes in a json dlio test-config file and generates'
+          ' helm install commands.'
+      ),
+      # epilog='Text at the bottom of help',
+  )
+  parser.add_argument('--workload-config')  # positional argument
+  args = parser.parse_args()
+  main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -18,11 +18,7 @@
 """This program takes in a json dlio test-config file and generates and deploys helm charts."""
 
 import argparse
-from collections.abc import Sequence
-import os
 import subprocess
-
-from absl import app
 import dlio_workload
 
 
@@ -60,18 +56,27 @@ def main(args) -> None:
   helmInstallCommands = createHelmInstallCommands(dlioWorkloads)
   for helmInstallCommand in helmInstallCommands:
     print(f'{helmInstallCommand}')
-    run_command(helmInstallCommand)
+    if not args.dry_run:
+      run_command(helmInstallCommand)
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
-      prog='DLIO test runner',
+      prog='DLIO Unet3d test runner',
       description=(
           'This program takes in a json dlio test-config file and generates'
-          ' helm install commands.'
+          ' helm install commands to execute them using the active GKE cluster.'
       ),
-      # epilog='Text at the bottom of help',
   )
   parser.add_argument('--workload-config')  # positional argument
+  parser.add_argument(
+      '-n',
+      '--dry-run',
+      action='store_true',
+      help=(
+          'Only print out the test configurations that will run,'
+          ' not actually run them.'
+      ),
+  )
   args = parser.parse_args()
   main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -15,7 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This program takes in a json dlio test-config file and generates and deploys helm charts."""
+"""This program takes in a json test-config file, finds out valid
+
+DLIO workloads from it and generates and deploys a helm chart for
+each DLIO workload.
+"""
 
 import argparse
 import subprocess
@@ -23,12 +27,14 @@ import dlio_workload
 
 
 def run_command(command: str):
+  """Runs the given string command as a subprocess."""
   result = subprocess.run(command.split(' '), capture_output=True, text=True)
   print(result.stdout)
   print(result.stderr)
 
 
-def createHelmInstallCommands(dlioWorkloads):
+def createHelmInstallCommands(dlioWorkloads: set):
+  """Create helm install commands for the given set of dlioWorkload objects."""
   helm_commands = []
   for dlioWorkload in dlioWorkloads:
     for batchSize in dlioWorkload.batchSizes:
@@ -64,11 +70,16 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       prog='DLIO Unet3d test runner',
       description=(
-          'This program takes in a json dlio test-config file and generates'
-          ' helm install commands to execute them using the active GKE cluster.'
+          'This program takes in a json test-config file, finds out valid DLIO'
+          ' workloads from it and generates and deploys a helm chart for each'
+          ' DLIO workload.'
       ),
   )
-  parser.add_argument('--workload-config')  # positional argument
+  parser.add_argument(
+      '--workload-config',
+      help='Runs DLIO Unet3d tests using this JSON workload configuration.',
+      required=True,
+  )
   parser.add_argument(
       '-n',
       '--dry-run',

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This program takes in a json test-config file, finds out valid FIO
+"""Generates and deploys helm charts for FIO workloads.
 
-workloads from it and generates and deploys a helm chart for each FIO
-workload.
+This program takes in a json test-config file, finds out valid FIO workloads in
+it and generates and deploys a helm chart for each valid FIO workload.
 """
 
 import argparse
@@ -33,8 +33,8 @@ def run_command(command: str):
   print(result.stderr)
 
 
-def createHelmInstallCommands(fioWorkloads):
-  """Create helm install commands for the given set of fioWorkload objects."""
+def createHelmInstallCommands(fioWorkloads: set) -> list:
+  """Create helm install commands for the given fioWorkload objects."""
   helm_commands = []
   for fioWorkload in fioWorkloads:
     for readType in fioWorkload.readTypes:

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -18,13 +18,7 @@
 """This program takes in a json fio test-config file and generates and deploys helm charts."""
 
 import argparse
-from collections.abc import Sequence
-import json
-import os
-import pprint
 import subprocess
-
-from absl import app
 import fio_workload
 
 
@@ -61,23 +55,30 @@ def main(args) -> None:
   fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
       args.workload_config
   )
-  # for fioWorkload in fioWorkloads:
-  # fioWorkload.PPrint()
   helmInstallCommands = createHelmInstallCommands(fioWorkloads)
   for helmInstallCommand in helmInstallCommands:
     print(f'{helmInstallCommand}')
-    run_command(f'{helmInstallCommand}')
+    if not args.dry_run:
+      run_command(helmInstallCommand)
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       prog='FIO test runner',
       description=(
-          'This program takes in a json fio test-config file and generates'
-          ' helm install commands.'
+          'This program takes in a json test-config file and generates'
+          ' helm install commands to execute them using the active GKE cluster.'
       ),
-      # epilog='Text at the bottom of help',
   )
   parser.add_argument('--workload-config')
+  parser.add_argument(
+      '-n',
+      '--dry-run',
+      action='store_true',
+      help=(
+          'Only print out the test configurations that will run,'
+          ' not actually run them.'
+      ),
+  )
   args = parser.parse_args()
   main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -15,7 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This program takes in a json fio test-config file and generates and deploys helm charts."""
+"""This program takes in a json test-config file, finds out valid FIO
+
+workloads from it and generates and deploys a helm chart for each FIO
+workload.
+"""
 
 import argparse
 import subprocess
@@ -23,12 +27,14 @@ import fio_workload
 
 
 def run_command(command: str):
+  """Runs the given string command as a subprocess."""
   result = subprocess.run(command.split(' '), capture_output=True, text=True)
   print(result.stdout)
   print(result.stderr)
 
 
 def createHelmInstallCommands(fioWorkloads):
+  """Create helm install commands for the given set of fioWorkload objects."""
   helm_commands = []
   for fioWorkload in fioWorkloads:
     for readType in fioWorkload.readTypes:
@@ -66,11 +72,16 @@ if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       prog='FIO test runner',
       description=(
-          'This program takes in a json test-config file and generates'
-          ' helm install commands to execute them using the active GKE cluster.'
+          'This program takes in a json test-config file, finds out valid FIO'
+          ' workloads from it and generates and deploys a helm chart for each'
+          ' FIO workload.'
       ),
   )
-  parser.add_argument('--workload-config')
+  parser.add_argument(
+      '--workload-config',
+      help='Runs FIO tests using this JSON workload configuration',
+      required=True,
+  )
   parser.add_argument(
       '-n',
       '--dry-run',

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -15,46 +15,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""This program takes in a json fio test-config file and generates and deploys helm charts."""
+
+import argparse
+from collections.abc import Sequence
+import json
+import os
+import pprint
 import subprocess
+
+from absl import app
+import fio_workload
 
 
 def run_command(command: str):
-  result = subprocess.run(command.split(" "), capture_output=True, text=True)
+  result = subprocess.run(command.split(' '), capture_output=True, text=True)
   print(result.stdout)
   print(result.stderr)
 
 
-bucketName_fileSize_blockSize = [
-    ("gke-fio-64k-1m", "64K", "64K"),
-    ("gke-fio-128k-1m", "128K", "128K"),
-    ("gke-fio-1mb-1m", "1M", "256K"),
-    ("gke-fio-100mb-50k", "100M", "1M"),
-    ("gke-fio-200gb-1", "200G", "1M"),
-]
-
-scenarios = ["gcsfuse-file-cache", "gcsfuse-no-file-cache", "local-ssd"]
-
-for bucketName, fileSize, blockSize in bucketName_fileSize_blockSize:
-  for readType in ["read", "randread"]:
-    for scenario in scenarios:
-      if readType == "randread" and fileSize in ["64K", "128K"]:
-        continue
-
+def createHelmInstallCommands(fioWorkloads):
+  helm_commands = []
+  for fioWorkload in fioWorkloads:
+    for readType in fioWorkload.readTypes:
       commands = [
           (
-              "helm install"
-              f" fio-loading-test-{fileSize.lower()}-{readType}-{scenario} loading-test"
+              'helm install'
+              f' fio-loading-test-{fioWorkload.fileSize.lower()}-{readType}-{fioWorkload.scenario} loading-test'
           ),
-          f"--set bucketName={bucketName}",
-          f"--set scenario={scenario}",
-          f"--set fio.readType={readType}",
-          f"--set fio.fileSize={fileSize}",
-          f"--set fio.blockSize={blockSize}",
+          f'--set bucketName={fioWorkload.bucket}',
+          f'--set scenario={fioWorkload.scenario}',
+          f'--set fio.readType={readType}',
+          f'--set fio.fileSize={fioWorkload.fileSize}',
+          f'--set fio.blockSize={fioWorkload.blockSize}',
+          f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
+          f'--set fio.numThreads={fioWorkload.numThreads}',
       ]
 
-      if fileSize == "100M":
-        commands.append("--set fio.filesPerThread=1000")
+      helm_command = ' '.join(commands)
+      helm_commands.append(helm_command)
+  return helm_commands
 
-      helm_command = " ".join(commands)
 
-      run_command(helm_command)
+def main(args) -> None:
+  fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
+      args.workload_config
+  )
+  # for fioWorkload in fioWorkloads:
+  # fioWorkload.PPrint()
+  helmInstallCommands = createHelmInstallCommands(fioWorkloads)
+  for helmInstallCommand in helmInstallCommands:
+    print(f'{helmInstallCommand}')
+    run_command(f'{helmInstallCommand}')
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+      prog='FIO test runner',
+      description=(
+          'This program takes in a json fio test-config file and generates'
+          ' helm install commands.'
+      ),
+      # epilog='Text at the bottom of help',
+  )
+  parser.add_argument('--workload-config')
+  args = parser.parse_args()
+  main(args)


### PR DESCRIPTION
### Description
This adds on top of https://github.com/GoogleCloudPlatform/gcsfuse/pull/2247, https://github.com/GoogleCloudPlatform/gcsfuse/pull/2284 and https://github.com/GoogleCloudPlatform/gcsfuse/pull/2264 .

This is followed up in #2270 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
