### PR TITLE
Add code-owners for perfmetrics/scripts/testing_on_gke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 # the repo.
 *           @GoogleCloudPlatform/gcsfuse-codeowners
 
+perfmetrics/scripts/testing_on_gke/ @gargnitingoogle @kislaykishore @tulsishah @charith87 @GoogleCloudPlatform/gcsfuse-codeowners
 perfmetrics/scripts/ @tulsishah @GoogleCloudPlatform/gcsfuse-codeowners
 tools/ @tulsishah @GoogleCloudPlatform/gcsfuse-codeowners


### PR DESCRIPTION
Added additional code-owners in ai/ml synthetic test tool directory i.e. `perfmetrics/scripts/testing_on_gke`, to enable quicker merges of fixes/improvements :
1. gargnitingoogle (original author)
2. kislaykishore (original reviewer)
3. tulsishah (inheriting from perfmetrics/scripts)
4. charith87 (original reviewer)

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
