### PR TITLE
Replace gcloud command to access credential secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.0
+	cloud.google.com/go/secretmanager v1.13.5
 	cloud.google.com/go/storage v1.43.0
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/pubsub v1.41.0 h1:ZPaM/CvTO6T+1tQOs/jJ4OEMpjtel0PTLV7j1JK+ZrI=
 cloud.google.com/go/pubsub v1.41.0/go.mod h1:g+YzC6w/3N91tzG66e2BZtp7WrpBBMXVa3Y9zVoOGpk=
+cloud.google.com/go/secretmanager v1.13.5 h1:tXlHvpm97mFD0Lv50N4U4zlXfkoTNay3BmpNA/W7/oI=
+cloud.google.com/go/secretmanager v1.13.5/go.mod h1:/OeZ88l5Z6nBVilV0SXgv6XJ243KP2aIhSWRMrbvDCQ=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -199,8 +199,8 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	setup.RunTestsOnlyForStaticMount(mountDir, t)
 
 	// Fetch credentials and apply permission on bucket.
-	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials()
-	creds_tests.ApplyPermissionToServiceAccount(serviceAccount, AdminPermission, setup.TestBucket())
+	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials(ctx)
+	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
 
 	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=5", "--stat-cache-ttl=0"}
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
@@ -220,9 +220,9 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 		ts.bucketPermission = permissions[i][0]
 		if ts.bucketPermission == ViewPermission {
-			creds_tests.RevokePermission(serviceAccount, AdminPermission, setup.TestBucket())
-			creds_tests.ApplyPermissionToServiceAccount(serviceAccount, ViewPermission, setup.TestBucket())
-			defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
+			creds_tests.RevokePermission(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
+			creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
+			defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 		}
 		ts.managedFoldersPermission = permissions[i][1]
 

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -137,9 +137,9 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 	ts := &managedFoldersViewPermission{}
 
 	// Fetch credentials and apply permission on bucket.
-	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials()
-	creds_tests.ApplyPermissionToServiceAccount(serviceAccount, ViewPermission, setup.TestBucket())
-	defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
+	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(ctx)
+	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
+	defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 
 	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=3"}
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -213,7 +213,7 @@ func TestMain(m *testing.M) {
 
 	if successCode == 0 {
 		// Test for admin permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flagsSet, "objectAdmin", m)
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flagsSet, "objectAdmin", m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -159,7 +159,7 @@ func TestMain(m *testing.M) {
 
 	if successCode == 0 {
 		// Test for viewer permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectViewer", m)
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flags, "objectViewer", m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 
 	// Test for viewer permission on test bucket.
 	flags := [][]string{{"--implicit-dirs=true"}, {"--implicit-dirs=false"}}
-	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectViewer", m)
+	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flags, "objectViewer", m)
 
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -79,7 +79,7 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while creating credentials file %v", err))
 	}
-	_, err = io.WriteString(file, string(creds.Payload.Data))
+	_, err = io.Writer.Write(file, creds.Payload.Data)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
 	}

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -67,7 +67,7 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	}
 	defer client.Close()
 	req := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: CredentialsSecretName,
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", id, CredentialsSecretName),
 	}
 	creds, err := client.AccessSecretVersion(ctx, req)
 	if err != nil {

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -29,8 +29,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"cloud.google.com/go/iam"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -41,7 +43,7 @@ const CredentialsSecretName = "gcsfuse-integration-tests"
 
 var WhitelistedGcpProjects = []string{"gcs-fuse-test", "gcs-fuse-test-ml"}
 
-func CreateCredentials() (serviceAccount, localKeyFilePath string) {
+func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath string) {
 	log.Println("Running credentials tests...")
 
 	// Fetching project-id to get service account id.
@@ -60,7 +62,6 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	localKeyFilePath = path.Join(os.Getenv("HOME"), "creds.json")
 
 	// Download credentials
-	ctx := context.Background()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
@@ -88,30 +89,45 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	return
 }
 
-func ApplyPermissionToServiceAccount(serviceAccount, permission, bucket string) {
+func ApplyPermissionToServiceAccount(ctx context.Context, storageClient *storage.Client, serviceAccount, permission, bucket string) {
 	// Provide permission to service account for testing.
-	_, err := operations.ExecuteGcloudCommandf(fmt.Sprintf("storage buckets add-iam-policy-binding gs://%s --member=serviceAccount:%s --role=roles/storage.%s", bucket, serviceAccount, permission))
+	bucketHandle := storageClient.Bucket(bucket)
+	policy, err := bucketHandle.IAM().Policy(ctx)
 	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while setting permissions to SA: %v", err))
+		setup.LogAndExit(fmt.Sprintf("Error fetching: Bucket(%q).IAM().Policy: %v", bucket, err))
+	}
+	identity := fmt.Sprintf("serviceAccount:%s", serviceAccount)
+	role := iam.RoleName(fmt.Sprintf("roles/storage.%s", permission))
+
+	policy.Add(identity, role)
+	if err := bucketHandle.IAM().SetPolicy(ctx, policy); err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error applying permission to service account: Bucket(%q).IAM().SetPolicy: %v", bucket, err))
 	}
 	// Waiting for 2 minutes as it usually takes within 2 minutes for policy
 	// changes to propagate: https://cloud.google.com/iam/docs/access-change-propagation
 	time.Sleep(120 * time.Second)
 }
 
