### PR TITLE
[Do not review] Sync/flush changes for buffered writes

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -721,20 +721,15 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 		err = fmt.Errorf("SyncObject: %w", err)
 		return
 	}
-
+	minObj := storageutil.ConvertObjToMinObject(newObj)
 	// If we wrote out a new object, we need to update our state.
-	f.updateInodeStateAfterSync(newObj)
+	f.updateInodeStateAfterSync(minObj)
 	return
 }
 
-func (f *FileInode) updateInodeStateAfterSync(newObj *gcs.Object) {
-	if newObj != nil && !f.localFileCache {
-		var minObj gcs.MinObject
-		minObjPtr := storageutil.ConvertObjToMinObject(newObj)
-		if minObjPtr != nil {
-			minObj = *minObjPtr
-		}
-		f.src = minObj
+func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
+	if minObj != nil && !f.localFileCache {
+		f.src = *minObj
 		// Convert localFile to nonLocalFile after it is synced to GCS.
 		if f.IsLocal() {
 			f.local = false

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -541,7 +541,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	err := f.bwh.Write(data, offset)
 	if err == bufferedwrites.ErrOutOfOrderWrite || err == bufferedwrites.ErrUploadFailure {
 		// Finalize the object.
-		flushErr := f.flushBufferedWriteHandlerAndUpdateInode()
+		flushErr := f.flushUsingBufferedWriteHandler()
 		if flushErr != nil {
 			return fmt.Errorf("bwh.Write failed: %v, could not finalize what has been written so far: %w", err, flushErr)
 		}
@@ -559,7 +559,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 // new object.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) flushBufferedWriteHandlerAndUpdateInode() error {
+func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	obj, err := f.bwh.Flush()
 
 	var preconditionErr *gcs.PreconditionError
@@ -695,7 +695,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 
 	if f.bwh != nil {
 		// Finalize the object.
-		return f.flushBufferedWriteHandlerAndUpdateInode()
+		return f.flushUsingBufferedWriteHandler()
 	}
 
 	latestGcsObj, err := f.fetchLatestGcsObject(ctx)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -539,7 +539,7 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) error {
 	err := f.bwh.Write(data, offset)
-	if err != nil {
+	if err == bufferedwrites.ErrOutOfOrderWrite || err == bufferedwrites.ErrUploadFailure {
 		// Finalize the object.
 		flushErr := f.flushBufferedWriteHandlerAndUpdateInode()
 		if flushErr != nil {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -36,16 +36,16 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+const localFile = "local"
+const emptyGCSFile = "emptyGCS"
+
 type FileStreamingWritesTest struct {
 	suite.Suite
-	ctx    context.Context
-	bucket gcs.Bucket
-	clock  timeutil.SimulatedClock
-
-	initialContents string
-	backingObj      *gcs.MinObject
-
-	in *FileInode
+	ctx        context.Context
+	bucket     gcs.Bucket
+	clock      timeutil.SimulatedClock
+	backingObj *gcs.MinObject
+	in         *FileInode
 }
 
 func TestFileStreamingWritesTestSuite(t *testing.T) {
@@ -60,7 +60,7 @@ func (t *FileStreamingWritesTest) SetupTest() {
 	t.bucket = fake.NewFakeBucket(&t.clock, "some_bucket", gcs.NonHierarchical)
 
 	// Create the inode.
-	t.createInode(fileName, "local")
+	t.createInode(fileName, localFile)
 }
 
 func (t *FileStreamingWritesTest) TearDownTest() {
@@ -68,7 +68,7 @@ func (t *FileStreamingWritesTest) TearDownTest() {
 }
 
 func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) {
-	if fileType != "empty" && fileType != "local" {
+	if fileType != emptyGCSFile && fileType != localFile {
 		t.T().Errorf("fileType should be either local or empty")
 	}
 
@@ -82,12 +82,12 @@ func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) 
 		t.bucket)
 
 	isLocal := false
-	if fileType == "local" {
+	if fileType == localFile {
 		t.backingObj = nil
 		isLocal = true
 	}
 
-	if fileType == "empty" {
+	if fileType == emptyGCSFile {
 		object, err := storageutil.CreateObject(
 			t.ctx,
 			t.bucket,

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -1,0 +1,274 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/syncutil"
+	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/semaphore"
+)
+
+type FileStreamingWritesTest struct {
+	suite.Suite
+	ctx    context.Context
+	bucket gcs.Bucket
+	clock  timeutil.SimulatedClock
+
+	initialContents string
+	backingObj      *gcs.MinObject
+
+	in *FileInode
+}
+
+func TestFileStreamingWritesTestSuite(t *testing.T) {
+	suite.Run(t, new(FileStreamingWritesTest))
+}
+
+func (t *FileStreamingWritesTest) SetupTest() {
+	// Enabling invariant check for all tests.
+	syncutil.EnableInvariantChecking()
+	t.ctx = context.Background()
+	t.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
+	t.bucket = fake.NewFakeBucket(&t.clock, "some_bucket", gcs.NonHierarchical)
+
+	// Create the inode.
+	t.createInode(fileName, "local")
+}
+
+func (t *FileStreamingWritesTest) TearDownTest() {
+	t.in.Unlock()
+}
+
+func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) {
+	if fileType != "empty" && fileType != "local" {
+		t.T().Errorf("fileType should be either local or empty")
+	}
+
+	name := NewFileName(
+		NewRootName(""),
+		fileName,
+	)
+	syncerBucket := gcsx.NewSyncerBucket(
+		1, // Append threshold
+		".gcsfuse_tmp/",
+		t.bucket)
+
+	isLocal := false
+	if fileType == "local" {
+		t.backingObj = nil
+		isLocal = true
+	}
+
+	if fileType == "empty" {
+		object, err := storageutil.CreateObject(
+			t.ctx,
+			t.bucket,
+			fileName,
+			[]byte{})
+		t.backingObj = storageutil.ConvertObjToMinObject(object)
+
+		assert.Nil(t.T(), err)
+	}
+
+	t.in = NewFileInode(
+		fileInodeID,
+		name,
+		t.backingObj,
+		fuseops.InodeAttributes{
+			Uid:  uid,
+			Gid:  gid,
+			Mode: fileMode,
+		},
+		&syncerBucket,
+		false, // localFileCache
+		contentcache.New("", &t.clock),
+		&t.clock,
+		isLocal,
+		&cfg.WriteConfig{},
+		semaphore.NewWeighted(math.MaxInt64))
+
+	// Set buffered write config for created inode.
+	t.in.writeConfig = &cfg.WriteConfig{
+		MaxBlocksPerFile:                  10,
+		BlockSizeMb:                       10,
+		ExperimentalEnableStreamingWrites: true,
+	}
+
+	// Create write handler for the local inode created above.
+	err := t.in.CreateBufferedOrTempWriter()
+	assert.Nil(t.T(), err)
+
+	t.in.Lock()
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempFile() {
+	assert.True(t.T(), t.in.IsLocal())
+	createTime := t.in.mtimeClock.Now()
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
+	require.Nil(t.T(), err)
+	require.NotNil(t.T(), t.in.bwh)
+	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
+
+	err = t.in.Write(t.ctx, []byte("hello"), 5)
+	require.Nil(t.T(), err)
+
+	// Ensure bwh cleared and temp file created.
+	assert.Nil(t.T(), t.in.bwh)
+	assert.NotNil(t.T(), t.in.content)
+	// The inode should agree about the new mtime.
+	attrs, err := t.in.Attributes(t.ctx)
+	require.Nil(t.T(), err)
+	assert.Equal(t.T(), uint64(10), attrs.Size)
+	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
+	// sync file and validate content
+	err = t.in.Sync(t.ctx)
+	require.Nil(t.T(), err)
+	// Read the object's contents.
+	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), "hi\x00\x00\x00hello", string(contents))
+}
+
+func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFile_FileClobbered_ThrowsError() {
+	assert.True(t.T(), t.in.IsLocal())
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
+	require.Nil(t.T(), err)
+	require.NotNil(t.T(), t.in.bwh)
+	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
+	// Clobber the file.
+	objWritten, err := storageutil.CreateObject(t.ctx, t.bucket, fileName, []byte("taco"))
+	require.Nil(t.T(), err)
+
+	err = t.in.Write(t.ctx, []byte("hello"), 10)
+
+	require.Error(t.T(), err)
+	var fileClobberedError *gcsfuse_errors.FileClobberedError
+	assert.ErrorAs(t.T(), err, &fileClobberedError)
+	// Validate Object on GCS not updated.
+	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
+	objGot, _, err := t.bucket.StatObject(t.ctx, statReq)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), storageutil.ConvertObjToMinObject(objWritten), objGot)
+}
+
+func (t *FileStreamingWritesTest) TestWriteToLocalFileThenSync() {
+	assert.True(t.T(), t.in.IsLocal())
+	// Write some content to temp file.
+	err := t.in.Write(t.ctx, []byte("tacos"), 0)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), t.in.bwh)
+	t.clock.AdvanceTime(10 * time.Second)
+
+	// Sync.
+	err = t.in.Sync(t.ctx)
+
+	require.Nil(t.T(), err)
+	// Ensure bwh cleared.
+	assert.Nil(t.T(), t.in.bwh)
+	// Verify that fileInode is no more local
+	assert.False(t.T(), t.in.IsLocal())
+	// Check attributes.
+	attrs, err := t.in.Attributes(t.ctx)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
+	assert.Equal(t.T(), t.clock.Now().UTC(), attrs.Mtime.UTC())
+	// Validate Object on GCS.
+	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(len("tacos")), m.Size)
+	// Mtime metadata is not written for buffered writes.
+	assert.Equal(t.T(), "", m.Metadata["gcsfuse_mtime"])
+	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), "tacos", string(contents))
+}
+
+func (t *FileStreamingWritesTest) TestSyncEmptyLocalFile() {
+	assert.True(t.T(), t.in.IsLocal())
+	t.clock.AdvanceTime(10 * time.Second)
+
+	// Sync.
+	err := t.in.Sync(t.ctx)
+
+	require.Nil(t.T(), err)
+	// Ensure bwh cleared.
+	assert.Nil(t.T(), t.in.bwh)
+	// Verify that fileInode is no more local
+	assert.False(t.T(), t.in.IsLocal())
+	// Check attributes.
+	attrs, err := t.in.Attributes(t.ctx)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), uint64(0), attrs.Size)
+	assert.Equal(t.T(), t.clock.Now().UTC(), attrs.Mtime.UTC())
+	// Validate Object on GCS.
+	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
+	m, _, err := t.bucket.StatObject(t.ctx, statReq)
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), m)
+	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
+	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
+	assert.Equal(t.T(), uint64(0), m.Size)
+	// Mtime metadata is not written for buffered writes.
+	assert.Equal(t.T(), "", m.Metadata["gcsfuse_mtime"])
+	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), "", string(contents))
+}
+
+func (t *FileStreamingWritesTest) TestSyncClobberedLocalFile() {
+	assert.True(t.T(), t.in.IsLocal())
+	t.clock.AdvanceTime(10 * time.Second)
+	// Clobber the file.
+	objWritten, err := storageutil.CreateObject(t.ctx, t.bucket, fileName, []byte("taco"))
+	require.Nil(t.T(), err)
+
+	// Sync.
+	err = t.in.Sync(t.ctx)
+
+	require.Error(t.T(), err)
+	var fileClobberedError *gcsfuse_errors.FileClobberedError
+	assert.ErrorAs(t.T(), err, &fileClobberedError)
+	// Validate Object on GCS not updated.
+	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
+	objGot, _, err := t.bucket.StatObject(t.ctx, statReq)
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), storageutil.ConvertObjToMinObject(objWritten), objGot)
+}
+
+// TODO: add tests for empty file. Changes are required to set precondition in bwh.

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -16,7 +16,6 @@ package inode
 
 import (
 	"context"
-	"math"
 	"testing"
 	"time"
 
@@ -33,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const localFile = "local"
@@ -113,18 +111,17 @@ func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) 
 		contentcache.New("", &t.clock),
 		&t.clock,
 		isLocal,
