### PR TITLE
Add warning log for direct path connectivity

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -106,14 +106,14 @@ func (cht *cacheHandleTest) verifyContentRead(readStartOffset int64, expectedCon
 func (cht *cacheHandleTest) SetupTest() {
 	locker.EnableInvariantsCheck()
 	cht.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
+	ctx := context.Background()
 
 	// Create bucket in fake storage.
 	cht.fakeStorage = storage.NewFakeStorage()
 	storageHandle := cht.fakeStorage.CreateStorageHandle()
-	cht.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
+	cht.bucket = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 
 	// Create test object in the bucket.
-	ctx := context.Background()
 	testObjectContent := make([]byte, TestObjectSize)
 	n, err := rand.Read(testObjectContent)
 	assert.Equal(cht.T(), TestObjectSize, n)

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -63,7 +63,8 @@ func initializeCacheHandlerTestArgs(t *testing.T, fileCacheConfig *cfg.FileCache
 		fakeStorage.ShutDown()
 	})
 	storageHandle := fakeStorage.CreateStorageHandle()
-	bucket := storageHandle.BucketHandle(storage.TestBucketName, "")
+	ctx := context.Background()
+	bucket := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 
 	// Create test object in the bucket.
 	testObjectContent := make([]byte, TestObjectSize)

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -58,7 +58,8 @@ func (dt *downloaderTest) setupHelper() {
 	// Create bucket in fake storage.
 	dt.fakeStorage = storage.NewFakeStorage()
 	storageHandle := dt.fakeStorage.CreateStorageHandle()
-	dt.bucket = storageHandle.BucketHandle(storage.TestBucketName, "")
+	ctx := context.Background()
+	dt.bucket = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
 	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, dt.defaultFileCacheConfig)

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -196,7 +196,6 @@ func TestMultipleConcurrentDownloads(t *testing.T) {
 	job2 := jm.CreateJobIfNotExists(&minObj2, bucket)
 	s1 := job1.subscribe(10 * util.MiB)
 	s2 := job2.subscribe(5 * util.MiB)
-	ctx := context.Background()
 
 	_, err1 := job1.Download(ctx, 10*util.MiB, false)
 	_, err2 := job2.Download(ctx, 5*util.MiB, false)

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -138,7 +138,8 @@ func TestParallelDownloads(t *testing.T) {
 			t.Parallel()
 			cache, cacheDir := configureCache(t, 2*tc.objectSize)
 			storageHandle := configureFakeStorage(t)
-			bucket := storageHandle.BucketHandle(storage.TestBucketName, "")
+			ctx := context.Background()
+			bucket := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 			minObj, content := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", tc.objectSize)
 			fileCacheConfig := &cfg.FileCacheConfig{
 				EnableParallelDownloads:  true,
@@ -178,7 +179,8 @@ func TestMultipleConcurrentDownloads(t *testing.T) {
 	t.Parallel()
 	storageHandle := configureFakeStorage(t)
 	cache, cacheDir := configureCache(t, 30*util.MiB)
-	bucket := storageHandle.BucketHandle(storage.TestBucketName, "")
+	ctx := context.Background()
+	bucket := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 	minObj1, content1 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", 10*util.MiB)
 	minObj2, content2 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/bar.txt", 5*util.MiB)
 	fileCacheConfig := &cfg.FileCacheConfig{

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -161,7 +161,7 @@ func (bm *bucketManager) SetUpBucket(
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
 	} else {
-		b = bm.storageHandle.BucketHandle(name, bm.config.BillingProject)
+		b = bm.storageHandle.BucketHandle(ctx, name, bm.config.BillingProject)
 	}
 
 	// Enable monitoring.

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -47,7 +47,8 @@ func init() { RegisterTestSuite(&BucketManagerTest{}) }
 func (t *BucketManagerTest) SetUp(_ *TestInfo) {
 	t.fakeStorage = storage.NewFakeStorage()
 	t.storageHandle = t.fakeStorage.CreateStorageHandle()
-	t.bucket = t.storageHandle.BucketHandle(TestBucketName, "")
+	ctx := context.Background()
+	t.bucket = t.storageHandle.BucketHandle(ctx, TestBucketName, "")
 
 	AssertNe(nil, t.bucket)
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -86,7 +86,8 @@ func TestBucketHandleTestSuite(testSuite *testing.T) {
 func (testSuite *BucketHandleTest) SetupTest() {
 	testSuite.fakeStorage = NewFakeStorage()
 	testSuite.storageHandle = testSuite.fakeStorage.CreateStorageHandle()
-	testSuite.bucketHandle = testSuite.storageHandle.BucketHandle(TestBucketName, "")
+	ctx := context.Background()
+	testSuite.bucketHandle = testSuite.storageHandle.BucketHandle(ctx, TestBucketName, "")
 	testSuite.mockClient = new(MockStorageControlClient)
 	testSuite.bucketHandle.controlClient = testSuite.mockClient
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -270,7 +270,7 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 	}
 	if sh.directPathDetector != nil {
 		if err := sh.directPathDetector.isDirectPathPossible(ctx, bucketName); err != nil {
-			logger.Warnf("Direct path connectivity unavailable for %s, reason: %s", bucketName, err)
+			logger.Warnf("Direct path connectivity unavailable for %s, reason: %v", bucketName, err)
 		}
 	}
 	return

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -35,6 +35,7 @@ const projectID string = "valid-project-id"
 type StorageHandleTest struct {
 	suite.Suite
 	fakeStorage FakeStorage
+	ctx         context.Context
 }
 
 func TestStorageHandleTestSuite(t *testing.T) {
@@ -43,6 +44,7 @@ func TestStorageHandleTestSuite(t *testing.T) {
 
 func (testSuite *StorageHandleTest) SetupTest() {
 	testSuite.fakeStorage = NewFakeStorage()
+	testSuite.ctx = context.Background()
 }
 
 func (testSuite *StorageHandleTest) TearDownTest() {
@@ -51,8 +53,7 @@ func (testSuite *StorageHandleTest) TearDownTest() {
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	ctx := context.Background()
-	bucketHandle := storageHandle.BucketHandle(ctx, TestBucketName, "")
+	bucketHandle := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, "")
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Equal(testSuite.T(), TestBucketName, bucketHandle.bucketName)
@@ -61,16 +62,14 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBil
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	ctx := context.Background()
-	bucketHandle := storageHandle.BucketHandle(ctx, invalidBucketName, "")
+	bucketHandle := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, "")
 
 	assert.Nil(testSuite.T(), bucketHandle.Bucket)
 }
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	ctx := context.Background()
-	bucketHandle := storageHandle.BucketHandle(ctx, TestBucketName, projectID)
+	bucketHandle := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, projectID)
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Equal(testSuite.T(), TestBucketName, bucketHandle.bucketName)
@@ -79,8 +78,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmpty
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNonEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	ctx := context.Background()
-	bucketHandle := storageHandle.BucketHandle(ctx, invalidBucketName, projectID)
+	bucketHandle := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, projectID)
 
 	assert.Nil(testSuite.T(), bucketHandle.Bucket)
 }
@@ -88,7 +86,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNo
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
 	sc := storageutil.GetDefaultStorageClientConfig() // by default http1 enabled
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -99,7 +97,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2EnabledAndAuthEnabl
 	sc.ClientProtocol = cfg.HTTP2
 	sc.AnonymousAccess = false
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Contains(testSuite.T(), err.Error(), "no such file or directory")
@@ -110,7 +108,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithZeroMaxConnsPerHost(
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.MaxConnsPerHost = 0
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -120,7 +118,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenUserAgentIsSet() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.UserAgent = "gcsfuse/unknown (Go version go1.20-pre3 cl/474093167 +a813be86df) appName (GPN:Gcsfuse-DLC)"
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -133,7 +131,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndAut
 	sc.CustomEndpoint = url.String()
 	sc.AnonymousAccess = false
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Contains(testSuite.T(), err.Error(), "no such file or directory")
@@ -146,7 +144,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenCustomEndpointIsNilA
 	sc.CustomEndpoint = ""
 	sc.AnonymousAccess = false
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Contains(testSuite.T(), err.Error(), "no such file or directory")
@@ -157,7 +155,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenKeyFileIsEmpty() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.KeyFile = ""
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -167,7 +165,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenReuseTokenUrlFalse()
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ReuseTokenFromUrl = false
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -177,7 +175,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenTokenUrlIsSet() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.TokenUrl = storageutil.CustomTokenUrl
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -187,7 +185,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWhenJsonReadEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ExperimentalEnableJsonRead = true
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), handleCreated)
@@ -198,7 +196,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 	sc.ExperimentalEnableJsonRead = true
 	sc.ClientProtocol = "test-protocol"
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), handleCreated)
@@ -209,7 +207,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = cfg.GRPC
 
-	storageClient, err := createGRPCClientHandle(context.Background(), &sc)
+	storageClient, err := createGRPCClientHandle(testSuite.ctx, &sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), storageClient)
@@ -218,7 +216,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle() {
 func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 
-	storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+	storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), storageClient)
@@ -228,7 +226,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientProtocol()
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = cfg.GRPC
 
-	storageClient, err := NewStorageHandle(context.Background(), sc)
+	storageClient, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), storageClient)
@@ -238,7 +236,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_WithHTTPClientPro
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = cfg.HTTP1
 
