### PR TITLE
changing gcloud command in list dir

### DIFF
--- a/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/generate_folders_and_files.py
@@ -97,7 +97,7 @@ def _list_directory(path) -> list:
   """
   try:
     contents = subprocess.check_output(
-        'gcloud storage ls {}'.format(path), shell=True)
+        'gcloud alpha storage ls {}'.format(path), shell=True)
     contents_url = contents.decode('utf-8').split('\n')[:-1]
     # gcloud storage ls returns current directory with "/" suffix sometimes which can lead to
     # false inconsistency when listing.

--- a/perfmetrics/scripts/upgrade_gcloud.sh
+++ b/perfmetrics/scripts/upgrade_gcloud.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
 sudo apt-get update
 # Upgrade gcloud version.
 # Kokoro machine's outdated gcloud version prevents the use of the "gcloud storage" feature.


### PR DESCRIPTION
### Description
For listing directory, updated the call from gcloud storage to gcloud alpha to prevent kokoro build failure.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - tested on actual test data.working as intended.
2. Unit tests - NA
3. Integration tests - NA
