### PR TITLE
Remove latency checks as they should be part of perf_tests.

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -20,11 +20,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/assert"
 )
 
 // //////////////////////////////////////////////////////////////////////
@@ -155,30 +153,11 @@ func TestListDirectoryWithTwelveThousandFiles(t *testing.T) {
 	testDirPathOnBucket := path.Join(setup.TestBucket(), DirectoryForListLargeFileTests)
 	dirPath := path.Join(testDirPath, DirectoryWithTwelveThousandFiles)
 
-	// List Directory first time
-	startTime := time.Now()
 	objs, err := os.ReadDir(dirPath)
 	if err != nil {
 		t.Errorf("Error in listing directory: %v", err)
 	}
-	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFiles(objs, t)
-	firstListTime := endTime.Sub(startTime)
-	// Listing the directory a second time should retrieve the response from the kernel cache.
-	startTime = time.Now()
-	objs, err = os.ReadDir(dirPath)
-	if err != nil {
-		t.Errorf("Error in listing directory: %v", err)
-	}
-	endTime = time.Now()
-	validateDirectoryWithTwelveThousandFiles(objs, t)
-	secondListTime := endTime.Sub(startTime)
-
-	// Fetching data from the kernel for the second list will be faster.
-	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 2 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 2*secondListTime, firstListTime)
 	// Clear the data after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -192,30 +171,11 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir(t *testing.T)
 	// Create hundred explicit directories.
 	createHundredExplicitDir(dirPath, t)
 
-	// List Directory first time
-	startTime := time.Now()
 	objs, err := os.ReadDir(dirPath)
 	if err != nil {
 		t.Errorf("Error in listing directory: %v", err)
 	}
-	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFilesAndHundredExplicitDirectory(objs, t)
-	firstListTime := endTime.Sub(startTime)
-	// Listing the directory a second time should retrieve the response from the kernel cache.
-	startTime = time.Now()
-	objs, err = os.ReadDir(dirPath)
-	if err != nil {
-		t.Errorf("Error in listing directory: %v", err)
-	}
-	endTime = time.Now()
-	validateDirectoryWithTwelveThousandFilesAndHundredExplicitDirectory(objs, t)
-	secondListTime := endTime.Sub(startTime)
-
-	// Fetching data from the kernel for the second list will be faster.
-	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 2 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 2*secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }
@@ -231,30 +191,11 @@ func TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImpl
 	subDirPath := path.Join(testDirPathOnBucket, DirectoryWithTwelveThousandFiles)
 	setup.RunScriptForTestData("testdata/create_implicit_dir.sh", subDirPath, PrefixImplicitDirInLargeDirListTest, strconv.Itoa(NumberOfImplicitDirsInDirectoryWithTwelveThousandFiles))
 
-	// List Directory first time
-	startTime := time.Now()
 	objs, err := os.ReadDir(dirPath)
 	if err != nil {
 		t.Errorf("Error in listing directory: %v", err)
 	}
-	endTime := time.Now()
 	validateDirectoryWithTwelveThousandFilesHundredExplicitDirAndHundredImplicitDir(objs, t)
-	firstListTime := endTime.Sub(startTime)
-	// Listing the directory a second time should retrieve the response from the kernel cache.
-	startTime = time.Now()
-	objs, err = os.ReadDir(dirPath)
-	if err != nil {
-		t.Errorf("Error in listing directory: %v", err)
-	}
-	endTime = time.Now()
-	validateDirectoryWithTwelveThousandFilesHundredExplicitDirAndHundredImplicitDir(objs, t)
-	secondListTime := endTime.Sub(startTime)
-
-	// Fetching data from the kernel for the second list will be faster.
-	assert.Less(t, secondListTime, firstListTime)
-	// The second directory listing should be 2 times better performant since it
-	// will be retrieved from the kernel cache.
-	assert.Less(t, 2*secondListTime, firstListTime)
 	// Clear the bucket after testing.
 	setup.RunScriptForTestData("testdata/delete_objects.sh", testDirPathOnBucket)
 }


### PR DESCRIPTION
### Description
Removed latency checks in list_large_dir as they should be part of perf_tests and not e2e_tests and they were also failing on running concurrently with other tests.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