-	storageClient, err := createGRPCClientHandle(context.Background(), &sc)
+	storageClient, err := createGRPCClientHandle(testSuite.ctx, &sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), storageClient)
@@ -249,7 +247,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithGRPCClientPro
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = cfg.GRPC
 
-	storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+	storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), storageClient)
@@ -276,7 +274,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_WithReadStallRetr
 			sc := storageutil.GetDefaultStorageClientConfig()
 			sc.ReadStallRetryConfig.Enable = tc.enableReadStallRetry
 
-			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+			storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 			assert.Nil(testSuite.T(), err)
 			assert.NotNil(testSuite.T(), storageClient)
@@ -305,7 +303,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallInitialR
 			sc.ReadStallRetryConfig.Enable = true
 			sc.ReadStallRetryConfig.InitialReqTimeout = tc.initialReqTimeout
 
-			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+			storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 			assert.Nil(testSuite.T(), err)
 			assert.NotNil(testSuite.T(), storageClient)
@@ -334,7 +332,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallMinReqTi
 			sc.ReadStallRetryConfig.Enable = true
 			sc.ReadStallRetryConfig.MinReqTimeout = tc.minReqTimeout
 
-			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+			storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 			assert.Nil(testSuite.T(), err)
 			assert.NotNil(testSuite.T(), storageClient)
