### PR TITLE
[HNS test fix] change python to python3

### DIFF
--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -227,7 +227,7 @@ func (t *HNSBucketTests) TestRenameFolderWithExistingEmptyDestDirectory() {
 
 	// Go's Rename function does not support renaming a directory into an existing empty directory.
 	// To achieve this, we call a Python rename function as a workaround.
-	cmd := exec.Command("python", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
+	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
 	_, err = cmd.CombinedOutput()
 
 	assert.NoError(t.T(), err)


### PR DESCRIPTION
### Description
Test fail on local machine due to python not being present in $PATH. Changed to python3 instead as it is more likely to be present in the machine.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
