### PR TITLE
changing test framework of file_test from jacobsa/ogletest to stretchr

### DIFF
--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -88,7 +88,7 @@ func (t *FileTest) SetupTest() {
 		[]byte(t.initialContents))
 	t.backingObj = storageutil.ConvertObjToMinObject(object)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Create the inode.
 	t.createInode()
@@ -168,7 +168,7 @@ func (t *FileTest) TestInitialSourceGeneration() {
 
 func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len(t.initialContents)), attrs.Size)
 	assert.Equal(t.T(), uint32(1), attrs.Nlink)
@@ -193,7 +193,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 }
@@ -211,7 +211,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gsutil() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime.UTC(), mtime)
 }
@@ -232,7 +232,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_GcsfuseOutranks
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime, canonicalMtime)
 }
@@ -281,7 +281,7 @@ func (t *FileTest) TestRead() {
 			err = nil
 		}
 
-		assert.Equal(t.T(), nil, err, "%s", desc)
+		assert.Nil(t.T(), err, "%s", desc)
 		assert.Equal(t.T(), tc.expected, string(data), "%s", desc)
 	}
 }
@@ -293,14 +293,14 @@ func (t *FileTest) TestWrite() {
 
 	// Overwite a byte.
 	err = t.in.Write(t.ctx, []byte("p"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Add some data at the end.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("burrito"), 4)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
@@ -312,12 +312,12 @@ func (t *FileTest) TestWrite() {
 		err = nil
 	}
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "pacoburrito", string(buf[:n]))
 
 	// Check attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("pacoburrito")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, writeTime)
@@ -334,7 +334,7 @@ func (t *FileTest) TestTruncate() {
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 2)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
@@ -346,12 +346,12 @@ func (t *FileTest) TestTruncate() {
 		err = nil
 	}
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "ta", string(buf[:n]))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("ta")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, truncateTime)
@@ -368,13 +368,13 @@ func (t *FileTest) TestWriteThenSync() {
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("p"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -383,7 +383,7 @@ func (t *FileTest) TestWriteThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -395,12 +395,12 @@ func (t *FileTest) TestWriteThenSync() {
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "paco", string(contents))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("paco")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
@@ -413,24 +413,24 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Write some content to temp file.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 	err = t.in.Write(t.ctx, []byte("tacos"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -440,11 +440,11 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 		m.Metadata["gcsfuse_mtime"])
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "tacos", string(contents))
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
 }
@@ -457,18 +457,18 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 	creationTime := t.clock.Now()
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -480,11 +480,11 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 	assert.WithinDuration(t.T(), mtime, creationTime, Delta)
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "", string(contents))
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(0), attrs.Size)
 }
 
@@ -499,13 +499,13 @@ func (t *FileTest) TestAppendThenSync() {
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("burrito"), int64(len("taco")))
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -514,7 +514,7 @@ func (t *FileTest) TestAppendThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -526,12 +526,12 @@ func (t *FileTest) TestAppendThenSync() {
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), "tacoburrito", string(contents))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("tacoburrito")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
@@ -546,13 +546,13 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 2)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -561,7 +561,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -572,7 +572,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(2), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
@@ -589,13 +589,13 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 6)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -607,7 +607,7 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 		truncateTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -615,7 +615,7 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), uint64(6), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
@@ -627,18 +627,18 @@ func (t *FileTest) TestTestTruncateUpwardForLocalFileShouldUpdateLocalFileAttrib
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Fetch the attributes and check if the file is empty.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(0), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 6)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(6), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -653,21 +653,21 @@ func (t *FileTest) TestTestTruncateDownwardForLocalFileShouldUpdateLocalFileAttr
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Write some data to the local file.
 	err = t.in.Write(t.ctx, []byte("burrito"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Validate the new data is written correctly.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(7), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 2)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(2), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -681,7 +681,7 @@ func (t *FileTest) TestSync_Clobbered() {
 
 	// Truncate downward.
 	err = t.in.Truncate(t.ctx, 2)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Clobber the backing object.
 	newObj, err := storageutil.CreateObject(
@@ -690,7 +690,7 @@ func (t *FileTest) TestSync_Clobbered() {
 		t.in.Name().GcsObjectName(),
 		[]byte("burrito"))
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Sync. The call should not succeed, and we expect a FileClobberedError.
 	err = t.in.Sync(t.ctx)
@@ -705,7 +705,7 @@ func (t *FileTest) TestSync_Clobbered() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.Size, m.Size)
@@ -738,19 +738,19 @@ func (t *FileTest) TestSetMtime_ContentNotFaultedIn() {
 	mtime := time.Now().UTC().Add(123*time.Second).AddDate(0, 0, 0)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -763,25 +763,25 @@ func (t *FileTest) TestSetMtime_ContentClean() {
 
 	// Cause the content to be faulted in.
 	_, err = t.in.Read(t.ctx, make([]byte, 1), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123*time.Second).AddDate(0, 0, 0)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -794,29 +794,29 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 
 	// Dirty the content.
 	err = t.in.Write(t.ctx, []byte("a"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -833,18 +833,18 @@ func (t *FileTest) TestSetMtime_SourceObjectGenerationChanged() {
 		t.in.Name().GcsObjectName(),
 		[]byte("burrito"))
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), 0, len(m.Metadata))
@@ -862,18 +862,18 @@ func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 			ContentLanguage: &lang,
 		})
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.MetaGeneration, m.MetaGeneration)
@@ -886,20 +886,20 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 	assert.Equal(t.T(), attrs.Ctime, mtime)
 	assert.Equal(t.T(), attrs.Atime, mtime)
@@ -974,11 +974,11 @@ func (t *FileTest) TestTestCheckInvariantsShouldNotThrowExceptionForLocalFiles()
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 	err := t.in.CreateBufferedOrTempWriter()
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, t.in.content)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
@@ -1014,7 +1014,7 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	// Unlink.
 	t.in.Unlink()
