### PR TITLE
[testing-on-gke part 4] Fixes and improvements in the test setup

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -17,6 +17,7 @@
 
 import argparse
 import json, os, pprint, subprocess
+from os.path import dirname
 import sys
 import dlio_workload
 
@@ -42,6 +43,13 @@ record = {
     "lowest_cpu": 0.0,
     "gcsfuse_mount_options": "",
 }
+
+
+def ensureDir(dirpath):
+  try:
+    os.makedirs(dirpath)
+  except FileExistsError:
+    pass
 
 
 def downloadDlioOutputs(dlioWorkloads: set, instanceId: str):
@@ -97,12 +105,16 @@ if __name__ == "__main__":
       help="unique string ID for current test-run",
       required=True,
   )
+  parser.add_argument(
+      "-o",
+      "--output-file",
+      metavar="Output file (CSV) path",
+      help="File path of the output metrics (in CSV format)",
+      default="output.csv",
+  )
   args = parser.parse_args()
 
-  try:
-    os.makedirs(_LOCAL_LOGS_LOCATION)
-  except FileExistsError:
-    pass
+  ensureDir(_LOCAL_LOGS_LOCATION)
 
   dlioWorkloads = dlio_workload.ParseTestConfigForDlioWorkloads(
       args.workload_config
@@ -220,7 +232,9 @@ if __name__ == "__main__":
       "gcsfuse-file-cache",
   ]
 
-  output_file = open("./output.csv", "a")
+  output_file_path = args.output_file
+  ensureDir(os.path.dirname(output_file_path))
+  output_file = open(output_file_path, "a")
   output_file.write(
       "File Size,File #,Total Size (GB),Batch Size,Scenario,Epoch,Duration"
       " (s),GPU Utilization (%),Throughput (sample/s),Throughput"

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -15,13 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# standard library imports
 import argparse
-import json, os, pprint, subprocess
-from os.path import dirname
+import json
+import os
+import pprint
+import subprocess
 import sys
-import dlio_workload
 
+# local library imports
 sys.path.append("../")
+import dlio_workload
 from utils.utils import get_memory, get_cpu, standard_timestamp, is_mash_installed
 
 _LOCAL_LOGS_LOCATION = "../../bin/dlio-logs/logs"

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -34,9 +34,19 @@ def run_command(command: str):
   print(result.stderr)
 
 
-def createHelmInstallCommands(dlioWorkloads: set, instanceId: str):
+DEFAULT_GCSFUSE_MOUNT_OPTIONS = 'implicit-dirs'
+
+
+def createHelmInstallCommands(
+    dlioWorkloads: set,
+    instanceId: str,
+    gcsfuseMountOptions: str,
+    machineType: str,
+):
   """Create helm install commands for the given set of dlioWorkload objects."""
   helm_commands = []
+  if not gcsfuseMountOptions:
+    gcsfuseMountOptions = DEFAULT_GCSFUSE_MOUNT_OPTIONS
   for dlioWorkload in dlioWorkloads:
     for batchSize in dlioWorkload.batchSizes:
       commands = [
@@ -50,6 +60,8 @@ def createHelmInstallCommands(dlioWorkloads: set, instanceId: str):
           f'--set dlio.recordLength={dlioWorkload.recordLength}',
           f'--set dlio.batchSize={batchSize}',
           f'--set instanceId={instanceId}',
+          f'--set gcsfuse.mountOptions={gcsfuseMountOptions}',
+          f'--set nodeType={machineType}',
       ]
 
       helm_command = ' '.join(commands)
@@ -62,7 +74,10 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      dlioWorkloads, args.instance_id
+      dlioWorkloads,
+      args.instance_id,
+      args.gcsfuse_mount_options,
+      args.machine_type,
   )
   for helmInstallCommand in helmInstallCommands:
     print(f'{helmInstallCommand}')
