### PR TITLE
Specify coverpkg to include every package

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,10 +20,10 @@ jobs:
         run: go mod download
 
       - name: Coverage for all except cache tests parallely.
-        run: CGO_ENABLED=0 go test -count 1 -v -covermode=atomic -coverprofile=coverage.out `go list ./... | grep -v internal/cache/...`
+        run: CGO_ENABLED=0 go test -count 1 -v -covermode=atomic -coverprofile=coverage.out -coverpkg=./... `go list ./... | grep -v internal/cache/...`
 
       - name: Coverage  for cache tests
-        run: CGO_ENABLED=0 go test -p 1 -count 1 -v -covermode=atomic -coverprofile=coverage_cache.out ./internal/cache/...
+        run: CGO_ENABLED=0 go test -p 1 -count 1 -v -covermode=atomic -coverprofile=coverage_cache.out -coverpkg=./... ./internal/cache/...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.3.1


### PR DESCRIPTION
Without coverpkg being set, the coverage computed for a given test is limited to its own package alone and doesn't include the code from other packages that were involved. Setting coverpkg to ./... includes that coverage as well.

This is useful in cases like the cfg/ package where the `bindFlags` method is invoked by the tests in cmd/root_test.go package.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
