### PR TITLE
[testing-on-gke part 6.2] extract common runner code

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -22,21 +22,19 @@ DLIO workloads from it and generates and deploys a helm chart for
 each valid DLIO workload.
 """
 
+# system imports
 import argparse
+import os
 import subprocess
+import sys
+
+# local imports from other directories
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
+from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
+from utils import UnknownMachineTypeError, resource_limits_requests
+
+# local imports from same directory
 import dlio_workload
-
-
-def run_command(command: str):
-  """Runs the given string command as a subprocess."""
-  result = subprocess.run(command.split(' '), capture_output=True, text=True)
-  print(result.stdout)
-  print(result.stderr)
-
-
-def escapeCommasInString(unescapedStr: str) -> str:
-  """Returns equivalent string with ',' replaced with '\,' ."""
-  return unescapedStr.replace(',', '\,')
 
 
 def createHelmInstallCommands(
@@ -61,7 +59,7 @@ def createHelmInstallCommands(
           f'--set instanceId={instanceId}',
           (
               '--set'
-              f' gcsfuse.mountOptions={escapeCommasInString(dlioWorkload.gcsfuseMountOptions)}'
+              f' gcsfuse.mountOptions={escape_commas_in_string(dlioWorkload.gcsfuseMountOptions)}'
           ),
           f'--set nodeType={machineType}',
           f'--set podName={podName}',
@@ -89,57 +87,5 @@ def main(args) -> None:
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      prog='DLIO Unet3d test runner',
-      description=(
-          'This program takes in a json test-config file, finds out valid DLIO'
-          ' workloads from it and generates and deploys a helm chart for each'
-          ' DLIO workload.'
-      ),
-  )
-  parser.add_argument(
-      '--workload-config',
-      metavar='JSON workload configuration file path',
-      help='Runs DLIO Unet3d tests from this JSON workload configuration file.',
-      required=True,
-  )
-  parser.add_argument(
-      '--instance-id',
-      metavar='A unique string ID to represent the test-run',
-      help=(
-          'Set to a unique string ID for current test-run. Do not put spaces'
-          ' in it.'
-      ),
-      required=True,
-  )
-  parser.add_argument(
-      '--machine-type',
-      metavar='Machine-type of the GCE VM or GKE cluster node',
-      help='Machine-type of the GCE VM or GKE cluster node e.g. n2-standard-32',
-      required=True,
-  )
-  parser.add_argument(
-      '-n',
-      '--dry-run',
-      action='store_true',
-      help=(
-          'Only print out the test configurations that will run,'
-          ' not actually run them.'
-      ),
-  )
-
-  args = parser.parse_args()
-  for argument in ['instance_id', 'machine_type']:
-    value = getattr(args, argument)
-    if len(value) == 0 or str.isspace(value):
-      raise Exception(
-          f'Argument {argument} (value="{value}") is empty or contains only'
-          ' spaces.'
-      )
-    if ' ' in value:
-      raise Exception(
-          f'Argument {argument} (value="{value}") contains space in it, which'
-          ' is not supported.'
-      )
-
+  args = parse_args()
   main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -30,8 +30,7 @@ import sys
 
 # local imports from other directories
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
-from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
-from utils import UnknownMachineTypeError, resource_limits_requests
+from run_tests_common import escape_commas_in_string, parse_args, run_command
 
 # local imports from same directory
 import dlio_workload

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -21,21 +21,19 @@ This program takes in a json test-config file, finds out valid FIO workloads in
 it and generates and deploys a helm chart for each valid FIO workload.
 """
 
+# system imports
 import argparse
+import os
 import subprocess
+import sys
+
+# local imports from other directories
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
+from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
+from utils import UnknownMachineTypeError, resource_limits_requests
+
+# local imports from same directory
 import fio_workload
