### PR TITLE
Divide the latency by 1000

### DIFF
--- a/perfmetrics/scripts/vm_metrics/vm_metrics.py
+++ b/perfmetrics/scripts/vm_metrics/vm_metrics.py
@@ -286,7 +286,7 @@ class VmMetrics:
     ops_latency_mean = Metric(
         metric_type=OPS_LATENCY_METRIC_TYPE,
         extra_filter=ops_latency_filter,
-        factor=1,
+        factor=1000,
         aligner='ALIGN_DELTA')
 
     updated_metrics_list.append(ops_latency_mean)


### PR DESCRIPTION
We recently started publishing latency in microseconds instead of milliseconds. This resulted in the latency shooting up by a factor of
1000. Divide it by 1000 to bring it back to the previous levels.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
