### PR TITLE
Fix to not use O_DIRECT by default

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -382,7 +382,7 @@ func (job *Job) createCacheFile() (*os.File, error) {
 	var err error
 	// Try using O_DIRECT while opening file when parallel downloads are enabled
 	// and O_DIRECT use is not disabled.
-	if job.fileCacheConfig.EnableParallelDownloads && !job.fileCacheConfig.EnableODirect {
+	if job.fileCacheConfig.EnableParallelDownloads && job.fileCacheConfig.EnableODirect {
 		cacheFile, err = cacheutil.CreateFile(job.fileSpec, openFileFlags|syscall.O_DIRECT)
 		if errors.Is(err, fs.ErrInvalid) || errors.Is(err, syscall.EINVAL) {
 			logger.Warnf("downloadObjectAsync: failure in opening file with O_DIRECT, falling back to without O_DIRECT")

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -62,8 +62,11 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 
 	monitor.CaptureGCSReadMetrics(ctx, util.Parallel, end-start)
 
-	// Use memory aligned buffer if O_DIRECT is enabled.
-	if job.fileCacheConfig.EnableODirect {
+	// Use standard copy function if O_DIRECT is disabled and memory aligned
+	// buffer otherwise.
+	if !job.fileCacheConfig.EnableODirect {
+		_, err = io.CopyN(dstWriter, newReader, end-start)
+	} else {
 		_, err = cacheutil.CopyUsingMemoryAlignedBuffer(ctx, newReader, dstWriter, end-start,
 			job.fileCacheConfig.WriteBufferSize)
 		// If context is canceled while reading/writing in CopyUsingMemoryAlignedBuffer
@@ -72,8 +75,6 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 		if !errors.Is(err, context.Canceled) && errors.Is(ctx.Err(), context.Canceled) {
 			err = errors.Join(err, ctx.Err())
 		}
-	} else {
-		_, err = io.CopyN(dstWriter, newReader, end-start)
 	}
 
 	if err != nil {


### PR DESCRIPTION
### Description
Fix to not use O_DIRECT by default.

Tests performed manually:
machine spec:
n2-standard-96
16LSSDs

fio
```
; -- use nrfiles and rw to CLI args to control readtype and number of files --
[global]
ioengine=libaio
direct=0
fadvise_hint=0
iodepth=64
invalidate=1
nrfiles=16
thread=1
openfiles=1
group_reporting=1
create_serialize=0
allrandrepeat=0
file_service_type=random
numjobs=1
filename_format=$jobname.$jobnum/$filenum

[Workload]
directory=${DIR}
bs=128K
filesize=10G
rw=read
```

pytorch data loader
```
Loaded Llama 70B model
```

With `enable-o-direct=true` 
Fio throughput: 733MiB/s (221s)
Llama 70B model load time: 275s

Without `enable-o-direct=false` (default with this fix)
Fio throughput: 812MiB/s (201s)
Llama 70B model load time: 267s



### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