-		&cfg.WriteConfig{},
-		semaphore.NewWeighted(math.MaxInt64))
+		&cfg.Config{})
 
 	// Set buffered write config for created inode.
-	t.in.writeConfig = &cfg.WriteConfig{
+	t.in.config = &cfg.Config{Write: cfg.WriteConfig{
 		MaxBlocksPerFile:                  10,
 		BlockSizeMb:                       10,
 		ExperimentalEnableStreamingWrites: true,
-	}
+	}}
 
 	// Create write handler for the local inode created above.
-	err := t.in.CreateBufferedOrTempWriter()
+	err := t.in.CreateBufferedOrTempWriter(t.ctx)
 	assert.Nil(t.T(), err)
 
 	t.in.Lock()

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -78,6 +78,7 @@ func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) 
 	)
 	syncerBucket := gcsx.NewSyncerBucket(
 		1, // Append threshold
+		ChunkTransferTimeoutSecs,
 		".gcsfuse_tmp/",
 		t.bucket)
 


### PR DESCRIPTION
### Description
This PR includes changes to 
- integrate buffered write handler with sync/flush file flow.
- Fall back to temp file flow in case of out of order writes.
- Finalize the object in case of error during write.

Some refactoring is done to reuse the code.

**Note:** Flush empty file changes required precondition to be propagated to gcs request and will be taken up in the follow up PR. Unit tests are not added for it.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
