### PR TITLE
Un-deprecate create-empty-file flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -251,10 +251,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
-	if err := flagSet.MarkDeprecated("create-empty-file", "This flag will be deleted soon."); err != nil {
-		return err
-	}
-
 	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -601,8 +601,6 @@
   usage: "For a new file, it creates an empty file in Cloud Storage bucket as a
   hold."
   default: false
-  deprecated: true
-  deprecation-warning: "This flag will be deleted soon."
 
 - config-path: "write.experimental-enable-streaming-writes"
   flag-name: "experimental-enable-streaming-writes"


### PR DESCRIPTION
The create-empty-file flag helps in cases where local files are involved. So, we cannot deprecate it unless we have a viable alternative. Un-deprecate it.

### Description

### Link to the issue in case of a bug fix.
b/373302630

### Testing details
1. Manual - Verified that the flag is now appearing in the help doc.
2. Unit tests - NA
3. Integration tests - NA
