### PR TITLE
chores: disable the read-stall-retry by default

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -323,7 +323,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
+	flagSet.BoolP("enable-read-stall-retry", "", false, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
 	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -360,7 +360,7 @@
   usage: >-
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
-  default: true
+  default: false
   hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -703,7 +703,7 @@ func TestValidateConfigFile_ReadStallConfigSuccessful(t *testing.T) {
 			expectedConfig: &cfg.Config{
 				GcsRetries: cfg.GcsRetriesConfig{
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              true,
+						Enable:              false,
 						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,


### PR DESCRIPTION
### Description
Disabling the read-tail-latency by default.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
