### PR TITLE
Fix warning in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.23.2-alpine as builder
+FROM golang:1.23.2-alpine AS builder
 
 RUN apk add git
 


### PR DESCRIPTION
### Description
Dockerfile generates a warning while building saying that the casing is incorrect. Fix that.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the build manually.
2. Unit tests - NA
3. Integration tests - NA
