### PR TITLE
Add shadow reviewer when PR's review is requested

### DIFF
--- a/.github/workflows/shadow.yml
+++ b/.github/workflows/shadow.yml
@@ -3,7 +3,7 @@ name: "Shadow reviews"
 on:
   pull_request:
     types: 
-    - ready_for_review
+    - review_requested
     branches:
       - master
 


### PR DESCRIPTION
ready_for_review triggers the GitHub action only when a PR is moved from draft PR to "Ready to Review" stage. So, shadow-reviewers don't get added when a PR is directly created without going through the draft stage. Use review_requested to add shadow reviewer when a review is requested.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