-func RevokePermission(serviceAccount, permission, bucket string) {
+func RevokePermission(ctx context.Context, storageClient *storage.Client, serviceAccount, permission, bucket string) {
 	// Revoke the permission to service account after testing.
-	cmd := fmt.Sprintf("storage buckets remove-iam-policy-binding gs://%s --member=serviceAccount:%s --role=roles/storage.%s", bucket, serviceAccount, permission)
-	_, err := operations.ExecuteGcloudCommandf(cmd)
+	bucketHandle := storageClient.Bucket(bucket)
+	policy, err := bucketHandle.IAM().Policy(ctx)
 	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in unsetting permissions to SA: %v", err))
+		setup.LogAndExit(fmt.Sprintf("Error fetching: Bucket(%q).IAM().Policy: %v", bucket, err))
+	}
+	identity := fmt.Sprintf("serviceAccount:%s", serviceAccount)
+	role := iam.RoleName(fmt.Sprintf("roles/storage.%s", permission))
+
+	policy.Remove(identity, role)
+	if err := bucketHandle.IAM().SetPolicy(ctx, policy); err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error applying permission to service account: Bucket(%q).IAM().SetPolicy: %v", bucket, err))
 	}
 }
 
-func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
-	serviceAccount, localKeyFilePath := CreateCredentials()
-	ApplyPermissionToServiceAccount(serviceAccount, permission, setup.TestBucket())
-	defer RevokePermission(serviceAccount, permission, setup.TestBucket())
+func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx context.Context, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
+	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
+	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
+	defer RevokePermission(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
 
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -17,6 +17,7 @@
 package creds_tests
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -28,6 +29,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -57,8 +60,16 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	localKeyFilePath = path.Join(os.Getenv("HOME"), "creds.json")
 
 	// Download credentials
-	gcloudSecretAccessCmd := fmt.Sprintf("secrets versions access latest --secret %s", CredentialsSecretName)
-	creds, err := operations.ExecuteGcloudCommandf(gcloudSecretAccessCmd)
+	ctx := context.Background()
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
+	}
+	defer client.Close()
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: CredentialsSecretName,
+	}
+	creds, err := client.AccessSecretVersion(ctx, req)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while fetching key file %v", err))
 	}
@@ -68,7 +79,7 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while creating credentials file %v", err))
 	}
-	_, err = io.WriteString(file, string(creds))
+	_, err = io.WriteString(file, string(creds.Payload.Data))
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
 	}


### PR DESCRIPTION
### Description
Replacing gcloud command for accessing the credential secret for integration tests, currently using secret manager client to access it.
Motivation: gcloud commands can't be run concurrently as part of parallelizing CD tests.Thus, needs to be replaced.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the integration tests manually on GCE VM.
2. Unit tests - NA
3. Integration tests - NA
