### PR TITLE
Reduce test-parallelism to 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,8 @@ jobs:
         CGO_ENABLED=0 go build ./...
         go install ./tools/build_gcsfuse
         build_gcsfuse . /tmp ${GITHUB_SHA}
-    - name: Test all except caching parallely
-      run: CGO_ENABLED=0 go test -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./... | grep -v internal/cache/...`
-    - name: Test caching
-      run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage_cache.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
+    - name: Test all
+      run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
     - name: Cache RaceDetector Test
       run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -31,11 +31,8 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Test all except caching parallely
-        run: CGO_ENABLED=0 go test -timeout 75m -count 20 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./... | grep -v internal/cache/...`
-
-      - name: Test caching
-        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
+      - name: Test all
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
 
       - name: Cache RaceDetector Test
         run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 ./internal/cache/...


### PR DESCRIPTION
* Currently, tests get timed-out probably due to resource constraints on the machine. Reducing the parallelism to 1 so that the resource requirements reduces.
* Keeping the cache tests and 

### Description

### Link to the issue in case of a bug fix.
b/380798155

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
