### PR TITLE
[CLI Config Parity] migrate sequential read size mb flag and test GCS Connection configs

### DIFF
--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -33,3 +33,8 @@ const (
 	// ExperimentalMetadataPrefetchOnMountAsynchronous is the prefetch-mode where mounting is marked complete once prefetch has started.
 	ExperimentalMetadataPrefetchOnMountAsynchronous = "async"
 )
+
+const (
+	// MaxSequentialReadSizeMb is the max value supported by sequential-read-size-mb flag.
+	MaxSequentialReadSizeMB = 1024
+)

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -35,6 +35,6 @@ const (
 )
 
 const (
-	// MaxSequentialReadSizeMb is the max value supported by sequential-read-size-mb flag.
-	MaxSequentialReadSizeMB = 1024
+	// maxSequentialReadSizeMb is the max value supported by sequential-read-size-mb flag.
+	maxSequentialReadSizeMB = 1024
 )

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -73,7 +73,7 @@ func IsValidExperimentalMetadataPrefetchOnMount(mode string) error {
 }
 
 func isValidSequentialReadSizeMB(size int64) error {
-	if sequentialReadSizeMB < 1 || sequentialReadSizeMB > maxSequentialReadSizeMB {
+	if size < 1 || size > maxSequentialReadSizeMB {
 		return fmt.Errorf("sequential-read-size-mb should be between 1 and %d", maxSequentialReadSizeMB)
 	}
 	return nil

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -72,7 +72,7 @@ func IsValidExperimentalMetadataPrefetchOnMount(mode string) error {
 	}
 }
 
-func isValidSequentialReadSizeMB(sequentialReadSizeMB int64) error {
+func isValidSequentialReadSizeMB(size int64) error {
 	if sequentialReadSizeMB < 1 || sequentialReadSizeMB > maxSequentialReadSizeMB {
 		return fmt.Errorf("sequential-read-size-mb should be between 1 and %d", maxSequentialReadSizeMB)
 	}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -73,8 +73,8 @@ func IsValidExperimentalMetadataPrefetchOnMount(mode string) error {
 }
 
 func isValidSequentialReadSizeMB(sequentialReadSizeMB int64) error {
-	if sequentialReadSizeMB < 1 || sequentialReadSizeMB > MaxSequentialReadSizeMB {
-		return fmt.Errorf("SequentialReadSizeMb should be between 1 than %d", MaxSequentialReadSizeMB)
+	if sequentialReadSizeMB < 1 || sequentialReadSizeMB > maxSequentialReadSizeMB {
+		return fmt.Errorf("sequential-read-size-mb should be between 1 and %d", maxSequentialReadSizeMB)
 	}
 	return nil
 }
@@ -104,7 +104,7 @@ func ValidateConfig(config *Config) error {
 	}
 
 	if err = isValidSequentialReadSizeMB(config.GcsConnection.SequentialReadSizeMb); err != nil {
-		return fmt.Errorf("error parsing token-url config: %w", err)
+		return fmt.Errorf("error parsing gcs-connection config: %w", err)
 	}
 
 	return nil

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -72,6 +72,13 @@ func IsValidExperimentalMetadataPrefetchOnMount(mode string) error {
 	}
 }
 
+func isValidSequentialReadSizeMB(sequentialReadSizeMB int64) error {
+	if sequentialReadSizeMB < 1 || sequentialReadSizeMB > MaxSequentialReadSizeMB {
+		return fmt.Errorf("SequentialReadSizeMb should be between 1 than %d", MaxSequentialReadSizeMB)
+	}
+	return nil
+}
+
 // ValidateConfig returns a non-nil error if the config is invalid.
 func ValidateConfig(config *Config) error {
 	var err error
@@ -93,6 +100,10 @@ func ValidateConfig(config *Config) error {
 	}
 
 	if err = isValidURL(config.GcsAuth.TokenUrl); err != nil {
+		return fmt.Errorf("error parsing token-url config: %w", err)
+	}
+
+	if err = isValidSequentialReadSizeMB(config.GcsConnection.SequentialReadSizeMb); err != nil {
 		return fmt.Errorf("error parsing token-url config: %w", err)
 	}
 

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -211,7 +211,7 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 			},
 		},
 		{
-			name: "Sequential read size MB more than 1024 (max permissible value)",
+			name: "Sequential read size MB less than 1 (min permissible value)",
 			config: &Config{
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
 				FileCache: validFileCacheConfig(t),

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -52,7 +52,8 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
 				FileCache: validFileCacheConfig(t),
 				GcsConnection: GcsConnectionConfig{
-					CustomEndpoint: "https://bing.com/search?q=dotnet",
+					CustomEndpoint:       "https://bing.com/search?q=dotnet",
+					SequentialReadSizeMb: 200,
 				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "disabled",
@@ -65,7 +66,8 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
 				FileCache: validFileCacheConfig(t),
 				GcsConnection: GcsConnectionConfig{
-					CustomEndpoint: "https://j@ne:password@google.com",
+					CustomEndpoint:       "https://j@ne:password@google.com",
+					SequentialReadSizeMb: 200,
 				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "disabled",
@@ -80,6 +82,9 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "disabled",
 				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
 			},
 		},
 		{
@@ -90,6 +95,9 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "async",
 				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
 			},
 		},
 		{
@@ -97,6 +105,22 @@ func TestValidateConfigSuccessful(t *testing.T) {
 			config: &Config{
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
 				FileCache: validFileCacheConfig(t),
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
+			},
+		},
+		{
+			name: "Valid Sequential read size MB",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 10,
+				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "sync",
 				},
@@ -126,6 +150,9 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				GcsConnection: GcsConnectionConfig{
 					CustomEndpoint: "a_b://abc",
 				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
 			},
 		},
 		{
@@ -144,6 +171,35 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				FileCache: validFileCacheConfig(t),
 				GcsAuth: GcsAuthConfig{
 					TokenUrl: "a_b://abc",
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+			},
+		},
+		{
+			name: "Sequential read size MB more than 1024 (max permissible value)",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 2048,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+			},
+		},
+		{
+			name: "Sequential read size MB more than 1024 (max permissible value)",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 0,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
 				},
 			},
 		},

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -126,6 +126,19 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Valid Sequential read size MB",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 10,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -148,7 +161,8 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
 				FileCache: validFileCacheConfig(t),
 				GcsConnection: GcsConnectionConfig{
-					CustomEndpoint: "a_b://abc",
+					CustomEndpoint:       "a_b://abc",
+					SequentialReadSizeMb: 200,
 				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "sync",
@@ -162,6 +176,9 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "a",
 				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
 			},
 		},
 		{
@@ -174,6 +191,9 @@ func TestValidateConfigUnsuccessful(t *testing.T) {
 				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
 				},
 			},
 		},

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/stretchr/testify/assert"
@@ -340,6 +341,63 @@ func TestValidateConfigFile_GCSAuthConfigSuccessful(t *testing.T) {
 
 			if assert.NoError(t, err) {
 				assert.EqualValues(t, tc.expectedConfig.GcsAuth, gotConfig.GcsAuth)
+			}
+		})
+	}
+}
+
+func TestValidateConfigFile_GCSConnectionConfigSuccessful(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configFile     string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name:       "Empty config file [default values].",
+			configFile: "testdata/empty_file.yaml",
+			expectedConfig: &cfg.Config{
+				GcsConnection: cfg.GcsConnectionConfig{
+					BillingProject:             "",
+					ClientProtocol:             "http1",
+					CustomEndpoint:             "",
+					ExperimentalEnableJsonRead: false,
+					GrpcConnPoolSize:           1,
+					HttpClientTimeout:          0,
+					LimitBytesPerSec:           -1,
+					LimitOpsPerSec:             -1,
+					MaxConnsPerHost:            0,
+					MaxIdleConnsPerHost:        100,
+					SequentialReadSizeMb:       200,
+				},
+			},
+		},
+		{
+			name:       "Valid config file.",
+			configFile: "testdata/valid_config.yaml",
+			expectedConfig: &cfg.Config{
+				GcsConnection: cfg.GcsConnectionConfig{
+					BillingProject:             "abc",
+					ClientProtocol:             "http2",
+					CustomEndpoint:             "www.abc.com",
+					ExperimentalEnableJsonRead: true,
+					GrpcConnPoolSize:           200,
+					HttpClientTimeout:          400 * time.Second,
+					LimitBytesPerSec:           20,
+					LimitOpsPerSec:             30,
+					MaxConnsPerHost:            400,
+					MaxIdleConnsPerHost:        20,
+					SequentialReadSizeMb:       450,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConfig, err := getConfigObjectWithConfigFile(t, tc.configFile)
+
+			if assert.NoError(t, err) {
+				assert.EqualValues(t, tc.expectedConfig.GcsConnection, gotConfig.GcsConnection)
 			}
 		})
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -31,11 +31,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Defines the max value supported by sequential-read-size-mb flag.
 const (
-	// maxSequentialReadSizeMb is the max value supported by sequential-read-size-mb flag.
-	maxSequentialReadSizeMb = 1024
-
 	// ExperimentalMetadataPrefetchOnMountFlag is the name of the commandline flag for enabling
 	// metadata-prefetch mode aka 'ls -R' during mount.
 	ExperimentalMetadataPrefetchOnMountFlag = "experimental-metadata-prefetch-on-mount"
@@ -456,7 +452,8 @@ type flagStorage struct {
 	EgressBandwidthLimitBytesPerSecond float64
 
 	// Deprecated: Use the param from cfg/config.go
-	OpRateLimitHz        float64
+	OpRateLimitHz float64
+	// Deprecated: Use the param from cfg/config.go
 	SequentialReadSizeMb int32
 	// Deprecated: Use the param from cfg/config.go
 	AnonymousAccess bool
@@ -670,10 +667,6 @@ func populateFlags(c *cli.Context) (flags *flagStorage, err error) {
 }
 
 func validateFlags(flags *flagStorage) (err error) {
-	if flags.SequentialReadSizeMb < 1 || flags.SequentialReadSizeMb > maxSequentialReadSizeMb {
-		return fmt.Errorf("SequentialReadSizeMb should be less than %d", maxSequentialReadSizeMb)
-	}
-
 	if err = config.IsTtlInSecsValid(flags.KernelListCacheTtlSeconds); err != nil {
 		return fmt.Errorf("kernelListCacheTtlSeconds: %w", err)
 	}

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -298,41 +298,6 @@ func (t *FlagsTest) TestResolvePathForTheFlagsInContext() {
 	assert.Equal(t.T(), nil, err)
 }
 
-func (t *FlagsTest) TestValidateFlagsForZeroSequentialReadSize() {
-	flags := &flagStorage{
-		SequentialReadSizeMb:                0,
-		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
-	}
-
-	err := validateFlags(flags)
-
-	assert.NotEqual(t.T(), nil, err)
-	assert.Equal(t.T(), "SequentialReadSizeMb should be less than 1024", err.Error())
-}
-
-func (t *FlagsTest) TestValidateFlagsForSequentialReadSizeGreaterThan1024() {
-	flags := &flagStorage{
-		SequentialReadSizeMb:                2048,
-		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
-	}
-
-	err := validateFlags(flags)
-
-	assert.NotEqual(t.T(), nil, err)
-	assert.Equal(t.T(), "SequentialReadSizeMb should be less than 1024", err.Error())
-}
-
-func (t *FlagsTest) TestValidateFlagsForValidSequentialReadSize() {
-	flags := &flagStorage{
-		SequentialReadSizeMb:                10,
-		ExperimentalMetadataPrefetchOnMount: cfg.ExperimentalMetadataPrefetchOnMountDisabled,
-	}
-
-	err := validateFlags(flags)
-
-	assert.Equal(t.T(), nil, err)
-}
-
 func (t *FlagsTest) TestValidateFlagsForSupportedExperimentalMetadataPrefetchOnMount() {
 	for _, input := range []string{
 		"disabled", "sync", "async",

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -166,7 +166,6 @@ func mountWithArgs(
 		bucketName,
 		mountPoint,
 		newConfig,
-		flags,
 		mountConfig,
 		storageHandle)
 

--- a/cmd/legacy_param_mapper_test.go
+++ b/cmd/legacy_param_mapper_test.go
@@ -227,6 +227,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 			legacyFlagStorage: &flagStorage{
 				ClientProtocol:                      cfg.GRPC,
 				ExperimentalMetadataPrefetchOnMount: "disabled",
+				SequentialReadSizeMb:                200,
 			},
 			mockCLICtx: &mockCLIContext{isFlagSet: map[string]bool{}},
 			legacyMountConfig: &config.MountConfig{
@@ -302,8 +303,10 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 					EnableEmptyManagedFolders: true,
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
-					GrpcConnPoolSize: 29,
-					ClientProtocol:   cfg.Protocol("grpc")},
+					GrpcConnPoolSize:     29,
+					ClientProtocol:       cfg.Protocol("grpc"),
+					SequentialReadSizeMb: 200,
+				},
 				GcsAuth:   cfg.GcsAuthConfig{AnonymousAccess: true},
 				EnableHns: true,
 				FileSystem: cfg.FileSystemConfig{
@@ -325,6 +328,7 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 				MaxRetryAttempts:                    100,
 				ClientProtocol:                      cfg.HTTP2,
 				ExperimentalMetadataPrefetchOnMount: "disabled",
+				SequentialReadSizeMb:                200,
 			},
 			mockCLICtx: &mockCLIContext{
 				isFlagSet: map[string]bool{
@@ -398,7 +402,8 @@ func TestPopulateConfigFromLegacyFlags(t *testing.T) {
 					ExperimentalMetadataPrefetchOnMount: "disabled",
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
-					ClientProtocol: cfg.Protocol("http2"),
+					ClientProtocol:       cfg.Protocol("http2"),
+					SequentialReadSizeMb: 200,
 				},
 				GcsRetries: cfg.GcsRetriesConfig{
 					MaxRetryAttempts: 100,
@@ -616,6 +621,7 @@ func TestLogSeverityRationalization(t *testing.T) {
 			flags := &flagStorage{
 				ClientProtocol:                      mountpkg.ClientProtocol("http1"),
 				ExperimentalMetadataPrefetchOnMount: "disabled",
+				SequentialReadSizeMb:                200,
 				DebugFuse:                           tc.debugFuse,
 				DebugGCS:                            tc.debugGCS,
 				DebugMutex:                          tc.debugMutex,
@@ -672,6 +678,7 @@ func TestEnableEmptyManagedFoldersRationalization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			flags := &flagStorage{
 				ClientProtocol:                      mountpkg.ClientProtocol("http1"),
+				SequentialReadSizeMb:                200,
 				ExperimentalMetadataPrefetchOnMount: "disabled",
 			}
 			c := config.NewMountConfig()

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -40,7 +40,6 @@ func mountWithStorageHandle(
 	bucketName string,
 	mountPoint string,
 	newConfig *cfg.Config,
-	flags *flagStorage,
 	mountConfig *config.MountConfig,
 	storageHandle storage.StorageHandle) (mfs *fuse.MountedFileSystem, err error) {
 	// Sanity check: make sure the temporary directory exists and is writable
@@ -122,7 +121,7 @@ be interacting with the file system.`)
 		FilePerms:                  os.FileMode(newConfig.FileSystem.FileMode),
 		DirPerms:                   os.FileMode(newConfig.FileSystem.DirMode),
 		RenameDirLimit:             newConfig.FileSystem.RenameDirLimit,
-		SequentialReadSizeMb:       flags.SequentialReadSizeMb,
+		SequentialReadSizeMb:       int32(newConfig.GcsConnection.SequentialReadSizeMb),
 		EnableNonexistentTypeCache: newConfig.MetadataCache.EnableNonexistentTypeCache,
 		MountConfig:                mountConfig,
 		NewConfig:                  newConfig,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -525,7 +525,6 @@ func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
-		expectedConfig *cfg.Config
 	}{
 		{
 			name: "Invalid value for sequential read size flag 1",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -523,8 +523,8 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 }
 func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 	tests := []struct {
-		name           string
-		args           []string
+		name string
+		args []string
 	}{
 		{
 			name: "Invalid value for sequential read size flag 1",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/stretchr/testify/assert"
@@ -446,6 +447,111 @@ func TestArgsParsing_GCSAuthFlagsThrowsError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd, err := NewRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(tc.args)
+
+			assert.Error(t, cmd.Execute())
+		})
+	}
+}
+
+func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name: "Test gcs connection flags.",
+			args: []string{"gcsfuse", "--billing-project=abc", "--client-protocol=http2", "--custom-endpoint=www.abc.com", "--experimental-enable-json-read", "--experimental-grpc-conn-pool-size=20", "--http-client-timeout=20s", "--limit-bytes-per-sec=30", "--limit-ops-per-sec=10", "--max-conns-per-host=1000", "--max-idle-conns-per-host=20", "--sequential-read-size-mb=70", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsConnection: cfg.GcsConnectionConfig{
+					BillingProject:             "abc",
+					ClientProtocol:             "http2",
+					CustomEndpoint:             "www.abc.com",
+					ExperimentalEnableJsonRead: true,
+					GrpcConnPoolSize:           20,
+					HttpClientTimeout:          20 * time.Second,
+					LimitBytesPerSec:           30,
+					LimitOpsPerSec:             10,
+					MaxConnsPerHost:            1000,
+					MaxIdleConnsPerHost:        20,
+					SequentialReadSizeMb:       70,
+				},
+			},
+		},
+		{
+			name: "Test default gcs connection flags.",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsConnection: cfg.GcsConnectionConfig{
+					BillingProject:             "",
+					ClientProtocol:             "http1",
+					CustomEndpoint:             "",
+					ExperimentalEnableJsonRead: false,
+					GrpcConnPoolSize:           1,
+					HttpClientTimeout:          0,
+					LimitBytesPerSec:           -1,
+					LimitOpsPerSec:             -1,
+					MaxConnsPerHost:            0,
+					MaxIdleConnsPerHost:        100,
+					SequentialReadSizeMb:       200,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
+				gotConfig = cfg
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(tc.args)
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedConfig.GcsConnection, gotConfig.GcsConnection)
+			}
+		})
+	}
+}
+func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name: "Invalid value for sequential read size flag 1",
+			args: []string{"gcsfuse", "--sequential-read-size-mb=2040", "abc", "pqr"},
+		},
+		{
+			name: "Invalid value for sequential read size flag 2",
+			args: []string{"gcsfuse", "--sequential-read-size-mb=0", "abc", "pqr"},
+		},
+		{
+			name: "Invalid value for client-protocol flag",
+			args: []string{"gcsfuse", "--client-protocol=http3", "abc", "pqr"},
+		},
+		{
+			name: "Invalid value for custom-endpoint flag",
+			args: []string{"gcsfuse", "--custom-endpoint=a_b://abc", "abc", "pqr"},
+		},
+		{
+			name: "Invalid value for http-client-timeout flag",
+			args: []string{"gcsfuse", "--http-client-timeout=200", "abc", "pqr"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
 				return nil
 			})
 			require.Nil(t, err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -551,7 +551,7 @@ func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _, _ string) error {
 				return nil
 			})
 			require.Nil(t, err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -506,7 +506,7 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotConfig *cfg.Config
-			cmd, err := NewRootCmd(func(cfg *cfg.Config, _ string, _ string) error {
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _, _ string) error {
 				gotConfig = cfg
 				return nil
 			})

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -14,3 +14,15 @@ gcs-auth:
   key-file: "~/key.file"
   reuse-token-from-url: false
   token-url: "www.abc.com"
+gcs-connection:
+  billing-project: abc
+  client-protocol: http2
+  custom-endpoint: www.abc.com
+  experimental-enable-json-read: true
+  grpc-conn-pool-size: 200
+  http-client-timeout: 400s
+  limit-bytes-per-sec: 20
+  limit-ops-per-sec: 30
+  max-conns-per-host: 400
+  max-idle-conns-per-host: 20
+  sequential-read-size-mb: 450


### PR DESCRIPTION
### Description
migrate sequential read size mb flag and test GCS Connection configs.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - NA
