### PR TITLE
add debug logs for failure in gcloud rm call

### DIFF
--- a/tools/integration_tests/list_large_dir/testdata/delete_objects.sh
+++ b/tools/integration_tests/list_large_dir/testdata/delete_objects.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 set -e
 # Here $1 refers to the testBucket argument
-gcloud storage rm -r gs://$1/**
+gcloud storage rm -r --log-http --verbosity=debug gs://$1/**
 
 # If bucket is empty it will throw an CommandException.
 if [ $? -eq 1 ]; then


### PR DESCRIPTION
Internal issue b/380007938

### Description
`gcloud` command sometimes fails during cleanup. Printing debug logs in case of failure will help us debug this in future.

Note: these logs are printed only in case of failure in gcloud command so the noise it will create is ok.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
