### PR TITLE
Add support for setting numEpoch for each workload

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload_test.py
@@ -184,6 +184,45 @@ class DlioWorkloadTest(unittest.TestCase):
         )
     )
 
+  def test_validate_dlio_workload_invalid_unsupported_numEpochs(
+      self,
+  ):
+    workload = dict({
+        "dlioWorkload": {
+            "numFilesTrain": 1000,
+            "recordLength": 10000,
+            "batchSizes": [100, 200],
+        },
+        "bucket": "dummy-bucket",
+        "gcsfuseMountOptions": "implicit-dirs",
+        "numEpochs": False,
+    })
+    self.assertFalse(
+        validateDlioWorkload(
+            workload, "invalid-dlio-workload-unsupported-numEpochs"
+        )
+    )
+
+  def test_validate_dlio_workload_invalid_numEpochs_toolow(
+      self,
+  ):
+    workload = dict({
+        "dlioWorkload": {
+            "numFilesTrain": 1000,
+            "recordLength": 10000,
+            "batchSizes": [100, 200],
+        },
+        "bucket": "dummy-bucket",
+        "gcsfuseMountOptions": "implicit-dirs",
+        "numEpochs": -1,
+    })
+    self.assertFalse(
+        validateDlioWorkload(
+            workload,
+            "invalid-dlio-workload-unsupported-numEpochs-too-low",
+        )
+    )
+
   def test_validate_dlio_workload_invalid_missing_batchSizes(self):
     workload = dict({
         "dlioWorkload": {

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -95,10 +95,10 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
         "num_files_train": str
         "batch_size": str
         "records":
-            "local-ssd": [record1, record2, record3, record4]
-            "gcsfuse-generic": [record1, record2, record3, record4]
-            "gcsfuse-file-cache": [record1, record2, record3, record4]
-            "gcsfuse-no-file-cache": [record1, record2, record3, record4]
+            "local-ssd": [record1, record2, record3, ...]
+            "gcsfuse-generic": [record1, record2, record3, ...]
+            "gcsfuse-file-cache": [record1, record2, record3, ...]
+            "gcsfuse-no-file-cache": [record1, record2, record3, ...]
   """
 
   output = {}

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -55,33 +55,37 @@ def createHelmInstallCommands(
     resourceRequests = resourceLimits
 
   for dlioWorkload in dlioWorkloads:
-    for batchSize in dlioWorkload.batchSizes:
-      chartName, podName, outputDirPrefix = dlio_workload.DlioChartNamePodName(
-          dlioWorkload, instanceId, batchSize
-      )
-      commands = [
-          f'helm install {chartName} unet3d-loading-test',
-          f'--set bucketName={dlioWorkload.bucket}',
-          f'--set scenario={dlioWorkload.scenario}',
-          f'--set dlio.numFilesTrain={dlioWorkload.numFilesTrain}',
-          f'--set dlio.recordLength={dlioWorkload.recordLength}',
-          f'--set dlio.batchSize={batchSize}',
-          f'--set instanceId={instanceId}',
-          (
-              '--set'
-              f' gcsfuse.mountOptions={escape_commas_in_string(dlioWorkload.gcsfuseMountOptions)}'
-          ),
-          f'--set nodeType={machineType}',
-          f'--set podName={podName}',
-          f'--set outputDirPrefix={outputDirPrefix}',
-          f"--set resourceLimits.cpu={resourceLimits['cpu']}",
-          f"--set resourceLimits.memory={resourceLimits['memory']}",
-          f"--set resourceRequests.cpu={resourceRequests['cpu']}",
-          f"--set resourceRequests.memory={resourceRequests['memory']}",
-      ]
+    if dlioWorkload.numEpochs > 0:
+      for batchSize in dlioWorkload.batchSizes:
+        chartName, podName, outputDirPrefix = (
+            dlio_workload.DlioChartNamePodName(
+                dlioWorkload, instanceId, batchSize
+            )
+        )
+        commands = [
+            f'helm install {chartName} unet3d-loading-test',
+            f'--set bucketName={dlioWorkload.bucket}',
+            f'--set scenario={dlioWorkload.scenario}',
+            f'--set dlio.numFilesTrain={dlioWorkload.numFilesTrain}',
+            f'--set dlio.recordLength={dlioWorkload.recordLength}',
+            f'--set dlio.batchSize={batchSize}',
+            f'--set instanceId={instanceId}',
+            (
+                '--set'
+                f' gcsfuse.mountOptions={escape_commas_in_string(dlioWorkload.gcsfuseMountOptions)}'
+            ),
+            f'--set nodeType={machineType}',
+            f'--set podName={podName}',
+            f'--set outputDirPrefix={outputDirPrefix}',
+            f"--set resourceLimits.cpu={resourceLimits['cpu']}",
+            f"--set resourceLimits.memory={resourceLimits['memory']}",
+            f"--set resourceRequests.cpu={resourceRequests['cpu']}",
+            f"--set resourceRequests.memory={resourceRequests['memory']}",
+            f'--set numEpochs={dlioWorkload.numEpochs}',
+        ]
 
-      helm_command = ' '.join(commands)
-      helm_commands.append(helm_command)
+        helm_command = ' '.join(commands)
+        helm_commands.append(helm_command)
   return helm_commands
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -88,7 +88,7 @@ spec:
         echo "Testing {{ .Values.scenario }}"
         mpirun -np 8 dlio_benchmark workload=unet3d_a100 \
         ++workload.workflow.generate_data=True \
-        ++workload.train.epochs=4 \
+        ++workload.train.epochs={{ .Values.numEpochs }} \
         ++workload.workflow.profiling=True \
         ++workload.profiling.profiler=iostat \
         ++workload.profiling.iostat_devices=[md0] \

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
@@ -25,6 +25,7 @@ nodeType: n2-standard-96
 instanceId: ldap-yyyymmdd-hhmmss
 podName:
 outputDirPrefix:
+numEpochs: 4
 
 resourceLimits:
   cpu: 0

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -21,6 +21,9 @@ test-config file for a list of them.
 import json
 
 
+DefaultNumEpochs = 4
+
+
 def validateFioWorkload(workload: dict, name: str):
   """Validates the given json workload object."""
   for requiredWorkloadAttribute, expectedType in {
@@ -39,6 +42,17 @@ def validateFioWorkload(workload: dict, name: str):
       return False
     if expectedType == str and ' ' in workload[requiredWorkloadAttribute]:
       print(f"{name} has space in the value of '{requiredWorkloadAttribute}'")
+      return False
+
+  if 'numEpochs' in workload:
+    if not type(workload['numEpochs']) is int:
+      print(
+          f"In {name}, the type of workload['numEpochs'] is of type"
+          f" {type(workload['numEpochs'])}, not {int}"
+      )
+      return False
+    if int(workload['numEpochs']) < 0:
+      print(f"In {name}, the value of workload['numEpochs'] < 0, expected: >=0")
       return False
 
   if 'dlioWorkload' in workload:
@@ -117,6 +131,8 @@ class FioWorkload:
   "<config>[:<subconfig>[:<subsubconfig>[...]]]:<value>". For example, a legal
   value would be:
   "implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:true".
+  9. numEpochs: Number of runs of the fio workload. Default is DefaultNumEpochs
+  if missing.
   """
 
   def __init__(
@@ -129,6 +145,7 @@ class FioWorkload:
       bucket: str,
       readTypes: list,
       gcsfuseMountOptions: str,
+      numEpochs: int = DefaultNumEpochs,
   ):
     self.scenario = scenario
     self.fileSize = fileSize
@@ -138,6 +155,7 @@ class FioWorkload:
     self.bucket = bucket
     self.readTypes = set(readTypes)
     self.gcsfuseMountOptions = gcsfuseMountOptions
+    self.numEpochs = numEpochs
 
   def PPrint(self):
     print(
@@ -145,7 +163,7 @@ class FioWorkload:
         f' blockSize:{self.blockSize}, filesPerThread:{self.filesPerThread},'
         f' numThreads:{self.numThreads}, bucket:{self.bucket},'
         f' readTypes:{self.readTypes}, gcsfuseMountOptions:'
-        f' {gcsfuseMountOptions}'
+        f' {gcsfuseMountOptions}, numEpochs: {self.numEpochs}'
     )
 
 
@@ -184,6 +202,11 @@ def ParseTestConfigForFioWorkloads(fioTestConfigFile: str):
                       else ['read', 'randread']
                   ),
                   workload['gcsfuseMountOptions'],
+                  numEpochs=(
+                      workload['numEpochs']
+                      if 'numEpochs' in workload
+                      else DefaultNumEpochs
+                  ),
               )
           )
   return fioWorkloads

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload_test.py
@@ -249,6 +249,45 @@ class FioWorkloadTest(unittest.TestCase):
         )
     )
 
