### PR TITLE
Don't close file if file-creation returned error

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -49,16 +49,14 @@ func mountWithStorageHandle(
 	if newConfig.FileSystem.TempDir != "" {
 		logger.Infof("Creating a temporary directory at %q\n", newConfig.FileSystem.TempDir)
 		var f *os.File
-		f, err = fsutil.AnonymousFile(string(newConfig.FileSystem.TempDir))
-		f.Close()
-
-		if err != nil {
-			err = fmt.Errorf(
+		if f, err = fsutil.AnonymousFile(string(newConfig.FileSystem.TempDir)); err != nil {
+			return fmt.Errorf(
 				"Error writing to temporary directory (%q); are you sure it exists "+
 					"with the correct permissions?",
 				err.Error())
-			return
+
 		}
+		f.Close()
 	}
 
 	// Find the current process's UID and GID. If it was invoked as root and the


### PR DESCRIPTION
fsutil.AnonymousFile() returns the file-handle as nil if there is an error while creation the file.
So an attempt to close it will result in panic. Fix it.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