@@ -81,12 +96,27 @@ if __name__ == '__main__':
   )
   parser.add_argument(
       '--workload-config',
+      metavar='JSON workload configuration file path',
       help='Runs DLIO Unet3d tests using this JSON workload configuration.',
       required=True,
   )
   parser.add_argument(
       '--instance-id',
       help='unique string ID for current test-run',
+      required=True,
+  )
+  parser.add_argument(
+      '--gcsfuse-mount-options',
+      metavar='GCSFuse mount options',
+      help=(
+          'GCSFuse mount-options, in JSON stringified format, to be set for the'
+          ' scenario gcsfuse-generic.'
+      ),
+  )
+  parser.add_argument(
+      '--machine-type',
+      metavar='Machine-type of the GCE VM or GKE cluster node',
+      help='Machine-type of the GCE VM or GKE cluster node e.g. n2-standard-32',
       required=True,
   )
   parser.add_argument(

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -37,6 +37,10 @@ def run_command(command: str):
 DEFAULT_GCSFUSE_MOUNT_OPTIONS = 'implicit-dirs'
 
 
+def escapeCommasInString(gcsfuseMountOptions: str) -> str:
+  return gcsfuseMountOptions.replace(',', '\,')
+
+
 def createHelmInstallCommands(
     dlioWorkloads: set,
     instanceId: str,
@@ -60,7 +64,10 @@ def createHelmInstallCommands(
           f'--set dlio.recordLength={dlioWorkload.recordLength}',
           f'--set dlio.batchSize={batchSize}',
           f'--set instanceId={instanceId}',
-          f'--set gcsfuse.mountOptions={gcsfuseMountOptions}',
+          (
+              '--set'
+              f' gcsfuse.mountOptions={escapeCommasInString(gcsfuseMountOptions)}'
+          ),
           f'--set nodeType={machineType}',
       ]
 
@@ -112,6 +119,7 @@ if __name__ == '__main__':
           'GCSFuse mount-options, in JSON stringified format, to be set for the'
           ' scenario gcsfuse-generic.'
       ),
+      required=True,
   )
   parser.add_argument(
       '--machine-type',

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -27,6 +27,10 @@ import subprocess
 import dlio_workload
 
 
+# The default value of gcsfuse-mount-options to be used
+# for "gcsfuse-generic" scenario.
+# For description of how to specify the value for this,
+# look at the description of the argparser argument for gcsfuse-mount-options.
 _DEFAULT_GCSFUSE_MOUNT_OPTIONS = 'implicit-dirs'
 
 
@@ -47,8 +51,8 @@ def createHelmInstallCommands(
     instanceId: str,
     gcsfuseMountOptions: str,
     machineType: str,
-):
-  """Create helm install commands for the given dlioWorkload objects."""
+) -> list:
+  """Creates helm install commands for the given dlioWorkload objects."""
   helm_commands = []
   if not gcsfuseMountOptions:
     gcsfuseMountOptions = _DEFAULT_GCSFUSE_MOUNT_OPTIONS
@@ -105,7 +109,7 @@ if __name__ == '__main__':
   parser.add_argument(
       '--workload-config',
       metavar='JSON workload configuration file path',
-      help='Runs DLIO Unet3d tests using this JSON workload configuration.',
+      help='Runs DLIO Unet3d tests from this JSON workload configuration file.',
       required=True,
   )
   parser.add_argument(
@@ -121,8 +125,14 @@ if __name__ == '__main__':
       '--gcsfuse-mount-options',
       metavar='GCSFuse mount options',
       help=(
-          'GCSFuse mount-options, in JSON stringified format, to be set for the'
-          ' scenario gcsfuse-generic.'
+          'GCSFuse mount-options, in a compact stringified'
+          ' format, to be set for the '
+          ' scenario "gcsfuse-generic". The individual config/cli flag values'
+          ' should be separated by comma. Each cli flag should be of the form'
+          ' "<name>[=<value>]". Each config-file flag should be of form'
+          ' "<config>[:<subconfig>[:<subsubconfig>[...]]]:<value>". For'
+          ' example, a sample value would be:'
+          ' "implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:-1".'
       ),
       required=False,
   )
