### PR TITLE
Convert rpc error code in fuse error

### DIFF
--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -47,7 +47,8 @@ func errno(err error) error {
 	if errors.Is(err, context.Canceled) {
 		return syscall.EINTR
 	}
-	if errors.Is(err, storage.ErrObjectNotExist) {
+
+	if errors.Is(err, storage.ErrObjectNotExist) || strings.Contains(err.Error(), "NotFound") {
 		return syscall.ENOENT
 	}
 
@@ -56,8 +57,9 @@ func errno(err error) error {
 		return syscall.ECANCELED
 	}
 
-	// Cannot authenticate
-	if strings.Contains(err.Error(), "oauth2: cannot fetch token") {
+	// Cannot authenticate or Permission denied.
+	// The control client API returns an RPC error code instead of googleapi code.
+	if strings.Contains(err.Error(), "oauth2: cannot fetch token") || strings.Contains(err.Error(), "PermissionDenied") {
 		return syscall.EACCES
 	}
 

--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -48,6 +48,7 @@ func errno(err error) error {
 		return syscall.EINTR
 	}
 
+	// The control client API returns an RPC error code instead of googleapi code.
 	if errors.Is(err, storage.ErrObjectNotExist) || strings.Contains(err.Error(), "NotFound") {
 		return syscall.ENOENT
 	}

--- a/internal/fs/wrappers/error_mapping_test.go
+++ b/internal/fs/wrappers/error_mapping_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wrappers
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ErrorMapping struct {
+	suite.Suite
+}
+
+func TestWithErrorMapping(testSuite *testing.T) {
+	suite.Run(testSuite, new(ErrorMapping))
+}
+
+func (testSuite *ErrorMapping) TestPermissionDeniedError() {
+	err := fmt.Errorf("rpc error: code = PermissionDenied desc = xxx does not have storage.folders.create access to the Google Cloud Storage bucket. Permission denied on resource (or it may not exist).")
+
+	fsErr := errno(err)
+
+	assert.Equal(testSuite.T(), syscall.EACCES, fsErr)
+}
+
+func (testSuite *ErrorMapping) TestNotFoundError() {
+	err := fmt.Errorf("rpc error: code = NotFound desc = The folder does not exist.")
+
+	fsErr := errno(err)
+
+	assert.Equal(testSuite.T(), syscall.ENOENT, fsErr)
+}


### PR DESCRIPTION
### Description
The Control client folder APIs are currently returning RPC error codes instead of Google API codes. This discrepancy is causing incorrect error conversion within the FUSE layer.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested
2. Unit tests - NA
3. Integration tests - Automated
