### PR TITLE
[testing-on-gke independent] update default workload config

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/workloads.json
+++ b/perfmetrics/scripts/testing_on_gke/examples/workloads.json
@@ -26,7 +26,7 @@
             "blockSize": "64K",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"fio-64k-1m-us-west1",
           "_bucket_alt2":"fio-64k-1m-us-central1",
           "_bucket_alt3":"gke-fio-64k-1m"
@@ -39,7 +39,7 @@
             "blockSize": "128K",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"fio-128k-1m-us-west1",
           "_bucket_alt2":"fio-128k-1m-us-central1",
           "_bucket_alt3":"gke-fio-128k-1m"
@@ -52,7 +52,7 @@
             "blockSize": "256K",
             "readTypes": ["read","randread"]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"fio-1mb-1m-us-west1",
           "_bucket_alt2":"fio-1mb-1m-us-central1",
           "_bucket_alt3":"gke-fio-1mb-1m"
@@ -64,7 +64,7 @@
             "numThreads": 50,
             "blockSize": "1M"
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"fio-100mb-50k-us-west1",
           "_bucket_alt2":"fio-100mb-50k-us-central1",
           "_bucket_alt3":"gke-fio-100mb-50k"
@@ -77,7 +77,7 @@
             "numThreads": 100,
             "blockSize": "1M"
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"fio-200gb-1-us-west1",
           "_bucket_alt2":"fio-200gb-1-us-central1",
           "_bucket_alt3":"gke-fio-200gb-1"
@@ -126,7 +126,7 @@
             "recordLength": 102400,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"The bucket must have objects with name 'train/', 'valid/', and train/img_{i}_of_{numFilesTrain}.npz for every i where i:0-{numFilesTrain}-1 and each train/img_{i}_of_{numFilesTrain}.npz must be of size {recordLength} bytes. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s)."
         },
         {
@@ -135,7 +135,7 @@
             "recordLength": 102400,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"dlio-unet3d-100kb-500k-us-west1",
           "_bucket_alt2":"dlio-unet3d-100kb-500k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-100kb-500k"
@@ -146,7 +146,7 @@
             "recordLength": 512000,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"dlio-unet3d-500kb-1m-us-west1",
           "_bucket_alt2":"dlio-unet3d-500kb-1m-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-500kb-1m"
@@ -157,7 +157,7 @@
             "recordLength": 3145728,
             "batchSizes": [200]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"dlio-unet3d-3mb-100k-us-west1",
           "_bucket_alt2":"dlio-unet3d-3mb-100k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-3mb-100k"
@@ -168,7 +168,7 @@
             "recordLength": 157286400,
             "batchSizes": [4]
           },
-          "gcsfuseMountOptions": "implicit-dirs",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
           "bucket":"dlio-unet3d-150mb-5k-us-west1",
           "_bucket_alt2":"dlio-unet3d-150mb-5k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-150mb-5k"

--- a/perfmetrics/scripts/testing_on_gke/examples/workloads.json
+++ b/perfmetrics/scripts/testing_on_gke/examples/workloads.json
@@ -26,7 +26,7 @@
             "blockSize": "64K",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-64k-1m-us-west1",
           "_bucket_alt2":"fio-64k-1m-us-central1",
           "_bucket_alt3":"gke-fio-64k-1m"
@@ -39,7 +39,7 @@
             "blockSize": "128K",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-128k-1m-us-west1",
           "_bucket_alt2":"fio-128k-1m-us-central1",
           "_bucket_alt3":"gke-fio-128k-1m"
@@ -52,7 +52,7 @@
             "blockSize": "256K",
             "readTypes": ["read","randread"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-1mb-1m-us-west1",
           "_bucket_alt2":"fio-1mb-1m-us-central1",
           "_bucket_alt3":"gke-fio-1mb-1m"
@@ -64,7 +64,7 @@
             "numThreads": 50,
             "blockSize": "1M"
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-100mb-50k-us-west1",
           "_bucket_alt2":"fio-100mb-50k-us-central1",
           "_bucket_alt3":"gke-fio-100mb-50k"
@@ -77,7 +77,7 @@
             "numThreads": 100,
             "blockSize": "1M"
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-200gb-1-us-west1",
           "_bucket_alt2":"fio-200gb-1-us-central1",
           "_bucket_alt3":"gke-fio-200gb-1"
@@ -90,7 +90,7 @@
             "blockSize": "1M",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-10g-500-us-west1",
           "_bucket_alt2":"fio-10g-500-us-central1"
         },
@@ -102,7 +102,7 @@
             "blockSize": "1M",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-10g-500-us-west1",
           "_bucket_alt2":"fio-10g-500-us-central1"
         },
@@ -114,7 +114,7 @@
             "blockSize": "1M",
             "readTypes": ["read"]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"fio-10g-500-us-west1",
           "_bucket_alt2":"fio-10g-500-us-central1"
         },
@@ -126,7 +126,7 @@
             "recordLength": 102400,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"The bucket must have objects with name 'train/', 'valid/', and train/img_{i}_of_{numFilesTrain}.npz for every i where i:0-{numFilesTrain}-1 and each train/img_{i}_of_{numFilesTrain}.npz must be of size {recordLength} bytes. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s)."
         },
         {
@@ -135,7 +135,7 @@
             "recordLength": 102400,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"dlio-unet3d-100kb-500k-us-west1",
           "_bucket_alt2":"dlio-unet3d-100kb-500k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-100kb-500k"
@@ -146,7 +146,7 @@
             "recordLength": 512000,
             "batchSizes": [800,128]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"dlio-unet3d-500kb-1m-us-west1",
           "_bucket_alt2":"dlio-unet3d-500kb-1m-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-500kb-1m"
@@ -157,7 +157,7 @@
             "recordLength": 3145728,
             "batchSizes": [200]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"dlio-unet3d-3mb-100k-us-west1",
           "_bucket_alt2":"dlio-unet3d-3mb-100k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-3mb-100k"
@@ -168,7 +168,7 @@
             "recordLength": 157286400,
             "batchSizes": [4]
           },
-          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1",
+          "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
           "bucket":"dlio-unet3d-150mb-5k-us-west1",
           "_bucket_alt2":"dlio-unet3d-150mb-5k-us-central1",
           "_bucket_alt3":"gke-dlio-unet3d-150mb-5k"


### PR DESCRIPTION
### Description
In gcsfuseMountOptions in workloads.json
* Make metadata-cache infinite in all workloads
* Make cache-size infinite in all workloads
* Enable cache-file-for-range-read by default in all workloads

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
