### PR TITLE
Convert args to Posix compatible args in tests

### DIFF
--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -37,7 +37,7 @@ func getConfigObject(t *testing.T, args []string) (*cfg.Config, error) {
 	require.Nil(t, err)
 	cmdArgs := append([]string{"gcsfuse"}, args...)
 	cmdArgs = append(cmdArgs, "a")
-	cmd.SetArgs(cmdArgs)
+	cmd.SetArgs(ConvertToPosixArgs(cmdArgs))
 	if err = cmd.Execute(); err != nil {
 		return nil, err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
@@ -94,4 +95,25 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		return nil, fmt.Errorf("error while declaring/binding flags: %w", err)
 	}
 	return rootCmd, nil
+}
+
+// ConvertToPosixArgs converts a slice of commandline args and transforms them
+// into POSIX compliant args. All it does is that it converts flags specified
+// using a single-hyphen to double-hyphens. We are excluding "-v" because it's
+// reserved for showing version in Cobra.
+func ConvertToPosixArgs(args []string) []string {
+	pArgs := make([]string, 0, len(args))
+	for _, a := range args {
+		switch {
+		case a == "--v", a == "-v":
+			pArgs = append(pArgs, "-v")
+		case a == "--h", a == "-h":
+			pArgs = append(pArgs, "-h")
+		case strings.HasPrefix(a, "-") && !cfg.IsNegativeNumber(a) && !strings.HasPrefix(a, "--"):
+			pArgs = append(pArgs, "-"+a)
+		default:
+			pArgs = append(pArgs, a)
+		}
+	}
+	return pArgs
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -33,7 +33,7 @@ func TestDefaultMaxParallelDownloads(t *testing.T) {
 		return nil
 	})
 	require.Nil(t, err)
-	cmd.SetArgs([]string{"abc", "pqr"})
+	cmd.SetArgs(ConvertToPosixArgs([]string{"abc", "pqr"}))
 
 	if assert.Nil(t, cmd.Execute()) {
 		assert.LessOrEqual(t, int64(16), actual.FileCache.MaxParallelDownloads)
@@ -72,7 +72,7 @@ func TestCobraArgsNumInRange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd, err := NewRootCmd(func(*cfg.Config, string, string) error { return nil })
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -131,7 +131,7 @@ func TestArgsParsing_MountPoint(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -179,7 +179,7 @@ func TestArgsParsing_MountOptions(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -221,7 +221,7 @@ func TestArgsParsing_CreateEmptyFileFlag(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -282,7 +282,7 @@ func TestArgsParsing_FileCacheFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -334,7 +334,7 @@ func TestArgParsing_ExperimentalMetadataPrefetchFlag(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -366,7 +366,7 @@ func TestArgParsing_ExperimentalMetadataPrefetchFlag_Failed(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -417,7 +417,7 @@ func TestArgsParsing_GCSAuthFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -454,7 +454,7 @@ func TestArgsParsing_GCSAuthFlagsThrowsError(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			assert.Error(t, cmd.Execute())
 		})
@@ -515,7 +515,7 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -558,7 +558,7 @@ func TestArgsParsing_GCSConnectionFlagsThrowsError(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			assert.Error(t, cmd.Execute())
 		})
@@ -637,7 +637,7 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -681,7 +681,7 @@ func TestArgsParsing_FileSystemFlagsThrowsError(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			assert.Error(t, cmd.Execute())
 		})
@@ -718,7 +718,7 @@ func TestArgsParsing_ListFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -755,7 +755,7 @@ func TestArgsParsing_EnableHNSFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 
@@ -814,7 +814,7 @@ func TestArgsParsing_MetadataCacheFlags(t *testing.T) {
 				return nil
 			})
 			require.Nil(t, err)
-			cmd.SetArgs(tc.args)
+			cmd.SetArgs(ConvertToPosixArgs(tc.args))
 
 			err = cmd.Execute()
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/cmd"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/perf"
@@ -36,27 +35,6 @@ func logPanic() {
 	if a != nil {
 		logger.Fatal("Panic: %v", a)
 	}
-}
-
-// convertToPosixArgs converts a slice of commandline args and transforms them
-// into POSIX compliant args. All it does is that it converts flags specified
-// using a single-hyphen to double-hyphens. We are excluding "-v" because it's
-// reserved for showing version in Cobra.
-func convertToPosixArgs(args []string) []string {
-	pArgs := make([]string, 0, len(args))
-	for _, a := range args {
-		switch {
-		case a == "--v", a == "-v":
-			pArgs = append(pArgs, "-v")
-		case a == "--h", a == "-h":
-			pArgs = append(pArgs, "-h")
-		case strings.HasPrefix(a, "-") && !cfg.IsNegativeNumber(a) && !strings.HasPrefix(a, "--"):
-			pArgs = append(pArgs, "-"+a)
-		default:
-			pArgs = append(pArgs, a)
-		}
-	}
-	return pArgs
 }
 
 // Don't remove the comment below. It's used to generate config.go file
@@ -81,7 +59,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error occurred while creating the root command: %v", err)
 	}
-	rootCmd.SetArgs(convertToPosixArgs(os.Args))
+	rootCmd.SetArgs(cmd.ConvertToPosixArgs(os.Args))
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Error occurred during command execution: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cmd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,7 +85,7 @@ func TestPosixFlagsConversion(t *testing.T) {
 	}
 	for _, tc := range data {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, convertToPosixArgs(tc.input))
+			assert.Equal(t, tc.expected, cmd.ConvertToPosixArgs(tc.input))
 		})
 	}
 }


### PR DESCRIPTION
This makes the tests closer to the production case where the args are first modified to conform the Posix args format; one that pflag supports.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
