### PR TITLE
Prevent unit test failure due to flag parse

### DIFF
--- a/tools/integration_tests/emulator_tests/proxy_server/main_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/main_test.go
@@ -54,7 +54,7 @@ func TestAddRetryID(t *testing.T) {
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	// Skip running unit tests as a part of integration tests.
+	// Skip running unit tests as part of the integration tests. Although running these tests will not cause any failures.
 	if setup.IsIntegrationTest() {
 		return
 	}

--- a/tools/integration_tests/emulator_tests/proxy_server/main_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/main_test.go
@@ -54,5 +54,8 @@ func TestAddRetryID(t *testing.T) {
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	m.Run()
+	// Skip running unit tests as a part of integration tests.
+	if setup.IsIntegrationTest() {
+		return
+	}
 }

--- a/tools/integration_tests/emulator_tests/proxy_server/main_test.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/main_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +49,10 @@ func TestAddRetryID(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "test-id-123", req.Header.Get("x-retry-test-id"), "Unexpected x-retry-test-id header value")
+}
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	m.Run()
 }

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -75,6 +75,10 @@ func IsPresubmitRun() bool {
 	return *isPresubmitRun
 }
 
+func IsIntegrationTest() bool {
+	return *integrationTest
+}
+
 func TestBucket() string {
 	return *testBucket
 }


### PR DESCRIPTION
### Description
Previously, unit tests were failing when running alongside end-to-end (e2e) tests. The error message indicated an undefined flag: -integrationTest. This issue is resolved by adding the command that parse tests within the TestMain function and return if integrationTest flag passed.

**Note**: We can't use [this](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L264) as it accepts *testing.T but in TestMain we have *testing.M. If we want to use this function then we have to add this in each and every unit test.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
