### PR TITLE
refactoring changes to make testing possible for inode package using testify mock bucket

### DIFF
--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/block"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	storagemock "github.com/googlecloudplatform/gcsfuse/v2/internal/storage/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -37,7 +36,7 @@ const (
 type UploadHandlerTest struct {
 	uh         *UploadHandler
 	blockPool  *block.BlockPool
-	mockBucket *storage.TestifyMockBucket
+	mockBucket *storagemock.TestifyMockBucket
 	suite.Suite
 }
 
@@ -46,7 +45,7 @@ func TestUploadHandlerTestSuite(t *testing.T) {
 }
 
 func (t *UploadHandlerTest) SetupTest() {
-	t.mockBucket = new(storage.TestifyMockBucket)
+	t.mockBucket = new(storagemock.TestifyMockBucket)
 	var err error
 	t.blockPool, err = block.NewBlockPool(blockSize, 5, semaphore.NewWeighted(5))
 	require.NoError(t.T(), err)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -44,7 +44,7 @@ type FileInode struct {
 	// Dependencies
 	/////////////////////////
 
-	bucket     *gcsx.SyncerBucket
+	bucket     gcsx.SyncerBucketInterface
 	mtimeClock timeutil.Clock
 
 	/////////////////////////
@@ -112,7 +112,7 @@ func NewFileInode(
 	name Name,
 	m *gcs.MinObject,
 	attrs fuseops.InodeAttributes,
-	bucket *gcsx.SyncerBucket,
+	bucket gcsx.SyncerBucketInterface,
 	localFileCache bool,
 	contentCache *contentcache.ContentCache,
 	mtimeClock timeutil.Clock,
@@ -436,7 +436,7 @@ func (f *FileInode) Attributes(
 	return
 }
 
-func (f *FileInode) Bucket() *gcsx.SyncerBucket {
+func (f *FileInode) Bucket() gcsx.SyncerBucketInterface {
 	return f.bucket
 }
 

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	storagemock "github.com/googlecloudplatform/gcsfuse/v2/internal/storage/mock"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/timeutil"
@@ -42,7 +42,7 @@ type HNSDirTest struct {
 	ctx        context.Context
 	bucket     gcsx.SyncerBucket
 	in         DirInode
-	mockBucket *storage.TestifyMockBucket
+	mockBucket *storagemock.TestifyMockBucket
 	typeCache  metadata.TypeCache
 	fixedTime  timeutil.SimulatedClock
 }
@@ -51,7 +51,7 @@ func TestHNSDirSuite(testSuite *testing.T) { suite.Run(testSuite, new(HNSDirTest
 
 func (t *HNSDirTest) SetupTest() {
 	t.ctx = context.Background()
-	t.mockBucket = new(storage.TestifyMockBucket)
+	t.mockBucket = new(storagemock.TestifyMockBucket)
 	t.bucket = gcsx.NewSyncerBucket(
 		1,
 		".gcsfuse_tmp/",

--- a/internal/gcsx/syncer_bucket.go
+++ b/internal/gcsx/syncer_bucket.go
@@ -18,6 +18,11 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 )
 
+type SyncerBucketInterface interface {
+	gcs.Bucket
+	Syncer
+}
+
 type SyncerBucket struct {
 	gcs.Bucket
 	Syncer

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package mock
 
 import (
 	"context"
 	"io"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/mock"
 )
@@ -121,6 +122,14 @@ func (m *TestifyMockBucket) CreateFolder(ctx context.Context, folderName string)
 	args := m.Called(ctx, folderName)
 	if args.Get(0) != nil {
 		return args.Get(0).(*gcs.Folder), nil
+	}
+	return nil, args.Error(1)
+}
+
+func (m *TestifyMockBucket) SyncObject(ctx context.Context, fileName string, srcObject *gcs.Object, content gcsx.TempFile) (o *gcs.Object, err error) {
+	args := m.Called(ctx, fileName, srcObject, content)
+	if args.Get(0) != nil {
+		return args.Get(0).(*gcs.Object), nil
 	}
 	return nil, args.Error(1)
 }


### PR DESCRIPTION
### Description
This PR includes following refactoring changes:
-  testify mock bucket now implements SyncerBucketInterface
- file inode now uses SyncerBucketInterface instead of struct SyncerBucket

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - NA
