### PR TITLE
Disable flaky test

### DIFF
--- a/flaky_tests.lst
+++ b/flaky_tests.lst
@@ -6,3 +6,6 @@
 
 # b/361259658
 TestAppendObjectCreator
+
+# b/361477653
+TestParallelDiropsTestSuite/TestParallelReadDirs


### PR DESCRIPTION
Disable TestParallelDiropsTestSuite/TestParallelReadDirs since it's flaky.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
