### PR TITLE
fixing check dependency from listing benchmark script

### DIFF
--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -503,7 +503,7 @@ if __name__ == '__main__':
 
   args = _parse_arguments(argv)
 
-  check_dependencies(['gsutil', 'gcsfuse'])
+  check_dependencies(['gsutil', 'gcsfuse'],log)
 
   with open(os.path.abspath(args.config_file)) as file:
     config_json = json.load(file)


### PR DESCRIPTION
### Description
To fix the check_dependencies function call in the listing benchmark script.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the script manually .
2. Unit tests - NA
3. Integration tests - NA
