### PR TITLE
Upgrading gcloud version for rename perf tests

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/run_rename_benchmark.sh
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/run_rename_benchmark.sh
@@ -32,6 +32,8 @@ sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 UPLOAD_FLAGS=$1
 gsutil cp gs://periodic-perf-tests/creds.json ../gsheet/
 
+echo "Upgrading gcloud version"
+../upgrade_gcloud.sh
 
 #echo "Running renaming benchmark on flat bucket"
 #python3 renaming_benchmark.py config-flat.json flat "$UPLOAD_FLAGS"

--- a/perfmetrics/scripts/upgrade_gcloud.sh
+++ b/perfmetrics/scripts/upgrade_gcloud.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo apt-get update
+# Upgrade gcloud version.
+# Kokoro machine's outdated gcloud version prevents the use of the "gcloud storage" feature.
+gcloud version
+wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
+sudo tar xzf gcloud.tar.gz && sudo cp -r google-cloud-sdk /usr/local && sudo rm -r google-cloud-sdk
+sudo /usr/local/google-cloud-sdk/install.sh
+export PATH=/usr/local/google-cloud-sdk/bin:$PATH
+echo 'export PATH=/usr/local/google-cloud-sdk/bin:$PATH' >> ~/.bashrc
+gcloud version && rm gcloud.tar.gz
+sudo /usr/local/google-cloud-sdk/bin/gcloud components update
+sudo /usr/local/google-cloud-sdk/bin/gcloud components install alpha


### PR DESCRIPTION
### Description
- Upgraded gcloud version for rename benchmark run. Previously kokoro periodic perf tests build fails due to 
```
ERROR: (gcloud) Invalid choice: 'storage'.
This command is available in one or more alternate release tracks.  Try:
  gcloud alpha storage
```

This can be rectified by upgrading the gcloud version before the rename benchmark runs which makes use of gcloud commands.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran on actual test data. Working as intended.
2. Unit tests - NA
3. Integration tests - NA
