### PR TITLE
Fix for flaky list large dir

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -17,6 +17,7 @@ package list_large_dir_test
 import (
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -176,9 +177,17 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 5 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 5*secondListTime, firstListTime)
+	// Assert performance improvement for second directory listing, adjusting expectations based on CPU count.
+	if runtime.NumCPU() >= 32 {
+		// On systems with 32 or more CPUs, expect a 5x speedup for the second listing
+		// due to efficient kernel cache utilization.
+		assert.Less(t, 5*secondListTime, firstListTime)
+	} else {
+		// On systems with fewer than 32 CPUs, the cache benefit may be less pronounced.
+		// Expect a more conservative 2x speedup.
+		assert.Less(t, 2*secondListTime, firstListTime)
+	}
+
 	// Clear the data after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -213,9 +222,16 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 5 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 5*secondListTime, firstListTime)
+	// Assert performance improvement for second directory listing, adjusting expectations based on CPU count.
+	if runtime.NumCPU() >= 32 {
+		// On systems with 32 or more CPUs, expect a 5x speedup for the second listing
+		// due to efficient kernel cache utilization.
+		assert.Less(t, 5*secondListTime, firstListTime)
+	} else {
+		// On systems with fewer than 32 CPUs, the cache benefit may be less pronounced.
+		// Expect a more conservative 2x speedup.
+		assert.Less(t, 2*secondListTime, firstListTime)
+	}
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -252,9 +268,16 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 
 	// Fetching data from the kernel for the second list will be faster.
 	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 5 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 5*secondListTime, firstListTime)
+	// Assert performance improvement for second directory listing, adjusting expectations based on CPU count.
+	if runtime.NumCPU() >= 32 {
+		// On systems with 32 or more CPUs, expect a 5x speedup for the second listing
+		// due to efficient kernel cache utilization.
+		assert.Less(t, 5*secondListTime, firstListTime)
+	} else {
+		// On systems with fewer than 32 CPUs, the cache benefit may be less pronounced.
+		// Expect a more conservative 2x speedup.
+		assert.Less(t, 2*secondListTime, firstListTime)
+	}
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }


### PR DESCRIPTION
### Description
Fixed flaky TestListDirectoryWithTwelveThousandFiles by adjusting expected speedup according to number of logical CPUs usable by the current process.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
