### PR TITLE
Create a temp directory to avoid collisions while running tests parallelly

### DIFF
--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The directory name is generated with a random component to avoid collisions as we are running implicit_dir_test and explicit_dir test parallelly.
+temp_dir=$(mktemp -d)
+cd "$temp_dir"
 # Here $1 refers to the testBucket argument
 echo "This is from directory fileInImplicitDir1 file implicitDirectory" > fileInImplicitDir1
 # bucket/implicitDirectory/fileInImplicitDir1
@@ -19,3 +22,5 @@ gcloud storage cp fileInImplicitDir1 gs://$1/implicitDirectory/
 echo "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2" > fileInImplicitDir2
 # bucket/implicitDirectory/implicitSubDirectory/fileInImplicitDir2
 gcloud storage cp fileInImplicitDir2 gs://$1/implicitDirectory/implicitSubDirectory/
+cd ..
+rm -rf "$temp_dir"


### PR DESCRIPTION
### Description
Created a temp directory at runtime to avoid collisions while running tests parallely as implicit_dir_test and explicit_dir_test both use the same script.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
