### PR TITLE
[testing-on-gke part 6.4] Add support for GCE VM

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -470,7 +470,7 @@ function createCustomCsiDriverIfNeeded() {
     echo "Building custom CSI driver ..."
 
     # Create a bucket for storing custom-csi driver.
-    test -n "${package_bucket}" || export package_bucket=${USER}-gcsfuse-binary-package
+    test -n "${package_bucket}" || export package_bucket=${USER/google/}-gcsfuse-binary-package
     (gcloud storage buckets list | grep -wqo ${package_bucket}) || (region=$(echo ${zone} | rev | cut -d- -f2- | rev) && gcloud storage buckets create gs://${package_bucket} --location=${region})
 
     # Build a new gcsfuse binary

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -194,8 +194,6 @@ function installDependencies() {
   sudo apt-get install -y apt-transport-https ca-certificates gnupg curl
   # Ensure that realpath is installed.
   which realpath
-  # Ensure that python3 is installed.
-  which python3
   # Ensure that make is installed.
   which make || ( sudo apt-get install -y make time && which make )
   # Ensure that go is installed.

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -488,7 +488,6 @@ function createCustomCsiDriverIfNeeded() {
     ensureGcsFuseCsiDriverCode
     cd "${csi_src_dir}"
     make uninstall || true
-    which jq
     make generate-spec-yaml
     printf "\nBuilding a new custom CSI driver using the above GCSFuse binary ...\n\n"
     make build-image-and-push-multi-arch REGISTRY=gcr.io/${project_id}/${USER} GCSFUSE_PATH=gs://${package_bucket}


### PR DESCRIPTION
### Description
Handle dependencies for successful execution on a GCE VM.
- Install google-cloud-monitoring python package
- Wait 30 min after CSI driver installation, before deploying pods, to avoid failure
- Avoid putting `google` in the name of the package-bucket as `google` is not allowed in bucket names.

This is on top of #2495 and is followed up in #2496 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
