### PR TITLE
Rename flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -529,9 +529,9 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("log-rotate-max-log-file-size-mb", "", 512, "The maximum size in megabytes that a log file can reach before it is rotated.")
+	flagSet.IntP("log-rotate-max-file-size-mb", "", 512, "The maximum size in megabytes that a log file can reach before it is rotated.")
 
-	if err := v.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-log-file-size-mb")); err != nil {
+	if err := v.BindPFlag("logging.log-rotate.max-file-size-mb", flagSet.Lookup("log-rotate-max-file-size-mb")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -393,7 +393,7 @@
   default: "true"
 
 - config-path: "logging.log-rotate.max-file-size-mb"
-  flag-name: "log-rotate-max-log-file-size-mb"
+  flag-name: "log-rotate-max-file-size-mb"
   type: "int"
   usage: "The maximum size in megabytes that a log file can reach before it is rotated."
   default: "512"


### PR DESCRIPTION
Rename log-rotate-max-log-file-size-mb to log-rotate-max-file-size-mb to make it more consistent with the corresponding name of the param in the config file.
The flag is not yet published/released. So, it shouldn't impact any users.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
