### PR TITLE
Switch warning log to error log

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -763,7 +763,7 @@ func (d *dirInode) readObjects(
 		}
 	}
 	if len(unsupportedPrefixes) > 0 {
-		logger.Warnf("Encountered unsupported prefixes during listing: %v", unsupportedPrefixes)
+		logger.Errorf("Encountered unsupported prefixes during listing: %v", unsupportedPrefixes)
 	}
 	return
 }


### PR DESCRIPTION
### Description
Switch warning log to error log for unsupported prefixes encountered during listing.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
