### PR TITLE
adding gcs call log for storage layout api

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
@@ -64,15 +65,17 @@ func (bh *bucketHandle) BucketType() gcs.BucketType {
 			bh.bucketType = gcs.NonHierarchical
 			return bh.bucketType
 		}
-
+		startTime := time.Now()
+		logger.Infof("GetStorageLayout <- (%s)", bh.bucketName)
 		storageLayout, err := bh.getStorageLayout()
-
+		duration := time.Since(startTime)
 		// In case bucket does not exist, set type unknown instead of panic.
 		if err != nil {
 			bh.bucketType = gcs.Unknown
 			logger.Errorf("Error returned from GetStorageLayout: %v", err)
 			return bh.bucketType
 		}
+		logger.Infof("GetStorageLayout -> (%s) %v msec", bh.bucketName, duration.Milliseconds())
 
 		hierarchicalNamespace := storageLayout.GetHierarchicalNamespace()
 		if hierarchicalNamespace != nil && hierarchicalNamespace.Enabled {

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -126,16 +126,6 @@ func (b *debugBucket) Name() string {
 }
 
 func (b *debugBucket) BucketType() gcs.BucketType {
-	var err error
-
-	// BucketType internally calls  GetStorageLayout API from control client , hence
-	// logging this as a GetStorageLayout call.
-	id, desc, start := b.startRequest("GetStorageLayout(%q)", b.Name())
-	// In case getStorageLayout call returns error , the bucket type is set to unknown and
-	// underlying method does not panic.Since no error is returned here, gcs call is
-	// logged with error set to nil in this case.
-	defer b.finishRequest(id, desc, start, &err)
-
 	return b.wrapped.BucketType()
 }
 

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -126,6 +126,12 @@ func (b *debugBucket) Name() string {
 }
 
 func (b *debugBucket) BucketType() gcs.BucketType {
+	id, desc, start := b.startRequest("GetStorageLayout(%q)", b.Name())
+	var err error
+	// In case getStorageLayout call returns error , the bucket type is set to unknown and
+	// underlying method does not panic.Since no error is returned here, gcs call is
+	// logged with error set to nil in this case.
+	defer b.finishRequest(id, desc, start, &err)
 	return b.wrapped.BucketType()
 }
 

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -126,12 +126,16 @@ func (b *debugBucket) Name() string {
 }
 
 func (b *debugBucket) BucketType() gcs.BucketType {
-	id, desc, start := b.startRequest("GetStorageLayout(%q)", b.Name())
 	var err error
+
+	// BucketType internally calls  GetStorageLayout API from control client , hence
+	// logging this as a GetStorageLayout call.
+	id, desc, start := b.startRequest("GetStorageLayout(%q)", b.Name())
 	// In case getStorageLayout call returns error , the bucket type is set to unknown and
 	// underlying method does not panic.Since no error is returned here, gcs call is
 	// logged with error set to nil in this case.
 	defer b.finishRequest(id, desc, start, &err)
+
 	return b.wrapped.BucketType()
 }
 


### PR DESCRIPTION
### Description
[Updated]
Since the logging information was incorrect in the previous implementation described below, now we only add a log (at info level) for actual getStorageLayout API call and report the time taken to serve the request.

[Previous implementation detail]
As part of HNS , storage layout API is called, logs for this does not come at TRACE severity unlike other GCS calls. Hence, added the logic for the same so that when log severity is set to TRACE, then storage layout api calls are also logged as gcs calls. 


Any error faced during fetching the bucket type is already logged at error level, and will show up in the logs separately . However, as for the GCS call log, the storage layout api returns with status OK even when error is faced and logged immediately afterwards due to the nature of implementation.

For e.g:
```
{"timestamp":{"seconds":1729840243,"nanos":34938039},"severity":"TRACE","message":"gcs: Req              0x0: <- GetStorageLayout(\"non-existent-bucket\")"}
{"timestamp":{"seconds":1729840243,"nanos":653348262},"severity":"ERROR","message":"Error returned from GetStorageLayout: rpc error: code = NotFound desc = The specified bucket does not exist."}
{"timestamp":{"seconds":1729840243,"nanos":653398322},"severity":"TRACE","message":"gcs: Req              0x0: -> GetStorageLayout(\"non-existent-bucket\") (618.464263ms): OK"}
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - Yes
