### PR TITLE
Made the parallel downloads go routines running without synchronization

### DIFF
--- a/internal/cache/data/object_range.go
+++ b/internal/cache/data/object_range.go
@@ -1,0 +1,6 @@
+package data
+
+type ObjectRange struct {
+	Start uint64
+	End   uint64
+}

--- a/internal/cache/data/object_range.go
+++ b/internal/cache/data/object_range.go
@@ -1,6 +1,6 @@
 package data
 
 type ObjectRange struct {
-	Start uint64
-	End   uint64
+	Start int64
+	End   int64
 }

--- a/internal/cache/data/object_range.go
+++ b/internal/cache/data/object_range.go
@@ -1,5 +1,6 @@
 package data
 
+// ObjectRange specifies the range within the gcs object.
 type ObjectRange struct {
 	Start int64
 	End   int64

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -100,7 +100,7 @@ func TestParallelDownloads(t *testing.T) {
 		subscribedOffset         int64
 	}{
 		{
-			name:                     "download in chunks of concurrency * readReqSize",
+			name:                     "download the entire object when object size > no of goroutines * readReqSize",
 			objectSize:               15 * util.MiB,
 			readReqSize:              3,
 			parallelDownloadsPerFile: 100,

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -144,7 +144,7 @@ func TestParallelDownloads(t *testing.T) {
 				select {
 				case jobStatus := <-subscriberC:
 					if assert.Nil(t, err) {
-						assert.LessOrEqual(t, tc.expectedOffset, jobStatus.Offset)
+						assert.Equal(t, tc.expectedOffset, jobStatus.Offset)
 						verifyFileTillOffset(t,
 							data.FileSpec{Path: util.GetDownloadPath(path.Join(cacheDir, storage.TestBucketName), "path/in/gcs/foo.txt"), FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, tc.expectedOffset,
 							content)

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createObjectInBucket(t *testing.T, objPath string, objSize int64, bucket gcs.Bucket) []byte {
@@ -138,7 +139,7 @@ func TestParallelDownloads(t *testing.T) {
 				select {
 				case jobStatus := <-subscriberC:
 					if assert.Nil(t, err) {
-						assert.GreaterOrEqual(t, tc.objectSize, jobStatus.Offset)
+						require.GreaterOrEqual(t, tc.objectSize, jobStatus.Offset)
 						verifyFileTillOffset(t,
 							data.FileSpec{Path: util.GetDownloadPath(path.Join(cacheDir, storage.TestBucketName), "path/in/gcs/foo.txt"), FilePerm: util.DefaultFilePerm, DirPerm: util.DefaultDirPerm}, jobStatus.Offset,
 							content)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -275,7 +275,7 @@ func (job *Job) updateStatusOffset(downloadedOffset int64) (err error) {
 
 	err = job.fileInfoCache.UpdateWithoutChangingOrder(fileInfoKeyName, updatedFileInfo)
 	if err == nil {
-		job.status.Offset = int64(downloadedOffset)
+		job.status.Offset = downloadedOffset
 		// Notify subscribers if file cache is updated.
 		logger.Tracef("Job:%p (%s:/%s) downloaded till %v offset.", job, job.bucket.Name(), job.object.Name, job.status.Offset)
 		job.notifySubscribers()

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -94,7 +94,7 @@ type Job struct {
 
 	// Channel which is used by goroutines to know which offsets need to be
 	// downloaded when parallel download is enabled.
-	offsetChan chan offset
+	offsetChan chan data.ObjectRange
 }
 
 // JobStatus represents the status of job.
@@ -109,11 +109,6 @@ type JobStatus struct {
 type jobSubscriber struct {
 	notificationC    chan<- JobStatus
 	subscribedOffset int64
-}
-
-type offset struct {
-	start uint64
-	end   uint64
 }
 
 func NewJob(

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -105,7 +105,7 @@ func (job *Job) updateRangeMap(rangeMap map[uint64]uint64, offsetStart uint64, o
 	return nil
 }
 
-func (job *Job) downloadOffsets(ctx context.Context, goroutineIndex int, cacheFile *os.File, rangeMap map[uint64]uint64) func() error {
+func (job *Job) downloadOffsets(ctx context.Context, goroutineIndex int64, cacheFile *os.File, rangeMap map[uint64]uint64) func() error {
 	return func() error {
 		// Since we keep a goroutine for each job irrespective of the maxParallelism,
 		// not releasing the default goroutine to the pool.

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -91,6 +91,7 @@ func (job *Job) downloadOffsets(ctx context.Context, cacheFile *os.File) func() 
 // into given file handle using multiple NewReader method of gcs.Bucket running
 // in parallel. This function is canceled if job.cancelCtx is canceled.
 func (job *Job) parallelDownloadObjectToFile(cacheFile *os.File) (err error) {
+	fmt.Println(job.fileCacheConfig.ParallelDownloadsPerFile)
 	job.offsetChan = make(chan offset, 2*job.fileCacheConfig.ParallelDownloadsPerFile)
 	var numGoRoutines int64
 	var start uint64

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -70,11 +70,11 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 }
 
 // RangeMap maintains the ranges downloaded by the different goroutines. This
-// function takes a new range and merges with existng ranges if they are continuous.
+// function takes a new range and merges with existing ranges if they are continuous.
 //
 // Eg:
 // Input: rangeMap entries 0-3, 5-6. New input 7-8.
-// Output: rangeMap entires 0-3, 5-8.
+// Output: rangeMap entries 0-3, 5-8.
 func (job *Job) updateRangeMap(rangeMap map[uint64]uint64, offsetStart uint64, offsetEnd uint64) error {
 	// Check if the chunk downloaded completes a range [0, R) and find that
 	// R.

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -105,11 +105,11 @@ func (job *Job) updateRangeMap(rangeMap map[int64]int64, offsetStart int64, offs
 	rangeMap[finalEnd] = finalStart
 
 	if finalStart == 0 {
-		updateErr := job.updateStatusOffset(finalEnd)
-		if updateErr != nil {
+		if updateErr := job.updateStatusOffset(finalEnd); updateErr != nil {
 			return updateErr
 		}
 	}
+
 	return nil
 }
 

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -71,6 +71,7 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 
 // RangeMap maintains the ranges downloaded by the different goroutines. This
 // function takes a new range and merges with existing ranges if they are continuous.
+// If the start offset is 0, updates the job's status offset.
 //
 // Eg:
 // Input: rangeMap entries 0-3, 5-6. New input 7-8.
@@ -112,6 +113,8 @@ func (job *Job) updateRangeMap(rangeMap map[int64]int64, offsetStart int64, offs
 	return nil
 }
 
+// Reads the range input from the range channel continuously and downloads that
+// range from the GCS. If the range channel is closed, it will exit.
 func (job *Job) downloadOffsets(ctx context.Context, goroutineIndex int64, cacheFile *os.File, rangeMap map[int64]int64) func() error {
 	return func() error {
 		// Since we keep a goroutine for each job irrespective of the maxParallelism,

--- a/internal/cache/file/downloader/parallel_downloads_job_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_test.go
@@ -63,8 +63,8 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
 	AssertEq(nil, err)
-	verifyContentAtOffset := func(file *os.File, start, end int64) {
-		_, err = file.Seek(start, 0)
+	verifyContentAtOffset := func(file *os.File, start, end uint64) {
+		_, err = file.Seek(int64(start), 0)
 		AssertEq(nil, err)
 		buf := make([]byte, end-start)
 		_, err = file.Read(buf)
@@ -74,29 +74,29 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	}
 
 	// Download end 1MiB of object
-	start, end := int64(9*util.MiB), int64(10*util.MiB)
-	offsetWriter := io.NewOffsetWriter(file, start)
+	start, end := uint64(9*util.MiB), uint64(10*util.MiB)
+	offsetWriter := io.NewOffsetWriter(file, int64(start))
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download start 4MiB of object
-	start, end = int64(0*util.MiB), int64(4*util.MiB)
-	offsetWriter = io.NewOffsetWriter(file, start)
+	start, end = uint64(0*util.MiB), uint64(4*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, int64(start))
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download middle 1B of object
-	start, end = int64(5*util.MiB), int64(5*util.MiB+1)
-	offsetWriter = io.NewOffsetWriter(file, start)
+	start, end = uint64(5*util.MiB), uint64(5*util.MiB+1)
+	offsetWriter = io.NewOffsetWriter(file, int64(start))
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download 0B of object
-	start, end = int64(5*util.MiB), int64(5*util.MiB)
-	offsetWriter = io.NewOffsetWriter(file, start)
+	start, end = uint64(5*util.MiB), uint64(5*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, int64(start))
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)

--- a/internal/cache/file/downloader/parallel_downloads_job_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_test.go
@@ -63,7 +63,7 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
 	AssertEq(nil, err)
-	verifyContentAtOffset := func(file *os.File, start, end uint64) {
+	verifyContentAtOffset := func(file *os.File, start, end int64) {
 		_, err = file.Seek(int64(start), 0)
 		AssertEq(nil, err)
 		buf := make([]byte, end-start)
@@ -74,29 +74,29 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	}
 
 	// Download end 1MiB of object
-	start, end := uint64(9*util.MiB), uint64(10*util.MiB)
-	offsetWriter := io.NewOffsetWriter(file, int64(start))
+	start, end := int64(9*util.MiB), int64(10*util.MiB)
+	offsetWriter := io.NewOffsetWriter(file, start)
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download start 4MiB of object
-	start, end = uint64(0*util.MiB), uint64(4*util.MiB)
-	offsetWriter = io.NewOffsetWriter(file, int64(start))
+	start, end = int64(0*util.MiB), int64(4*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, start)
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download middle 1B of object
-	start, end = uint64(5*util.MiB), uint64(5*util.MiB+1)
-	offsetWriter = io.NewOffsetWriter(file, int64(start))
+	start, end = int64(5*util.MiB), int64(5*util.MiB+1)
+	offsetWriter = io.NewOffsetWriter(file, start)
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download 0B of object
-	start, end = uint64(5*util.MiB), uint64(5*util.MiB)
-	offsetWriter = io.NewOffsetWriter(file, int64(start))
+	start, end = int64(5*util.MiB), int64(5*util.MiB)
+	offsetWriter = io.NewOffsetWriter(file, start)
 	err = dt.job.downloadRange(context.Background(), offsetWriter, start, end)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
@@ -154,7 +154,7 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile_CtxCancelled
 }
 
 func (dt *parallelDownloaderTest) Test_updateRangeMap_withNoEntries() {
-	rangeMap := make(map[uint64]uint64)
+	rangeMap := make(map[int64]int64)
 
 	err := dt.job.updateRangeMap(rangeMap, 0, 10)
 
@@ -165,7 +165,7 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withNoEntries() {
 }
 
 func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithEndOffset() {
-	rangeMap := make(map[uint64]uint64)
+	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 2
 	rangeMap[2] = 0
 	rangeMap[4] = 6
@@ -182,7 +182,7 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithEnd
 }
 
 func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithStartOffset() {
-	rangeMap := make(map[uint64]uint64)
+	rangeMap := make(map[int64]int64)
 	rangeMap[2] = 4
 	rangeMap[4] = 2
 	rangeMap[8] = 10
@@ -199,7 +199,7 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithSta
 }
 
 func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputFillingTheMissingRange() {
-	rangeMap := make(map[uint64]uint64)
+	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 4
 	rangeMap[4] = 0
 	rangeMap[6] = 8
@@ -214,7 +214,7 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputFillingTheMissing
 }
 
 func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputNotOverlappingWithAnyRanges() {
-	rangeMap := make(map[uint64]uint64)
+	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 4
 	rangeMap[4] = 0
 	rangeMap[12] = 14

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -95,7 +95,7 @@ func (s *jobChunkTest) TestJobChunkSizeForSingleFileReads(t *testing.T) {
 	// and is in multiples of chunkSize.
 	for i := 1; i < len(structuredJobLogs[0].JobEntries); i++ {
 		offsetDiff := structuredJobLogs[0].JobEntries[i].Offset - structuredJobLogs[0].JobEntries[i-1].Offset
-		assert.Greater(t, offsetDiff, 0)
+		assert.Greater(t, offsetDiff, int64(0))
 		assert.Equal(t, int64(0), offsetDiff%s.chunkSize)
 	}
 

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -17,7 +17,6 @@ package read_cache
 import (
 	"context"
 	"log"
-	"math"
 	"path"
 	"sync"
 	"testing"
@@ -39,11 +38,10 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 type jobChunkTest struct {
-	flags                           []string
-	storageClient                   *storage.Client
-	ctx                             context.Context
-	chunkSize                       int64
-	isLimitedByMaxParallelDownloads bool
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	chunkSize     int64
 }
 
 func (s *jobChunkTest) Setup(t *testing.T) {
@@ -83,7 +81,7 @@ func createConfigFileForJobChunkTest(cacheSize int64, cacheFileForRangeRead bool
 
 func (s *jobChunkTest) TestJobChunkSizeForSingleFileReads(t *testing.T) {
 	var fileSize int64 = 24 * util.MiB
-	chunkCount := math.Ceil(float64(fileSize) / float64(s.chunkSize))
+	//chunkCount := math.Ceil(float64(fileSize) / float64(s.chunkSize))
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSize, t)
 
 	expectedOutcome := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, false, t)
@@ -92,16 +90,21 @@ func (s *jobChunkTest) TestJobChunkSizeForSingleFileReads(t *testing.T) {
 	structuredJobLogs := read_logs.GetJobLogsSortedByTimestamp(setup.LogFile(), t)
 	assert.Equal(t, expectedOutcome.BucketName, structuredJobLogs[0].BucketName)
 	assert.Equal(t, expectedOutcome.ObjectName, structuredJobLogs[0].ObjectName)
-	require.EqualValues(t, chunkCount, len(structuredJobLogs[0].JobEntries))
-	for i := 0; int64(i) < int64(chunkCount); i++ {
-		offset := min(s.chunkSize*int64(i+1), fileSize)
-		assert.Equal(t, offset, structuredJobLogs[0].JobEntries[i].Offset)
+
+	// We need to check that downloadedOffset is always greater than the previous downloadedOffset
+	// and is in multiples of chunkSize.
+	for i := 1; i < len(structuredJobLogs[0].JobEntries); i++ {
+		offsetDiff := structuredJobLogs[0].JobEntries[i].Offset - structuredJobLogs[0].JobEntries[i-1].Offset
+		assert.Greater(t, offsetDiff, 0)
+		assert.Equal(t, int64(0), offsetDiff%s.chunkSize)
 	}
+
+	// Validate that last downloadedOffset is same as fileSize.
+	assert.Equal(t, fileSize, structuredJobLogs[0].JobEntries[len(structuredJobLogs[0].JobEntries)-1].Offset)
 }
 
 func (s *jobChunkTest) TestJobChunkSizeForMultipleFileReads(t *testing.T) {
 	var fileSize int64 = 24 * util.MiB
-	chunkCount := fileSize / s.chunkSize
 	var testFileNames [2]string
 	var expectedOutcome [2]*Expected
 	testFileNames[0] = setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSize, t)
@@ -129,22 +132,22 @@ func (s *jobChunkTest) TestJobChunkSizeForMultipleFileReads(t *testing.T) {
 		expectedOutcome[0], expectedOutcome[1] = expectedOutcome[1], expectedOutcome[0]
 		testFileNames[0], testFileNames[1] = testFileNames[1], testFileNames[0]
 	}
-	assert.Equal(t, expectedOutcome[0].BucketName, structuredJobLogs[0].BucketName)
-	assert.Equal(t, expectedOutcome[1].BucketName, structuredJobLogs[1].BucketName)
-	assert.Equal(t, expectedOutcome[0].ObjectName, structuredJobLogs[0].ObjectName)
-	assert.Equal(t, expectedOutcome[1].ObjectName, structuredJobLogs[1].ObjectName)
-	if s.isLimitedByMaxParallelDownloads {
-		require.LessOrEqual(t, chunkCount, int64(len(structuredJobLogs[0].JobEntries)))
-		for i := 0; int64(i) < int64(len(structuredJobLogs[0].JobEntries)); i++ {
-			offset := min(s.chunkSize*int64(i+1), fileSize)
-			assert.GreaterOrEqual(t, offset, structuredJobLogs[0].JobEntries[i].Offset)
+
+	for fileIndex := 0; fileIndex < 2; fileIndex++ {
+		assert.Equal(t, expectedOutcome[fileIndex].BucketName, structuredJobLogs[fileIndex].BucketName)
+		assert.Equal(t, expectedOutcome[fileIndex].ObjectName, structuredJobLogs[fileIndex].ObjectName)
+
+		// We need to check that downloadedOffset is always greater than the previous downloadedOffset
+		// and is in multiples of chunkSize.
+		entriesLen := len(structuredJobLogs[fileIndex].JobEntries)
+		for entryIndex := 1; entryIndex < entriesLen; entryIndex++ {
+			offsetDiff := structuredJobLogs[fileIndex].JobEntries[entryIndex].Offset - structuredJobLogs[fileIndex].JobEntries[entryIndex-1].Offset
+			assert.Greater(t, offsetDiff, int64(0))
+			assert.Equal(t, int64(0), offsetDiff%s.chunkSize)
 		}
-	} else {
-		require.EqualValues(t, chunkCount, len(structuredJobLogs[0].JobEntries))
-		for i := 0; int64(i) < chunkCount; i++ {
-			offset := min(s.chunkSize*int64(i+1), fileSize)
-			assert.Equal(t, offset, structuredJobLogs[0].JobEntries[i].Offset)
-		}
+
+		// Validate that last downloadedOffset is same as fileSize.
+		assert.Equal(t, fileSize, structuredJobLogs[fileIndex].JobEntries[entriesLen-1].Offset)
 	}
 }
 
@@ -182,7 +185,7 @@ func TestJobChunkTest(t *testing.T) {
 	// with unlimited max parallel downloads.
 	ts.flags = []string{"--config-file=" +
 		createConfigFileForJobChunkTest(cacheSizeMB, false, "unlimitedMaxParallelDownloads", parallelDownloadsPerFile, maxParallelDownloads, downloadChunkSizeMB)}
-	ts.chunkSize = parallelDownloadsPerFile * downloadChunkSizeMB * util.MiB
+	ts.chunkSize = downloadChunkSizeMB * util.MiB
 	log.Printf("Running tests with flags: %s", ts.flags)
 	test_setup.RunTests(t, ts)
 
@@ -193,7 +196,7 @@ func TestJobChunkTest(t *testing.T) {
 	downloadChunkSizeMB := 3
 	ts.flags = []string{"--config-file=" +
 		createConfigFileForJobChunkTest(cacheSizeMB, false, "limitedMaxParallelDownloadsNotEffectingChunkSize", parallelDownloadsPerFile, maxParallelDownloads, downloadChunkSizeMB)}
-	ts.chunkSize = int64(parallelDownloadsPerFile) * int64(downloadChunkSizeMB) * util.MiB
+	ts.chunkSize = int64(downloadChunkSizeMB) * util.MiB
 	log.Printf("Running tests with flags: %s", ts.flags)
 	test_setup.RunTests(t, ts)
 
@@ -204,8 +207,7 @@ func TestJobChunkTest(t *testing.T) {
 	downloadChunkSizeMB = 3
 	ts.flags = []string{"--config-file=" +
 		createConfigFileForJobChunkTest(cacheSizeMB, false, "limitedMaxParallelDownloadsEffectingChunkSize", parallelDownloadsPerFile, maxParallelDownloads, downloadChunkSizeMB)}
-	ts.chunkSize = int64(maxParallelDownloads+1) * int64(downloadChunkSizeMB) * util.MiB
-	ts.isLimitedByMaxParallelDownloads = true
+	ts.chunkSize = int64(downloadChunkSizeMB) * util.MiB
 	log.Printf("Running tests with flags: %s", ts.flags)
 	test_setup.RunTests(t, ts)
 

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -81,7 +81,6 @@ func createConfigFileForJobChunkTest(cacheSize int64, cacheFileForRangeRead bool
 
 func (s *jobChunkTest) TestJobChunkSizeForSingleFileReads(t *testing.T) {
 	var fileSize int64 = 24 * util.MiB
-	//chunkCount := math.Ceil(float64(fileSize) / float64(s.chunkSize))
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSize, t)
 
 	expectedOutcome := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, false, t)
@@ -96,6 +95,8 @@ func (s *jobChunkTest) TestJobChunkSizeForSingleFileReads(t *testing.T) {
 	for i := 1; i < len(structuredJobLogs[0].JobEntries); i++ {
 		offsetDiff := structuredJobLogs[0].JobEntries[i].Offset - structuredJobLogs[0].JobEntries[i-1].Offset
 		assert.Greater(t, offsetDiff, int64(0))
+		// This is true for all entries except last one.
+		// Will be true for last entry only if the fileSize is multiple of chunkSize.
 		assert.Equal(t, int64(0), offsetDiff%s.chunkSize)
 	}
 
@@ -143,6 +144,8 @@ func (s *jobChunkTest) TestJobChunkSizeForMultipleFileReads(t *testing.T) {
 		for entryIndex := 1; entryIndex < entriesLen; entryIndex++ {
 			offsetDiff := structuredJobLogs[fileIndex].JobEntries[entryIndex].Offset - structuredJobLogs[fileIndex].JobEntries[entryIndex-1].Offset
 			assert.Greater(t, offsetDiff, int64(0))
+			// This is true for all entries except last one.
+			// Will be true for last entry only if the fileSize is multiple of chunkSize.
 			assert.Equal(t, int64(0), offsetDiff%s.chunkSize)
 		}
 


### PR DESCRIPTION
### Description
Incase of parallel downloads, we trigger n number of goroutines each downloading xMB and then we wait for x*nMB to be downloaded and then make the goroutines fetch another x*nMB.
Instead of that, we are making each goroutine continuously download xMB and then next xMB instead of worrying about other goroutines. Which offset to fetch will be passed via channel,.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Existing tests are sufficient
3. Integration tests - Fixed as required.
