### PR TITLE
Don't print usage when command execution errs out.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,9 @@ func NewRootCmd(m mountFn) (*cobra.Command, error) {
 		Long: `Cloud Storage FUSE is an open source FUSE adapter that lets you mount 
 and access Cloud Storage buckets as local file systems. For a technical overview
 of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
-		Version: common.GetVersion(),
-		Args:    cobra.RangeArgs(2, 3),
+		Version:      common.GetVersion(),
+		Args:         cobra.RangeArgs(2, 3),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfgErr != nil {
 				return fmt.Errorf("error while parsing config: %w", cfgErr)


### PR DESCRIPTION
### Description
Currently, if the gcsfuse mounting fails on any error, the command's usage is printed. This is not always desirable since there is an overload of superfluous information and the actual error gets lost.
With this change, we now just show the actual error and suppress the usage. The usage continues to remain available if the user passes "-h" or "--help" as arguments.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
