### PR TITLE
chore: enabling existing e2e test for gRPC

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -18,7 +18,7 @@
 set -e
 
 readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=true
-readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
+readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
 readonly PROJECT_ID="gcs-fuse-test-ml"
 readonly BUCKET_LOCATION=us-central1

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -18,7 +18,7 @@ readonly EXECUTE_PERF_TEST_LABEL="execute-perf-test"
 readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
 readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
-readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
+readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 readonly BUCKET_LOCATION=us-west1
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
 

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 
 	flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"}}
 	if !testing.Short() {
-		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0"})
+		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"})
 	}
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {


### PR DESCRIPTION
### Description
1. Enabling existing e2e tests for presubmit, periodic e2e test automation.
2. Not enabling the test for louhi pipeline, will do that separately.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
