### PR TITLE
Modify fake bucket implementation to throw accurate error.

### DIFF
--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -442,7 +442,7 @@ func (b *bucket) newReaderLocked(
 	// Find the object with the requested name.
 	index = b.objects.find(req.Name)
 	if index == len(b.objects) {
-		err = storage.ErrObjectNotExist
+		err = fmt.Errorf("object %s not found: %w", req.Name, storage.ErrObjectNotExist)
 		return
 	}
 
@@ -450,7 +450,7 @@ func (b *bucket) newReaderLocked(
 
 	// Does the generation match?
 	if req.Generation != 0 && req.Generation != o.metadata.Generation {
-		err = storage.ErrObjectNotExist
+		err = fmt.Errorf("object %s generation %v not found: %w", req.Name, req.Generation, storage.ErrObjectNotExist)
 		return
 	}
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -442,10 +442,7 @@ func (b *bucket) newReaderLocked(
 	// Find the object with the requested name.
 	index = b.objects.find(req.Name)
 	if index == len(b.objects) {
-		err = &gcs.NotFoundError{
-			Err: fmt.Errorf("object %s not found", req.Name),
-		}
-
+		err = storage.ErrObjectNotExist
 		return
 	}
 

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -2154,7 +2154,7 @@ func (t *composeTest) OneSourceDoesntExist() {
 			},
 		})
 
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	ExpectThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
 
 	// Make sure the destination object doesn't exist.
 	_, _, err = t.bucket.StatObject(
@@ -2687,8 +2687,8 @@ func (t *readTest) ObjectNameDoesntExist() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
-	ExpectThat(err, Error(MatchesRegexp("(?i)not found|404")))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
 }
 
 func (t *readTest) EmptyObject() {
@@ -2790,8 +2790,8 @@ func (t *readTest) ParticularGeneration_HasBeenDeleted() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
-	ExpectThat(err, Error(MatchesRegexp("(?i)not found|404")))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
 }
 
 func (t *readTest) ParticularGeneration_Exists() {
@@ -3674,7 +3674,7 @@ func (t *deleteTest) NoParticularGeneration_Successful() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
 }
 
 func (t *deleteTest) ParticularGeneration_NameDoesntExist() {
@@ -3745,7 +3745,7 @@ func (t *deleteTest) ParticularGeneration_Successful() {
 
 	// The object should no longer exist.
 	_, err = storageutil.ReadObject(t.ctx, t.bucket, name)
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
 }
 
 func (t *deleteTest) MetaGenerationPrecondition_Unsatisfied_ObjectExists() {
@@ -3850,7 +3850,7 @@ func (t *deleteTest) MetaGenerationPrecondition_Satisfied() {
 
 	// The object should no longer exist.
 	_, err = storageutil.ReadObject(t.ctx, t.bucket, name)
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -32,7 +32,6 @@ import (
 	"time"
 	"unicode"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	. "github.com/jacobsa/oglematchers"
@@ -2154,7 +2153,7 @@ func (t *composeTest) OneSourceDoesntExist() {
 			},
 		})
 
-	ExpectThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 
 	// Make sure the destination object doesn't exist.
 	_, _, err = t.bucket.StatObject(
@@ -2231,7 +2230,7 @@ func (t *composeTest) ExplicitGenerations_OneDoesntExist() {
 			},
 		})
 
-	ExpectThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 
 	// Make sure the destination object doesn't exist.
 	_, _, err = t.bucket.StatObject(
@@ -2687,8 +2686,7 @@ func (t *readTest) ObjectNameDoesntExist() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
-	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 func (t *readTest) EmptyObject() {
@@ -2754,8 +2752,7 @@ func (t *readTest) ParticularGeneration_NeverExisted() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
-	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 func (t *readTest) ParticularGeneration_HasBeenDeleted() {
@@ -2790,8 +2787,7 @@ func (t *readTest) ParticularGeneration_HasBeenDeleted() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
-	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 func (t *readTest) ParticularGeneration_Exists() {
@@ -2856,8 +2852,7 @@ func (t *readTest) ParticularGeneration_ObjectHasBeenOverwritten() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
-	ExpectThat(err, Error(MatchesRegexp("(?i)object doesn't exist")))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 
 	// Reading by the new generation should work.
 	req.Generation = o2.Generation
@@ -3674,7 +3669,7 @@ func (t *deleteTest) NoParticularGeneration_Successful() {
 		_, err = rc.Read(make([]byte, 1))
 	}
 
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 func (t *deleteTest) ParticularGeneration_NameDoesntExist() {
@@ -3745,7 +3740,7 @@ func (t *deleteTest) ParticularGeneration_Successful() {
 
 	// The object should no longer exist.
 	_, err = storageutil.ReadObject(t.ctx, t.bucket, name)
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 func (t *deleteTest) MetaGenerationPrecondition_Unsatisfied_ObjectExists() {
@@ -3850,7 +3845,7 @@ func (t *deleteTest) MetaGenerationPrecondition_Satisfied() {
 
 	// The object should no longer exist.
 	_, err = storageutil.ReadObject(t.ctx, t.bucket, name)
-	AssertThat(err, HasSameTypeAs(storage.ErrObjectNotExist))
+	ExpectThat(err.Error(), HasSubstr("object doesn't exist"))
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
Modify fake bucket implementation to throw same error that is thrown by GCS Bucket.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
