### PR TITLE
Change default priority of bug report from p1 to p2

### DIFF
--- a/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/gcsfuse-bug-report.md
@@ -2,7 +2,7 @@
 name: GCSFuse Issue report
 about: Describe information users can provide to enable faster interaction
 title: ''
-labels: "question,p1"
+labels: "question,p2"
 assignees: ''
 
 ---


### PR DESCRIPTION
### Description
Changing the default priority of issue from p1 to p2.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
