### PR TITLE
Handle empty gsheet credentials when running load tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -40,23 +40,23 @@ then
 fi
 
 run_load_test_and_fetch_metrics(){
-  GCSFUSE_FIO_FLAGS=$1
-  UPLOAD_FLAGS=$2
-  BUCKET_NAME=$3
-  SPREADSHEET_ID=$4
-  GSHEET_CREDENTIALS=$5
-  TEST_TYPE=$6
-  GCSFUSE_LS_FLAGS=$7
-  LS_CONFIG_FILE=$8
+  gcsfuse_fio_flags=$1
+  upload_flags=$2
+  bucket_name=$3
+  spreadsheet_id=$4
+  gsheet_credentials=$5
+  test_type=$6
+  gcsfuse_ls_flags=$7
+  ls_config_file=$8
 
   # Executing perf tests
-  ./run_load_test_and_fetch_metrics.sh "$MOUNT_FLAGS" "$UPLOAD_FLAGS" "$BUCKET_NAME" "$SPREADSHEET_ID" "$GSHEET_CREDENTIALS"
+  ./run_load_test_and_fetch_metrics.sh "$gcsfuse_fio_flags" "$upload_flags" "$bucket_name" "$spreadsheet_id" "$gsheet_credentials"
 
   # ls_metrics test. This test does gcsfuse mount with the passed flags first and then does the testing.
-  LOG_FILE_LIST_TESTS=${KOKORO_ARTIFACTS_DIR}/gcsfuse-list-logs-$TEST_TYPE.txt
-  GCSFUSE_LIST_FLAGS="$GCSFUSE_LS_FLAGS --log-file $LOG_FILE_LIST_TESTS"
+  log_file_list_tests=${KOKORO_ARTIFACTS_DIR}/gcsfuse-list-logs-$test_type.txt
+  gcsfuse_list_flags="$gcsfuse_ls_flags --log-file $log_file_list_tests"
   cd "./ls_metrics"
-  ./run_ls_benchmark.sh "$GCSFUSE_LIST_FLAGS" "$UPLOAD_FLAGS" "$SPREADSHEET_ID" "$LS_CONFIG_FILE"
+  ./run_ls_benchmark.sh "$gcsfuse_list_flags" "$upload_flags" "$spreadsheet_id" "$ls_config_file"
   cd "../"
 }
 

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -42,6 +42,9 @@ sudo umount $MOUNT_POINT
 
 echo Installing requirements..
 pip install --require-hashes -r requirements.txt --user
-gsutil cp $GSHEET_CREDENTIALS gsheet
+if [ ! -z "${GSHEET_CREDENTIALS}" ];
+then
+  gsutil cp $GSHEET_CREDENTIALS gsheet
+fi
 echo Fetching results..
 python3 fetch_and_upload_metrics.py "fio-output${EXPERIMENT_NUMBER}.json" $UPLOAD_FLAGS --spreadsheet_id=$SPREADSHEET_ID

--- a/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
+++ b/perfmetrics/scripts/run_load_test_and_fetch_metrics.sh
@@ -27,7 +27,6 @@ GCSFUSE_FLAGS=$1
 UPLOAD_FLAGS=$2
 BUCKET_NAME=$3
 SPREADSHEET_ID=$4
-GSHEET_CREDENTIALS=$5
 MOUNT_POINT=gcs
 # The VM will itself exit if the gcsfuse mount fails.
 gcsfuse $GCSFUSE_FLAGS $BUCKET_NAME $MOUNT_POINT
@@ -42,9 +41,6 @@ sudo umount $MOUNT_POINT
 
 echo Installing requirements..
 pip install --require-hashes -r requirements.txt --user
-if [ ! -z "${GSHEET_CREDENTIALS}" ];
-then
-  gsutil cp $GSHEET_CREDENTIALS gsheet
-fi
+gsutil cp gs://periodic-perf-tests/creds.json gsheet
 echo Fetching results..
 python3 fetch_and_upload_metrics.py "fio-output${EXPERIMENT_NUMBER}.json" $UPLOAD_FLAGS --spreadsheet_id=$SPREADSHEET_ID


### PR DESCRIPTION
### Description
Includes fixes to the build scripts from continuous tests , which ensures that the perf tests are executed for both hns and flat buckets and the results are uploaded to respective gsheet whenever the perf experiments are triggered. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually tested perf tests script which runs load test for fio benchmarking and performs listing benchmark.Successful run and upload to gsheet.
2. Unit tests - NA
3. Integration tests - NA
