### PR TITLE
Increasing mount timeout threshold and taking minimum of 10 iterations

### DIFF
--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -104,6 +104,7 @@ func (testSuite *MountTimeoutTest) TearDownTest() {
 func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientProtocol string, expectedMountTime time.Duration) error {
 	minMountTime := time.Duration(math.MaxInt64)
 
+	// Iterating 10 times to account for randomness in time taken to mount.
 	for i := 0; i < iterations; i++ {
 		args := []string{"--client-protocol", clientProtocol, bucketName, testSuite.dir}
 		start := time.Now()
@@ -115,7 +116,7 @@ func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientPr
 		minMountTime = time.Duration(math.Min(float64(minMountTime), float64(mountTime)))
 
 		if err := util.Unmount(mountDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: unmount failed: %v\n", err)
+			err = fmt.Errorf("Warning: unmount failed: %v\n", err)
 			return err
 		}
 	}

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -49,12 +49,12 @@ const (
 	dualRegionAsiaBucket                   string        = "mount_timeout_test_bucket_asia1"
 	singleRegionUSCentralBucket            string        = "mount_timeout_test_bucket_us-central1"
 	singleRegionAsiaEastBucket             string        = "mount_timeout_test_bucket_asia-east1"
-	singleRegionAsiaEastExpectedMountTime  time.Duration = 3200 * time.Millisecond
-	multiRegionUSExpectedMountTime         time.Duration = 2000 * time.Millisecond
-	multiRegionAsiaExpectedMountTime       time.Duration = 4500 * time.Millisecond
-	dualRegionUSExpectedMountTime          time.Duration = 2700 * time.Millisecond
-	dualRegionAsiaExpectedMountTime        time.Duration = 3750 * time.Millisecond
-	singleRegionUSCentralExpectedMountTime time.Duration = 2000 * time.Millisecond
+	singleRegionAsiaEastExpectedMountTime  time.Duration = 5500 * time.Millisecond
+	multiRegionUSExpectedMountTime         time.Duration = 4500 * time.Millisecond
+	multiRegionAsiaExpectedMountTime       time.Duration = 7500 * time.Millisecond
+	dualRegionUSExpectedMountTime          time.Duration = 4500 * time.Millisecond
+	dualRegionAsiaExpectedMountTime        time.Duration = 6250 * time.Millisecond
+	singleRegionUSCentralExpectedMountTime time.Duration = 2500 * time.Millisecond
 	relaxedExpectedMountTime               time.Duration = 8000 * time.Millisecond
 	logfilePathPrefix                      string        = "/tmp/gcsfuse_mount_timeout_"
 )


### PR DESCRIPTION
### Description

- Relaxing region based timeout thresholds to 2.5x
- The time used to compare will be the minimum out of 10 iterations 

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
