### PR TITLE
Throwing OutOfOrder error for out of order writes

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -15,11 +15,13 @@
 package bufferedwrites
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/block"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/sync/semaphore"
 )
@@ -46,6 +48,8 @@ type WriteFileInfo struct {
 	Mtime     time.Time
 }
 
+var ErrOutOfOrderWrite = errors.New("outOfOrder write detected")
+
 // NewBWHandler creates the bufferedWriteHandler struct.
 func NewBWHandler(objectName string, bucket gcs.Bucket, blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bwh *BufferedWriteHandler, err error) {
 	bp, err := block.NewBlockPool(blockSize, maxBlocks, globalMaxBlocksSem)
@@ -66,9 +70,10 @@ func NewBWHandler(objectName string, bucket gcs.Bucket, blockSize int64, maxBloc
 // Write writes the given data to the buffer. It writes to an existing buffer if
 // the capacity is available otherwise writes to a new buffer.
 func (wh *BufferedWriteHandler) Write(data []byte, offset int64) (err error) {
-	if offset > wh.totalSize {
-		// TODO: Will be handled as part of ordered writes.
-		return fmt.Errorf("non sequential writes")
+	if offset != wh.totalSize {
+		logger.Errorf("BufferedWriteHandler.OutOfOrderError for object: %s, expectedOffset: %d, actualOffset: %d",
+			wh.uploadHandler.objectName, wh.totalSize, offset)
+		return ErrOutOfOrderWrite
 	}
 
 	// Fail early if the uploadHandler has failed.

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1001,7 +1001,7 @@ func (t *FileTest) MultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
 	AssertNe(nil, t.in.bwh)
 	AssertEq(2, t.in.bwh.WriteFileInfo().TotalSize)
 
-	err = t.in.Write(t.ctx, []byte("hello"), 0)
+	err = t.in.Write(t.ctx, []byte("hello"), 2)
 	AssertEq(nil, err)
 	AssertEq(7, t.in.bwh.WriteFileInfo().TotalSize)
 }


### PR DESCRIPTION
### Description
Throwing custom error when non-sequential writes are detected. The caller will finalize and fallback to current approach. Those changes will be done after the flush changes are submitted.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
