### PR TITLE
Using control client to delete managed folders instead of executing gcloud command

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -229,7 +230,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		test_setup.RunTests(t, ts)
 	}
 	t.Cleanup(func() {
-		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
+		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), setup.TestBucket())
+		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), setup.TestBucket())
 	})
 }

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -54,8 +54,8 @@ func (s *enableEmptyManagedFoldersTrue) Setup(t *testing.T) {
 func (s *enableEmptyManagedFoldersTrue) Teardown(t *testing.T) {
 	// Clean up test directory.
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForEmptyManagedFoldersTest)
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(bucket, testDir))
 }
 

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -25,8 +25,6 @@ import (
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 
@@ -93,7 +91,7 @@ func TestMain(m *testing.M) {
 		log.Println("Running only dir mounting tests...")
 		setup.SetOnlyDirMounted(onlyDirMounted + "/")
 		client.CreateManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
-		defer operations.DeleteManagedFoldersInBucket(onlyDirMounted, setup.TestBucket())
+		defer client.DeleteManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
 		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
 		successCode = m.Run()
 		setup.SaveLogFileInCaseOfFailure(successCode)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -122,12 +122,12 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), testDir, bucket, t)
 }
 
-func cleanup(ctx context.Context, client *storage.Client, bucket, testDir, serviceAccount, iam_role string, t *testing.T) {
+func cleanup(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, bucket, testDir, serviceAccount, iam_role string, t *testing.T) {
 	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, iam_role, t)
 	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, iam_role, t)
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
-	setup.CleanupDirectoryOnGCS(ctx, client, path.Join(bucket, testDir))
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), setup.TestBucket())
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(bucket, testDir))
 }
 
 func listNonEmptyManagedFolders(t *testing.T) {

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -153,7 +153,7 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	// Create directory structure for testing.
 	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, t)
-	defer cleanup(ctx, storageClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
+	defer cleanup(ctx, storageClient, controlClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
 
 	// Run tests.
 	log.Printf("Running tests with flags and managed folder have nil permissions: %s", flags)


### PR DESCRIPTION
### Description
Replacing operations.DeleteManagedFoldersInBucket with client.DeleteManagedFoldersInBucket (Making calls to the function which uses control client instead of gcloud commands)
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran integration tests on GCE VM
2. Unit tests - NA
3. Integration tests - NA
