### PR TITLE
fixes and improvements in gke test setup

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
@@ -45,7 +45,7 @@ spec:
         # Print out the individual commands run.
         set -x
 
-        echo "Installing gsutil..."
+        echo "Installing gcloud ..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -62,7 +62,7 @@ spec:
         ++workload.dataset.record_length_stdev=0 \
         ++workload.dataset.record_length_resize=0
 
-        gsutil -m cp -R /data/train gs://{{ .Values.bucketName }}
+        gcloud storage cp -r /data/train gs://{{ .Values.bucketName }}
         mkdir -p /bucket/valid
     volumeMounts:
     - name: local-dir

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/data-loader/templates/dlio-data-loader.yaml
@@ -40,6 +40,11 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
+        # Fail if any of the commands fails.
+        set -e
+        # Print out the individual commands run.
+        set -x
+
         echo "Installing gsutil..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -79,9 +79,11 @@ spec:
         {{ end }}
 
         outputDir=/logs/{{ .Values.outputDirPrefix }}
+        mkdir -pv /data/train /data/valid
 
         echo "Testing {{ .Values.scenario }}"
         mpirun -np 8 dlio_benchmark workload=unet3d_a100 \
+        ++workload.workflow.generate_data=True \
         ++workload.train.epochs=4 \
         ++workload.workflow.profiling=True \
         ++workload.profiling.profiler=iostat \

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -44,6 +44,11 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
+        # Fail if any of the commands fails.
+        set -e
+        # Print out the individual commands run.
+        set -x
+
         # Change the source code of dlio benchmark so that page cache is cleared at every epoch
         main_file="dlio_benchmark/main.py"
         x=$(grep -n "for epoch in range(1, self.epochs + 1):" $main_file | cut -f1 -d ':')

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -55,7 +55,7 @@ spec:
         x=$((x + 1))
         sed -i "${x} i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ os.system(\"sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'\")" $main_file
 
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -100,7 +100,7 @@ spec:
         echo "{{ .Values.gcsfuse.mountOptions }}" > ${outputDir}/gcsfuse_mount_options
         {{ end }}
 
