### PR TITLE
Adding folder containing 1m files to ls perf tests config file for hns bucket

### DIFF
--- a/perfmetrics/scripts/ls_metrics/config-hns.json
+++ b/perfmetrics/scripts/ls_metrics/config-hns.json
@@ -1,6 +1,6 @@
 {
   "name": "list-benchmark-tests-hns" ,
-  "num_folders": 11 ,
+  "num_folders": 12 ,
   "folders": [
     {
       "name": "1KB_1000files_0subdir" ,
@@ -65,6 +65,12 @@
     {
       "name": "1KB_200000files_0subdir" ,
       "num_files": 200000 ,
+      "file_name_prefix": "file" ,
+      "file_size": "1kb"
+    },
+    {
+      "name": "1KB_1000000files_0subdir" ,
+      "num_files": 1000000 ,
       "file_name_prefix": "file" ,
       "file_size": "1kb"
     }


### PR DESCRIPTION
### Description
Updated config-hns.json with folder containing 1 million files for periodic listing perf tests for HNS bucket.### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
