### PR TITLE
Fix for managed folders e2e test - intermittent

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -56,7 +56,7 @@ type managedFoldersAdminPermission struct {
 }
 
 func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
-	createDirectoryStructureForNonEmptyManagedFolders(t)
+	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, t)
 	if s.managedFoldersPermission != "nil" {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFoldersPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFoldersPermission, t)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -106,8 +106,8 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest/testFile
 	// testBucket/NonEmptyManagedFoldersTest/testFile
+	client.SetupTestDirectory(ctx, storageClient, TestDirForManagedFolderTest)
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
-	testDir = client.SetupTestDirectory(ctx, storageClient, testDir)
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -107,7 +107,7 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest/testFile
 	// testBucket/NonEmptyManagedFoldersTest/testFile
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
-	testDir = client.SetupTestDirectory(ctx, storageClient, TestDirForManagedFolderTest)
+	client.SetupTestDirectory(ctx, storageClient, testDir)
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -109,7 +109,7 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, testDir)
 	if err != nil {
-		log.Printf("Failed to clean up test directory: %v", err)
+		log.Fatalf("Failed to clean up test directory: %v", err)
 	}
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -107,7 +107,7 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest/testFile
 	// testBucket/NonEmptyManagedFoldersTest/testFile
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
-	client.SetupTestDirectory(ctx, storageClient, testDir)
+	testDir = client.SetupTestDirectory(ctx, storageClient, testDir)
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -106,8 +106,11 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest/testFile
 	// testBucket/NonEmptyManagedFoldersTest/testFile
-	client.SetupTestDirectory(ctx, storageClient, TestDirForManagedFolderTest)
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
+	err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, testDir)
+	if err != nil {
+		log.Printf("Failed to clean up test directory: %v", err)
+	}
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
@@ -97,7 +98,7 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
-func createDirectoryStructureForNonEmptyManagedFolders(t *testing.T) {
+func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, storageClient *storage.Client, t *testing.T) {
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1/testFile
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder2
@@ -106,6 +107,7 @@ func createDirectoryStructureForNonEmptyManagedFolders(t *testing.T) {
 	// testBucket/NonEmptyManagedFoldersTest/SimulatedFolderNonEmptyManagedFoldersTest/testFile
 	// testBucket/NonEmptyManagedFoldersTest/testFile
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
+	testDir = client.SetupTestDirectory(ctx, storageClient, TestDirForManagedFolderTest)
 	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -151,7 +151,7 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	// Create directory structure for testing.
-	createDirectoryStructureForNonEmptyManagedFolders(t)
+	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, t)
 	defer cleanup(ctx, storageClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
 
 	// Run tests.


### PR DESCRIPTION
### Description
End-to-end tests were failing on some buckets due to the presence of that pre-existing data. This was fixed by cleaning up the directory before creating new data.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
