### PR TITLE
Revert "Migrate downloader and duration tests to stretchr/testify"

### DIFF
--- a/benchmarks/internal/percentile/duration_test.go
+++ b/benchmarks/internal/percentile/duration_test.go
@@ -15,20 +15,29 @@
 package percentile_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/benchmarks/internal/percentile"
-	"github.com/stretchr/testify/assert"
+	. "github.com/jacobsa/ogletest"
 )
+
+func TestDuration(t *testing.T) { RunTests(t) }
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type DurationTest struct {
+}
+
+func init() { RegisterTestSuite(&DurationTest{}) }
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func TestOneObservation(t *testing.T) {
-	t.Parallel()
+func (t *DurationTest) OneObservation() {
 	vals := []time.Duration{
 		17,
 	}
@@ -46,18 +55,15 @@ func TestOneObservation(t *testing.T) {
 		{100, 17},
 	}
 
-	for idx, tc := range testCases {
-		tc := tc
-		t.Run(fmt.Sprintf("case_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tc.expected, percentile.Duration(vals, tc.p), "p: %d", tc.p)
-		})
+	for _, tc := range testCases {
+		ExpectEq(
+			tc.expected,
+			percentile.Duration(vals, tc.p),
+			"p: %d", tc.p)
 	}
 }
 
-func TestTwoObservations(t *testing.T) {
-	t.Parallel()
+func (t *DurationTest) TwoObservations() {
 	vals := []time.Duration{
 		100,
 		200,
@@ -76,21 +82,15 @@ func TestTwoObservations(t *testing.T) {
 		{100, 200},
 	}
 
-	for idx, tc := range testCases {
-		tc := tc
-		t.Run(fmt.Sprintf("case_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t,
-				tc.expected,
-				percentile.Duration(vals, tc.p),
-				"p: %d", tc.p)
-		})
+	for _, tc := range testCases {
+		ExpectEq(
+			tc.expected,
+			percentile.Duration(vals, tc.p),
+			"p: %d", tc.p)
 	}
 }
 
-func TestThreeObservations(t *testing.T) {
-	t.Parallel()
+func (t *DurationTest) ThreeObservations() {
 	vals := []time.Duration{
 		100,
 		200,
@@ -110,21 +110,15 @@ func TestThreeObservations(t *testing.T) {
 		{100, 300},
 	}
 
-	for idx, tc := range testCases {
-		tc := tc
-		t.Run(fmt.Sprintf("case_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t,
-				tc.expected,
-				percentile.Duration(vals, tc.p),
-				"p: %d", tc.p)
-		})
+	for _, tc := range testCases {
+		ExpectEq(
+			tc.expected,
+			percentile.Duration(vals, tc.p),
+			"p: %d", tc.p)
 	}
 }
 
-func TestFiveObservations(t *testing.T) {
-	t.Parallel()
+func (t *DurationTest) FiveObservations() {
 	vals := []time.Duration{
 		100,
 		200,
@@ -163,14 +157,10 @@ func TestFiveObservations(t *testing.T) {
 		{100, 1000},
 	}
 
-	for idx, tc := range testCases {
-		t.Run(fmt.Sprintf("case_%d", idx), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t,
-				tc.expected,
-				percentile.Duration(vals, tc.p),
-				"p: %d", tc.p)
-		})
+	for _, tc := range testCases {
+		ExpectEq(
+			tc.expected,
+			percentile.Duration(vals, tc.p),
+			"p: %d", tc.p)
 	}
 }

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
-	"github.com/stretchr/testify/assert"
+	. "github.com/jacobsa/ogletest"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -50,7 +50,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	ctx := context.Background()
 	objects := map[string][]byte{objectName: objectContent}
 	err := storageutil.CreateObjects(ctx, dt.bucket, objects)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	dt.object = getMinObject(objectName, dt.bucket)
 	dt.fileSpec = data.FileSpec{
 		Path:     dt.fileCachePath(dt.bucket.Name(), dt.object.Name),
@@ -71,39 +71,39 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 		Offset:           0,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 }
 
 func (dt *downloaderTest) verifyInvalidError(err error) {
-	assert.True(dt.T(), (nil == err) || (errors.Is(err, context.Canceled)) || (strings.Contains(err.Error(), lru.EntryNotExistErrMsg)),
+	AssertTrue((nil == err) || (errors.Is(err, context.Canceled)) || (strings.Contains(err.Error(), lru.EntryNotExistErrMsg)),
 		fmt.Sprintf("actual error:%v is not as expected", err))
 }
 
 func (dt *downloaderTest) verifyFile(content []byte) {
 	fileStat, err := os.Stat(dt.fileSpec.Path)
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), dt.fileSpec.FilePerm, fileStat.Mode())
-	assert.LessOrEqual(dt.T(), int64(len(content)), fileStat.Size())
+	AssertEq(nil, err)
+	AssertEq(dt.fileSpec.FilePerm, fileStat.Mode())
+	AssertLe(len(content), fileStat.Size())
 	// Verify the content of file downloaded only till the size of content passed.
 	fileContent, err := os.ReadFile(dt.fileSpec.Path)
-	assert.Nil(dt.T(), err)
-	assert.True(dt.T(), reflect.DeepEqual(content, fileContent[:len(content)]))
+	AssertEq(nil, err)
+	AssertTrue(reflect.DeepEqual(content, fileContent[:len(content)]))
 }
 
 func (dt *downloaderTest) verifyFileInfoEntry(offset uint64) {
 	fileInfo := dt.getFileInfo()
-	assert.True(dt.T(), fileInfo != nil)
-	assert.Equal(dt.T(), dt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
-	assert.LessOrEqual(dt.T(), offset, fileInfo.(data.FileInfo).Offset)
-	assert.Equal(dt.T(), dt.object.Size, fileInfo.(data.FileInfo).Size())
+	AssertTrue(fileInfo != nil)
+	AssertEq(dt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
+	AssertLe(offset, fileInfo.(data.FileInfo).Offset)
+	AssertEq(dt.object.Size, fileInfo.(data.FileInfo).Size())
 }
 
 func (dt *downloaderTest) getFileInfo() lru.ValueType {
 	fileInfoKey := data.FileInfoKey{BucketName: dt.bucket.Name(), ObjectName: dt.object.Name}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	return dt.cache.LookUp(fileInfoKeyName)
 }
 
@@ -120,10 +120,10 @@ func (dt *downloaderTest) Test_init() {
 
 	dt.job.init()
 
-	assert.Equal(dt.T(), NotStarted, dt.job.status.Name)
-	assert.Nil(dt.T(), dt.job.status.Err)
-	assert.EqualValues(dt.T(), 0, dt.job.status.Offset)
-	assert.True(dt.T(), reflect.DeepEqual(list.List{}, dt.job.subscribers))
+	AssertEq(NotStarted, dt.job.status.Name)
+	AssertEq(nil, dt.job.status.Err)
+	AssertEq(0, dt.job.status.Offset)
+	AssertTrue(reflect.DeepEqual(list.List{}, dt.job.subscribers))
 }
 
 func (dt *downloaderTest) Test_subscribe() {
@@ -133,16 +133,16 @@ func (dt *downloaderTest) Test_subscribe() {
 	notificationC1 := dt.job.subscribe(subscriberOffset1)
 	notificationC2 := dt.job.subscribe(subscriberOffset2)
 
-	assert.Equal(dt.T(), 2, dt.job.subscribers.Len())
+	AssertEq(2, dt.job.subscribers.Len())
 	receivingC := make(<-chan JobStatus, 1)
-	assert.Equal(dt.T(), reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
-	assert.Equal(dt.T(), reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
+	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
+	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
 	// Check 1st and 2nd subscribers
 	var subscriber jobSubscriber
-	assert.Equal(dt.T(), reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Front().Value.(jobSubscriber)))
-	assert.EqualValues(dt.T(), 0, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
-	assert.Equal(dt.T(), reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Back().Value.(jobSubscriber)))
-	assert.EqualValues(dt.T(), 1, dt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
+	AssertEq(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Front().Value.(jobSubscriber)))
+	AssertEq(0, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+	AssertEq(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Back().Value.(jobSubscriber)))
+	AssertEq(1, dt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
 }
 
 func (dt *downloaderTest) Test_notifySubscriber_Failed() {
@@ -154,11 +154,11 @@ func (dt *downloaderTest) Test_notifySubscriber_Failed() {
 
 	dt.job.notifySubscribers()
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 0}
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification))
-	assert.Equal(dt.T(), true, ok)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification))
+	AssertEq(true, ok)
 }
 
 func (dt *downloaderTest) Test_notifySubscriber_Invalid() {
@@ -168,11 +168,11 @@ func (dt *downloaderTest) Test_notifySubscriber_Invalid() {
 
 	dt.job.notifySubscribers()
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Invalid, Err: nil, Offset: 0}
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification))
-	assert.Equal(dt.T(), true, ok)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification))
+	AssertEq(true, ok)
 }
 
 func (dt *downloaderTest) Test_notifySubscriber_SubscribedOffset() {
@@ -185,13 +185,13 @@ func (dt *downloaderTest) Test_notifySubscriber_SubscribedOffset() {
 
 	dt.job.notifySubscribers()
 
-	assert.Equal(dt.T(), 1, dt.job.subscribers.Len())
+	AssertEq(1, dt.job.subscribers.Len())
 	notification1, ok := <-notificationC1
 	jobStatus := JobStatus{Name: Downloading, Err: nil, Offset: 4}
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification1))
-	assert.Equal(dt.T(), true, ok)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
+	AssertEq(true, ok)
 	// Check 2nd subscriber's offset
-	assert.Equal(dt.T(), subscriberOffset2, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+	AssertEq(subscriberOffset2, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
 }
 
 func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
@@ -205,15 +205,15 @@ func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
 	customErr := fmt.Errorf("custom error")
 	dt.job.updateStatusAndNotifySubscribers(Failed, customErr)
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification1, ok1 := <-notificationC1
 	notification2, ok2 := <-notificationC2
 	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 4}
 	// Check 1st and 2nd subscriber notifications
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification1))
-	assert.Equal(dt.T(), true, ok1)
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification2))
-	assert.Equal(dt.T(), true, ok2)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
+	AssertEq(true, ok1)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification2))
+	AssertEq(true, ok2)
 
 	// Complete without error
 	subscriberOffset1 = int64(3)
