### PR TITLE
Ignoring  JSON files from header checks

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -38,3 +38,4 @@ ignoreFiles:
   - 'internal/storage/mock_bucket.go'
   - 'perfmetrics/scripts/load_tests/python/sample_tasks.yaml'
   - 'perfmetrics/scripts/ls_metrics/directory_pb2.py'
+  - '*.json'


### PR DESCRIPTION
### Description
Currently, header-checks on PR fails for JSON files due to absence of license but comments are  unsupported in JSON,thus ignoring all json files from header-check.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
