### PR TITLE
Fix e2e test by python3 installation

### DIFF
--- a/tools/integration_tests/rename_dir_limit/config_hns.yaml
+++ b/tools/integration_tests/rename_dir_limit/config_hns.yaml
@@ -1,1 +1,0 @@
-enable-hns: true

--- a/tools/integration_tests/rename_dir_limit/config_hns.yaml
+++ b/tools/integration_tests/rename_dir_limit/config_hns.yaml
@@ -1,0 +1,1 @@
+enable-hns: true

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -139,7 +139,6 @@ function install_packages() {
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
   sudo apt-get install python3
-  sudo apt-get install python3-pip
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -138,7 +138,7 @@ function install_packages() {
   wget -O go_tar.tar.gz https://go.dev/dl/go1.23.2.linux-${architecture}.tar.gz -q
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
-  sudo apt-get install python3
+  sudo apt-get install -y python3
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -138,6 +138,8 @@ function install_packages() {
   wget -O go_tar.tar.gz https://go.dev/dl/go1.23.2.linux-${architecture}.tar.gz -q
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
+  sudo apt-get install python3
+  sudo apt-get install python3-pip
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.


### PR DESCRIPTION
### Description
We are getting this error `exec: "python": executable file not found in $PATH` while running e2e tests in periodically due to newly added test which uses python library. Fixing it by installing python3.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
