### PR TITLE
Add enable-otel flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -202,6 +202,8 @@ type MetadataCacheConfig struct {
 type MetricsConfig struct {
 	CloudMetricsExportIntervalSecs int64 `yaml:"cloud-metrics-export-interval-secs"`
 
+	EnableOtel bool `yaml:"enable-otel"`
+
 	PrometheusPort int64 `yaml:"prometheus-port"`
 
 	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
@@ -314,6 +316,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
+
+	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OTel for capturing and exporting metrics. If false, use OpenCensus.")
+
+	if err := flagSet.MarkHidden("enable-otel"); err != nil {
+		return err
+	}
 
 	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
@@ -617,6 +625,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.enable-otel", flagSet.Lookup("enable-otel")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -317,7 +317,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OTel for capturing and exporting metrics. If false, use OpenCensus.")
+	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
 
 	if err := flagSet.MarkHidden("enable-otel"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -557,6 +557,13 @@
   usage: "Specifies the interval at which the metrics are uploaded to cloud monitoring"
   default: 0
 
+- config-path: "metrics.enable-otel"
+  flag-name: "enable-otel"
+  type: "bool"
+  usage: "Specifies whether to use OTel for capturing and exporting metrics. If false, use OpenCensus."
+  default: false
+  hide-flag: true
+
 - config-path: "metrics.prometheus-port"
   flag-name: "prometheus-port"
   type: "int"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -560,7 +560,7 @@
 - config-path: "metrics.enable-otel"
   flag-name: "enable-otel"
   type: "bool"
-  usage: "Specifies whether to use OTel for capturing and exporting metrics. If false, use OpenCensus."
+  usage: "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus."
   default: false
   hide-flag: true
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -863,6 +863,13 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "enable_otel_false",
+			args: []string{"gcsfuse", "--enable-otel=true", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				EnableOtel: true,
+			},
+		},
+		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -842,6 +842,27 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 		expected *cfg.MetricsConfig
 	}{
 		{
+			name: "default",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				EnableOtel: false,
+			},
+		},
+		{
+			name: "enable_otel_normal",
+			args: []string{"gcsfuse", "--enable-otel", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				EnableOtel: true,
+			},
+		},
+		{
+			name: "enable_otel_false",
+			args: []string{"gcsfuse", "--enable-otel=false", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				EnableOtel: false,
+			},
+		},
+		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},
@@ -877,6 +898,27 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 		cfgFile  string
 		expected *cfg.MetricsConfig
 	}{
+		{
+			name:    "default",
+			cfgFile: "empty.yml",
+			expected: &cfg.MetricsConfig{
+				EnableOtel: false,
+			},
+		},
+		{
+			name:    "enable_otel_true",
+			cfgFile: "enable_otel_true.yml",
+			expected: &cfg.MetricsConfig{
+				EnableOtel: true,
+			},
+		},
+		{
+			name:    "enable_otel_false",
+			cfgFile: "enable_otel_false.yml",
+			expected: &cfg.MetricsConfig{
+				EnableOtel: false,
+			},
+		},
 		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			cfgFile:  "metrics_export_interval_positive.yml",

--- a/cmd/testdata/metrics_config/empty.yml
+++ b/cmd/testdata/metrics_config/empty.yml
@@ -1,0 +1,1 @@
+# To verify that the defaults are getting parsed correctly

--- a/cmd/testdata/metrics_config/enable_otel_false.yml
+++ b/cmd/testdata/metrics_config/enable_otel_false.yml
@@ -1,0 +1,2 @@
+metrics:
+  enable-otel: false

--- a/cmd/testdata/metrics_config/enable_otel_true.yml
+++ b/cmd/testdata/metrics_config/enable_otel_true.yml
@@ -1,0 +1,2 @@
+metrics:
+  enable-otel: true


### PR DESCRIPTION
This flag is used to toggle between OTel and OpenCensus exporters.

### Description

### Link to the issue in case of a bug fix.
b/377226855

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
