### PR TITLE
Remove global err variable from fs_test package.

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -290,8 +290,7 @@ func (t *fsTest) createEmptyObjects(names []string) error {
 
 func (t *fsTest) createFolders(folders []string) error {
 	for i := 0; i < len(folders); i++ {
-		_, err := bucket.CreateFolder(ctx, folders[i])
-		if err != nil {
+		if _, err := bucket.CreateFolder(ctx, folders[i]); err != nil {
 			return err
 		}
 	}

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -290,7 +290,7 @@ func (t *fsTest) createEmptyObjects(names []string) error {
 
 func (t *fsTest) createFolders(folders []string) error {
 	for i := 0; i < len(folders); i++ {
-		_, err = bucket.CreateFolder(ctx, folders[i])
+		_, err := bucket.CreateFolder(ctx, folders[i])
 		if err != nil {
 			return err
 		}

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -65,7 +65,7 @@ func (t *HNSBucketTests) TearDownSuite() {
 }
 
 func (t *HNSBucketTests) SetupTest() {
-	err = t.createFolders([]string{"foo/", "bar/", "foo/test2/", "foo/test/"})
+	err := t.createFolders([]string{"foo/", "bar/", "foo/test2/", "foo/test/"})
 	require.NoError(t.T(), err)
 
 	err = t.createObjects(
@@ -103,7 +103,7 @@ func (t *HNSBucketTests) TestReadDir() {
 func (t *HNSBucketTests) TestDeleteFolder() {
 	dirPath := path.Join(mntDir, "foo")
 
-	err = os.RemoveAll(dirPath)
+	err := os.RemoveAll(dirPath)
 
 	assert.NoError(t.T(), err)
 	_, err = os.Stat(dirPath)
@@ -114,7 +114,7 @@ func (t *HNSBucketTests) TestDeleteFolder() {
 func (t *HNSBucketTests) TestDeleteImplicitDir() {
 	dirPath := path.Join(mntDir, "foo", "implicit_dir")
 
-	err = os.RemoveAll(dirPath)
+	err := os.RemoveAll(dirPath)
 
 	assert.NoError(t.T(), err)
 	_, err = os.Stat(dirPath)
@@ -126,7 +126,7 @@ func (t *HNSBucketTests) TestRenameFolderWithSrcDirectoryDoesNotExist() {
 	oldDirPath := path.Join(mntDir, "foo_not_exist")
 	newDirPath := path.Join(mntDir, "foo_rename")
 
-	err = os.Rename(oldDirPath, newDirPath)
+	err := os.Rename(oldDirPath, newDirPath)
 
 	assert.Error(t.T(), err)
 	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
@@ -137,7 +137,7 @@ func (t *HNSBucketTests) TestRenameFolderWithSrcDirectoryDoesNotExist() {
 
 func (t *HNSBucketTests) TestRenameFolderWithDstDirectoryNotEmpty() {
 	oldDirPath := path.Join(mntDir, "foo")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
 	// In the setup phase, we created file1.txt within the bar directory.
 	newDirPath := path.Join(mntDir, "bar")
@@ -152,7 +152,7 @@ func (t *HNSBucketTests) TestRenameFolderWithDstDirectoryNotEmpty() {
 
 func (t *HNSBucketTests) TestRenameFolderWithEmptySourceDirectory() {
 	oldDirPath := path.Join(mntDir, "foo", "test2")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "foo_rename")
 	_, err = os.Stat(newDirPath)
@@ -173,7 +173,7 @@ func (t *HNSBucketTests) TestRenameFolderWithEmptySourceDirectory() {
 
 func (t *HNSBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
 	oldDirPath := path.Join(mntDir, "foo", "test")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
 	file, err := os.OpenFile(path.Join(oldDirPath, "file4.txt"), os.O_RDWR|os.O_CREATE, filePerms)
 	assert.NoError(t.T(), err)
@@ -191,7 +191,7 @@ func (t *HNSBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
 
 func (t *HNSBucketTests) TestRenameFolderWithSameParent() {
 	oldDirPath := path.Join(mntDir, "foo")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	require.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "foo_rename")
 	_, err = os.Stat(newDirPath)
@@ -221,7 +221,7 @@ func (t *HNSBucketTests) TestRenameFolderWithSameParent() {
 
 func (t *HNSBucketTests) TestRenameFolderWithExistingEmptyDestDirectory() {
 	oldDirPath := path.Join(mntDir, "foo", "test")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	require.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "foo", "test2")
 	_, err = os.Stat(newDirPath)
@@ -247,7 +247,7 @@ func (t *HNSBucketTests) TestRenameFolderWithExistingEmptyDestDirectory() {
 
 func (t *HNSBucketTests) TestRenameFolderWithDifferentParents() {
 	oldDirPath := path.Join(mntDir, "foo")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "bar", "foo_rename")
 
@@ -274,7 +274,7 @@ func (t *HNSBucketTests) TestRenameFolderWithDifferentParents() {
 
 func (t *HNSBucketTests) TestRenameFolderWithOpenGCSFile() {
 	oldDirPath := path.Join(mntDir, "bar")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "bar_rename")
 	filePath := path.Join(oldDirPath, "file1.txt")
@@ -311,7 +311,7 @@ func (t *HNSBucketTests) TestRenameFolderWithOpenGCSFile() {
 // Read directory again and validate it is empty.
 func (t *HNSBucketTests) TestCreateDirectoryWithSameNameAfterRename() {
 	oldDirPath := path.Join(mntDir, "foo")
-	_, err = os.Stat(oldDirPath)
+	_, err := os.Stat(oldDirPath)
 	require.NoError(t.T(), err)
 	newDirPath := path.Join(mntDir, "foo_rename")
 	// Rename directory foo --> foo_rename

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -840,7 +840,6 @@ func (t *LocalFileTest) AtimeMtimeAndCtime() {
 // Stat that local file.
 func (t *LocalFileTest) TestStatLocalFileAfterRecreatingItWithSameName() {
 	filePath := path.Join(mntDir, "test.txt")
-	AssertEq(nil, err)
 	f1, err := os.Create(filePath)
 	defer AssertEq(nil, f1.Close())
 	AssertEq(nil, err)
@@ -871,7 +870,6 @@ func (t *LocalFileTest) TestStatFailsOnNewFileAfterDeletion() {
 	}
 	t.serverCfg.MetricHandle = common.NewNoopMetrics()
 	filePath := path.Join(mntDir, "test.txt")
-	AssertEq(nil, err)
 	f1, err := os.Create(filePath)
 	AssertEq(nil, err)
 	defer AssertEq(nil, f1.Close())

--- a/internal/fs/type_cache_test.go
+++ b/internal/fs/type_cache_test.go
@@ -20,7 +20,6 @@ package fs_test
 
 import (
 	"fmt"
-	"io/fs"
 	"math"
 	"os"
 	"path"
@@ -71,9 +70,6 @@ var (
 	typeCacheMaxSizeMb int64
 
 	contentInBytes []byte
-
-	fi  fs.FileInfo
-	err error
 )
 
 func (t *typeCacheTestCommon) SetUpTestSuite() {
@@ -176,7 +172,7 @@ func (t *typeCacheTestCommon) createObjectOnGCS(name string) *gcs.Object {
 }
 
 func (t *typeCacheTestCommon) statAndConfirmIsDir(name string, isDir bool) {
-	fi, err = os.Stat(name)
+	fi, err := os.Stat(name)
 
 	ExpectEq(nil, err)
 	AssertNe(nil, fi)
@@ -184,7 +180,7 @@ func (t *typeCacheTestCommon) statAndConfirmIsDir(name string, isDir bool) {
 }
 
 func (t *typeCacheTestCommon) statAndExpectNotADirectoryError(name string) {
-	_, err = os.Stat(name)
+	_, err := os.Stat(name)
 
 	ExpectNe(nil, err)
 	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("not a directory")))
@@ -212,7 +208,7 @@ func (t *typeCacheTestCommon) testNoInsertionSupported() {
 func (t *TypeCacheTestWithMaxSize1MB) TestNoEntryInitially() {
 	// Initially, without any existing object, type-cache
 	// should not contain any entry and os.Stat should fail.
-	_, err = os.Stat(path.Join(mntDir, foo))
+	_, err := os.Stat(path.Join(mntDir, foo))
 
 	ExpectNe(nil, err)
 	ExpectThat(err, oglematchers.Error(oglematchers.HasSubstr("no such file or directory")))


### PR DESCRIPTION
### Description
Removed global err variable from fs_test package.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
