### PR TITLE
[testing-on-gke part 6.7] Improvements in run script

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -113,6 +113,7 @@ readonly DEFAULT_INSTANCE_ID=${USER}-$(date +%Y%m%d-%H%M%S)
 readonly DEFAULT_POD_WAIT_TIME_IN_SECONDS=300
 # 1 week
 readonly DEFAULT_POD_TIMEOUT_IN_SECONDS=604800
+readonly DEFAULT_FORCE_UPDATE_GCSFUSE_CODE=false
 
 function printHelp() {
   echo "Usage guide: "
@@ -206,6 +207,10 @@ if test -n "${gcsfuse_src_dir}"; then
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
 else
   export gcsfuse_src_dir="${src_dir}"/gcsfuse
+fi
+
+if test -z "${force_update_gcsfuse_code}"; then
+  export force_update_gcsfuse_code=${DEFAULT_FORCE_UPDATE_GCSFUSE_CODE}
 fi
 
 export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
@@ -540,6 +545,8 @@ function ensureGcsfuseCode() {
   # clone gcsfuse code if needed
   if ! test -d "${gcsfuse_src_dir}"; then
     cd $(dirname "${gcsfuse_src_dir}") && git clone ${gcsfuse_github_path} && cd "${gcsfuse_src_dir}" && git switch ${gcsfuse_branch} && cd - && cd -
+  elif ${force_update_gcsfuse_code}; then
+    cd ${gcsfuse_src_dir} && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
   test -d "${gke_testing_dir}" || (echo "${gke_testing_dir} does not exist" && exit 1)

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -22,7 +22,7 @@
 # It installs all the necessary dependencies on its own.
 # It creates a GKE cluster and other GCP resources (as needed), based on a number of configuration parameters e.g. gcp-project-name/number, cluster-name, zone (for resource location), machine-type (of node), number of local SSDs.
 # It creates fio/dlio tests as helm charts, based on the provided JSON workload configuration file and deploys them on the GKE cluster.
-# A sample workload-configuration file is available at https://github.com/GoogleCloudPlatform/gcsfuse/blob/b2286ec3466dd285b2d5ea3be8636a809efbfb1b/perfmetrics/scripts/testing_on_gke/examples/workloads.json#L2 .
+# A sample workload-configuration file is available at https://github.com/GoogleCloudPlatform/gcsfuse/blob/garnitin/add-gke-load-testing/v1/perfmetrics/scripts/testing_on_gke/examples/workloads.json .
 
 # Fail script if any of the commands fail.
 set -e
@@ -172,8 +172,6 @@ else
   export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
 fi
 
-# GCSFuse configuration related - deprecated. Will cause error.
-test -z "${gcsfuse_mount_options}" || (exitWithError "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." )
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${pod_timeout_in_seconds}" || export pod_timeout_in_seconds="${DEFAULT_POD_TIMEOUT_IN_SECONDS}"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -546,7 +546,7 @@ function ensureGcsfuseCode() {
   if ! test -d "${gcsfuse_src_dir}"; then
     cd $(dirname "${gcsfuse_src_dir}") && git clone ${gcsfuse_github_path} && cd "${gcsfuse_src_dir}" && git switch ${gcsfuse_branch} && cd - && cd -
   elif ${force_update_gcsfuse_code}; then
-    cd ${gcsfuse_src_dir} && git reset --hard origin/${gcsfuse_branch} && cd -
+    cd ${gcsfuse_src_dir} && git fetch --all && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
   test -d "${gke_testing_dir}" || (echo "${gke_testing_dir} does not exist" && exit 1)

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -529,7 +529,7 @@ function createCustomCsiDriverIfNeeded() {
 
     printf "\nCreating a new custom CSI driver ...\n\n"
 
-    # Create a bucket for storing custom-csi driver.
+    # Create a bucket (if needed) for storing GCSFuse binaries.
     if test -z "${package_bucket}"; then
       package_bucket=${project_id}-${cluster_name}-gcsfuse-bin
       package_bucket=${package_bucket/google/}
@@ -544,7 +544,7 @@ function createCustomCsiDriverIfNeeded() {
       gcloud storage buckets create gs://${package_bucket} --project=${project_id} --location=${region}
     fi
 
-    # Build a new gcsfuse binary
+    # Build new gcsfuse binaries.
     printf "\nBuilding a new GCSFuse binary from ${gcsfuse_src_dir} ...\n\n"
     cd "${gcsfuse_src_dir}"
     rm -rfv ./bin ./sbin
@@ -567,11 +567,13 @@ function createCustomCsiDriverIfNeeded() {
     printf "\nInstalling the new custom CSI driver built above ...\n\n"
     make install PROJECT=${project_id} REGISTRY=${registry}
     cd -
+
     # Wait some time after csi driver installation before deploying pods
     # to avoid failures caused by 'the webhook failed to inject the
     # sidecar container into the Pod spec' error.
     printf "\nSleeping 30 seconds after csi custom driver installation before deploying pods ...\n\n"
     sleep 30
+
   else
     echo ""
     echo "Enabling managed CSI driver ..."

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -99,7 +99,7 @@ function printHelp() {
   echo "ARGS (all are optional) : "
   echo ""
   echo "--debug     Print out shell commands for debugging. Aliases: -debug "
-  echo "--help      Print out this help. Aliases: help , -help , -h , --h"
+  echo "--help      Print out this help. Aliases: -help, -h"
 }
 
 # Print out help if user passes argument `--help`
@@ -112,11 +112,11 @@ fi
 # GCP related
 if test -n "${project_id}"; then
   if test -z "${project_number}"; then
-    echo "Error: project_id was set, but not project_number. Either both should be specified, or neither."
+    >&2 echo "Error: project_id was set, but not project_number. Either both should be specified, or neither."
     exitWithFailure
   fi
 elif test -n "${project_number}"; then
-    echo "Error: project_number was set, but not project_id. Either both should be specified, or neither."
+    >&2 echo "Error: project_number was set, but not project_id. Either both should be specified, or neither."
     exitWithFailure
 else
   export project_id=${DEFAULT_PROJECT_ID}
@@ -148,7 +148,7 @@ fi
 
 if test -n "${gcsfuse_src_dir}"; then
   if ! test -d "${gcsfuse_src_dir}"; then
-    echo "Error: gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
+    >&2 echo "Error: gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
     exitWithFailure
   fi
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
@@ -164,7 +164,7 @@ export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
 
 if test -n "${csi_src_dir}"; then
   if ! test -d "${csi_src_dir}"; then
-    echo "Error: csi_src_dir \"${csi_src_dir}\" does not exist"
+    >&2 echo "Error: csi_src_dir \"${csi_src_dir}\" does not exist"
     exitWithFailure
   fi
   export csi_src_dir="$(realpath "${csi_src_dir}")"
@@ -173,20 +173,20 @@ else
 fi
 
 # GCSFuse configuration related - deprecated. Will cause error.
-test -z "${gcsfuse_mount_options}" || (echo "Error: gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
+test -z "${gcsfuse_mount_options}" || (>&2 echo "Error: gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${pod_timeout_in_seconds}" || export pod_timeout_in_seconds="${DEFAULT_POD_TIMEOUT_IN_SECONDS}"
 test -n "${instance_id}" || export instance_id="${DEFAULT_INSTANCE_ID}"
 
 if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
-  echo "Error: pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
+  >&2 echo "Error: pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
   exitWithFailure
 fi
 
 if test -n "${workload_config}"; then
   if ! test -f "${workload_config}"; then
-    echo "Error: workload_config \"${workload_config}\" does not exist"
+    >&2 echo "Error: workload_config \"${workload_config}\" does not exist"
     exitWithFailure
   fi
   export workload_config="$(realpath "${workload_config}")"
@@ -196,7 +196,7 @@ fi
 
 if test -n "${output_dir}"; then
   if ! test -d "${output_dir}"; then
-    echo "Error: output_dir \"${output_dir}\" does not exist"
+    >&2 echo "Error: output_dir \"${output_dir}\" does not exist"
     exitWithFailure
   fi
   export output_dir="$(realpath "${output_dir}")"
@@ -308,8 +308,8 @@ function installDependencies() {
   which jq || sudo apt-get install -y jq
   # Ensure sudoless docker is installed.
   if ! docker ps 1>/dev/null ; then
-    >2 echo "Error: sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
-    >2 echo "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
+    >&2 echo "Error: sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
+    >&2 echo "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
     return 1
   fi
   # Install python modules for gsheet.
@@ -343,19 +343,19 @@ function validateMachineConfig() {
   case "${machine_type}" in
   "n2-standard-96")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
+      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-48")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
+      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-32")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 4 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
+      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
       return 1
     fi
     ;;
@@ -511,7 +511,7 @@ function ensureGcsfuseCode() {
     cd ${gcsfuse_src_dir} && git fetch --all && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
-  test -d "${gke_testing_dir}" || (echo "Error: ${gke_testing_dir} does not exist" && exitWithFailure )
+  test -d "${gke_testing_dir}" || (>&2 echo "Error: ${gke_testing_dir} does not exist" && exitWithFailure )
 }
 
 function ensureGcsFuseCsiDriverCode() {
@@ -535,7 +535,7 @@ function createCustomCsiDriverIfNeeded() {
       package_bucket=${package_bucket/google/}
     fi
     if [[ ${#package_bucket} -gt 63 ]] ; then
-      >2 echo "Error: package_bucket \"${package_bucket}\" is too long (should be <= 63)"
+      >&2 echo "Error: package_bucket \"${package_bucket}\" is too long (should be <= 63)"
       return 1
     fi
     # If package_bucket does not already exist, create it.
@@ -610,7 +610,7 @@ function waitTillAllPodsComplete() {
     cur_epoch=$(date +%s)
     time_till_timeout=$((start_epoch+pod_timeout_in_seconds-cur_epoch))
     if [[ ${time_till_timeout} -lt 0 ]]; then
-      printf "\nError: Pod-run timed out!\n\n"
+      >&2 printf "\nError: Pod-run timed out!\n\n"
       printf "Clearing all pods created in this run...\n"
       deleteAllPods
       exitWithFailure

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -37,6 +37,7 @@ fi
 function exitWithSuccess() { exit 0; }
 function exitWithFailure() { exit 1; }
 function echoerror()  { >&2 echo "Error: "$@; }
+function exitWithError()  { echoerror $@ ; exitWithFailure ; }
 
 # Default values, to be used for parameters in case user does not specify them.
 # GCP related
@@ -113,12 +114,10 @@ fi
 # GCP related
 if test -n "${project_id}"; then
   if test -z "${project_number}"; then
-    echoerror "project_id was set, but not project_number. Either both should be specified, or neither."
-    exitWithFailure
+    exitWithError "project_id was set, but not project_number. Either both should be specified, or neither."
   fi
 elif test -n "${project_number}"; then
-    echoerror "project_number was set, but not project_id. Either both should be specified, or neither."
-    exitWithFailure
+    exitWithError "project_number was set, but not project_id. Either both should be specified, or neither."
 else
   export project_id=${DEFAULT_PROJECT_ID}
   export project_number=${DEFAULT_PROJECT_NUMBER}
@@ -149,8 +148,7 @@ fi
 
 if test -n "${gcsfuse_src_dir}"; then
   if ! test -d "${gcsfuse_src_dir}"; then
-    echoerror "gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
-    exitWithFailure
+    exitWithError "gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
   fi
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
 else
@@ -165,8 +163,7 @@ export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
 
 if test -n "${csi_src_dir}"; then
   if ! test -d "${csi_src_dir}"; then
-    echoerror "csi_src_dir \"${csi_src_dir}\" does not exist"
-    exitWithFailure
+    exitWithError "csi_src_dir \"${csi_src_dir}\" does not exist"
   fi
   export csi_src_dir="$(realpath "${csi_src_dir}")"
 else
@@ -174,21 +171,19 @@ else
 fi
 
 # GCSFuse configuration related - deprecated. Will cause error.
-test -z "${gcsfuse_mount_options}" || (echoerror "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
+test -z "${gcsfuse_mount_options}" || (exitWithError "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." )
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${pod_timeout_in_seconds}" || export pod_timeout_in_seconds="${DEFAULT_POD_TIMEOUT_IN_SECONDS}"
 test -n "${instance_id}" || export instance_id="${DEFAULT_INSTANCE_ID}"
 
 if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
-  echoerror "pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
-  exitWithFailure
+  exitWithError "pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
 fi
 
 if test -n "${workload_config}"; then
   if ! test -f "${workload_config}"; then
-    echoerror "workload_config \"${workload_config}\" does not exist"
-    exitWithFailure
+    exitWithError "workload_config \"${workload_config}\" does not exist"
   fi
   export workload_config="$(realpath "${workload_config}")"
 else
@@ -197,8 +192,7 @@ fi
 
 if test -n "${output_dir}"; then
   if ! test -d "${output_dir}"; then
-    echoerror "output_dir \"${output_dir}\" does not exist"
-    exitWithFailure
+    exitWithError "output_dir \"${output_dir}\" does not exist"
   fi
   export output_dir="$(realpath "${output_dir}")"
 else
@@ -512,7 +506,7 @@ function ensureGcsfuseCode() {
     cd ${gcsfuse_src_dir} && git fetch --all && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
-  test -d "${gke_testing_dir}" || (echoerror "${gke_testing_dir} does not exist" && exitWithFailure )
+  test -d "${gke_testing_dir}" || (exitWithError "${gke_testing_dir} does not exist" )
 }
 
 function ensureGcsFuseCsiDriverCode() {

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -36,6 +36,7 @@ fi
 # Utilities
 function exitWithSuccess() { exit 0; }
 function exitWithFailure() { exit 1; }
+function echoerror()  { >&2 echo "Error: "$@; }
 
 # Default values, to be used for parameters in case user does not specify them.
 # GCP related
@@ -112,11 +113,11 @@ fi
 # GCP related
 if test -n "${project_id}"; then
   if test -z "${project_number}"; then
-    >&2 echo "Error: project_id was set, but not project_number. Either both should be specified, or neither."
+    echoerror "project_id was set, but not project_number. Either both should be specified, or neither."
     exitWithFailure
   fi
 elif test -n "${project_number}"; then
-    >&2 echo "Error: project_number was set, but not project_id. Either both should be specified, or neither."
+    echoerror "project_number was set, but not project_id. Either both should be specified, or neither."
     exitWithFailure
 else
   export project_id=${DEFAULT_PROJECT_ID}
@@ -148,7 +149,7 @@ fi
 
 if test -n "${gcsfuse_src_dir}"; then
   if ! test -d "${gcsfuse_src_dir}"; then
-    >&2 echo "Error: gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
+    echoerror "gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
     exitWithFailure
   fi
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
@@ -164,7 +165,7 @@ export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
 
 if test -n "${csi_src_dir}"; then
   if ! test -d "${csi_src_dir}"; then
-    >&2 echo "Error: csi_src_dir \"${csi_src_dir}\" does not exist"
+    echoerror "csi_src_dir \"${csi_src_dir}\" does not exist"
     exitWithFailure
   fi
   export csi_src_dir="$(realpath "${csi_src_dir}")"
@@ -173,20 +174,20 @@ else
 fi
 
 # GCSFuse configuration related - deprecated. Will cause error.
-test -z "${gcsfuse_mount_options}" || (>&2 echo "Error: gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
+test -z "${gcsfuse_mount_options}" || (echoerror "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${pod_timeout_in_seconds}" || export pod_timeout_in_seconds="${DEFAULT_POD_TIMEOUT_IN_SECONDS}"
 test -n "${instance_id}" || export instance_id="${DEFAULT_INSTANCE_ID}"
 
 if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
-  >&2 echo "Error: pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
+  echoerror "pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
   exitWithFailure
 fi
 
 if test -n "${workload_config}"; then
   if ! test -f "${workload_config}"; then
-    >&2 echo "Error: workload_config \"${workload_config}\" does not exist"
+    echoerror "workload_config \"${workload_config}\" does not exist"
     exitWithFailure
   fi
   export workload_config="$(realpath "${workload_config}")"
@@ -196,7 +197,7 @@ fi
 
 if test -n "${output_dir}"; then
   if ! test -d "${output_dir}"; then
-    >&2 echo "Error: output_dir \"${output_dir}\" does not exist"
+    echoerror "output_dir \"${output_dir}\" does not exist"
     exitWithFailure
   fi
   export output_dir="$(realpath "${output_dir}")"
@@ -308,8 +309,8 @@ function installDependencies() {
   which jq || sudo apt-get install -y jq
   # Ensure sudoless docker is installed.
   if ! docker ps 1>/dev/null ; then
-    >&2 echo "Error: sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
-    >&2 echo "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
+    echoerror "sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
+    echoerror "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
     return 1
   fi
   # Install python modules for gsheet.
@@ -343,19 +344,19 @@ function validateMachineConfig() {
   case "${machine_type}" in
   "n2-standard-96")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
+      echoerror "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-48")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
+      echoerror "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-32")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 4 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      >&2 echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
+      echoerror "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
       return 1
     fi
     ;;
@@ -511,7 +512,7 @@ function ensureGcsfuseCode() {
     cd ${gcsfuse_src_dir} && git fetch --all && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
-  test -d "${gke_testing_dir}" || (>&2 echo "Error: ${gke_testing_dir} does not exist" && exitWithFailure )
+  test -d "${gke_testing_dir}" || (echoerror "${gke_testing_dir} does not exist" && exitWithFailure )
 }
 
 function ensureGcsFuseCsiDriverCode() {
@@ -535,7 +536,7 @@ function createCustomCsiDriverIfNeeded() {
       package_bucket=${package_bucket/google/}
     fi
     if [[ ${#package_bucket} -gt 63 ]] ; then
-      >&2 echo "Error: package_bucket \"${package_bucket}\" is too long (should be <= 63)"
+      echoerror "package_bucket \"${package_bucket}\" is too long (should be <= 63)"
       return 1
     fi
     # If package_bucket does not already exist, create it.
@@ -610,7 +611,7 @@ function waitTillAllPodsComplete() {
     cur_epoch=$(date +%s)
     time_till_timeout=$((start_epoch+pod_timeout_in_seconds-cur_epoch))
     if [[ ${time_till_timeout} -lt 0 ]]; then
-      >&2 printf "\nError: Pod-run timed out!\n\n"
+      echoerror printf "\nPod-run timed out!\n\n"
       printf "Clearing all pods created in this run...\n"
       deleteAllPods
       exitWithFailure

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -589,9 +589,10 @@ function createCustomCsiDriverIfNeeded() {
     make uninstall || true
     make generate-spec-yaml
     printf "\nBuilding a new custom CSI driver using the above GCSFuse binary ...\n\n"
-    make build-image-and-push-multi-arch REGISTRY=gcr.io/${project_id}/${USER} GCSFUSE_PATH=gs://${package_bucket}
+    registry=gcr.io/${project_id}/${USER}/${cluster_name}
+    make build-image-and-push-multi-arch REGISTRY=${registry} GCSFUSE_PATH=gs://${package_bucket}
     printf "\nInstalling the new custom CSI driver built above ...\n\n"
-    make install PROJECT=${project_id} REGISTRY=gcr.io/${project_id}/${USER}
+    make install PROJECT=${project_id} REGISTRY=${registry}
     cd -
     # Wait some time after csi driver installation before deploying pods
     # to avoid failures caused by 'the webhook failed to inject the

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -666,7 +666,7 @@ function waitTillAllPodsComplete() {
     else
       printf "\n${num_noncompleted_pods} pod(s) is/are still pending or running (time till timeout=${time_till_timeout} seconds). Will check again in "${pod_wait_time_in_seconds}" seconds. Sleeping for now.\n\n"
       printf "\nYou can take a break too if you want. Just kill this run and connect back to it later, for fetching and parsing outputs, using the following command: \n"
-      printf "   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type} use_custom_csi_driver=${use_custom_csi_driver} gcsfuse_src_dir=\"${gcsfuse_src_dir}\" csi_src_dir=\"${csi_src_dir}\" pod_wait_time_in_seconds=${pod_wait_time_in_seconds} workload_config=\"${workload_config}\" cluster_name=${cluster_name} output_dir=\"${output_dir}\" $0 \n"
+      printf "   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type} use_custom_csi_driver=${use_custom_csi_driver} gcsfuse_src_dir=\"${gcsfuse_src_dir}\" csi_src_dir=\"${csi_src_dir}\" pod_wait_time_in_seconds=${pod_wait_time_in_seconds} pod_timeout_in_seconds=${pod_timeout_in_seconds} workload_config=\"${workload_config}\" cluster_name=${cluster_name} output_dir=\"${output_dir}\" $0 \n"
       printf "\nbut remember that this will reset the start-timer for pod timeout.\n\n"
       printf "\nTo ssh to any specific pod, use the following command: \n"
       printf "  gcloud container clusters get-credentials ${cluster_name} --location=${zone}\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -350,8 +350,14 @@ function installDependencies() {
   pip install --upgrade google-cloud-monitoring
   # Ensure that jq is installed.
   which jq || sudo apt-get install -y jq
-  # # Ensure sudoless docker is installed.
-  # docker ps >/dev/null || (sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker)
+  # Ensure sudoless docker is installed.
+  if ! docker ps 1>/dev/null ; then
+    >2 echo "sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
+    >2 echo "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
+    return 1
+  fi
+  # Install python modules for gsheet.
+  python3 -m pip install google-api-python-client
 }
 
 # Make sure you have access to the necessary GCP resources. The easiest way to enable it is to use <your-ldap>@google.com as active auth.

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -471,7 +471,7 @@ function ensureGkeCluster() {
     fi
     gcloud container clusters update ${cluster_name} --project=${project_id} --location=${zone} --workload-pool=${project_id}.svc.id.goog
   else
-    gcloud container --project "${project_id}" clusters create ${cluster_name} --project=${project_id} --zone "${zone}" --workload-pool=${project_id}.svc.id.goog --machine-type "${machine_type}" --image-type "COS_CONTAINERD" --num-nodes ${num_nodes} --ephemeral-storage-local-ssd count=${num_ssd}
+    gcloud container clusters create ${cluster_name} --project=${project_id} --zone "${zone}" --workload-pool=${project_id}.svc.id.goog --machine-type "${machine_type}" --image-type "COS_CONTAINERD" --num-nodes ${num_nodes} --ephemeral-storage-local-ssd count=${num_ssd}
   fi
 }
 

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -110,8 +110,19 @@ fi
 
 # Set environment variables.
 # GCP related
-test -n "${project_id}" || export project_id=${DEFAULT_PROJECT_ID}
-test -n "${project_number}" || export project_number=${DEFAULT_PROJECT_NUMBER}
+if test -n "${project_id}"; then
+  if test -z "${project_number}"; then
+    echo "Error: project_id was set, but not project_number. Either both should be specified, or neither."
+    exitWithFailure
+  fi
+elif test -n "${project_number}"; then
+    echo "Error: project_number was set, but not project_id. Either both should be specified, or neither."
+    exitWithFailure
+else
+  export project_id=${DEFAULT_PROJECT_ID}
+  export project_number=${DEFAULT_PROJECT_NUMBER}
+  echo "Neither project_id, nor project_number were set, so defaulting to project_id=${DEFAULT_PROJECT_ID}, project_number=${DEFAULT_PROJECT_NUMBER}"
+fi
 test -n "${zone}" || export zone=${DEFAULT_ZONE}
 # GKE cluster related
 test -n "${cluster_name}" || export cluster_name=${DEFAULT_CLUSTER_NAME}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -648,7 +648,7 @@ function waitTillAllPodsComplete() {
     if [ ${num_completed_pods} -gt 0 ]; then
       printf ${num_completed_pods}" pod(s) completed.\n"
     fi
-    num_noncompleted_pods=$(echo "${podslist}" | tail -n +2 | grep -i -v 'completed\|succeeded\|fail' | wc -l)
+    num_noncompleted_pods=$(echo "${podslist}" | tail -n +2 | grep -i -v 'completed\|succeeded\|fail\|error' | wc -l)
     num_failed_pods=$(echo "${podslist}" | tail -n +2 | grep -i 'failed' | wc -l)
     if [ ${num_failed_pods} -gt 0 ]; then
       printf ${num_failed_pods}" pod(s) failed.\n\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -351,10 +351,11 @@ function installDependencies() {
 
 # Make sure you have access to the necessary GCP resources. The easiest way to enable it is to use <your-ldap>@google.com as active auth.
 function ensureGcpAuthsAndConfig() {
-  if ! $(gcloud auth list | grep -q ${USER}); then
-    gcloud auth application-default login --no-launch-browser && (gcloud auth list | grep -q ${USER})
-  fi
-  gcloud config set project ${project_id} && gcloud config list
+  # gcloud auth application-default login --no-launch-browser
+  gcloud auth list
+  # grep -q ${USER}
+  gcloud config set project ${project_id}
+  gcloud config list
 }
 
 # Verify that the passed machine configuration parameters (machine-type, num-nodes, num-ssd) are compatible.

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -203,7 +203,10 @@ else
 fi
 
 if test -n "${gcsfuse_src_dir}"; then
-  test -d "${gcsfuse_src_dir}"
+  if ! test -d "${gcsfuse_src_dir}"; then
+    echo "gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
+    exitWithFailure
+  fi
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
 else
   export gcsfuse_src_dir="${src_dir}"/gcsfuse
@@ -216,7 +219,10 @@ fi
 export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
 
 if test -n "${csi_src_dir}"; then
-  test -d "${csi_src_dir}"
+  if ! test -d "${csi_src_dir}"; then
+    echo "csi_src_dir \"${csi_src_dir}\" does not exist"
+    exitWithFailure
+  fi
   export csi_src_dir="$(realpath "${csi_src_dir}")"
 else
   export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
@@ -235,14 +241,20 @@ if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
 fi
 
 if test -n "${workload_config}"; then
-  test -f "${workload_config}"
+  if ! test -f "${workload_config}"; then
+    echo "workload_config \"${workload_config}\" does not exist"
+    exitWithFailure
+  fi
   export workload_config="$(realpath "${workload_config}")"
 else
     export workload_config="${gke_testing_dir}"/examples/workloads.json
 fi
 
 if test -n "${output_dir}"; then
-  test -d "${output_dir}"
+  if ! test -d "${output_dir}"; then
+    echo "output_dir \"${output_dir}\" does not exist"
+    exitWithFailure
+  fi
   export output_dir="$(realpath "${output_dir}")"
 else
   export output_dir="${gke_testing_dir}"/examples

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -693,32 +693,38 @@ function fetchAndParseDlioOutputs() {
 
 # prep
 printRunParameters
-validateMachineConfig ${machine_type} ${num_nodes} ${num_ssd}
 installDependencies
 
-# GCP configuration
-ensureGcpAuthsAndConfig
-ensureGkeCluster
-# ensureRequiredNodePoolConfiguration
-enableManagedCsiDriverIfNeeded
-activateCluster
-createKubernetesServiceAccountForCluster
+# if only_parse is not set or is set as false, then
+if test -z ${only_parse} || ! ${only_parse} ; then
+  validateMachineConfig ${machine_type} ${num_nodes} ${num_ssd}
 
-# GCSFuse driver source code
-ensureGcsfuseCode
+  # GCP configuration
+  ensureGcpAuthsAndConfig
+  ensureGkeCluster
+  # ensureRequiredNodePoolConfiguration
+  enableManagedCsiDriverIfNeeded
+  activateCluster
+  createKubernetesServiceAccountForCluster
 
-# GCP/GKE configuration dependent on GCSFuse/CSI driver source code
-createCustomCsiDriverIfNeeded
+  # GCSFuse driver source code
+  ensureGcsfuseCode
 
-# Run latest workload configuration
-deleteAllPods
-deployAllFioHelmCharts
-deployAllDlioHelmCharts
+  # GCP/GKE configuration dependent on GCSFuse/CSI driver source code
+  createCustomCsiDriverIfNeeded
+
+  # Run latest workload configuration
+  deleteAllPods
+  deployAllFioHelmCharts
+  deployAllDlioHelmCharts
+fi
 
 # monitor pods
 waitTillAllPodsComplete
 
 # clean-up after run
 deleteAllPods
+
+# parse outputs
 fetchAndParseFioOutputs
 fetchAndParseDlioOutputs

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -139,7 +139,9 @@ test -n "${gcsfuse_branch}" || export gcsfuse_branch="${DEFAULT_GCSFUSE_BRANCH}"
 
 # GCSFuse/GKE GCSFuse CSI Driver source code related
 if test -n "${src_dir}"; then
-  test -d "${src_dir}"
+  if ! test -d "${src_dir}"; then
+    exitWithError "src_dir \"${src_dir}\" does not exist"
+  fi
   export src_dir="$(realpath "${src_dir}")"
 else
   export src_dir=${DEFAULT_SRC_DIR}
@@ -616,18 +618,18 @@ function waitTillAllPodsComplete() {
     echo "${podslist}"
     num_completed_pods=$(echo "${podslist}" | tail -n +2 | grep -i 'completed\|succeeded' | wc -l)
     if [ ${num_completed_pods} -gt 0 ]; then
-      printf ${num_completed_pods}" pod(s) completed.\n"
+      printf ${num_completed_pods}" pod(s) have completed.\n"
     fi
     num_noncompleted_pods=$(echo "${podslist}" | tail -n +2 | grep -i -v 'completed\|succeeded\|fail\|error' | wc -l)
     num_failed_pods=$(echo "${podslist}" | tail -n +2 | grep -i 'failed' | wc -l)
     if [ ${num_failed_pods} -gt 0 ]; then
-      printf ${num_failed_pods}" pod(s) failed.\n\n"
+      printf ${num_failed_pods}" pod(s) have failed.\n\n"
     fi
     if [ ${num_noncompleted_pods} -eq 0 ]; then
-      printf "\nAll pods completed.\n\n"
+      printf "\nAll pods have completed.\n\n"
       break
     else
-      printf "\n${num_noncompleted_pods} pod(s) is/are still pending or running (time till timeout=${time_till_timeout} seconds). Will check again in "${pod_wait_time_in_seconds}" seconds. Sleeping for now.\n\n"
+      printf "\n${num_noncompleted_pods} pod(s) is/are still pending/running (time till timeout=${time_till_timeout} seconds). Will check again in "${pod_wait_time_in_seconds}" seconds. Sleeping for now.\n\n"
       printf "\nYou can take a break too if you want. Just kill this run and connect back to it later, for fetching and parsing outputs, using the following command: \n"
       printf "   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type} use_custom_csi_driver=${use_custom_csi_driver} gcsfuse_src_dir=\"${gcsfuse_src_dir}\" csi_src_dir=\"${csi_src_dir}\" pod_wait_time_in_seconds=${pod_wait_time_in_seconds} pod_timeout_in_seconds=${pod_timeout_in_seconds} workload_config=\"${workload_config}\" cluster_name=${cluster_name} output_dir=\"${output_dir}\" $0 \n"
       printf "\nbut remember that this will reset the start-timer for pod timeout.\n\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -575,7 +575,6 @@ function createCustomCsiDriverIfNeeded() {
     printf "\nBuilding a new GCSFuse binary from ${gcsfuse_src_dir} ...\n\n"
     cd "${gcsfuse_src_dir}"
     rm -rfv ./bin ./sbin
-    go mod vendor
     GOOS=linux GOARCH=amd64 go run tools/build_gcsfuse/main.go . . v3
     # Copy the binary to a GCS bucket for csi driver build.
     gcloud storage -q cp ./bin/gcsfuse gs://${package_bucket}/linux/amd64/
@@ -626,17 +625,6 @@ function deployAllFioHelmCharts() {
 function deployAllDlioHelmCharts() {
   printf "\nDeploying all dlio helm charts ...\n\n"
   cd "${gke_testing_dir}"/examples/dlio && python3 ./run_tests.py --workload-config "${workload_config}" --instance-id ${instance_id} --machine-type="${machine_type}" --project-id=${project_id} --project-number=${project_number} --namespace=${appnamespace} --ksa=${ksa} && cd -
-}
-
-function listAllHelmCharts() {
-  echo "Listing all helm charts ..."
-  # monitor and debug pods
-  helm ls --namespace=${appnamespace}  | tr -s '\t' | cut -f1,5,6
-
-  # Sample output.
-  # NAME STATUS CHART \
-  # fio-loading-test-100m-randread-gcsfuse-file-cache deployed fio-loading-test-0.1.0
-  # gke-dlio-unet3d-100kb-500k-128-gcsfuse-file-cache deployed unet3d-loading-test-0.1.0
 }
 
 function waitTillAllPodsComplete() {
@@ -728,7 +716,6 @@ deployAllFioHelmCharts
 deployAllDlioHelmCharts
 
 # monitor pods
-listAllHelmCharts
 waitTillAllPodsComplete
 
 # clean-up after run

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -106,7 +106,7 @@ readonly DEFAULT_SRC_DIR="$(realpath .)/src"
 readonly csi_driver_github_path=https://github.com/googlecloudplatform/gcs-fuse-csi-driver
 readonly csi_driver_branch=main
 readonly gcsfuse_github_path=https://github.com/googlecloudplatform/gcsfuse
-readonly gcsfuse_branch=garnitin/add-gke-load-testing/v1
+readonly DEFAULT_GCSFUSE_BRANCH=garnitin/add-gke-load-testing/v1
 # Test runtime configuration
 readonly DEFAULT_INSTANCE_ID=${USER}-$(date +%Y%m%d-%H%M%S)
 # 5 minutes
@@ -132,7 +132,8 @@ function printHelp() {
   echo "num_ssd=<number from 0-16, default=\"${DEFAULT_NUM_SSD}\">"
   echo "use_custom_csi_driver=<true|false, true means build and use a new custom csi driver using gcsfuse code, default=\"${DEFAULT_USE_CUSTOM_CSI_DRIVER}\">"
   # GCSFuse/GKE GCSFuse CSI Driver source code related
-  echo "src_dir=<\"directory/to/clone/github/repos/if/needed\", default=\"${DEFAULT_SRC_DIR}\">"
+  echo "src_dir=<\"directory/to/clone/github/repos/if/needed\", used for locally cloning in case gcsfuse_src_dir or csi_src_dir are not passed, default=\"${DEFAULT_SRC_DIR}\">"
+  echo "gcsfuse_branch=<name-of-gcsfuse-branch-for-cloning>, used for locally cloning, in case gcsfuse_src_dir has not been passed, default=\"${DEFAULT_GCSFUSE_BRANCH}\">"
   echo "gcsfuse_src_dir=<\"/path/of/gcsfuse/src/to/use/if/available\", default=\"${DEFAULT_SRC_DIR}/gcsfuse\">"
   echo "csi_src_dir=<\"/path/of/gcs-fuse-csi-driver/to/use/if/available\", default=\"${DEFAULT_SRC_DIR}\"/gcs-fuse-csi-driver>"
   # Test runtime configuration
@@ -189,6 +190,8 @@ export appnamespace=${DEFAULT_APPNAMESPACE}
 # test -n "${ksa}" ||
 export ksa=${DEFAULT_KSA}
 test -n "${use_custom_csi_driver}" || export use_custom_csi_driver="${DEFAULT_USE_CUSTOM_CSI_DRIVER}"
+test -n "${gcsfuse_branch}" || export gcsfuse_branch="${DEFAULT_GCSFUSE_BRANCH}"
+
 # GCSFuse/GKE GCSFuse CSI Driver source code related
 (test -n "${src_dir}" && src_dir="$(realpath "${src_dir}")") || export src_dir=${DEFAULT_SRC_DIR}
 test -d "${src_dir}" || mkdir -pv "${src_dir}"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -193,11 +193,30 @@ test -n "${use_custom_csi_driver}" || export use_custom_csi_driver="${DEFAULT_US
 test -n "${gcsfuse_branch}" || export gcsfuse_branch="${DEFAULT_GCSFUSE_BRANCH}"
 
 # GCSFuse/GKE GCSFuse CSI Driver source code related
-(test -n "${src_dir}" && src_dir="$(realpath "${src_dir}")") || export src_dir=${DEFAULT_SRC_DIR}
-test -d "${src_dir}" || mkdir -pv "${src_dir}"
-(test -n "${gcsfuse_src_dir}" && gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")") || export gcsfuse_src_dir="${src_dir}"/gcsfuse
+if test -n "${src_dir}"; then
+  test -d "${src_dir}"
+  export src_dir="$(realpath "${src_dir}")"
+else
+  export src_dir=${DEFAULT_SRC_DIR}
+  mkdir -pv "${src_dir}"
+fi
+
+if test -n "${gcsfuse_src_dir}"; then
+  test -d "${gcsfuse_src_dir}"
+  export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
+else
+  export gcsfuse_src_dir="${src_dir}"/gcsfuse
+fi
+
 export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
-(test -n "${csi_src_dir}" && csi_src_dir="$(realpath "${csi_src_dir}")") || export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
+
+if test -n "${csi_src_dir}"; then
+  test -d "${csi_src_dir}"
+  export csi_src_dir="$(realpath "${csi_src_dir}")"
+else
+  export csi_src_dir="${src_dir}"/gcs-fuse-csi-driver
+fi
+
 # GCSFuse configuration related - deprecated. Will cause error.
 test -z "${gcsfuse_mount_options}" || (echo "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exit 1)
 # Test runtime configuration
@@ -211,15 +230,15 @@ if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
 fi
 
 if test -n "${workload_config}"; then
-  workload_config="$(realpath "${workload_config}")"
   test -f "${workload_config}"
+  export workload_config="$(realpath "${workload_config}")"
 else
     export workload_config="${gke_testing_dir}"/examples/workloads.json
 fi
 
 if test -n "${output_dir}"; then
-  output_dir="$(realpath "${output_dir}")"
   test -d "${output_dir}"
+  export output_dir="$(realpath "${output_dir}")"
 else
   export output_dir="${gke_testing_dir}"/examples
 fi
@@ -244,6 +263,7 @@ function printRunParameters() {
   echo "src_dir=\"${src_dir}\""
   echo "gcsfuse_src_dir=\"${gcsfuse_src_dir}\""
   echo "csi_src_dir=\"${csi_src_dir}\""
+  echo "gke_testing_dir=\"${gke_testing_dir}\""
   # Test runtime configuration
   echo "pod_wait_time_in_seconds=\"${pod_wait_time_in_seconds}\""
   echo "pod_timeout_in_seconds=\"${pod_timeout_in_seconds}\""

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -594,7 +594,11 @@ function createCustomCsiDriverIfNeeded() {
       >2 echo "package_bucket \"${package_bucket}\" is too long (should be <= 63)"
       return 1
     fi
-    (gcloud storage buckets list --project=${project_id} | grep -wqo ${package_bucket}) || (region=$(echo ${zone} | rev | cut -d- -f2- | rev) && gcloud storage buckets create gs://${package_bucket} --project=${project_id} --location=${region})
+    # If package_bucket does not already exist, create it.
+    if (! (gcloud storage buckets list --project=${project_id} | grep -wqo ${package_bucket}) ); then
+      region=$(echo ${zone} | rev | cut -d- -f2- | rev)
+      gcloud storage buckets create gs://${package_bucket} --project=${project_id} --location=${region}
+    fi
 
     # Build a new gcsfuse binary
     printf "\nBuilding a new GCSFuse binary from ${gcsfuse_src_dir} ...\n\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -561,7 +561,14 @@ function createCustomCsiDriverIfNeeded() {
     printf "\nCreating a new custom CSI driver ...\n\n"
 
     # Create a bucket for storing custom-csi driver.
-    test -n "${package_bucket}" || export package_bucket=${USER/google/}-gcsfuse-binary-package
+    if test -z "${package_bucket}"; then
+      package_bucket=${project_id}-${cluster_name}-gcsfuse-bin
+      package_bucket=${package_bucket/google/}
+    fi
+    if [[ ${#package_bucket} -gt 63 ]] ; then
+      >2 echo "package_bucket \"${package_bucket}\" is too long (should be <= 63)"
+      return 1
+    fi
     (gcloud storage buckets list --project=${project_id} | grep -wqo ${package_bucket}) || (region=$(echo ${zone} | rev | cut -d- -f2- | rev) && gcloud storage buckets create gs://${package_bucket} --project=${project_id} --location=${region})
 
     # Build a new gcsfuse binary

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -464,6 +464,11 @@ function doesClusterExist() {
 function ensureGkeCluster() {
   echo "Creating/updating cluster ${cluster_name} ..."
   if doesClusterExist ${cluster_name}; then
+    existing_machine_type=$(getMachineTypeInNodePool ${cluster_name} ${node_pool} ${zone})
+    if [ "${existing_machine_type}" != "${machine_type}" ] ; then
+      echo "Internally changing machine-type from ${machine_type} to ${existing_machine_type} ..."
+      machine_type=${existing_machine_type}
+    fi
     gcloud container clusters update ${cluster_name} --project=${project_id} --location=${zone} --workload-pool=${project_id}.svc.id.goog
   else
     gcloud container --project "${project_id}" clusters create ${cluster_name} --project=${project_id} --zone "${zone}" --workload-pool=${project_id}.svc.id.goog --machine-type "${machine_type}" --image-type "COS_CONTAINERD" --num-nodes ${num_nodes} --ephemeral-storage-local-ssd count=${num_ssd}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -37,56 +37,6 @@ fi
 function exitWithSuccess() { exit 0; }
 function exitWithFailure() { exit 1; }
 
-function gcpProjectNumberFromProjectID() {
-  if [ $# -lt 1 ]; then
-    >2 echo "no arguments passed to function gcpProjectNumberFromProjectID. Expected args: <gcp-project-id>"
-    return 1
-  fi
-  local project_id=$1
-  # gcloud projects describe ${project_id} | grep -ie 'project.*number' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # $ gcloud projects describe gcs-fuse-test-ml | grep -ie 'project.*number' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # '786757290066'
-  # $ gcloud projects describe gcs-fuse-test | grep -ie 'project.*number' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # '927584127901'
-  case "${project_id}" in
-  "gcs-fuse-test-ml")
-      echo "786757290066"
-    ;;
-  "gcs-fuse-test")
-      echo "927584127901"
-    ;;
-  *)
-    >2 echo "Unknown project_id: "{project_id}
-    return 1
-    ;;
-  esac
-}
-
-function gcpProjectIdFromProjectNumber() {
-  if [ $# -lt 1 ]; then
-    >2 echo "no arguments passed to function gcpProjectIdFromProjectNumber. Expected args: <gcp-project-number>"
-    return 1
-  fi
-  local project_number=$1
-  # gcloud projects describe ${project_number} | grep -ie 'project.*id' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # $ gcloud projects describe 786757290066 | grep -ie 'project.*id' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # 'gcs-fuse-test-ml'
-  # $ gcloud projects describe 927584127901 | grep -ie 'project.*id' | tr -s ' ' | rev | cut -d' ' -f1 | rev
-  # 'gcs-fuse-test'
-  case "${project_number}" in
-  "786757290066")
-      echo "gcs-fuse-test-ml"
-    ;;
-  "927584127901")
-      echo "gcs-fuse-test"
-    ;;
-  *)
-    >2 echo "Unknown project_number: "{project_number}
-    return 1
-    ;;
-  esac
-}
-
 # Default values, to be used for parameters in case user does not specify them.
 # GCP related
 readonly DEFAULT_PROJECT_ID="gcs-fuse-test"
@@ -160,25 +110,8 @@ fi
 
 # Set environment variables.
 # GCP related
-if test -n "${project_id}"; then
-  if ! test -n "${project_number}"; then
-    export project_number=`gcpProjectNumberFromProjectID ${project_id}`
-    if ( [ $? -ne 0 ] || ! test -n "${project_number}" ) ; then
-      echo "No project_number found for project_id ${project_id}"
-      exitWithFailure
-    fi
-  fi
-elif test -n "${project_number}" ; then
-  export project_id=`gcpProjectIdFromProjectNumber ${project_number}`
-  if  [ $? -ne 0 ] || ! test -n "${project_id}"; then
-    echo "No project_id found for project_number ${project_number}"
-    exitWithFailure
-  fi
-else
-  export project_id=${DEFAULT_PROJECT_ID}
-  export project_number=${DEFAULT_PROJECT_NUMBER}
-fi
-
+test -n "${project_id}" || export project_id=${DEFAULT_PROJECT_ID}
+test -n "${project_number}" || export project_number=${DEFAULT_PROJECT_NUMBER}
 test -n "${zone}" || export zone=${DEFAULT_ZONE}
 # GKE cluster related
 test -n "${cluster_name}" || export cluster_name=${DEFAULT_CLUSTER_NAME}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -148,7 +148,7 @@ fi
 
 if test -n "${gcsfuse_src_dir}"; then
   if ! test -d "${gcsfuse_src_dir}"; then
-    echo "gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
+    echo "Error: gcsfuse_src_dir \"${gcsfuse_src_dir}\" does not exist"
     exitWithFailure
   fi
   export gcsfuse_src_dir="$(realpath "${gcsfuse_src_dir}")"
@@ -164,7 +164,7 @@ export gke_testing_dir="${gcsfuse_src_dir}"/perfmetrics/scripts/testing_on_gke
 
 if test -n "${csi_src_dir}"; then
   if ! test -d "${csi_src_dir}"; then
-    echo "csi_src_dir \"${csi_src_dir}\" does not exist"
+    echo "Error: csi_src_dir \"${csi_src_dir}\" does not exist"
     exitWithFailure
   fi
   export csi_src_dir="$(realpath "${csi_src_dir}")"
@@ -173,20 +173,20 @@ else
 fi
 
 # GCSFuse configuration related - deprecated. Will cause error.
-test -z "${gcsfuse_mount_options}" || (echo "gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exit 1)
+test -z "${gcsfuse_mount_options}" || (echo "Error: gcsfuse_mount_options set by user is a deprecated option. Please set gcsfuseMountOptions in workload objects in workload configuration file in its place." && exitWithFailure )
 # Test runtime configuration
 test -n "${pod_wait_time_in_seconds}" || export pod_wait_time_in_seconds="${DEFAULT_POD_WAIT_TIME_IN_SECONDS}"
 test -n "${pod_timeout_in_seconds}" || export pod_timeout_in_seconds="${DEFAULT_POD_TIMEOUT_IN_SECONDS}"
 test -n "${instance_id}" || export instance_id="${DEFAULT_INSTANCE_ID}"
 
 if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
-  echo "pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
+  echo "Error: pod_timeout_in_seconds (${pod_timeout_in_seconds}) <= pod_wait_time_in_seconds (${pod_wait_time_in_seconds})"
   exitWithFailure
 fi
 
 if test -n "${workload_config}"; then
   if ! test -f "${workload_config}"; then
-    echo "workload_config \"${workload_config}\" does not exist"
+    echo "Error: workload_config \"${workload_config}\" does not exist"
     exitWithFailure
   fi
   export workload_config="$(realpath "${workload_config}")"
@@ -196,7 +196,7 @@ fi
 
 if test -n "${output_dir}"; then
   if ! test -d "${output_dir}"; then
-    echo "output_dir \"${output_dir}\" does not exist"
+    echo "Error: output_dir \"${output_dir}\" does not exist"
     exitWithFailure
   fi
   export output_dir="$(realpath "${output_dir}")"
@@ -308,7 +308,7 @@ function installDependencies() {
   which jq || sudo apt-get install -y jq
   # Ensure sudoless docker is installed.
   if ! docker ps 1>/dev/null ; then
-    >2 echo "sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
+    >2 echo "Error: sudoless docker is not installed on this machine ($(hostname)). Please install sudoless-docker using the following commands and re-run this script ($0)"
     >2 echo "sudo addgroup docker && sudo usermod -aG docker $USER && newgrp docker"
     return 1
   fi
@@ -343,19 +343,19 @@ function validateMachineConfig() {
   case "${machine_type}" in
   "n2-standard-96")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
+      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-48")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
+      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 8, 16 or 24"
       return 1
     fi
     ;;
   "n2-standard-32")
     if [ ${num_ssd} -ne 0 -a ${num_ssd} -ne 4 -a ${num_ssd} -ne 8 -a ${num_ssd} -ne 16 -a ${num_ssd} -ne 24 ]; then
-      echo "Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
+      echo "Error: Unsupported num-ssd "${num_ssd}" with given machine-type "${machine_type}". It should be 0, 4, 8, 16 or 24"
       return 1
     fi
     ;;
@@ -511,7 +511,7 @@ function ensureGcsfuseCode() {
     cd ${gcsfuse_src_dir} && git fetch --all && git reset --hard origin/${gcsfuse_branch} && cd -
   fi
 
-  test -d "${gke_testing_dir}" || (echo "${gke_testing_dir} does not exist" && exit 1)
+  test -d "${gke_testing_dir}" || (echo "Error: ${gke_testing_dir} does not exist" && exitWithFailure )
 }
 
 function ensureGcsFuseCsiDriverCode() {
@@ -535,7 +535,7 @@ function createCustomCsiDriverIfNeeded() {
       package_bucket=${package_bucket/google/}
     fi
     if [[ ${#package_bucket} -gt 63 ]] ; then
-      >2 echo "package_bucket \"${package_bucket}\" is too long (should be <= 63)"
+      >2 echo "Error: package_bucket \"${package_bucket}\" is too long (should be <= 63)"
       return 1
     fi
     # If package_bucket does not already exist, create it.
@@ -608,7 +608,7 @@ function waitTillAllPodsComplete() {
     cur_epoch=$(date +%s)
     time_till_timeout=$((start_epoch+pod_timeout_in_seconds-cur_epoch))
     if [[ ${time_till_timeout} -lt 0 ]]; then
-      printf "\nPod-run timed out!\n\n"
+      printf "\nError: Pod-run timed out!\n\n"
       printf "Clearing all pods created in this run...\n"
       deleteAllPods
       exitWithFailure

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -100,7 +100,7 @@ readonly DEFAULT_NUM_NODES=8
 readonly DEFAULT_NUM_SSD=16
 readonly DEFAULT_APPNAMESPACE=default
 readonly DEFAULT_KSA=default
-readonly DEFAULT_USE_CUSTOM_CSI_DRIVER=false
+readonly DEFAULT_USE_CUSTOM_CSI_DRIVER=true
 # GCSFuse/GKE GCSFuse CSI Driver source code related
 readonly DEFAULT_SRC_DIR="$(realpath .)/src"
 readonly csi_driver_github_path=https://github.com/googlecloudplatform/gcs-fuse-csi-driver


### PR DESCRIPTION
### Description
Improvements in run-script:
* handle pod status 'error'
* unique AR image-name for each run
* implement only_parse
* remove unused code
* fix package-bucket name
* improve logs
* use existing cluster machine-type
* simplify gcloud auth login
* pass project-id in gcloud commands
* Remove need to pass absolute paths
* support setting gcsfuse_branch for cloning
* Throw error if exactly one out of project_id and project_number has been set.
* Improve error logs by adding `Error: ` as prefix.

This is on top of #2497 and is followed up in #2499, #2322, and #2528 .

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
