### PR TITLE
Fix documentation

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -29,5 +29,3 @@ new param available in both the modes:
     [config_rationalization_test.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/cmd/config_rationalization_test.go)
     and
     [root_test.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/cmd/root_test.go)
-1.  Add the name of flag with underscores in
-    [mount_gcsfuse/main.go](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/mount_gcsfuse/main.go)


### PR DESCRIPTION
Adding flags to mount_gcsfuse/main.go is no longer required. So remove it.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
