### PR TITLE
[CLI Config Parity] Migrate Ignore Interrupts config and flag. 

### DIFF
--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -247,7 +247,7 @@ func TestValidateConfigFile_InvalidConfigThrowsError(t *testing.T) {
 			configFile: "testdata/file_cache_config/invalid_write_buffer_size.yaml",
 		},
 		{
-			name:       "Invalid value of ignore interrupts.",
+			name:       "Invalid ignore interrupts",
 			configFile: "testdata/file_system_config/invalid_ignore_interrupts.yaml",
 		},
 	}
@@ -426,7 +426,8 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 		expectedConfig *cfg.Config
 	}{
 		{
-			name:       "Empty config file [default values].",
+			// Test default values.
+			name:       "Empty config file",
 			configFile: "testdata/empty_file.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -444,7 +445,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			},
 		},
 		{
-			name:       "File system config unset.",
+			name:       "File system config unset",
 			configFile: "testdata/file_system_config/unset_file_system_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -462,7 +463,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			},
 		},
 		{
-			name:       "Valid config file.",
+			name:       "Valid config file",
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -247,7 +247,7 @@ func TestValidateConfigFile_InvalidConfigThrowsError(t *testing.T) {
 			configFile: "testdata/file_cache_config/invalid_write_buffer_size.yaml",
 		},
 		{
-			name:       "Invalid ignore interrupts",
+			name:       "invalid_ignore_interrupts",
 			configFile: "testdata/file_system_config/invalid_ignore_interrupts.yaml",
 		},
 	}
@@ -427,7 +427,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 	}{
 		{
 			// Test default values.
-			name:       "Empty config file",
+			name:       "empty_config_file",
 			configFile: "testdata/empty_file.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -445,7 +445,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			},
 		},
 		{
-			name:       "File system config unset",
+			name:       "file_system_config_unset",
 			configFile: "testdata/file_system_config/unset_file_system_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -463,7 +463,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			},
 		},
 		{
-			name:       "Valid config file",
+			name:       "valid_config_file",
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 
@@ -419,14 +418,6 @@ func TestValidateConfigFile_GCSConnectionConfigSuccessful(t *testing.T) {
 }
 
 func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
-	defaultDirMode, err := strconv.ParseInt("0755", 8, 0)
-	require.NoError(t, err)
-	defaultFileMode, err := strconv.ParseInt("0644", 8, 0)
-	require.NoError(t, err)
-	fileMode666, err := strconv.ParseInt("0666", 8, 0)
-	require.NoError(t, err)
-	dirMode777, err := strconv.ParseInt("0777", 8, 0)
-	require.NoError(t, err)
 	hd, err := os.UserHomeDir()
 	require.NoError(t, err)
 	testCases := []struct {
@@ -439,9 +430,9 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			configFile: "testdata/empty_file.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
-					DirMode:                cfg.Octal(defaultDirMode),
+					DirMode:                0755,
 					DisableParallelDirops:  false,
-					FileMode:               cfg.Octal(defaultFileMode),
+					FileMode:               0644,
 					FuseOptions:            []string{},
 					Gid:                    -1,
 					IgnoreInterrupts:       true,
@@ -457,9 +448,9 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			configFile: "testdata/file_system_config/unset_file_system_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
-					DirMode:                cfg.Octal(defaultDirMode),
+					DirMode:                0755,
 					DisableParallelDirops:  false,
-					FileMode:               cfg.Octal(defaultFileMode),
+					FileMode:               0644,
 					FuseOptions:            []string{},
 					Gid:                    -1,
 					IgnoreInterrupts:       true,
@@ -475,9 +466,9 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
-					DirMode:                cfg.Octal(dirMode777),
+					DirMode:                0777,
 					DisableParallelDirops:  true,
-					FileMode:               cfg.Octal(fileMode666),
+					FileMode:               0666,
 					FuseOptions:            []string{"ro"},
 					Gid:                    7,
 					IgnoreInterrupts:       false,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -429,7 +429,8 @@ type flagStorage struct {
 	OnlyDir string
 
 	// Deprecated: Use the param from cfg/config.go
-	RenameDirLimit   int64
+	RenameDirLimit int64
+	// Deprecated: Use the param from cfg/config.go
 	IgnoreInterrupts bool
 
 	// GCS

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -259,7 +259,6 @@ func runCLIApp(c *cli.Context) (err error) {
 		return fmt.Errorf("error resolving flags and configs: %w", err)
 	}
 
-	config.OverrideWithIgnoreInterruptsFlag(c, mountConfig, flags.IgnoreInterrupts)
 	config.OverrideWithKernelListCacheTtlFlag(c, mountConfig, flags.KernelListCacheTtlSeconds)
 
 	// Ideally this call to SetLogFormat (which internally creates a new defaultLogger)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -591,7 +591,7 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "mode flags without 0 prefix",
+			name: "mode_flags_without_0_prefix",
 			args: []string{"gcsfuse", "--dir-mode=777", "--file-mode=666", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -652,19 +652,19 @@ func TestArgsParsing_FileSystemFlagsThrowsError(t *testing.T) {
 		args []string
 	}{
 		{
-			name: "Invalid dir-mode 999",
+			name: "invalid_dir_mode_999",
 			args: []string{"gcsfuse", "--dir-mode=999", "abc", "pqr"},
 		},
 		{
-			name: "Invalid dir-mode 0999",
+			name: "invalid_dir_mode_0999",
 			args: []string{"gcsfuse", "--dir-mode=0999", "abc", "pqr"},
 		},
 		{
-			name: "Invalid file-mode 888",
+			name: "invalid_file_mode_888",
 			args: []string{"gcsfuse", "--file-mode=888", "abc", "pqr"},
 		},
 		{
-			name: "Invalid file-mode 0888",
+			name: "invalid_file_mode_0888",
 			args: []string{"gcsfuse", "--file-mode=0888", "abc", "pqr"},
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -566,7 +566,6 @@ func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 func TestArgsParsing_FileSystemFlags(t *testing.T) {
 	hd, err := os.UserHomeDir()
 	require.NoError(t, err)
-	require.NoError(t, err)
 	tests := []struct {
 		name           string
 		args           []string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -573,7 +573,7 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 		expectedConfig *cfg.Config
 	}{
 		{
-			name: "Test file system flags.",
+			name: "normal",
 			args: []string{"gcsfuse", "--dir-mode=0777", "--disable-parallel-dirops", "--file-mode=0666", "--o", "ro", "--gid=7", "--ignore-interrupts=false", "--kernel-list-cache-ttl-secs=300", "--rename-dir-limit=10", "--temp-dir=~/temp", "--uid=8", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -591,7 +591,25 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "Test default file system flags.",
+			name: "mode flags without 0 prefix",
+			args: []string{"gcsfuse", "--dir-mode=777", "--file-mode=666", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					DirMode:                0777,
+					DisableParallelDirops:  false,
+					FileMode:               0666,
+					FuseOptions:            []string{},
+					Gid:                    -1,
+					IgnoreInterrupts:       true,
+					KernelListCacheTtlSecs: 0,
+					RenameDirLimit:         0,
+					TempDir:                "",
+					Uid:                    -1,
+				},
+			},
+		},
+		{
+			name: "default",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
@@ -634,12 +652,20 @@ func TestArgsParsing_FileSystemFlagsThrowsError(t *testing.T) {
 		args []string
 	}{
 		{
-			name: "Invalid value for dir-mode flag",
+			name: "Invalid dir-mode 999",
 			args: []string{"gcsfuse", "--dir-mode=999", "abc", "pqr"},
 		},
 		{
-			name: "Invalid value for file-mode flag",
+			name: "Invalid dir-mode 0999",
+			args: []string{"gcsfuse", "--dir-mode=0999", "abc", "pqr"},
+		},
+		{
+			name: "Invalid file-mode 888",
 			args: []string{"gcsfuse", "--file-mode=888", "abc", "pqr"},
+		},
+		{
+			name: "Invalid file-mode 0888",
+			args: []string{"gcsfuse", "--file-mode=0888", "abc", "pqr"},
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 
@@ -565,14 +564,6 @@ func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 }
 
 func TestArgsParsing_FileSystemFlags(t *testing.T) {
-	defaultDirMode, err := strconv.ParseInt("0755", 8, 0)
-	require.NoError(t, err)
-	defaultFileMode, err := strconv.ParseInt("0644", 8, 0)
-	require.NoError(t, err)
-	fileMode666, err := strconv.ParseInt("0666", 8, 0)
-	require.NoError(t, err)
-	dirMode777, err := strconv.ParseInt("0777", 8, 0)
-	require.NoError(t, err)
 	hd, err := os.UserHomeDir()
 	require.NoError(t, err)
 	require.NoError(t, err)
@@ -586,9 +577,9 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 			args: []string{"gcsfuse", "--dir-mode=0777", "--disable-parallel-dirops", "--file-mode=0666", "--o", "ro", "--gid=7", "--ignore-interrupts=false", "--kernel-list-cache-ttl-secs=300", "--rename-dir-limit=10", "--temp-dir=~/temp", "--uid=8", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
-					DirMode:                cfg.Octal(dirMode777),
+					DirMode:                0777,
 					DisableParallelDirops:  true,
-					FileMode:               cfg.Octal(fileMode666),
+					FileMode:               0666,
 					FuseOptions:            []string{"ro"},
 					Gid:                    7,
 					IgnoreInterrupts:       false,
@@ -604,9 +595,9 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileSystem: cfg.FileSystemConfig{
-					DirMode:                cfg.Octal(defaultDirMode),
+					DirMode:                0755,
 					DisableParallelDirops:  false,
-					FileMode:               cfg.Octal(defaultFileMode),
+					FileMode:               0644,
 					FuseOptions:            []string{},
 					Gid:                    -1,
 					IgnoreInterrupts:       true,

--- a/cmd/testdata/file_system_config/invalid_ignore_interrupts.yaml
+++ b/cmd/testdata/file_system_config/invalid_ignore_interrupts.yaml
@@ -1,0 +1,2 @@
+file-system:
+  ignore-interrupts: abc

--- a/cmd/testdata/file_system_config/unset_file_system_config.yaml
+++ b/cmd/testdata/file_system_config/unset_file_system_config.yaml
@@ -1,0 +1,2 @@
+write:
+  create-empty-file: true

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -27,3 +27,14 @@ gcs-connection:
   max-conns-per-host: 400
   max-idle-conns-per-host: 20
   sequential-read-size-mb: 450
+file-system:
+  dir-mode: 0777
+  disable-parallel-dirops: true
+  file-mode: 0666
+  fuse-options: "ro"
+  gid: 7
+  uid: 8
+  ignore-interrupts: false
+  kernel-list-cache-ttl-secs: 300
+  rename-dir-limit: 10
+  temp-dir: ~/temp

--- a/internal/config/config_util.go
+++ b/internal/config/config_util.go
@@ -39,15 +39,6 @@ type cliContext interface {
 	IsSet(string) bool
 }
 
-// OverrideWithIgnoreInterruptsFlag overwrites the ignore-interrupts config with
-// the ignore-interrupts flag value if the flag is set.
-func OverrideWithIgnoreInterruptsFlag(c cliContext, mountConfig *MountConfig, ignoreInterruptsFlag bool) {
-	// If the ignore-interrupts flag is set, give it priority over the value in config file.
-	if c.IsSet(IgnoreInterruptsFlagName) {
-		mountConfig.FileSystemConfig.IgnoreInterrupts = ignoreInterruptsFlag
-	}
-}
-
 // OverrideWithKernelListCacheTtlFlag overwrites the kernel-list-cache-ttl-secs config
 // with the kernel-list-cache-ttl-secs cli-flag value if the cli-flag is set by user.
 func OverrideWithKernelListCacheTtlFlag(c cliContext, mountConfig *MountConfig, ttl int64) {

--- a/internal/config/config_util_test.go
+++ b/internal/config/config_util_test.go
@@ -57,34 +57,6 @@ func (s *TestCliContext) IsSet(flag string) bool {
 	return s.isSet
 }
 
-func TestOverrideWithIgnoreInterruptsFlag(t *testing.T) {
-	var overrideWithIgnoreInterruptsFlagTests = []struct {
-		testName                   string
-		ignoreInterruptConfigValue bool
-		isFlagSet                  bool
-		ignoreInterruptFlagValue   bool
-		expectedIgnoreInterrupt    bool
-	}{
-		{"ignore-interrupts config true and flag not set", true, false, false, true},
-		{"ignore-interrupts config false and flag not set", false, false, false, false},
-		{"ignore-interrupts config false and ignore-interrupts flag false", false, true, false, false},
-		{"ignore-interrupts config false and ignore-interrupts flag true", false, true, true, true},
-		{"ignore-interrupts config true and ignore-interrupts flag false", true, true, false, false},
-		{"ignore-interrupts config true and ignore-interrupts flag true", true, true, true, true},
-	}
-
-	for _, tt := range overrideWithIgnoreInterruptsFlagTests {
-		t.Run(tt.testName, func(t *testing.T) {
-			testContext := &TestCliContext{isSet: tt.isFlagSet}
-			mountConfig := &MountConfig{FileSystemConfig: FileSystemConfig{IgnoreInterrupts: tt.ignoreInterruptConfigValue}}
-
-			OverrideWithIgnoreInterruptsFlag(testContext, mountConfig, tt.ignoreInterruptFlagValue)
-
-			assert.Equal(t, tt.expectedIgnoreInterrupt, mountConfig.FileSystemConfig.IgnoreInterrupts)
-		})
-	}
-}
-
 func Test_OverrideWithKernelListCacheTtlFlag(t *testing.T) {
 	var testCases = []struct {
 		configValue   int64

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -190,6 +190,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		localFileInodes:            make(map[inode.Name]inode.Inode),
 		handles:                    make(map[fuseops.HandleID]interface{}),
 		mountConfig:                serverCfg.MountConfig,
+		newConfig:                  serverCfg.NewConfig,
 		fileCacheHandler:           fileCacheHandler,
 		cacheFileForRangeRead:      serverCfg.NewConfig.FileCache.CacheFileForRangeRead,
 	}
@@ -469,8 +470,11 @@ type fileSystem struct {
 	// GUARDED_BY(mu)
 	nextHandleID fuseops.HandleID
 
-	// Config specified by the user using config-file flag.
+	// Deprecated Config specified by the user using config-file flag.
 	mountConfig *config.MountConfig
+
+	// newConfig specified by the user using config-file flag and CLI flags.
+	newConfig *cfg.Config
 
 	// fileCacheHandler manages read only file cache. It is non-nil only when
 	// file cache is enabled at the time of mounting.
@@ -1377,7 +1381,7 @@ func (fs *fileSystem) StatFS(
 func (fs *fileSystem) LookUpInode(
 	ctx context.Context,
 	op *fuseops.LookUpInodeOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1413,7 +1417,7 @@ func (fs *fileSystem) LookUpInode(
 func (fs *fileSystem) GetInodeAttributes(
 	ctx context.Context,
 	op *fuseops.GetInodeAttributesOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1441,7 +1445,7 @@ func (fs *fileSystem) GetInodeAttributes(
 func (fs *fileSystem) SetInodeAttributes(
 	ctx context.Context,
 	op *fuseops.SetInodeAttributesOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1507,7 +1511,7 @@ func (fs *fileSystem) ForgetInode(
 func (fs *fileSystem) MkDir(
 	ctx context.Context,
 	op *fuseops.MkDirOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1566,7 +1570,7 @@ func (fs *fileSystem) MkDir(
 func (fs *fileSystem) MkNode(
 	ctx context.Context,
 	op *fuseops.MkNodeOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1696,7 +1700,7 @@ func (fs *fileSystem) createLocalFile(
 func (fs *fileSystem) CreateFile(
 	ctx context.Context,
 	op *fuseops.CreateFileOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1745,7 +1749,7 @@ func (fs *fileSystem) CreateFile(
 func (fs *fileSystem) CreateSymlink(
 	ctx context.Context,
 	op *fuseops.CreateSymlinkOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1815,7 +1819,7 @@ func (fs *fileSystem) RmDir(
 
 	ctx context.Context,
 	op *fuseops.RmDirOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -1923,7 +1927,7 @@ func (fs *fileSystem) RmDir(
 func (fs *fileSystem) Rename(
 	ctx context.Context,
 	op *fuseops.RenameOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2160,7 +2164,7 @@ func (fs *fileSystem) renameDir(
 func (fs *fileSystem) Unlink(
 	ctx context.Context,
 	op *fuseops.UnlinkOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2244,7 +2248,7 @@ func (fs *fileSystem) OpenDir(
 func (fs *fileSystem) ReadDir(
 	ctx context.Context,
 	op *fuseops.ReadDirOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2316,7 +2320,7 @@ func (fs *fileSystem) OpenFile(
 func (fs *fileSystem) ReadFile(
 	ctx context.Context,
 	op *fuseops.ReadFileOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2367,7 +2371,7 @@ func (fs *fileSystem) ReadSymlink(
 func (fs *fileSystem) WriteFile(
 	ctx context.Context,
 	op *fuseops.WriteFileOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2394,7 +2398,7 @@ func (fs *fileSystem) WriteFile(
 func (fs *fileSystem) SyncFile(
 	ctx context.Context,
 	op *fuseops.SyncFileOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc
@@ -2427,7 +2431,7 @@ func (fs *fileSystem) SyncFile(
 func (fs *fileSystem) FlushFile(
 	ctx context.Context,
 	op *fuseops.FlushFileOp) (err error) {
-	if fs.mountConfig.FileSystemConfig.IgnoreInterrupts {
+	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
 		var cancel context.CancelFunc


### PR DESCRIPTION
### Description
This PR migrate Ignore Interrupts config and flag. Also added tests for file system config.
I will make kernel list cache and Enable Parallel Dirops migration changes in a follow up PR.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Via KOKORO
