### PR TITLE
Fixing kokoro timeout issue for perf test: Skipping testing folder with 1M files from HNS bucket from listing tests

### DIFF
--- a/perfmetrics/scripts/ls_metrics/config.json
+++ b/perfmetrics/scripts/ls_metrics/config.json
@@ -1,6 +1,6 @@
 {
         "name": "list-benchmark-tests" ,
-        "num_folders": 11 ,
+        "num_folders": 12 ,
         "folders": [
                 {
                         "name": "1KB_1000files_0subdir" ,
@@ -65,6 +65,12 @@
                 {
                         "name": "1KB_200000files_0subdir" ,
                         "num_files": 200000 ,
+                        "file_name_prefix": "file" ,
+                        "file_size": "1kb"
+                },
+                {
+                        "name": "1KB_1000000files_0subdir" ,
+                        "num_files": 1000000 ,
                         "file_name_prefix": "file" ,
                         "file_size": "1kb"
                 }

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -539,15 +539,14 @@ if __name__ == '__main__':
 
   # If similar directory structure not found in the GCS bucket then delete all
   # the files in the bucket and make it from scratch.
-  print(directory_structure_present)
-  # if not directory_structure_present:
-  #   log.info(
-  #       """Similar directory structure not found in the GCS bucket.
-  #       Creating a new one.\n""")
-  #   log.info('Deleting previously present directories in the GCS bucket.\n')
-  #   subprocess.call(
-  #       'gsutil -m rm -r gs://{}/*'.format(directory_structure.name),
-  #       shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+  if not directory_structure_present:
+    log.info(
+        """Similar directory structure not found in the GCS bucket.
+        Creating a new one.\n""")
+    log.info('Deleting previously present directories in the GCS bucket.\n')
+    subprocess.call(
+        'gsutil -m rm -r gs://{}/*'.format(directory_structure.name),
+        shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
   # Creating a temp directory which will be needed by the generate_files
   # method to create files in batches.

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -45,6 +45,8 @@ Typical usage example:
                           details of the tests.
 
 Note: This python script is dependent on generate_files.py.
+Note: This script currently skips folder with 1000000 files to facilitate periodic kokoro tests
+without timeout .To run that test case, comment out lines [124-126],[180-182],[259-261],[317-319],[377-379]
 """
 
 import argparse
@@ -119,6 +121,9 @@ def _get_values_to_export(folders, metrics, command) -> list:
 
   list_metrics_data = []
   for testing_folder in folders:
+    if testing_folder.name == "1KB_1000000files_0subdir":
+      # Excluding test case with 1m files from HNS in daily periodic tests.
+      continue
     num_files, num_folders = _count_number_of_files_and_folders(
         testing_folder, 0, 0)
     row = [
@@ -172,6 +177,9 @@ def _parse_results(folders, results_list, message, num_samples) -> dict:
   metrics = dict()
 
   for testing_folder in folders:
+    if testing_folder.name == "1KB_1000000files_0subdir":
+      # Excluding test case with 1m files from HNS in daily periodic tests.
+      continue
     metrics[testing_folder.name] = dict()
     metrics[testing_folder.name]['Test Desc.'] = message
     metrics[testing_folder.name]['Number of samples'] = num_samples
@@ -248,6 +256,10 @@ def _perform_testing(
   persistent_disk_results = {}
 
   for testing_folder in folders:
+    if testing_folder.name == "1KB_1000000files_0subdir":
+      # Excluding test case with 1m files from HNS in daily periodic tests.
+      continue
+
     log.info('Testing started for testing folder: %s\n', testing_folder.name)
     local_dir_path = './{}/{}/'.format(persistent_disk, testing_folder.name)
     gcs_bucket_path = './{}/{}/'.format(gcs_bucket, testing_folder.name)
@@ -302,6 +314,9 @@ def _create_directory_structure(
 
   result = 0
   for folder in directory_structure.folders:
+    if folder.name == "1KB_1000000files_0subdir":
+      # Excluding test case with 1m files from HNS in daily periodic tests.
+      continue
     result += _create_directory_structure(gcs_bucket_url + folder.name + '/',
                                           persistent_disk_url + folder.name + '/',
                                           folder, create_files_in_gcs)
@@ -359,6 +374,9 @@ def _compare_directory_structure(url, directory_structure) -> bool:
 
   result = True
   for folder in directory_structure.folders:
+    if folder.name == "1KB_1000000files_0subdir":
+      # Excluding test case with 1m files from HNS in daily periodic tests.
+      continue
     new_url = url + folder.name + '/'
     if new_url not in folders:
       return False
@@ -521,14 +539,15 @@ if __name__ == '__main__':
 
   # If similar directory structure not found in the GCS bucket then delete all
   # the files in the bucket and make it from scratch.
-  if not directory_structure_present:
-    log.info(
-        """Similar directory structure not found in the GCS bucket.
-        Creating a new one.\n""")
-    log.info('Deleting previously present directories in the GCS bucket.\n')
-    subprocess.call(
-        'gsutil -m rm -r gs://{}/*'.format(directory_structure.name),
-        shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+  print(directory_structure_present)
+  # if not directory_structure_present:
+  #   log.info(
+  #       """Similar directory structure not found in the GCS bucket.
+  #       Creating a new one.\n""")
+  #   log.info('Deleting previously present directories in the GCS bucket.\n')
+  #   subprocess.call(
+  #       'gsutil -m rm -r gs://{}/*'.format(directory_structure.name),
+  #       shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
   # Creating a temp directory which will be needed by the generate_files
   # method to create files in batches.


### PR DESCRIPTION
### Description
HNS bucket in use for the listing benchmarks script contains test folder with 1m files. Making that a one time manual run only since Kokoro periodic test job times out due to this case.

To run list perf test on folder with 1m files, comment out lines mentioned in the script header.


Part1: To prevent data deletion, did the necessary changes
Part2: Will add flag whether to run 1m files test or not.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran to check if the script is working as intended and skips 1m files folder while performing tests.
2. Unit tests - NA
3. Integration tests - NA
