### PR TITLE
Made changes to support setting mtime and getting when buffered writes are enabled

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1685,13 +1685,10 @@ func (fs *fileSystem) createLocalFile(
 	}
 	child = fs.mintInode(core)
 	fs.localFileInodes[child.Name()] = child
-	// For buffered writes, we don't create temp files on disk.
-	if !fs.newConfig.Write.ExperimentalEnableStreamingWrites {
-		// Empty file is created to be able to set attributes on the file.
-		fileInode := child.(*inode.FileInode)
-		if err := fileInode.CreateEmptyTempFile(); err != nil {
-			return nil, err
-		}
+	// Empty file is created to be able to set attributes on the file.
+	fileInode := child.(*inode.FileInode)
+	if err := fileInode.CreateEmptyTempFile(); err != nil {
+		return nil, err
 	}
 	fs.mu.Unlock()
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1687,7 +1687,7 @@ func (fs *fileSystem) createLocalFile(
 	fs.localFileInodes[child.Name()] = child
 	// Empty file is created to be able to set attributes on the file.
 	fileInode := child.(*inode.FileInode)
-	if err := fileInode.CreateEmptyTempFile(); err != nil {
+	if err := fileInode.CreateBufferedOrTempWriter(); err != nil {
 		return nil, err
 	}
 	fs.mu.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -706,14 +706,6 @@ func (f *FileInode) CreateEmptyTempFile() (err error) {
 	return
 }
 
-// writeToBuffer writes the given content to the in-memory buffer.
-func (f *FileInode) writeToBuffer(data []byte, offset int64) (err error) {
-
-	err = f.bwh.Write(data, offset)
-
-	return
-}
-
 func (f *FileInode) ensureBufferedWriteHandler() error {
 	var err error
 	if f.bwh == nil {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -695,7 +695,7 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	return
 }
 
-func (f *FileInode) CreateEmptyTempFile() (err error) {
+func (f *FileInode) CreateBufferedOrTempWriter() (err error) {
 	// Skip creating empty file when streaming writes are enabled
 	if f.local && f.writeConfig.ExperimentalEnableStreamingWrites {
 		err = f.ensureBufferedWriteHandler()

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -878,6 +878,26 @@ func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
 	AssertEq("gcs.NotFoundError: object test not found", err.Error())
 }
 
+func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
+	var err error
+	var attrs fuseops.InodeAttributes
+	// Create a local file inode.
+	t.createInodeWithLocalParam("test", true)
+	t.in.writeConfig = getWriteConfig()
+
+	// Set mtime.
+	mtime := time.Now().UTC().Add(123 * time.Second)
+	err = t.in.SetMtime(t.ctx, mtime)
+
+	AssertEq(nil, err)
+	// The inode should agree about the new mtime.
+	attrs, err = t.in.Attributes(t.ctx)
+	AssertEq(nil, err)
+	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
+	ExpectThat(attrs.Ctime, timeutil.TimeEq(mtime))
+	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
+}
+
 func (t *FileTest) ContentEncodingGzip() {
 	// Set up an explicit content-encoding on the backing object and re-create the inode.
 	contentEncoding := "gzip"

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -415,7 +415,7 @@ func (t *FileTest) WriteToLocalFileThenSync() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 	// Write some content to temp file.
 	t.clock.AdvanceTime(time.Second)
@@ -459,7 +459,7 @@ func (t *FileTest) SyncEmptyLocalFile() {
 	t.createInodeWithLocalParam("test", true)
 	creationTime := t.clock.Now()
 	// Create a temp file for the local inode created above.
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 
 	// Sync.
@@ -629,7 +629,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 	// Fetch the attributes and check if the file is empty.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -655,7 +655,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 	// Write some data to the local file.
 	err = t.in.Write(t.ctx, []byte("burrito"), 0)
@@ -867,7 +867,7 @@ func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -898,7 +898,7 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 
 	// Set mtime.
@@ -953,8 +953,8 @@ func (t *FileTest) TestCheckInvariantsShouldNotThrowExceptionForLocalFiles() {
 	AssertNe(nil, t.in)
 }
 
-func (t *FileTest) TestCreateEmptyTempFileShouldCreateEmptyFile() {
-	err := t.in.CreateEmptyTempFile()
+func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
+	err := t.in.CreateBufferedOrTempWriter()
 
 	AssertEq(nil, err)
 	AssertNe(nil, t.in.content)
@@ -964,22 +964,22 @@ func (t *FileTest) TestCreateEmptyTempFileShouldCreateEmptyFile() {
 	AssertEq(0, sr.Size)
 }
 
-func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
 
-	err := t.in.CreateEmptyTempFile()
+	err := t.in.CreateBufferedOrTempWriter()
 
 	AssertEq(nil, err)
 	AssertEq(nil, t.in.content)
 	AssertNe(nil, t.in.bwh)
 }
 
-func (t *FileTest) TestCreateEmptyTempFileShouldCreateFileForNonLocalFilesForStreamingWrites() {
+func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFilesForStreamingWrites() {
 	// Enabling buffered writes.
 	t.in.writeConfig = getWriteConfig()
 
-	err := t.in.CreateEmptyTempFile()
+	err := t.in.CreateBufferedOrTempWriter()
 
 	AssertEq(nil, err)
 	AssertNe(nil, t.in.content)
@@ -995,7 +995,7 @@ func (t *FileTest) UnlinkLocalFile() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
-	err = t.in.CreateEmptyTempFile()
+	err = t.in.CreateBufferedOrTempWriter()
 	AssertEq(nil, err)
 
 	// Unlink.

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1055,6 +1055,7 @@ func (t *FileTest) WriteToLocalFileWhenStreamingWritesAreEnabled() {
 func (t *FileTest) MultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
+	createTime := t.in.mtimeClock.Now()
 	t.in.writeConfig = getWriteConfig()
 	AssertEq(nil, t.in.bwh)
 
@@ -1070,11 +1071,13 @@ func (t *FileTest) MultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
 	attrs, err := t.in.Attributes(t.ctx)
 	AssertEq(nil, err)
 	AssertEq(7, attrs.Size)
+	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
 }
 
 func (t *FileTest) WriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.writeConfig = getWriteConfig()
+	createTime := t.in.mtimeClock.Now()
 	AssertEq(nil, t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
@@ -1083,6 +1086,11 @@ func (t *FileTest) WriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	AssertNe(nil, t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
 	AssertEq(2, writeFileInfo.TotalSize)
+	// The inode should agree about the new mtime.
+	attrs, err := t.in.Attributes(t.ctx)
+	AssertEq(nil, err)
+	AssertEq(2, attrs.Size)
+	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
 }
 
 func (t *FileTest) SetMtimeOnEmptyGCSFileWhenStreamingWritesAreEnabled() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1121,24 +1121,6 @@ func (t *FileTest) SetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEnable
 	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
 }
 
-func (t *FileTest) TestTruncateForLocalFileWhenStreamingWritesAreEnabled() {
-	var err error
-	var attrs fuseops.InodeAttributes
-	// Create a local file inode.
-	t.createInodeWithLocalParam("test", true)
-	t.in.writeConfig = getWriteConfig()
-	err = t.in.CreateEmptyTempFile()
-	AssertEq(nil, err)
-	// Fetch the attributes and check if the file is empty.
-	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(0, attrs.Size)
-
-	err = t.in.Truncate(t.ctx, 6)
-
-	AssertEq(nil, err)
-}
-
 func getWriteConfig() *cfg.WriteConfig {
 	return &cfg.WriteConfig{
 		MaxBlocksPerFile:                  10,

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -959,6 +959,7 @@ func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileWhenStreamingWrites
 }
 
 func (t *FileTest) TestCreateEmptyTempFileShouldCreateFileForNonLocalFiles() {
+	// Enabling buffered writes.
 	t.in.writeConfig = getWriteConfig()
 
 	err := t.in.CreateEmptyTempFile()

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1048,6 +1048,10 @@ func (t *FileTest) MultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
 	err = t.in.Write(t.ctx, []byte("hello"), 0)
 	AssertEq(nil, err)
 	AssertEq(7, t.in.bwh.WriteFileInfo().TotalSize)
+	// The inode should agree about the new mtime.
+	attrs, err := t.in.Attributes(t.ctx)
+	AssertEq(nil, err)
+	AssertEq(7, attrs.Size)
 }
 
 func getWriteConfig() *cfg.WriteConfig {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -948,6 +948,29 @@ func (t *FileTest) TestCreateEmptyTempFileShouldCreateEmptyFile() {
 	AssertEq(0, sr.Size)
 }
 
+func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileWhenStreamingWritesAreEnabled() {
+	t.createInodeWithLocalParam("test", true)
+	t.in.writeConfig = getWriteConfig()
+
+	err := t.in.CreateEmptyTempFile()
+
+	AssertEq(nil, err)
+	AssertEq(nil, t.in.content)
+}
+
+func (t *FileTest) TestCreateEmptyTempFileShouldCreateFileForNonLocalFiles() {
+	t.in.writeConfig = getWriteConfig()
+
+	err := t.in.CreateEmptyTempFile()
+
+	AssertEq(nil, err)
+	AssertNe(nil, t.in.content)
+	// Validate that file size is 0.
+	sr, err := t.in.content.Stat()
+	AssertEq(nil, err)
+	AssertEq(0, sr.Size)
+}
+
 func (t *FileTest) UnlinkLocalFile() {
 	var err error
 	// Create a local file inode.


### PR DESCRIPTION
### Description
Updated SetInodeattributes and getAttributes for handling mtime for local files and empty GCS files.
invoking bufferedWrites flow for empty gcs files.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
