### PR TITLE
[Buffered Writes] bucket interface changes for buffered writes part 2

### DIFF
--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -57,3 +57,13 @@ func (b contentTypeBucket) ComposeObjects(
 	o, err = b.Bucket.ComposeObjects(ctx, req)
 	return
 }
+
+func (b contentTypeBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
+	// Guess a content type if necessary.
+	if req.ContentType == "" {
+		req.ContentType = mime.TypeByExtension(path.Ext(req.Name))
+	}
+
+	// Pass on the request.
+	return b.Bucket.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
+}

--- a/internal/gcsx/content_type_bucket_test.go
+++ b/internal/gcsx/content_type_bucket_test.go
@@ -104,6 +104,31 @@ func TestContentTypeBucket_CreateObject(t *testing.T) {
 	}
 }
 
+func TestContentTypeBucket_CreateObjectChunkWriter(t *testing.T) {
+	for i, tc := range contentTypeBucketTestCases {
+		// Set up a bucket.
+		bucket := gcsx.NewContentTypeBucket(
+			fake.NewFakeBucket(timeutil.RealClock(), "", gcs.NonHierarchical))
+
+		// Create the object.
+		req := &gcs.CreateObjectRequest{
+			Name:        tc.name,
+			ContentType: tc.request,
+		}
+
+		w, err := bucket.CreateObjectChunkWriter(context.Background(), req, 0, func(_ int64) {})
+		if err != nil {
+			t.Fatalf("Test case %d: CreateObjectChunkWriter: %v", i, err)
+		}
+
+		// Check the content type.
+		writerImpl := w.(*fake.FakeObjectWriter)
+		if got, want := writerImpl.ContentType, tc.expected; got != want {
+			t.Errorf("Test case %d: o.ContentType is %q, want %q", i, got, want)
+		}
+	}
+}
+
 func TestContentTypeBucket_ComposeObjects(t *testing.T) {
 	var err error
 	ctx := context.Background()

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -98,13 +98,26 @@ func (b *prefixBucket) CreateObject(
 }
 
 func (b *prefixBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
-	// TODO: will be implemented in subsequent PR.
-	return nil, nil
+	// Modify the request and call through.
+	mReq := new(gcs.CreateObjectRequest)
+	*mReq = *req
+	mReq.Name = b.wrappedName(req.Name)
+
+	wc, err := b.wrapped.CreateObjectChunkWriter(ctx, mReq, chunkSize, callBack)
+	if err != nil {
+		return nil, err
+	}
+
+	return wc, err
 }
 
 func (b *prefixBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.Object, err error) {
-	// TODO: will be implemented in subsequent PR.
-	return nil, nil
+	o, err = b.wrapped.FinalizeUpload(ctx, w)
+	// Modify the returned object.
+	if o != nil {
+		o.Name = b.localName(o.Name)
+	}
+	return
 }
 
 func (b *prefixBucket) CopyObject(

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -672,8 +672,8 @@ func (b *bucket) CreateObject(
 	return
 }
 
-func (b *bucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
-	return NewFakeObjectWriter(b, req, chunkSize, callBack)
+func (b *bucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, _ int, _ func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
+	return NewFakeObjectWriter(b, req)
 }
 
 func (b *bucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.Object, error) {

--- a/internal/storage/fake/fake_object_writer.go
+++ b/internal/storage/fake/fake_object_writer.go
@@ -32,11 +32,9 @@ type FakeObjectWriter struct {
 	io.WriteCloser
 	buf bytes.Buffer
 	storage.ObjectAttrs
-	ChunkSize    int
-	ProgressFunc func(_ int64)
-	bkt          *bucket
-	req          *gcs.CreateObjectRequest
-	Object       *gcs.Object // Object created by writer
+	bkt    *bucket
+	req    *gcs.CreateObjectRequest
+	Object *gcs.Object // Object created by writer
 }
 
 func (w *FakeObjectWriter) Write(p []byte) (n int, err error) {
@@ -66,7 +64,7 @@ func (w *FakeObjectWriter) Attrs() *storage.ObjectAttrs {
 	return &w.ObjectAttrs
 }
 
-func NewFakeObjectWriter(b *bucket, req *gcs.CreateObjectRequest, chunkSize int, callback func(int64)) (w gcs.Writer, err error) {
+func NewFakeObjectWriter(b *bucket, req *gcs.CreateObjectRequest) (w gcs.Writer, err error) {
 	// Check that the name is legal.
 	err = checkName(req.Name)
 	if err != nil {
@@ -74,11 +72,9 @@ func NewFakeObjectWriter(b *bucket, req *gcs.CreateObjectRequest, chunkSize int,
 	}
 
 	wr := &FakeObjectWriter{
-		buf:          bytes.Buffer{},
-		bkt:          b,
-		req:          req,
-		ChunkSize:    chunkSize,
-		ProgressFunc: callback,
+		buf: bytes.Buffer{},
+		bkt: b,
+		req: req,
 		ObjectAttrs: storage.ObjectAttrs{
 			Name: req.Name,
 		},

--- a/internal/storage/fake/fake_object_writer.go
+++ b/internal/storage/fake/fake_object_writer.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For now, we are not writing the unit test, which requires multiple
+// version of same object. As this is not supported by fake-storage-server.
+// Although API is exposed to enable the object versioning for a bucket,
+// but it returns "method not allowed" when we call it.
+
+package fake
+
+import (
+	"bytes"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+)
+
+// FakeObjectWriter is a mock implementation of storage.Writer used by FakeBucket.
+type FakeObjectWriter struct {
+	io.WriteCloser
+	buf bytes.Buffer
+	storage.ObjectAttrs
+	ChunkSize    int
+	ProgressFunc func(_ int64)
+	bkt          *bucket
+	req          *gcs.CreateObjectRequest
+	Object       *gcs.Object // Object created by writer
+}
+
+func (w *FakeObjectWriter) Write(p []byte) (n int, err error) {
+	return w.buf.Write(p)
+}
+
+func (w *FakeObjectWriter) Close() error {
+	contents := w.buf.Bytes()
+
+	// Validate for preconditions.
+	if err := preconditionChecks(w.bkt, w.req, contents); err != nil {
+		return err
+	}
+
+	o, err := createOrUpdateFakeObject(w.bkt, w.req, contents)
+	if err == nil {
+		w.Object = o
+	}
+
+	return err
+}
+
+func (w *FakeObjectWriter) ObjectName() string {
+	return w.Name
+}
+func (w *FakeObjectWriter) Attrs() *storage.ObjectAttrs {
+	return &w.ObjectAttrs
+}
+
+func NewFakeObjectWriter(b *bucket, req *gcs.CreateObjectRequest, chunkSize int, callback func(int64)) (w gcs.Writer, err error) {
+	// Check that the name is legal.
+	err = checkName(req.Name)
+	if err != nil {
+		return
+	}
+
+	wr := &FakeObjectWriter{
+		buf:          bytes.Buffer{},
+		bkt:          b,
+		req:          req,
+		ChunkSize:    chunkSize,
+		ProgressFunc: callback,
+		ObjectAttrs: storage.ObjectAttrs{
+			Name: req.Name,
+		},
+	}
+	wr.ContentType = req.ContentType
+
+	return wr, nil
+}


### PR DESCRIPTION
This PR implements the following methods for fake bucket, prefix bucket and and content type bucket:
- CreateObjectChunkWriter()
- FinalizeUpload()

This PR builds on top of PR #2597

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
