### PR TITLE
Add enable-parallel-downloads flag in user agent

### DIFF
--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -30,6 +30,10 @@ func IsFileCacheEnabled(mountConfig *Config) bool {
 	return mountConfig.FileCache.MaxSizeMb != 0 && string(mountConfig.CacheDir) != ""
 }
 
+func IsParallelDownloadsEnabled(mountConfig *Config) bool {
+	return IsFileCacheEnabled(mountConfig) && mountConfig.FileCache.EnableParallelDownloads
+}
+
 // ListCacheTTLSecsToDuration converts TTL in seconds to time.Duration.
 func ListCacheTTLSecsToDuration(secs int64) time.Duration {
 	err := isTTLInSecsValid(secs)

--- a/cfg/config_util_test.go
+++ b/cfg/config_util_test.go
@@ -76,6 +76,59 @@ func TestIsFileCacheEnabled(t *testing.T) {
 
 }
 
+func TestIsParallelDownloadsEnabled(t *testing.T) {
+	testCases := []struct {
+		name                               string
+		config                             *Config
+		expectedIsParallelDownloadsEnabled bool
+	}{
+		{
+			name: "Config with file-cache enabled",
+			config: &Config{
+				CacheDir: "/tmp/folder/",
+				FileCache: FileCacheConfig{
+					MaxSizeMb: -1,
+				},
+			},
+			expectedIsParallelDownloadsEnabled: false,
+		},
+		{
+			name:                               "Empty Config.",
+			config:                             &Config{},
+			expectedIsParallelDownloadsEnabled: false,
+		},
+		{
+			name: "Config with file-cache disabled but enable parallel downloads is set.",
+			config: &Config{
+				CacheDir: "",
+				FileCache: FileCacheConfig{
+					MaxSizeMb:               -1,
+					EnableParallelDownloads: true,
+				},
+			},
+			expectedIsParallelDownloadsEnabled: false,
+		},
+		{
+			name: "Config with file-cache and parallel downloads enabled.",
+			config: &Config{
+				CacheDir: "//tmp//folder//",
+				FileCache: FileCacheConfig{
+					MaxSizeMb:               -1,
+					EnableParallelDownloads: true,
+				},
+			},
+			expectedIsParallelDownloadsEnabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedIsParallelDownloadsEnabled, IsParallelDownloadsEnabled(tc.config))
+		})
+	}
+
+}
+
 func Test_ListCacheTtlSecsToDuration(t *testing.T) {
 	var testCases = []struct {
 		testName         string

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -99,7 +99,11 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	if mountConfig.FileCache.CacheFileForRangeRead {
 		isFileCacheForRangeReadEnabled = "1"
 	}
-	return fmt.Sprintf("%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled)
+	isParallelDownloadsEnabled := "0"
+	if cfg.IsParallelDownloadsEnabled(mountConfig) {
+		isParallelDownloadsEnabled = "1"
+	}
+	return fmt.Sprintf("%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled)
 }
 func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{


### PR DESCRIPTION
### Description
Add enable-parallel-downloads flag in user agent so that we can track the adoption. Also did some refactoring in the existing unit tests.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - [Run 1](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/9f6db78c-9df0-4605-860b-2b658d55340d)
