### PR TITLE
Revert create-empty-file flag deprecation

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -251,10 +251,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
-	if err := flagSet.MarkDeprecated("create-empty-file", "This flag will be deleted soon."); err != nil {
-		return err
-	}
-
 	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -601,8 +601,7 @@
   usage: "For a new file, it creates an empty file in Cloud Storage bucket as a
   hold."
   default: false
-  deprecated: true
-  deprecation-warning: "This flag will be deleted soon."
+  deprecated: false
 
 - config-path: "write.experimental-enable-streaming-writes"
   flag-name: "experimental-enable-streaming-writes"


### PR DESCRIPTION
### Description
Revert create-empty-file flag deprecation as sometimes users need creation of empty file for their use cases. Eg Issue #2570 .

### Link to the issue in case of a bug fix.
#2570 

### Testing details
1. Manual - Manually verified that deprecation warning is not showing up anymore.
2. Unit tests - NA
3. Integration tests - Via KOKORO
