### PR TITLE
Remove unnecessary noises while deleting bucket in CI Pipeline

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -320,7 +320,7 @@ function clean_up() {
       # Empty bucket name may cause deletions of all the buckets.
       if [ "$bucket" != "" ];
       then
-        gcloud alpha storage rm --recursive gs://$bucket
+        gcloud alpha storage rm --recursive gs://$bucket 2>&1 | grep "ERROR"
       fi
     done
 }


### PR DESCRIPTION
### Description
Improved CI reliability by suppressing unnecessary output from gcloud during bucket deletion. This prevents exceeding Kokoro's log limits and ensures critical logs are preserved.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
