### PR TITLE
Migrate constants to new config

### DIFF
--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -25,6 +25,7 @@ const (
 	OFF     string = "OFF"
 )
 
+// Metadata-cache related constants.
 const (
 	// ExperimentalMetadataPrefetchOnMountDisabled is the mode without metadata-prefetch.
 	ExperimentalMetadataPrefetchOnMountDisabled = "disabled"
@@ -32,4 +33,26 @@ const (
 	ExperimentalMetadataPrefetchOnMountSynchronous = "sync"
 	// ExperimentalMetadataPrefetchOnMountAsynchronous is the prefetch-mode where mounting is marked complete once prefetch has started.
 	ExperimentalMetadataPrefetchOnMountAsynchronous = "async"
+	// DefaultStatOrTypeCacheTTL is the default value used for
+	// stat-cache-ttl or type-cache-ttl if they have not been set
+	// by the user.
+	DefaultStatOrTypeCacheTTL time.Duration = time.Minute
+	// DefaultStatCacheCapacity is the default value for stat-cache-capacity.
+	// This is equivalent of setting metadata-cache: stat-cache-max-size-mb.
+	DefaultStatCacheCapacity = 20460
+
+	// DefaultStatCacheMaxSizeMB is the default for stat-cache-max-size-mb
+	// and is to be used when neither stat-cache-max-size-mb nor
+	// stat-cache-capacity is set.
+	DefaultStatCacheMaxSizeMB = 32
+	// AverageSizeOfPositiveStatCacheEntry is the assumed size of each positive stat-cache-entry,
+	// meant for two purposes.
+	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
+	// 2. internal testing.
+	AverageSizeOfPositiveStatCacheEntry uint64 = 1400
+	// AverageSizeOfNegativeStatCacheEntry is the assumed size of each negative stat-cache-entry,
+	// meant for two purposes..
+	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
+	// 2. internal testing.
+	AverageSizeOfNegativeStatCacheEntry uint64 = 240
 )

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -14,6 +14,8 @@
 
 package cfg
 
+import "time"
+
 const (
 	// Logging-level constants
 

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -14,7 +14,12 @@
 
 package cfg
 
-import "time"
+import (
+	"math"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+)
 
 const (
 	// Logging-level constants
@@ -57,4 +62,41 @@ const (
 	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
 	// 2. internal testing.
 	AverageSizeOfNegativeStatCacheEntry uint64 = 240
+
+	// TtlInSecsUnsetSentinel is the value internally
+	// set for metada-cache:ttl-secs
+	// when it is not set in the gcsfuse mount config file.
+	// The constant value has been chosen deliberately
+	// to be improbable for a user to explicitly set.
+	TtlInSecsUnsetSentinel int64 = math.MinInt64
+
+	// DefaultTypeCacheMaxSizeMB is the default value of type-cache max-size for every directory in MiBs.
+	// The value is set at the size needed for about 21k type-cache entries,
+	// each of which is about 200 bytes in size.
+	DefaultTypeCacheMaxSizeMB int = 4
+
+	// StatCacheMaxSizeMBUnsetSentinel is the value internally
+	// set for metada-cache:stat-cache-max-size-mb
+	// when it is not set in the gcsfuse mount config file.
+	StatCacheMaxSizeMBUnsetSentinel int64 = math.MinInt64
+
+	DefaultEnableEmptyManagedFoldersListing = false
+	DefaultGrpcConnPoolSize                 = 1
+	DefaultAnonymousAccess                  = false
+	DefaultEnableHNS                        = false
+	DefaultIgnoreInterrupts                 = true
+	DefaultPrometheusPort                   = 0
+
+	DefaultKernelListCacheTtlSeconds int64 = 0
+	DefaultMaxRetryAttempts                = int64(0)
+
+	// File Cache Config constants.
+
+	DefaultFileCacheMaxSizeMB       = -1
+	DefaultEnableCRC                = false
+	DefaultEnableParallelDownloads  = false
+	DefaultDownloadChunkSizeMB      = 50
+	DefaultParallelDownloadsPerFile = 16
+
+	MaxSupportedStatCacheMaxSizeMB = util.MaxMiBsInUint64
 )

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -278,7 +278,7 @@ func newApp() (app *cli.App) {
 
 			cli.StringFlag{
 				Name:  "client-protocol",
-				Value: string(mountpkg.HTTP1),
+				Value: string(cfg.HTTP1),
 				Usage: "The protocol used for communicating with the GCS backend. " +
 					"Value can be 'http1' (HTTP/1.1) or 'http2' (HTTP/2) or grpc.",
 			},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,7 +25,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/urfave/cli"
@@ -228,19 +227,19 @@ func newApp() (app *cli.App) {
 
 			cli.IntFlag{
 				Name:  "stat-cache-capacity",
-				Value: mount.DefaultStatCacheCapacity,
+				Value: cfg.DefaultStatCacheCapacity,
 				Usage: "How many entries can the stat-cache hold (impacts memory consumption). This flag has been deprecated (starting v2.0) and in its place only metadata-cache:stat-cache-max-size-mb in the gcsfuse config-file will be supported. For now, the value of stat-cache-capacity will be translated to the next higher corresponding value of metadata-cache:stat-cache-max-size-mb (assuming stat-cache entry-size ~= 1640 bytes, including 1400 for positive entry and 240 for corresponding negative entry), when metadata-cache:stat-cache-max-size-mb is not set.",
 			},
 
 			cli.DurationFlag{
 				Name:  "stat-cache-ttl",
-				Value: mount.DefaultStatOrTypeCacheTTL,
+				Value: cfg.DefaultStatOrTypeCacheTTL,
 				Usage: "How long to cache StatObject results and inode attributes. This flag has been deprecated (starting v2.0) and in its place only metadata-cache:ttl-secs in the gcsfuse config-file will be supported. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second, is used as ttl for both stat-cache and type-cache, when metadata-cache:ttl-secs is not set.",
 			},
 
 			cli.DurationFlag{
 				Name:  "type-cache-ttl",
-				Value: mount.DefaultStatOrTypeCacheTTL,
+				Value: cfg.DefaultStatOrTypeCacheTTL,
 				Usage: "How long to cache name -> file/dir mappings in directory inodes. This flag has been deprecated (starting v2.0) and in its place only metadata-cache:ttl-secs in the gcsfuse config-file will be supported. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second, is used as ttl for both stat-cache and type-cache, when metadata-cache:ttl-secs is not set.",
 			},
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -245,7 +245,7 @@ func newApp() (app *cli.App) {
 
 			cli.Int64Flag{
 				Name:  config.KernelListCacheTtlFlagName,
-				Value: config.DefaultKernelListCacheTtlSeconds,
+				Value: cfg.DefaultKernelListCacheTtlSeconds,
 				Usage: "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache." +
 					"If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation " +
 					"by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. " +

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
-	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -222,7 +221,7 @@ func (t *FlagsTest) TestStrings() {
 	assert.Equal(t.T(), "-asdf", f.KeyFile)
 	assert.Equal(t.T(), "foobar", f.TempDir)
 	assert.Equal(t.T(), "baz", f.OnlyDir)
-	assert.Equal(t.T(), mountpkg.HTTP2, f.ClientProtocol)
+	assert.EqualValues(t.T(), cfg.HTTP2, f.ClientProtocol)
 	assert.Equal(t.T(), cfg.ExperimentalMetadataPrefetchOnMountAsynchronous, f.ExperimentalMetadataPrefetchOnMount)
 }
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -75,7 +75,7 @@ func (t *FlagsTest) TestDefaults() {
 	assert.EqualValues(t.T(), -1, f.Gid)
 	assert.False(t.T(), f.ImplicitDirs)
 	assert.True(t.T(), f.IgnoreInterrupts)
-	assert.Equal(t.T(), config.DefaultKernelListCacheTtlSeconds, f.KernelListCacheTtlSeconds)
+	assert.Equal(t.T(), cfg.DefaultKernelListCacheTtlSeconds, f.KernelListCacheTtlSeconds)
 
 	// GCS
 	assert.Equal(t.T(), "", f.KeyFile)
@@ -91,7 +91,7 @@ func (t *FlagsTest) TestDefaults() {
 	assert.Equal(t.T(), cfg.DefaultStatOrTypeCacheTTL, f.TypeCacheTTL)
 	assert.EqualValues(t.T(), 0, f.HttpClientTimeout)
 	assert.Equal(t.T(), "", f.TempDir)
-	assert.Equal(t.T(), config.DefaultMaxRetryAttempts, f.MaxRetryAttempts)
+	assert.Equal(t.T(), cfg.DefaultMaxRetryAttempts, f.MaxRetryAttempts)
 	assert.EqualValues(t.T(), 2, f.RetryMultiplier)
 	assert.False(t.T(), f.EnableNonexistentTypeCache)
 	assert.Equal(t.T(), 0, f.MaxConnsPerHost)

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	mountpkg "github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,9 +87,9 @@ func (t *FlagsTest) TestDefaults() {
 	assert.False(t.T(), f.AnonymousAccess)
 
 	// Tuning
-	assert.Equal(t.T(), mount.DefaultStatCacheCapacity, f.StatCacheCapacity)
-	assert.Equal(t.T(), mount.DefaultStatOrTypeCacheTTL, f.StatCacheTTL)
-	assert.Equal(t.T(), mount.DefaultStatOrTypeCacheTTL, f.TypeCacheTTL)
+	assert.Equal(t.T(), cfg.DefaultStatCacheCapacity, f.StatCacheCapacity)
+	assert.Equal(t.T(), cfg.DefaultStatOrTypeCacheTTL, f.StatCacheTTL)
+	assert.Equal(t.T(), cfg.DefaultStatOrTypeCacheTTL, f.TypeCacheTTL)
 	assert.EqualValues(t.T(), 0, f.HttpClientTimeout)
 	assert.Equal(t.T(), "", f.TempDir)
 	assert.Equal(t.T(), config.DefaultMaxRetryAttempts, f.MaxRetryAttempts)

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/monitor"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/perf"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
@@ -313,12 +312,12 @@ func runCLIApp(c *cli.Context) (err error) {
 	}
 
 	// The following will not warn if the user explicitly passed the default value for StatCacheCapacity.
-	if newConfig.MetadataCache.DeprecatedStatCacheCapacity != mount.DefaultStatCacheCapacity {
+	if newConfig.MetadataCache.DeprecatedStatCacheCapacity != cfg.DefaultStatCacheCapacity {
 		logger.Warnf("Deprecated flag stat-cache-capacity used! Please switch to config parameter 'metadata-cache: stat-cache-max-size-mb'.")
 	}
 
 	// The following will not warn if the user explicitly passed the default value for StatCacheTTL or TypeCacheTTL.
-	if newConfig.MetadataCache.DeprecatedStatCacheTtl != mount.DefaultStatOrTypeCacheTTL || newConfig.MetadataCache.DeprecatedTypeCacheTtl != mount.DefaultStatOrTypeCacheTTL {
+	if newConfig.MetadataCache.DeprecatedStatCacheTtl != cfg.DefaultStatOrTypeCacheTTL || newConfig.MetadataCache.DeprecatedTypeCacheTtl != cfg.DefaultStatOrTypeCacheTTL {
 		logger.Warnf("Deprecated flag stat-cache-ttl and/or type-cache-ttl used! Please switch to config parameter 'metadata-cache: ttl-secs' .")
 	}
 

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -117,7 +117,7 @@ type MultiBucketStatCacheTest struct {
 }
 
 func (t *StatCacheTest) SetupTest() {
-	cache := lru.NewCache(uint64((mount.AverageSizeOfPositiveStatCacheEntry + mount.AverageSizeOfNegativeStatCacheEntry) * capacity))
+	cache := lru.NewCache(uint64((cfg.AverageSizeOfPositiveStatCacheEntry + cfg.AverageSizeOfNegativeStatCacheEntry) * capacity))
 	t.cache.wrapped = metadata.NewStatCacheBucketView(cache, "") // this demonstrates
 	t.statCache = metadata.NewStatCacheBucketView(cache, "")     // this demonstrates
 	// that if you are using a cache for a single bucket, then
@@ -125,7 +125,7 @@ func (t *StatCacheTest) SetupTest() {
 }
 
 func (t *MultiBucketStatCacheTest) SetupTest() {
-	sharedCache := lru.NewCache(uint64((mount.AverageSizeOfPositiveStatCacheEntry + mount.AverageSizeOfNegativeStatCacheEntry) * capacity))
+	sharedCache := lru.NewCache(uint64((cfg.AverageSizeOfPositiveStatCacheEntry + cfg.AverageSizeOfNegativeStatCacheEntry) * capacity))
 	t.multiBucketCache.fruits = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "fruits")}
 	t.multiBucketCache.spices = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "spices")}
 }

--- a/internal/config/mount_config.go
+++ b/internal/config/mount_config.go
@@ -15,47 +15,7 @@
 package config
 
 import (
-	"math"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-)
-
-const (
-
-	// TtlInSecsUnsetSentinel is the value internally
-	// set for metada-cache:ttl-secs
-	// when it is not set in the gcsfuse mount config file.
-	// The constant value has been chosen deliberately
-	// to be improbable for a user to explicitly set.
-	TtlInSecsUnsetSentinel int64 = math.MinInt64
-
-	// DefaultTypeCacheMaxSizeMB is the default value of type-cache max-size for every directory in MiBs.
-	// The value is set at the size needed for about 21k type-cache entries,
-	// each of which is about 200 bytes in size.
-	DefaultTypeCacheMaxSizeMB int = 4
-
-	// StatCacheMaxSizeMBUnsetSentinel is the value internally
-	// set for metada-cache:stat-cache-max-size-mb
-	// when it is not set in the gcsfuse mount config file.
-	StatCacheMaxSizeMBUnsetSentinel int64 = math.MinInt64
-
-	DefaultEnableEmptyManagedFoldersListing = false
-	DefaultGrpcConnPoolSize                 = 1
-	DefaultAnonymousAccess                  = false
-	DefaultEnableHNS                        = false
-	DefaultIgnoreInterrupts                 = true
-	DefaultPrometheusPort                   = 0
-
-	DefaultKernelListCacheTtlSeconds int64 = 0
-	DefaultMaxRetryAttempts                = int64(0)
-
-	// File Cache Config constants.
-
-	DefaultFileCacheMaxSizeMB       = -1
-	DefaultEnableCRC                = false
-	DefaultEnableParallelDownloads  = false
-	DefaultDownloadChunkSizeMB      = 50
-	DefaultParallelDownloadsPerFile = 16
 )
 
 type LogConfig struct {
@@ -178,41 +138,41 @@ func NewMountConfig() *MountConfig {
 		},
 	}
 	mountConfig.FileCacheConfig = FileCacheConfig{
-		MaxSizeMB:                DefaultFileCacheMaxSizeMB,
-		EnableParallelDownloads:  DefaultEnableParallelDownloads,
-		ParallelDownloadsPerFile: DefaultParallelDownloadsPerFile,
+		MaxSizeMB:                cfg.DefaultFileCacheMaxSizeMB,
+		EnableParallelDownloads:  cfg.DefaultEnableParallelDownloads,
+		ParallelDownloadsPerFile: cfg.DefaultParallelDownloadsPerFile,
 		MaxParallelDownloads:     cfg.DefaultMaxParallelDownloads(),
-		DownloadChunkSizeMB:      DefaultDownloadChunkSizeMB,
-		EnableCRC:                DefaultEnableCRC,
+		DownloadChunkSizeMB:      cfg.DefaultDownloadChunkSizeMB,
+		EnableCRC:                cfg.DefaultEnableCRC,
 	}
 	mountConfig.MetadataCacheConfig = MetadataCacheConfig{
-		TtlInSeconds:       TtlInSecsUnsetSentinel,
-		TypeCacheMaxSizeMB: DefaultTypeCacheMaxSizeMB,
-		StatCacheMaxSizeMB: StatCacheMaxSizeMBUnsetSentinel,
+		TtlInSeconds:       cfg.TtlInSecsUnsetSentinel,
+		TypeCacheMaxSizeMB: cfg.DefaultTypeCacheMaxSizeMB,
+		StatCacheMaxSizeMB: cfg.StatCacheMaxSizeMBUnsetSentinel,
 	}
 	mountConfig.ListConfig = ListConfig{
-		EnableEmptyManagedFolders: DefaultEnableEmptyManagedFoldersListing,
+		EnableEmptyManagedFolders: cfg.DefaultEnableEmptyManagedFoldersListing,
 	}
 	mountConfig.GCSConnection = GCSConnection{
-		GRPCConnPoolSize: DefaultGrpcConnPoolSize,
+		GRPCConnPoolSize: cfg.DefaultGrpcConnPoolSize,
 	}
 	mountConfig.GCSAuth = GCSAuth{
-		AnonymousAccess: DefaultAnonymousAccess,
+		AnonymousAccess: cfg.DefaultAnonymousAccess,
 	}
-	mountConfig.EnableHNS = DefaultEnableHNS
+	mountConfig.EnableHNS = cfg.DefaultEnableHNS
 
 	mountConfig.FileSystemConfig = FileSystemConfig{
-		KernelListCacheTtlSeconds: DefaultKernelListCacheTtlSeconds,
+		KernelListCacheTtlSeconds: cfg.DefaultKernelListCacheTtlSeconds,
 	}
 
-	mountConfig.FileSystemConfig.IgnoreInterrupts = DefaultIgnoreInterrupts
+	mountConfig.FileSystemConfig.IgnoreInterrupts = cfg.DefaultIgnoreInterrupts
 
 	mountConfig.GCSRetries = GCSRetries{
-		MaxRetryAttempts: DefaultMaxRetryAttempts,
+		MaxRetryAttempts: cfg.DefaultMaxRetryAttempts,
 	}
 
 	mountConfig.MetricsConfig = MetricsConfig{
-		PrometheusPort: DefaultPrometheusPort,
+		PrometheusPort: cfg.DefaultPrometheusPort,
 	}
 
 	return mountConfig

--- a/internal/config/yaml_parser.go
+++ b/internal/config/yaml_parser.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -34,7 +33,6 @@ const (
 	TypeCacheMaxSizeMBInvalidValueError   = "the value of type-cache-max-size-mb for metadata-cache can't be less than -1"
 	StatCacheMaxSizeMBInvalidValueError   = "the value of stat-cache-max-size-mb for metadata-cache can't be less than -1"
 	StatCacheMaxSizeMBTooHighError        = "the value of stat-cache-max-size-mb for metadata-cache is too high! Max supported: 17592186044415"
-	MaxSupportedStatCacheMaxSizeMB        = util.MaxMiBsInUint64
 )
 
 func IsValidLogSeverity(severity string) bool {
@@ -52,7 +50,7 @@ func IsValidLogSeverity(severity string) bool {
 }
 
 func (metadataCacheConfig *MetadataCacheConfig) validate() error {
-	if metadataCacheConfig.TtlInSeconds != TtlInSecsUnsetSentinel {
+	if metadataCacheConfig.TtlInSeconds != cfg.TtlInSecsUnsetSentinel {
 		if metadataCacheConfig.TtlInSeconds < -1 {
 			return fmt.Errorf(MetadataCacheTtlSecsInvalidValueError)
 		}
@@ -64,11 +62,11 @@ func (metadataCacheConfig *MetadataCacheConfig) validate() error {
 		return fmt.Errorf(TypeCacheMaxSizeMBInvalidValueError)
 	}
 
-	if metadataCacheConfig.StatCacheMaxSizeMB != StatCacheMaxSizeMBUnsetSentinel {
+	if metadataCacheConfig.StatCacheMaxSizeMB != cfg.StatCacheMaxSizeMBUnsetSentinel {
 		if metadataCacheConfig.StatCacheMaxSizeMB < -1 {
 			return fmt.Errorf(StatCacheMaxSizeMBInvalidValueError)
 		}
-		if metadataCacheConfig.StatCacheMaxSizeMB > int64(MaxSupportedStatCacheMaxSizeMB) {
+		if metadataCacheConfig.StatCacheMaxSizeMB > int64(cfg.MaxSupportedStatCacheMaxSizeMB) {
 			return fmt.Errorf(StatCacheMaxSizeMBTooHighError)
 		}
 	}

--- a/internal/config/yaml_parser_test.go
+++ b/internal/config/yaml_parser_test.go
@@ -53,8 +53,8 @@ func validateDefaultConfig(t *testing.T, mountConfig *MountConfig) {
 	assert.False(t, bool(mountConfig.EnableHNS))
 	assert.True(t, mountConfig.FileSystemConfig.IgnoreInterrupts)
 	assert.False(t, mountConfig.FileSystemConfig.DisableParallelDirops)
-	assert.Equal(t, DefaultKernelListCacheTtlSeconds, mountConfig.KernelListCacheTtlSeconds)
-	assert.Equal(t, DefaultMaxRetryAttempts, mountConfig.GCSRetries.MaxRetryAttempts)
+	assert.Equal(t, cfg.DefaultKernelListCacheTtlSeconds, mountConfig.KernelListCacheTtlSeconds)
+	assert.Equal(t, cfg.DefaultMaxRetryAttempts, mountConfig.GCSRetries.MaxRetryAttempts)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_EmptyFileName() {
@@ -156,7 +156,7 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TtlNotSet() {
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), TtlInSecsUnsetSentinel, mountConfig.MetadataCacheConfig.TtlInSeconds)
+	assert.Equal(t.T(), cfg.TtlInSecsUnsetSentinel, mountConfig.MetadataCacheConfig.TtlInSeconds)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TtlTooHigh() {
@@ -176,7 +176,7 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_TypeCacheMaxSize
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), DefaultTypeCacheMaxSizeMB, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB)
+	assert.Equal(t.T(), cfg.DefaultTypeCacheMaxSizeMB, mountConfig.MetadataCacheConfig.TypeCacheMaxSizeMB)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_InvalidStatCacheSize() {
@@ -190,7 +190,7 @@ func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_StatCacheSizeNot
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), StatCacheMaxSizeMBUnsetSentinel, mountConfig.MetadataCacheConfig.StatCacheMaxSizeMB)
+	assert.Equal(t.T(), cfg.StatCacheMaxSizeMBUnsetSentinel, mountConfig.MetadataCacheConfig.StatCacheMaxSizeMB)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_MetatadaCacheConfig_StatCacheSizeTooHigh() {
@@ -210,7 +210,7 @@ func (t *YamlParserTest) TestReadConfigFile_GrpcClientConfig_unsetConnPoolSize()
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), DefaultGrpcConnPoolSize, mountConfig.GCSConnection.GRPCConnPoolSize)
+	assert.Equal(t.T(), cfg.DefaultGrpcConnPoolSize, mountConfig.GCSConnection.GRPCConnPoolSize)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_InvalidIgnoreInterruptsValue() {
@@ -272,7 +272,7 @@ func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_UnsetKernelListCach
 
 	assert.NoError(t.T(), err)
 	assert.NotNil(t.T(), mountConfig)
-	assert.Equal(t.T(), DefaultKernelListCacheTtlSeconds, mountConfig.FileSystemConfig.KernelListCacheTtlSeconds)
+	assert.Equal(t.T(), cfg.DefaultKernelListCacheTtlSeconds, mountConfig.FileSystemConfig.KernelListCacheTtlSeconds)
 }
 
 func (t *YamlParserTest) TestReadConfigFile_FileSystemConfig_ValidKernelListCacheTtl() {

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -21,10 +21,10 @@ import (
 	"path"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/inode"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -57,7 +57,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 	// Wrap the bucket in a stat caching layer for the purposes of the file
 	// system.
 	uncachedBucket = fake.NewFakeBucket(timeutil.RealClock(), "some_bucket", gcs.NonHierarchical)
-	lruCache := newLruCache(uint64(1000 * mount.AverageSizeOfPositiveStatCacheEntry))
+	lruCache := newLruCache(uint64(1000 * cfg.AverageSizeOfPositiveStatCacheEntry))
 	statCache := metadata.NewStatCacheBucketView(lruCache, "")
 	bucket = caching.NewFastStatBucket(
 		ttl,
@@ -456,7 +456,7 @@ func getMultiMountBucketDir(bucketName string) string {
 }
 
 func (t *MultiBucketMountCachingTest) SetUpTestSuite() {
-	sharedCache := newLruCache(uint64(1000 * mount.AverageSizeOfPositiveStatCacheEntry))
+	sharedCache := newLruCache(uint64(1000 * cfg.AverageSizeOfPositiveStatCacheEntry))
 	uncachedBuckets = make(map[string]gcs.Bucket)
 	buckets = make(map[string]gcs.Bucket)
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -95,7 +95,7 @@ func (p DirentSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // This poses a challenge for writing unit tests for enableManagedFoldersListing.
 
 func (t *DirTest) resetInode(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing bool) {
-	t.resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing, config.DefaultTypeCacheMaxSizeMB, typeCacheTTL)
+	t.resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing, cfg.DefaultTypeCacheMaxSizeMB, typeCacheTTL)
 }
 
 func (t *DirTest) resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing bool, typeCacheMaxSizeMB int, typeCacheTTL time.Duration) {
@@ -659,7 +659,7 @@ func (t *DirTest) LookUpChild_TypeCacheEnabled() {
 		typeCacheMaxSizeMB int
 		typeCacheTTL       time.Duration
 	}{{
-		typeCacheMaxSizeMB: config.DefaultTypeCacheMaxSizeMB,
+		typeCacheMaxSizeMB: cfg.DefaultTypeCacheMaxSizeMB,
 		typeCacheTTL:       time.Second,
 	}, {
 		typeCacheMaxSizeMB: -1,
@@ -695,7 +695,7 @@ func (t *DirTest) LookUpChild_TypeCacheDisabled() {
 		typeCacheMaxSizeMB: 0,
 		typeCacheTTL:       time.Second,
 	}, {
-		typeCacheMaxSizeMB: config.DefaultTypeCacheMaxSizeMB,
+		typeCacheMaxSizeMB: cfg.DefaultTypeCacheMaxSizeMB,
 		typeCacheTTL:       0,
 	}}
 

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/jacobsa/fuse/fuseops"
@@ -61,7 +61,7 @@ func (t *HNSDirTest) SetupTest() {
 }
 
 func (t *HNSDirTest) resetDirInode(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing bool) {
-	t.resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing, config.DefaultTypeCacheMaxSizeMB, typeCacheTTL)
+	t.resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing, cfg.DefaultTypeCacheMaxSizeMB, typeCacheTTL)
 }
 
 func (t *HNSDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing bool, typeCacheMaxSizeMB int, typeCacheTTL time.Duration) {

--- a/internal/fs/type_cache_test.go
+++ b/internal/fs/type_cache_test.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	gcsfusefs "github.com/googlecloudplatform/gcsfuse/v2/internal/fs"
@@ -85,7 +86,7 @@ func (t *typeCacheTestCommon) SetUpTestSuite() {
 
 	// Fill server-cfg from mount-config.
 	func(mountConfig *config.MountConfig, serverCfg *gcsfusefs.ServerConfig) {
-		serverCfg.DirTypeCacheTTL = mount.ResolveMetadataCacheTTL(mount.DefaultStatOrTypeCacheTTL, mount.DefaultStatOrTypeCacheTTL,
+		serverCfg.DirTypeCacheTTL = mount.ResolveMetadataCacheTTL(cfg.DefaultStatOrTypeCacheTTL, cfg.DefaultStatOrTypeCacheTTL,
 			mountConfig.TtlInSeconds)
 		serverCfg.InodeAttributeCacheTTL = serverCfg.DirTypeCacheTTL
 		// We can add more logic here to fill other fileds in serverCfg

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -27,18 +27,9 @@ import (
 
 type ClientProtocol string
 
-const (
-	// Deprecated: Use the constant from cfg package
-	HTTP1 ClientProtocol = "http1"
-	// Deprecated: Use the constant from cfg package
-	HTTP2 ClientProtocol = "http2"
-	// Deprecated: Use the constant from cfg package
-	GRPC ClientProtocol = "grpc"
-)
-
 func (cp ClientProtocol) IsValid() bool {
 	switch cp {
-	case HTTP1, HTTP2, GRPC:
+	case cfg.HTTP1, cfg.HTTP2, cfg.GRPC:
 		return true
 	}
 	return false

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 )
@@ -33,27 +34,6 @@ const (
 	HTTP2 ClientProtocol = "http2"
 	// Deprecated: Use the constant from cfg package
 	GRPC ClientProtocol = "grpc"
-	// DefaultStatOrTypeCacheTTL is the default value used for
-	// stat-cache-ttl or type-cache-ttl if they have not been set
-	// by the user.
-	DefaultStatOrTypeCacheTTL time.Duration = time.Minute
-	// DefaultStatCacheCapacity is the default value for stat-cache-capacity.
-	// This is equivalent of setting metadata-cache: stat-cache-max-size-mb.
-	DefaultStatCacheCapacity = 20460
-	// DefaultStatCacheMaxSizeMB is the default for stat-cache-max-size-mb
-	// and is to be used when neither stat-cache-max-size-mb nor
-	// stat-cache-capacity is set.
-	DefaultStatCacheMaxSizeMB = 32
-	// AverageSizeOfPositiveStatCacheEntry is the assumed size of each positive stat-cache-entry,
-	// meant for two purposes.
-	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
-	// 2. internal testing.
-	AverageSizeOfPositiveStatCacheEntry uint64 = 1400
-	// AverageSizeOfNegativeStatCacheEntry is the assumed size of each negative stat-cache-entry,
-	// meant for two purposes..
-	// 1. for conversion from stat-cache-capacity to stat-cache-max-size-mb.
-	// 2. internal testing.
-	AverageSizeOfNegativeStatCacheEntry uint64 = 240
 )
 
 func (cp ClientProtocol) IsValid() bool {
@@ -129,15 +109,15 @@ func ResolveStatCacheMaxSizeMB(mountConfigStatCacheMaxSizeMB int64, flagStatCach
 			statCacheMaxSizeMB = uint64(mountConfigStatCacheMaxSizeMB)
 		}
 	} else {
-		if flagStatCacheCapacity != DefaultStatCacheCapacity {
+		if flagStatCacheCapacity != cfg.DefaultStatCacheCapacity {
 			if flagStatCacheCapacity < 0 {
 				return 0, fmt.Errorf("invalid value of stat-cache-capacity (%v), can't be less than 0", flagStatCacheCapacity)
 			}
-			avgTotalStatCacheEntrySize := AverageSizeOfPositiveStatCacheEntry + AverageSizeOfNegativeStatCacheEntry
+			avgTotalStatCacheEntrySize := cfg.AverageSizeOfPositiveStatCacheEntry + cfg.AverageSizeOfNegativeStatCacheEntry
 			return util.BytesToHigherMiBs(
 				uint64(flagStatCacheCapacity) * avgTotalStatCacheEntrySize), nil
 		} else {
-			return DefaultStatCacheMaxSizeMB, nil
+			return cfg.DefaultStatCacheMaxSizeMB, nil
 		}
 	}
 	return

--- a/internal/mount/flag.go
+++ b/internal/mount/flag.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 )
 
@@ -77,7 +76,7 @@ func ParseOptions(m map[string]string, s string) {
 func ResolveMetadataCacheTTL(statCacheTTL, typeCacheTTL time.Duration, ttlInSeconds int64) (metadataCacheTTL time.Duration) {
 	// If metadata-cache:ttl-secs has been set in config-file, then
 	// it overrides both stat-cache-ttl and type-cache-tll.
-	if ttlInSeconds != config.TtlInSecsUnsetSentinel {
+	if ttlInSeconds != cfg.TtlInSecsUnsetSentinel {
 		// if ttl-secs is set to -1, set StatOrTypeCacheTTL to the max possible duration.
 		if ttlInSeconds == -1 {
 			metadataCacheTTL = time.Duration(math.MaxInt64)
@@ -93,9 +92,9 @@ func ResolveMetadataCacheTTL(statCacheTTL, typeCacheTTL time.Duration, ttlInSeco
 
 // ResolveStatCacheMaxSizeMB returns the stat-cache size in MiBs based on the user old and new flags/configs.
 func ResolveStatCacheMaxSizeMB(mountConfigStatCacheMaxSizeMB int64, flagStatCacheCapacity int) (statCacheMaxSizeMB uint64, err error) {
-	if mountConfigStatCacheMaxSizeMB != config.StatCacheMaxSizeMBUnsetSentinel {
+	if mountConfigStatCacheMaxSizeMB != cfg.StatCacheMaxSizeMBUnsetSentinel {
 		if mountConfigStatCacheMaxSizeMB == -1 {
-			statCacheMaxSizeMB = config.MaxSupportedStatCacheMaxSizeMB
+			statCacheMaxSizeMB = cfg.MaxSupportedStatCacheMaxSizeMB
 		} else {
 			statCacheMaxSizeMB = uint64(mountConfigStatCacheMaxSizeMB)
 		}

--- a/internal/mount/flag_test.go
+++ b/internal/mount/flag_test.go
@@ -57,7 +57,7 @@ func (t *FlagTest) TestResolveMetadataCacheTTL() {
 			// Most common scenario, when user doesn't set any of the TTL config parameters.
 			statCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
 			typeCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
-			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
+			ttlInSeconds:             cfg.TtlInSecsUnsetSentinel,
 			expectedMetadataCacheTTL: cfg.DefaultStatOrTypeCacheTTL,
 		},
 		{
@@ -107,28 +107,28 @@ func (t *FlagTest) TestResolveMetadataCacheTTL() {
 			// Old-scenario where user sets only stat/type-cache-ttl flag(s), and not metadata-cache:ttl-secs. Case 1.
 			statCacheTTL:             0,
 			typeCacheTTL:             0,
-			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
+			ttlInSeconds:             cfg.TtlInSecsUnsetSentinel,
 			expectedMetadataCacheTTL: 0,
 		},
 		{
 			// Old-scenario where user sets only stat/type-cache-ttl flag(s), and not metadata-cache:ttl-secs. Case 2. Stat-cache enabled, but not type-cache.
 			statCacheTTL:             time.Hour,
 			typeCacheTTL:             0,
-			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
+			ttlInSeconds:             cfg.TtlInSecsUnsetSentinel,
 			expectedMetadataCacheTTL: 0,
 		},
 		{
 			// Old-scenario where user sets only stat/type-cache-ttl flag(s), and not metadata-cache:ttl-secs. Case 3. Type-cache enabled, but not stat-cache.
 			statCacheTTL:             0,
 			typeCacheTTL:             time.Hour,
-			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
+			ttlInSeconds:             cfg.TtlInSecsUnsetSentinel,
 			expectedMetadataCacheTTL: 0,
 		},
 		{
 			// Old-scenario where user sets only stat/type-cache-ttl flag(s), and not metadata-cache:ttl-secs. Case 4. Both Type-cache and stat-cache enabled. The lower of the two TTLs is taken.
 			statCacheTTL:             time.Second,
 			typeCacheTTL:             time.Minute,
-			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
+			ttlInSeconds:             cfg.TtlInSecsUnsetSentinel,
 			expectedMetadataCacheTTL: time.Second,
 		},
 	}
@@ -151,14 +151,14 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 		{
 			// Most common scenario, when user doesn't set either the flag or the config.
 			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
-			mountConfigStatCacheMaxSizeMB: config.StatCacheMaxSizeMBUnsetSentinel,
+			mountConfigStatCacheMaxSizeMB: cfg.StatCacheMaxSizeMBUnsetSentinel,
 			expectedStatCacheMaxSizeMB:    cfg.DefaultStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to -1.
 			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: -1,
-			expectedStatCacheMaxSizeMB:    config.MaxSupportedStatCacheMaxSizeMB,
+			expectedStatCacheMaxSizeMB:    cfg.MaxSupportedStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to 0.
@@ -175,8 +175,8 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to its highest user-input value.
 			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
-			mountConfigStatCacheMaxSizeMB: int64(config.MaxSupportedStatCacheMaxSizeMB),
-			expectedStatCacheMaxSizeMB:    config.MaxSupportedStatCacheMaxSizeMB,
+			mountConfigStatCacheMaxSizeMB: int64(cfg.MaxSupportedStatCacheMaxSizeMB),
+			expectedStatCacheMaxSizeMB:    cfg.MaxSupportedStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets both stat-cache-capacity and the metadata-cache:stat-cache-max-size-mb. Here stat-cache-max-size-mb overrides stat-cache-capacity. case 1.
@@ -188,7 +188,7 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 			// Scenario where user sets both stat-cache-capacity and the metadata-cache:stat-cache-max-size-mb. Here stat-cache-max-size-mb overrides stat-cache-capacity. case 2.
 			flagStatCacheCapacity:         10000,
 			mountConfigStatCacheMaxSizeMB: -1,
-			expectedStatCacheMaxSizeMB:    config.MaxSupportedStatCacheMaxSizeMB,
+			expectedStatCacheMaxSizeMB:    cfg.MaxSupportedStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets both stat-cache-capacity and the metadata-cache:stat-cache-max-size-mb. Here stat-cache-max-size-mb overrides stat-cache-capacity. case 3.
@@ -199,13 +199,13 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 		{
 			// Old-scenario where user sets only stat-cache-capacity flag(s), and not metadata-cache:stat-cache-max-size-mb. Case 1: stat-cache-capacity is 0.
 			flagStatCacheCapacity:         0,
-			mountConfigStatCacheMaxSizeMB: config.StatCacheMaxSizeMBUnsetSentinel,
+			mountConfigStatCacheMaxSizeMB: cfg.StatCacheMaxSizeMBUnsetSentinel,
 			expectedStatCacheMaxSizeMB:    0,
 		},
 		{
 			// Old-scenario where user sets only stat-cache-capacity flag(s), and not metadata-cache:stat-cache-max-size-mb. Case 2: stat-cache-capacity is non-zero.
 			flagStatCacheCapacity:         10000,
-			mountConfigStatCacheMaxSizeMB: config.StatCacheMaxSizeMBUnsetSentinel,
+			mountConfigStatCacheMaxSizeMB: cfg.StatCacheMaxSizeMBUnsetSentinel,
 			expectedStatCacheMaxSizeMB:    16, // 16 MiB = MiB ceiling (10k entries * 1640 bytes (AssumedSizeOfPositiveStatCacheEntry + AssumedSizeOfNegativeStatCacheEntry))
 		},
 	} {

--- a/internal/mount/flag_test.go
+++ b/internal/mount/flag_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -54,36 +55,36 @@ func (t *FlagTest) TestResolveMetadataCacheTTL() {
 	}{
 		{
 			// Most common scenario, when user doesn't set any of the TTL config parameters.
-			statCacheTTL:             DefaultStatOrTypeCacheTTL,
-			typeCacheTTL:             DefaultStatOrTypeCacheTTL,
+			statCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
+			typeCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
 			ttlInSeconds:             config.TtlInSecsUnsetSentinel,
-			expectedMetadataCacheTTL: DefaultStatOrTypeCacheTTL,
+			expectedMetadataCacheTTL: cfg.DefaultStatOrTypeCacheTTL,
 		},
 		{
 			// Scenario where user sets only metadata-cache:ttl-secs and sets it to -1.
-			statCacheTTL:             DefaultStatOrTypeCacheTTL,
-			typeCacheTTL:             DefaultStatOrTypeCacheTTL,
+			statCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
+			typeCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
 			ttlInSeconds:             -1,
 			expectedMetadataCacheTTL: time.Duration(math.MaxInt64),
 		},
 		{
 			// Scenario where user sets only metadata-cache:ttl-secs and sets it to 0.
-			statCacheTTL:             DefaultStatOrTypeCacheTTL,
-			typeCacheTTL:             DefaultStatOrTypeCacheTTL,
+			statCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
+			typeCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
 			ttlInSeconds:             0,
 			expectedMetadataCacheTTL: 0,
 		},
 		{
 			// Scenario where user sets only metadata-cache:ttl-secs and sets it to a positive value.
-			statCacheTTL:             DefaultStatOrTypeCacheTTL,
-			typeCacheTTL:             DefaultStatOrTypeCacheTTL,
+			statCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
+			typeCacheTTL:             cfg.DefaultStatOrTypeCacheTTL,
 			ttlInSeconds:             30,
 			expectedMetadataCacheTTL: 30 * time.Second,
 		},
 		{
 			// Scenario where user sets only metadata-cache:ttl-secs and sets it to its highest supported value.
-			statCacheTTL: DefaultStatOrTypeCacheTTL,
-			typeCacheTTL: DefaultStatOrTypeCacheTTL,
+			statCacheTTL: cfg.DefaultStatOrTypeCacheTTL,
+			typeCacheTTL: cfg.DefaultStatOrTypeCacheTTL,
 			ttlInSeconds: config.MaxSupportedTtlInSeconds,
 
 			expectedMetadataCacheTTL: time.Second * time.Duration(config.MaxSupportedTtlInSeconds),
@@ -149,31 +150,31 @@ func (t *FlagTest) TestResolveStatCacheMaxSizeMB() {
 	}{
 		{
 			// Most common scenario, when user doesn't set either the flag or the config.
-			flagStatCacheCapacity:         DefaultStatCacheCapacity,
+			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: config.StatCacheMaxSizeMBUnsetSentinel,
-			expectedStatCacheMaxSizeMB:    DefaultStatCacheMaxSizeMB,
+			expectedStatCacheMaxSizeMB:    cfg.DefaultStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to -1.
-			flagStatCacheCapacity:         DefaultStatCacheCapacity,
+			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: -1,
 			expectedStatCacheMaxSizeMB:    config.MaxSupportedStatCacheMaxSizeMB,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to 0.
-			flagStatCacheCapacity:         DefaultStatCacheCapacity,
+			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: 0,
 			expectedStatCacheMaxSizeMB:    0,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to a positive value.
-			flagStatCacheCapacity:         DefaultStatCacheCapacity,
+			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: 100,
 			expectedStatCacheMaxSizeMB:    100,
 		},
 		{
 			// Scenario where user sets only metadata-cache:stat-cache-max-size-mb and sets it to its highest user-input value.
-			flagStatCacheCapacity:         DefaultStatCacheCapacity,
+			flagStatCacheCapacity:         cfg.DefaultStatCacheCapacity,
 			mountConfigStatCacheMaxSizeMB: int64(config.MaxSupportedStatCacheMaxSizeMB),
 			expectedStatCacheMaxSizeMB:    config.MaxSupportedStatCacheMaxSizeMB,
 		},

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -57,7 +57,7 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 
 	// Set up dependencies.
 	const cacheCapacity = 100
-	lruCache := lru.NewCache(mount.AverageSizeOfPositiveStatCacheEntry * cacheCapacity)
+	lruCache := lru.NewCache(cfg.AverageSizeOfPositiveStatCacheEntry * cacheCapacity)
 	cache := metadata.NewStatCacheBucketView(lruCache, "")
 	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName, gcs.NonHierarchical)
 


### PR DESCRIPTION
### Description
Migrate metadata-cache, client-protocol and other constants to new config. Left those constants intact which will likely not be required to moved after the migration to the new config.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
