### PR TITLE
Disabling Cross-Platform Package Execution on AMD64

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -216,6 +216,5 @@ func (sh *storageClient) BucketHandle(bucketName string, billingProject string) 
 		bucketName:    bucketName,
 		controlClient: sh.storageControlClient,
 	}
-
 	return
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -216,5 +216,6 @@ func (sh *storageClient) BucketHandle(bucketName string, billingProject string) 
 		bucketName:    bucketName,
 		controlClient: sh.storageControlClient,
 	}
+
 	return
 }

--- a/tools/cd_scripts/package_gcsfuse.sh
+++ b/tools/cd_scripts/package_gcsfuse.sh
@@ -74,7 +74,7 @@ git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse/tools/package_gcsfuse_docker/
 git checkout "v$RELEASE_VERSION_TAG"
 echo "Building docker for ${architecture} ..."
-sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="v$RELEASE_VERSION_TAG"
+sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="v$RELEASE_VERSION_TAG" &> docker_${architecture}.log
 gsutil cp docker_${architecture}.log gs://"$UPLOAD_BUCKET"/v"$RELEASE_VERSION"/
 sudo docker run  -v $HOME/gcsfuse/release:/release gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" cp -r /packages/. /release/v"$RELEASE_VERSION"
 

--- a/tools/cd_scripts/package_gcsfuse.sh
+++ b/tools/cd_scripts/package_gcsfuse.sh
@@ -83,9 +83,6 @@ cd gcsfuse/tools/package_gcsfuse_docker/
 
 echo "Building docker for ${architecture} ..."
 sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="v$RELEASE_VERSION_TAG"
-
-# Below steps are taking less than one second, so we are not parallelising them.
-# Copy packages from docket container to disk.
 sudo docker run  -v $HOME/gcsfuse/release:/release gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" cp -r /packages/. /release/v"$RELEASE_VERSION"
 
 echo "Upload files in the bucket ..."

--- a/tools/cd_scripts/package_gcsfuse.sh
+++ b/tools/cd_scripts/package_gcsfuse.sh
@@ -78,17 +78,12 @@ echo Install git
 sudo apt-get install git -y
 # It is require for multi-arch support
 sudo apt-get install qemu-user-static binfmt-support
-git clone https://github.com/Tulsishah/gcsfuse
+git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse/tools/package_gcsfuse_docker/
-# Setting set +e to capture error output in log file and send it on the bucket.
-set +e
-exit_code=0
-echo "Building docker for ${architecture} ..."
-sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="v$RELEASE_VERSION_TAG" &> docker_${architecture}.log
-echo "Waiting for build to complete ..."
-gsutil cp docker_${architecture}.log gs://"$UPLOAD_BUCKET"/v"$RELEASE_VERSION"/
 
-set -e
+echo "Building docker for ${architecture} ..."
+sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="v$RELEASE_VERSION_TAG"
+
 # Below steps are taking less than one second, so we are not parallelising them.
 # Copy packages from docket container to disk.
 sudo docker run  -v $HOME/gcsfuse/release:/release gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" cp -r /packages/. /release/v"$RELEASE_VERSION"


### PR DESCRIPTION
### Description
Removing changes that attempt to run both ARM64 and AMD64 packages on the same AMD64 machine. This is because cross-platform builds can sometimes get stuck and fail to build ARM64 packages on an AMD64 machine.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested on louhi
2. Unit tests - NA
3. Integration tests - NA