-        gsutil -m cp -R /logs/* gs://{{ .Values.bucketName }}/logs/
+        gcloud storage cp -r /logs/* gs://{{ .Values.bucketName }}/logs/
     volumeMounts:
     - name: dshm
       mountPath: /dev/shm

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
@@ -44,7 +44,7 @@ spec:
         apt-get update
         apt-get install -y libaio-dev gcc make git wget
 
-        echo "Installing gsutil..."
+        echo "Installing gcloud ..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -91,7 +91,7 @@ spec:
         NUMJOBS=50 NRFILES={{ .Values.fio.filesPerThread }} FILE_SIZE={{ .Values.fio.fileSize }} BLOCK_SIZE={{ .Values.fio.blockSize }} READ_TYPE=read DIR=/data fio ${filename} --alloc-size=1048576
 
         echo "Uploading data to bucket {{ .Values.bucketName }}..."
-        gsutil -m cp -R /data/* gs://{{ .Values.bucketName }}
+        gcloud cp -r /data/* gs://{{ .Values.bucketName }}
     volumeMounts:
     - name: local-dir
       mountPath: /data

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/data-loader/templates/fio-data-loader.yaml
@@ -35,10 +35,15 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
+        # Fail if any of the commands fails.
+        set -e
+        # Print out the individual commands run.
+        set -x
+
         echo "Install dependencies..."
         apt-get update
         apt-get install -y libaio-dev gcc make git wget
-        
+
         echo "Installing gsutil..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
@@ -82,7 +87,7 @@ spec:
         {{ else }}
         wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/perfmetrics/scripts/job_files/read_cache_load_test.fio
         {{ end }}
-        
+
         NUMJOBS=50 NRFILES={{ .Values.fio.filesPerThread }} FILE_SIZE={{ .Values.fio.fileSize }} BLOCK_SIZE={{ .Values.fio.blockSize }} READ_TYPE=read DIR=/data fio ${filename} --alloc-size=1048576
 
         echo "Uploading data to bucket {{ .Values.bucketName }}..."

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -57,13 +57,13 @@ spec:
         num_of_threads={{ .Values.fio.numThreads }}
 
         {{ if eq .Values.scenario "local-ssd" }}
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         apt-get update && apt-get install -y google-cloud-cli
 
-        gsutil -m cp -R gs://{{ .Values.bucketName }}/* /data
+        gcloud storage cp -r gs://{{ .Values.bucketName }}/* /data
 
         echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
         sleep 300
@@ -161,7 +161,7 @@ spec:
         done
 
         {{ if eq .Values.scenario "local-ssd" }}
-        gsutil -m cp -R /data/fio-output/* gs://{{ .Values.bucketName }}/fio-output/
+        gcloud storage cp -r /data/fio-output/* gs://{{ .Values.bucketName }}/fio-output/
         {{ end }}
 
         echo "fio job completed!"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -42,6 +42,11 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
+        # Fail if any of the commands fails.
+        set -e
+        # Print out the individual commands run.
+        set -x
+
         echo "Install dependencies..."
         apt-get update
         apt-get install -y libaio-dev gcc make git time wget
@@ -58,7 +63,7 @@ spec:
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         apt-get update && apt-get install -y google-cloud-cli
 
-        gsutil -m cp -R gs://{{ .Values.bucketName }}/* /data 
+        gsutil -m cp -R gs://{{ .Values.bucketName }}/* /data
 
         echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
         sleep 300
@@ -154,11 +159,11 @@ spec:
 
           sleep $pause_in_seconds
         done
-        
+
         {{ if eq .Values.scenario "local-ssd" }}
         gsutil -m cp -R /data/fio-output/* gs://{{ .Values.bucketName }}/fio-output/
         {{ end }}
-        
+
         echo "fio job completed!"
     volumeMounts:
     - name: dshm

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -629,7 +629,11 @@ function waitTillAllPodsComplete() {
     else
       printf "\n${num_noncompleted_pods} pod(s) is/are still pending/running (time till timeout=${time_till_timeout} seconds). Will check again in "${pod_wait_time_in_seconds}" seconds. Sleeping for now.\n\n"
       printf "\nYou can take a break too if you want. Just kill this run and connect back to it later, for fetching and parsing outputs, using the following command: \n"
-      printf "   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type} use_custom_csi_driver=${use_custom_csi_driver} gcsfuse_src_dir=\"${gcsfuse_src_dir}\" csi_src_dir=\"${csi_src_dir}\" pod_wait_time_in_seconds=${pod_wait_time_in_seconds} pod_timeout_in_seconds=${pod_timeout_in_seconds} workload_config=\"${workload_config}\" cluster_name=${cluster_name} output_dir=\"${output_dir}\" $0 \n"
+      printf "   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type} use_custom_csi_driver=${use_custom_csi_driver} gcsfuse_src_dir=\"${gcsfuse_src_dir}\" "
+      if test -d "${csi_src_dir}"; then
+        printf "csi_src_dir=\"${csi_src_dir}\" "
+      fi
+      printf "pod_wait_time_in_seconds=${pod_wait_time_in_seconds} pod_timeout_in_seconds=${pod_timeout_in_seconds} workload_config=\"${workload_config}\" cluster_name=${cluster_name} output_dir=\"${output_dir}\" output_gsheet_id=\"${output_gsheet_id}\" output_gsheet_keyfile=\"${output_gsheet_keyfile}\" $0 \n"
       printf "\nbut remember that this will reset the start-timer for pod timeout.\n\n"
       printf "\nTo ssh to any specific pod, use the following command: \n"
       printf "  gcloud container clusters get-credentials ${cluster_name} --location=${zone}\n"


### PR DESCRIPTION
### Description
1. Print the shell commands being run in the fio/dlio workloads.
1. Error out the fio/dlio workloads if any of their commands fail, for fail-fast.
1. Don't print out `csi_src_dir` in `only_parse=true` command if it's not applicable.
1. Replace all gsutil commands with gcloud commands in fio/dlio load-test/data-loader workloads.
1. Create training data files in dlio unet3d-load workload if missing.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - I've tested these manually by running my sample workloads, meant for testing this setup, locally.
5. Unit tests - NA
6. Integration tests - NA
