### PR TITLE
increase_timeout

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -172,7 +172,7 @@ TEST_DIR_NON_PARALLEL=(
 # Create a temporary file to store the log file name.
 TEST_LOGS_FILE=$(mktemp)
 
-INTEGRATION_TEST_TIMEOUT=180m
+INTEGRATION_TEST_TIMEOUT=240m
 
 function run_non_parallel_tests() {
   local exit_code=0


### PR DESCRIPTION
### Description
Increase timeout for running e2e tests as some tests got timeout error in v2.6.0 release

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