+  def test_validate_fio_workload_invalid_unsupported_numEpochs(self):
+    workload = dict({
+        "fioWorkload": {
+            "fileSize": "1kb",
+            "filesPerThread": 2,
+            "blockSize": "1kb",
+            "numThreads": "1k",
+        },
+        "bucket": "dummy-bucket",
+        "gcsfuseMountOptions": "implicit-dirs",
+        "numEpochs": False,
+    })
+    self.assertFalse(
+        validateFioWorkload(
+            workload, "invalid-fio-workload-unsupported-numEpochs"
+        )
+    )
+
+  def test_validate_fio_workload_invalid_numEpochsTooLow(
+      self,
+  ):
+    workload = dict({
+        "fioWorkload": {
+            "fileSize": "1kb",
+            "filesPerThread": 2,
+            "blockSize": "1kb",
+            "numThreads": "1k",
+        },
+        "bucket": "dummy-bucket",
+        "gcsfuseMountOptions": "implicit-dirs",
+        "numEpochs": -1,
+    })
+    self.assertFalse(
+        validateFioWorkload(
+            workload,
+            "invalid-fio-workload-unsupported-numEpochs-too-low",
+        )
+    )
+
   def test_validate_fio_workload_invalid_unsupported_readTypes_1(self):
     workload = dict({
         "fioWorkload": {

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -118,7 +118,7 @@ spec:
         {{ end }}
 
         echo "Setup default values..."
-        epoch=4
+        epoch={{ .Values.numEpochs }}
         read_type={{ .Values.fio.readType }}
         pause_in_seconds=20
         workload_dir=/data

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -25,6 +25,7 @@ nodeType: n2-standard-96
 instanceId: ldap-yyyymmdd-hhmmss
 podName:
 outputDirPrefix:
+numEpochs: 4
 
 resourceLimits:
   cpu: 0

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -91,7 +91,7 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
   from the downloaded fio output files, which are in the following format.
 
     <_LOCAL_LOGS_LOCATION>/<instanceId>/<fileSize>/<fileSize>-<blockSize>-<numThreads>-<filesPerThread>-<hash>/<scenario>/<readType>/epoch[N].json
-    where N=1-4
+    where N=1-#epochs
     <_LOCAL_LOGS_LOCATION>/<instanceId>/<fileSize>/<fileSize>-<blockSize>-<numThreads>-<filesPerThread>-<hash>/<scenario>/<readType>/pod_name
     <_LOCAL_LOGS_LOCATION>/<instanceId>/<fileSize>/<fileSize>-<blockSize>-<numThreads>-<filesPerThread>-<hash>/gcsfuse-generic/<readType>/gcsfuse_mount_options
 
@@ -100,10 +100,10 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
         "mean_file_size": str
         "read_type": str
         "records":
-            "local-ssd": [record1, record2, record3, record4]
-            "gcsfuse-generic": [record1, record2, record3, record4]
-            "gcsfuse-file-cache": [record1, record2, record3, record4]
-            "gcsfuse-no-file-cache": [record1, record2, record3, record4]
+            "local-ssd": [record1, record2, record3, ...]
+            "gcsfuse-generic": [record1, record2, record3, ...]
+            "gcsfuse-file-cache": [record1, record2, record3, ...]
+            "gcsfuse-no-file-cache": [record1, record2, record3, ...]
   """
 
   output = {}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -54,35 +54,37 @@ def createHelmInstallCommands(
     resourceRequests = resourceLimits
 
   for fioWorkload in fioWorkloads:
-    for readType in fioWorkload.readTypes:
-      chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
-          fioWorkload, instanceId, readType
-      )
-      commands = [
-          f'helm install {chartName} loading-test',
-          f'--set bucketName={fioWorkload.bucket}',
-          f'--set scenario={fioWorkload.scenario}',
-          f'--set fio.readType={readType}',
-          f'--set fio.fileSize={fioWorkload.fileSize}',
-          f'--set fio.blockSize={fioWorkload.blockSize}',
-          f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
-          f'--set fio.numThreads={fioWorkload.numThreads}',
-          f'--set instanceId={instanceId}',
-          (
-              '--set'
-              f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
-          ),
-          f'--set nodeType={machineType}',
-          f'--set podName={podName}',
-          f'--set outputDirPrefix={outputDirPrefix}',
-          f"--set resourceLimits.cpu={resourceLimits['cpu']}",
-          f"--set resourceLimits.memory={resourceLimits['memory']}",
-          f"--set resourceRequests.cpu={resourceRequests['cpu']}",
-          f"--set resourceRequests.memory={resourceRequests['memory']}",
-      ]
+    if fioWorkload.numEpochs > 0:
+      for readType in fioWorkload.readTypes:
+        chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
+            fioWorkload, instanceId, readType
+        )
+        commands = [
+            f'helm install {chartName} loading-test',
+            f'--set bucketName={fioWorkload.bucket}',
+            f'--set scenario={fioWorkload.scenario}',
+            f'--set fio.readType={readType}',
+            f'--set fio.fileSize={fioWorkload.fileSize}',
+            f'--set fio.blockSize={fioWorkload.blockSize}',
+            f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
+            f'--set fio.numThreads={fioWorkload.numThreads}',
+            f'--set instanceId={instanceId}',
+            (
+                '--set'
+                f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
+            ),
+            f'--set nodeType={machineType}',
+            f'--set podName={podName}',
+            f'--set outputDirPrefix={outputDirPrefix}',
+            f"--set resourceLimits.cpu={resourceLimits['cpu']}",
+            f"--set resourceLimits.memory={resourceLimits['memory']}",
+            f"--set resourceRequests.cpu={resourceRequests['cpu']}",
+            f"--set resourceRequests.memory={resourceRequests['memory']}",
+            f'--set numEpochs={fioWorkload.numEpochs}',
+        ]
 
-      helm_command = ' '.join(commands)
-      helm_commands.append(helm_command)
+        helm_command = ' '.join(commands)
+        helm_commands.append(helm_command)
   return helm_commands
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/workloads.json
+++ b/perfmetrics/scripts/testing_on_gke/examples/workloads.json
@@ -16,6 +16,7 @@
             "readTypes": ["read","randread"]
           },
           "gcsfuseMountOptions": "GCSFuse mount-options, in a compact stringified format, to be used for the test scenario gcsfuse-generic. The individual config/cli flag values should be separated by comma. Each cli flag should be of the form <flag>[=<value>], while each config-file flag should be of form <config>[:<subconfig>[:<subsubconfig>[...]]]:<value>. For example, a legal value would be: implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:-1 .",
+          "numEpochs": "Optional integer value > 0, default = 4.",
           "bucket":"The bucket must have objects with name Workload.{i}/{j} for every i,j where i:0-{numThreads}-1, j:0-{filesPerThread}-1, and each of these objects must be of size {fileSize}. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s)."
         },
         {
@@ -127,6 +128,7 @@
             "batchSizes": [800,128]
           },
           "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
+          "numEpochs": "Optional integer value > 0, default = 4.",
           "bucket":"The bucket must have objects with name 'train/', 'valid/', and train/img_{i}_of_{numFilesTrain}.npz for every i where i:0-{numFilesTrain}-1 and each train/img_{i}_of_{numFilesTrain}.npz must be of size {recordLength} bytes. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s)."
         },
         {

--- a/perfmetrics/scripts/testing_on_gke/examples/workloads_test.json
+++ b/perfmetrics/scripts/testing_on_gke/examples/workloads_test.json
@@ -16,6 +16,7 @@
             "readTypes": ["read","randread"]
           },
           "gcsfuseMountOptions": "GCSFuse mount-options, in a compact stringified format, to be used for the test scenario gcsfuse-generic. The individual config/cli flag values should be separated by comma. Each cli flag should be of the form <flag>[=<value>], while each config-file flag should be of form <config>[:<subconfig>[:<subsubconfig>[...]]]:<value>. For example, a legal value would be: implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:-1 .",
+          "numEpochs": "Optional integer value > 0, default = 4.",
           "bucket":"The bucket must have objects with name Workload.{i}/{j} for every i,j where i:0-{numThreads}-1, j:0-{filesPerThread}-1, and each of these objects must be of size {fileSize}. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s). For best performance, please ensure that the bucket is in the same google-cloud region and GCP project as that of the GKE cluster used for running this test configuration."
         },
         {
@@ -40,6 +41,7 @@
             "batchSizes": [800,128]
           },
           "gcsfuseMountOptions": "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true",
+          "numEpochs": "Optional integer value > 0, default = 4.",
           "bucket":"The bucket must have objects with name 'train/', 'valid/', and train/img_{i}_of_{numFilesTrain}.npz for every i where i:0-{numFilesTrain}-1 and each train/img_{i}_of_{numFilesTrain}.npz must be of size {recordLength} bytes. The buckets gke-* are all in us-central1, are owned by GKE team and are in their GCP project(s). For best performance, please ensure that the bucket is in the same google-cloud region and GCP project as that of the GKE cluster used for running this test configuration."
         },
         {


### PR DESCRIPTION
This is for gke-testing scripts available in perfmetrics/scripts/testing_on_gke/examples/ . With this change, you can add a "numEpochs" attribute in each workload element in the workload configuration JSON file.

### Description

### Link to the issue in case of a bug fix.
[b/367949393](http://b/367949393)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
