### PR TITLE
using the latest ubuntu version for long haul tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -84,7 +84,7 @@ function delete_existing_vm_and_create_new () {
           --service-account=927584127901-compute@developer.gserviceaccount.com \
           --scopes=https://www.googleapis.com/auth/cloud-platform \
           --accelerator=count=2,type=nvidia-tesla-a100 \
-          --create-disk=auto-delete=yes,boot=yes,device-name=$VM_NAME,image=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20231213,mode=rw,size=150,type=projects/$GCP_PROJECT/zones/$ZONE_NAME/diskTypes/pd-balanced \
+          --create-disk=auto-delete=yes,boot=yes,device-name=$VM_NAME,image=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20241115,mode=rw,size=150,type=projects/$GCP_PROJECT/zones/$ZONE_NAME/diskTypes/pd-balanced \
           --no-shielded-secure-boot \
           --shielded-vtpm \
           --shielded-integrity-monitoring \


### PR DESCRIPTION
### Description
Long haul tests are trying to create a vm with specific os version which is no longer supported by google. Hence updated to the latest version.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Ran the command manually to check if we are able to create the vm.
2. Unit tests - NA
3. Integration tests - NA
