### PR TITLE
Fix e2e test

### DIFF
--- a/tools/integration_tests/rename_dir_limit/rename_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_test.go
@@ -170,7 +170,8 @@ func TestRenameDirectoryWithExistingEmptyDestDirectory(t *testing.T) {
 	// testBucket/dirForRenameDirLimitTests/srcDirectory                                      -- Dir
 	// testBucket/dirForRenameDirLimitTests/srcDirectory/temp1.txt                            -- File
 	// testBucket/dirForRenameDirLimitTests/srcDirectory/NonEmptySubDirectory                 -- Dir
-	// testBucket/dirForRenameDirLimitTests/srcDirectory/NonEmptySubDirectory/temp3.txt   		 -- File
+	// testBucket/dirForRenameDirLimitTests/srcDirectory/NonEmptySubDirectory/temp3.txt   		-- File
+	// testBucket/dirForRenameDirLimitTests/emptyDestDirectory   		 													-- Dir
 	oldDirPath := path.Join(testDir, SrcDirectory)
 	subDirPath := path.Join(oldDirPath, NonEmptySubDirectory)
 	operations.CreateDirectoryWithNFiles(1, oldDirPath, PrefixTempFile, t)
@@ -180,7 +181,7 @@ func TestRenameDirectoryWithExistingEmptyDestDirectory(t *testing.T) {
 
 	// Go's Rename function does not support renaming a directory into an existing empty directory.
 	// To achieve this, we call a Python rename function as a workaround.
-	cmd := exec.Command("python", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
+	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
 	_, err := cmd.CombinedOutput()
 
 	assert.NoError(t, err)

--- a/tools/integration_tests/rename_dir_limit/rename_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_test.go
@@ -185,6 +185,8 @@ func TestRenameDirectoryWithExistingEmptyDestDirectory(t *testing.T) {
 	_, err := cmd.CombinedOutput()
 
 	assert.NoError(t, err)
+	_, err = os.Stat(oldDirPath)
+	assert.ErrorContains(t, err, "no such file or directory")
 	_, err = os.Stat(newDirPath)
 	assert.NoError(t, err)
 	dirEntries, err := os.ReadDir(newDirPath)

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -139,9 +139,7 @@ function install_packages() {
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
   sudo apt-get install -y python3
-  export PATH=$PATH:/usr/local/python3/bin
-  echo "Python3 path"
-  which python3
+  export PATH=$PATH:/usr/bin/python3
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -139,7 +139,6 @@ function install_packages() {
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
   sudo apt-get install -y python3
-  export PATH=$PATH:/usr/bin/python3
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -139,6 +139,9 @@ function install_packages() {
   sudo rm -rf /usr/local/go && tar -xzf go_tar.tar.gz && sudo mv go /usr/local
   export PATH=$PATH:/usr/local/go/bin
   sudo apt-get install -y python3
+  export PATH=$PATH:/usr/local/python3/bin
+  echo "Python3 path"
+  which python3
   # install python3-setuptools tools.
   sudo apt-get install -y gcc python3-dev python3-setuptools
   # Downloading composite object requires integrity checking with CRC32c in gsutil.


### PR DESCRIPTION
### Description
We are getting this error exec: "python": executable file not found in $PATH while running e2e tests in periodically due to newly added test which uses python library. Fixing it by using python3 instead of python while running tests.
- Small fixes to stat directory after renaming not exist.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
