### PR TITLE
map storage.ErrObjectNotExist in NewReader method to gcs.NotFoundError

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -90,8 +90,8 @@ func (bh *bucketHandle) BucketType() gcs.BucketType {
 }
 
 func (bh *bucketHandle) NewReader(
-		ctx context.Context,
-		req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
+	ctx context.Context,
+	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
 	// Initialising the starting offset and the length to be read by the reader.
 	start := int64(0)
 	length := int64(-1)
@@ -159,7 +159,7 @@ func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectR
 }
 
 func (bh *bucketHandle) StatObject(ctx context.Context,
-		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	var attrs *storage.ObjectAttrs
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = bh.bucket.Object(req.Name).Attrs(ctx)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -153,6 +153,8 @@ func (testSuite *BucketHandleTest) TestNewReaderMethodWithNilRange() {
 }
 
 func (testSuite *BucketHandleTest) TestNewReaderMethodWithInValidObject() {
+	var notFoundErr *gcs.NotFoundError
+
 	rc, err := testSuite.bucketHandle.NewReader(context.Background(),
 		&gcs.ReadObjectRequest{
 			Name: missingObjectName,
@@ -163,6 +165,7 @@ func (testSuite *BucketHandleTest) TestNewReaderMethodWithInValidObject() {
 		})
 
 	assert.NotNil(testSuite.T(), err)
+	assert.True(testSuite.T(), errors.As(err, &notFoundErr))
 	assert.Nil(testSuite.T(), rc)
 }
 
@@ -186,6 +189,8 @@ func (testSuite *BucketHandleTest) TestNewReaderMethodWithValidGeneration() {
 }
 
 func (testSuite *BucketHandleTest) TestNewReaderMethodWithInvalidGeneration() {
+	var notFoundErr *gcs.NotFoundError
+
 	rc, err := testSuite.bucketHandle.NewReader(context.Background(),
 		&gcs.ReadObjectRequest{
 			Name: TestObjectName,
@@ -197,6 +202,7 @@ func (testSuite *BucketHandleTest) TestNewReaderMethodWithInvalidGeneration() {
 		})
 
 	assert.NotNil(testSuite.T(), err)
+	assert.True(testSuite.T(), errors.As(err, &notFoundErr))
 	assert.Nil(testSuite.T(), rc)
 }
 
@@ -1374,9 +1380,9 @@ func (testSuite *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstO
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-		Return(&controlpb.StorageLayout{
-			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		}, nil)
+			Return(&controlpb.StorageLayout{
+				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+			}, nil)
 
 	testSuite.bucketHandle.BucketType()
 
@@ -1385,9 +1391,9 @@ func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() 
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceFalse() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-		Return(&controlpb.StorageLayout{
-			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
-		}, nil)
+			Return(&controlpb.StorageLayout{
+				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
+			}, nil)
 
 	testSuite.bucketHandle.BucketType()
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1380,9 +1380,9 @@ func (testSuite *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstO
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-			Return(&controlpb.StorageLayout{
-				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-			}, nil)
+		Return(&controlpb.StorageLayout{
+			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		}, nil)
 
 	testSuite.bucketHandle.BucketType()
 
@@ -1391,9 +1391,9 @@ func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() 
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceFalse() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-			Return(&controlpb.StorageLayout{
-				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
-			}, nil)
+		Return(&controlpb.StorageLayout{
+			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
+		}, nil)
 
 	testSuite.bucketHandle.BucketType()
 


### PR DESCRIPTION
### Description
map storage.ErrObjectNotExist in NewReader method to gcs.NotFoundError since for all other methods in bucket_handle.go storage.ErrObjectNotExist is mapped to gcs.NotFoundError.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - Automated
