### PR TITLE
Add lock for erasing/inserting entries for folder

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -85,6 +85,7 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 	}
 }
 
+// LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) eraseEntriesWithGivenPrefix(folderName string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -34,10 +34,10 @@ import (
 // bucket. Records are invalidated when modifications are made through this
 // bucket, and after the supplied TTL.
 func NewFastStatBucket(
-		ttl time.Duration,
-		cache metadata.StatCache,
-		clock timeutil.Clock,
-		wrapped gcs.Bucket) (b gcs.Bucket) {
+	ttl time.Duration,
+	cache metadata.StatCache,
+	clock timeutil.Clock,
+	wrapped gcs.Bucket) (b gcs.Bucket) {
 	fsb := &fastStatBucket{
 		cache:   cache,
 		clock:   clock,
@@ -85,7 +85,7 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 	}
 }
 
-func (b *fastStatBucket) eraseEntriesWithGivenPrefixes(folderName string) {
+func (b *fastStatBucket) eraseEntriesWithGivenPrefix(folderName string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -183,16 +183,16 @@ func (b *fastStatBucket) BucketType() gcs.BucketType {
 }
 
 func (b *fastStatBucket) NewReader(
-		ctx context.Context,
-		req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
+	ctx context.Context,
+	req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
 	rc, err = b.wrapped.NewReader(ctx, req)
 	return
 }
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) CreateObject(
-		ctx context.Context,
-		req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
+	ctx context.Context,
+	req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for this object.
 	b.invalidate(req.Name)
 
@@ -210,8 +210,8 @@ func (b *fastStatBucket) CreateObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) CopyObject(
-		ctx context.Context,
-		req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
+	ctx context.Context,
+	req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for the destination name.
 	b.invalidate(req.DstName)
 
@@ -229,8 +229,8 @@ func (b *fastStatBucket) CopyObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) ComposeObjects(
-		ctx context.Context,
-		req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
+	ctx context.Context,
+	req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for the destination name.
 	b.invalidate(req.DstName)
 
@@ -248,8 +248,8 @@ func (b *fastStatBucket) ComposeObjects(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) StatObject(
-		ctx context.Context,
-		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	ctx context.Context,
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
 	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
 		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnExtendedObjectAttributes: true")
@@ -284,8 +284,8 @@ func (b *fastStatBucket) StatObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) ListObjects(
-		ctx context.Context,
-		req *gcs.ListObjectsRequest) (listing *gcs.Listing, err error) {
+	ctx context.Context,
+	req *gcs.ListObjectsRequest) (listing *gcs.Listing, err error) {
 	// Fetch the listing.
 	listing, err = b.wrapped.ListObjects(ctx, req)
 	if err != nil {
@@ -304,8 +304,8 @@ func (b *fastStatBucket) ListObjects(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) UpdateObject(
-		ctx context.Context,
-		req *gcs.UpdateObjectRequest) (o *gcs.Object, err error) {
+	ctx context.Context,
+	req *gcs.UpdateObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for this object.
 	b.invalidate(req.Name)
 
@@ -323,8 +323,8 @@ func (b *fastStatBucket) UpdateObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) DeleteObject(
-		ctx context.Context,
-		req *gcs.DeleteObjectRequest) (err error) {
+	ctx context.Context,
+	req *gcs.DeleteObjectRequest) (err error) {
 	b.invalidate(req.Name)
 	err = b.wrapped.DeleteObject(ctx, req)
 	return
@@ -342,7 +342,7 @@ func (b *fastStatBucket) DeleteFolder(ctx context.Context, folderName string) er
 }
 
 func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
-		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	m, e, err = b.wrapped.StatObject(ctx, req)
 	if err != nil {
 		// Special case: NotFoundError -> negative entry.
@@ -361,8 +361,8 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 }
 
 func (b *fastStatBucket) GetFolder(
-		ctx context.Context,
-		prefix string) (*gcs.Folder, error) {
+	ctx context.Context,
+	prefix string) (*gcs.Folder, error) {
 
 	if hit, entry := b.lookUpFolder(prefix); hit {
 		// Negative entries result in NotFoundError.
@@ -409,7 +409,7 @@ func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, de
 	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
 
 	// Invalidate cache for old directory.
-	b.eraseEntriesWithGivenPrefixes(folderName)
+	b.eraseEntriesWithGivenPrefix(folderName)
 
 	return o, err
 }

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -133,7 +133,7 @@ func (b *fastStatBucket) insertFolder(f *gcs.Folder) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.cache.InsertFolder(f,  b.clock.Now().Add(b.ttl))
+	b.cache.InsertFolder(f, b.clock.Now().Add(b.ttl))
 }
 
 // LOCKS_EXCLUDED(b.mu)

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -34,10 +34,10 @@ import (
 // bucket. Records are invalidated when modifications are made through this
 // bucket, and after the supplied TTL.
 func NewFastStatBucket(
-	ttl time.Duration,
-	cache metadata.StatCache,
-	clock timeutil.Clock,
-	wrapped gcs.Bucket) (b gcs.Bucket) {
+		ttl time.Duration,
+		cache metadata.StatCache,
+		clock timeutil.Clock,
+		wrapped gcs.Bucket) (b gcs.Bucket) {
 	fsb := &fastStatBucket{
 		cache:   cache,
 		clock:   clock,
@@ -83,6 +83,13 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 		m := storageutil.ConvertObjToMinObject(o)
 		b.cache.Insert(m, expiration)
 	}
+}
+
+func (b *fastStatBucket) eraseEntriesWithGivenPrefixes(folderName string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.cache.EraseEntriesWithGivenPrefix(folderName)
 }
 
 // insertHierarchicalListing saves the objects in cache excluding zero byte objects corresponding to folders
@@ -176,16 +183,16 @@ func (b *fastStatBucket) BucketType() gcs.BucketType {
 }
 
 func (b *fastStatBucket) NewReader(
-	ctx context.Context,
-	req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
+		ctx context.Context,
+		req *gcs.ReadObjectRequest) (rc io.ReadCloser, err error) {
 	rc, err = b.wrapped.NewReader(ctx, req)
 	return
 }
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) CreateObject(
-	ctx context.Context,
-	req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
+		ctx context.Context,
+		req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for this object.
 	b.invalidate(req.Name)
 
@@ -203,8 +210,8 @@ func (b *fastStatBucket) CreateObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) CopyObject(
-	ctx context.Context,
-	req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
+		ctx context.Context,
+		req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for the destination name.
 	b.invalidate(req.DstName)
 
@@ -222,8 +229,8 @@ func (b *fastStatBucket) CopyObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) ComposeObjects(
-	ctx context.Context,
-	req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
+		ctx context.Context,
+		req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for the destination name.
 	b.invalidate(req.DstName)
 
@@ -241,8 +248,8 @@ func (b *fastStatBucket) ComposeObjects(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) StatObject(
-	ctx context.Context,
-	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+		ctx context.Context,
+		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
 	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
 		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnExtendedObjectAttributes: true")
@@ -277,8 +284,8 @@ func (b *fastStatBucket) StatObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) ListObjects(
-	ctx context.Context,
-	req *gcs.ListObjectsRequest) (listing *gcs.Listing, err error) {
+		ctx context.Context,
+		req *gcs.ListObjectsRequest) (listing *gcs.Listing, err error) {
 	// Fetch the listing.
 	listing, err = b.wrapped.ListObjects(ctx, req)
 	if err != nil {
@@ -297,8 +304,8 @@ func (b *fastStatBucket) ListObjects(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) UpdateObject(
-	ctx context.Context,
-	req *gcs.UpdateObjectRequest) (o *gcs.Object, err error) {
+		ctx context.Context,
+		req *gcs.UpdateObjectRequest) (o *gcs.Object, err error) {
 	// Throw away any existing record for this object.
 	b.invalidate(req.Name)
 
@@ -316,8 +323,8 @@ func (b *fastStatBucket) UpdateObject(
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) DeleteObject(
-	ctx context.Context,
-	req *gcs.DeleteObjectRequest) (err error) {
+		ctx context.Context,
+		req *gcs.DeleteObjectRequest) (err error) {
 	b.invalidate(req.Name)
 	err = b.wrapped.DeleteObject(ctx, req)
 	return
@@ -335,7 +342,7 @@ func (b *fastStatBucket) DeleteFolder(ctx context.Context, folderName string) er
 }
 
 func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
-	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	m, e, err = b.wrapped.StatObject(ctx, req)
 	if err != nil {
 		// Special case: NotFoundError -> negative entry.
@@ -354,8 +361,8 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 }
 
 func (b *fastStatBucket) GetFolder(
-	ctx context.Context,
-	prefix string) (*gcs.Folder, error) {
+		ctx context.Context,
+		prefix string) (*gcs.Folder, error) {
 
 	if hit, entry := b.lookUpFolder(prefix); hit {
 		// Negative entries result in NotFoundError.
@@ -402,7 +409,7 @@ func (b *fastStatBucket) RenameFolder(ctx context.Context, folderName string, de
 	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)
 
 	// Invalidate cache for old directory.
-	b.cache.EraseEntriesWithGivenPrefix(folderName)
+	b.eraseEntriesWithGivenPrefixes(folderName)
 
 	return o, err
 }

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -104,6 +104,7 @@ TEST_DIR_HNS_PARALLEL_GROUP=(
   "list_large_dir"
   "mounting"
   "kernel_list_cache"
+  "concurrent_operations"
 )
 
 TEST_DIR_HNS_NON_PARALLEL=(

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -288,14 +288,6 @@ function run_e2e_tests_for_hns_bucket(){
    wait $non_parallel_tests_hns_group_pid
    non_parallel_tests_hns_group_exit_code=$?
 
-   # TODO: The tests are currently flaky. Please unblock this after the issue is fixed.
-   # The concurrent_operations package, which experiences intermittent failures on presubmit tests, primarily due to parallel execution on the FLAT bucket, has been executed.
-   # Added it serially after all the tests are completed to avoid failures.
-  #   local log_file="/tmp/concurrent_operation_${hns_bucket_name_parallel_group}.log"
-  #   echo $log_file >> $TEST_LOGS_FILE
-  #   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/concurrent_operations $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG -p 1 --integrationTest -v --testbucket=$hns_bucket_name_non_parallel_group --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
-  #   non_parallel_tests_hns_group_exit_code_2=$?
-
    hns_buckets=("$hns_bucket_name_parallel_group" "$hns_bucket_name_non_parallel_group")
    clean_up hns_buckets
 


### PR DESCRIPTION
### Description
While inserting and removing folder entries from the cache, we did not implement a lock. Consequently, during concurrent operations tests, it was failing with the error `Concurrent operation on map iterating and erasing`.

To resolve this issue, implement a lock before performing any operation on the cache.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested by running concurrent_operation package many times locally.
2. Unit tests - NA
3. Integration tests - Automated
