### PR TITLE
add benchmarking test package to e2e testing 

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -203,6 +203,9 @@ function run_parallel_tests() {
 
   for test_dir_p in "${test_array[@]}"
   do
+    # Unlike regular tests,benchmark tests are not executed by default when using go test .
+    # The -bench flag yells go test to run the benchmark tests and report their results by
+    # enabling the benchmarking framework.
     if [ $test_dir_p == "benchmarking" ]; then
         benchmark_flags="-bench=."
     fi

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -157,6 +157,7 @@ TEST_DIR_PARALLEL=(
   "log_content"
   "kernel_list_cache"
   "concurrent_operations"
+  "benchmarking"
 )
 
 # These tests never become parallel as they are changing bucket permissions.

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -199,15 +199,20 @@ function run_parallel_tests() {
   local -n test_array=$1
   local BUCKET_NAME=$2
   local pids=()
+  local benchmark_flags=""
+
   for test_dir_p in "${test_array[@]}"
   do
+    if [ $test_dir_p == "benchmarking" ]; then
+        benchmark_flags="-bench=."
+    fi
     test_path_parallel="./tools/integration_tests/$test_dir_p"
     # To make it clear whether tests are running on a flat or HNS bucket, We kept the log file naming
     # convention to include the bucket name as a suffix (e.g., package_name_bucket_name).
     local log_file="/tmp/${test_dir_p}_${BUCKET_NAME}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel -p 1 --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $benchmark_flags -p 1 --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/benchmark_setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
@@ -26,7 +27,7 @@ import (
 )
 
 const (
-	deleteThreshold int = 450
+	expectedDeleteLatency time.Duration = 450 * time.Millisecond
 )
 
 type benchmarkDeleteTest struct{}
@@ -57,8 +58,9 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 			b.Errorf("testing error: %v", err)
 		}
 	}
-	if timeTaken := b.Elapsed().Milliseconds(); timeTaken > int64(deleteThreshold*b.N) {
-		b.Errorf("Test failed due to timeout, time taken:%d msec", timeTaken)
+	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
+	if averageDeleteLatency > expectedDeleteLatency {
+		b.Errorf("Test failed due to timeout -> DeleteFile took more time (%d msec) than expected (%d msec)", averageDeleteLatency.Milliseconds(), expectedDeleteLatency.Milliseconds())
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -60,7 +60,7 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 	}
 	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageDeleteLatency > expectedDeleteLatency {
-		b.Errorf("Test failed due to timeout -> DeleteFile took more time (%d msec) than expected (%d msec)", averageDeleteLatency.Milliseconds(), expectedDeleteLatency.Milliseconds())
+		b.Errorf("DeleteFile took more time (%d msec) than expected (%d msec)", averageDeleteLatency.Milliseconds(), expectedDeleteLatency.Milliseconds())
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
+const (
+	deleteThreshold int = 450
+)
+
 type benchmarkDeleteTest struct{}
 
 func (s *benchmarkDeleteTest) SetupB(b *testing.B) {
@@ -52,6 +56,9 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 		if err := os.Remove(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))); err != nil {
 			b.Errorf("testing error: %v", err)
 		}
+	}
+	if timeTaken := b.Elapsed().Milliseconds(); timeTaken > int64(deleteThreshold*b.N) {
+		b.Errorf("Test failed due to timeout, time taken:%d msec", timeTaken)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -17,6 +17,7 @@ package benchmarking
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/benchmark_setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
@@ -28,7 +29,7 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 const (
-	statThreshold int = 260
+	expectedStatLatency time.Duration = 260 * time.Millisecond
 )
 
 type benchmarkStatTest struct{}
@@ -57,8 +58,9 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 			b.Errorf("testing error: %v", err)
 		}
 	}
-	if timeTaken := b.Elapsed().Milliseconds(); timeTaken > int64(statThreshold*b.N) {
-		b.Errorf("Test failed due to timeout, time taken:%d msec", timeTaken)
+	averageStatLatency := time.Duration(int(b.Elapsed()) / b.N)
+	if averageStatLatency > expectedStatLatency {
+		b.Errorf("Test failed due to timeout -> DeleteFile took more time (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -60,7 +60,7 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	}
 	averageStatLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageStatLatency > expectedStatLatency {
-		b.Errorf("Test failed due to timeout -> DeleteFile took more time (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
+		b.Errorf("StatFile took more time (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -27,6 +27,10 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
+const (
+	statThreshold int = 260
+)
+
 type benchmarkStatTest struct{}
 
 func (s *benchmarkStatTest) SetupB(b *testing.B) {
@@ -52,6 +56,9 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 		if _, err := operations.StatFile(path.Join(testDirPath, "a.txt")); err != nil {
 			b.Errorf("testing error: %v", err)
 		}
+	}
+	if timeTaken := b.Elapsed().Milliseconds(); timeTaken > int64(statThreshold*b.N) {
+		b.Errorf("Test failed due to timeout, time taken:%d msec", timeTaken)
 	}
 }
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -171,17 +171,21 @@ function run_parallel_tests() {
   local exit_code=0
   local -n test_array=$1
   local bucket_name_parallel=$2
+  local benchmark_flags=""
   local pids=()
 
   for test_dir_p in "${test_array[@]}"
   do
+    if [ $test_dir_p == "benchmarking" ]; then
+      benchmark_flags="-bench=."
+    fi
     test_path_parallel="./tools/integration_tests/$test_dir_p"
     # To make it clear whether tests are running on a flat or HNS bucket, We kept the log file naming
     # convention to include the bucket name as a suffix (e.g., package_name_bucket_name).
     local log_file="/tmp/${test_dir_p}_${bucket_name_parallel}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG $benchmark_flags -p 1 --integrationTest -v --testbucket=$bucket_name_parallel --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -176,6 +176,9 @@ function run_parallel_tests() {
 
   for test_dir_p in "${test_array[@]}"
   do
+    # Unlike regular tests,benchmark tests are not executed by default when using go test .
+    # The -bench flag yells go test to run the benchmark tests and report their results by
+    # enabling the benchmarking framework.
     if [ $test_dir_p == "benchmarking" ]; then
       benchmark_flags="-bench=."
     fi

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -80,6 +80,7 @@ TEST_DIR_PARALLEL=(
   "log_content"
   "kernel_list_cache"
   "concurrent_operations"
+  "mounting"
 )
 
 # These tests never become parallel as it is changing bucket permissions.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -80,7 +80,7 @@ TEST_DIR_PARALLEL=(
   "log_content"
   "kernel_list_cache"
   "concurrent_operations"
-  "mounting"
+  "benchmarking"
 )
 
 # These tests never become parallel as it is changing bucket permissions.


### PR DESCRIPTION
### Description
The benchmarking test package performs delete and stat benchmark, the test will fail if the time taken for the operation is beyond the threshold.Also, added this to e2e test scripts(both kokoro and louhi pipeline).
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - on cloudtop and GCE VM
2. Unit tests - NA
3. Integration tests - NA
