### PR TITLE
Modify fake bucket implementation to throw accurate error.

### DIFF
--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -452,11 +453,7 @@ func (b *bucket) newReaderLocked(
 
 	// Does the generation match?
 	if req.Generation != 0 && req.Generation != o.metadata.Generation {
-		err = &gcs.NotFoundError{
-			Err: fmt.Errorf(
-				"object %s generation %v not found", req.Name, req.Generation),
-		}
-
+		err = storage.ErrObjectNotExist
 		return
 	}
 

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -32,6 +32,7 @@ import (
 	"time"
 	"unicode"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	. "github.com/jacobsa/oglematchers"
@@ -2230,7 +2231,7 @@ func (t *composeTest) ExplicitGenerations_OneDoesntExist() {
 			},
 		})
 
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	ExpectThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
 
 	// Make sure the destination object doesn't exist.
 	_, _, err = t.bucket.StatObject(
@@ -2753,8 +2754,8 @@ func (t *readTest) ParticularGeneration_NeverExisted() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
-	ExpectThat(err, Error(MatchesRegexp("(?i)not found|404")))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
 }
 
 func (t *readTest) ParticularGeneration_HasBeenDeleted() {
@@ -2855,8 +2856,8 @@ func (t *readTest) ParticularGeneration_ObjectHasBeenOverwritten() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
-	ExpectThat(err, Error(MatchesRegexp("(?i)not found|404")))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
 
 	// Reading by the new generation should work.
 	req.Generation = o2.Generation


### PR DESCRIPTION
Modify fake bucket implementation to throw same error that is thrown by GCS Bucket.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
