### PR TITLE
replacing gcloud command with storage client to delete GCS object

### DIFF
--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -168,9 +168,9 @@ func setup_testdata(m *testing.M, ctx context.Context) error {
 	return nil
 }
 
-func destroy_testdata(m *testing.M) error {
+func destroy_testdata(m *testing.M, ctx context.Context, storageClient *storage.Client) error {
 	for _, gcsObjectPath := range gcsObjectsToBeDeletedEventually {
-		err := operations.DeleteGcsObject(gcsObjectPath)
+		err := client.DeleteObjectOnGCS(ctx, storageClient, gcsObjectPath)
 		if err != nil {
 			return fmt.Errorf("Failed to delete gcs object gs://%s", gcsObjectPath)
 		}
@@ -224,7 +224,7 @@ func TestMain(m *testing.M) {
 	}
 
 	defer func() {
-		err := destroy_testdata(m)
+		err := destroy_testdata(m, ctx, storageClient)
 		if err != nil {
 			log.Printf("Failed to destoy gzip test data: %v", err)
 		}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -583,7 +583,7 @@ func SyncFile(fh *os.File, t *testing.T) {
 }
 
 func CreateFileWithContent(filePath string, filePerms os.FileMode,
-		content string, t *testing.T) {
+	content string, t *testing.T) {
 	fh := CreateFile(filePath, filePerms, t)
 	WriteAt(content, 0, fh, t)
 	CloseFile(fh)

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -583,7 +583,7 @@ func SyncFile(fh *os.File, t *testing.T) {
 }
 
 func CreateFileWithContent(filePath string, filePerms os.FileMode,
-	content string, t *testing.T) {
+		content string, t *testing.T) {
 	fh := CreateFile(filePath, filePerms, t)
 	WriteAt(content, 0, fh, t)
 	CloseFile(fh)


### PR DESCRIPTION
### Description
Replaced gcloud command with storage client to delete GCS object as gcloud commands can't be run concurrently as part of parallelizing CD tests.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually ran the integration tests on cloudtop.
2. Unit tests - NA
3. Integration tests - NA
