### PR TITLE
[Error fix] GCSFuse mount command results in error if directory with bucket name exists in the working directory

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -187,10 +187,19 @@ func parseArgs(
 		// Is this the device?
 		case positionalCount == 0:
 			device = s
-			if strings.Contains(device, "\\") {
+			fmt.Println("device before: ", device)
+			// Kernel might be converting bucket name to path if a directory with same
+			// name as bucket exists in the root folder from which mount command is
+			// executed.
+			// As of 10th Oct, 2024, bucket names don't support "/", so it is safe to
+			// convert received bucket name with "/" to it's base file name.
+			if strings.Contains(device, "/") {
+				fmt.Println("Changing device..")
 				// Get the last part of the path (bucket name)
 				device = filepath.Base(device)
 			}
+			fmt.Println("device after: ", device)
+			fmt.Println("filepath.Base = ", filepath.Base(device))
 			positionalCount++
 
 		// Is this the mount point?
@@ -213,6 +222,8 @@ func parseArgs(
 }
 
 func run(args []string) (err error) {
+	fmt.Println("os.Args = ", args)
+
 	// If invoked with a single "--help" argument, print a usage message and exit
 	// successfully.
 	if len(args) == 2 && args[1] == "--help" {

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -59,6 +59,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -186,6 +187,10 @@ func parseArgs(
 		// Is this the device?
 		case positionalCount == 0:
 			device = s
+			if strings.Contains(device, "\\") {
+				// Get the last part of the path (bucket name)
+				device = filepath.Base(device)
+			}
 			positionalCount++
 
 		// Is this the mount point?

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -193,6 +193,7 @@ func parseArgs(
 			// As of October 10th, 2024, bucket names don't support "/", so it is safe to
 			// assume any received bucket name containing "/" is actually a path and
 			// extract the base file name.
+			// Ref: https://cloud.google.com/storage/docs/buckets#naming
 			if strings.Contains(device, "/") {
 				// Get the last part of the path (bucket name)
 				device = filepath.Base(device)

--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -187,19 +187,16 @@ func parseArgs(
 		// Is this the device?
 		case positionalCount == 0:
 			device = s
-			fmt.Println("device before: ", device)
-			// Kernel might be converting bucket name to path if a directory with same
-			// name as bucket exists in the root folder from which mount command is
-			// executed.
-			// As of 10th Oct, 2024, bucket names don't support "/", so it is safe to
-			// convert received bucket name with "/" to it's base file name.
+			// The kernel might be converting the bucket name to a path if a directory with the
+			// same name as the bucket exists in the folder where the mount command is executed.
+			//
+			// As of October 10th, 2024, bucket names don't support "/", so it is safe to
+			// assume any received bucket name containing "/" is actually a path and
+			// extract the base file name.
 			if strings.Contains(device, "/") {
-				fmt.Println("Changing device..")
 				// Get the last part of the path (bucket name)
 				device = filepath.Base(device)
 			}
-			fmt.Println("device after: ", device)
-			fmt.Println("filepath.Base = ", filepath.Base(device))
 			positionalCount++
 
 		// Is this the mount point?
@@ -222,8 +219,6 @@ func parseArgs(
 }
 
 func run(args []string) (err error) {
-	fmt.Println("os.Args = ", args)
-
 	// If invoked with a single "--help" argument, print a usage message and exit
 	// successfully.
 	if len(args) == 2 && args[1] == "--help" {

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -148,3 +148,35 @@ func TestMakeGcsfuseArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestParseArgs_DeviceIsParsedCorrectly(t *testing.T) {
+	testCases := []struct {
+		name           string
+		device         string
+		mountPoint     string
+		expectedDevice string
+	}{
+		{
+			name:           "device_bucket_name",
+			device:         "fake_bucket",
+			mountPoint:     "/mnt/fake_bucket",
+			expectedDevice: "fake_bucket",
+		},
+		{
+			name:           "device_bucket_name",
+			device:         "/mnt/fake_bucket",
+			mountPoint:     "/mnt/fake_bucket",
+			expectedDevice: "fake_bucket",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDevice, _, _, err := parseArgs([]string{"/path_to_executable", tc.device, tc.mountPoint})
+
+			if assert.Nil(t, err) {
+				assert.Equal(t, tc.expectedDevice, gotDevice)
+			}
+		})
+	}
+}

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -159,13 +159,19 @@ func TestParseArgs_DeviceIsParsedCorrectly(t *testing.T) {
 		{
 			name:           "device_bucket_name",
 			device:         "fake_bucket",
+			mountPoint:     "a/b/mnt/fake_bucket",
+			expectedDevice: "fake_bucket",
+		},
+		{
+			name:           "path_device_name",
+			device:         "/mnt/fake_bucket",
 			mountPoint:     "/mnt/fake_bucket",
 			expectedDevice: "fake_bucket",
 		},
 		{
-			name:           "device_bucket_name",
-			device:         "/mnt/fake_bucket",
-			mountPoint:     "/mnt/fake_bucket",
+			name:           "nested_path_device_name",
+			device:         "a/b/mnt/fake_bucket",
+			mountPoint:     "a/b/mnt/fake_bucket",
 			expectedDevice: "fake_bucket",
 		},
 	}

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -180,7 +180,7 @@ func TestParseArgs_DeviceIsParsedCorrectly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotDevice, _, _, err := parseArgs([]string{"/path_to_executable", tc.device, tc.mountPoint})
 
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expectedDevice, gotDevice)
 			}
 		})


### PR DESCRIPTION
### Description
Kernel mount command converts device/bucket name to path if directory with same name as bucket exists in the working directory. This results into error and failure of GCSFuse persistent mounts.
In order to fix this issue, we will convert the device name path received from kernel to it's base file name which will be bucket name.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Manually verified that after this fix, user is able to mount GCSFuse even if bucket name directory exists in current working directory. The fix is working for both 
- `mount -t` command and 
- `/etc/fstab` entry.
2. Unit tests - Added
3. Integration tests - Via KOKORO