@@ -222,12 +222,12 @@ func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
 
 	dt.job.updateStatusAndNotifySubscribers(Completed, nil)
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification1, ok1 = <-notificationC1
 	jobStatus = JobStatus{Name: Completed, Err: nil, Offset: 4}
 	// Check subscriber notification
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification1))
-	assert.Equal(dt.T(), true, ok1)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
+	AssertEq(true, ok1)
 }
 
 func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
@@ -243,9 +243,9 @@ func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
 		Offset:           0,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	dt.job.mu.Lock()
 	dt.job.status.Name = Downloading
 	notificationCh := dt.job.subscribe(5)
@@ -253,21 +253,21 @@ func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
 
 	err = dt.job.updateStatusOffset(10)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Confirm fileInfoCache is updated with new offset.
 	lookupResult := dt.cache.LookUp(fileInfoKeyName)
-	assert.False(dt.T(), lookupResult == nil)
+	AssertFalse(lookupResult == nil)
 	fileInfo = lookupResult.(data.FileInfo)
-	assert.EqualValues(dt.T(), 10, fileInfo.Offset)
-	assert.Equal(dt.T(), dt.job.object.Generation, fileInfo.ObjectGeneration)
-	assert.Equal(dt.T(), dt.job.object.Size, fileInfo.FileSize)
+	AssertEq(10, fileInfo.Offset)
+	AssertEq(dt.job.object.Generation, fileInfo.ObjectGeneration)
+	AssertEq(dt.job.object.Size, fileInfo.FileSize)
 	// Confirm job's status offset