-
-
-def run_command(command: str):
-  """Runs the given string command as a subprocess."""
-  result = subprocess.run(command.split(' '), capture_output=True, text=True)
-  print(result.stdout)
-  print(result.stderr)
-
-
-def escapeCommasInString(unescapedStr: str) -> str:
-  """Returns equivalent string with ',' replaced with '\,' ."""
-  return unescapedStr.replace(',', '\,')
 
 
 def createHelmInstallCommands(
@@ -62,7 +60,7 @@ def createHelmInstallCommands(
           f'--set instanceId={instanceId}',
           (
               '--set'
-              f' gcsfuse.mountOptions={escapeCommasInString(fioWorkload.gcsfuseMountOptions)}'
+              f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
           ),
           f'--set nodeType={machineType}',
           f'--set podName={podName}',
@@ -90,57 +88,5 @@ def main(args) -> None:
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      prog='FIO test runner',
-      description=(
-          'This program takes in a json test-config file, finds out valid FIO'
-          ' workloads from it and generates and deploys a helm chart for each'
-          ' FIO workload.'
-      ),
-  )
-  parser.add_argument(
-      '--workload-config',
-      metavar='JSON workload configuration file path',
-      help='Runs FIO tests from this JSON workload configuration file.',
-      required=True,
-  )
-  parser.add_argument(
-      '--instance-id',
-      metavar='A unique string ID to represent the test-run',
-      help=(
-          'Set to a unique string ID for current test-run. Do not put spaces'
-          ' in it.'
-      ),
-      required=True,
-  )
-  parser.add_argument(
-      '--machine-type',
-      metavar='Machine-type of the GCE VM or GKE cluster node',
-      help='Machine-type of the GCE VM or GKE cluster node e.g. n2-standard-32',
-      required=True,
-  )
-  parser.add_argument(
-      '-n',
-      '--dry-run',
-      action='store_true',
-      help=(
-          'Only print out the test configurations that will run,'
-          ' not actually run them.'
-      ),
-  )
-
-  args = parser.parse_args()
-  for argument in ['instance_id', 'machine_type']:
-    value = getattr(args, argument)
-    if len(value) == 0 or str.isspace(value):
-      raise Exception(
-          f'Argument {argument} (value="{value}") is empty or contains only'
-          ' spaces.'
-      )
-    if ' ' in value:
-      raise Exception(
-          f'Argument {argument} (value="{value}") contains space in it, which'
-          ' is not supported.'
-      )
-
-  main(args)
+  args = parse_args()
+main(args)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -29,8 +29,7 @@ import sys
 
 # local imports from other directories
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
-from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
-from utils import UnknownMachineTypeError, resource_limits_requests
+from run_tests_common import escape_commas_in_string, parse_args, run_command
 
 # local imports from same directory
 import fio_workload

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -73,33 +73,6 @@ def parse_args():
       required=True,
   )
   parser.add_argument(
-      '--project-id',
-      metavar='project-id of the user gke cluster',
-      help='project-id of the user gke cluster e.g. gcs-fuse-test',
-      required=True,
-  )
-  parser.add_argument(
-      '--project-number',
-      metavar='project-number of the user gke cluster',
-      help='project-number of the user gke cluster e.g. 927584127901',
-      required=True,
-      type=int,
-  )
-  parser.add_argument(
-      '--namespace',
-      metavar='kubectl namespace of the user',
-      help='kubectl namespace of the user e.g. default',
-      required=False,
-      default='default',
-  )
-  parser.add_argument(
-      '--ksa',
-      metavar='kubernetes service account of the user',
-      help='kubernetest service account of the user e.g. default',
-      required=False,
-      default='default',
-  )
-  parser.add_argument(
       '-n',
       '--dry-run',
       action='store_true',
@@ -113,9 +86,6 @@ def parse_args():
   for argument in [
       'instance_id',
       'machine_type',
-      'project_id',
-      'namespace',
-      'ksa',
   ]:
     value = getattr(args, argument)
     if len(value) == 0 or str.isspace(value):

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -86,7 +86,7 @@ def parse_args():
       'machine_type',
   ]:
     value = getattr(args, argument)
