### PR TITLE
update buffered write sync and flush methods

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -227,6 +227,8 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	err = testSuite.bwh.Sync()
 
 	assert.NoError(testSuite.T(), err)
+	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
+	assert.Equal(testSuite.T(), 5, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -266,10 +266,7 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 	// AwaitBlocksUpload.
 	t.uh.AwaitBlocksUpload()
 
-	// The blocks should be available on the free channel for reuse.
-	for _, expect := range blocks {
-		got := <-t.uh.freeBlocksCh
-		assert.Equal(t.T(), expect, got)
-	}
+	assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 0, len(t.uh.uploadCh))
 	assertAllBlocksProcessed(t.T(), t.uh)
 }


### PR DESCRIPTION
### Description

This PR includes changes to:

**BufferedWriteHandler:**
- The Sync call now waits for all in-progress blocks to be processed.
- The Flush call finalizes the object as possible in case of an upload failure. It will return an error along with the object if a failure occurs.
**UploadHandler:**
- The uploader goroutine now frees all blocks, even in the event of an upload failure.
- `AwaitBlocksUpload` has been added to wait for all blocks to be uploaded.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA
