### PR TITLE
Fix size of symlinks and enable kernel symlink cache

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -174,6 +174,9 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config, mountConfig *confi
 		// access two files under same directory parallely, then the lookups also
 		// happen parallely.
 		EnableParallelDirOps: !(mountConfig.FileSystemConfig.DisableParallelDirops),
+		// Symlink target is not mutable (removing and re-creating would cause a different
+		// inode to be created), so it's safe to enable symlink caching.
+		EnableSymlinkCaching: true,
 	}
 
 	mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse: ")

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -84,6 +84,10 @@ func NewSymlinkInode(
 			Atime: m.Updated,
 			Ctime: m.Updated,
 			Mtime: m.Updated,
+			// POSIX spec requires that for symbolic links, size attribute
+			// reflects the length in bytes of the pathname contained in the
+			// symbolic link. This is also expected by symlink cache in FUSE.
+			Size: uint64(len(m.Metadata[SymlinkMetadataKey])),
 		},
 		target: m.Metadata[SymlinkMetadataKey],
 	}


### PR DESCRIPTION
### Description
Symlink inodes are expected to have size equal to the length of its target. This is defined in POSIX spec.

FUSE's symlink cache also expects this, so fixing this allows the enabling of the symlink cache. Note that since symlink targets are not mutable, the cache is always valid while the inode is valid, so there is no need for any TTL or invalidation logic.

This is expected to bring significant time saving for workloads that make use of symlinks (especially for a directory symlink, since all ops inside the symlink directory would require reading the symlink at least once).

### Link to the issue in case of a bug fix.
#2273 

### Testing details
1. Manual:
    - Mount a bucket on two mount points (with separate GCSFuse processes)
    - Create a symlink in mount1
    - Stat and see its size is correct and point to the correct target in mount2.
    - Remove and recreate the symlink in mount1 to a different target
    - Stat and see its size is correct and point to the correct target in mount2.
2. Unit tests - NA
3. Integration tests - I didn't add a test because I'm unfamiliar with this project (and go in general)'s test setup and it seems that the test infra is being reworked on.
