### PR TITLE
[CLI Config Parity] Remove config object from integration tests

### DIFF
--- a/tools/integration_tests/interrupt/interrupt_test.go
+++ b/tools/integration_tests/interrupt/interrupt_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -57,14 +56,16 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 
 	// Set up flags to run tests on.
-	mountConfig := config.MountConfig{
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
+	yamlContent1 := map[string]interface{}{
+		"file-system": map[string]interface{}{
+			"ignore-interrupts": true,
 		},
 	}
-	flags := [][]string{{"--implicit-dirs=true"},
-		{"--config-file=" + setup.YAMLConfigFile(mountConfig, "config.yaml")}}
+	yamlContent2 := map[string]interface{}{} // test default
+	flags := [][]string{
+		{"--implicit-dirs=true"},
+		{"--config-file=" + setup.YAMLConfigFile(yamlContent1, "ignore_interrupts.yaml")},
+		{"--config-file=" + setup.YAMLConfigFile(yamlContent2, "default_ignore_interrupts.yaml")}}
 
 	successCode := static_mounting.RunTests(flags, m)
 

--- a/tools/integration_tests/log_rotation/log_rotation_test.go
+++ b/tools/integration_tests/log_rotation/log_rotation_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -46,20 +45,19 @@ var (
 	logFilePath string
 )
 
-func getMountConfigForLogRotation(maxFileSizeMB, backupFileCount int, compress bool,
-	logFilePath string) config.MountConfig {
-	mountConfig := config.MountConfig{
-		LogConfig: config.LogConfig{
-			Severity: config.TRACE,
-			FilePath: logFilePath,
-			LogRotateConfig: config.LogRotateConfig{
-				MaxFileSizeMB:   maxFileSizeMB,
-				BackupFileCount: backupFileCount,
-				Compress:        compress,
+func getMountConfigForLogRotation(maxFileSizeMB, backupFileCount int, compress bool, logFilePath string) map[string]interface{} {
+	yamlContent := map[string]interface{}{
+		"logging": map[string]interface{}{
+			"severity":  "TRACE",
+			"file-path": logFilePath,
+			"log-rotate": map[string]interface{}{
+				"max-file-size-mb":  maxFileSizeMB,
+				"backup-file-count": backupFileCount,
+				"compress":          compress,
 			},
 		},
 	}
-	return mountConfig
+	return yamlContent
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
@@ -144,17 +142,12 @@ func (s *enableEmptyManagedFoldersTrue) TestListDirectoryForEmptyManagedFolders(
 	}
 }
 
-func getMountConfigForEmptyManagedFolders() config.MountConfig {
-	mountConfig := config.MountConfig{
-		ListConfig: config.ListConfig{
-			EnableEmptyManagedFolders: true,
-		},
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
+func getMountConfigForEmptyManagedFolders() map[string]interface{} {
+	mountConfig := map[string]interface{}{
+		"list": map[string]interface{}{
+			"enable-empty-managed-folders": true,
 		},
 	}
-
 	return mountConfig
 }
 
@@ -170,9 +163,7 @@ func TestEnableEmptyManagedFoldersTrue(t *testing.T) {
 		return
 	}
 
-	configFile := setup.YAMLConfigFile(
-		getMountConfigForEmptyManagedFolders(),
-		"config.yaml")
+	configFile := setup.YAMLConfigFile(getMountConfigForEmptyManagedFolders(), "config.yaml")
 	flags := []string{"--implicit-dirs", "--config-file=" + configFile}
 
 	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
@@ -98,55 +96,38 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "operations-cache-dir")
 
 	// Set up config file with create-empty-file: true.
-	mountConfig1 := config.MountConfig{
-		WriteConfig: cfg.WriteConfig{
-			CreateEmptyFile: true,
-		},
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
+	mountConfig1 := map[string]interface{}{
+		"write": map[string]interface{}{
+			"create-empty-file": true,
 		},
 	}
+
 	filePath1 := setup.YAMLConfigFile(mountConfig1, "config1.yaml")
 	flags = append(flags, []string{"--config-file=" + filePath1})
 
 	// Set up config file for file cache.
-	mountConfig2 := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
+	mountConfig2 := map[string]interface{}{
+		"file-cache": map[string]interface{}{
 			// Keeping the size as low because the operations are performed on small
 			// files
-			MaxSizeMB: 2,
+			"max-size-mb": 2,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath2 := setup.YAMLConfigFile(mountConfig2, "config2.yaml")
 	flags = append(flags, []string{"--config-file=" + filePath2})
 
-	mountConfig3 := config.MountConfig{
-		// Run with metadata caches disabled.
-		MetadataCacheConfig: config.MetadataCacheConfig{
-			TtlInSeconds: 0,
-		},
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
+	mountConfig3 := map[string]interface{}{
+		"metadata-cache": map[string]interface{}{
+			"ttl-secs": 0,
 		},
 	}
 	filePath3 := setup.YAMLConfigFile(mountConfig3, "config3.yaml")
 	flags = append(flags, []string{"--config-file=" + filePath3})
 
-	mountConfig4 := config.MountConfig{
-		// Run with metadata caches disabled.
-		FileSystemConfig: config.FileSystemConfig{
-			KernelListCacheTtlSeconds: -1,
-		},
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
+	mountConfig4 := map[string]interface{}{
+		"file-system": map[string]interface{}{
+			"kernel-list-cache-ttl-secs": -1,
 		},
 	}
 	filePath4 := setup.YAMLConfigFile(mountConfig4, "config4.yaml")

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -25,7 +25,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/log_parser/json_parser/read_logs"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
@@ -62,25 +61,17 @@ func createConfigFileForJobChunkTest(cacheSize int64, cacheFileForRangeRead bool
 	cacheDirPath = path.Join(setup.TestDir(), cacheDirName)
 
 	// Set up config file for file cache.
-	mountConfig := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
-			// Keeping the size as low because the operations are performed on small
-			// files
-			MaxSizeMB:                cacheSize,
-			CacheFileForRangeRead:    cacheFileForRangeRead,
-			EnableParallelDownloads:  true,
-			ParallelDownloadsPerFile: parallelDownloadsPerFile,
-			MaxParallelDownloads:     maxParallelDownloads,
-			DownloadChunkSizeMB:      downloadChunkSizeMB,
-			EnableCRC:                enableCrcCheck,
+	mountConfig := map[string]interface{}{
+		"file-cache": map[string]interface{}{
+			"max-size-mb":                 cacheSize,
+			"cache-file-for-range-read":   cacheFileForRangeRead,
+			"enable-parallel-downloads":   true,
+			"parallel-downloads-per-file": parallelDownloadsPerFile,
+			"max-parallel-downloads":      maxParallelDownloads,
+			"download-chunk-size-mb":      downloadChunkSizeMB,
+			"enable-crc":                  enableCrcCheck,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			Format:          "json",
-			FilePath:        setup.LogFile(),
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath := setup.YAMLConfigFile(mountConfig, fileName)
 	return filePath

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -24,7 +24,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
@@ -104,25 +103,17 @@ func createConfigFile(cacheSize int64, cacheFileForRangeRead bool, fileName stri
 	cacheDirPath = path.Join(setup.TestDir(), cacheDirName)
 
 	// Set up config file for file cache.
-	mountConfig := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
-			// Keeping the size as low because the operations are performed on small
-			// files
-			MaxSizeMB:                cacheSize,
-			CacheFileForRangeRead:    cacheFileForRangeRead,
-			EnableParallelDownloads:  enableParallelDownloads,
-			ParallelDownloadsPerFile: parallelDownloadsPerFile,
-			MaxParallelDownloads:     maxParallelDownloads,
-			DownloadChunkSizeMB:      downloadChunkSizeMB,
-			EnableCRC:                enableCrcCheck,
+	mountConfig := map[string]interface{}{
+		"file-cache": map[string]interface{}{
+			"max-size-mb":                 cacheSize,
+			"cache-file-for-range-read":   cacheFileForRangeRead,
+			"enable-parallel-downloads":   enableParallelDownloads,
+			"parallel-downloads-per-file": parallelDownloadsPerFile,
+			"max-parallel-downloads":      maxParallelDownloads,
+			"download-chunk-size-mb":      downloadChunkSizeMB,
+			"enable-crc":                  enableCrcCheck,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			Format:          "json",
-			FilePath:        setup.LogFile(),
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath := setup.YAMLConfigFile(mountConfig, fileName)
 	return filePath

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -41,33 +40,25 @@ func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dri")
 
 	// Set up config file for file cache with cache-file-for-range-read: false
-	mountConfig1 := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
+	mountConfig1 := map[string]interface{}{
+		"file-cache": map[string]interface{}{
 			// Keeping the size as high because the operations are performed on large
-			// files
-			MaxSizeMB:             700,
-			CacheFileForRangeRead: true,
+			// files.
+			"max-size-mb":               700,
+			"cache-file-for-range-read": true,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath1 := setup.YAMLConfigFile(mountConfig1, "config1.yaml")
 	flags = append(flags, []string{"--implicit-dirs=true", "--config-file=" + filePath1})
 
 	// Set up config file for file cache with unlimited capacity
-	mountConfig2 := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
-			MaxSizeMB:             -1,
-			CacheFileForRangeRead: false,
+	mountConfig2 := map[string]interface{}{
+		"file-cache": map[string]interface{}{
+			"max-size-mb":               -1,
+			"cache-file-for-range-read": false,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath2 := setup.YAMLConfigFile(mountConfig2, "config2.yaml")
 	flags = append(flags, []string{"--implicit-dirs=true", "--config-file=" + filePath2})

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/persistent_mounting"
@@ -96,18 +95,14 @@ func checkErrorForObjectNotExist(err error, t *testing.T) {
 func createMountConfigsAndEquivalentFlags() (flags [][]string) {
 	cacheDirPath := path.Join(os.Getenv("HOME"), "cache-dir")
 
-	// Set up config file for file cache
-	mountConfig := config.MountConfig{
-		FileCacheConfig: config.FileCacheConfig{
+	// Set up config file for file cache.
+	mountConfig := map[string]interface{}{
+		"file-cache": map[string]interface{}{
 			// Keeping the size as small because the operations are performed on small
-			// files
-			MaxSizeMB: 3,
+			// files.
+			"max-size-mb": 3,
 		},
-		CacheDir: cacheDirPath,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+		"cache-dir": cacheDirPath,
 	}
 	filePath := setup.YAMLConfigFile(mountConfig, "config.yaml")
 	flags = append(flags, []string{"--o=ro", "--implicit-dirs=true", "--config-file=" + filePath})

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/util"
 	"google.golang.org/api/iterator"
@@ -421,12 +420,8 @@ func AddHNSFlagForHierarchicalBucket(ctx context.Context, storageClient *storage
 	}
 
 	var flags []string
-	mountConfig4 := config.MountConfig{
-		EnableHNS: true,
-		LogConfig: config.LogConfig{
-			Severity:        config.TRACE,
-			LogRotateConfig: config.DefaultLogRotateConfig(),
-		},
+	mountConfig4 := map[string]interface{}{
+		"enable-hns": true,
 	}
 	filePath4 := YAMLConfigFile(mountConfig4, "config_hns.yaml")
 	// TODO: Remove --implicit-dirs flag, once the GetFolder API has been successfully implemented.

--- a/tools/integration_tests/util/setup/yaml-config.go
+++ b/tools/integration_tests/util/setup/yaml-config.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"path"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
-func YAMLConfigFile(config config.MountConfig, fileName string) (filePath string) {
-	yamlData, err := yaml.Marshal(&config)
+func YAMLConfigFile(yamlContent interface{}, fileName string) (filePath string) {
+	yamlData, err := yaml.Marshal(yamlContent)
 	if err != nil {
 		LogAndExit(fmt.Sprintf("Error while marshaling config file: %v", err))
 	}


### PR DESCRIPTION
### Description
Currently GCSFuse integration tests rely on internal mount config object in order to create the yaml file for testing. This is not a good practice as this doesn't allow catching failures in case of any breaking change to internal config. Updated the integration tests to manually create the yaml structure using `map[string]interface{}`

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Updated and ran via KOKORO
