### PR TITLE
feat: support to retry for stalled read request

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -107,7 +107,6 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	return fmt.Sprintf("%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled)
 }
 func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle storage.StorageHandle, err error) {
-	readStallRetryConfig := newConfig.GcsRetries.ReadStall
 	storageClientConfig := storageutil.StorageClientConfig{
 		ClientProtocol:             newConfig.GcsConnection.ClientProtocol,
 		MaxConnsPerHost:            int(newConfig.GcsConnection.MaxConnsPerHost),
@@ -125,12 +124,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle
 		ExperimentalEnableJsonRead: newConfig.GcsConnection.ExperimentalEnableJsonRead,
 		GrpcConnPoolSize:           int(newConfig.GcsConnection.GrpcConnPoolSize),
 		EnableHNS:                  newConfig.EnableHns,
-		EnableReadStallRetry:       readStallRetryConfig.Enable,
-		InitialReqTimeout:          readStallRetryConfig.InitialReqTimeout,
-		MaxReqTimeout:              readStallRetryConfig.MaxReqTimeout,
-		MinReqTimeout:              readStallRetryConfig.MinReqTimeout,
-		ReqIncreaseRate:            readStallRetryConfig.ReqIncreaseRate,
-		ReqTargetPercentile:        readStallRetryConfig.ReqTargetPercentile,
+		ReadStallRetryConfig:       newConfig.GcsRetries.ReadStall,
 	}
 	logger.Infof("UserAgent = %s\n", storageClientConfig.UserAgent)
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -107,6 +107,7 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	return fmt.Sprintf("%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled)
 }
 func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle storage.StorageHandle, err error) {
+	readStallRetryConfig := newConfig.GcsRetries.ReadStall
 	storageClientConfig := storageutil.StorageClientConfig{
 		ClientProtocol:             newConfig.GcsConnection.ClientProtocol,
 		MaxConnsPerHost:            int(newConfig.GcsConnection.MaxConnsPerHost),
@@ -124,6 +125,12 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle
 		ExperimentalEnableJsonRead: newConfig.GcsConnection.ExperimentalEnableJsonRead,
 		GrpcConnPoolSize:           int(newConfig.GcsConnection.GrpcConnPoolSize),
 		EnableHNS:                  newConfig.EnableHns,
+		EnableReadStallRetry:       readStallRetryConfig.Enable,
+		InitialReqTimeout:          readStallRetryConfig.InitialReqTimeout,
+		MaxReqTimeout:              readStallRetryConfig.MaxReqTimeout,
+		MinReqTimeout:              readStallRetryConfig.MinReqTimeout,
+		ReqIncreaseRate:            readStallRetryConfig.ReqIncreaseRate,
+		ReqTargetPercentile:        readStallRetryConfig.ReqTargetPercentile,
 	}
 	logger.Infof("UserAgent = %s\n", storageClientConfig.UserAgent)
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	// Used to modify the hidden options in go-sdk for read stall retry.
+	// Ref: http://shortn/_DIoIm9dDT3
 	dynamicReadReqIncreaseRateEnv   = "DYNAMIC_READ_REQ_INCREASE_RATE"
 	dynamicReadReqInitialTimeoutEnv = "DYNAMIC_READ_REQ_INITIAL_TIMEOUT"
 )
@@ -169,7 +170,6 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 			TargetPercentile: clientConfig.ReqTargetPercentile,
 		}))
 	}
-
 	return storage.NewClient(ctx, clientOpts...)
 }
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// Used to modify the hidden options in go-sdk for read stall retry.
-	// Ref: http://shortn/_DIoIm9dDT3
+	// Ref: https://github.com/googleapis/google-cloud-go/blob/main/storage/option.go#L30
 	dynamicReadReqIncreaseRateEnv   = "DYNAMIC_READ_REQ_INCREASE_RATE"
 	dynamicReadReqInitialTimeoutEnv = "DYNAMIC_READ_REQ_INITIAL_TIMEOUT"
 )
