### PR TITLE
Add label automated tests for package building

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -123,5 +123,5 @@ then
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   echo "Running package build tests...."
-  ./perfmetrics/scripts/build_and_install_gcsfuse.sh "xxxx"
+  ./perfmetrics/scripts/build_and_install_gcsfuse.sh master
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -123,6 +123,5 @@ then
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   echo "Running package build tests...."
-  # $1 argument is refering to value of testInstalledPackage.
   ./perfmetrics/scripts/build_and_install_gcsfuse.sh master
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -16,6 +16,7 @@
 # Running test only for when PR contains execute-perf-test or execute-integration-tests label
 readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
+readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
 readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
 readonly BUCKET_LOCATION=us-west1
@@ -27,10 +28,12 @@ readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=true
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
 integrationTests=$(grep "$EXECUTE_INTEGRATION_TEST_LABEL" pr.json)
+packageBuildTests=$(grep "$EXECUTE_PACKAGE_BUILD_TEST_LABEL" pr.json)
 rm pr.json
 perfTestStr="$perfTest"
 integrationTestsStr="$integrationTests"
-if [[ "$perfTestStr" != *"$EXECUTE_PERF_TEST_LABEL"*  &&  "$integrationTestsStr" != *"$EXECUTE_INTEGRATION_TEST_LABEL"* ]]
+packageBuildTestsStr="$packageBuildTests"
+if [[ "$perfTestStr" != *"$EXECUTE_PERF_TEST_LABEL"*  &&  "$integrationTestsStr" != *"$EXECUTE_INTEGRATION_TEST_LABEL"*  && "$packageBuildTestsStr" != *"$EXECUTE_PACKAGE_BUILD_TEST_LABEL"* ]]
 then
   echo "No need to execute tests"
   exit 0
@@ -111,4 +114,15 @@ then
   echo "Running e2e tests...."
   # $1 argument is refering to value of testInstalledPackage.
   ./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG
+fi
+
+# Execute package build tests.
+if [[ "$packageBuildTestsStr" == *"$EXECUTE_PACKAGE_BUILD_TEST_LABEL"* ]];
+then
+  echo checkout PR branch
+  git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
+
+  echo "Running package build tests...."
+  # $1 argument is refering to value of testInstalledPackage.
+  ./perfmetrics/scripts/build_and_install_gcsfuse.sh master
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -123,5 +123,5 @@ then
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   echo "Running package build tests...."
-  ./perfmetrics/scripts/build_and_install_gcsfuse.sh master
+  ./perfmetrics/scripts/build_and_install_gcsfuse.sh "xxxx"
 fi


### PR DESCRIPTION
### Description
Adding label for automating package build tests as a part of CI.
1. It will execute [build_and_install_gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/perfmetrics/scripts/build_and_install_gcsfuse.sh) script.
2. [execute-package-build-tests](https://github.com/GoogleCloudPlatform/gcsfuse/labels/execute-package-build-tests) label need to attach to test.

**Motivation:**
- Reduce the toil while upgrading the gem dependency.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
4. Unit tests - NA
5. Integration tests - NA
6. Package build - Success
