### PR TITLE
Fix flaky managed folder test

### DIFF
--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -78,7 +78,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 
 	f, err := os.CreateTemp(os.TempDir(), "iam-policy-*.json")
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error in creating file for iam-policy : %v", err))
+		t.Fatalf("error in creating file for iam-policy : %v", err)
 	}
 	fileName := path.Join(os.TempDir(), f.Name())
 	defer operations.RemoveFile(fileName)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -76,7 +76,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
 	}
 
-	localIAMPolicyFilePath := path.Join(os.TempDir(), "iam_policy" + setup.GenerateRandomString(5) + ".json")
+	localIAMPolicyFilePath := path.Join(os.TempDir(), "iam_policy-"+setup.GenerateRandomString(5)+".json")
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	err = os.WriteFile(localIAMPolicyFilePath, jsonData, setup.FilePermission_0600)
 	if err != nil {

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -80,15 +80,14 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 	if err != nil {
 		t.Fatalf("error in creating file for iam-policy : %v", err)
 	}
-	fileName := path.Join(os.TempDir(), f.Name())
-	defer operations.RemoveFile(fileName)
+	defer operations.RemoveFile(f.Name())
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	_, err = f.Write(jsonData)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error in writing iam policy in json FileInNonEmptyManagedFoldersTest : %v", err))
 	}
 
-	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders set-iam-policy gs://%s/%s %s", bucket, managedFolderPath, fileName)
+	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders set-iam-policy gs://%s/%s %s", bucket, managedFolderPath, f.Name())
 	_, err = operations.ExecuteGcloudCommandf(gcloudProvidePermissionCmd)
 	if err != nil {
 		t.Fatalf("Error in providing permission to managed folder: %v", err)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -76,18 +76,19 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
 	}
 
-	f, err := os.CreateTemp(os.TempDir(),"iam-policy-*.json")
+	f, err := os.CreateTemp(os.TempDir(), "iam-policy-*.json")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error in creating file for iam-policy : %v", err))
 	}
-	defer operations.RemoveFile(f.Name())
+	fileName := path.Join(os.TempDir(), f.Name())
+	defer operations.RemoveFile(fileName)
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	_, err = f.Write(jsonData)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error in writing iam policy in json FileInNonEmptyManagedFoldersTest : %v", err))
 	}
 
-	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders set-iam-policy gs://%s/%s %s", bucket, managedFolderPath, localIAMPolicyFilePath)
+	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders set-iam-policy gs://%s/%s %s", bucket, managedFolderPath, fileName)
 	_, err = operations.ExecuteGcloudCommandf(gcloudProvidePermissionCmd)
 	if err != nil {
 		t.Fatalf("Error in providing permission to managed folder: %v", err)

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -76,9 +76,13 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
 	}
 
-	localIAMPolicyFilePath := path.Join(os.TempDir(), "iam_policy-"+setup.GenerateRandomString(5)+".json")
+	f, err := os.CreateTemp(os.TempDir(),"iam-policy-*.json")
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("Error in creating file for iam-policy : %v", err))
+	}
+	defer operations.RemoveFile(f.Name())
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
-	err = os.WriteFile(localIAMPolicyFilePath, jsonData, setup.FilePermission_0600)
+	_, err = f.Write(jsonData)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error in writing iam policy in json FileInNonEmptyManagedFoldersTest : %v", err))
 	}

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -76,7 +76,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
 	}
 
-	localIAMPolicyFilePath := path.Join(os.Getenv("HOME"), "iam_policy" + setup.GenerateRandomString(5) + ".json")
+	localIAMPolicyFilePath := path.Join(os.TempDir(), "iam_policy" + setup.GenerateRandomString(5) + ".json")
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	err = os.WriteFile(localIAMPolicyFilePath, jsonData, setup.FilePermission_0600)
 	if err != nil {

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -76,7 +76,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
 	}
 
-	localIAMPolicyFilePath := path.Join(os.Getenv("HOME"), "iam_policy.json")
+	localIAMPolicyFilePath := path.Join(os.Getenv("HOME"), "iam_policy" + setup.GenerateRandomString(5) + ".json")
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	err = os.WriteFile(localIAMPolicyFilePath, jsonData, setup.FilePermission_0600)
 	if err != nil {


### PR DESCRIPTION
### Description
- Created a file in the temporary directory with a random suffix because tests were intermittently failing due to permission overrides during parallelization.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
