### PR TITLE
[Emulator tests] Add proxy server - 1

### DIFF
--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -38,15 +38,15 @@ type RequestTypeAndInstruction struct {
 	Instruction string
 }
 
-// deduceRequestType determines the type of request and its corresponding instruction
-func deduceRequestType(r *http.Request) RequestTypeAndInstruction {
+// deduceRequestTypeAndInstruction determines the type of request and its corresponding instruction
+func deduceRequestTypeAndInstruction(r *http.Request) RequestTypeAndInstruction {
 	path := r.URL.Path
 	method := r.Method
 
 	if isJsonAPI(path) {
-		return deduceJsonRequestType(method)
+		return deduceJsonRequestTypeAndInstruction(method)
 	}
-	return deduceXmlRequestType(method)
+	return deduceXmlRequestTypeAndInstruction(method)
 }
 
 // isJsonAPI checks if the request is targeting the JSON API
@@ -54,8 +54,8 @@ func isJsonAPI(path string) bool {
 	return strings.Contains(path, "/storage/v1")
 }
 
-// deduceJsonRequestType determines the request type and instruction for JSON API requests
-func deduceJsonRequestType(method string) RequestTypeAndInstruction {
+// deduceJsonRequestTypeAndInstruction determines the request type and instruction for JSON API requests
+func deduceJsonRequestTypeAndInstruction(method string) RequestTypeAndInstruction {
 	switch method {
 	case http.MethodGet:
 		return RequestTypeAndInstruction{JsonStat, "storage.objects.get"}
@@ -70,8 +70,8 @@ func deduceJsonRequestType(method string) RequestTypeAndInstruction {
 	}
 }
 
-// deduceXmlRequestType determines the request type and instruction for XML API requests
-func deduceXmlRequestType(method string) RequestTypeAndInstruction {
+// deduceXmlRequestTypeAndInstruction determines the request type and instruction for XML API requests
+func deduceXmlRequestTypeAndInstruction(method string) RequestTypeAndInstruction {
 	switch method {
 	case http.MethodGet:
 		return RequestTypeAndInstruction{XmlRead, "storage.objects.get"}

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -63,7 +63,6 @@ func deduceRequestTypeAndInstruction(r *http.Request) RequestTypeAndInstruction 
 		default:
 			return RequestTypeAndInstruction{Unknown, ""}
 		}
-		return RequestTypeAndInstruction{Unknown, ""}
 	}
 	switch method {
 	case http.MethodGet:

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package proxy_server
 
 import (
 	"net/http"

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -74,5 +74,6 @@ func deduceRequestTypeAndInstruction(r *http.Request) RequestTypeAndInstruction 
 
 // isJsonAPI checks if the request is targeting the JSON API
 func isJsonAPI(path string) bool {
+	// The JSON API path includes "/storage/v1", while the XML API path does not.
 	return strings.Contains(path, "/storage/v1")
 }

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -60,7 +60,7 @@ func deduceJsonRequestTypeAndInstruction(method string) RequestTypeAndInstructio
 	case http.MethodGet:
 		return RequestTypeAndInstruction{JsonStat, "storage.objects.get"}
 	case http.MethodPost:
-		return RequestTypeAndInstruction{JsonCreate, "storage.objects.create"}
+		return RequestTypeAndInstruction{JsonCreate, "storage.objects.insert"}
 	case http.MethodDelete:
 		return RequestTypeAndInstruction{JsonDelete, "storage.objects.delete"}
 	case http.MethodPut:

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -45,6 +45,7 @@ func deduceRequestTypeAndInstruction(r *http.Request) RequestTypeAndInstruction 
 
 	if isJsonAPI(path) {
 		switch method {
+		// TODO: Implement logic to differentiate JSON read requests from general HTTP GET requests for the purpose of testing JSON read functionality.
 		case http.MethodGet:
 			// Check if path ends with `/o` (indicates listing objects)
 			if strings.HasSuffix(path, "/o") {

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mapper.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+type RequestType string
+
+const (
+	XmlRead     RequestType = "XmlRead"
+	JsonStat    RequestType = "JsonStat"
+	JsonDelete  RequestType = "JsonDelete"
+	JsonUpdate  RequestType = "JsonUpdate"
+	JsonCreate  RequestType = "JsonCreate"
+	JsonCopy    RequestType = "JsonCopy"
+	JsonList    RequestType = "JsonList"
+	JsonCompose RequestType = "JsonCompose"
+	Unknown     RequestType = "Unknown"
+)
+
+type RequestTypeAndInstruction struct {
+	RequestType RequestType
+	Instruction string
+}
+
+// deduceRequestType determines the type of request and its corresponding instruction
+func deduceRequestType(r *http.Request) RequestTypeAndInstruction {
+	path := r.URL.Path
+	method := r.Method
+
+	if isJsonAPI(path) {
+		return deduceJsonRequestType(method)
+	}
+	return deduceXmlRequestType(method)
+}
+
+// isJsonAPI checks if the request is targeting the JSON API
+func isJsonAPI(path string) bool {
+	return strings.Contains(path, "/storage/v1")
+}
+
+// deduceJsonRequestType determines the request type and instruction for JSON API requests
+func deduceJsonRequestType(method string) RequestTypeAndInstruction {
+	switch method {
+	case http.MethodGet:
+		return RequestTypeAndInstruction{JsonStat, "storage.objects.get"}
+	case http.MethodPost:
+		return RequestTypeAndInstruction{JsonCreate, "storage.objects.create"}
+	case http.MethodDelete:
+		return RequestTypeAndInstruction{JsonDelete, "storage.objects.delete"}
+	case http.MethodPut:
+		return RequestTypeAndInstruction{JsonUpdate, "storage.objects.update"}
+	default:
+		return RequestTypeAndInstruction{Unknown, ""}
+	}
+}
+
+// deduceXmlRequestType determines the request type and instruction for XML API requests
+func deduceXmlRequestType(method string) RequestTypeAndInstruction {
+	switch method {
+	case http.MethodGet:
+		return RequestTypeAndInstruction{XmlRead, "storage.objects.get"}
+	default:
+		return RequestTypeAndInstruction{Unknown, ""}
+	}
+}

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduceRequestType(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		expectedReq RequestType
+		expectedIns string
+	}{
+		// JSON API Tests
+		{"JsonStat GET", http.MethodGet, "/storage/v1/bucket/object", JsonStat, "storage.objects.get"},
+		{"JsonCreate POST", http.MethodPost, "/storage/v1/bucket/object", JsonCreate, "storage.objects.create"},
+		{"JsonDelete DELETE", http.MethodDelete, "/storage/v1/bucket/object", JsonDelete, "storage.objects.delete"},
+		{"JsonUpdate PUT", http.MethodPut, "/storage/v1/bucket/object", JsonUpdate, "storage.objects.update"},
+		{"JsonUnknown PATCH", http.MethodPatch, "/storage/v1/bucket/object", Unknown, ""},
+
+		// XML API Tests
+		{"XmlRead GET", http.MethodGet, "/bucket/object", XmlRead, "storage.objects.get"},
+		{"XmlUnknown POST", http.MethodPost, "/bucket/object", Unknown, ""},
+
+		// Other Edge Cases
+		{"UnknownPath GET", http.MethodGet, "/unknown/path", XmlRead, "storage.objects.get"},
+		{"EmptyPath GET", http.MethodPost, "", Unknown, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &http.Request{
+				Method: test.method,
+				URL:    &url.URL{Path: test.path},
+			}
+
+			result := deduceRequestType(req)
+			assert.Equal(t, test.expectedReq, result.RequestType)
+			assert.Equal(t, test.expectedIns, result.Instruction)
+		})
+	}
+}

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -53,7 +53,7 @@ func TestDeduceRequestType(t *testing.T) {
 				URL:    &url.URL{Path: test.path},
 			}
 
-			result := deduceRequestType(req)
+			result := deduceRequestTypeAndInstruction(req)
 			assert.Equal(t, test.expectedReq, result.RequestType)
 			assert.Equal(t, test.expectedIns, result.Instruction)
 		})

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -40,10 +40,6 @@ func TestDeduceRequestTypeAndInstruction(t *testing.T) {
 		// XML API Tests
 		{"XmlRead GET", http.MethodGet, "/bucket/object", XmlRead, "storage.objects.get"},
 		{"XmlUnknown POST", http.MethodPost, "/bucket/object", Unknown, ""},
-
-		// Other Edge Cases
-		{"UnknownPath GET", http.MethodGet, "/unknown/path", XmlRead, "storage.objects.get"},
-		{"EmptyPath GET", http.MethodPost, "", Unknown, ""},
 	}
 
 	for _, test := range tests {

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package proxy_server
 
 import (
 	"net/http"

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -32,7 +32,7 @@ func TestDeduceRequestTypeAndInstruction(t *testing.T) {
 	}{
 		// JSON API Tests
 		{"JsonStat GET", http.MethodGet, "/storage/v1/bucket/object", JsonStat, "storage.objects.get"},
-		{"JsonCreate POST", http.MethodPost, "/storage/v1/bucket/object", JsonCreate, "storage.objects.create"},
+		{"JsonCreate POST", http.MethodPost, "/storage/v1/bucket/object", JsonCreate, "storage.objects.insert"},
 		{"JsonDelete DELETE", http.MethodDelete, "/storage/v1/bucket/object", JsonDelete, "storage.objects.delete"},
 		{"JsonUpdate PUT", http.MethodPut, "/storage/v1/bucket/object", JsonUpdate, "storage.objects.update"},
 		{"JsonUnknown PATCH", http.MethodPatch, "/storage/v1/bucket/object", Unknown, ""},

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -31,11 +31,12 @@ func TestDeduceRequestTypeAndInstruction(t *testing.T) {
 		expectedIns string
 	}{
 		// JSON API Tests
-		{"JsonStat GET", http.MethodGet, "/storage/v1/bucket/object", JsonStat, "storage.objects.get"},
-		{"JsonCreate POST", http.MethodPost, "/storage/v1/bucket/object", JsonCreate, "storage.objects.insert"},
-		{"JsonDelete DELETE", http.MethodDelete, "/storage/v1/bucket/object", JsonDelete, "storage.objects.delete"},
-		{"JsonUpdate PUT", http.MethodPut, "/storage/v1/bucket/object", JsonUpdate, "storage.objects.update"},
-		{"JsonUnknown PATCH", http.MethodPatch, "/storage/v1/bucket/object", Unknown, ""},
+		{"JsonStat GET", http.MethodGet, "/storage/v1/bucket/o/object", JsonStat, "storage.objects.get"},
+		{"JsonList GET", http.MethodGet, "/storage/v1/bucket/o", JsonList, "storage.objects.list"},
+		{"JsonCreate POST", http.MethodPost, "/storage/v1/bucket/o", JsonCreate, "storage.objects.insert"},
+		{"JsonDelete DELETE", http.MethodDelete, "/storage/v1/bucket/o", JsonDelete, "storage.objects.delete"},
+		{"JsonUpdate PUT", http.MethodPut, "/storage/v1/bucket/o", JsonUpdate, "storage.objects.update"},
+		{"JsonUnknown PATCH", http.MethodPatch, "/storage/v1/bucket/o", Unknown, ""},
 
 		// XML API Tests
 		{"XmlRead GET", http.MethodGet, "/bucket/object", XmlRead, "storage.objects.get"},

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeduceRequestType(t *testing.T) {
+func TestDeduceRequestTypeAndInstruction(t *testing.T) {
 	tests := []struct {
 		name        string
 		method      string

--- a/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/request_mappper_test.go
@@ -51,6 +51,7 @@ func TestDeduceRequestTypeAndInstruction(t *testing.T) {
 			}
 
 			result := deduceRequestTypeAndInstruction(req)
+
 			assert.Equal(t, test.expectedReq, result.RequestType)
 			assert.Equal(t, test.expectedIns, result.Instruction)
 		})


### PR DESCRIPTION
### Description
- Introducing a proxy server  between GCSFuse and the storage testbench server. The proxy's sole purpose is to attach the retry ID to requests, enabling the server to recognize and respond according to the test instructions. This is require to add e2e tests on retries in GCSFuse.
- In this PR we are adding request mapper which can map http request to Json, XML request type and instruction.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
