### PR TITLE
Add script changes to run tensor flow model with control client APIs on HNS bucket

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -159,7 +159,7 @@ then
   delete_existing_vm_and_create_new
   
   echo "Clone the gcsfuse repo on test VM"
-  sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "mkdir github; cd github; git clone https://github.com/GoogleCloudPlatform/gcsfuse.git; cd gcsfuse; git checkout tensor_flow_model_with_hns;"
+  sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "mkdir github; cd github; git clone https://github.com/GoogleCloudPlatform/gcsfuse.git; cd gcsfuse; git checkout master;"
   echo "Trigger the build script on test VM"
   sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "bash \$HOME/$TEST_SCRIPT_PATH $BUCKET_TYPE 1> \$HOME/build.out 2> \$HOME/build.err &"
   echo "Wait for 15 minutes for test VM to setup for test and to change the status from START to RUNNING."

--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -159,7 +159,7 @@ then
   delete_existing_vm_and_create_new
   
   echo "Clone the gcsfuse repo on test VM"
-  sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "mkdir github; cd github; git clone https://github.com/GoogleCloudPlatform/gcsfuse.git; cd gcsfuse; git checkout master;"
+  sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "mkdir github; cd github; git clone https://github.com/GoogleCloudPlatform/gcsfuse.git; cd gcsfuse; git checkout tensor_flow_model_with_hns;"
   echo "Trigger the build script on test VM"
   sudo gcloud compute ssh $VM_NAME --zone $ZONE_NAME --internal-ip --command "bash \$HOME/$TEST_SCRIPT_PATH $BUCKET_TYPE 1> \$HOME/build.out 2> \$HOME/build.err &"
   echo "Wait for 15 minutes for test VM to setup for test and to change the status from START to RUNNING."

--- a/perfmetrics/scripts/continuous_test/ml_tests/tf/resnet_hns/build.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/tf/resnet_hns/build.sh
@@ -16,11 +16,11 @@
 # This will stop execution when any command will have non-zero status.
 set -e
 
-VM_NAME="tf-resnet-7d"
-ZONE_NAME="us-west1-b"
-ARTIFACTS_BUCKET_PATH="gs://gcsfuse-ml-tests-logs/ci_artifacts/tf/resnet"
+VM_NAME="tf-resnet-7d-a100-gpu-hns-bucket"
+ZONE_NAME="us-central1-f"
+ARTIFACTS_BUCKET_PATH="gs://gcsfuse-ml-tests-logs/ci_artifacts/tf/resnet_hns"
 TEST_SCRIPT_PATH="github/gcsfuse/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh"
-BUCKET_TYPE="non-hns"
+BUCKET_TYPE="hns"
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts/continuous_test/ml_tests/"
 

--- a/perfmetrics/scripts/continuous_test/ml_tests/tf/resnet_hns/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/ml_tests/tf/resnet_hns/continuous.cfg
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This will stop execution when any command will have non-zero status.
-set -e
+# Config file for kokoro test
+build_file: "gcsfuse/perfmetrics/scripts/continuous_test/ml_tests/tf/resnet_hns/build.sh"
 
-VM_NAME="tf-resnet-7d"
-ZONE_NAME="us-west1-b"
-ARTIFACTS_BUCKET_PATH="gs://gcsfuse-ml-tests-logs/ci_artifacts/tf/resnet"
-TEST_SCRIPT_PATH="github/gcsfuse/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh"
-BUCKET_TYPE="non-hns"
-
-cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse/perfmetrics/scripts/continuous_test/ml_tests/"
-
-source run_and_manage_test.sh $VM_NAME $ZONE_NAME $ARTIFACTS_BUCKET_PATH $TEST_SCRIPT_PATH "" $BUCKET_TYPE
+# 1 hours timeout.
+timeout_mins: 60

--- a/perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile
@@ -31,5 +31,8 @@ WORKDIR "/tf_test/"
 COPY ./perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh .
 COPY ./perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/resnet_runner.py .
 
+ARG BUCKET_TYPE
+ENV BUCKET_TYPE=${BUCKET_TYPE}
+
 RUN mkdir -p "myBucket"
