### PR TITLE
Do away with the requirement of adding every flag in mount_gcsfuse

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -213,37 +213,17 @@ type WriteConfig struct {
 	CreateEmptyFile bool `yaml:"create-empty-file"`
 }
 
-func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
+func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
 
-	if err := v.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
-
-	if err := v.BindPFlag("app-name", flagSet.Lookup("app-name")); err != nil {
-		return err
-	}
 
 	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
 
-	if err := v.BindPFlag("gcs-connection.billing-project", flagSet.Lookup("billing-project")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("cache-dir", "", "", "Enables file-caching. Specifies the directory to use for file-cache.")
 
-	if err := v.BindPFlag("cache-dir", flagSet.Lookup("cache-dir")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("client-protocol", "", "http1", "The protocol used for communicating with the GCS backend. Value can be 'http1' (HTTP/1.1), 'http2' (HTTP/2) or 'grpc'.")
-
-	if err := v.BindPFlag("gcs-connection.client-protocol", flagSet.Lookup("client-protocol")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
@@ -251,15 +231,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("write.create-empty-file", flagSet.Lookup("create-empty-file")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
-
-	if err := v.BindPFlag("gcs-connection.custom-endpoint", flagSet.Lookup("custom-endpoint")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 
@@ -270,10 +242,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("debug_fuse", "", false, "Enables debug logs.")
 
 	if err := flagSet.MarkDeprecated("debug_fuse", "Please set log-severity to TRACE instead."); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("debug.fuse", flagSet.Lookup("debug_fuse")); err != nil {
 		return err
 	}
 
@@ -289,10 +257,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("debug.gcs", flagSet.Lookup("debug_gcs")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("debug_http", "", false, "This flag is currently unused.")
 
 	if err := flagSet.MarkDeprecated("debug_http", "This flag is currently unused."); err != nil {
@@ -301,21 +265,9 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("debug_invariants", "", false, "Exit when internal invariants are violated.")
 
-	if err := v.BindPFlag("debug.exit-on-invariant-violation", flagSet.Lookup("debug_invariants")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("debug_mutex", "", false, "Print debug messages when a mutex is held too long.")
 
-	if err := v.BindPFlag("debug.log-mutex", flagSet.Lookup("debug_mutex")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("dir-mode", "", "0755", "Permissions bits for directories, in octal.")
-
-	if err := v.BindPFlag("file-system.dir-mode", flagSet.Lookup("dir-mode")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("disable-parallel-dirops", "", false, "Specifies whether to allow parallel dir operations (lookups and readers)")
 
@@ -323,35 +275,15 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("file-system.disable-parallel-dirops", flagSet.Lookup("disable-parallel-dirops")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
-
-	if err := v.BindPFlag("list.enable-empty-managed-folders", flagSet.Lookup("enable-empty-managed-folders")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
 
-	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
-
-	if err := v.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("experimental-enable-json-read", "", false, "By default, GCSFuse uses the GCS XML API to get and read objects. When this flag is specified, GCSFuse uses the GCS JSON API instead.\"")
 
 	if err := flagSet.MarkDeprecated("experimental-enable-json-read", "Experimental flag: could be dropped even in a minor release."); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("gcs-connection.experimental-enable-json-read", flagSet.Lookup("experimental-enable-json-read")); err != nil {
 		return err
 	}
 
@@ -361,17 +293,9 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("experimental-metadata-prefetch-on-mount", "", "disabled", "Experimental: This indicates whether or not to prefetch the metadata (prefilling of metadata caches and creation of inodes) of the mounted bucket at the time of mounting the bucket. Supported values: \"disabled\", \"sync\" and \"async\". Any other values will return error on mounting. This is applicable only to static mounting, and not to dynamic mounting.")
 
 	if err := flagSet.MarkDeprecated("experimental-metadata-prefetch-on-mount", "Experimental flag: could be removed even in a minor release."); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("metadata-cache.experimental-metadata-prefetch-on-mount", flagSet.Lookup("experimental-metadata-prefetch-on-mount")); err != nil {
 		return err
 	}
 
@@ -381,17 +305,9 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("monitoring.experimental-opentelemetry-collector-address", flagSet.Lookup("experimental-opentelemetry-collector-address")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("experimental-tracing-mode", "", "", "Experimental: specify tracing mode")
 
 	if err := flagSet.MarkHidden("experimental-tracing-mode"); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("monitoring.experimental-tracing-mode", flagSet.Lookup("experimental-tracing-mode")); err != nil {
 		return err
 	}
 
@@ -401,29 +317,13 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("monitoring.experimental-tracing-sampling-ratio", flagSet.Lookup("experimental-tracing-sampling-ratio")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("file-cache-cache-file-for-range-read", "", false, "Whether to cache file for range reads.")
 
-	if err := v.BindPFlag("file-cache.cache-file-for-range-read", flagSet.Lookup("file-cache-cache-file-for-range-read")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("file-cache-download-chunk-size-mb", "", 50, "Size of chunks in MiB that each concurrent request downloads.")
-
-	if err := v.BindPFlag("file-cache.download-chunk-size-mb", flagSet.Lookup("file-cache-download-chunk-size-mb")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("file-cache-enable-crc", "", false, "Performs CRC to ensure that file is correctly downloaded into cache.")
 
 	if err := flagSet.MarkHidden("file-cache-enable-crc"); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("file-cache.enable-crc", flagSet.Lookup("file-cache-enable-crc")); err != nil {
 		return err
 	}
 
@@ -433,33 +333,13 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("file-cache.enable-o-direct", flagSet.Lookup("file-cache-enable-o-direct")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("file-cache-enable-parallel-downloads", "", false, "Enable parallel downloads.")
-
-	if err := v.BindPFlag("file-cache.enable-parallel-downloads", flagSet.Lookup("file-cache-enable-parallel-downloads")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("file-cache-max-parallel-downloads", "", DefaultMaxParallelDownloads(), "Sets an uber limit of number of concurrent file download requests that are made across all files.")
 
-	if err := v.BindPFlag("file-cache.max-parallel-downloads", flagSet.Lookup("file-cache-max-parallel-downloads")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("file-cache-max-size-mb", "", -1, "Maximum size of the file-cache in MiBs")
 
-	if err := v.BindPFlag("file-cache.max-size-mb", flagSet.Lookup("file-cache-max-size-mb")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("file-cache-parallel-downloads-per-file", "", 16, "Number of concurrent download requests per file.")
-
-	if err := v.BindPFlag("file-cache.parallel-downloads-per-file", flagSet.Lookup("file-cache-parallel-downloads-per-file")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("file-cache-write-buffer-size", "", 4194304, "Size of in-memory buffer that is used per goroutine in parallel downloads while writing to file-cache.")
 
@@ -467,123 +347,43 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("file-cache.write-buffer-size", flagSet.Lookup("file-cache-write-buffer-size")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
-
-	if err := v.BindPFlag("file-system.file-mode", flagSet.Lookup("file-mode")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("foreground", "", false, "Stay in the foreground after mounting.")
 
-	if err := v.BindPFlag("foreground", flagSet.Lookup("foreground")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
-
-	if err := v.BindPFlag("file-system.gid", flagSet.Lookup("gid")); err != nil {
-		return err
-	}
 
 	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
 
-	if err := v.BindPFlag("gcs-connection.http-client-timeout", flagSet.Lookup("http-client-timeout")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations. (default: true)")
-
-	if err := v.BindPFlag("file-system.ignore-interrupts", flagSet.Lookup("ignore-interrupts")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("implicit-dirs", "", false, "Implicitly define directories based on content. See files and directories in docs/semantics for more information")
 
-	if err := v.BindPFlag("implicit-dirs", flagSet.Lookup("implicit-dirs")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
-
-	if err := v.BindPFlag("file-system.kernel-list-cache-ttl-secs", flagSet.Lookup("kernel-list-cache-ttl-secs")); err != nil {
-		return err
-	}
 
 	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
 
-	if err := v.BindPFlag("gcs-auth.key-file", flagSet.Lookup("key-file")); err != nil {
-		return err
-	}
-
 	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
-
-	if err := v.BindPFlag("gcs-connection.limit-bytes-per-sec", flagSet.Lookup("limit-bytes-per-sec")); err != nil {
-		return err
-	}
 
 	flagSet.Float64P("limit-ops-per-sec", "", -1, "Operations per second limit, measured over a 30-second window (use -1 for no limit)")
 
-	if err := v.BindPFlag("gcs-connection.limit-ops-per-sec", flagSet.Lookup("limit-ops-per-sec")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("log-file", "", "", "The file for storing logs that can be parsed by fluentd. When not provided, plain text logs are printed to stdout when Cloud Storage FUSE is run  in the foreground, or to syslog when Cloud Storage FUSE is run in the  background.")
-
-	if err := v.BindPFlag("logging.file-path", flagSet.Lookup("log-file")); err != nil {
-		return err
-	}
 
 	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
 
-	if err := v.BindPFlag("logging.format", flagSet.Lookup("log-format")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
-
-	if err := v.BindPFlag("logging.log-rotate.backup-file-count", flagSet.Lookup("log-rotate-backup-file-count")); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
-	if err := v.BindPFlag("logging.log-rotate.compress", flagSet.Lookup("log-rotate-compress")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("log-rotate-max-file-size-mb", "", 512, "The maximum size in megabytes that a log file can reach before it is rotated.")
-
-	if err := v.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-file-size-mb")); err != nil {
-		return err
-	}
 
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
-	if err := v.BindPFlag("logging.severity", flagSet.Lookup("log-severity")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
-
-	if err := v.BindPFlag("gcs-connection.max-conns-per-host", flagSet.Lookup("max-conns-per-host")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	if err := v.BindPFlag("gcs-connection.max-idle-conns-per-host", flagSet.Lookup("max-idle-conns-per-host")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value 0 indicates no limit.")
-
-	if err := v.BindPFlag("gcs-retries.max-retry-attempts", flagSet.Lookup("max-retry-attempts")); err != nil {
-		return err
-	}
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
 
@@ -593,63 +393,23 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 
 	flagSet.DurationP("max-retry-sleep", "", 30000000000*time.Nanosecond, "The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry continues with this specified maximum value.")
 
-	if err := v.BindPFlag("gcs-retries.max-retry-sleep", flagSet.Lookup("max-retry-sleep")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("metadata-cache-ttl-secs", "", 60, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.\"")
-
-	if err := v.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl-secs")); err != nil {
-		return err
-	}
 
 	flagSet.StringSliceP("o", "", []string{}, "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro")
 
-	if err := v.BindPFlag("file-system.fuse-options", flagSet.Lookup("o")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("only-dir", "", "", "Mount only a specific directory within the bucket. See docs/mounting for more information")
-
-	if err := v.BindPFlag("only-dir", flagSet.Lookup("only-dir")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
-	if err := v.BindPFlag("metrics.prometheus-port", flagSet.Lookup("prometheus-port")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("rename-dir-limit", "", 0, "Allow rename a directory containing fewer descendants than this limit.")
-
-	if err := v.BindPFlag("file-system.rename-dir-limit", flagSet.Lookup("rename-dir-limit")); err != nil {
-		return err
-	}
 
 	flagSet.Float64P("retry-multiplier", "", 2, "Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.")
 
-	if err := v.BindPFlag("gcs-retries.multiplier", flagSet.Lookup("retry-multiplier")); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("reuse-token-from-url", "", true, "If false, the token acquired from token-url is not reused.")
-
-	if err := v.BindPFlag("gcs-auth.reuse-token-from-url", flagSet.Lookup("reuse-token-from-url")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("sequential-read-size-mb", "", 200, "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported")
 
-	if err := v.BindPFlag("gcs-connection.sequential-read-size-mb", flagSet.Lookup("sequential-read-size-mb")); err != nil {
-		return err
-	}
-
 	flagSet.DurationP("stackdriver-export-interval", "", 0*time.Nanosecond, "Export metrics to stackdriver with this interval. The default value 0 indicates no exporting.")
-
-	if err := v.BindPFlag("metrics.stackdriver-export-interval", flagSet.Lookup("stackdriver-export-interval")); err != nil {
-		return err
-	}
 
 	flagSet.IntP("stat-cache-capacity", "", 20460, "How many entries can the stat-cache hold (impacts memory consumption). This flag has been deprecated (starting v2.0) and in favor of stat-cache-max-size-mb. For now, the value of stat-cache-capacity will be translated to the next higher corresponding value of stat-cache-max-size-mb (assuming stat-cache entry-size ~= 1640 bytes, including 1400 for positive entry and 240 for corresponding negative entry), if stat-cache-max-size-mb is not set.\"")
 
@@ -657,15 +417,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("metadata-cache.deprecated-stat-cache-capacity", flagSet.Lookup("stat-cache-capacity")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("stat-cache-max-size-mb", "", 32, "The maximum size of stat-cache in MiBs. It can also be set to -1 for no-size-limit, 0 for no cache. Values below -1 are not supported.")
-
-	if err := v.BindPFlag("metadata-cache.stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb")); err != nil {
-		return err
-	}
 
 	flagSet.DurationP("stat-cache-ttl", "", 60000000000*time.Nanosecond, "How long to cache StatObject results and inode attributes. This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second is used as ttl for both stat-cache and type-cache, when metadata-cache-ttl-secs is not set.")
 
@@ -673,27 +425,11 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("metadata-cache.deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl")); err != nil {
-		return err
-	}
-
 	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)\"")
-
-	if err := v.BindPFlag("file-system.temp-dir", flagSet.Lookup("temp-dir")); err != nil {
-		return err
-	}
 
 	flagSet.StringP("token-url", "", "", "A url for getting an access token when the key-file is absent.")
 
-	if err := v.BindPFlag("gcs-auth.token-url", flagSet.Lookup("token-url")); err != nil {
-		return err
-	}
-
 	flagSet.IntP("type-cache-max-size-mb", "", 4, "Max size of type-cache maps which are maintained at a per-directory level.")
-
-	if err := v.BindPFlag("metadata-cache.type-cache-max-size-mb", flagSet.Lookup("type-cache-max-size-mb")); err != nil {
-		return err
-	}
 
 	flagSet.DurationP("type-cache-ttl", "", 60000000000*time.Nanosecond, "Usage: How long to cache StatObject results and inode attributes. This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs. For now, the minimum of stat-cache-ttl and type-cache-ttl values, rounded up to the next higher multiple of a second is used as ttl for both stat-cache and type-cache, when metadata-cache-ttl-secs is not set.")
 
@@ -701,11 +437,280 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("metadata-cache.deprecated-type-cache-ttl", flagSet.Lookup("type-cache-ttl")); err != nil {
+	flagSet.IntP("uid", "", -1, "UID owner of all inodes.")
+
+	return nil
+}
+
+func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
+
+	if err := v.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access")); err != nil {
 		return err
 	}
 
-	flagSet.IntP("uid", "", -1, "UID owner of all inodes.")
+	if err := v.BindPFlag("app-name", flagSet.Lookup("app-name")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.billing-project", flagSet.Lookup("billing-project")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("cache-dir", flagSet.Lookup("cache-dir")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.client-protocol", flagSet.Lookup("client-protocol")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("write.create-empty-file", flagSet.Lookup("create-empty-file")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.custom-endpoint", flagSet.Lookup("custom-endpoint")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("debug.fuse", flagSet.Lookup("debug_fuse")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("debug.gcs", flagSet.Lookup("debug_gcs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("debug.exit-on-invariant-violation", flagSet.Lookup("debug_invariants")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("debug.log-mutex", flagSet.Lookup("debug_mutex")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.dir-mode", flagSet.Lookup("dir-mode")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.disable-parallel-dirops", flagSet.Lookup("disable-parallel-dirops")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("list.enable-empty-managed-folders", flagSet.Lookup("enable-empty-managed-folders")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.experimental-enable-json-read", flagSet.Lookup("experimental-enable-json-read")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.experimental-metadata-prefetch-on-mount", flagSet.Lookup("experimental-metadata-prefetch-on-mount")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("monitoring.experimental-opentelemetry-collector-address", flagSet.Lookup("experimental-opentelemetry-collector-address")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("monitoring.experimental-tracing-mode", flagSet.Lookup("experimental-tracing-mode")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("monitoring.experimental-tracing-sampling-ratio", flagSet.Lookup("experimental-tracing-sampling-ratio")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.cache-file-for-range-read", flagSet.Lookup("file-cache-cache-file-for-range-read")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.download-chunk-size-mb", flagSet.Lookup("file-cache-download-chunk-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.enable-crc", flagSet.Lookup("file-cache-enable-crc")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.enable-o-direct", flagSet.Lookup("file-cache-enable-o-direct")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.enable-parallel-downloads", flagSet.Lookup("file-cache-enable-parallel-downloads")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.max-parallel-downloads", flagSet.Lookup("file-cache-max-parallel-downloads")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.max-size-mb", flagSet.Lookup("file-cache-max-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.parallel-downloads-per-file", flagSet.Lookup("file-cache-parallel-downloads-per-file")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.write-buffer-size", flagSet.Lookup("file-cache-write-buffer-size")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.file-mode", flagSet.Lookup("file-mode")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("foreground", flagSet.Lookup("foreground")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.gid", flagSet.Lookup("gid")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.http-client-timeout", flagSet.Lookup("http-client-timeout")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.ignore-interrupts", flagSet.Lookup("ignore-interrupts")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("implicit-dirs", flagSet.Lookup("implicit-dirs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.kernel-list-cache-ttl-secs", flagSet.Lookup("kernel-list-cache-ttl-secs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-auth.key-file", flagSet.Lookup("key-file")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.limit-bytes-per-sec", flagSet.Lookup("limit-bytes-per-sec")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.limit-ops-per-sec", flagSet.Lookup("limit-ops-per-sec")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.file-path", flagSet.Lookup("log-file")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.format", flagSet.Lookup("log-format")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.log-rotate.backup-file-count", flagSet.Lookup("log-rotate-backup-file-count")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.log-rotate.compress", flagSet.Lookup("log-rotate-compress")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-file-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.severity", flagSet.Lookup("log-severity")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.max-conns-per-host", flagSet.Lookup("max-conns-per-host")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.max-idle-conns-per-host", flagSet.Lookup("max-idle-conns-per-host")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-retries.max-retry-attempts", flagSet.Lookup("max-retry-attempts")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-retries.max-retry-sleep", flagSet.Lookup("max-retry-sleep")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl-secs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.fuse-options", flagSet.Lookup("o")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("only-dir", flagSet.Lookup("only-dir")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.prometheus-port", flagSet.Lookup("prometheus-port")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.rename-dir-limit", flagSet.Lookup("rename-dir-limit")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-retries.multiplier", flagSet.Lookup("retry-multiplier")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-auth.reuse-token-from-url", flagSet.Lookup("reuse-token-from-url")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.sequential-read-size-mb", flagSet.Lookup("sequential-read-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.stackdriver-export-interval", flagSet.Lookup("stackdriver-export-interval")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.deprecated-stat-cache-capacity", flagSet.Lookup("stat-cache-capacity")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.stat-cache-max-size-mb", flagSet.Lookup("stat-cache-max-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.temp-dir", flagSet.Lookup("temp-dir")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-auth.token-url", flagSet.Lookup("token-url")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.type-cache-max-size-mb", flagSet.Lookup("type-cache-max-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.deprecated-type-cache-ttl", flagSet.Lookup("type-cache-ttl")); err != nil {
+		return err
+	}
 
 	if err := v.BindPFlag("file-system.uid", flagSet.Lookup("uid")); err != nil {
 		return err

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -81,3 +81,5 @@ const (
 	StatCacheMaxSizeConfigKey      = "metadata-cache.stat-cache-max-size-mb"
 	maxSupportedStatCacheMaxSizeMB = util.MaxMiBsInUint64
 )
+
+const ConfigFileFlagName = "config-file"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,8 +95,11 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		"Refer to 'https://cloud.google.com/storage/docs/gcsfuse-cli#config-file' for possible configurations.")
 
 	// Add all the other flags.
+	if err := cfg.BuildFlagSet(rootCmd.PersistentFlags()); err != nil {
+		return nil, fmt.Errorf("error while declaring flags: %w", err)
+	}
 	if err := cfg.BindFlags(v, rootCmd.PersistentFlags()); err != nil {
-		return nil, fmt.Errorf("error while declaring/binding flags: %w", err)
+		return nil, fmt.Errorf("error while binding flags: %w", err)
 	}
 	return rootCmd, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 		}
 	}
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", "", "The path to the config file where all gcsfuse related config needs to be specified. "+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, cfg.ConfigFileFlagName, "", "The path to the config file where all gcsfuse related config needs to be specified. "+
 		"Refer to 'https://cloud.google.com/storage/docs/gcsfuse-cli#config-file' for possible configurations.")
 
 	// Add all the other flags.

--- a/tools/config-gen/templates/config.tpl
+++ b/tools/config-gen/templates/config.tpl
@@ -32,7 +32,7 @@ type {{ .TypeName}} struct {
 }
 {{end}}
 
-func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
+func BuildFlagSet(flagSet *pflag.FlagSet) error {
   {{range .FlagTemplateData}}
   flagSet.{{ .Fn}}("{{ .FlagName}}", "{{ .Shorthand}}", {{ .DefaultValue}}, {{ .Usage}})
   {{if .IsDeprecated}}
@@ -46,6 +46,12 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
   }
   {{end}}
   {{if .HideShorthand}}flagSet.ShorthandLookup("{{ .Shorthand}}").Hidden = true{{end}}
+  {{end}}
+  return nil
+}
+
+func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
+  {{range .FlagTemplateData}}
   {{if ne .ConfigPath ""}}
   if err := v.BindPFlag("{{ .ConfigPath}}", flagSet.Lookup("{{ .FlagName}}")); err != nil {
     return err

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -106,6 +106,11 @@ func makeGcsfuseArgs(
 	}
 
 	boolFlags, nonBoolFlags := flagTypes(&flagSet)
+	// Handle "o" by not treating it as a flag for persistent mounting.
+	nonBoolFlags = slices.DeleteFunc(nonBoolFlags, func(s string) bool {
+		return s == "o"
+	})
+
 	nonBoolFlags = append(nonBoolFlags, cfg.ConfigFileFlagName)
 	// TODO: Clean this up after we gain enough confidence on CLI-Config Parity changes.
 	boolFlags = append(boolFlags, "disable-viper-config")

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -106,6 +106,7 @@ func makeGcsfuseArgs(
 	}
 
 	boolFlags, nonBoolFlags := flagTypes(&flagSet)
+	nonBoolFlags = append(nonBoolFlags, "config-file")
 	noopOptions := []string{"user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
 
 	// Deal with options.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -106,7 +106,7 @@ func makeGcsfuseArgs(
 	}
 
 	boolFlags, nonBoolFlags := flagTypes(&flagSet)
-	nonBoolFlags = append(nonBoolFlags, "config-file")
+	nonBoolFlags = append(nonBoolFlags, cfg.ConfigFileFlagName)
 	noopOptions := []string{"user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
 
 	// Deal with options.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -59,10 +59,41 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"slices"
 	"strings"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
+	"github.com/spf13/pflag"
 )
+
+func flagTypes(flagSet *pflag.FlagSet) (boolFlags, nonBoolFlags []string) {
+	flagSet.VisitAll(func(flag *pflag.Flag) {
+		if flag.Value.Type() == "bool" {
+			boolFlags = append(boolFlags, flag.Name)
+		} else {
+			nonBoolFlags = append(nonBoolFlags, flag.Name)
+		}
+	})
+	return boolFlags, nonBoolFlags
+}
+
+func isEquiv(s1, s2 string) bool {
+	return strings.ReplaceAll(s1, "_", "-") == strings.ReplaceAll(s2, "_", "-")
+}
+
+func findEquivFlag(s string, lst []string) string {
+	idx := slices.IndexFunc(lst, func(e string) bool {
+		if isEquiv(s, e) {
+			return true
+		}
+		return false
+	})
+	if idx == -1 {
+		return ""
+	}
+	return lst[idx]
+}
 
 // Turn mount-style options into gcsfuse arguments. Skip known detritus that
 // the mount command gives us.
@@ -72,85 +103,30 @@ func makeGcsfuseArgs(
 	device string,
 	mountPoint string,
 	opts map[string]string) (args []string, err error) {
+	var flagSet pflag.FlagSet
+	if err := cfg.BuildFlagSet(&flagSet); err != nil {
+		return nil, err
+	}
+
+	boolFlags, nonBoolFlags := flagTypes(&flagSet)
+	noopOptions := []string{"user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
+
 	// Deal with options.
 	for name, value := range opts {
-		switch strings.ReplaceAll(name, "-", "_") {
-		// Don't pass through options that are relevant to mount(8) but not to
-		// gcsfuse, and that fusermount chokes on with "Invalid argument" on Linux.
-		case "user", "nouser", "auto", "noauto", "_netdev", "no_netdev":
-
-		// Special case: support mount-like formatting for gcsfuse bool flags.
-		case "implicit_dirs",
-			"foreground",
-			"reuse_token_from_url",
-			"enable_nonexistent_type_cache",
-			"experimental_enable_json_read",
-			"enable_hns",
-			"ignore_interrupts",
-			"anonymous_access",
-			"log_rotate_compress",
-			"disable_viper_config":
+		if flg := findEquivFlag(name, noopOptions); flg != "" {
+			// Don't pass through options that are relevant to mount(8) but not to
+			// gcsfuse, and that fusermount chokes on with "Invalid argument" on Linux.
+			continue
+		}
+		if flg := findEquivFlag(name, boolFlags); flg != "" {
 			if value == "" {
 				value = "true"
 			}
-			args = append(args, "--"+strings.ReplaceAll(name, "_", "-")+"="+value)
-
-		// Special case: support mount-like formatting for gcsfuse string flags.
-		case "dir_mode",
-			"file_mode",
-			"uid",
-			"gid",
-			"app_name",
-			"only_dir",
-			"billing_project",
-			"client_protocol",
-			"key_file",
-			"token_url",
-			"limit_bytes_per_sec",
-			"limit_ops_per_sec",
-			"rename_dir_limit",
-			"max_retry_sleep",
-			"max_retry_duration",
-			"retry_multiplier",
-			"stat_cache_capacity",
-			"stat_cache_ttl",
-			"type_cache_ttl",
-			"http_client_timeout",
-			"sequential_read_size_mb",
-			"temp_dir",
-			"max_conns_per_host",
-			"max_idle_conns_per_host",
-			"stackdriver_export_interval",
-			"experimental_opentelemetry_collector_address",
-			"log_format",
-			"log_file",
-			"custom_endpoint",
-			"config_file",
-			"experimental_metadata_prefetch_on_mount",
-			"kernel_list_cache_ttl_secs",
-			"stat_cache_max_size_mb",
-			"type_cache_max_size_mb",
-			"metadata_cache_ttl_secs",
-			"log_severity",
-			"log_rotate_max_file_size_mb",
-			"log_rotate_backup_file_count",
-			"file_cache_max_size_mb",
-			"experimental_grpc_conn_pool_size":
-
-			args = append(args, "--"+strings.ReplaceAll(name, "_", "-"), value)
-
-		// Special case: support mount-like formatting for gcsfuse debug flags.
-		case "debug_fuse",
-			"debug_fuse_errors",
-			"debug_fs",
-			"debug_gcs",
-			"debug_http",
-			"debug_invariants",
-			"debug_mutex":
-			args = append(args, "--"+name)
-
-		// Pass through everything else.
-		default:
+			args = append(args, fmt.Sprintf("--%s=%s", flg, value))
+		} else if flg := findEquivFlag(name, nonBoolFlags); flg != "" {
+			args = append(args, fmt.Sprintf("--%s", flg), value)
+		} else {
+			// Pass through everything else
 			var formatted string
 			if value == "" {
 				formatted = name
@@ -163,9 +139,7 @@ func makeGcsfuseArgs(
 	}
 
 	// Set the bucket and mount point.
-	args = append(args, device, mountPoint)
-
-	return
+	return append(args, device, mountPoint), nil
 }
 
 // Parse the supplied command-line arguments from a mount(8) invocation on OS X

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -84,10 +84,7 @@ func isEquiv(s1, s2 string) bool {
 
 func findEquivFlag(s string, lst []string) string {
 	idx := slices.IndexFunc(lst, func(e string) bool {
-		if isEquiv(s, e) {
-			return true
-		}
-		return false
+		return isEquiv(s, e)
 	})
 	if idx == -1 {
 		return ""

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -104,13 +104,11 @@ func makeGcsfuseArgs(
 	if err := cfg.BuildFlagSet(&flagSet); err != nil {
 		return nil, err
 	}
-
 	boolFlags, nonBoolFlags := flagTypes(&flagSet)
 	// Handle "o" by not treating it as a flag for persistent mounting.
 	nonBoolFlags = slices.DeleteFunc(nonBoolFlags, func(s string) bool {
 		return s == "o"
 	})
-
 	nonBoolFlags = append(nonBoolFlags, cfg.ConfigFileFlagName)
 	// TODO: Clean this up after we gain enough confidence on CLI-Config Parity changes.
 	boolFlags = append(boolFlags, "disable-viper-config")

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -107,6 +107,8 @@ func makeGcsfuseArgs(
 
 	boolFlags, nonBoolFlags := flagTypes(&flagSet)
 	nonBoolFlags = append(nonBoolFlags, cfg.ConfigFileFlagName)
+	// TODO: Clean this up after we gain enough confidence on CLI-Config Parity changes.
+	boolFlags = append(boolFlags, "disable-viper-config")
 	noopOptions := []string{"user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
 
 	// Deal with options.

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -125,10 +125,8 @@ func makeGcsfuseArgs(
 			args = append(args, fmt.Sprintf("--%s", flg), value)
 		} else {
 			// Pass through everything else
-			var formatted string
-			if value == "" {
-				formatted = name
-			} else {
+			formatted := name
+			if value != "" {
 				formatted = fmt.Sprintf("%s=%s", name, value)
 			}
 

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -103,7 +103,7 @@ func TestMakeGcsfuseArgs(t *testing.T) {
 		{
 			name:          "TestMakeGcsfuseArgs with DebugFlags",
 			opts:          map[string]string{"debug_fuse": "", "debug_gcs": ""},
-			expectedFlags: []string{"--debug_fuse", "--debug_gcs"},
+			expectedFlags: []string{"--debug_fuse=true", "--debug_gcs=true"},
 		},
 
 		// Test ignored options
@@ -124,7 +124,7 @@ func TestMakeGcsfuseArgs(t *testing.T) {
 			opts: map[string]string{
 				"implicit_dirs": "", "file_mode": "0644", "debug_fuse": "", "allow_other": "",
 			},
-			expectedFlags: []string{"--implicit-dirs=true", "--file-mode", "0644", "--debug_fuse", "-o", "allow_other"},
+			expectedFlags: []string{"--implicit-dirs=true", "--file-mode", "0644", "--debug_fuse=true", "-o", "allow_other"},
 		},
 	}
 	device := "gcsfuse"

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -126,6 +126,13 @@ func TestMakeGcsfuseArgs(t *testing.T) {
 			},
 			expectedFlags: []string{"--implicit-dirs=true", "--file-mode", "0644", "--debug_fuse=true", "-o", "allow_other"},
 		},
+		{
+			name: "TestMakeGcsfuseArgs with o as flag",
+			opts: map[string]string{
+				"o": "a", "allow_other": "",
+			},
+			expectedFlags: []string{"-o", "o=a", "-o", "allow_other"},
+		},
 	}
 	device := "gcsfuse"
 	mountPoint := "/mnt/gcs"


### PR DESCRIPTION
* Get the list of flags from the code-generated list and use that to automatically convert the persistent mount flags to appropriate format.

### Description

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/368503898

### Testing details
1. Manual - NA
2. Unit tests - Tested with existing unit tests.
3. Integration tests - NA
