### PR TITLE
Modified Fs operations to support streaming writes

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -29,10 +29,10 @@ type BlockPool struct {
 	blockSize int64
 
 	// Max number of blocks this blockPool can create.
-	maxBlocks int32
+	maxBlocks int64
 
 	// Total number of blocks created so far.
-	totalBlocks int32
+	totalBlocks int64
 
 	// Semaphore used to limit the total number of blocks created across
 	// different files.
@@ -40,7 +40,7 @@ type BlockPool struct {
 }
 
 // NewBlockPool creates the blockPool based on the user configuration.
-func NewBlockPool(blockSize int64, maxBlocks int32, globalMaxBlocksSem *semaphore.Weighted) (bp *BlockPool, err error) {
+func NewBlockPool(blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bp *BlockPool, err error) {
 	if blockSize <= 0 || maxBlocks <= 0 {
 		err = fmt.Errorf("invalid configuration provided for blockPool, blocksize: %d, maxBlocks: %d", blockSize, maxBlocks)
 		return

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -42,8 +42,8 @@ func (t *BlockPoolTest) TestInitBlockPool() {
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), bp)
 	assert.Equal(t.T(), int64(1024), bp.blockSize)
-	assert.Equal(t.T(), int32(10), bp.maxBlocks)
-	assert.Equal(t.T(), int32(0), bp.totalBlocks)
+	assert.Equal(t.T(), int64(10), bp.maxBlocks)
+	assert.Equal(t.T(), int64(0), bp.totalBlocks)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForZeroBlockSize() {
@@ -144,12 +144,12 @@ func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 	// Adding 2 blocks to freeBlocksCh
 	bp.freeBlocksCh <- b1
 	bp.freeBlocksCh <- b2
-	require.Equal(t.T(), int32(3), bp.totalBlocks)
+	require.Equal(t.T(), int64(3), bp.totalBlocks)
 
 	err = bp.ClearFreeBlockChannel()
 
 	require.Nil(t.T(), err)
-	require.Equal(t.T(), int32(1), bp.totalBlocks)
+	require.Equal(t.T(), int64(1), bp.totalBlocks)
 	require.Nil(t.T(), b1.(*memoryBlock).buffer)
 	require.Nil(t.T(), b2.(*memoryBlock).buffer)
 	require.NotNil(t.T(), b3.(*memoryBlock).buffer)
@@ -182,7 +182,7 @@ func (t *BlockPoolTest) TestGetWhenTotalBlocksEqualToGlobalBlocks() {
 	b2, err := bp.Get()
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), b2)
-	require.Equal(t.T(), int32(2), bp.totalBlocks)
+	require.Equal(t.T(), int64(2), bp.totalBlocks)
 
 	t.validateGetBlockIsBlocked(bp)
 }

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -45,7 +45,7 @@ type WriteFileInfo struct {
 }
 
 // NewBWHandler creates the bufferedWriteHandler struct.
-func NewBWHandler(blockSize int64, maxBlocks int32, globalMaxBlocksSem *semaphore.Weighted) (bwh *BufferedWriteHandler, err error) {
+func NewBWHandler(blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bwh *BufferedWriteHandler, err error) {
 	bp, err := block.NewBlockPool(blockSize, maxBlocks, globalMaxBlocksSem)
 	if err != nil {
 		return

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -16,9 +16,11 @@ package handle
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
@@ -29,6 +31,7 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestDirHandle(t *testing.T) { RunTests(t) }
@@ -102,7 +105,9 @@ func (t *DirHandleTest) createLocalFileInode(name string, id fuseops.InodeID) (i
 		false, // localFileCache
 		contentcache.New("", &t.clock),
 		&t.clock,
-		true) // localFile
+		true,
+		&cfg.WriteConfig{},
+		semaphore.NewWeighted(math.MaxInt64)) // localFile
 	return
 }
 

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -105,9 +105,9 @@ func (t *DirHandleTest) createLocalFileInode(name string, id fuseops.InodeID) (i
 		false, // localFileCache
 		contentcache.New("", &t.clock),
 		&t.clock,
-		true,
+		true, // localFile
 		&cfg.WriteConfig{},
-		semaphore.NewWeighted(math.MaxInt64)) // localFile
+		semaphore.NewWeighted(math.MaxInt64))
 	return
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -16,13 +16,16 @@ package inode
 
 import (
 	"errors"
+	"math"
 	"os"
 	"path"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
@@ -203,7 +206,9 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		false, // localFileCache
 		contentcache.New("", &t.clock),
 		&t.clock,
-		true) //localFile
+		true,
+		&cfg.WriteConfig{},
+		semaphore.NewWeighted(math.MaxInt64)) //localFile
 	return
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -206,9 +206,9 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		false, // localFileCache
 		contentcache.New("", &t.clock),
 		&t.clock,
-		true,
+		true, //localFile
 		&cfg.WriteConfig{},
-		semaphore.NewWeighted(math.MaxInt64)) //localFile
+		semaphore.NewWeighted(math.MaxInt64))
 	return
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -681,6 +681,7 @@ func (f *FileInode) CreateEmptyTempFile() (err error) {
 	return
 }
 
+// writeToBuffer writes the given content to the in-memory buffer.
 func (f *FileInode) writeToBuffer(data []byte, offset int64) (err error) {
 	// Initialize bufferedWriteHandler if not done already.
 	if f.bwh == nil {


### PR DESCRIPTION
### Description
Made changes to createFile, readFile and writeFile to support streaming writes. 
Composite tests (local_file_test.go) will be added after all operations are modified. goal is to run all tests in local_file_test.go with streamingWrites enabled. We can't run now since all operations are not fixed. Hence will be done after all operations are modified.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA
