### PR TITLE
Add SetRetry in CreateStorageClient

### DIFF
--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -52,9 +52,10 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewClient: %w", err)
 	}
-	//RetryAlways causes all operations to be retried when the service returns transient error,
-	//regardless of idempotency considerations. Since the concurrent execution of our CI/CD tests
-	//(VMs, threads) doesn't share any cloud-storage resources, hence it's safe to disregard idempotency.
+	// RetryAlways causes all operations to be retried when the service returns
+	// transient error, regardless of idempotency considerations. Since the
+	// concurrent execution of our CI/CD tests (VMs, threads) doesn't share any
+	// cloud-storage resources, hence it's safe to disregard idempotency.
 	client.SetRetry(
 		storage.WithBackoff(gax.Backoff{
 			Max:        30 * time.Second,

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -22,8 +22,11 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"golang.org/x/oauth2"
@@ -49,6 +52,13 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewClient: %w", err)
 	}
+	client.SetRetry(
+		storage.WithBackoff(gax.Backoff{
+			Max:        30 * time.Second,
+			Multiplier: 2,
+		}),
+		storage.WithPolicy(storage.RetryAlways),
+		storage.WithErrorFunc(storageutil.ShouldRetry))
 	return client, nil
 }
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -58,7 +58,8 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 			Multiplier: 2,
 		}),
 		storage.WithPolicy(storage.RetryAlways),
-		storage.WithErrorFunc(storageutil.ShouldRetry))
+		storage.WithErrorFunc(storageutil.ShouldRetry),
+		storage.WithMaxAttempts(5))
 	return client, nil
 }
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -52,6 +52,9 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewClient: %w", err)
 	}
+	//RetryAlways causes all operations to be retried when the service returns transient error,
+	//regardless of idempotency considerations. Since the concurrent execution of our CI/CD tests
+	//(VMs, threads) doesn't share any cloud-storage resources, hence it's safe to disregard idempotency.
 	client.SetRetry(
 		storage.WithBackoff(gax.Backoff{
 			Max:        30 * time.Second,


### PR DESCRIPTION
### Description
Added a SetRetry feature in CreateStorageClient to handle transient errors. Since our end-to-end tests use separate buckets for different VMs and each test operates on distinct resources, we can safely bypass the idempotency check.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Not tested as required effort was more than scope of project.
2. Unit tests - NA
3. Integration tests - Automated