-    if len(value) == 0 or str.isspace(value):
+    if not value.strip():
       raise Exception(
           f'Argument {argument} (value="{value}") is empty or contains only'
           ' spaces.'

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common code for fio/run_tests.py and dlio/run_tests.py"""
+
+import argparse
+import subprocess
+import sys
+
+
+def run_command(command: str) -> int:
+  """Runs the given string command as a subprocess.
+
+  Returns exit-code which would be non-zero for error.
+  """
+  result = subprocess.run(
+      [word for word in command.split(' ') if (word and not str.isspace(word))],
+      capture_output=True,
+      text=True,
+  )
+  print(result.stdout)
+  print(result.stderr)
+  return result.returncode
+
+
+def escape_commas_in_string(unescapedStr: str) -> str:
+  """Returns equivalent string with ',' replaced with '\,' ."""
+  return unescapedStr.replace(',', '\,')
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(
+      prog='FIO test runner',
+      description=(
+          'This program takes in a json test-config file, finds out valid FIO'
+          ' workloads from it and generates and deploys a helm chart for each'
+          ' FIO workload.'
+      ),
+  )
+  parser.add_argument(
+      '--workload-config',
+      metavar='JSON workload configuration file path',
+      help='Runs FIO tests from this JSON workload configuration file.',
+      required=True,
+  )
+  parser.add_argument(
+      '--instance-id',
+      metavar='A unique string ID to represent the test-run',
+      help=(
+          'Set to a unique string ID for current test-run. Do not put spaces'
+          ' in it.'
+      ),
+      required=True,
+  )
+  parser.add_argument(
+      '--machine-type',
+      metavar='Machine-type of the GCE VM or GKE cluster node',
+      help='Machine-type of the GCE VM or GKE cluster node e.g. n2-standard-32',
+      required=True,
+  )
+  parser.add_argument(
+      '--project-id',
+      metavar='project-id of the user gke cluster',
+      help='project-id of the user gke cluster e.g. gcs-fuse-test',
+      required=True,
+  )
+  parser.add_argument(
+      '--project-number',
+      metavar='project-number of the user gke cluster',
+      help='project-number of the user gke cluster e.g. 927584127901',
+      required=True,
+      type=int,
+  )
+  parser.add_argument(
+      '--namespace',
+      metavar='kubectl namespace of the user',
+      help='kubectl namespace of the user e.g. default',
+      required=False,
+      default='default',
+  )
+  parser.add_argument(
+      '--ksa',
+      metavar='kubernetes service account of the user',
+      help='kubernetest service account of the user e.g. default',
+      required=False,
+      default='default',
+  )
+  parser.add_argument(
+      '-n',
+      '--dry-run',
+      action='store_true',
+      help=(
+          'Only print out the test configurations that will run,'
+          ' not actually run them.'
+      ),
+  )
+
+  args = parser.parse_args()
+  for argument in [
+      'instance_id',
+      'machine_type',
+      'project_id',
+      'namespace',
+      'ksa',
+  ]:
+    value = getattr(args, argument)
+    if len(value) == 0 or str.isspace(value):
+      raise Exception(
+          f'Argument {argument} (value="{value}") is empty or contains only'
+          ' spaces.'
+      )
+    if ' ' in value:
+      raise Exception(
+          f'Argument {argument} (value="{value}") contains space in it, which'
+          ' is not supported.'
+      )
+
+  return args

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
@@ -1,0 +1,25 @@
+import unittest
+from run_tests_common import escape_commas_in_string
+# import utils
+
+
+class RunTestsCommonTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(self):
+    pass
+
+  def test_escape_commas_in_string(self):
+    tcs = [
+        {"input": "a:b,c=d,", "expected_output": "a:b\,c=d\,"},
+        {"input": "", "expected_output": ""},
+    ]
+    for tc in tcs:
+      self.assertEqual(
+          tc["expected_output"], escape_commas_in_string(tc["input"])
+      )
+      pass
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
@@ -1,3 +1,18 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from run_tests_common import escape_commas_in_string
 # import utils

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common_test.py
@@ -15,14 +15,9 @@
 
 import unittest
 from run_tests_common import escape_commas_in_string
-# import utils
 
 
 class RunTestsCommonTest(unittest.TestCase):
-
-  @classmethod
-  def setUpClass(self):
-    pass
 
   def test_escape_commas_in_string(self):
     tcs = [
@@ -33,7 +28,6 @@ class RunTestsCommonTest(unittest.TestCase):
       self.assertEqual(
           tc["expected_output"], escape_commas_in_string(tc["input"])
       )
-      pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
It extracts common code from fio/run_tests.py and dlio/run_tests.py and puts it in utils/run_tests_common.py for sharing.

This is on top of #2489 and is followed in #2495 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