@@ -155,7 +155,7 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	if clientConfig.ReadStallRetryConfig.Enable {
 		// Hidden way to modify the increase rate for dynamic delay algorithm in go-sdk.
-		// Ref: http://shortn/_417eTbNbKK
+		// Ref: https://github.com/googleapis/google-cloud-go/blob/main/storage/option.go#L47
 		// Temporarily we kept an option to change the increase-rate, will be removed
 		// once we get a good default.
 		err = os.Setenv(dynamicReadReqIncreaseRateEnv, strconv.FormatFloat(clientConfig.ReadStallRetryConfig.ReqIncreaseRate, 'f', -1, 64))
@@ -164,7 +164,7 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		}
 
 		// Hidden way to modify the initial-timeout of the dynamic delay algorithm in go-sdk.
-		// Ref: http://shortn/_xArUKvvGQZ
+		// Ref: https://github.com/googleapis/google-cloud-go/blob/main/storage/option.go#L62
 		// Temporarily we kept an option to change the initial-timeout, will be removed
 		// once we get a good default.
 		err = os.Setenv(dynamicReadReqInitialTimeoutEnv, clientConfig.ReadStallRetryConfig.InitialReqTimeout.String())

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -153,12 +153,12 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		clientOpts = append(clientOpts, option.WithEndpoint(clientConfig.CustomEndpoint))
 	}
 