@@ -143,9 +153,19 @@ if __name__ == '__main__':
   )
 
   args = parser.parse_args()
-  if ' ' in args.instance_id:
-    raise Exception('Argument --instance-id contains space in it')
-  if len(args.machine_type) == 0 or str.isspace(args.machine_type):
-    raise Exception('Argument --machine-type is empty or only spaces')
+  for argument in ['instance_id', 'gcsfuse_mount_options', 'machine_type']:
+    value = getattr(args, argument)
+    if ' ' in value:
+      raise Exception(
+          f'Argument {argument} (value="{value}") contains space in it, which'
+          ' is not supported.'
+      )
+  for argument in ['machine_type', 'instance_id']:
+    value = getattr(args, argument)
+    if len(value) == 0 or str.isspace(value):
+      raise Exception(
+          f'Argument {argument} (value="{value}") is empty or contains only'
+          ' spaces.'
+      )
 
   main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -17,6 +17,7 @@
 
 import argparse
 import json, os, pprint, subprocess
+from os.path import dirname
 import sys
 import fio_workload
 
@@ -46,15 +47,19 @@ record = {
 }
 
 
+def ensureDir(dirpath):
+  try:
+    os.makedirs(dirpath)
+  except FileExistsError:
+    pass
+
+
 def downloadFioOutputs(fioWorkloads: set, instanceId: str):
   for fioWorkload in fioWorkloads:
     dstDir = (
         _LOCAL_LOGS_LOCATION + "/" + instanceId + "/" + fioWorkload.fileSize
     )
-    try:
-      os.makedirs(dstDir)
-    except FileExistsError:
-      pass
+    ensureDir(dstDir)
 
     print(f"Downloading FIO outputs from {fioWorkload.bucket}...")
     result = subprocess.run(
@@ -107,12 +112,16 @@ if __name__ == "__main__":
       help="unique string ID for current test-run",
       required=True,
   )
+  parser.add_argument(
+      "-o",
+      "--output-file",
+      metavar="Output file (CSV) path",
+      help="File path of the output metrics (in CSV format)",
+      default="output.csv",
+  )
   args = parser.parse_args()
 
-  try:
-    os.makedirs(_LOCAL_LOGS_LOCATION)
-  except FileExistsError:
-    pass
+  ensureDir(_LOCAL_LOGS_LOCATION)
 
   fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
       args.workload_config
@@ -247,7 +256,9 @@ if __name__ == "__main__":
       "gcsfuse-file-cache",
   ]
 
