### PR TITLE
Remove custom CODEOWNERS for kislayk@

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
 *           @GoogleCloudPlatform/gcsfuse-codeowners
-
-# Co-owners for config
-tools/config-gen/ @kislaykishore @GoogleCloudPlatform/gcsfuse-codeowners
-cmd/ @kislaykishore @GoogleCloudPlatform/gcsfuse-codeowners
-cfg/ @kislaykishore @GoogleCloudPlatform/gcsfuse-codeowners
-internal/config/ @kislaykishore @GoogleCloudPlatform/gcsfuse-codeowners


### PR DESCRIPTION
kislayk@ is part of CODEOWNERS so, no custom configuration is necessary.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
