### PR TITLE
Ensure that test workloads get scheduled on different nodes.

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -24,12 +24,16 @@ metadata:
   {{- end }}
 spec:
   restartPolicy: Never
+  activeDeadlineSeconds: 5000
   nodeSelector:
     cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
     node.kubernetes.io/instance-type: {{ .Values.nodeType }}
   containers:
   - name: dlio-tester
     image: {{ .Values.image }}
+    ports:
+    - containerPort: 11021
+      hostPort: 11021
     resources:
       limits:
         cpu: {{ .Values.resourceLimits.cpu }}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -23,12 +23,16 @@ metadata:
   {{- end }}
 spec:
   restartPolicy: Never
+  activeDeadlineSeconds: 5000
   nodeSelector:
     cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
     node.kubernetes.io/instance-type: {{ .Values.nodeType }}
   containers:
   - name: fio-tester
     image: {{ .Values.image }}
+    ports:
+    - containerPort: 11021
+      hostPort: 11021
     securityContext: # for cache dropping in the benchmarking tests.
       privileged: true
     resources:


### PR DESCRIPTION
* This is so that the performance doesn't get affected due to multiple pods running on the same node.
* Specify timeout so that a pod doesn't keep running indefinitely

### Description

### Link to the issue in case of a bug fix.
b/379205752

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