@@ -1033,7 +1033,7 @@ func (t *FileTest) TestReadLocalFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 	data := make([]byte, 10)
 
@@ -1064,7 +1064,7 @@ func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
 	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
@@ -1078,7 +1078,7 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 	assert.Nil(t.T(), t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 	assert.NotEqual(t.T(), nil, t.in.bwh)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -384,7 +384,7 @@ func (t *FileTest) TestWriteThenSync() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("paco")), m.Size)
@@ -431,7 +431,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("tacos")), m.Size)
@@ -469,7 +469,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(0), m.Size)
@@ -515,7 +515,7 @@ func (t *FileTest) TestAppendThenSync() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("tacoburrito")), m.Size)
@@ -562,7 +562,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(2), m.Size)
@@ -608,7 +608,7 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 		m.Metadata["gcsfuse_mtime"])
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(6), m.Size)
@@ -643,7 +643,7 @@ func (t *FileTest) TestTestTruncateUpwardForLocalFileShouldUpdateLocalFileAttrib
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -672,7 +672,7 @@ func (t *FileTest) TestTestTruncateDownwardForLocalFileShouldUpdateLocalFileAttr
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -706,7 +706,7 @@ func (t *FileTest) TestSync_Clobbered() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.Size, m.Size)
 }
@@ -751,7 +751,7 @@ func (t *FileTest) TestSetMtime_ContentNotFaultedIn() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
@@ -782,7 +782,7 @@ func (t *FileTest) TestSetMtime_ContentClean() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
@@ -817,7 +817,7 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
@@ -845,7 +845,7 @@ func (t *FileTest) TestSetMtime_SourceObjectGenerationChanged() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), 0, len(m.Metadata))
 }
@@ -874,7 +874,7 @@ func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.MetaGeneration, m.MetaGeneration)
 }
@@ -906,7 +906,7 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -968,14 +968,14 @@ func (t *FileTest) TestContentEncodingOther() {
 func (t *FileTest) TestTestCheckInvariantsShouldNotThrowExceptionForLocalFiles() {
 	t.createInodeWithLocalParam("test", true)
 
-	assert.NotEqual(t.T(), nil, t.in)
+	assert.NotNil(t.T(), t.in)
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 	err := t.in.CreateBufferedOrTempWriter()
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, t.in.content)
+	assert.NotNil(t.T(), t.in.content)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
 	assert.Nil(t.T(), err)
@@ -1024,7 +1024,7 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -1040,7 +1040,7 @@ func (t *FileTest) TestReadLocalFileWhenStreamingWritesAreEnabled() {
 	n, err := t.in.Read(t.ctx, data, 0)
 
 	assert.Equal(t.T(), 0, n)
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.Equal(t.T(), "cannot read a local file when upload in progress", err.Error())
 }
 
@@ -1052,7 +1052,7 @@ func (t *FileTest) TestWriteToLocalFileWithInvalidConfigWhenStreamingWritesAreEn
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	assert.NotEqual(t.T(), nil, err)
+	assert.NotNil(t.T(), err)
 	assert.True(t.T(), strings.Contains(err.Error(), "invalid configuration"))
 }
 