-ENTRYPOINT ["/bin/bash", "-c", "./setup_container.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "./setup_container.sh ${BUCKET_TYPE}"]

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_host_and_run_model.sh
@@ -16,6 +16,7 @@
 # This will stop execution when any command will have non-zero status.
 set -e
 
+BUCKET_TYPE=$1
 cd "$HOME/github/gcsfuse/perfmetrics/scripts"
 
 echo "Setting up the machine with Docker and Nvidia Driver..."
@@ -26,7 +27,7 @@ cd "$HOME/github/gcsfuse/"
 mkdir container_artifacts && mkdir container_artifacts/logs && mkdir container_artifacts/output
 
 echo "Building tf DLC docker image containing all tensorflow libraries..."
-sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf-gpu.2-13
+sudo docker build . -f perfmetrics/scripts/ml_tests/tf/resnet/Dockerfile -t tf-dlc-gcsfuse --build-arg DLC_IMAGE_NAME=tf-gpu.2-13 --build-arg BUCKET_TYPE="${BUCKET_TYPE}"
 
 echo "Running the docker image build in the previous step..."
 sudo docker run --gpus all --name tf_model_container --privileged -d \

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -48,7 +48,7 @@ DIR="resnet"
 if [ ${BUCKET_TYPE} == "hns" ];
 then
   TEST_BUCKET="gcsfuse-ml-data-hns-central1"
-  echo "enable-hns: true" >> $config_filename
+  echo "enable-hns: true" >> /tmp/gcsfuse_config.yaml
   DIR=${DIR}_${BUCKET_TYPE}
 fi
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -41,7 +41,7 @@ echo "logging:
           compress: true
        " > /tmp/gcsfuse_config.yaml
 
-TEST_BUCKET=gcsfuse-ml-tf-data
+TEST_BUCKET="gcsfuse-ml-tf-data"
 DIR="resnet"
 # Enable the enable-hns flag to run tests on the folder APIs with an HNS bucket.
 if [ ${BUCKET_TYPE} == "hns" ];

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -18,6 +18,7 @@
 # and epochs functionality, and runs the model
 
 # Install go lang
+BUCKET_TYPE=$1
 wget -O go_tar.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
@@ -39,11 +40,22 @@ echo "logging:
           backup-file-count: 3
           compress: true
        " > /tmp/gcsfuse_config.yaml
+
+TEST_BUCKET=gcsfuse-ml-tf-data
+DIR="resnet"
+# Enable the enable-hns flag to run tests on the folder APIs with an HNS bucket.
+if [ ${BUCKET_TYPE} == "hns" ];
+then
+  TEST_BUCKET="gcsfuse-ml-data-hns-central1"
+  echo "enable-hns: true" >> $config_filename
+  DIR=${DIR}_${BUCKET_TYPE}
+fi
+
 nohup gcsfuse/gcsfuse --foreground \
       --implicit-dirs \
       --stackdriver-export-interval 60s \
       --config-file /tmp/gcsfuse_config.yaml \
-      gcsfuse-ml-tf-data myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
+     $TEST_BUCKET myBucket > /home/output/gcsfuse.out 2> /home/output/gcsfuse.err &
 
 # Install tensorflow model garden library
 pip3 install --user tf-models-official==2.13.2
@@ -190,7 +202,7 @@ sed -i "$lines"'d' $train_lib_file
 x=$((x-1))
 sed -i "$x"'r bypassed_code.py' $train_lib_file
 
-ARTIFACTS_BUCKET_PATH="gs://gcsfuse-ml-tests-logs/ci_artifacts/tf/resnet"
+ARTIFACTS_BUCKET_PATH="gs://gcsfuse-ml-tests-logs/ci_artifacts/tf/${DIR}"
 echo "Update status file"
 echo "RUNNING" > status.txt
 gsutil cp status.txt $ARTIFACTS_BUCKET_PATH/

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -26,7 +26,6 @@ export PATH=$PATH:/usr/local/go/bin
 # Clone the repo and build gcsfuse
 git clone "https://github.com/GoogleCloudPlatform/gcsfuse.git"
 cd gcsfuse
-git checkout tensor_flow_model_with_hns
 CGO_ENABLED=0 go build .
 cd -
 

--- a/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
+++ b/perfmetrics/scripts/ml_tests/tf/resnet/setup_scripts/setup_container.sh
@@ -26,6 +26,7 @@ export PATH=$PATH:/usr/local/go/bin
 # Clone the repo and build gcsfuse
 git clone "https://github.com/GoogleCloudPlatform/gcsfuse.git"
 cd gcsfuse
+git checkout tensor_flow_model_with_hns
 CGO_ENABLED=0 go build .
 cd -
 


### PR DESCRIPTION
### Description

- Add the necessary setup to run Tensorflow AI/ML tests with an HNS bucket, utilizing the newly integrated folder APIs.
- Created HNS bucket in us-central1 region and copied all ai-ml training data.
- Created reservation for a2-gpu machine in gcs-fuse-test project.
- Validated from the logs, folder APIs are getting called.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually
2. Unit tests - NA
3. Integration tests - NA
