### PR TITLE
Use a script to yield list of skipped tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
         go install ./tools/build_gcsfuse
         build_gcsfuse . /tmp ${GITHUB_SHA}
     - name: Test all except caching parallely
-      run: CGO_ENABLED=0 go test -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | sed '/^$/d' | sed '/^#.*/d' | tr '\n' '|' |head -c -1 | cat - <(printf "\n")` `go list ./... | grep -v internal/cache/...`
+      run: CGO_ENABLED=0 go test -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./... | grep -v internal/cache/...`
     - name: Test caching
-      run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage_cache.out -coverpkg=./... -v -skip `cat flaky_tests.lst | sed '/^$/d' | sed '/^#.*/d' | tr '\n' '|' |head -c -1 | cat - <(printf "\n")` ./internal/cache/...
+      run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage_cache.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
     - name: Cache RaceDetector Test
-      run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | sed '/^$/d' | sed '/^#.*/d' | tr '\n' '|' |head -c -1 | cat - <(printf "\n")` ./internal/cache/...
+      run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.3.1
       timeout-minutes: 5

--- a/tools/scripts/skip_tests.go
+++ b/tools/scripts/skip_tests.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Split(bufio.ScanLines)
+	skipsList := make([]string, 0, 16)
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		skipsList = append(skipsList, line)
+	}
+	fmt.Println(strings.Join(skipsList, "|"))
+}

--- a/tools/scripts/skip_tests/main.go
+++ b/tools/scripts/skip_tests/main.go
@@ -26,8 +26,7 @@ func main() {
 	scanner.Split(bufio.ScanLines)
 	skipsList := make([]string, 0, 16)
 	for scanner.Scan() {
-		line := scanner.Text()
-		line = strings.TrimSpace(line)
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}


### PR DESCRIPTION
### Description
A convoluted shell pipeline was being used to generate the list of skipped tests in a format that `go test -skip` accepts. Use a script to simplify that.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
