### PR TITLE
Fix emulator based kokoro tests

### DIFF
--- a/tools/integration_tests/emulator_tests/emulator_tests.sh
+++ b/tools/integration_tests/emulator_tests/emulator_tests.sh
@@ -19,6 +19,13 @@ set -eo pipefail
 # Display commands being run
 set -x
 
+architecture=$(dpkg --print-architecture)
+if [ $architecture == "arm64" ];then
+  # TODO: Remove this when we have an ARM64 image for the storage test bench.
+  echo "These tests will not run for arm64 machine..."
+  exit 0
+fi
+
 RUN_E2E_TESTS_ON_PACKAGE=$1
 # Only run on Go 1.17+
 min_minor_ver=17

--- a/tools/integration_tests/emulator_tests/emulator_tests.sh
+++ b/tools/integration_tests/emulator_tests/emulator_tests.sh
@@ -21,7 +21,7 @@ set -x
 
 architecture=$(dpkg --print-architecture)
 if [ $architecture == "arm64" ];then
-  # TODO: Remove this when we have an ARM64 image for the storage test bench.
+  # TODO: Remove this when we have an ARM64 image for the storage test bench.(b/384388821)
   echo "These tests will not run for arm64 machine..."
   exit 0
 fi


### PR DESCRIPTION
### Description
Tests were failing on arm64 machine as we don't have arm64 docker image. Remove this fix when we have an ARM64 image for the storage test bench.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