-	if clientConfig.EnableReadStallRetry {
+	if clientConfig.ReadStallRetryConfig.Enable {
 		// Hidden way to modify the increase rate for dynamic delay algorithm in go-sdk.
 		// Ref: http://shortn/_417eTbNbKK
 		// Temporarily we kept an option to change the increase-rate, will be removed
 		// once we get a good default.
-		err = os.Setenv(dynamicReadReqIncreaseRateEnv, strconv.FormatFloat(clientConfig.ReqIncreaseRate, 'f', -1, 64))
+		err = os.Setenv(dynamicReadReqIncreaseRateEnv, strconv.FormatFloat(clientConfig.ReadStallRetryConfig.ReqIncreaseRate, 'f', -1, 64))
 		if err != nil {
 			logger.Warnf("Error while setting the env %s: %v", dynamicReadReqIncreaseRateEnv, err)
 		}
@@ -167,13 +167,13 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		// Ref: http://shortn/_xArUKvvGQZ
 		// Temporarily we kept an option to change the initial-timeout, will be removed
 		// once we get a good default.
-		err = os.Setenv(dynamicReadReqInitialTimeoutEnv, clientConfig.InitialReqTimeout.String())
+		err = os.Setenv(dynamicReadReqInitialTimeoutEnv, clientConfig.ReadStallRetryConfig.InitialReqTimeout.String())
 		if err != nil {
 			logger.Warnf("Error while setting the env %s: %v", dynamicReadReqInitialTimeoutEnv, err)
 		}
 		clientOpts = append(clientOpts, experimental.WithReadStallTimeout(&experimental.ReadStallTimeoutConfig{
-			Min:              clientConfig.MinReqTimeout,
-			TargetPercentile: clientConfig.ReqTargetPercentile,
+			Min:              clientConfig.ReadStallRetryConfig.MinReqTimeout,
+			TargetPercentile: clientConfig.ReadStallRetryConfig.ReqTargetPercentile,
 		}))
 	}
 	return storage.NewClient(ctx, clientOpts...)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -158,13 +158,19 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		// Ref: http://shortn/_417eTbNbKK
 		// Temporarily we kept an option to change the increase-rate, will be removed
 		// once we get a good default.
-		os.Setenv(dynamicReadReqIncreaseRateEnv, strconv.FormatFloat(clientConfig.ReqIncreaseRate, 'f', -1, 64))
+		err = os.Setenv(dynamicReadReqIncreaseRateEnv, strconv.FormatFloat(clientConfig.ReqIncreaseRate, 'f', -1, 64))
+		if err != nil {
+			logger.Warnf("Error while setting the env %s: %v", dynamicReadReqIncreaseRateEnv, err)
+		}
 
 		// Hidden way to modify the initial-timeout of the dynamic delay algorithm in go-sdk.
 		// Ref: http://shortn/_xArUKvvGQZ
 		// Temporarily we kept an option to change the initial-timeout, will be removed
 		// once we get a good default.
-		os.Setenv(dynamicReadReqInitialTimeoutEnv, clientConfig.InitialReqTimeout.String())
+		err = os.Setenv(dynamicReadReqInitialTimeoutEnv, clientConfig.InitialReqTimeout.String())
+		if err != nil {
+			logger.Warnf("Error while setting the env %s: %v", dynamicReadReqInitialTimeoutEnv, err)
+		}
 		clientOpts = append(clientOpts, experimental.WithReadStallTimeout(&experimental.ReadStallTimeoutConfig{
 			Min:              clientConfig.MinReqTimeout,
 			TargetPercentile: clientConfig.ReqTargetPercentile,

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -254,16 +254,6 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithGRPCClientPro
 	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not HTTP1 or HTTP2: %s", cfg.GRPC))
 }
 
-func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetryEnabled() {
-	sc := storageutil.GetDefaultStorageClientConfig()
-	sc.EnableReadStallRetry = true
-
-	storageClient, err := createHTTPClientHandle(context.Background(), &sc)
-
-	assert.NotNil(testSuite.T(), err)
-	assert.Nil(testSuite.T(), storageClient)
-}
-
 func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetry() {
 	testCases := []struct {
 		name                 string
@@ -292,7 +282,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetr
 	}
 }
 
-func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_InitialReqTimeout() {
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallInitialReqTimeout() {
 	testCases := []struct {
 		name              string
 		initialReqTimeout time.Duration
@@ -321,18 +311,18 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_InitialReqTimeout
 	}
 }
 
-func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_MinReqTimeout() {
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallMinReqTimeout() {
 	testCases := []struct {
-		name              string
-		initialReqTimeout time.Duration
+		name          string
+		minReqTimeout time.Duration
 	}{
 		{
-			name:              "ShortTimeout",
-			initialReqTimeout: 1 * time.Millisecond,
+			name:          "ShortTimeout",
+			minReqTimeout: 1 * time.Millisecond,
 		},
 		{
-			name:              "LongTimeout",
-			initialReqTimeout: 10 * time.Second,
+			name:          "LongTimeout",
+			minReqTimeout: 10 * time.Second,
 		},
 	}
 
@@ -340,7 +330,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_MinReqTimeout() {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
 			sc.EnableReadStallRetry = true
-			sc.MinReqTimeout = tc.initialReqTimeout
+			sc.MinReqTimeout = tc.minReqTimeout
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
@@ -350,7 +340,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_MinReqTimeout() {
 	}
 }
 
-func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReqIncreaseRate() {
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqIncreaseRate() {
 	testCases := []struct {
 		name            string
 		reqIncreaseRate float64
@@ -392,7 +382,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReqIncreaseRate()
 	}
 }
 
-func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_TargetPercentile() {
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqTargetPercentile() {
 	testCases := []struct {
 		name                string
 		reqTargetPercentile float64

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -373,7 +373,6 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqIncre
 
 			if tc.expectErr {
 				assert.NotNil(testSuite.T(), err)
-				assert.Nil(testSuite.T(), storageClient)
 			} else {
 				assert.Nil(testSuite.T(), err)
 				assert.NotNil(testSuite.T(), storageClient)
@@ -425,7 +424,6 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqTarge
 
 			if tc.expectErr {
 				assert.NotNil(testSuite.T(), err)
-				assert.Nil(testSuite.T(), storageClient)
 			} else {
 				assert.Nil(testSuite.T(), err)
 				assert.NotNil(testSuite.T(), storageClient)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -251,6 +252,196 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithGRPCClientPro
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), storageClient)
 	assert.Contains(testSuite.T(), err.Error(), fmt.Sprintf("client-protocol requested is not HTTP1 or HTTP2: %s", cfg.GRPC))
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetryEnabled() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.EnableReadStallRetry = true
+
+	storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+	assert.NotNil(testSuite.T(), err)
+	assert.Nil(testSuite.T(), storageClient)
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetry() {
+	testCases := []struct {
+		name                 string
+		enableReadStallRetry bool
+	}{
+		{
+			name:                 "ReadStallRetryEnabled",
+			enableReadStallRetry: true,
+		},
+		{
+			name:                 "ReadStallRetryDisabled",
+			enableReadStallRetry: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			sc := storageutil.GetDefaultStorageClientConfig()
+			sc.EnableReadStallRetry = tc.enableReadStallRetry
+
+			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+			assert.Nil(testSuite.T(), err)
+			assert.NotNil(testSuite.T(), storageClient)
+		})
+	}
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_InitialReqTimeout() {
+	testCases := []struct {
+		name              string
+		initialReqTimeout time.Duration
+	}{
+		{
+			name:              "ShortTimeout",
+			initialReqTimeout: 1 * time.Millisecond,
+		},
+		{
+			name:              "LongTimeout",
+			initialReqTimeout: 10 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			sc := storageutil.GetDefaultStorageClientConfig()
+			sc.EnableReadStallRetry = true
+			sc.InitialReqTimeout = tc.initialReqTimeout
+
+			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+			assert.Nil(testSuite.T(), err)
+			assert.NotNil(testSuite.T(), storageClient)
+		})
+	}
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_MinReqTimeout() {
+	testCases := []struct {
+		name              string
+		initialReqTimeout time.Duration
+	}{
+		{
+			name:              "ShortTimeout",
+			initialReqTimeout: 1 * time.Millisecond,
+		},
+		{
+			name:              "LongTimeout",
+			initialReqTimeout: 10 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			sc := storageutil.GetDefaultStorageClientConfig()
+			sc.EnableReadStallRetry = true
+			sc.MinReqTimeout = tc.initialReqTimeout
+
+			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+			assert.Nil(testSuite.T(), err)
+			assert.NotNil(testSuite.T(), storageClient)
+		})
+	}
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReqIncreaseRate() {
+	testCases := []struct {
+		name            string
+		reqIncreaseRate float64
+		expectErr       bool
+	}{
+		{
+			name:            "NegativeRate",
+			reqIncreaseRate: -0.5,
+			expectErr:       true,
+		},
+		{
+			name:            "ZeroRate",
+			reqIncreaseRate: 0.0,
+			expectErr:       true,
+		},
+		{
+			name:            "PositiveRate",
+			reqIncreaseRate: 1.5,
+			expectErr:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			sc := storageutil.GetDefaultStorageClientConfig()
+			sc.EnableReadStallRetry = true
+			sc.ReqIncreaseRate = tc.reqIncreaseRate
+
+			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+			if tc.expectErr {
+				assert.NotNil(testSuite.T(), err)
+				assert.Nil(testSuite.T(), storageClient)
+			} else {
+				assert.Nil(testSuite.T(), err)
+				assert.NotNil(testSuite.T(), storageClient)
+			}
+		})
+	}
+}
+
+func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_TargetPercentile() {
+	testCases := []struct {
+		name                string
+		reqTargetPercentile float64
+		expectErr           bool
+	}{
+		{
+			name:                "LowPercentile",
+			reqTargetPercentile: 0.25, // 25th percentile
+			expectErr:           false,
+		},
+		{
+			name:                "MidPercentile",
+			reqTargetPercentile: 0.50, // 50th percentile
+			expectErr:           false,
+		},
+		{
+			name:                "HighPercentile",
+			reqTargetPercentile: 0.90, // 90th percentile
+			expectErr:           false,
+		},
+		{
+			name:                "InvalidPercentile-Low",
+			reqTargetPercentile: -0.5, // Invalid percentile
+			expectErr:           true,
+		},
+		{
+			name:                "InvalidPercentile-High",
+			reqTargetPercentile: 1.5, // Invalid percentile
+			expectErr:           true,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			sc := storageutil.GetDefaultStorageClientConfig()
+			sc.EnableReadStallRetry = true
+			sc.ReqTargetPercentile = tc.reqTargetPercentile
+
+			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+
+			if tc.expectErr {
+				assert.NotNil(testSuite.T(), err)
+				assert.Nil(testSuite.T(), storageClient)
+			} else {
+				assert.Nil(testSuite.T(), err)
+				assert.NotNil(testSuite.T(), storageClient)
+			}
+		})
+	}
 }
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustomEndpointNilAndAuthEnabled() {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -272,7 +272,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetr
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
-			sc.EnableReadStallRetry = tc.enableReadStallRetry
+			sc.ReadStallRetryConfig.Enable = tc.enableReadStallRetry
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
@@ -300,8 +300,8 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallInitialR
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
-			sc.EnableReadStallRetry = true
-			sc.InitialReqTimeout = tc.initialReqTimeout
+			sc.ReadStallRetryConfig.Enable = true
+			sc.ReadStallRetryConfig.InitialReqTimeout = tc.initialReqTimeout
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
@@ -329,8 +329,8 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallMinReqTi
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
-			sc.EnableReadStallRetry = true
-			sc.MinReqTimeout = tc.minReqTimeout
+			sc.ReadStallRetryConfig.Enable = true
+			sc.ReadStallRetryConfig.MinReqTimeout = tc.minReqTimeout
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
@@ -366,8 +366,8 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqIncre
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
-			sc.EnableReadStallRetry = true
-			sc.ReqIncreaseRate = tc.reqIncreaseRate
+			sc.ReadStallRetryConfig.Enable = true
+			sc.ReadStallRetryConfig.ReqIncreaseRate = tc.reqIncreaseRate
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 
@@ -418,8 +418,8 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqTarge
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
 			sc := storageutil.GetDefaultStorageClientConfig()
-			sc.EnableReadStallRetry = true
-			sc.ReqTargetPercentile = tc.reqTargetPercentile
+			sc.ReadStallRetryConfig.Enable = true
+			sc.ReadStallRetryConfig.ReqTargetPercentile = tc.reqTargetPercentile
 
 			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -56,13 +56,7 @@ type StorageClientConfig struct {
 	// Enabling new API flow for HNS bucket.
 	EnableHNS bool
 
-	// Parameters to define retry behavior for stalled read.
-	EnableReadStallRetry bool
-	InitialReqTimeout    time.Duration
-	MaxReqTimeout        time.Duration
-	MinReqTimeout        time.Duration
-	ReqIncreaseRate      float64
-	ReqTargetPercentile  float64
+	ReadStallRetryConfig cfg.ReadStallGcsRetriesConfig
 }
 
 func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *http.Client, err error) {

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -55,6 +55,14 @@ type StorageClientConfig struct {
 
 	// Enabling new API flow for HNS bucket.
 	EnableHNS bool
+
+	// Parameters to define retry behavior for stalled read.
+	EnableReadStallRetry bool
+	InitialReqTimeout    time.Duration
+	MaxReqTimeout        time.Duration
+	MinReqTimeout        time.Duration
+	ReqIncreaseRate      float64
+	ReqTargetPercentile  float64
 }
 
 func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *http.Client, err error) {

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -42,11 +42,13 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		ExperimentalEnableJsonRead: false,
 		AnonymousAccess:            true,
 		EnableHNS:                  false,
-		EnableReadStallRetry:       false,
-		InitialReqTimeout:          20 * time.Second,
-		MaxReqTimeout:              120 * time.Hour,
-		MinReqTimeout:              500 * time.Millisecond,
-		ReqIncreaseRate:            15,
-		ReqTargetPercentile:        0.99,
+		ReadStallRetryConfig: cfg.ReadStallGcsRetriesConfig{
+			Enable:              false,
+			InitialReqTimeout:   20 * time.Second,
+			MaxReqTimeout:       1200 * time.Second,
+			MinReqTimeout:       500 * time.Millisecond,
+			ReqIncreaseRate:     15,
+			ReqTargetPercentile: 0.99,
+		},
 	}
 }

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -42,5 +42,11 @@ func GetDefaultStorageClientConfig() (clientConfig StorageClientConfig) {
 		ExperimentalEnableJsonRead: false,
 		AnonymousAccess:            true,
 		EnableHNS:                  false,
+		EnableReadStallRetry:       false,
+		InitialReqTimeout:          20 * time.Second,
+		MaxReqTimeout:              120 * time.Hour,
+		MinReqTimeout:              500 * time.Millisecond,
+		ReqIncreaseRate:            15,
+		ReqTargetPercentile:        0.99,
 	}
 }


### PR DESCRIPTION
### Description
- Integrating the go-sdk's read-stall-retry changes: https://pkg.go.dev/cloud.google.com/go/storage@v1.45.0/experimental#WithReadStallTimeout
- Disabled by default.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - NA
