### PR TITLE
Handle SIGTERM to gracefully unmount

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -395,7 +395,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
-	flagSet.BoolP("handle-sigterm", "", false, "Instructs gcsfuse to handle SIGTERM to gracefully shutdown")
+	flagSet.BoolP("handle-sigterm", "", true, "Instructs gcsfuse to handle SIGTERM to gracefully shutdown")
 
 	if err := flagSet.MarkHidden("handle-sigterm"); err != nil {
 		return err

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -102,6 +102,8 @@ type FileSystemConfig struct {
 
 	Gid int64 `yaml:"gid"`
 
+	HandleSigterm bool `yaml:"handle-sigterm"`
+
 	IgnoreInterrupts bool `yaml:"ignore-interrupts"`
 
 	KernelListCacheTtlSecs int64 `yaml:"kernel-list-cache-ttl-secs"`
@@ -393,6 +395,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
+	flagSet.BoolP("handle-sigterm", "", false, "Instructs gcsfuse to handle SIGTERM to gracefully shutdown")
+
+	if err := flagSet.MarkHidden("handle-sigterm"); err != nil {
+		return err
+	}
+
 	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
 
 	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations. (default: true)")
@@ -677,6 +685,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.gid", flagSet.Lookup("gid")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.handle-sigterm", flagSet.Lookup("handle-sigterm")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -165,6 +165,14 @@
   default: -1
   usage: "GID owner of all inodes."
 
+- config-path: "file-system.handle-sigterm"
+  flag-name: "handle-sigterm"
+  type: "bool"
+  usage: >-
+    Instructs gcsfuse to handle SIGTERM to gracefully shutdown
+  default: false
+  hide-flag: true
+
 - config-path: "file-system.ignore-interrupts"
   flag-name: "ignore-interrupts"
   type: "bool"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -170,7 +170,7 @@
   type: "bool"
   usage: >-
     Instructs gcsfuse to handle SIGTERM to gracefully shutdown
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "file-system.ignore-interrupts"

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -28,6 +28,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/canned"
@@ -53,22 +55,32 @@ const (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-func registerSIGINTHandler(mountPoint string) {
+func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 	// Register for SIGINT.
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
+	signal.Notify(signalChan, unix.SIGINT)
+	if c.FileSystem.HandleSigterm {
+		signal.Notify(signalChan, unix.SIGTERM)
+	}
 
 	// Start a goroutine that will unmount when the signal is received.
 	go func() {
 		for {
-			<-signalChan
-			logger.Info("Received SIGINT, attempting to unmount...")
+			sig := <-signalChan
+			sigName := "undefined"
+			switch sig {
+			case unix.SIGTERM:
+				sigName = "SIGTERM"
+			case unix.SIGINT:
+				sigName = "SIGINT"
+			}
+			logger.Infof("Received %s, attempting to unmount...", sigName)
 
 			err := fuse.Unmount(mountPoint)
 			if err != nil {
-				logger.Errorf("Failed to unmount in response to SIGINT: %v", err)
+				logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
 			} else {
-				logger.Infof("Successfully unmounted in response to SIGINT.")
+				logger.Infof("Successfully unmounted in response to %s.", sigName)
 				return
 			}
 		}
@@ -419,7 +431,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	}
 
 	// Let the user unmount with Ctrl-C (SIGINT).
-	registerSIGINTHandler(mfs.Dir())
+	registerTerminatingSignalHandler(mfs.Dir(), newConfig)
 
 	// Wait for the file system to be unmounted.
 	err = mfs.Join(ctx)

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -58,7 +58,7 @@ const (
 func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 	// Register for SIGINT.
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, unix.SIGINT)
+	signal.Notify(signalChan, os.Interrupt)
 	if c.FileSystem.HandleSigterm {
 		signal.Notify(signalChan, unix.SIGTERM)
 	}
@@ -71,7 +71,7 @@ func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 			switch sig {
 			case unix.SIGTERM:
 				sigName = "SIGTERM"
-			case unix.SIGINT:
+			case os.Interrupt:
 				sigName = "SIGINT"
 			}
 			logger.Infof("Received %s, attempting to unmount...", sigName)


### PR DESCRIPTION
SIGTERM is a termination signal that's sent by system (like SIGINT is sent by user). For instance, `docker stop` command uses it to give the container a chance to gracefully terminate.
Handle it to gracefully unmount GCSFuse.

### Description

### Link to the issue in case of a bug fix.
b/376174285

### Testing details
1. Manual - Tested with and without flag
2. Unit tests - NA
3. Integration tests - NA
