### PR TITLE
enabling grpc for concurrent operations test

### DIFF
--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -64,8 +64,7 @@ func TestMain(m *testing.M) {
 		{"--kernel-list-cache-ttl-secs=-1"}, {"--kernel-list-cache-ttl-secs=0"},
 	}
 	if !testing.Short() {
-		flagsSet = append(flagsSet, []string{"--kernel-list-cache-ttl-secs=-1", "--client-protocol=grpc"})
-		flagsSet = append(flagsSet, []string{"--kernel-list-cache-ttl-secs=0", "--client-protocol=grpc"})
+		setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "", "--client-protocol=grpc")
 	}
 	successCode := static_mounting.RunTests(flagsSet, m)
 

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -63,6 +63,10 @@ func TestMain(m *testing.M) {
 	flagsSet := [][]string{
 		{"--kernel-list-cache-ttl-secs=-1"}, {"--kernel-list-cache-ttl-secs=0"},
 	}
+	if !testing.Short() {
+		flagsSet = append(flagsSet, []string{"--kernel-list-cache-ttl-secs=-1", "--client-protocol=grpc"})
+		flagsSet = append(flagsSet, []string{"--kernel-list-cache-ttl-secs=0", "--client-protocol=grpc"})
+	}
 	successCode := static_mounting.RunTests(flagsSet, m)
 
 	if successCode == 0 {


### PR DESCRIPTION
### Description
Enabling grpc for concurrent operations test package guarded under short flag.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
