### PR TITLE
updating benchmark(list/stat) thresholds to 1.5x times 

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	expectedDeleteLatency time.Duration = 450 * time.Millisecond
+	expectedDeleteLatency time.Duration = 675 * time.Millisecond
 )
 
 type benchmarkDeleteTest struct{}

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -29,7 +29,7 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 const (
-	expectedStatLatency time.Duration = 260 * time.Millisecond
+	expectedStatLatency time.Duration = 390 * time.Millisecond
 )
 
 type benchmarkStatTest struct{}


### PR DESCRIPTION
### Description
For the benchmark tests recently introduced, thresholds were very strict due to which they were frequent failures in presubmit tests. So, increasing to 1.5x of average for both delete and stat operations.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
