### PR TITLE
Fix creation of gRPC client with enable-hns true on custom endpoint

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -169,7 +169,7 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 
 	// TODO: We will implement an additional check for the HTTP control client protocol once the Go SDK supports HTTP.
 	// TODO: Custom endpoints do not currently support gRPC. Remove this additional check once TPC(custom-endpoint) supports gRPC.
-	if clientConfig.EnableHNS && clientConfig.CustomEndpoint != "" {
+	if clientConfig.EnableHNS && clientConfig.CustomEndpoint == "" {
 		clientOpts, err := createClientOptionForGRPCClient(&clientConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -168,7 +168,8 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	}
 
 	// TODO: We will implement an additional check for the HTTP control client protocol once the Go SDK supports HTTP.
-	if clientConfig.EnableHNS {
+	// TODO: Custom endpoints do not currently support gRPC. Remove this additional check once TPC(custom-endpoint) supports gRPC.
+	if clientConfig.EnableHNS && clientConfig.CustomEndpoint != "" {
 		clientOpts, err := createClientOptionForGRPCClient(&clientConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -287,6 +288,19 @@ func (testSuite *StorageHandleTest) TestCreateStorageHandleWithEnableHNSTrue() {
 	sh, err := NewStorageHandle(context.Background(), sc)
 
 	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), sh)
+}
+
+func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndEnableHNSTrue() {
+	url, err := url.Parse(storageutil.CustomEndpoint)
+	require.NoError(testSuite.T(), err)
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.CustomEndpoint = url.String()
+	sc.EnableHNS = true
+
+	sh, err := NewStorageHandle(context.Background(), sc)
+
+	assert.NoError(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), sh)
 }
 

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -41,6 +41,6 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		ReuseTokenFromUrl:          true,
 		ExperimentalEnableJsonRead: false,
 		AnonymousAccess:            true,
-		EnableHNS:                  true,
+		EnableHNS:                  false,
 	}
 }

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -41,6 +41,6 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		ReuseTokenFromUrl:          true,
 		ExperimentalEnableJsonRead: false,
 		AnonymousAccess:            true,
-		EnableHNS:                  false,
+		EnableHNS:                  true,
 	}
 }


### PR DESCRIPTION
### Description
Do not create a gRPC client if a custom endpoint is provided, as custom endpoints may not support gRPC client functionality.(e.g. TPC)

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested on TPC environment
2. Unit tests - NA
3. Integration tests - Automated
