### PR TITLE
Replaced gcloud command with control client code in Create/DeleteManagedFoldersInBucket in managed_folders test package 

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -56,7 +56,7 @@ type managedFoldersAdminPermission struct {
 }
 
 func (s *managedFoldersAdminPermission) Setup(t *testing.T) {
-	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, t)
+	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, t)
 	if s.managedFoldersPermission != "nil" {
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFoldersPermission, t)
 		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFoldersPermission, t)

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -229,7 +230,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 		test_setup.RunTests(t, ts)
 	}
 	t.Cleanup(func() {
-		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-		operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
+		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), setup.TestBucket())
+		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), setup.TestBucket())
 	})
 }

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
 
@@ -68,8 +69,8 @@ func createDirectoryStructureForEmptyManagedFoldersTest(t *testing.T) {
 	// testBucket/EmptyManagedFoldersTest/simulatedFolder
 	// testBucket/EmptyManagedFoldersTest/testFile
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForEmptyManagedFoldersTest)
-	operations.CreateManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder1), bucket)
-	operations.CreateManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder2), bucket)
+	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder1), bucket)
+	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), bucket)
 	operations.CreateDirectory(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, SimulatedFolder), t)
 	f := operations.CreateFile(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, File), setup.FilePermission_0600, t)
 	operations.CloseFile(f)

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -54,8 +54,8 @@ func (s *enableEmptyManagedFoldersTrue) Setup(t *testing.T) {
 func (s *enableEmptyManagedFoldersTrue) Teardown(t *testing.T) {
 	// Clean up test directory.
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForEmptyManagedFoldersTest)
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(bucket, testDir))
 }
 

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -25,8 +25,6 @@ import (
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
 
@@ -93,7 +91,7 @@ func TestMain(m *testing.M) {
 		log.Println("Running only dir mounting tests...")
 		setup.SetOnlyDirMounted(onlyDirMounted + "/")
 		client.CreateManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
-		defer operations.DeleteManagedFoldersInBucket(onlyDirMounted, setup.TestBucket())
+		defer client.DeleteManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
 		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
 		successCode = m.Run()
 		setup.SaveLogFileInCaseOfFailure(successCode)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -122,12 +122,12 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), testDir, bucket, t)
 }
 
-func cleanup(ctx context.Context, client *storage.Client, bucket, testDir, serviceAccount, iam_role string, t *testing.T) {
+func cleanup(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, bucket, testDir, serviceAccount, iam_role string, t *testing.T) {
 	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, iam_role, t)
 	revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, iam_role, t)
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), setup.TestBucket())
-	operations.DeleteManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), setup.TestBucket())
-	setup.CleanupDirectoryOnGCS(ctx, client, path.Join(bucket, testDir))
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), setup.TestBucket())
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(bucket, testDir))
 }
 
 func listNonEmptyManagedFolders(t *testing.T) {

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -98,7 +99,7 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
-func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, storageClient *storage.Client, t *testing.T) {
+func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, t *testing.T) {
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1/testFile
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder2
@@ -111,11 +112,11 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	if err != nil {
 		log.Fatalf("Failed to clean up test directory: %v", err)
 	}
-	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder1), bucket)
+	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), bucket)
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
 	defer operations.CloseFile(f)
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(testDir, ManagedFolder1), bucket, t)
-	operations.CreateManagedFoldersInBucket(path.Join(testDir, ManagedFolder2), bucket)
+	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), bucket)
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(testDir, ManagedFolder2), bucket, t)
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(testDir, SimulatedFolderNonEmptyManagedFoldersTest), bucket, t)
 	operations.CopyFileInBucket(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), testDir, bucket, t)

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -153,7 +153,7 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	// Create directory structure for testing.
 	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, t)
-	defer cleanup(ctx, storageClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
+	defer cleanup(ctx, storageClient, controlClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
 
 	// Run tests.
 	log.Printf("Running tests with flags and managed folder have nil permissions: %s", flags)

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -152,7 +152,7 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
 	// Create directory structure for testing.
-	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, t)
+	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, t)
 	defer cleanup(ctx, storageClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
 
 	// Run tests.

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
@@ -37,19 +51,17 @@ func CreateControlClientWithCancel(ctx *context.Context, controlClient **control
 	}
 }
 
