### PR TITLE
Increase timeout of test runs

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -32,10 +32,10 @@ jobs:
         run: go mod download
 
       - name: Test all except caching parallely
-        run: CGO_ENABLED=0 go test  -count 20 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./... | grep -v internal/cache/...`
+        run: CGO_ENABLED=0 go test -timeout 75m -count 20 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./... | grep -v internal/cache/...`
 
       - name: Test caching
-        run: CGO_ENABLED=0 go test -p 1 -count 20 -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
 
       - name: Cache RaceDetector Test
-        run: CGO_ENABLED=0 go test -p 1 -count 20 ./internal/cache/...
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 ./internal/cache/...


### PR DESCRIPTION
go tests have a timeout of 10 minutes by default. Since the tests are run several times in this workflow, we need to increase the timeout accordingly. Otherwise, the tests will time-out after 10 minutes.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
