### PR TITLE
Local file bug fix - Recreation of local file had issue in stating

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1680,7 +1680,7 @@ func (fs *fileSystem) createLocalFile(
 		return
 	}
 
-	// Create a new inode when a new file is created, or when a local file is unlinked and then recreated with the same name.
+	// Create a new inode when a file is created first time, or when a local file is unlinked and then recreated with the same name.
 	var result *inode.Core
 	result, err = parent.CreateLocalChildFile(name)
 	if err != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1680,7 +1680,7 @@ func (fs *fileSystem) createLocalFile(
 		return
 	}
 
-	// Create a new inode if a local file is unlinked and then recreated with the same name.
+	// Create a new inode when a new file is created, or when a local file is unlinked and then recreated with the same name.
 	var result *inode.Core
 	result, err = parent.CreateLocalChildFile(name)
 	if err != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1676,11 +1676,7 @@ func (fs *fileSystem) createLocalFile(
 	fullName := inode.NewFileName(parent.Name(), name)
 	child, ok := fs.localFileInodes[fullName]
 	// Create a new inode if a local file is unlinked and then recreated with the same name.
-	var fileInode *inode.FileInode
-	if child != nil {
-		fileInode = fs.fileInodeOrDie(child.ID())
-	}
-	if !ok || (fileInode != nil && fileInode.IsUnlinked()) {
+	if !ok || (child != nil && child.(*inode.FileInode).IsUnlinked()) {
 		var result *inode.Core
 		result, err = parent.CreateLocalChildFile(name)
 		if err != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1675,7 +1675,11 @@ func (fs *fileSystem) createLocalFile(
 
 	fullName := inode.NewFileName(parent.Name(), name)
 	child, ok := fs.localFileInodes[fullName]
-	if !ok {
+	var fileInode *inode.FileInode
+	if child != nil {
+		fileInode = fs.fileInodeOrDie(child.ID())
+	}
+	if !ok || (fileInode != nil && fileInode.IsUnlinked()) {
 		var result *inode.Core
 		result, err = parent.CreateLocalChildFile(name)
 		if err != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1675,6 +1675,7 @@ func (fs *fileSystem) createLocalFile(
 
 	fullName := inode.NewFileName(parent.Name(), name)
 	child, ok := fs.localFileInodes[fullName]
+	// Create a new inode if a local file is unlinked and then recreated with the same name.
 	var fileInode *inode.FileInode
 	if child != nil {
 		fileInode = fs.fileInodeOrDie(child.ID())

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -526,7 +526,7 @@ func (fs *fileSystem) checkInvariantsForLocalFileInodes() {
 	for _, in := range fs.inodes {
 		fileInode, ok := in.(*inode.FileInode)
 
-		if ok && fileInode.IsLocal() && !fileInode.IsUnlinked(){
+		if ok && fileInode.IsLocal() && !fileInode.IsUnlinked() {
 			if !(fs.localFileInodes[in.Name()] == in) {
 				panic(fmt.Sprintf(
 					"localFileInodes mismatch: %q %v %v",

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -526,7 +526,7 @@ func (fs *fileSystem) checkInvariantsForLocalFileInodes() {
 	for _, in := range fs.inodes {
 		fileInode, ok := in.(*inode.FileInode)
 
-		if ok && fileInode.IsLocal() {
+		if ok && fileInode.IsLocal() && !fileInode.IsUnlinked(){
 			if !(fs.localFileInodes[in.Name()] == in) {
 				panic(fmt.Sprintf(
 					"localFileInodes mismatch: %q %v %v",

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -858,7 +858,9 @@ func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentD
 	AssertEq(nil, err)
 	defer AssertEq(nil, f2.Close())
 
-	_, err = os.Stat(filePath)
+	f, err := os.Stat(filePath)
 
 	AssertEq(nil, err)
+	ExpectEq(filePath, f.Name())
+	ExpectFalse(f.IsDir())
 }

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -832,3 +832,25 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 	ExpectThat(atime, timeutil.TimeNear(createTime, Delta))
 	ExpectThat(ctime, timeutil.TimeNear(createTime, Delta))
 }
+
+func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory() {
+	dirPath := path.Join(mntDir, "foo")
+	filePath := path.Join(dirPath, "test.txt")
+	err = os.Mkdir(dirPath, dirPerms)
+	AssertEq(nil, err)
+	f1, err := os.Create(filePath)
+	defer AssertEq(nil, f1.Close())
+	AssertEq(nil, err)
+	_, err = os.Stat(filePath)
+	AssertEq(nil, err)
+	err = os.RemoveAll(dirPath)
+	AssertEq(nil, err)
+	err = os.Mkdir(dirPath, 0755)
+	AssertEq(nil, err)
+	f2, err := os.Create(filePath)
+	defer AssertEq(nil, f2.Close())
+
+	_, err = os.Stat(filePath)
+
+	AssertEq(nil, err)
+}

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -833,26 +833,20 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 	ExpectThat(ctime, timeutil.TimeNear(createTime, Delta))
 }
 
-// Create directory - foo
-// Create local file inside - foo/test.txt
+// Create local file inside - test.txt
 // Stat that local file.
-// Remove directory.
-// Create directory with the same name - foo
-// Create local file with the same name - foo/test.txt
+// Remove the local file.
+// Create local file with the same name - test.txt
 // Stat that local file.
-func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory() {
-	dirPath := path.Join(mntDir, "foo")
-	filePath := path.Join(dirPath, "test.txt")
-	err = os.Mkdir(dirPath, dirPerms)
+func (t *LocalFileTest) TestStatLocalFileAfterRecreatingItWithSameName() {
+	filePath := path.Join(mntDir, "test.txt")
 	AssertEq(nil, err)
 	f1, err := os.Create(filePath)
 	defer AssertEq(nil, f1.Close())
 	AssertEq(nil, err)
 	_, err = os.Stat(filePath)
 	AssertEq(nil, err)
-	err = os.RemoveAll(dirPath)
-	AssertEq(nil, err)
-	err = os.Mkdir(dirPath, dirPerms)
+	err = os.Remove(filePath)
 	AssertEq(nil, err)
 	f2, err := os.Create(filePath)
 	AssertEq(nil, err)

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -855,6 +855,7 @@ func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentD
 	err = os.Mkdir(dirPath, dirPerms)
 	AssertEq(nil, err)
 	f2, err := os.Create(filePath)
+	AssertEq(nil, err)
 	defer AssertEq(nil, f2.Close())
 
 	_, err = os.Stat(filePath)

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -833,6 +833,13 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 	ExpectThat(ctime, timeutil.TimeNear(createTime, Delta))
 }
 
+// Create directory - foo
+// Create local file inside - foo/test.txt
+// Stat that local file.
+// Remove directory.
+// Create directory with the same name - foo
+// Create local file with the same name - foo/test.txt
+// Stat that local file.
 func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory() {
 	dirPath := path.Join(mntDir, "foo")
 	filePath := path.Join(dirPath, "test.txt")
@@ -845,7 +852,7 @@ func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentD
 	AssertEq(nil, err)
 	err = os.RemoveAll(dirPath)
 	AssertEq(nil, err)
-	err = os.Mkdir(dirPath, 0755)
+	err = os.Mkdir(dirPath, dirPerms)
 	AssertEq(nil, err)
 	f2, err := os.Create(filePath)
 	defer AssertEq(nil, f2.Close())

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -861,6 +861,6 @@ func (t *LocalFileTest) TestCreateAndStatLocalFileInSamePathAfterDeletingParentD
 	f, err := os.Stat(filePath)
 
 	AssertEq(nil, err)
-	ExpectEq(filePath, f.Name())
+	ExpectEq("test.txt", f.Name())
 	ExpectFalse(f.IsDir())
 }

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -204,6 +204,6 @@ func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing
 	f, err := os.Stat(filePath)
 
 	assert.NoError(t, err)
-	assert.Equal(t, filePath, f.Name())
+	assert.Equal(t, FileName1, f.Name())
 	assert.False(t, f.IsDir())
 }

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -190,7 +190,6 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 
 func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
-	operations.CreateDirectory(testDirPath, t)
 	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
 	filePath := path.Join(testDirPath, FileName1)
 	operations.CreateFile(filePath, FilePerms, t)

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -189,7 +189,7 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 }
 
 func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T){
-	testDirPath = path.Join(setup.MntDir(), testDirName)
+	testDirPath = setup.SetupTestDirectory(testDirName)
 	operations.CreateDirectory(testDirPath, t)
 	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
 	filePath := path.Join(testDirPath, FileName1)

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -200,7 +201,9 @@ func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing
 	operations.CreateDirectory(testDirPath, t)
 	operations.CreateFile(filePath, FilePerms, t)
 
-	_, err = os.Stat(filePath)
+	f, err := os.Stat(filePath)
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
+	assert.Equal(t, filePath, f.Name())
+	assert.False(t, f.IsDir())
 }

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
 )
 
 // //////////////////////////////////////////////////////////////////////
@@ -185,4 +186,22 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 	go readingDirNTimesShouldNotThrowError(200, &wg, t)
 
 	wg.Wait()
+}
+
+func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T){
+	testDirPath = path.Join(setup.MntDir(), testDirName)
+	operations.CreateDirectory(testDirPath, t)
+	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
+	filePath := path.Join(testDirPath, FileName1)
+	operations.CreateFile(filePath, FilePerms, t)
+	_, err := os.Stat(filePath)
+	require.NoError(t, err)
+	err = os.RemoveAll(testDirPath)
+	require.NoError(t, err)
+	operations.CreateDirectory(testDirPath, t)
+	operations.CreateFile(filePath, FilePerms, t)
+
+	_, err = os.Stat(filePath)
+
+	require.NoError(t, err)
 }

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -188,7 +188,7 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 	wg.Wait()
 }
 
-func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T){
+func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
 	operations.CreateDirectory(testDirPath, t)
 	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)

--- a/tools/integration_tests/local_file/read_dir_test.go
+++ b/tools/integration_tests/local_file/read_dir_test.go
@@ -189,16 +189,14 @@ func TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError(t *testing.T
 	wg.Wait()
 }
 
-func TestCreateAndStatLocalFileInSamePathAfterDeletingParentDirectory(t *testing.T) {
+func TestStatLocalFileAfterRecreatingItWithSameName(t *testing.T) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
-	operations.CreateDirectory(path.Join(testDirPath, ExplicitDirName), t)
 	filePath := path.Join(testDirPath, FileName1)
 	operations.CreateFile(filePath, FilePerms, t)
 	_, err := os.Stat(filePath)
 	require.NoError(t, err)
-	err = os.RemoveAll(testDirPath)
+	err = os.Remove(filePath)
 	require.NoError(t, err)
-	operations.CreateDirectory(testDirPath, t)
 	operations.CreateFile(filePath, FilePerms, t)
 
 	f, err := os.Stat(filePath)


### PR DESCRIPTION
### Description
I found an issue with the behavior of local files where recreating a local file with the same name causes a problem. The situation is as follows.
**Behavior:**
1. Directory creation: Successful.
2. Local file creation within the directory: Successful.
3. Stat operation on the local file: Successful.
4. Delete local file: Successful
5. Recreation of the local file within the directory with the same name: Successful.
6. Stat operation on the recreated local file: Failed (due to the reuse of the same inode).

e.g.
```
create dir
create local file dir/file.txt
stat dir/file.txt
rm dir/file.txt
create local file dir/file.txt
stat dir/file.txt -- Fail
```

**Fix:**
The issue was resolved by ensuring the creation of a new inode whenever a file with the same name created which unlinked.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Added
