### PR TITLE
Add cloud-metrics-export-interval-secs flag

### DIFF
--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -543,6 +543,12 @@
   usage: "Max size of type-cache maps which are maintained at a per-directory level."
   default: "4"
 
+- config-path: "metrics.cloud-metrics-export-interval-secs"
+  flag-name: "cloud-metrics-export-interval-secs"
+  type: "int"
+  usage: "Specifies the interval at which the metrics are uploaded to cloud monitoring"
+  default: 0
+
 - config-path: "metrics.prometheus-port"
   flag-name: "prometheus-port"
   type: "int"
@@ -557,6 +563,8 @@
     Export metrics to stackdriver with this interval. The default value 0
     indicates no exporting.
   default: "0s"
+  deprecated: true
+  deprecation-warning: "Please use --cloud-metrics-export-interval-secs instead."
 
 - config-path: "monitoring.experimental-opentelemetry-collector-address"
   flag-name: "experimental-opentelemetry-collector-address"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -86,6 +86,12 @@ func resolveStreamingWriteConfig(w *WriteConfig) {
 	}
 }
 
+func resolveCloudMetricsUploadIntervalSecs(m *MetricsConfig) {
+	if m.CloudMetricsExportIntervalSecs == 0 {
+		m.CloudMetricsExportIntervalSecs = int64(m.StackdriverExportInterval.Seconds())
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v isSet, c *Config) error {
 	var err error
@@ -104,6 +110,7 @@ func Rationalize(v isSet, c *Config) error {
 	resolveStreamingWriteConfig(&c.Write)
 	resolveMetadataCacheTTL(v, &c.MetadataCache)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache)
+	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -371,3 +371,54 @@ func TestRationalize_WriteConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestRationalizeMetricsConfig(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		config   *Config
+		expected int64
+	}{
+		{
+			name: "both_0",
+			config: &Config{
+				Metrics: MetricsConfig{
+					StackdriverExportInterval:      0,
+					CloudMetricsExportIntervalSecs: 0,
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "stackdriver_set",
+			config: &Config{
+				Metrics: MetricsConfig{
+					StackdriverExportInterval:      2 * time.Hour,
+					CloudMetricsExportIntervalSecs: 0,
+				},
+			},
+			expected: 7200,
+		},
+		{
+			name: "cloud_metrics_set",
+			config: &Config{
+				Metrics: MetricsConfig{
+					StackdriverExportInterval:      0,
+					CloudMetricsExportIntervalSecs: 10,
+				},
+			},
+			expected: 10,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if assert.NoError(t, Rationalize(&mockIsSet{}, tc.config)) {
+				assert.Equal(t, tc.expected, tc.config.Metrics.CloudMetricsExportIntervalSecs)
+			}
+		})
+	}
+}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -173,6 +173,13 @@ func isValidReadStallGcsRetriesConfig(rsrc *ReadStallGcsRetriesConfig) error {
 	return nil
 }
 
+func isValidMetricsConfig(m *MetricsConfig) error {
+	if m.StackdriverExportInterval != 0 && m.CloudMetricsExportIntervalSecs != 0 {
+		return fmt.Errorf("exactly one of stackdriver-export-interval and cloud-metrics-export-interval-secs must be specified")
+	}
+	return nil
+}
+
 // ValidateConfig returns a non-nil error if the config is invalid.
 func ValidateConfig(v isSet, config *Config) error {
 	var err error
@@ -215,6 +222,10 @@ func ValidateConfig(v isSet, config *Config) error {
 
 	if err = isValidReadStallGcsRetriesConfig(&config.GcsRetries.ReadStall); err != nil {
 		return fmt.Errorf("error parsing read-stall-gcs-retries config: %w", err)
+	}
+
+	if err = isValidMetricsConfig(&config.Metrics); err != nil {
+		return fmt.Errorf("error parsing metrics config: %w", err)
 	}
 
 	return nil

--- a/cmd/config_rationalization_test.go
+++ b/cmd/config_rationalization_test.go
@@ -83,3 +83,31 @@ func TestRationalizeMetadataCache(t *testing.T) {
 		})
 	}
 }
+
+func TestRationalizeCloudMetricsExportIntervalSecs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     []string
+		expected int64
+	}{
+		{
+			name:     "stackdriver-export-interval-set",
+			args:     []string{"--stackdriver-export-interval=30h"},
+			expected: 30 * 3600,
+		},
+		{
+			name:     "cloud-metrics-export-interval-set",
+			args:     []string{"--cloud-metrics-export-interval-secs=3200"},
+			expected: 3200,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := getConfigObject(t, tc.args)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expected, c.Metrics.CloudMetricsExportIntervalSecs)
+			}
+		})
+	}
+}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
@@ -360,7 +361,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	}
 
 	// The returned error is ignored as we do not enforce monitoring exporters
