### PR TITLE
Propagate the context augmented with trace info

### DIFF
--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -331,14 +331,14 @@ func (fs *monitoring) Destroy() {
 	fs.wrapped.Destroy()
 }
 
-type wrappedCall func() error
+type wrappedCall func(ctx context.Context) error
 
 func (fs *monitoring) invokeWrapped(ctx context.Context, opName string, w wrappedCall) error {
 	// Span's SpanKid is set to trace.SpanKindServer since GCSFuse is like a server for the requests that the Kernel sends.
 	ctx, span := fs.tracer.Start(ctx, opName, trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 	startTime := time.Now()
-	err := w()
+	err := w(ctx)
 
 	if err != nil {
 		span.RecordError(err)
@@ -350,117 +350,117 @@ func (fs *monitoring) invokeWrapped(ctx context.Context, opName string, w wrappe
 }
 
 func (fs *monitoring) StatFS(ctx context.Context, op *fuseops.StatFSOp) error {
-	return fs.invokeWrapped(ctx, "StatFS", func() error { return fs.wrapped.StatFS(ctx, op) })
+	return fs.invokeWrapped(ctx, "StatFS", func(ctx context.Context) error { return fs.wrapped.StatFS(ctx, op) })
 }
 
 func (fs *monitoring) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) error {
-	return fs.invokeWrapped(ctx, "LookUpInode", func() error { return fs.wrapped.LookUpInode(ctx, op) })
+	return fs.invokeWrapped(ctx, "LookUpInode", func(ctx context.Context) error { return fs.wrapped.LookUpInode(ctx, op) })
 }
 
 func (fs *monitoring) GetInodeAttributes(ctx context.Context, op *fuseops.GetInodeAttributesOp) error {
-	return fs.invokeWrapped(ctx, "GetInodeAttributes", func() error { return fs.wrapped.GetInodeAttributes(ctx, op) })
+	return fs.invokeWrapped(ctx, "GetInodeAttributes", func(ctx context.Context) error { return fs.wrapped.GetInodeAttributes(ctx, op) })
 }
 
 func (fs *monitoring) SetInodeAttributes(ctx context.Context, op *fuseops.SetInodeAttributesOp) error {
-	return fs.invokeWrapped(ctx, "SetInodeAttributes", func() error { return fs.wrapped.SetInodeAttributes(ctx, op) })
+	return fs.invokeWrapped(ctx, "SetInodeAttributes", func(ctx context.Context) error { return fs.wrapped.SetInodeAttributes(ctx, op) })
 }
 
 func (fs *monitoring) ForgetInode(ctx context.Context, op *fuseops.ForgetInodeOp) error {
-	return fs.invokeWrapped(ctx, "ForgetInode", func() error { return fs.wrapped.ForgetInode(ctx, op) })
+	return fs.invokeWrapped(ctx, "ForgetInode", func(ctx context.Context) error { return fs.wrapped.ForgetInode(ctx, op) })
 }
 
 func (fs *monitoring) BatchForget(ctx context.Context, op *fuseops.BatchForgetOp) error {
-	return fs.invokeWrapped(ctx, "BatchForget", func() error { return fs.wrapped.BatchForget(ctx, op) })
+	return fs.invokeWrapped(ctx, "BatchForget", func(ctx context.Context) error { return fs.wrapped.BatchForget(ctx, op) })
 }
 
 func (fs *monitoring) MkDir(ctx context.Context, op *fuseops.MkDirOp) error {
-	return fs.invokeWrapped(ctx, "MkDir", func() error { return fs.wrapped.MkDir(ctx, op) })
+	return fs.invokeWrapped(ctx, "MkDir", func(ctx context.Context) error { return fs.wrapped.MkDir(ctx, op) })
 }
 
 func (fs *monitoring) MkNode(ctx context.Context, op *fuseops.MkNodeOp) error {
-	return fs.invokeWrapped(ctx, "MkNode", func() error { return fs.wrapped.MkNode(ctx, op) })
+	return fs.invokeWrapped(ctx, "MkNode", func(ctx context.Context) error { return fs.wrapped.MkNode(ctx, op) })
 }
 
 func (fs *monitoring) CreateFile(ctx context.Context, op *fuseops.CreateFileOp) error {
-	return fs.invokeWrapped(ctx, "CreateFile", func() error { return fs.wrapped.CreateFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "CreateFile", func(ctx context.Context) error { return fs.wrapped.CreateFile(ctx, op) })
 }
 
 func (fs *monitoring) CreateLink(ctx context.Context, op *fuseops.CreateLinkOp) error {
-	return fs.invokeWrapped(ctx, "CreateLink", func() error { return fs.wrapped.CreateLink(ctx, op) })
+	return fs.invokeWrapped(ctx, "CreateLink", func(ctx context.Context) error { return fs.wrapped.CreateLink(ctx, op) })
 }
 
 func (fs *monitoring) CreateSymlink(ctx context.Context, op *fuseops.CreateSymlinkOp) error {
-	return fs.invokeWrapped(ctx, "CreateSymlink", func() error { return fs.wrapped.CreateSymlink(ctx, op) })
+	return fs.invokeWrapped(ctx, "CreateSymlink", func(ctx context.Context) error { return fs.wrapped.CreateSymlink(ctx, op) })
 }
 
 func (fs *monitoring) Rename(ctx context.Context, op *fuseops.RenameOp) error {
-	return fs.invokeWrapped(ctx, "Rename", func() error { return fs.wrapped.Rename(ctx, op) })
+	return fs.invokeWrapped(ctx, "Rename", func(ctx context.Context) error { return fs.wrapped.Rename(ctx, op) })
 }
 
 func (fs *monitoring) RmDir(ctx context.Context, op *fuseops.RmDirOp) error {
-	return fs.invokeWrapped(ctx, "RmDir", func() error { return fs.wrapped.RmDir(ctx, op) })
+	return fs.invokeWrapped(ctx, "RmDir", func(ctx context.Context) error { return fs.wrapped.RmDir(ctx, op) })
 }
 
 func (fs *monitoring) Unlink(ctx context.Context, op *fuseops.UnlinkOp) error {
-	return fs.invokeWrapped(ctx, "Unlink", func() error { return fs.wrapped.Unlink(ctx, op) })
+	return fs.invokeWrapped(ctx, "Unlink", func(ctx context.Context) error { return fs.wrapped.Unlink(ctx, op) })
 }
 
 func (fs *monitoring) OpenDir(ctx context.Context, op *fuseops.OpenDirOp) error {
-	return fs.invokeWrapped(ctx, "OpenDir", func() error { return fs.wrapped.OpenDir(ctx, op) })
+	return fs.invokeWrapped(ctx, "OpenDir", func(ctx context.Context) error { return fs.wrapped.OpenDir(ctx, op) })
 }
 
 func (fs *monitoring) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
-	return fs.invokeWrapped(ctx, "ReadDir", func() error { return fs.wrapped.ReadDir(ctx, op) })
+	return fs.invokeWrapped(ctx, "ReadDir", func(ctx context.Context) error { return fs.wrapped.ReadDir(ctx, op) })
 }
 
 func (fs *monitoring) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDirHandleOp) error {
-	return fs.invokeWrapped(ctx, "ReleaseDirHandle", func() error { return fs.wrapped.ReleaseDirHandle(ctx, op) })
+	return fs.invokeWrapped(ctx, "ReleaseDirHandle", func(ctx context.Context) error { return fs.wrapped.ReleaseDirHandle(ctx, op) })
 }
 
 func (fs *monitoring) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error {
-	return fs.invokeWrapped(ctx, "OpenFile", func() error { return fs.wrapped.OpenFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "OpenFile", func(ctx context.Context) error { return fs.wrapped.OpenFile(ctx, op) })
 }
 
 func (fs *monitoring) ReadFile(ctx context.Context, op *fuseops.ReadFileOp) error {
-	return fs.invokeWrapped(ctx, "ReadFile", func() error { return fs.wrapped.ReadFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "ReadFile", func(ctx context.Context) error { return fs.wrapped.ReadFile(ctx, op) })
 }
 
 func (fs *monitoring) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) error {
-	return fs.invokeWrapped(ctx, "WriteFile", func() error { return fs.wrapped.WriteFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "WriteFile", func(ctx context.Context) error { return fs.wrapped.WriteFile(ctx, op) })
 }
 
 func (fs *monitoring) SyncFile(ctx context.Context, op *fuseops.SyncFileOp) error {
-	return fs.invokeWrapped(ctx, "SyncFile", func() error { return fs.wrapped.SyncFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "SyncFile", func(ctx context.Context) error { return fs.wrapped.SyncFile(ctx, op) })
 }
 
 func (fs *monitoring) FlushFile(ctx context.Context, op *fuseops.FlushFileOp) error {
-	return fs.invokeWrapped(ctx, "FlushFile", func() error { return fs.wrapped.FlushFile(ctx, op) })
+	return fs.invokeWrapped(ctx, "FlushFile", func(ctx context.Context) error { return fs.wrapped.FlushFile(ctx, op) })
 }
 
 func (fs *monitoring) ReleaseFileHandle(ctx context.Context, op *fuseops.ReleaseFileHandleOp) error {
-	return fs.invokeWrapped(ctx, "ReleaseFileHandle", func() error { return fs.wrapped.ReleaseFileHandle(ctx, op) })
+	return fs.invokeWrapped(ctx, "ReleaseFileHandle", func(ctx context.Context) error { return fs.wrapped.ReleaseFileHandle(ctx, op) })
 }
 
 func (fs *monitoring) ReadSymlink(ctx context.Context, op *fuseops.ReadSymlinkOp) error {
-	return fs.invokeWrapped(ctx, "ReadSymlink", func() error { return fs.wrapped.ReadSymlink(ctx, op) })
+	return fs.invokeWrapped(ctx, "ReadSymlink", func(ctx context.Context) error { return fs.wrapped.ReadSymlink(ctx, op) })
 }
 
 func (fs *monitoring) RemoveXattr(ctx context.Context, op *fuseops.RemoveXattrOp) error {
-	return fs.invokeWrapped(ctx, "RemoveXattr", func() error { return fs.wrapped.RemoveXattr(ctx, op) })
+	return fs.invokeWrapped(ctx, "RemoveXattr", func(ctx context.Context) error { return fs.wrapped.RemoveXattr(ctx, op) })
 }
 
 func (fs *monitoring) GetXattr(ctx context.Context, op *fuseops.GetXattrOp) error {
-	return fs.invokeWrapped(ctx, "GetXattr", func() error { return fs.wrapped.GetXattr(ctx, op) })
+	return fs.invokeWrapped(ctx, "GetXattr", func(ctx context.Context) error { return fs.wrapped.GetXattr(ctx, op) })
 }
 
 func (fs *monitoring) ListXattr(ctx context.Context, op *fuseops.ListXattrOp) error {
-	return fs.invokeWrapped(ctx, "ListXattr", func() error { return fs.wrapped.ListXattr(ctx, op) })
+	return fs.invokeWrapped(ctx, "ListXattr", func(ctx context.Context) error { return fs.wrapped.ListXattr(ctx, op) })
 }
 
 func (fs *monitoring) SetXattr(ctx context.Context, op *fuseops.SetXattrOp) error {
-	return fs.invokeWrapped(ctx, "SetXattr", func() error { return fs.wrapped.SetXattr(ctx, op) })
+	return fs.invokeWrapped(ctx, "SetXattr", func(ctx context.Context) error { return fs.wrapped.SetXattr(ctx, op) })
 }
 
 func (fs *monitoring) Fallocate(ctx context.Context, op *fuseops.FallocateOp) error {
-	return fs.invokeWrapped(ctx, "Fallocate", func() error { return fs.wrapped.Fallocate(ctx, op) })
+	return fs.invokeWrapped(ctx, "Fallocate", func(ctx context.Context) error { return fs.wrapped.Fallocate(ctx, op) })
 }


### PR DESCRIPTION
OTel tracing leverages context to propagate information about the ongoing trace. While the invokeWrapped method creates a new context as part of creating a new trace, it doesn't propagate that context to the subsequent method calls; the old context gets propagated. This causes the subsequent spans to create a new trace instead of joining the ongoing one. Fix that by propagating the context containing span information.

Verified that there is no memory leak:
![image](https://github.com/user-attachments/assets/0f2c1d06-f3cf-4ad1-839c-1df23921b317)

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested that the traces are getting correctly recorded.
2. Unit tests - NA
3. Integration tests - NA
