### PR TITLE
[testing-on-gke part 6.6] Enforce one pod per node

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -31,6 +31,7 @@ import sys
 # local imports from other directories
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
 from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
+from utils import UnknownMachineTypeError, resource_limits
 
 # local imports from same directory
 import dlio_workload
@@ -43,6 +44,16 @@ def createHelmInstallCommands(
 ) -> list:
   """Creates helm install commands for the given dlioWorkload objects."""
   helm_commands = []
+  try:
+    resourceLimits, resourceRequests = resource_limits(machineType)
+  except UnknownMachineTypeError:
+    print(
+        f'Found unknown machine-type: {machineType}, defaulting resource limits'
+        ' to cpu=0,memory=0'
+    )
+    resourceLimits = {'cpu': 0, 'memory': '0'}
+    resourceRequests = resourceLimits
+
   for dlioWorkload in dlioWorkloads:
     for batchSize in dlioWorkload.batchSizes:
       chartName, podName, outputDirPrefix = dlio_workload.DlioChartNamePodName(
@@ -63,6 +74,10 @@ def createHelmInstallCommands(
           f'--set nodeType={machineType}',
           f'--set podName={podName}',
           f'--set outputDirPrefix={outputDirPrefix}',
+          f"--set resourceLimits.cpu={resourceLimits['cpu']}",
+          f"--set resourceLimits.memory={resourceLimits['memory']}",
+          f"--set resourceRequests.cpu={resourceRequests['cpu']}",
+          f"--set resourceRequests.memory={resourceRequests['memory']}",
       ]
 
       helm_command = ' '.join(commands)

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
@@ -160,6 +160,35 @@ def timestamp_to_epoch(timestamp: str) -> int:
     )
 
 
+class UnknownMachineTypeError(Exception):
+  """Defines custom exception for unknown machine-type scenario.
+
+  It holds value of machineType as str.
+  """
+
+  def __init__(self, message, machineType: str):
+    super().__init__(message)
+    self.machineType = machineType
+
+
+def resource_limits(nodeType: str) -> Tuple[dict, dict]:
+  """Returns resource limits and requests for cpu/memory for different machine types."""
+  if nodeType == "n2-standard-96":
+    return {"cpu": 96, "memory": "384Gi"}, {"cpu": 90, "memory": "300Gi"}
+  elif nodeType == "n2-standard-48":
+    return {"cpu": 48, "memory": "192Gi"}, {"cpu": 45, "memory": "150Gi"}
+  elif nodeType == "n2-standard-32":
+    return {"cpu": 32, "memory": "128Gi"}, {"cpu": 30, "memory": "100Gi"}
+  elif nodeType == "c3-standard-176" or nodeType == "c3-standard-176-lssd":
+    return {"cpu": 176, "memory": "704Gi"}, {"cpu": 100, "memory": "400Gi"}
+  else:
+    raise UnknownMachineTypeError(
+        f"Unknown machine-type: {nodeType}. Unable to decide the"
+        " resource-limits for it.",
+        nodeType,
+    )
+
+
 def _is_relevant_monitoring_result(
     result,
     cluster_name: str,

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
@@ -88,6 +88,48 @@ class UtilsTest(unittest.TestCase):
         timestamp_to_epoch('2024-08-21T19:20:25.547456'), 1724268025
     )
 
+  def test_resource_limit(self):
+    inputs = [
+        {
+            'nodeType': 'n2-standard-32',
+            'expected_limits_cpu': 32,
+            'expected_error': False,
+        },
+        {
+            'nodeType': 'n2-standard-96',
+            'expected_limits_cpu': 96,
+            'expected_error': False,
+        },
+        {
+            'nodeType': 'n2-standard-96',
+            'expected_limits_cpu': 96,
+            'expected_error': False,
+        },
+        {
+            'nodeType': 'c3-standard-176',
+            'expected_limits_cpu': 176,
+            'expected_error': False,
+        },
+        {
+            'nodeType': 'c3-standard-176-lssd',
+            'expected_limits_cpu': 176,
+            'expected_error': False,
+        },
+        {'nodeType': 'n2-standard-1', 'expected_error': True},
+        {'nodeType': 'unknown-machine-type', 'expected_error': True},
+    ]
+    for input in inputs:
+      self.assertEqual(dict, type(input))
+      try:
+        resource_limits = utils.resource_limits(input['nodeType'])
+        self.assertEqual(
+            input['expected_limits_cpu'],
+            resource_limits[0]['cpu'],
+        )
+        self.assertFalse(input['expected_error'])
+      except utils.UnknownMachineTypeError:
+        self.assertTrue(input['expected_error'])
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
### Description

This is on top of #2496 and is followed up in #2498 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
