### PR TITLE
adding unit test for direct path detector functionality

### DIFF
--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -203,6 +203,32 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 	assert.Contains(testSuite.T(), err.Error(), "invalid client-protocol requested: test-protocol")
 }
 
+func (testSuite *StorageHandleTest) TestNewStorageHandleWithNonNilDirectPathDetector() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.ExperimentalEnableJsonRead = true
+	sc.ClientProtocol = "grpc"
+
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
+	storageClient, _ := handleCreated.(*storageClient)
+
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), handleCreated)
+	assert.NotNil(testSuite.T(), storageClient.directPathDetector)
+}
+
+func (testSuite *StorageHandleTest) TestNewStorageHandleWithNilDirectPathDetector() {
+	sc := storageutil.GetDefaultStorageClientConfig()
+	sc.ExperimentalEnableJsonRead = true
+	sc.ClientProtocol = "http1"
+
+	handleCreated, err := NewStorageHandle(testSuite.ctx, sc)
+	storageClient, _ := handleCreated.(*storageClient)
+
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), handleCreated)
+	assert.Nil(testSuite.T(), storageClient.directPathDetector)
+}
+
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle() {
 	sc := storageutil.GetDefaultStorageClientConfig()
 	sc.ClientProtocol = cfg.GRPC


### PR DESCRIPTION
### Description
Follow-up PR for https://github.com/GoogleCloudPlatform/gcsfuse/pull/2691

Added unit test for the following scenario:

- When client protocol is set to grpc, then directPathDetector is initialized and should be used for checking direct connectivity.
- When client protocol is set to http1, then directPathDetector is nil since we do not require checking direct connectivity. 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done on cloudtop.
2. Unit tests - NA
3. Integration tests - NA