@@ -1065,7 +1065,7 @@ func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, t.in.bwh)
+	assert.NotNil(t.T(), t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
 	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
 }
@@ -1079,7 +1079,7 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, t.in.bwh)
+	assert.NotNil(t.T(), t.in.bwh)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 
 	err = t.in.Write(t.ctx, []byte("hello"), 2)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -31,17 +31,16 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
 )
-
-func TestFile(t *testing.T) { RunTests(t) }
 
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
@@ -56,6 +55,7 @@ const fileMode os.FileMode = 0641
 const Delta = 30 * time.Minute
 
 type FileTest struct {
+	suite.Suite
 	ctx    context.Context
 	bucket gcs.Bucket
 	clock  timeutil.SimulatedClock
@@ -66,15 +66,14 @@ type FileTest struct {
 	in *FileInode
 }
 
-var _ SetUpInterface = &FileTest{}
-var _ TearDownInterface = &FileTest{}
+func TestFileTestSuite(t *testing.T) {
+	suite.Run(t, new(FileTest))
+}
 
-func init() { RegisterTestSuite(&FileTest{}) }
-
-func (t *FileTest) SetUp(ti *TestInfo) {
+func (t *FileTest) SetupTest() {
 	// Enabling invariant check for all tests.
 	syncutil.EnableInvariantChecking()
-	t.ctx = ti.Ctx
+	t.ctx = context.Background()
 	t.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
 	t.bucket = fake.NewFakeBucket(&t.clock, "some_bucket", gcs.NonHierarchical)
 
@@ -89,13 +88,13 @@ func (t *FileTest) SetUp(ti *TestInfo) {
 		[]byte(t.initialContents))
 	t.backingObj = storageutil.ConvertObjToMinObject(object)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Create the inode.
 	t.createInode()
 }
 
-func (t *FileTest) TearDown() {
+func (t *FileTest) TearDownTest() {
 	t.in.Unlock()
 }
 
@@ -107,7 +106,7 @@ func (t *FileTest) createInodeWithEmptyObject() {
 		[]byte{})
 	t.backingObj = storageutil.ConvertObjToMinObject(object)
 
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 
 	// Create the inode.
 	t.createInode()
@@ -117,10 +116,6 @@ func (t *FileTest) createInode() {
 	t.createInodeWithLocalParam(fileName, false)
 }
 func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
-	if t.in != nil {
-		t.in.Unlock()
-	}
-
 	name := NewFileName(
 		NewRootName(""),
 		fileName,
@@ -157,35 +152,35 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *FileTest) ID() {
-	ExpectEq(fileInodeID, t.in.ID())
+func (t *FileTest) TestID() {
+	assert.Equal(t.T(), fileInodeID, int(t.in.ID()))
 }
 
-func (t *FileTest) Name() {
-	ExpectEq(fileName, t.in.Name().GcsObjectName())
+func (t *FileTest) TestName() {
+	assert.Equal(t.T(), fileName, t.in.Name().GcsObjectName())
 }
 
-func (t *FileTest) InitialSourceGeneration() {
+func (t *FileTest) TestInitialSourceGeneration() {
 	sg := t.in.SourceGeneration()
-	ExpectEq(t.backingObj.Generation, sg.Object)
-	ExpectEq(t.backingObj.MetaGeneration, sg.Metadata)
+	assert.Equal(t.T(), t.backingObj.Generation, sg.Object)
+	assert.Equal(t.T(), t.backingObj.MetaGeneration, sg.Metadata)
 }
 
-func (t *FileTest) InitialAttributes() {
+func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(len(t.initialContents), attrs.Size)
-	ExpectEq(1, attrs.Nlink)
-	ExpectEq(uid, attrs.Uid)
-	ExpectEq(gid, attrs.Gid)
-	ExpectEq(fileMode, attrs.Mode)
-	ExpectThat(attrs.Atime, timeutil.TimeEq(t.backingObj.Updated))
-	ExpectThat(attrs.Ctime, timeutil.TimeEq(t.backingObj.Updated))
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(t.backingObj.Updated))
+	assert.Equal(t.T(), uint64(len(t.initialContents)), attrs.Size)
+	assert.Equal(t.T(), uint32(1), attrs.Nlink)
+	assert.Equal(t.T(), uint32(uid), attrs.Uid)
+	assert.Equal(t.T(), uint32(gid), attrs.Gid)
+	assert.Equal(t.T(), fileMode, attrs.Mode)
+	assert.Equal(t.T(), attrs.Atime, t.backingObj.Updated)
+	assert.Equal(t.T(), attrs.Ctime, t.backingObj.Updated)
+	assert.Equal(t.T(), attrs.Mtime, t.backingObj.Updated)
 }
 
-func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
+func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 	// Set up an explicit mtime on the backing object and re-create the inode.
 	if t.backingObj.Metadata == nil {
 		t.backingObj.Metadata = make(map[string]string)
@@ -198,12 +193,12 @@ func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), attrs.Mtime, mtime)
 }
 
-func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_Gsutil() {
+func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gsutil() {
 	// Set up an explicit mtime on the backing object and re-create the inode.
 	if t.backingObj.Metadata == nil {
 		t.backingObj.Metadata = make(map[string]string)
@@ -216,12 +211,12 @@ func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_Gsutil() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectThat(attrs.Mtime.UTC(), timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), attrs.Mtime.UTC(), mtime)
 }
 
-func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_GcsfuseOutranksGsutil() {
+func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_GcsfuseOutranksGsutil() {
 	// Set up an explicit mtime on the backing object and re-create the inode.
 	if t.backingObj.Metadata == nil {
 		t.backingObj.Metadata = make(map[string]string)
@@ -237,13 +232,13 @@ func (t *FileTest) InitialAttributes_MtimeFromObjectMetadata_GcsfuseOutranksGsut
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(canonicalMtime))
+	assert.Equal(t.T(), attrs.Mtime, canonicalMtime)
 }
 
-func (t *FileTest) Read() {
-	AssertEq("taco", t.initialContents)
+func (t *FileTest) TestRead() {
+	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Make several reads, checking the expected contents.
 	testCases := []struct {
@@ -286,26 +281,26 @@ func (t *FileTest) Read() {
 			err = nil
 		}
 
-		AssertEq(nil, err, "%s", desc)
-		ExpectEq(tc.expected, string(data), "%s", desc)
+		assert.Equal(t.T(), nil, err, "%s", desc)
+		assert.Equal(t.T(), tc.expected, string(data), "%s", desc)
 	}
 }
 
-func (t *FileTest) Write() {
+func (t *FileTest) TestWrite() {
 	var err error
 
-	AssertEq("taco", t.initialContents)
+	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Overwite a byte.
 	err = t.in.Write(t.ctx, []byte("p"), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Add some data at the end.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("burrito"), 4)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
@@ -317,29 +312,29 @@ func (t *FileTest) Write() {
 		err = nil
 	}
 
-	AssertEq(nil, err)
-	ExpectEq("pacoburrito", string(buf[:n]))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "pacoburrito", string(buf[:n]))
 
 	// Check attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(len("pacoburrito"), attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(writeTime))
+	assert.Equal(t.T(), uint64(len("pacoburrito")), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, writeTime)
 }
 
-func (t *FileTest) Truncate() {
+func (t *FileTest) TestTruncate() {
 	var attrs fuseops.InodeAttributes
 	var err error
 
-	AssertEq("taco", t.initialContents)
+	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Truncate downward.
 	t.clock.AdvanceTime(time.Second)
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 2)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
@@ -351,110 +346,110 @@ func (t *FileTest) Truncate() {
 		err = nil
 	}
 
-	AssertEq(nil, err)
-	ExpectEq("ta", string(buf[:n]))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "ta", string(buf[:n]))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(len("ta"), attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(truncateTime))
+	assert.Equal(t.T(), uint64(len("ta")), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, truncateTime)
 }
 
-func (t *FileTest) WriteThenSync() {
+func (t *FileTest) TestWriteThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
 
-	AssertEq("taco", t.initialContents)
+	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Overwite a byte.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("p"), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The generation should have advanced.
-	ExpectLt(t.backingObj.Generation, t.in.SourceGeneration().Object)
+	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(len("paco"), m.Size)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(len("paco")), m.Size)
+	assert.Equal(t.T(),
 		writeTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-	AssertEq(nil, err)
-	ExpectEq("paco", string(contents))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "paco", string(contents))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(len("paco"), attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(writeTime.UTC()))
+	assert.Equal(t.T(), uint64(len("paco")), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
 }
 
-func (t *FileTest) WriteToLocalFileThenSync() {
+func (t *FileTest) TestWriteToLocalFileThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Write some content to temp file.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 	err = t.in.Write(t.ctx, []byte("tacos"), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Verify that fileInode is no more local
-	AssertFalse(t.in.IsLocal())
+	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(len("tacos"), m.Size)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(len("tacos")), m.Size)
+	assert.Equal(t.T(),
 		writeTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	AssertEq(nil, err)
-	ExpectEq("tacos", string(contents))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "tacos", string(contents))
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectEq(len("tacos"), attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(writeTime.UTC()))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
 }
 
-func (t *FileTest) SyncEmptyLocalFile() {
+func (t *FileTest) TestSyncEmptyLocalFile() {
 	var attrs fuseops.InodeAttributes
 	var err error
 	// Create a local file inode.
@@ -462,87 +457,87 @@ func (t *FileTest) SyncEmptyLocalFile() {
 	creationTime := t.clock.Now()
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Verify that fileInode is no more local
-	AssertFalse(t.in.IsLocal())
+	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(0, m.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(0), m.Size)
 	// Validate the mtime.
 	mtimeInBucket, ok := m.Metadata["gcsfuse_mtime"]
-	AssertTrue(ok)
+	assert.True(t.T(), ok)
 	mtime, _ := time.Parse(time.RFC3339Nano, mtimeInBucket)
-	ExpectThat(mtime, timeutil.TimeNear(creationTime, Delta))
+	assert.WithinDuration(t.T(), mtime, creationTime, Delta)
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	AssertEq(nil, err)
-	ExpectEq("", string(contents))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "", string(contents))
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectEq(0, attrs.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(0), attrs.Size)
 }
 
-func (t *FileTest) AppendThenSync() {
+func (t *FileTest) TestAppendThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
 
-	AssertEq("taco", t.initialContents)
+	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Append some data.
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 
 	err = t.in.Write(t.ctx, []byte("burrito"), int64(len("taco")))
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The generation should have advanced.
-	ExpectLt(t.backingObj.Generation, t.in.SourceGeneration().Object)
+	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(len("tacoburrito"), m.Size)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(len("tacoburrito")), m.Size)
+	assert.Equal(t.T(),
 		writeTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-	AssertEq(nil, err)
-	ExpectEq("tacoburrito", string(contents))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "tacoburrito", string(contents))
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(len("tacoburrito"), attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(writeTime.UTC()))
+	assert.Equal(t.T(), uint64(len("tacoburrito")), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
 }
 
-func (t *FileTest) TruncateDownwardThenSync() {
+func (t *FileTest) TestTruncateDownwardThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
 
@@ -551,142 +546,142 @@ func (t *FileTest) TruncateDownwardThenSync() {
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 2)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The generation should have advanced.
-	ExpectLt(t.backingObj.Generation, t.in.SourceGeneration().Object)
+	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(2, m.Size)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(2), m.Size)
+	assert.Equal(t.T(),
 		truncateTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(2, attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(truncateTime.UTC()))
+	assert.Equal(t.T(), uint64(2), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
 }
 
-func (t *FileTest) TruncateUpwardThenSync() {
+func (t *FileTest) TestTruncateUpwardThenSync() {
 	var attrs fuseops.InodeAttributes
 	var err error
 
-	AssertEq(4, len(t.initialContents))
+	assert.Equal(t.T(), 4, len(t.initialContents))
 
 	// Truncate upward.
 	t.clock.AdvanceTime(time.Second)
 	truncateTime := t.clock.Now()
 
 	err = t.in.Truncate(t.ctx, 6)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	t.clock.AdvanceTime(time.Second)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The generation should have advanced.
-	ExpectLt(t.backingObj.Generation, t.in.SourceGeneration().Object)
+	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
 	// Stat the current object in the bucket.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
-	ExpectEq(
+	assert.Equal(t.T(),
 		truncateTime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(t.in.SourceGeneration().Object, m.Generation)
-	ExpectEq(t.in.SourceGeneration().Metadata, m.MetaGeneration)
-	ExpectEq(6, m.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(6), m.Size)
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
-	ExpectEq(6, attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(truncateTime.UTC()))
+	assert.Equal(t.T(), uint64(6), attrs.Size)
+	assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
 }
 
-func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes() {
+func (t *FileTest) TestTestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes() {
 	var err error
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Fetch the attributes and check if the file is empty.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(0, attrs.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(0), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 6)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(6, attrs.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(6), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	AssertNe(nil, err)
-	AssertEq("gcs.NotFoundError: object test not found", err.Error())
+	assert.NotEqual(t.T(), nil, err)
+	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
-func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttributes() {
+func (t *FileTest) TestTestTruncateDownwardForLocalFileShouldUpdateLocalFileAttributes() {
 	var err error
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Write some data to the local file.
 	err = t.in.Write(t.ctx, []byte("burrito"), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Validate the new data is written correctly.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(7, attrs.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(7), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 2)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(2, attrs.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), uint64(2), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	AssertNe(nil, err)
-	AssertEq("gcs.NotFoundError: object test not found", err.Error())
+	assert.NotEqual(t.T(), nil, err)
+	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
-func (t *FileTest) Sync_Clobbered() {
+func (t *FileTest) TestSync_Clobbered() {
 	var err error
 
 	// Truncate downward.
 	err = t.in.Truncate(t.ctx, 2)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Clobber the backing object.
 	newObj, err := storageutil.CreateObject(
@@ -695,47 +690,47 @@ func (t *FileTest) Sync_Clobbered() {
 		t.in.Name().GcsObjectName(),
 		[]byte("burrito"))
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Sync. The call should not succeed, and we expect a FileClobberedError.
 	err = t.in.Sync(t.ctx)
 
 	// Check if the error is a FileClobberedError
 	var fcErr *gcsfuse_errors.FileClobberedError
-	AssertTrue(errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
-	ExpectEq(t.backingObj.Generation, t.in.SourceGeneration().Object)
-	ExpectEq(t.backingObj.MetaGeneration, t.in.SourceGeneration().Metadata)
+	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
+	assert.Equal(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
+	assert.Equal(t.T(), t.backingObj.MetaGeneration, t.in.SourceGeneration().Metadata)
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(newObj.Generation, m.Generation)
-	ExpectEq(newObj.Size, m.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), newObj.Generation, m.Generation)
+	assert.Equal(t.T(), newObj.Size, m.Size)
 }
 
 func (t *FileTest) TestOpenReader_ThrowsFileClobberedError() {
 	// Modify the file locally.
 	err := t.in.Truncate(t.ctx, 2)
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 	// Clobber the backing object.
 	_, err = storageutil.CreateObject(
 		t.ctx,
 		t.bucket,
 		t.in.Name().GcsObjectName(),
 		[]byte("burrito"))
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 
 	_, err = t.in.openReader(t.ctx)
 
 	// assert error is not nil.
 	var fcErr *gcsfuse_errors.FileClobberedError
-	AssertTrue(errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
+	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
 }
 
-func (t *FileTest) SetMtime_ContentNotFaultedIn() {
+func (t *FileTest) TestSetMtime_ContentNotFaultedIn() {
 	var err error
 	var attrs fuseops.InodeAttributes
 
@@ -743,92 +738,92 @@ func (t *FileTest) SetMtime_ContentNotFaultedIn() {
 	mtime := time.Now().UTC().Add(123*time.Second).AddDate(0, 0, 0)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 }
 
-func (t *FileTest) SetMtime_ContentClean() {
+func (t *FileTest) TestSetMtime_ContentClean() {
 	var err error
 	var attrs fuseops.InodeAttributes
 
 	// Cause the content to be faulted in.
 	_, err = t.in.Read(t.ctx, make([]byte, 1), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123*time.Second).AddDate(0, 0, 0)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 }
 
-func (t *FileTest) SetMtime_ContentDirty() {
+func (t *FileTest) TestSetMtime_ContentDirty() {
 	var err error
 	var attrs fuseops.InodeAttributes
 
 	// Dirty the content.
 	err = t.in.Write(t.ctx, []byte("a"), 0)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 
 	err = t.in.SetMtime(t.ctx, mtime)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// Sync.
 	err = t.in.Sync(t.ctx)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
 		m.Metadata["gcsfuse_mtime"])
 }
 
-func (t *FileTest) SetMtime_SourceObjectGenerationChanged() {
+func (t *FileTest) TestSetMtime_SourceObjectGenerationChanged() {
 	var err error
 
 	// Clobber the backing object.
@@ -838,24 +833,24 @@ func (t *FileTest) SetMtime_SourceObjectGenerationChanged() {
 		t.in.Name().GcsObjectName(),
 		[]byte("burrito"))
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(newObj.Generation, m.Generation)
-	ExpectEq(0, len(m.Metadata))
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), newObj.Generation, m.Generation)
+	assert.Equal(t.T(), 0, len(m.Metadata))
 }
 
-func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
+func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 	var err error
 
 	// Update the backing object.
@@ -867,52 +862,52 @@ func (t *FileTest) SetMtime_SourceObjectMetaGenerationChanged() {
 			ContentLanguage: &lang,
 		})
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// The object in the bucket should not have been changed.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(newObj.Generation, m.Generation)
-	ExpectEq(newObj.MetaGeneration, m.MetaGeneration)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), newObj.Generation, m.Generation)
+	assert.Equal(t.T(), newObj.MetaGeneration, m.MetaGeneration)
 }
 
-func (t *FileTest) TestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
+func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {
 	var err error
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
+	assert.Equal(t.T(), nil, err)
+	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
 
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Ctime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
+	assert.Equal(t.T(), attrs.Ctime, mtime)
+	assert.Equal(t.T(), attrs.Atime, mtime)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	AssertNe(nil, err)
-	AssertEq("gcs.NotFoundError: object test not found", err.Error())
+	assert.NotEqual(t.T(), nil, err)
+	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
 func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
@@ -922,69 +917,69 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
 
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Ctime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
+	assert.Equal(t.T(), attrs.Ctime, mtime)
+	assert.Equal(t.T(), attrs.Atime, mtime)
 }
 
-func (t *FileTest) ContentEncodingGzip() {
+func (t *FileTest) TestContentEncodingGzip() {
 	// Set up an explicit content-encoding on the backing object and re-create the inode.
 	contentEncoding := "gzip"
 	t.backingObj.ContentEncoding = contentEncoding
 
 	t.createInode()
 
-	AssertEq(contentEncoding, t.in.Source().ContentEncoding)
-	AssertTrue(t.in.Source().HasContentEncodingGzip())
+	assert.Equal(t.T(), contentEncoding, t.in.Source().ContentEncoding)
+	assert.True(t.T(), t.in.Source().HasContentEncodingGzip())
 }
 
-func (t *FileTest) ContentEncodingNone() {
+func (t *FileTest) TestContentEncodingNone() {
 	// Set up an explicit content-encoding on the backing object and re-create the inode.
 	contentEncoding := ""
 	t.backingObj.ContentEncoding = contentEncoding
 
 	t.createInode()
 
-	AssertEq(contentEncoding, t.in.Source().ContentEncoding)
-	AssertFalse(t.in.Source().HasContentEncodingGzip())
+	assert.Equal(t.T(), contentEncoding, t.in.Source().ContentEncoding)
+	assert.False(t.T(), t.in.Source().HasContentEncodingGzip())
 }
 
-func (t *FileTest) ContentEncodingOther() {
+func (t *FileTest) TestContentEncodingOther() {
 	// Set up an explicit content-encoding on the backing object and re-create the inode.
 	contentEncoding := "other"
 	t.backingObj.ContentEncoding = contentEncoding
 
 	t.createInode()
 
-	AssertEq(contentEncoding, t.in.Source().ContentEncoding)
-	AssertFalse(t.in.Source().HasContentEncodingGzip())
+	assert.Equal(t.T(), contentEncoding, t.in.Source().ContentEncoding)
+	assert.False(t.T(), t.in.Source().HasContentEncodingGzip())
 }
 
-func (t *FileTest) TestCheckInvariantsShouldNotThrowExceptionForLocalFiles() {
+func (t *FileTest) TestTestCheckInvariantsShouldNotThrowExceptionForLocalFiles() {
 	t.createInodeWithLocalParam("test", true)
 
-	AssertNe(nil, t.in)
+	assert.NotEqual(t.T(), nil, t.in)
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 	err := t.in.CreateBufferedOrTempWriter()
 
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.content)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, t.in.content)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
-	AssertEq(nil, err)
-	AssertEq(0, sr.Size)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamingWritesAreEnabled() {
@@ -993,9 +988,9 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamin
 
 	err := t.in.CreateBufferedOrTempWriter()
 
-	AssertEq(nil, err)
-	AssertEq(nil, t.in.content)
-	AssertNe(nil, t.in.bwh)
+	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
+	assert.NotNil(t.T(), t.in.bwh)
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFilesForStreamingWrites() {
@@ -1004,152 +999,152 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFile
 
 	err := t.in.CreateBufferedOrTempWriter()
 
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.content)
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), t.in.content)
+	assert.Nil(t.T(), t.in.bwh)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
-	AssertEq(nil, err)
-	AssertEq(0, sr.Size)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
-func (t *FileTest) UnlinkLocalFile() {
+func (t *FileTest) TestUnlinkLocalFile() {
 	var err error
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
 	err = t.in.CreateBufferedOrTempWriter()
-	AssertEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 
 	// Unlink.
 	t.in.Unlink()
 
 	// Verify that fileInode is now unlinked
-	AssertTrue(t.in.IsUnlinked())
+	assert.True(t.T(), t.in.IsUnlinked())
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	AssertNe(nil, err)
-	AssertEq("gcs.NotFoundError: object test not found", err.Error())
+	assert.NotEqual(t.T(), nil, err)
+	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
-func (t *FileTest) ReadLocalFileWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestReadLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
-	AssertEq(nil, err)
-	AssertEq(2, t.in.bwh.WriteFileInfo().TotalSize)
+	assert.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 	data := make([]byte, 10)
 
 	n, err := t.in.Read(t.ctx, data, 0)
 
-	AssertEq(0, n)
-	AssertNe(nil, err)
-	AssertEq("cannot read a local file when upload in progress", err.Error())
+	assert.Equal(t.T(), 0, n)
+	assert.NotEqual(t.T(), nil, err)
+	assert.Equal(t.T(), "cannot read a local file when upload in progress", err.Error())
 }
 
-func (t *FileTest) WriteToLocalFileWithInvalidConfigWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestWriteToLocalFileWithInvalidConfigWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig.ExperimentalEnableStreamingWrites = true
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "invalid configuration"))
+	assert.NotEqual(t.T(), nil, err)
+	assert.True(t.T(), strings.Contains(err.Error(), "invalid configuration"))
 }
 
-func (t *FileTest) WriteToLocalFileWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.writeConfig = getWriteConfig()
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.bwh)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
-	AssertEq(2, writeFileInfo.TotalSize)
+	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
 }
 
-func (t *FileTest) MultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
 	t.in.writeConfig = getWriteConfig()
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.bwh)
-	AssertEq(2, t.in.bwh.WriteFileInfo().TotalSize)
+	assert.Equal(t.T(), nil, err)
+	assert.NotEqual(t.T(), nil, t.in.bwh)
+	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 
 	err = t.in.Write(t.ctx, []byte("hello"), 2)
-	AssertEq(nil, err)
-	AssertEq(7, t.in.bwh.WriteFileInfo().TotalSize)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(7, attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), uint64(7), attrs.Size)
+	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 }
 
 func (t *FileTest) WriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.writeConfig = getWriteConfig()
 	createTime := t.in.mtimeClock.Now()
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.bwh)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
-	AssertEq(2, writeFileInfo.TotalSize)
+	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	AssertEq(2, attrs.Size)
-	ExpectThat(attrs.Mtime, timeutil.TimeNear(createTime, Delta))
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), int64(2), attrs.Size)
+	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 }
 
 func (t *FileTest) SetMtimeOnEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.writeConfig = getWriteConfig()
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 
 	// This test checks if the mtime is updated to GCS. Since test framework
 	// doesn't support t.run, calling the test method here directly.
-	t.SetMtime_ContentNotFaultedIn()
+	t.TestSetMtime_ContentNotFaultedIn()
 	// bufferedWritesHandler shouldn't get initialized.
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 }
 
 func (t *FileTest) SetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.writeConfig = getWriteConfig()
-	AssertEq(nil, t.in.bwh)
+	assert.Nil(t.T(), t.in.bwh)
 	// Initiate write call.
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
-	AssertEq(nil, err)
-	AssertNe(nil, t.in.bwh)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
-	AssertEq(2, writeFileInfo.TotalSize)
+	assert.Equal(t.T(), 2, writeFileInfo.TotalSize)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
 	err = t.in.SetMtime(t.ctx, mtime)
 
-	AssertEq(nil, err)
+	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	AssertEq(nil, err)
-	ExpectThat(attrs.Mtime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Ctime, timeutil.TimeEq(mtime))
-	ExpectThat(attrs.Atime, timeutil.TimeEq(mtime))
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), attrs.Mtime, mtime)
+	assert.Equal(t.T(), attrs.Ctime, mtime)
+	assert.Equal(t.T(), attrs.Atime, mtime)
 }
 
 func getWriteConfig() *cfg.WriteConfig {


### PR DESCRIPTION
### Description
Stretchr is needed to write new tests based on t.Run()

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
