### PR TITLE
[CLI Config Parity] fix error to handle negative numbers in gcsfuse arguments

### DIFF
--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -17,6 +17,8 @@ package cfg
 import (
 	"fmt"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -40,4 +42,13 @@ func ListCacheTTLSecsToDuration(secs int64) time.Duration {
 	}
 
 	return time.Duration(secs * int64(time.Second))
+}
+
+func IsNegativeNumber(str string) bool {
+	str = strings.TrimSpace(str)
+	num, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return false // Conversion failed; not a valid number
+	}
+	return num < 0
 }

--- a/cfg/config_util_test.go
+++ b/cfg/config_util_test.go
@@ -105,3 +105,25 @@ func Test_ListCacheTtlSecsToDuration_InvalidCall(t *testing.T) {
 	// Calling with invalid argument to trigger panic.
 	ListCacheTTLSecsToDuration(-3)
 }
+
+func TestIsNegativeNumber(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"negative_integer", "-123", true},
+		{"positive_integer", "456", false},
+		{"negative_float", "-3.14", true},
+		{"zero", "0", false},
+		{"string", "abc", false},
+		{"invalid", "-12.34invalid", false},
+		{"negative_with_spaces", "  -5  ", true}, // Test with leading/trailing spaces
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsNegativeNumber(tc.input))
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/cmd"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/perf"
@@ -49,7 +50,7 @@ func convertToPosixArgs(args []string) []string {
 			pArgs = append(pArgs, "-v")
 		case a == "--h", a == "-h":
 			pArgs = append(pArgs, "-h")
-		case strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--"):
+		case strings.HasPrefix(a, "-") && !cfg.IsNegativeNumber(a) && !strings.HasPrefix(a, "--"):
 			pArgs = append(pArgs, "-"+a)
 		default:
 			pArgs = append(pArgs, a)

--- a/main_test.go
+++ b/main_test.go
@@ -67,9 +67,19 @@ func TestPosixFlagsConversion(t *testing.T) {
 			expected: []string{"abc", "-v"},
 		},
 		{
-			name:     "negative_numbers_are_unchanged.",
+			name:     "negative_numbers_are_unchanged",
 			input:    []string{"abc", "-1", "-238", "-300.987"},
 			expected: []string{"abc", "-1", "-238", "-300.987"},
+		},
+		{
+			name:     "positive_numbers_are_unchanged",
+			input:    []string{"abc", "1", "238", "300.987"},
+			expected: []string{"abc", "1", "238", "300.987"},
+		},
+		{
+			name:     "numbers_are_unchanged_with_=_flag",
+			input:    []string{"abc", "-flag1=-1", "--flag2=-238", "-flag3=300.987", "-flag4=67"},
+			expected: []string{"abc", "--flag1=-1", "--flag2=-238", "--flag3=300.987", "--flag4=67"},
 		},
 	}
 	for _, tc := range data {

--- a/main_test.go
+++ b/main_test.go
@@ -66,6 +66,11 @@ func TestPosixFlagsConversion(t *testing.T) {
 			input:    []string{"abc", "--v"},
 			expected: []string{"abc", "-v"},
 		},
+		{
+			name:     "negative_numbers_are_unchanged.",
+			input:    []string{"abc", "-1", "-238", "-300.987"},
+			expected: []string{"abc", "-1", "-238", "-300.987"},
+		},
 	}
 	for _, tc := range data {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### Description
To maintain backward compatibility, we're adding a "-" prefix to all GCSFuse arguments, aligning with cobra/viper's use of POSIX-compliant flags (which require a "--" prefix). However, this led to a bug where negative numbers were also receiving the "-" prefix, as we hadn't explicitly accounted for this scenario. The fix involves implementing a check to bypass negative numbers when adding prefixes.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified '--kernel-list-cache-ttl-secs -1` flag is working now.
2. Unit tests - Added
3. Integration tests - NA
