### PR TITLE
Fix error return in tokenSrc 

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -58,13 +58,14 @@ func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oau
 		err = fmt.Errorf("JWTConfigFromJSON: %w", err)
 		return nil, err
 	}
-	// Create the token source.
-	ts := jwtConfig.TokenSource(ctx)
 
 	domain, err := getUniverseDomain(ctx, contents, scope)
 	if err != nil {
 		return nil, err
 	}
+
+	// By default, a standard OAuth 2.0 token source is created
+	ts := jwtConfig.TokenSource(ctx)
 
 	// For non-GDU universe domains, token exchange is impossible and services
 	// must support self-signed JWTs with scopes.
@@ -74,7 +75,7 @@ func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oau
 		ts, err = google.JWTAccessTokenSourceWithScope(contents, scope)
 		if err != nil {
 			err = fmt.Errorf("JWTAccessTokenSourceWithScope: %w", err)
-			return ts, err
+			return nil, err
 		}
 	}
 	return ts, err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -43,16 +43,12 @@ func getUniverseDomain(ctx context.Context, contents []byte, scope string) (stri
 }
 
 // Create token source from the JSON file at the supplide path.
-func newTokenSourceFromPath(
-	ctx context.Context,
-	path string,
-	scope string,
-) (ts oauth2.TokenSource, err error) {
+func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oauth2.TokenSource, error) {
 	// Read the file.
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		err = fmt.Errorf("ReadFile(%q): %w", path, err)
-		return
+		return nil, err
 	}
 
 	// By default, a standard OAuth 2.0 token source is created
@@ -60,13 +56,14 @@ func newTokenSourceFromPath(
 	jwtConfig, err := google.JWTConfigFromJSON(contents, scope)
 	if err != nil {
 		err = fmt.Errorf("JWTConfigFromJSON: %w", err)
+		return nil, err
 	}
 	// Create the token source.
-	ts = jwtConfig.TokenSource(ctx)
+	ts := jwtConfig.TokenSource(ctx)
 
 	domain, err := getUniverseDomain(ctx, contents, scope)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// For non-GDU universe domains, token exchange is impossible and services
@@ -77,10 +74,10 @@ func newTokenSourceFromPath(
 		ts, err = google.JWTAccessTokenSourceWithScope(contents, scope)
 		if err != nil {
 			err = fmt.Errorf("JWTAccessTokenSourceWithScope: %w", err)
-			return
+			return ts, err
 		}
 	}
-	return
+	return ts, err
 }
 
 // GetTokenSource generates the token-source for GCS endpoint by following oauth2.0 authentication


### PR DESCRIPTION
### Description
- Made it more readable
- Fixed return  error
```
jwtConfig, err := google.JWTConfigFromJSON(contents, scope)
if err != nil {
	err = fmt.Errorf("JWTConfigFromJSON: %w", err)
	return nil, err
}
```
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested on TPC environment
2. Unit tests - NA
3. Integration tests - Automated