-func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) error {
+func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) {
 	folderPath := fmt.Sprintf("projects/_/buckets/%v/managedFolders/%v/", bucket, managedFolderPath)
 	req := &controlpb.DeleteManagedFolderRequest{
 		Name: folderPath,
 	}
 	if err := client.DeleteManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The following URLs matched no objects or files") {
-		log.Fatalf(fmt.Sprintf("Error while deleting managed folder: %v", err))
-		return err
+		log.Fatalf("Error while deleting managed folder: %v", err)
 	}
-	return nil
 }
 
-func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) error {
+func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) {
 	mf := &controlpb.ManagedFolder{}
 	req := &controlpb.CreateManagedFolderRequest{
 		Parent:          fmt.Sprintf("projects/_/buckets/%v", bucket),
@@ -57,8 +69,6 @@ func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 		ManagedFolderId: managedFolderPath,
 	}
 	if _, err := client.CreateManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
-		log.Fatalf(fmt.Sprintf("Error while creating managed folder: %v", err))
-		return err
+		log.Fatalf("Error while creating managed folder: %v", err)
 	}
-	return nil
 }

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -54,7 +54,8 @@ func CreateControlClientWithCancel(ctx *context.Context, controlClient **control
 func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) {
 	folderPath := fmt.Sprintf("projects/_/buckets/%v/managedFolders/%v/", bucket, managedFolderPath)
 	req := &controlpb.DeleteManagedFolderRequest{
-		Name: folderPath,
+		Name:          folderPath,
+		AllowNonEmpty: true,
 	}
 	if err := client.DeleteManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The following URLs matched no objects or files") {
 		log.Fatalf("Error while deleting managed folder: %v", err)

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	control "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+func CreateControlClient(ctx context.Context) (client *control.StorageControlClient, err error) {
+	client, err = control.NewStorageControlClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("control.NewStorageControlClient: #{err}")
+	}
+	return client, nil
+}
+
+func CreateControlClientWithCancel(ctx *context.Context, controlClient **control.StorageControlClient) func() error {
+	var err error
+	var cancel context.CancelFunc
+	*ctx, cancel = context.WithCancel(*ctx)
+	*controlClient, err = CreateControlClient(*ctx)
+	if err != nil {
+		log.Fatalf("client.CreateControlClient: %v", err)
+	}
+	// Return func to close storage client and release resources.
+	return func() error {
+		err := (*controlClient).Close()
+		if err != nil {
+			return fmt.Errorf("failed to close control client: %v", err)
+		}
+		defer cancel()
+		return nil
+	}
+}
+
+func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) error {
+	folderPath := fmt.Sprintf("projects/_/buckets/%v/managedFolders/%v/", bucket, managedFolderPath)
+	req := &controlpb.DeleteManagedFolderRequest{
+		Name: folderPath,
+	}
+	if err := client.DeleteManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The following URLs matched no objects or files") {
+		log.Fatalf(fmt.Sprintf("Error while deleting managed folder: %v", err))
+		return err
+	}
+	return nil
+}
+
+func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) error {
+	mf := &controlpb.ManagedFolder{}
+	req := &controlpb.CreateManagedFolderRequest{
+		Parent:          fmt.Sprintf("projects/_/buckets/%v", bucket),
+		ManagedFolder:   mf,
+		ManagedFolderId: managedFolderPath,
+	}
+	if _, err := client.CreateManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
+		log.Fatalf(fmt.Sprintf("Error while creating managed folder: %v", err))
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### Description
Replaced gcloud command in helper function in  managed folders test package, using control client to :
1.  DeleteManagedFoldersinBucket
2. CreateManagedFoldersinBucket
Motivation:  gcloud commands can't be run concurrently as part of parallelizing CD tests.Thus, needs to be replaced.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran integration tests on GCE VM
3. Unit tests - NA
4. Integration tests - NA