-	assert.EqualValues(dt.T(), 10, dt.job.status.Offset)
+	AssertEq(10, dt.job.status.Offset)
 	// Check the subscriber's notification
 	notification, ok := <-notificationCh
-	assert.Equal(dt.T(), true, ok)
+	AssertEq(true, ok)
 	jobStatus := JobStatus{Name: Downloading, Err: nil, Offset: 10}
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification))
+	AssertTrue(reflect.DeepEqual(jobStatus, notification))
 }
 
 func (dt *downloaderTest) Test_updateStatusOffset_InsertNew() {
@@ -276,16 +276,16 @@ func (dt *downloaderTest) Test_updateStatusOffset_InsertNew() {
 		ObjectName: dt.object.Name,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	value := dt.cache.Erase(fileInfoKeyName)
-	assert.True(dt.T(), value != nil)
+	AssertTrue(value != nil)
 
 	err = dt.job.updateStatusOffset(10)
 
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
 	// Confirm job's status offset
-	assert.EqualValues(dt.T(), 0, dt.job.status.Offset)
+	AssertEq(0, dt.job.status.Offset)
 }
 
 func (dt *downloaderTest) Test_updateStatusOffset_Fail() {
@@ -300,18 +300,18 @@ func (dt *downloaderTest) Test_updateStatusOffset_Fail() {
 		Offset:           0,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 
 	// Change the size of object and then try to update file info cache.
 	dt.job.object.Size = 10
 	err = dt.job.updateStatusOffset(15)
 
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), strings.Contains(err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
 	// Confirm job's status offset
-	assert.EqualValues(dt.T(), 0, dt.job.status.Offset)
+	AssertEq(0, dt.job.status.Offset)
 }
 
 func (dt *downloaderTest) Test_cleanUpDownloadAsyncJob() {
@@ -326,18 +326,18 @@ func (dt *downloaderTest) Test_cleanUpDownloadAsyncJob() {
 	dt.job.cleanUpDownloadAsyncJob()
 
 	// Verify context is canceled
-	assert.True(dt.T(), errors.Is(cancelCtx.Err(), context.Canceled))
+	AssertTrue(errors.Is(cancelCtx.Err(), context.Canceled))
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	// doneCh is closed
 	_, ok := <-dt.job.doneCh
-	assert.False(dt.T(), ok)
+	AssertFalse(ok)
 	// References to context and cancel function are removed
-	assert.Nil(dt.T(), dt.job.cancelCtx)
-	assert.Nil(dt.T(), dt.job.cancelFunc)
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(nil, dt.job.cancelCtx)
+	AssertEq(nil, dt.job.cancelFunc)
+	AssertEq(nil, dt.job.removeJobCallback)
 	// Call back function should have been called
-	assert.True(dt.T(), callbackExecuted.Load())
+	AssertTrue(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_downloadObjectToFile() {
@@ -351,7 +351,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile() {
 	notificationC := dt.job.subscribe(subscribedOffset)
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -359,11 +359,11 @@ func (dt *downloaderTest) Test_downloadObjectToFile() {
 	// Start download
 	err = dt.job.downloadObjectToFile(file)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	jobStatus, ok := <-notificationC
-	assert.Equal(dt.T(), true, ok)
+	AssertEq(true, ok)
 	// Check the notification is sent after subscribed offset
-	assert.GreaterOrEqual(dt.T(), jobStatus.Offset, subscribedOffset)
+	AssertGe(jobStatus.Offset, subscribedOffset)
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	// Verify file is downloaded
@@ -380,7 +380,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -388,7 +388,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
 	dt.job.cancelFunc()
 	err = dt.job.downloadObjectToFile(file)
 
-	assert.True(dt.T(), errors.Is(err, context.Canceled), fmt.Sprintf("didn't get context canceled error: %v", err))
+	AssertTrue(errors.Is(err, context.Canceled), fmt.Sprintf("didn't get context canceled error: %v", err))
 }
 
 // Note: We can't test Test_downloadObjectAsync_MoreThanSequentialReadSize as
@@ -411,14 +411,14 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanSequentialReadSize() 
 	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, dt.job.status))
+	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
 	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	assert.True(dt.T(), callbackExecuted.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
@@ -437,14 +437,14 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
 	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, dt.job.status))
+	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
 	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	assert.True(dt.T(), callbackExecuted.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
@@ -464,19 +464,19 @@ func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 
 	jobStatus := <-notificationC
 	// check the notification is sent after subscribed offset
-	assert.GreaterOrEqual(dt.T(), jobStatus.Offset, subscribedOffset)
+	AssertGe(jobStatus.Offset, subscribedOffset)
 	// check job completed successfully
 	jobStatus = JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, dt.job.status))
+	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
 	// verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	assert.True(dt.T(), callbackExecuted.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Download_WhenNotStarted() {
@@ -489,11 +489,11 @@ func (dt *downloaderTest) Test_Download_WhenNotStarted() {
 	offset := int64(8 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify that jobStatus is downloading and downloaded more than 8 Mib.
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
-	assert.Nil(dt.T(), jobStatus.Err)
-	assert.GreaterOrEqual(dt.T(), jobStatus.Offset, offset)
+	AssertEq(Downloading, jobStatus.Name)
+	AssertEq(nil, jobStatus.Err)
+	AssertGe(jobStatus.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
@@ -509,18 +509,18 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 	// Start download but not wait for download
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, 1, false)
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
+	AssertEq(nil, err)
+	AssertEq(Downloading, jobStatus.Name)
 
 	// Again call download but wait for download this time.
 	offset := int64(25 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify that jobStatus is downloading and downloaded at least 25 Mib.
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
-	assert.Nil(dt.T(), jobStatus.Err)
-	assert.GreaterOrEqual(dt.T(), jobStatus.Offset, offset)
+	AssertEq(Downloading, jobStatus.Name)
+	AssertEq(nil, jobStatus.Err)
+	AssertGe(jobStatus.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// verify file info cache
@@ -535,23 +535,23 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	// Wait for whole download to be completed.
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize), true)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify that jobStatus is Downloading but offset is object size
 	expectedJobStatus := JobStatus{Downloading, nil, int64(objectSize)}
-	assert.True(dt.T(), reflect.DeepEqual(expectedJobStatus, jobStatus))
+	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
 	dt.waitForCrcCheckToBeCompleted()
-	assert.Equal(dt.T(), Completed, dt.job.status.Name)
+	AssertEq(Completed, dt.job.status.Name)
 
 	// Try to request for some offset when job was already completed.
 	offset := int64(16 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify that jobStatus is completed & offset returned is still 16 MiB
 	// this ensures that async job is not started again.
-	assert.Equal(dt.T(), Completed, jobStatus.Name)
-	assert.Nil(dt.T(), jobStatus.Err)
-	assert.GreaterOrEqual(dt.T(), jobStatus.Offset, int64(objectSize))
+	AssertEq(Completed, jobStatus.Name)
+	AssertEq(nil, jobStatus.Err)
+	AssertGe(jobStatus.Offset, objectSize)
 	// Verify file
 	dt.verifyFile(objectContent)
 	// Verify file info cache
@@ -573,13 +573,13 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize-10), true)
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify that jobStatus is failed
-	assert.Equal(dt.T(), Failed, jobStatus.Name)
-	assert.GreaterOrEqual(dt.T(), int64(0), jobStatus.Offset)
-	assert.True(dt.T(), strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertEq(Failed, jobStatus.Name)
+	AssertGe(jobStatus.Offset, 0)
+	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
 	// Verify callback is executed
-	assert.True(dt.T(), callbackExecuted.Load())
+	AssertTrue(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_Download_AlreadyFailed() {
@@ -594,9 +594,9 @@ func (dt *downloaderTest) Test_Download_AlreadyFailed() {
 	// Requesting again from download job which is in failed state
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize-1), true)
 
-	assert.Nil(dt.T(), err)
-	assert.EqualValues(dt.T(), Failed, jobStatus.Name)
-	assert.True(dt.T(), strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertEq(nil, err)
+	AssertEq(Failed, jobStatus.Name)
+	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
 }
 
 func (dt *downloaderTest) Test_Download_AlreadyInvalid() {
@@ -612,8 +612,8 @@ func (dt *downloaderTest) Test_Download_AlreadyInvalid() {
 	// Requesting download when already invalid.
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize), true)
 
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), Invalid, jobStatus.Name)
+	AssertEq(nil, err)
+	AssertEq(Invalid, jobStatus.Name)
 	dt.verifyInvalidError(jobStatus.Err)
 }
 
@@ -629,11 +629,11 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 	offset := int64(objectSize) + 1
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), strings.Contains(err.Error(), fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
 	expectedJobStatus := JobStatus{NotStarted, nil, 0}
-	assert.True(dt.T(), reflect.DeepEqual(expectedJobStatus, jobStatus))
-	assert.False(dt.T(), callbackExecuted.Load())
+	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
+	AssertFalse(callbackExecuted.Load())
 }
 
 func (dt *downloaderTest) Test_Download_CtxCancelled() {
@@ -651,21 +651,21 @@ func (dt *downloaderTest) Test_Download_CtxCancelled() {
 	offset := int64(objectSize)
 	jobStatus, err := dt.job.Download(ctx, offset, true)
 
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), errors.Is(err, context.DeadlineExceeded))
+	AssertNe(nil, err)
+	AssertTrue(errors.Is(err, context.DeadlineExceeded))
 	// jobStatus is empty in this case.
-	assert.EqualValues(dt.T(), "", jobStatus.Name)
-	assert.Nil(dt.T(), jobStatus.Err)
+	AssertEq("", jobStatus.Name)
+	AssertEq(nil, jobStatus.Err)
 	// job should be either Downloading or Completed.
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.True(dt.T(), dt.job.status.Name == Downloading || dt.job.status.Name == Completed)
+	AssertTrue(dt.job.status.Name == Downloading || dt.job.status.Name == Completed)
 	if dt.job.status.Name == Downloading {
-		assert.False(dt.T(), callbackExecuted.Load())
+		AssertFalse(callbackExecuted.Load())
 	} else {
-		assert.True(dt.T(), callbackExecuted.Load())
+		AssertTrue(callbackExecuted.Load())
 	}
-	assert.Nil(dt.T(), dt.job.status.Err)
+	AssertEq(nil, dt.job.status.Err)
 	// Verify file
 	dt.verifyFile(objectContent[:dt.job.status.Offset])
 	// Verify file info cache
@@ -686,14 +686,14 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 		var jobStatus JobStatus
 		var err error
 		jobStatus, err = dt.job.Download(ctx, expectedOffset, true)
-		assert.NotEqualValues(dt.T(), Failed, jobStatus.Name)
+		AssertNe(Failed, jobStatus.Name)
 		if expectedErr != nil {
-			assert.True(dt.T(), strings.Contains(err.Error(), expectedErr.Error()))
+			AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
 			return
 		} else {
-			assert.Equal(dt.T(), expectedErr, err)
+			AssertEq(expectedErr, err)
 		}
-		assert.GreaterOrEqual(dt.T(), jobStatus.Offset, expectedOffset)
+		AssertGe(jobStatus.Offset, expectedOffset)
 	}
 
 	// Start concurrent downloads
@@ -707,7 +707,7 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	expectedJobStatus := JobStatus{Completed, nil, int64(objectSize)}
-	assert.True(dt.T(), reflect.DeepEqual(expectedJobStatus, dt.job.status))
+	AssertTrue(reflect.DeepEqual(expectedJobStatus, dt.job.status))
 	// Verify file
 	dt.verifyFile(objectContent)
 	// Verify file info cache
@@ -722,15 +722,15 @@ func (dt *downloaderTest) Test_GetStatus() {
 	ctx := context.Background()
 	// Start download
 	jobStatus, err := dt.job.Download(ctx, util.MiB, true)
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
+	AssertEq(nil, err)
+	AssertEq(Downloading, jobStatus.Name)
 
 	// GetStatus in between downloading
 	jobStatus = dt.job.GetStatus()
 
-	assert.True(dt.T(), (jobStatus.Name == Downloading) || (jobStatus.Name == Completed))
-	assert.Nil(dt.T(), jobStatus.Err)
-	assert.LessOrEqual(dt.T(), int64(0), jobStatus.Offset)
+	AssertTrue((jobStatus.Name == Downloading) || (jobStatus.Name == Completed))
+	AssertEq(nil, jobStatus.Err)
+	AssertGe(jobStatus.Offset, 0)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 }
@@ -745,17 +745,17 @@ func (dt *downloaderTest) Test_Invalidate_WhenDownloading() {
 	ctx := context.Background()
 	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
+	AssertEq(nil, err)
+	AssertEq(Downloading, jobStatus.Name)
 
 	dt.job.Invalidate()
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	dt.verifyInvalidError(dt.job.status.Err)
-	assert.Equal(dt.T(), Invalid, dt.job.status.Name)
-	assert.True(dt.T(), callbackExecuted.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(Invalid, dt.job.status.Name)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Invalidate_NotStarted() {
@@ -770,10 +770,10 @@ func (dt *downloaderTest) Test_Invalidate_NotStarted() {
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.Nil(dt.T(), dt.job.status.Err)
-	assert.Equal(dt.T(), Invalid, dt.job.status.Name)
-	assert.True(dt.T(), callbackExecuted.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(nil, dt.job.status.Err)
+	AssertEq(Invalid, dt.job.status.Name)
+	AssertTrue(callbackExecuted.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
@@ -786,19 +786,19 @@ func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
 	ctx := context.Background()
 	// Start download with waiting
 	_, err := dt.job.Download(ctx, int64(objectSize), true)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	dt.waitForCrcCheckToBeCompleted()
 	jobStatus := dt.job.GetStatus()
-	assert.Equal(dt.T(), Completed, jobStatus.Name)
+	AssertEq(Completed, jobStatus.Name)
 
 	dt.job.Invalidate()
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.Equal(dt.T(), Invalid, dt.job.status.Name)
+	AssertEq(Invalid, dt.job.status.Name)
 	dt.verifyInvalidError(dt.job.status.Err)
-	assert.EqualValues(dt.T(), 1, callbackExecutionCount.Load())
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(1, callbackExecutionCount.Load())
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Invalidate_Concurrent() {
@@ -811,14 +811,14 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	ctx := context.Background()
 	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
-	assert.Nil(dt.T(), err)
-	assert.Equal(dt.T(), Downloading, jobStatus.Name)
+	AssertEq(nil, err)
+	AssertEq(Downloading, jobStatus.Name)
 	wg := sync.WaitGroup{}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		assert.Equal(dt.T(), Invalid, currJobStatus.Name)
+		AssertEq(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 
@@ -829,10 +829,10 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	}
 	wg.Wait()
 
-	assert.EqualValues(dt.T(), 1, callbackExecutionCount.Load())
+	AssertEq(1, callbackExecutionCount.Load())
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
@@ -848,19 +848,19 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 		ctx := context.Background()
 		// Start download without waiting
 		jobStatus, err := dt.job.Download(ctx, offset, waitForDownload)
-		assert.Nil(dt.T(), err)
-		assert.True(dt.T(), jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
+		AssertEq(nil, err)
+		AssertTrue(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
 		// If status is downloading/complete and wait for download is true then
 		// status offset should be at least requested offset.
 		if waitForDownload && (jobStatus.Name == Downloading || jobStatus.Name == Completed) {
-			assert.GreaterOrEqual(dt.T(), jobStatus.Offset, offset)
+			AssertGe(jobStatus.Offset, offset)
 		}
 	}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		assert.Equal(dt.T(), Invalid, currJobStatus.Name)
+		AssertEq(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 
@@ -877,10 +877,10 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 	}
 	wg.Wait()
 
-	assert.EqualValues(dt.T(), 1, callbackExecutionCount.Load())
+	AssertEq(1, callbackExecutionCount.Load())
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	assert.Nil(dt.T(), dt.job.removeJobCallback)
+	AssertEq(nil, dt.job.removeJobCallback)
 }
 
 func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue() {
@@ -891,29 +891,29 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue() 
 	// Start download
 	offset := int64(8 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Here the crc check will be successful
 	dt.waitForCrcCheckToBeCompleted()
-	assert.Equal(dt.T(), Completed, dt.job.status.Name)
-	assert.Nil(dt.T(), dt.job.status.Err)
-	assert.GreaterOrEqual(dt.T(), dt.job.status.Offset, offset)
+	AssertEq(Completed, dt.job.status.Name)
+	AssertEq(nil, dt.job.status.Err)
+	AssertGe(dt.job.status.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 	// Tamper the file
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), strings.Contains(err.Error(), "checksum mismatch detected"))
-	assert.Nil(dt.T(), dt.getFileInfo())
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "checksum mismatch detected"))
+	AssertEq(nil, dt.getFileInfo())
 	_, err = os.Stat(dt.fileSpec.Path)
-	assert.NotNil(dt.T(), err)
-	assert.True(dt.T(), strings.Contains(err.Error(), "no such file or directory"))
+	AssertNe(nil, err)
+	AssertTrue(strings.Contains(err.Error(), "no such file or directory"))
 }
 
 func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse() {
@@ -924,25 +924,25 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse()
 	// Start download
 	offset := int64(1 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Here the crc check will be successful
 	dt.waitForCrcCheckToBeCompleted()
-	assert.Equal(dt.T(), Completed, dt.job.status.Name)
-	assert.Nil(dt.T(), dt.job.status.Err)
-	assert.GreaterOrEqual(dt.T(), dt.job.status.Offset, offset)
+	AssertEq(Completed, dt.job.status.Name)
+	AssertEq(nil, dt.job.status.Err)
+	AssertGe(dt.job.status.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 	// Tamper the file
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	dt.job.fileCacheConfig.EnableCrc = false
 
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	// Verify file
 	dt.verifyFile([]byte("test"))
 	// Verify fileInfoCache update
@@ -957,15 +957,15 @@ func (dt *downloaderTest) Test_validateCRC_WheContextIsCancelled() {
 	// Start download
 	offset := int64(10 * util.MiB)
 	_, err := dt.job.Download(context.Background(), offset, true)
-	assert.Nil(dt.T(), err)
-	assert.True(dt.T(), (dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
-	assert.Nil(dt.T(), dt.job.status.Err)
-	assert.GreaterOrEqual(dt.T(), dt.job.status.Offset, offset)
+	AssertEq(nil, err)
+	AssertTrue((dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
+	AssertEq(nil, dt.job.status.Err)
+	AssertGe(dt.job.status.Offset, offset)
 
 	dt.job.cancelFunc()
 	dt.waitForCrcCheckToBeCompleted()
 
-	assert.Equal(dt.T(), Invalid, dt.job.status.Name)
+	AssertEq(Invalid, dt.job.status.Name)
 	dt.verifyInvalidError(dt.job.status.Err)
 }
 
@@ -977,12 +977,12 @@ func (dt *downloaderTest) Test_handleError_SetStatusAsInvalidWhenContextIsCancel
 	err = fmt.Errorf("Wrapping with custom message %w", err)
 	dt.job.handleError(err)
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
-	assert.Equal(dt.T(), Invalid, notification.Name)
+	AssertEq(Invalid, notification.Name)
 	dt.verifyInvalidError(notification.Err)
-	assert.EqualValues(dt.T(), 0, notification.Offset)
-	assert.True(dt.T(), ok)
+	AssertEq(0, notification.Offset)
+	AssertEq(true, ok)
 }
 
 func (dt *downloaderTest) Test_handleError_SetStatusAsErrorWhenContextIsNotCancelled() {
@@ -993,12 +993,12 @@ func (dt *downloaderTest) Test_handleError_SetStatusAsErrorWhenContextIsNotCance
 	updatedErr := fmt.Errorf("Custom message %w", err)
 	dt.job.handleError(updatedErr)
 
-	assert.Equal(dt.T(), 0, dt.job.subscribers.Len())
+	AssertEq(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Failed, Err: updatedErr, Offset: 0}
 	fmt.Println(notification)
-	assert.True(dt.T(), reflect.DeepEqual(jobStatus, notification))
-	assert.Equal(dt.T(), true, ok)
+	AssertTrue(reflect.DeepEqual(jobStatus, notification))
+	AssertEq(true, ok)
 }
 
 func (dt *downloaderTest) Test_When_Parallel_Download_Is_Enabled() {
@@ -1007,7 +1007,7 @@ func (dt *downloaderTest) Test_When_Parallel_Download_Is_Enabled() {
 
 	result := dt.job.IsParallelDownloadsEnabled()
 
-	assert.True(dt.T(), result)
+	AssertTrue(result)
 }
 
 func (dt *downloaderTest) Test_When_Parallel_Download_Is_Disabled() {
@@ -1016,7 +1016,7 @@ func (dt *downloaderTest) Test_When_Parallel_Download_Is_Disabled() {
 
 	result := dt.job.IsParallelDownloadsEnabled()
 
-	assert.False(dt.T(), result)
+	AssertFalse(result)
 }
 
 func (dt *downloaderTest) Test_createCacheFile_WhenNonParallelDownloads() {
@@ -1025,7 +1025,7 @@ func (dt *downloaderTest) Test_createCacheFile_WhenNonParallelDownloads() {
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()
@@ -1037,7 +1037,7 @@ func (dt *downloaderTest) Test_createCacheFile_WhenParallelDownloads() {
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()
@@ -1050,7 +1050,7 @@ func (dt *downloaderTest) Test_createCacheFile_WhenParallelDownloadsEnabledAndOD
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	assert.Nil(dt.T(), err)
+	AssertEq(nil, err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcsfuse#2523 since it seems to break race-detector tests