@@ -371,7 +369,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqIncre
 			sc.ReadStallRetryConfig.Enable = true
 			sc.ReadStallRetryConfig.ReqIncreaseRate = tc.reqIncreaseRate
 
-			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+			storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 			if tc.expectErr {
 				assert.NotNil(testSuite.T(), err)
@@ -422,7 +420,7 @@ func (testSuite *StorageHandleTest) TestCreateHTTPClientHandle_ReadStallReqTarge
 			sc.ReadStallRetryConfig.Enable = true
 			sc.ReadStallRetryConfig.ReqTargetPercentile = tc.reqTargetPercentile
 
-			storageClient, err := createHTTPClientHandle(context.Background(), &sc)
+			storageClient, err := createHTTPClientHandle(testSuite.ctx, &sc)
 
 			if tc.expectErr {
 				assert.NotNil(testSuite.T(), err)
@@ -440,7 +438,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustom
 	sc.AnonymousAccess = false
 	sc.ClientProtocol = cfg.GRPC
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Contains(testSuite.T(), err.Error(), "no such file or directory")
@@ -455,7 +453,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithGRPCClientWithCustom
 	sc.AnonymousAccess = false
 	sc.ClientProtocol = cfg.GRPC
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Contains(testSuite.T(), err.Error(), "GRPC client doesn't support auth for custom-endpoint. Please set anonymous-access: true via config-file.")
@@ -466,7 +464,7 @@ func (testSuite *StorageHandleTest) TestCreateStorageHandleWithEnableHNSTrue() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.EnableHNS = true
 
-	sh, err := NewStorageHandle(context.Background(), sc)
+	sh, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), sh)
@@ -479,7 +477,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndEna
 	sc.CustomEndpoint = url.String()
 	sc.EnableHNS = true
 
-	sh, err := NewStorageHandle(context.Background(), sc)
+	sh, err := NewStorageHandle(testSuite.ctx, sc)
 
 	assert.NoError(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), sh)
@@ -498,7 +496,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithMaxRetryAttemptsNotZ
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.MaxRetryAttempts = 100
 
-	handleCreated, err := NewStorageHandle(context.Background(), sc)
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
 
 	if assert.NoError(testSuite.T(), err) {
 		assert.NotNil(testSuite.T(), handleCreated)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -51,7 +51,8 @@ func (testSuite *StorageHandleTest) TearDownTest() {
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	bucketHandle := storageHandle.BucketHandle(TestBucketName, "")
+	ctx := context.Background()
+	bucketHandle := storageHandle.BucketHandle(ctx, TestBucketName, "")
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Equal(testSuite.T(), TestBucketName, bucketHandle.bucketName)
@@ -60,14 +61,16 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBil
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	bucketHandle := storageHandle.BucketHandle(invalidBucketName, "")
+	ctx := context.Background()
+	bucketHandle := storageHandle.BucketHandle(ctx, invalidBucketName, "")
 
 	assert.Nil(testSuite.T(), bucketHandle.Bucket)
 }
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	bucketHandle := storageHandle.BucketHandle(TestBucketName, projectID)
+	ctx := context.Background()
+	bucketHandle := storageHandle.BucketHandle(ctx, TestBucketName, projectID)
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Equal(testSuite.T(), TestBucketName, bucketHandle.bucketName)
@@ -76,7 +79,8 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmpty
 
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNonEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
-	bucketHandle := storageHandle.BucketHandle(invalidBucketName, projectID)
+	ctx := context.Background()
+	bucketHandle := storageHandle.BucketHandle(ctx, invalidBucketName, projectID)
 
 	assert.Nil(testSuite.T(), bucketHandle.Bucket)
 }


### PR DESCRIPTION
### Description
 Using  the [storage.CheckDirectConnectivitySupported](https://pkg.go.dev/cloud.google.com/go/storage@v1.47.0#CheckDirectConnectivitySupported) function to check for direct connectivity support, this PR
adds a warning log message if direct connectivity is unavailable, including the bucket name and the error message.
This logging is only for GRPC data client.


Sample log:
```
Direct path connectivity unavailable for <bucket-name>, reason: storage: direct connectivity not detected
```

Time observed for figuring out direct connectivity :
For vm located in us-west1-b: 10159 msec(issue actively tracked in internal bug)
For vm located in us-central1-f : 365 msec
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
