### PR TITLE
change permissions so that dependabot PRs don't fail

### DIFF
--- a/.github/workflows/shadow.yml
+++ b/.github/workflows/shadow.yml
@@ -2,18 +2,20 @@ name: "Shadow reviews"
 
 on:
   pull_request:
-    types: 
+    types:
     - review_requested
     branches:
-      - master
+    - master
+
+permissions:
+  pull-requests: write
 
 jobs:
   shadow-reviewer:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Add shadow reviewer
-        run: gh pr edit --add-reviewer @GoogleCloudPlatform/gcsfuse-shadow-reviewers "$PR_URL"
-        env:
-          GH_TOKEN: ${{ secrets.SHADOW_REVIEWER_CLASSIC }}
-          PR_URL: ${{github.event.pull_request.html_url}}
+    - name: Add shadow reviewer
+      run: gh pr edit --add-reviewer @GoogleCloudPlatform/gcsfuse-shadow-reviewers "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
### Description
This is in accordance with https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
