### PR TITLE
replacing gcloud command for updating/revoking permission to service account

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -199,8 +199,8 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	setup.RunTestsOnlyForStaticMount(mountDir, t)
 
 	// Fetch credentials and apply permission on bucket.
-	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials()
-	creds_tests.ApplyPermissionToServiceAccount(serviceAccount, AdminPermission, setup.TestBucket())
+	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials(ctx)
+	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
 
 	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=5", "--stat-cache-ttl=0"}
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
@@ -220,9 +220,9 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 		ts.bucketPermission = permissions[i][0]
 		if ts.bucketPermission == ViewPermission {
-			creds_tests.RevokePermission(serviceAccount, AdminPermission, setup.TestBucket())
-			creds_tests.ApplyPermissionToServiceAccount(serviceAccount, ViewPermission, setup.TestBucket())
-			defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
+			creds_tests.RevokePermission(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
+			creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
+			defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 		}
 		ts.managedFoldersPermission = permissions[i][1]
 

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -137,9 +137,9 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 	ts := &managedFoldersViewPermission{}
 
 	// Fetch credentials and apply permission on bucket.
-	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials()
-	creds_tests.ApplyPermissionToServiceAccount(serviceAccount, ViewPermission, setup.TestBucket())
-	defer creds_tests.RevokePermission(serviceAccount, ViewPermission, setup.TestBucket())
+	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(ctx)
+	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
+	defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 
 	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=3"}
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -213,7 +213,7 @@ func TestMain(m *testing.M) {
 
 	if successCode == 0 {
 		// Test for admin permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flagsSet, "objectAdmin", m)
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flagsSet, "objectAdmin", m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -159,7 +159,7 @@ func TestMain(m *testing.M) {
 
 	if successCode == 0 {
 		// Test for viewer permission on test bucket.
-		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectViewer", m)
+		successCode = creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flags, "objectViewer", m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 
 	// Test for viewer permission on test bucket.
 	flags := [][]string{{"--implicit-dirs=true"}, {"--implicit-dirs=false"}}
-	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(flags, "objectViewer", m)
+	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flags, "objectViewer", m)
 
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -29,8 +29,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"cloud.google.com/go/iam"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -41,7 +43,7 @@ const CredentialsSecretName = "gcsfuse-integration-tests"
 
 var WhitelistedGcpProjects = []string{"gcs-fuse-test", "gcs-fuse-test-ml"}
 
-func CreateCredentials() (serviceAccount, localKeyFilePath string) {
+func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath string) {
 	log.Println("Running credentials tests...")
 
 	// Fetching project-id to get service account id.
@@ -60,7 +62,6 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	localKeyFilePath = path.Join(os.Getenv("HOME"), "creds.json")
 
 	// Download credentials
-	ctx := context.Background()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
@@ -88,30 +89,45 @@ func CreateCredentials() (serviceAccount, localKeyFilePath string) {
 	return
 }
 
-func ApplyPermissionToServiceAccount(serviceAccount, permission, bucket string) {
+func ApplyPermissionToServiceAccount(ctx context.Context, storageClient *storage.Client, serviceAccount, permission, bucket string) {
 	// Provide permission to service account for testing.
-	_, err := operations.ExecuteGcloudCommandf(fmt.Sprintf("storage buckets add-iam-policy-binding gs://%s --member=serviceAccount:%s --role=roles/storage.%s", bucket, serviceAccount, permission))
+	bucketHandle := storageClient.Bucket(bucket)
+	policy, err := bucketHandle.IAM().Policy(ctx)
 	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while setting permissions to SA: %v", err))
+		setup.LogAndExit(fmt.Sprintf("Error fetching: Bucket(%q).IAM().Policy: %v", bucket, err))
+	}
+	identity := fmt.Sprintf("serviceAccount:%s", serviceAccount)
+	role := iam.RoleName(fmt.Sprintf("roles/storage.%s", permission))
+
+	policy.Add(identity, role)
+	if err := bucketHandle.IAM().SetPolicy(ctx, policy); err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error applying permission to service account: Bucket(%q).IAM().SetPolicy: %v", bucket, err))
 	}
 	// Waiting for 2 minutes as it usually takes within 2 minutes for policy
 	// changes to propagate: https://cloud.google.com/iam/docs/access-change-propagation
 	time.Sleep(120 * time.Second)
 }
 
-func RevokePermission(serviceAccount, permission, bucket string) {
+func RevokePermission(ctx context.Context, storageClient *storage.Client, serviceAccount, permission, bucket string) {
 	// Revoke the permission to service account after testing.
-	cmd := fmt.Sprintf("storage buckets remove-iam-policy-binding gs://%s --member=serviceAccount:%s --role=roles/storage.%s", bucket, serviceAccount, permission)
-	_, err := operations.ExecuteGcloudCommandf(cmd)
+	bucketHandle := storageClient.Bucket(bucket)
+	policy, err := bucketHandle.IAM().Policy(ctx)
 	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in unsetting permissions to SA: %v", err))
+		setup.LogAndExit(fmt.Sprintf("Error fetching: Bucket(%q).IAM().Policy: %v", bucket, err))
+	}
+	identity := fmt.Sprintf("serviceAccount:%s", serviceAccount)
+	role := iam.RoleName(fmt.Sprintf("roles/storage.%s", permission))
+
+	policy.Remove(identity, role)
+	if err := bucketHandle.IAM().SetPolicy(ctx, policy); err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error applying permission to service account: Bucket(%q).IAM().SetPolicy: %v", bucket, err))
 	}
 }
 
-func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
-	serviceAccount, localKeyFilePath := CreateCredentials()
-	ApplyPermissionToServiceAccount(serviceAccount, permission, setup.TestBucket())
-	defer RevokePermission(serviceAccount, permission, setup.TestBucket())
+func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx context.Context, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
+	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
+	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
+	defer RevokePermission(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
 
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.


### PR DESCRIPTION
Using storage client instead of executing gcloud command to apply/revoke permission for service account for integration tests.
Motivation: gcloud commands can't be run concurrently as part of parallelizing CD tests.Thus, needs to be replaced.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual -  Ran the integration tests manually on GCE VM.
2. Unit tests - NA
3. Integration tests - NA
