### PR TITLE
Enabling read-stall-retry by default with best default

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -309,7 +309,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-read-stall-retry", "", false, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
+	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
 	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
 		return err
@@ -457,7 +457,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.DurationP("read-stall-min-req-timeout", "", 500000000*time.Nanosecond, "Lower bound of the read request dynamic timeout.")
+	flagSet.DurationP("read-stall-min-req-timeout", "", 1500000000*time.Nanosecond, "Lower bound of the read request dynamic timeout.")
 
 	if err := flagSet.MarkHidden("read-stall-min-req-timeout"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -352,7 +352,7 @@
   usage: >-
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"
@@ -373,7 +373,7 @@
   flag-name: "read-stall-min-req-timeout"
   type: "duration"
   usage: Lower bound of the read request dynamic timeout.
-  default: 500ms
+  default: 1500ms
   hide-flag: true
 
 - config-path: "gcs-retries.read-stall.req-increase-rate"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -700,8 +700,8 @@ func TestValidateConfigFile_ReadStallConfigSuccessful(t *testing.T) {
 			expectedConfig: &cfg.Config{
 				GcsRetries: cfg.GcsRetriesConfig{
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              false,
-						MinReqTimeout:       500 * time.Millisecond,
+						Enable:              true,
+						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,
 						ReqTargetPercentile: 0.99,


### PR DESCRIPTION
### Description
- Enabling read-stall retry with `read-stall-min-timeout = 1.5s` and `read-stall-initial-timeout = 20s`
- Currently, submitting it to take advantage of existing automation. We will revert this PR if we find any issue because of read-stall feature.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested: working fine.
2. Unit tests - NA
3. Integration tests - NA
