### PR TITLE
Change category name to look more like codes

### DIFF
--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -48,7 +48,7 @@ var (
 
 // Error categories
 const (
-	deviceErr         = "DEVICE_ERRORS"
+	deviceErr         = "DEVICE_ERROR"
 	dirNotEmptyErr    = "DIR_NOT_EMPTY"
 	fileExistsErr     = "FILE_EXISTS"
 	fileDirErr        = "FILE_DIR_ERROR"

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -48,22 +48,22 @@ var (
 
 // Error categories
 const (
-	deviceErr         = "DEVICE_ERROR"
-	dirNotEmptyErr    = "DIR_NOT_EMPTY"
-	fileExistsErr     = "FILE_EXISTS"
-	fileDirErr        = "FILE_DIR_ERROR"
-	notImplementedErr = "NOT_IMPLEMENTED"
-	ioErr             = "IO_ERROR"
-	intrErr           = "INTERRUPT_ERROR"
-	invalidArgErr     = "INVALID_ARGUMENT"
-	invalidOpErr      = "INVALID_OPERATION"
-	miscErr           = "MISC_ERROR"
-	nwErr             = "NETWORK_ERROR"
-	noFileOrDirErr    = "NO_FILE_OR_DIR"
-	notADirErr        = "NOT_A_DIR"
-	permError         = "PERM_ERROR"
-	processMgmtErr    = "PROCESS_RESOURCE_MGMT_ERROR"
-	tooManyFilesErr   = "TOO_MANY_OPEN_FILES"
+	errDevice         = "DEVICE_ERROR"
+	errDirNotEmpty    = "DIR_NOT_EMPTY"
+	errFileExists     = "FILE_EXISTS"
+	errFileDir        = "FILE_DIR_ERROR"
+	errNotImplemented = "NOT_IMPLEMENTED"
+	errIO             = "IO_ERROR"
+	errInterrupt      = "INTERRUPT_ERROR"
+	errInvalidArg     = "INVALID_ARGUMENT"
+	errInvalidOp      = "INVALID_OPERATION"
+	errMisc           = "MISC_ERROR"
+	errNetwork        = "NETWORK_ERROR"
+	errNoFileOrDir    = "NO_FILE_OR_DIR"
+	errNotADir        = "NOT_A_DIR"
+	errPerm           = "PERM_ERROR"
+	errProcessMgmt    = "PROCESS_RESOURCE_MGMT_ERROR"
+	errTooManyFiles   = "TOO_MANY_OPEN_FILES"
 )
 
 // Initialize the metrics.
@@ -117,13 +117,13 @@ func categorize(err error) string {
 		syscall.EPROTO,
 		syscall.ERFKILL,
 		syscall.EXDEV:
-		return deviceErr
+		return errDevice
 
 	case syscall.ENOTEMPTY:
-		return dirNotEmptyErr
+		return errDirNotEmpty
 
 	case syscall.EEXIST:
-		return fileExistsErr
+		return errFileExists
 
 	case syscall.EBADF,
 		syscall.EBADFD,
@@ -131,20 +131,20 @@ func categorize(err error) string {
 		syscall.EISDIR,
 		syscall.EISNAM,
 		syscall.ENOTBLK:
-		return fileDirErr
+		return errFileDir
 
 	case syscall.ENOSYS:
-		return notImplementedErr
+		return errNotImplemented
 
 	case syscall.EIO:
-		return ioErr
+		return errIO
 
 	case syscall.ECANCELED,
 		syscall.EINTR:
-		return intrErr
+		return errInterrupt
 
 	case syscall.EINVAL:
-		return invalidArgErr
+		return errInvalidArg
 
 	case syscall.E2BIG,
 		syscall.EALREADY,
@@ -157,7 +157,7 @@ func categorize(err error) string {
 		syscall.ENOTTY,
 		syscall.ERANGE,
 		syscall.ESPIPE:
-		return invalidOpErr
+		return errInvalidOp
 
 	case syscall.EADV,
 		syscall.EBADSLT,
@@ -191,7 +191,7 @@ func categorize(err error) string {
 		syscall.EUCLEAN,
 		syscall.EUNATCH,
 		syscall.EXFULL:
-		return miscErr
+		return errMisc
 
 	case syscall.EADDRINUSE,
 		syscall.EADDRNOTAVAIL,
@@ -231,13 +231,13 @@ func categorize(err error) string {
 		syscall.ESOCKTNOSUPPORT,
 		syscall.ESTRPIPE,
 		syscall.ETIMEDOUT:
-		return nwErr
+		return errNetwork
 
 	case syscall.ENOENT:
-		return noFileOrDirErr
+		return errNoFileOrDir
 
 	case syscall.ENOTDIR:
-		return notADirErr
+		return errNotADir
 
 	case syscall.EACCES,
 		syscall.EKEYEXPIRED,
@@ -247,7 +247,7 @@ func categorize(err error) string {
 		syscall.EPERM,
 		syscall.EROFS,
 		syscall.ETXTBSY:
-		return permError
+		return errPerm
 
 	case syscall.EAGAIN,
 		syscall.EBUSY,
@@ -264,13 +264,13 @@ func categorize(err error) string {
 		syscall.EOWNERDEAD,
 		syscall.ESRCH,
 		syscall.EUSERS:
-		return processMgmtErr
+		return errProcessMgmt
 
 	case syscall.EMFILE,
 		syscall.ENFILE:
-		return tooManyFilesErr
+		return errTooManyFiles
 	}
-	return miscErr
+	return errMisc
 }
 
 // Records file system operation count, failed operation count and the operation latency.

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -46,6 +46,26 @@ var (
 	tracer = otel.Tracer(name)
 )
 
+// Error categories
+const (
+	deviceErr         = "DEVICE_ERRORS"
+	dirNotEmptyErr    = "DIR_NOT_EMPTY"
+	fileExistsErr     = "FILE_EXISTS"
+	fileDirErr        = "FILE_DIR_ERROR"
+	notImplementedErr = "NOT_IMPLEMENTED"
+	ioErr             = "IO_ERROR"
+	intrErr           = "INTERRUPT_ERROR"
+	invalidArgErr     = "INVALID_ARGUMENT"
+	invalidOpErr      = "INVALID_OPERATION"
+	miscErr           = "MISC_ERROR"
+	nwErr             = "NETWORK_ERROR"
+	noFileOrDirErr    = "NO_FILE_OR_DIR"
+	notADirErr        = "NOT_A_DIR"
+	permError         = "PERM_ERROR"
+	processMgmtErr    = "PROCESS_RESOURCE_MGMT_ERROR"
+	tooManyFilesErr   = "TOO_MANY_OPEN_FILES"
+)
+
 // Initialize the metrics.
 func init() {
 
@@ -97,13 +117,13 @@ func categorize(err error) string {
 		syscall.EPROTO,
 		syscall.ERFKILL,
 		syscall.EXDEV:
-		return "device errors"
+		return deviceErr
 
 	case syscall.ENOTEMPTY:
-		return "directory not empty"
+		return dirNotEmptyErr
 
 	case syscall.EEXIST:
-		return "file exists"
+		return fileExistsErr
 
 	case syscall.EBADF,
 		syscall.EBADFD,
@@ -111,20 +131,20 @@ func categorize(err error) string {
 		syscall.EISDIR,
 		syscall.EISNAM,
 		syscall.ENOTBLK:
-		return "file/directory errors"
+		return fileDirErr
 
 	case syscall.ENOSYS:
-		return "function not implemented"
+		return notImplementedErr
 
 	case syscall.EIO:
-		return "input/output error"
+		return ioErr
 
 	case syscall.ECANCELED,
 		syscall.EINTR:
-		return "interrupt errors"
+		return intrErr
 
 	case syscall.EINVAL:
-		return "invalid argument"
+		return invalidArgErr
 
 	case syscall.E2BIG,
 		syscall.EALREADY,
@@ -137,7 +157,7 @@ func categorize(err error) string {
 		syscall.ENOTTY,
 		syscall.ERANGE,
 		syscall.ESPIPE:
-		return "invalid operation"
+		return invalidOpErr
 
 	case syscall.EADV,
 		syscall.EBADSLT,
@@ -171,7 +191,7 @@ func categorize(err error) string {
 		syscall.EUCLEAN,
 		syscall.EUNATCH,
 		syscall.EXFULL:
-		return "miscellaneous errors"
+		return miscErr
 
 	case syscall.EADDRINUSE,
 		syscall.EADDRNOTAVAIL,
@@ -211,13 +231,13 @@ func categorize(err error) string {
 		syscall.ESOCKTNOSUPPORT,
 		syscall.ESTRPIPE,
 		syscall.ETIMEDOUT:
-		return "network errors"
+		return nwErr
 
 	case syscall.ENOENT:
-		return "no such file or directory"
+		return noFileOrDirErr
 
 	case syscall.ENOTDIR:
-		return "not a directory"
+		return notADirErr
 
 	case syscall.EACCES,
 		syscall.EKEYEXPIRED,
@@ -227,7 +247,7 @@ func categorize(err error) string {
 		syscall.EPERM,
 		syscall.EROFS,
 		syscall.ETXTBSY:
-		return "permission errors"
+		return permError
 
 	case syscall.EAGAIN,
 		syscall.EBUSY,
@@ -244,13 +264,13 @@ func categorize(err error) string {
 		syscall.EOWNERDEAD,
 		syscall.ESRCH,
 		syscall.EUSERS:
-		return "process/resource management errors"
+		return processMgmtErr
 
 	case syscall.EMFILE,
 		syscall.ENFILE:
-		return "too many open files"
+		return tooManyFilesErr
 	}
-	return "miscellaneous errors"
+	return miscErr
 }
 
 // Records file system operation count, failed operation count and the operation latency.

--- a/internal/fs/wrappers/monitoring_test.go
+++ b/internal/fs/wrappers/monitoring_test.go
@@ -37,63 +37,63 @@ func TestFsErrStrAndCategory(t *testing.T) {
 	}{
 		{
 			fsErr:            fmt.Errorf("some random error"),
-			expectedCategory: "input/output error",
+			expectedCategory: ioErr,
 		},
 		{
 			fsErr:            syscall.ENOTEMPTY,
-			expectedCategory: "directory not empty",
+			expectedCategory: dirNotEmptyErr,
 		},
 		{
 			fsErr:            syscall.EEXIST,
-			expectedCategory: "file exists",
+			expectedCategory: fileExistsErr,
 		},
 		{
 			fsErr:            syscall.EINVAL,
-			expectedCategory: "invalid argument",
+			expectedCategory: invalidArgErr,
 		},
 		{
 			fsErr:            syscall.EINTR,
-			expectedCategory: "interrupt errors",
+			expectedCategory: intrErr,
 		},
 		{
 			fsErr:            syscall.ENOSYS,
-			expectedCategory: "function not implemented",
+			expectedCategory: notImplementedErr,
 		},
 		{
 			fsErr:            syscall.ENOSPC,
-			expectedCategory: "process/resource management errors",
+			expectedCategory: processMgmtErr,
 		},
 		{
 			fsErr:            syscall.E2BIG,
-			expectedCategory: "invalid operation",
+			expectedCategory: invalidOpErr,
 		},
 		{
 			fsErr:            syscall.EHOSTDOWN,
-			expectedCategory: "network errors",
+			expectedCategory: nwErr,
 		},
 		{
 			fsErr:            syscall.ENODATA,
-			expectedCategory: "miscellaneous errors",
+			expectedCategory: miscErr,
 		},
 		{
 			fsErr:            syscall.ENODEV,
-			expectedCategory: "device errors",
+			expectedCategory: deviceErr,
 		},
 		{
 			fsErr:            syscall.EISDIR,
-			expectedCategory: "file/directory errors",
+			expectedCategory: fileDirErr,
 		},
 		{
 			fsErr:            syscall.ENOSYS,
-			expectedCategory: "function not implemented",
+			expectedCategory: notImplementedErr,
 		},
 		{
 			fsErr:            syscall.ENFILE,
-			expectedCategory: "too many open files",
+			expectedCategory: tooManyFilesErr,
 		},
 		{
 			fsErr:            syscall.EPERM,
-			expectedCategory: "permission errors",
+			expectedCategory: permError,
 		},
 	}
 

--- a/internal/fs/wrappers/monitoring_test.go
+++ b/internal/fs/wrappers/monitoring_test.go
@@ -37,63 +37,63 @@ func TestFsErrStrAndCategory(t *testing.T) {
 	}{
 		{
 			fsErr:            fmt.Errorf("some random error"),
-			expectedCategory: ioErr,
+			expectedCategory: errIO,
 		},
 		{
 			fsErr:            syscall.ENOTEMPTY,
-			expectedCategory: dirNotEmptyErr,
+			expectedCategory: errDirNotEmpty,
 		},
 		{
 			fsErr:            syscall.EEXIST,
-			expectedCategory: fileExistsErr,
+			expectedCategory: errFileExists,
 		},
 		{
 			fsErr:            syscall.EINVAL,
-			expectedCategory: invalidArgErr,
+			expectedCategory: errInvalidArg,
 		},
 		{
 			fsErr:            syscall.EINTR,
-			expectedCategory: intrErr,
+			expectedCategory: errInterrupt,
 		},
 		{
 			fsErr:            syscall.ENOSYS,
-			expectedCategory: notImplementedErr,
+			expectedCategory: errNotImplemented,
 		},
 		{
 			fsErr:            syscall.ENOSPC,
-			expectedCategory: processMgmtErr,
+			expectedCategory: errProcessMgmt,
 		},
 		{
 			fsErr:            syscall.E2BIG,
-			expectedCategory: invalidOpErr,
+			expectedCategory: errInvalidOp,
 		},
 		{
 			fsErr:            syscall.EHOSTDOWN,
-			expectedCategory: nwErr,
+			expectedCategory: errNetwork,
 		},
 		{
 			fsErr:            syscall.ENODATA,
-			expectedCategory: miscErr,
+			expectedCategory: errMisc,
 		},
 		{
 			fsErr:            syscall.ENODEV,
-			expectedCategory: deviceErr,
+			expectedCategory: errDevice,
 		},
 		{
 			fsErr:            syscall.EISDIR,
-			expectedCategory: fileDirErr,
+			expectedCategory: errFileDir,
 		},
 		{
 			fsErr:            syscall.ENOSYS,
-			expectedCategory: notImplementedErr,
+			expectedCategory: errNotImplemented,
 		},
 		{
 			fsErr:            syscall.ENFILE,
-			expectedCategory: tooManyFilesErr,
+			expectedCategory: errTooManyFiles,
 		},
 		{
 			fsErr:            syscall.EPERM,
-			expectedCategory: permError,
+			expectedCategory: errPerm,
 		},
 	}
 


### PR DESCRIPTION
Currently, the category names are phrases/sentences. Keeping it as codes makes them more succinct and easily searchable.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