-  output_file = open("./output.csv", "a")
+  output_file_path = args.output_file
+  ensureDir(os.path.dirname(output_file_path))
+  output_file = open(output_file_path, "a")
   output_file.write(
       "File Size,Read Type,Scenario,Epoch,Duration"
       " (s),Throughput (MB/s),IOPS,Throughput over Local SSD (%),GCSFuse Lowest"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -15,14 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# standard library imports
 import argparse
-import json, os, pprint, subprocess
-from os.path import dirname
+import json
+import os
+import pprint
+import subprocess
 import sys
-import fio_workload
 
+# local library imports
 sys.path.append("../")
-from utils.utils import get_memory, get_cpu, unix_to_timestamp, is_mash_installed
+import fio_workload
+from utils.utils import get_memory, get_cpu, standard_timestamp, is_mash_installed
 
 _LOCAL_LOGS_LOCATION = "../../bin/fio-logs"
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -36,6 +36,10 @@ def run_command(command: str):
 DEFAULT_GCSFUSE_MOUNT_OPTIONS = 'implicit-dirs'
 
 
+def escapeCommasInString(gcsfuseMountOptions: str) -> str:
+  return gcsfuseMountOptions.replace(',', '\,')
+
+
 def createHelmInstallCommands(
     fioWorkloads: set,
     instanceId: str,
@@ -61,7 +65,10 @@ def createHelmInstallCommands(
           f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
           f'--set fio.numThreads={fioWorkload.numThreads}',
           f'--set instanceId={instanceId}',
-          f'--set gcsfuse.mountOptions={gcsfuseMountOptions}',
+          (
+              '--set'
+              f' gcsfuse.mountOptions={escapeCommasInString(gcsfuseMountOptions)}'
+          ),
           f'--set nodeType={machineType}',
       ]
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -26,6 +26,10 @@ import subprocess
 import fio_workload
 
 
+# The default value of gcsfuse-mount-options to be used
+# for "gcsfuse-generic" scenario.
+# For description of how to specify the value for this,
+# look at the description of the argparser argument for gcsfuse-mount-options.
 _DEFAULT_GCSFUSE_MOUNT_OPTIONS = 'implicit-dirs'
 
 
@@ -106,7 +110,7 @@ if __name__ == '__main__':
   parser.add_argument(
       '--workload-config',
       metavar='JSON workload configuration file path',
-      help='Runs FIO tests using this JSON workload configuration',
+      help='Runs FIO tests from this JSON workload configuration file.',
       required=True,
   )
   parser.add_argument(
@@ -122,8 +126,14 @@ if __name__ == '__main__':
       '--gcsfuse-mount-options',
       metavar='GCSFuse mount options',
       help=(
-          'GCSFuse mount-options, in JSON stringified format, to be set for the'
-          ' scenario gcsfuse-generic.'
+          'GCSFuse mount-options, in a compact stringified'
+          ' format, to be set for the '
+          ' scenario "gcsfuse-generic". The individual config/cli flag values'
+          ' should be separated by comma. Each cli flag should be of the form'
+          ' "<name>[=<value>]". Each config-file flag should be of form'
+          ' "<config>[:<subconfig>[:<subsubconfig>[...]]]:<value>". For'
+          ' example, a sample value would be:'
+          ' "implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:-1".'
       ),
       required=False,
   )
@@ -144,9 +154,19 @@ if __name__ == '__main__':
   )
 
   args = parser.parse_args()
-  if ' ' in args.instance_id:
-    raise Exception('Argument --instance-id contains space in it')
-  if len(args.machine_type) == 0 or str.isspace(args.machine_type):
-    raise Exception('Argument --machine-type is empty or only spaces')
+  for argument in ['instance_id', 'gcsfuse_mount_options', 'machine_type']:
+    value = getattr(args, argument)
+    if ' ' in value:
+      raise Exception(
+          f'Argument {argument} (value="{value}") contains space in it, which'
+          ' is not supported.'
+      )
+  for argument in ['machine_type', 'instance_id']:
+    value = getattr(args, argument)
+    if len(value) == 0 or str.isspace(value):
+      raise Exception(
+          f'Argument {argument} (value="{value}") is empty or contains only'
+          ' spaces.'
+      )
 
   main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -445,12 +445,12 @@ function deleteAllPods() {
 
 function deployAllFioHelmCharts() {
   echo "Deploying all fio helm charts ..."
-  cd "${gke_testing_dir}"/examples/fio && python3 ./run_tests.py --workload-config "${gke_testing_dir}"/examples/workloads.json --instance-id ${instance_id} && cd -
+  cd "${gke_testing_dir}"/examples/fio && python3 ./run_tests.py --workload-config "${gke_testing_dir}"/examples/workloads.json --instance-id ${instance_id} --gcsfuse-mount-options="${gcsfuse_mount_options}" --machine-type="${machine_type}" && cd -
 }
 
 function deployAllDlioHelmCharts() {
   echo "Deploying all dlio helm charts ..."
-  cd "${gke_testing_dir}"/examples/dlio && python3 ./run_tests.py --workload-config "${gke_testing_dir}"/examples/workloads.json --instance-id ${instance_id} && cd -
+  cd "${gke_testing_dir}"/examples/dlio && python3 ./run_tests.py --workload-config "${gke_testing_dir}"/examples/workloads.json --instance-id ${instance_id} --gcsfuse-mount-options="${gcsfuse_mount_options}" --machine-type="${machine_type}" && cd -
 }
 
 function listAllHelmCharts() {

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -498,6 +498,8 @@ function waitTillAllPodsComplete() {
       break
     else
       printf "There are still "${num_noncompleted_pods}" pod(s) incomplete (either still pending or running). So, sleeping for now... will check again in "${pod_wait_time_in_seconds}" seconds.\n\n"
+      printf "To ssh to any specific pod, use the following command: \n"
+      printf "     kubectl exec -it pods/<podname> -- /bin/bash \n\n"
     fi
     sleep ${pod_wait_time_in_seconds}
     unset podslist # necessary to update the value of podslist every iteration

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -490,32 +490,6 @@ function waitTillAllPodsComplete() {
   done
 }
 
-function updateMachineTypeInPodConfigs() {
-  local file="${1}"
-  sed -i -E "s/nodeType: [0-9a-z_-]+$/nodeType: ${machine_type}/g" "${file}"
-}
-
-function updateGcsfuseMountOptionsInPodConfigs() {
-  local file="${1}"
-  sed -i -E "s/mountOptions:[ \t]*\"?[a-zA-Z0-9,:_-]+\"? *$/mountOptions: \"${gcsfuse_mount_options}\"/g" "${file}"
-}
-
-function updatePodConfigs() {
-  echo "Updating pod configs according to workloads ..."
-  for file in "${gke_testing_dir}"/examples/fio/loading-test/values.yaml "${gke_testing_dir}"/examples/dlio/unet3d-loading-test/values.yaml; do
-    test -f "${file}"
-    cp -fv "${file}" "${file}.bak"
-    updateMachineTypeInPodConfigs "${file}"
-    updateGcsfuseMountOptionsInPodConfigs "${file}"
-  done
-}
-
-function revertPodConfigsFilesAfterTestRuns() {
-  echo "Reverting pod configs according to workloads ..."
-  for file in "${gke_testing_dir}"/examples/fio/loading-test/values.yaml "${gke_testing_dir}"/examples/dlio/unet3d-loading-test/values.yaml; do
-    ! test -f "${file}.bak" || mv -v "${file}.bak" "${file}"
-  done
-}
 
 function fetchAndParseFioOutputs() {
   echo "Fetching and parsing fio outputs ..."
@@ -554,10 +528,8 @@ createCustomCsiDriverIfNeeded
 
 # Run latest workload configuration
 deleteAllPods
-updatePodConfigs
 deployAllFioHelmCharts
 deployAllDlioHelmCharts
-revertPodConfigsFilesAfterTestRuns
 
 # monitor pods
 listAllHelmCharts

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -353,12 +353,13 @@ function ensureRequiredNodePoolConfiguration() {
 }
 
 function enableManagedCsiDriverIfNeeded() {
-  echo "Enabling/disabling csi add-on ..."
   if ${use_custom_csi_driver}; then
+    echo "Disabling csi add-on ..."
     gcloud -q container clusters update ${cluster_name} \
     --update-addons GcsFuseCsiDriver=DISABLED \
     --location=${zone}
   else
+    echo "Enabling csi add-on ..."
     gcloud -q container clusters update ${cluster_name} \
       --update-addons GcsFuseCsiDriver=ENABLED \
       --location=${zone}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -61,8 +61,10 @@ readonly gcsfuse_branch=garnitin/add-gke-load-testing/v1
 readonly DEFAULT_GCSFUSE_MOUNT_OPTIONS="implicit-dirs"
 # Test runtime configuration
 readonly DEFAULT_INSTANCE_ID=${USER}-$(date +%Y%m%d-%H%M%S)
+# 5 minutes
 readonly DEFAULT_POD_WAIT_TIME_IN_SECONDS=300
-readonly DEFAULT_POD_TIMEOUT_IN_SECONDS=3600
+# 1 week
+readonly DEFAULT_POD_TIMEOUT_IN_SECONDS=604800
 
 function printHelp() {
   echo "Usage guide: "

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -380,10 +380,9 @@ function ensureGcsfuseCode() {
   echo "Ensuring we have gcsfuse code ..."
   # clone gcsfuse code if needed
   if ! test -d "${gcsfuse_src_dir}"; then
-    cd $(dirname "${gcsfuse_src_dir}") && git clone ${gcsfuse_github_path} && cd -
+    cd $(dirname "${gcsfuse_src_dir}") && git clone ${gcsfuse_github_path} && cd "${gcsfuse_src_dir}" && git switch ${gcsfuse_branch} && cd - && cd -
   fi
 
-  cd "${gcsfuse_src_dir}" && git switch ${gcsfuse_branch} && cd -
   test -d "${gke_testing_dir}" || (echo "${gke_testing_dir} does not exist" && exit 1)
 }
 
@@ -391,10 +390,8 @@ function ensureGcsFuseCsiDriverCode() {
   echo "Ensuring we have gcs-fuse-csi-driver code ..."
   # clone csi-driver code if needed
   if ! test -d "${csi_src_dir}"; then
-    cd $(dirname "${csi_src_dir}") && git clone ${csi_driver_github_path} && cd -
+    cd $(dirname "${csi_src_dir}") && git clone ${csi_driver_github_path} && cd "${csi_src_dir}" && git switch ${csi_driver_branch} && cd - && cd -
   fi
-
-  cd "${csi_src_dir}" && git switch ${csi_driver_branch} && cd -
 }
 
 function createCustomCsiDriverIfNeeded() {

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -117,8 +117,10 @@ test -n "${node_pool}" || export node_pool=${DEFAULT_NODE_POOL}
 test -n "${machine_type}" || export machine_type=${DEFAULT_MACHINE_TYPE}
 test -n "${num_nodes}" || export num_nodes=${DEFAULT_NUM_NODES}
 test -n "${num_ssd}" || export num_ssd=${DEFAULT_NUM_SSD}
-test -n "${appnamespace}" || export appnamespace=${DEFAULT_APPNAMESPACE}
-test -n "${ksa}" || export ksa=${DEFAULT_KSA}
+# test -n "${appnamespace}" ||
+export appnamespace=${DEFAULT_APPNAMESPACE}
+# test -n "${ksa}" ||
+export ksa=${DEFAULT_KSA}
 test -n "${use_custom_csi_driver}" || export use_custom_csi_driver="${DEFAULT_USE_CUSTOM_CSI_DRIVER}"
 # GCSFuse/GKE GCSFuse CSI Driver source code related
 (test -n "${src_dir}" && src_dir="$(realpath "${src_dir}")") || export src_dir=${DEFAULT_SRC_DIR}
@@ -451,14 +453,14 @@ function createCustomCsiDriverIfNeeded() {
 
 function deleteAllHelmCharts() {
   echo "Deleting all existing helm charts ..."
-  helm ls | tr -s '\t' ' ' | cut -d' ' -f1 | tail -n +2 | while read helmchart; do helm uninstall ${helmchart}; done
+  helm ls --namespace=${appnamespace} | tr -s '\t' ' ' | cut -d' ' -f1 | tail -n +2 | while read helmchart; do helm uninstall ${helmchart} --namespace=${appnamespace}; done
 }
 
 function deleteAllPods() {
   deleteAllHelmCharts
 
   echo "Deleting all existing pods ..."
-  kubectl get pods | tail -n +2 | cut -d' ' -f1 | while read podname; do kubectl delete pods/${podname} --grace-period=0 --force || true; done
+  kubectl get pods --namespace=${appnamespace}  | tail -n +2 | cut -d' ' -f1 | while read podname; do kubectl delete pods/${podname} --namespace=${appnamespace} --grace-period=0 --force || true; done
 }
 
 function deployAllFioHelmCharts() {
@@ -474,7 +476,7 @@ function deployAllDlioHelmCharts() {
 function listAllHelmCharts() {
   echo "Listing all helm charts ..."
   # monitor and debug pods
-  helm ls | tr -s '\t' | cut -f1,5,6
+  helm ls --namespace=${appnamespace}  | tr -s '\t' | cut -f1,5,6
 
   # Sample output.
   # NAME STATUS CHART \
@@ -486,7 +488,7 @@ function waitTillAllPodsComplete() {
   echo "Scanning and waiting till all pods either complete or fail ..."
   while true; do
     printf "Checking pods status at "$(date +%s)":\n-----------------------------------\n"
-    podslist="$(kubectl get pods)"
+    podslist="$(kubectl get pods --namespace=${appnamespace} )"
     echo "${podslist}"
     num_completed_pods=$(echo "${podslist}" | tail -n +2 | grep -i 'completed\|succeeded' | wc -l)
     if [ ${num_completed_pods} -gt 0 ]; then
@@ -503,7 +505,7 @@ function waitTillAllPodsComplete() {
     else
       printf "There are still "${num_noncompleted_pods}" pod(s) incomplete (either still pending or running). So, sleeping for now... will check again in "${pod_wait_time_in_seconds}" seconds.\n\n"
       printf "To ssh to any specific pod, use the following command: \n"
-      printf "     kubectl exec -it pods/<podname> -- /bin/bash \n\n"
+      printf "  kubectl exec -it pods/<podname> --namespace=${appnamespace} -- /bin/bash \n\n"
     fi
     sleep ${pod_wait_time_in_seconds}
     unset podslist # necessary to update the value of podslist every iteration

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -52,7 +52,7 @@ readonly DEFAULT_APPNAMESPACE=default
 readonly DEFAULT_KSA=default
 readonly DEFAULT_USE_CUSTOM_CSI_DRIVER=false
 # GCSFuse/GKE GCSFuse CSI Driver source code related
-readonly DEFAULT_SRC_DIR=$(realpath .)/src
+readonly DEFAULT_SRC_DIR="$(realpath .)/src"
 readonly csi_driver_github_path=https://github.com/googlecloudplatform/gcs-fuse-csi-driver
 readonly csi_driver_branch=main
 readonly gcsfuse_github_path=https://github.com/googlecloudplatform/gcsfuse
@@ -121,26 +121,28 @@ test -n "${appnamespace}" || export appnamespace=${DEFAULT_APPNAMESPACE}
 test -n "${ksa}" || export ksa=${DEFAULT_KSA}
 test -n "${use_custom_csi_driver}" || export use_custom_csi_driver="${DEFAULT_USE_CUSTOM_CSI_DRIVER}"
 # GCSFuse/GKE GCSFuse CSI Driver source code related
-test -n "${src_dir}" || export src_dir=${DEFAULT_SRC_DIR}
+(test -n "${src_dir}" && src_dir="$(realpath "${src_dir}")") || export src_dir=${DEFAULT_SRC_DIR}
 test -d "${src_dir}" || mkdir -pv "${src_dir}"
-test -n "${gcsfuse_src_dir}" || export gcsfuse_src_dir="${src_dir}"/gcsfuse
+(test -n "${gcsfuse_src_dir}" && gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")") || export gcsfuse_src_dir="${src_dir}"/gcsfuse
 export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
-test -n "${csi_src_dir}" || export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
+(test -n "${csi_src_dir}" && csi_src_dir="$(realpath "${csi_src_dir}")") || export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
 # GCSFuse configuration related
 test -n "${gcsfuse_mount_options}" || export gcsfuse_mount_options="${DEFAULT_GCSFUSE_MOUNT_OPTIONS}"
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${instance_id}" || export instance_id="${DEFAULT_INSTANCE_ID}"
 if test -n "${workload_config}"; then
-  test -f "${workload_config}"
+  workload_config="$(realpath "${workload_config}")"
 else
     export workload_config="${gke_testing_dir}"/examples/workloads.json
 fi
+test -f "${workload_config}"
 if test -n "${output_dir}"; then
-  test -d "${output_dir}"
+  output_dir="$(realpath "${output_dir}")"
 else
   export output_dir="${gke_testing_dir}"/examples
 fi
+test -d "${output_dir}"
 
 function printRunParameters() {
   echo "Running $0 with following parameters:"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -90,6 +90,7 @@ function printHelp() {
   echo "pod_wait_time_in_seconds=<number e.g. 60 for checking pod status every 1 min, default=\"${DEFAULT_POD_WAIT_TIME_IN_SECONDS}\">"
   echo "instance_id=<string, not containing spaces, representing unique id for particular test-run e.g. \"${DEFAULT_INSTANCE_ID}\""
   echo "workload_config=<path/to/workload/configuration/file e.g. /a/b/c.json >"
+  echo "output_dir=</absolute/path/to/output/dir, output files will be written at output_dir/fio/output.csv and output_dir/dlio/output.csv>"
   echo ""
   echo ""
   echo ""
@@ -135,6 +136,11 @@ if test -n "${workload_config}"; then
 else
     export workload_config="${gke_testing_dir}"/examples/workloads.json
 fi
+if test -n "${output_dir}"; then
+  test -d "${output_dir}"
+else
+  export output_dir="${gke_testing_dir}"/examples
+fi
 
 function printRunParameters() {
   echo "Running $0 with following parameters:"
@@ -163,6 +169,7 @@ function printRunParameters() {
   echo "pod_wait_time_in_seconds=\"${pod_wait_time_in_seconds}\""
   echo "instance_id=\"${instance_id}\""
   echo "workload_config=\"${workload_config}\""
+  echo "output_dir=\"${output_dir}\""
   echo ""
   echo ""
   echo ""
@@ -501,14 +508,14 @@ function waitTillAllPodsComplete() {
 function fetchAndParseFioOutputs() {
   echo "Fetching and parsing fio outputs ..."
   cd "${gke_testing_dir}"/examples/fio
-  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --instance-id ${instance_id}
+  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --instance-id ${instance_id} --output-file "${output_dir}"/fio/output.csv
   cd -
 }
 
 function fetchAndParseDlioOutputs() {
   echo "Fetching and parsing dlio outputs ..."
   cd "${gke_testing_dir}"/examples/dlio
-  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --instance-id ${instance_id}
+  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --instance-id ${instance_id} --output-file "${output_dir}"/dlio/output.csv
   cd -
 }
 

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -435,6 +435,7 @@ function createCustomCsiDriverIfNeeded() {
 
     echo "Installing custom CSI driver ..."
     # Build and install csi driver
+    ensureGcsFuseCsiDriverCode
     cd "${csi_src_dir}"
     make uninstall || true
     make build-image-and-push-multi-arch REGISTRY=gcr.io/${project_id}/${USER} GCSFUSE_PATH=gs://${package_bucket}
@@ -508,7 +509,6 @@ function waitTillAllPodsComplete() {
   done
 }
 
-
 function fetchAndParseFioOutputs() {
   echo "Fetching and parsing fio outputs ..."
   cd "${gke_testing_dir}"/examples/fio
@@ -536,9 +536,8 @@ enableManagedCsiDriverIfNeeded
 activateCluster
 createKubernetesServiceAccountForCluster
 
-# GCSFuse/CSI driver source code
+# GCSFuse driver source code
 ensureGcsfuseCode
-ensureGcsFuseCsiDriverCode
 
 # GCP/GKE configuration dependent on GCSFuse/CSI driver source code
 addGCSAccessPermissions
@@ -555,6 +554,5 @@ waitTillAllPodsComplete
 
 # clean-up after run
 deleteAllPods
-deleteAllHelmCharts
 fetchAndParseFioOutputs
 fetchAndParseDlioOutputs


### PR DESCRIPTION
### Description
1. This removes dependence on user having to pass absolute paths for arguments in the run-script.
2. Passes gcsfuse-mount-options, machine-type from run-script down to the python run script for better programmability rather than manipulating pod configs using SED.
3. Uses kubectl namespace properly in the run-script.
4. Makes output file/dir configurable.
5. Added overall timeout on pod runs.

This is on top of https://github.com/GoogleCloudPlatform/gcsfuse/pull/2359 (and #2319) .

This is followed up in https://github.com/GoogleCloudPlatform/gcsfuse/pull/2348 . 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
6. Unit tests - NA
7. Integration tests - NA
