### PR TITLE
Enable new config by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,17 +71,18 @@ func main() {
 	// Set up profiling handlers.
 	go perf.HandleCPUProfileSignals()
 	go perf.HandleMemoryProfileSignals()
-	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "true" {
-		// TODO: implement the mount logic instead of simply returning nil.
-		rootCmd, err := cmd.NewRootCmd(cmd.Mount)
-		if err != nil {
-			log.Fatalf("Error occurred while creating the root command: %v", err)
-		}
-		rootCmd.SetArgs(convertToPosixArgs(os.Args))
-		if err := rootCmd.Execute(); err != nil {
-			log.Fatalf("Error occurred during command execution: %v", err)
-		}
+	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "false" {
+		cmd.ExecuteLegacyMain()
 		return
 	}
-	cmd.ExecuteLegacyMain()
+
+	rootCmd, err := cmd.NewRootCmd(cmd.Mount)
+	if err != nil {
+		log.Fatalf("Error occurred while creating the root command: %v", err)
+	}
+	rootCmd.SetArgs(convertToPosixArgs(os.Args))
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Error occurred during command execution: %v", err)
+	}
+
 }

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-
 	//"runtime"
 	"syscall"
 	"testing"
@@ -114,13 +113,13 @@ func (t *GcsfuseTest) BadUsage() {
 		// Too many args
 		0: {
 			[]string{canned.FakeBucketName, "a", "b"},
-			"gcsfuse takes one or two arguments.",
+			"Error: accepts between 2 and 3 arg\\(s\\), received 4",
 		},
 
 		// Unknown flag
 		1: {
 			[]string{"--tweak_frobnicator", canned.FakeBucketName, "a"},
-			"not defined.*tweak_frobnicator",
+			"unknown flag: --tweak_frobnicator",
 		},
 	}
 


### PR DESCRIPTION
### Description
This switches the defaults to use the new Viper based configuration instead of urfave/cli.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