-	_ = monitor.EnableStackdriverExporter(newConfig.Metrics.StackdriverExportInterval)
+	_ = monitor.EnableStackdriverExporter(time.Duration(newConfig.Metrics.CloudMetricsExportIntervalSecs) * time.Second)
 	_ = monitor.EnableOpenTelemetryCollectorExporter(newConfig.Monitoring.ExperimentalOpentelemetryCollectorAddress)
 	_ = monitor.EnablePrometheusCollectorExporter(int(newConfig.Metrics.PrometheusPort))
 	ctx := context.Background()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path"
@@ -826,6 +827,78 @@ func TestArgsParsing_EnableHNSFlags(t *testing.T) {
 
 			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expectedEnableHNS, gotEnableHNS)
+			}
+		})
+	}
+}
+
+func TestArgsParsing_MetricsFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected *cfg.MetricsConfig
+	}{
+		{
+			name:     "cloud-metrics-export-interval-secs-positive",
+			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},
+		},
+		{
+			name:     "stackdriver-export-interval-positive",
+			args:     []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10 * 3600, StackdriverExportInterval: time.Duration(10) * time.Hour},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotConfig = cfg
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expected, &gotConfig.Metrics)
+			}
+		})
+	}
+}
+
+func TestArgsParsing_MetricsViewConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfgFile  string
+		expected *cfg.MetricsConfig
+	}{
+		{
+			name:     "cloud-metrics-export-interval-secs-positive",
+			cfgFile:  "metrics_export_interval_positive.yml",
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100},
+		},
+		{
+			name:     "stackdriver-export-interval-positive",
+			cfgFile:  "stackdriver_export_interval_positive.yml",
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 12 * 3600, StackdriverExportInterval: 12 * time.Hour},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := NewRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotConfig = cfg
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs([]string{"gcsfuse", fmt.Sprintf("--config-file=testdata/metrics_config/%s", tc.cfgFile), "abc", "pqr"}, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expected, &gotConfig.Metrics)
 			}
 		})
 	}

--- a/cmd/testdata/invalid_metrics_config_both_set.yaml
+++ b/cmd/testdata/invalid_metrics_config_both_set.yaml
@@ -1,0 +1,3 @@
+metrics:
+  stackdriver-export-interval: 10s
+  cloud-metrics-export-interval-secs: 100

--- a/cmd/testdata/metrics_config/metrics_export_interval_positive.yml
+++ b/cmd/testdata/metrics_config/metrics_export_interval_positive.yml
@@ -1,0 +1,2 @@
+metrics:
+  cloud-metrics-export-interval-secs: 100

--- a/cmd/testdata/metrics_config/stackdriver_export_interval_positive.yml
+++ b/cmd/testdata/metrics_config/stackdriver_export_interval_positive.yml
@@ -1,0 +1,2 @@
+metrics:
+  stackdriver-export-interval: 12h

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -63,3 +63,6 @@ metadata-cache:
   stat-cache-max-size-mb: 40
   ttl-secs: 100
   type-cache-max-size-mb: 10
+
+metrics:
+  cloud-metrics-export-interval-secs: 10


### PR DESCRIPTION
    * This flag controls the export interval of metrics to GCP cloud monitoring.
    * Deprecate stackdriver-export-interval flag in favor of cloud-metrics-export-interval-secs.

### Description

### Link to the issue in case of a bug fix.
b/377176812

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
