### PR TITLE
Set FUSE entry expiration time

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1358,6 +1358,12 @@ func (fs *fileSystem) LookUpInode(
 		return err
 	}
 
+	// If list cache is enabled, directory entries returned by ReadDir may be cached.
+	// So we can also cache the directory entries returned by Lookup.
+	if fs.kernelListCacheTTL > 0 {
+		e.EntryExpiration = time.Now().Add(fs.kernelListCacheTTL)
+	}
+
 	return
 }
 


### PR DESCRIPTION
### Description

Currently entry expiration is not set, which means that the dentry is thrown away after each use, causing significant overhead since every lookup operation needs to call into userspace.

Entry captures the mapping from file name to inode. The kernel list cache option allows readdir response to be cached, which is also dentry, so I reuse the same TTL for entry expiration timeout. This is conservative, and I am pretty sure there can be further performance improvement by setting the expiration in more cases (as the object generation number is also cached).

There are a few other places where dentry is returned, e.g. create or mkdir, but since the cache is more useful for readonly/read-mostly FS, I didn't bother setting the dentry expiration time for these calls.

This change brings significant performance improvement due for readonly workloads.
* I tested the change with a bucket that have 6000 files, using `du -hs` on the directory (it will stat all the files.). I ran the command once to populate the cache, and then time the second run. The change reduces time taken by the command from 532ms to 72ms.
* I also tested the change in a production compilation workload. The time taken for each run reduces from 7 minutes to 1 minute.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
