### PR TITLE
Update Flush call to return an object

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -152,26 +152,28 @@ func (testSuite *BufferedWriteTest) TestWrite_SignalUploadFailureInBetween() {
 
 func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 	err := testSuite.bwh.Write([]byte("hi"), 0)
-	currentBlock := testSuite.bwh.current
 	require.Nil(testSuite.T(), err)
 
-	err = testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush()
 
 	require.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), nil, testSuite.bwh.current)
-	// The current block should be available on the free channel as flush triggers
-	// an upload before finalize.
-	freeCh := testSuite.bwh.blockPool.FreeBlocksChannel()
-	got := <-freeCh
-	assert.Equal(testSuite.T(), &currentBlock, &got)
+	// Validate object.
+	assert.NotNil(testSuite.T(), obj)
+	assert.Equal(testSuite.T(), uint64(2), obj.Size)
+	// Validate that all blocks have been freed up.
+	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
 	require.Nil(testSuite.T(), testSuite.bwh.current)
 
-	err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush()
 
 	assert.NoError(testSuite.T(), err)
+	// Validate empty object created.
+	assert.NotNil(testSuite.T(), obj)
+	assert.Equal(testSuite.T(), uint64(0), obj.Size)
 }
 
 func (testSuite *BufferedWriteTest) TestFlush_SignalUploadFailureDuringWrite() {
@@ -181,7 +183,8 @@ func (testSuite *BufferedWriteTest) TestFlush_SignalUploadFailureDuringWrite() {
 	// Close the channel to simulate failure in uploader.
 	close(testSuite.bwh.uploadHandler.SignalUploadFailure())
 
-	err = testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush()
 	require.Error(testSuite.T(), err)
 	assert.ErrorContains(testSuite.T(), err, "file cannot be finalized: error while uploading object to GCS")
+	assert.Nil(testSuite.T(), obj)
 }

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/block"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	storagemock "github.com/googlecloudplatform/gcsfuse/v2/internal/storage/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -64,8 +65,9 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	}
 	// CreateObjectChunkWriter -- should be called once.
 	writer := &storagemock.Writer{}
+	mockObj := &gcs.Object{}
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
-	writer.On("Close").Return(nil)
+	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 
 	// Upload the blocks.
 	for _, b := range blocks {
@@ -74,8 +76,10 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	}
 
 	// Finalize.
-	err := t.uh.Finalize()
+	obj, err := t.uh.Finalize()
 	require.NoError(t.T(), err)
+	require.NotNil(t.T(), obj)
+	assert.Equal(t.T(), mockObj, obj)
 	// The blocks should be available on the free channel for reuse.
 	for _, expect := range blocks {
 		got := <-t.uh.freeBlocksCh
@@ -111,46 +115,56 @@ func (t *UploadHandlerTest) TestUpload_CreateObjectWriterFails() {
 
 func (t *UploadHandlerTest) TestFinalizeWithWriterAlreadyPresent() {
 	writer := &storagemock.Writer{}
-	writer.On("Close").Return(nil)
+	mockObj := &gcs.Object{}
+	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 	t.uh.writer = writer
 
-	err := t.uh.Finalize()
+	obj, err := t.uh.Finalize()
 
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), obj)
+	assert.Equal(t.T(), mockObj, obj)
 }
 
 func (t *UploadHandlerTest) TestFinalizeWithNoWriter() {
 	writer := &storagemock.Writer{}
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 	assert.Nil(t.T(), t.uh.writer)
-	writer.On("Close").Return(nil)
+	mockObj := &gcs.Object{}
+	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 
-	err := t.uh.Finalize()
+	obj, err := t.uh.Finalize()
 
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), obj)
+	assert.Equal(t.T(), mockObj, obj)
 }
 
 func (t *UploadHandlerTest) TestFinalizeWithNoWriter_CreateObjectWriterFails() {
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("taco"))
 	assert.Nil(t.T(), t.uh.writer)
 
-	err := t.uh.Finalize()
+	obj, err := t.uh.Finalize()
 
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "taco")
 	assert.ErrorContains(t.T(), err, "createObjectWriter")
+	assert.Nil(t.T(), obj)
 }
 
-func (t *UploadHandlerTest) TestFinalize_WriterCloseFails() {
+func (t *UploadHandlerTest) TestFinalize_FinalizeUploadFails() {
 	writer := &storagemock.Writer{}
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 	assert.Nil(t.T(), t.uh.writer)
-	writer.On("Close").Return(fmt.Errorf("taco"))
+	mockObj := &gcs.Object{}
+	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, fmt.Errorf("taco"))
 
-	err := t.uh.Finalize()
+	obj, err := t.uh.Finalize()
 
 	require.Error(t.T(), err)
-	assert.ErrorContains(t.T(), err, "writer.Close")
+	assert.Nil(t.T(), obj)
+	assert.ErrorContains(t.T(), err, "taco")
+	assert.ErrorContains(t.T(), err, "FinalizeUpload failed for object")
 }
 
 func (t *UploadHandlerTest) TestUploadHandler_singleBlock_ErrorInCopy() {

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -59,7 +59,7 @@ func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 }
 
 func (m *TestifyMockBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.Object, error) {
-	args := m.Called(ctx, w.ObjectName())
+	args := m.Called(ctx, w)
 	return args.Get(0).(*gcs.Object), args.Error(1)
 }
 


### PR DESCRIPTION
### Description
This PR changes flush call to return an object.
Also ClearFreeBlockChannel is included in Flush call to clear up all the buffers.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - NA
