### PR TITLE
Add kill switch flag for cli config parity

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -49,6 +49,7 @@ import (
 const (
 	SuccessfulMountMessage         = "File system has been successfully mounted."
 	UnsuccessfulMountMessagePrefix = "Error while mounting gcsfuse"
+	EnableViperConfigEnvVariable   = "ENABLE_GCSFUSE_VIPER_CONFIG"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -317,7 +318,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 
 		// Pass along ENABLE_GCSFUSE_VIPER_CONFIG environment variable, since we
 		// need to use Viper config if this environment variable is set.
-		env = append(env, fmt.Sprintf("ENABLE_GCSFUSE_VIPER_CONFIG=%s", os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")))
+		env = append(env, fmt.Sprintf(EnableViperConfigEnvVariable+"=%s", os.Getenv(EnableViperConfigEnvVariable)))
 
 		// Pass along GOOGLE_APPLICATION_CREDENTIALS, since we document in
 		// mounting.md that it can be used for specifying a key file.

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -315,6 +315,10 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 			fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		}
 
+		// Pass along ENABLE_GCSFUSE_VIPER_CONFIG environment variable, since we
+		// need to use Viper config if this environment variable is set.
+		env = append(env, fmt.Sprintf("ENABLE_GCSFUSE_VIPER_CONFIG=%s", os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")))
+
 		// Pass along GOOGLE_APPLICATION_CREDENTIALS, since we document in
 		// mounting.md that it can be used for specifying a key file.
 		if p, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
@@ -476,7 +480,7 @@ func run() (err error) {
 	return
 }
 
-func ExecuteLegacyMain() {
+var ExecuteLegacyMain = func() {
 	err := run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -139,4 +141,15 @@ func ConvertToPosixArgs(args []string, c *cobra.Command) []string {
 		}
 	}
 	return pArgs
+}
+
+var ExecuteNewMain = func() {
+	rootCmd, err := NewRootCmd(Mount)
+	if err != nil {
+		log.Fatalf("Error occurred while creating the root command: %v", err)
+	}
+	rootCmd.SetArgs(ConvertToPosixArgs(os.Args, rootCmd))
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Error occurred during command execution: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -50,18 +50,29 @@ func main() {
 	// Set up profiling handlers.
 	go perf.HandleCPUProfileSignals()
 	go perf.HandleMemoryProfileSignals()
+
+	// TODO: Clean this up after we gain enough confidence on CLI-Config Parity changes.
+	disableViperConfigFlag := "disable-viper-config"
+	var newOsArgs []string
+	for _, arg := range os.Args {
+		if arg == "-"+disableViperConfigFlag || arg == "--"+disableViperConfigFlag || arg == "-"+disableViperConfigFlag+"=true" || arg == "--"+disableViperConfigFlag+"=true" {
+			err := os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", "false")
+			if err != nil {
+				logger.Infof("error while setting ENABLE_GCSFUSE_VIPER_CONFIG environment variable: %v", err)
+			}
+		}
+		if !strings.Contains(arg, disableViperConfigFlag) {
+			newOsArgs = append(newOsArgs, arg)
+		}
+	}
+	os.Args = newOsArgs
+
 	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "false" {
 		cmd.ExecuteLegacyMain()
 		return
 	}
 
-	rootCmd, err := cmd.NewRootCmd(cmd.Mount)
-	if err != nil {
-		log.Fatalf("Error occurred while creating the root command: %v", err)
-	}
-	rootCmd.SetArgs(cmd.ConvertToPosixArgs(os.Args, rootCmd))
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatalf("Error occurred during command execution: %v", err)
-	}
+	cmd.ExecuteNewMain()
+	return
 
 }

--- a/main.go
+++ b/main.go
@@ -56,9 +56,9 @@ func main() {
 	var newOsArgs []string
 	for _, arg := range os.Args {
 		if arg == "-"+disableViperConfigFlag || arg == "--"+disableViperConfigFlag || arg == "-"+disableViperConfigFlag+"=true" || arg == "--"+disableViperConfigFlag+"=true" {
-			err := os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", "false")
+			err := os.Setenv(cmd.EnableViperConfigEnvVariable, "false")
 			if err != nil {
-				logger.Infof("error while setting ENABLE_GCSFUSE_VIPER_CONFIG environment variable: %v", err)
+				logger.Infof("error while setting"+cmd.EnableViperConfigEnvVariable+" environment variable: %v", err)
 			}
 		}
 		if !strings.Contains(arg, disableViperConfigFlag) {
@@ -67,7 +67,7 @@ func main() {
 	}
 	os.Args = newOsArgs
 
-	if strings.ToLower(os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")) == "false" {
+	if strings.ToLower(os.Getenv(cmd.EnableViperConfigEnvVariable)) == "false" {
 		cmd.ExecuteLegacyMain()
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -73,6 +73,4 @@ func main() {
 	}
 
 	cmd.ExecuteNewMain()
-	return
-
 }

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		if arg == "-"+disableViperConfigFlag || arg == "--"+disableViperConfigFlag || arg == "-"+disableViperConfigFlag+"=true" || arg == "--"+disableViperConfigFlag+"=true" {
 			err := os.Setenv(cmd.EnableViperConfigEnvVariable, "false")
 			if err != nil {
-				logger.Infof("error while setting"+cmd.EnableViperConfigEnvVariable+" environment variable: %v", err)
+				logger.Infof("error while setting "+cmd.EnableViperConfigEnvVariable+" environment variable: %v", err)
 			}
 		}
 		if !strings.Contains(arg, disableViperConfigFlag) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainArgParsing(t *testing.T) {
+	originalArgs := os.Args
+	originalEnvVar := os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG")
+	originalExecuteLegacyMain := cmd.ExecuteLegacyMain
+	originalExecuteNewMain := cmd.ExecuteNewMain
+	defer func() {
+		// Restore original os.Args after the test.
+		os.Args = originalArgs
+		// Reset the environment variable.
+		_ = os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", originalEnvVar)
+		// Restore original execute functions.
+		cmd.ExecuteLegacyMain = originalExecuteLegacyMain
+		cmd.ExecuteNewMain = originalExecuteNewMain
+	}()
+
+	tests := []struct {
+		name                  string
+		inputArgs             []string
+		inputEnvVariable      string
+		expectedEnvVar        string
+		expectedRemainingArgs []string
+		expectLegacyCall      bool
+		expectNewMainCall     bool
+	}{
+		{
+			name:                  "disable_viper_config_with_short_flag",
+			inputArgs:             []string{"gcsfuse", "-disable-viper-config", "bucket-name", "mount-point"},
+			expectedEnvVar:        "false",
+			expectedRemainingArgs: []string{"gcsfuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      true,
+			expectNewMainCall:     false,
+		},
+		{
+			name:                  "disable_viper_config_with_posix_flag",
+			inputArgs:             []string{"gcsfuse", "--disable-viper-config", "bucket-name", "mount-point"},
+			expectedEnvVar:        "false",
+			expectedRemainingArgs: []string{"gcsfuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      true,
+			expectNewMainCall:     false,
+		},
+		{
+			name:                  "disable_viper_config_with_short_flag_and_value",
+			inputArgs:             []string{"gcsfuse", "-disable-viper-config=true", "bucket-name", "mount-point"},
+			expectedEnvVar:        "false",
+			expectedRemainingArgs: []string{"gcsfuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      true,
+			expectNewMainCall:     false,
+		},
+		{
+			name:                  "disable_viper_config_with_posix_flag_and_value",
+			inputArgs:             []string{"gcsfuse", "--disable-viper-config=true", "bucket-name", "mount-point"},
+			expectedEnvVar:        "false",
+			expectedRemainingArgs: []string{"gcsfuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      true,
+			expectNewMainCall:     false,
+		},
+		{
+			name:                  "no_disable_flag",
+			inputArgs:             []string{"gcsfuse", "--implicit-dirs", "--debug_fuse", "bucket-name", "mount-point"},
+			expectedEnvVar:        "", // No change expected
+			expectedRemainingArgs: []string{"gcsfuse", "--implicit-dirs", "--debug_fuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      false,
+			expectNewMainCall:     true,
+		},
+		{
+			name:                  "disable_via_env_variable",
+			inputArgs:             []string{"gcsfuse", "--implicit-dirs", "--debug_fuse", "bucket-name", "mount-point"},
+			inputEnvVariable:      "false",
+			expectedEnvVar:        "false",
+			expectedRemainingArgs: []string{"gcsfuse", "--implicit-dirs", "--debug_fuse", "bucket-name", "mount-point"},
+			expectLegacyCall:      true,
+			expectNewMainCall:     false,
+		},
+		{
+			name:                  "enable_via_env_variable",
+			inputArgs:             []string{"gcsfuse", "--flag1", "bucket-name", "mount-point"},
+			inputEnvVariable:      "true",
+			expectedEnvVar:        "true",
+			expectedRemainingArgs: []string{"gcsfuse", "--flag1", "bucket-name", "mount-point"},
+			expectLegacyCall:      false,
+			expectNewMainCall:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = tt.inputArgs
+			err := os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", tt.inputEnvVariable)
+			assert.NoError(t, err)
+			// Mock cmd.ExecuteLegacyMain
+			legacyMainCalled := false
+			cmd.ExecuteLegacyMain = func() {
+				legacyMainCalled = true
+			}
+
+			newMainCalled := false
+			cmd.ExecuteNewMain = func() {
+				newMainCalled = true
+			}
+
+			main()
+
+			assert.EqualValues(t, tt.expectedEnvVar, os.Getenv("ENABLE_GCSFUSE_VIPER_CONFIG"))
+			assert.EqualValues(t, tt.expectedRemainingArgs, os.Args)
+			assert.Equal(t, tt.expectLegacyCall, legacyMainCalled)
+			assert.Equal(t, tt.expectNewMainCall, newMainCalled)
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cmd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLegacyMainExecution(t *testing.T) {
@@ -79,7 +80,7 @@ func TestLegacyMainExecution(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Args = tt.inputArgs
 			err := os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", tt.inputEnvVariable)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			legacyMainCalled := false
 			cmd.ExecuteLegacyMain = func() {
 				legacyMainCalled = true
@@ -133,7 +134,7 @@ func TestNewMainExecution(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Args = tt.inputArgs
 			err := os.Setenv("ENABLE_GCSFUSE_VIPER_CONFIG", tt.inputEnvVariable)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			newMainCalled := false
 			cmd.ExecuteNewMain = func() {
 				newMainCalled = true

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -727,3 +727,82 @@ func (t *GcsfuseTest) BothLogAndKeyFilePath() {
 		ExpectEq(nil, err)
 	}
 }
+
+func (t *GcsfuseTest) TestDisableViperConfig() {
+	testCases := []struct {
+		name string
+		args []string
+		env  string
+	}{
+		{
+			name: "disable_viper_config_with_short_flag",
+			args: []string{"-disable-viper-config", "-metadata-cache-ttl-secs", "100"},
+			env:  "",
+		},
+		{
+			name: "disable_viper_config_with_posix_flag",
+			args: []string{"--disable-viper-config", "--metadata-cache-ttl-secs", "100"},
+			env:  "",
+		},
+		{
+			name: "disable_viper_config_with_short_flag_and_value",
+			args: []string{"-disable-viper-config=true", "-metadata-cache-ttl-secs=100"},
+			env:  "",
+		},
+		{
+			name: "disable_viper_config_with_posix_flag_and_value",
+			args: []string{"--disable-viper-config=true", "--metadata-cache-ttl-secs=100"},
+			env:  "",
+		},
+		{
+			name: "disable_via_env_variable",
+			args: []string{"--metadata-cache-ttl-secs=100"},
+			env:  "false",
+		},
+		{
+			name: "env_true_flag_disabled",
+			args: []string{"--metadata-cache-ttl-secs=100", "--disable-viper-config=true"},
+			env:  "true",
+		},
+	}
+
+	for _, tc := range testCases {
+		args := append(tc.args, canned.FakeBucketName, t.dir)
+		env := []string{fmt.Sprintf("ENABLE_GCSFUSE_VIPER_CONFIG=%s", tc.env)}
+
+		err := t.runGcsfuseWithEnv(args, env)
+
+		// Expect that the mount fails as we are using a flag in viper config (which is disabled).
+		ExpectNe(nil, err)
+	}
+}
+
+func (t *GcsfuseTest) TestEnabledViperConfig() {
+	testCases := []struct {
+		name string
+		args []string
+		env  string
+	}{
+		{
+			name: "no_disable_flag_or_env",
+			args: []string{"--metadata-cache-ttl-secs=100"},
+			env:  "",
+		},
+		{
+			name: "enabled_via_env_variable",
+			args: []string{"--metadata-cache-ttl-secs=100"},
+			env:  "true",
+		},
+	}
+
+	for _, tc := range testCases {
+		args := append(tc.args, canned.FakeBucketName, t.dir)
+		env := []string{fmt.Sprintf("ENABLE_GCSFUSE_VIPER_CONFIG=%s", tc.env)}
+
+		err := t.runGcsfuseWithEnv(args, env)
+
+		ExpectEq(nil, err)
+		err = util.Unmount(t.dir)
+		ExpectEq(nil, err)
+	}
+}


### PR DESCRIPTION
### Description
Added a kill-switch flag "--disable-viper-config" to use legacy config/flags in case something goes wrong. This will be cleaned up after 2 releases.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that old configs are being used when kill switch flag is added.
2. Unit tests - Added
3. Integration tests - Added
