### PR TITLE
Throw ErrUploadFailure error in buffered writes

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -49,6 +49,7 @@ type WriteFileInfo struct {
 }
 
 var ErrOutOfOrderWrite = errors.New("outOfOrder write detected")
+var ErrUploadFailure = errors.New("error while uploading object to GCS")
 
 // NewBWHandler creates the bufferedWriteHandler struct.
 func NewBWHandler(objectName string, bucket gcs.Bucket, blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bwh *BufferedWriteHandler, err error) {
@@ -79,7 +80,7 @@ func (wh *BufferedWriteHandler) Write(data []byte, offset int64) (err error) {
 	// Fail early if the uploadHandler has failed.
 	select {
 	case <-wh.uploadHandler.SignalUploadFailure():
-		return fmt.Errorf("BufferedWriteHandler.Write(): error while uploading object to GCS")
+		return ErrUploadFailure
 	default:
 		break
 	}
@@ -127,7 +128,7 @@ func (wh *BufferedWriteHandler) Flush() (err error) {
 	// Fail early if the uploadHandler has failed.
 	select {
 	case <-wh.uploadHandler.SignalUploadFailure():
-		return fmt.Errorf("file cannot be finalized: error while uploading object to GCS")
+		return ErrUploadFailure
 	default:
 		break
 	}

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -147,7 +147,7 @@ func (testSuite *BufferedWriteTest) TestWrite_SignalUploadFailureInBetween() {
 
 	err = testSuite.bwh.Write([]byte("hello"), 5)
 	require.Error(testSuite.T(), err)
-	assert.ErrorContains(testSuite.T(), err, "BufferedWriteHandler.Write(): error while uploading object to GCS")
+	assert.Equal(testSuite.T(), err, ErrUploadFailure)
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
@@ -183,5 +183,5 @@ func (testSuite *BufferedWriteTest) TestFlush_SignalUploadFailureDuringWrite() {
 
 	err = testSuite.bwh.Flush()
 	require.Error(testSuite.T(), err)
-	assert.ErrorContains(testSuite.T(), err, "file cannot be finalized: error while uploading object to GCS")
+	assert.Equal(testSuite.T(), err, ErrUploadFailure)
 }


### PR DESCRIPTION
### Description
Throw ErrUploadFailure error in case of failure during Write or Flush call.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - NA
