### PR TITLE
Support Unlink operation when streaming writes in progress

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -250,3 +250,12 @@ func (wh *BufferedWriteHandler) writeDataForTruncatedSize() error {
 
 	return nil
 }
+
+func (wh *BufferedWriteHandler) Unlink() {
+	wh.uploadHandler.CancelUpload()
+	err := wh.blockPool.ClearFreeBlockChannel()
+	if err != nil {
+		// Only logging an error in case of resource leak.
+		logger.Errorf("blockPool.ClearFreeBlockChannel() failed: %v", err)
+	}
+}

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -15,7 +15,6 @@
 package bufferedwrites
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -349,15 +348,15 @@ func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthGreaterT
 	assert.Equal(testSuite.T(), testSuite.bwh.truncatedSize, fileInfo.TotalSize)
 }
 
-func (testSuite *BufferedWriteTest) TestUnlinkWhenWriterIsNotCreated() {
+func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {
 	testSuite.bwh.Unlink()
 
-	assert.Nil(testSuite.T(), testSuite.bwh.uploadHandler.ctx)
+	assert.Nil(testSuite.T(), testSuite.bwh.uploadHandler.cancelFunc)
 	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
 	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
 }
 
-func (testSuite *BufferedWriteTest) TestUnlinkWhenWriterIsCreated() {
+func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
 	buffer, err := operations.GenerateRandomData(blockSize)
 	assert.NoError(testSuite.T(), err)
 	// Write 5 blocks.
@@ -365,11 +364,12 @@ func (testSuite *BufferedWriteTest) TestUnlinkWhenWriterIsCreated() {
 		err = testSuite.bwh.Write(buffer, int64(blockSize*i))
 		require.Nil(testSuite.T(), err)
 	}
+	cancelCalled := false
+	testSuite.bwh.uploadHandler.cancelFunc = func() { cancelCalled = true }
 
 	testSuite.bwh.Unlink()
 
-	require.NotNil(testSuite.T(), testSuite.bwh.uploadHandler.ctx)
-	assert.Equal(testSuite.T(), context.Canceled, testSuite.bwh.uploadHandler.ctx.Err())
+	assert.True(testSuite.T(), cancelCalled)
 	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
 	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
 }

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -44,6 +44,10 @@ type UploadHandler struct {
 	// inode. This signals permanent failure in the buffered write job.
 	signalUploadFailure chan error
 
+	// Context and CancelFunc persisted to cancel the uploads in case of unlink operation.
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+
 	// Parameters required for creating a new GCS chunk writer.
 	bucket               gcs.Bucket
 	objectName           string
@@ -103,7 +107,8 @@ func (uh *UploadHandler) createObjectWriter() (err error) {
 	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, uh.chunkTransferTimeout)
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
-	uh.writer, err = uh.bucket.CreateObjectChunkWriter(context.Background(), req, int(uh.blockSize), nil)
+	uh.ctx, uh.cancelFunc = context.WithCancel(context.Background())
+	uh.writer, err = uh.bucket.CreateObjectChunkWriter(uh.ctx, req, int(uh.blockSize), nil)
 	return
 }
 
@@ -145,6 +150,15 @@ func (uh *UploadHandler) Finalize() (*gcs.MinObject, error) {
 		return nil, fmt.Errorf("FinalizeUpload failed for object %s: %w", uh.objectName, err)
 	}
 	return obj, nil
+}
+
+func (uh *UploadHandler) CancelUpload() {
+	if uh.cancelFunc != nil {
+		// cancel the context to cancel the ongoing GCS upload.
+		uh.cancelFunc()
+	}
+	// Wait for all in progress buffers to be added to the free channel.
+	uh.wg.Wait()
 }
 
 func (uh *UploadHandler) SignalUploadFailure() chan error {

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -44,8 +44,7 @@ type UploadHandler struct {
 	// inode. This signals permanent failure in the buffered write job.
 	signalUploadFailure chan error
 
-	// Context and CancelFunc persisted to cancel the uploads in case of unlink operation.
-	ctx        context.Context
+	// CancelFunc persisted to cancel the uploads in case of unlink operation.
 	cancelFunc context.CancelFunc
 
 	// Parameters required for creating a new GCS chunk writer.
@@ -107,8 +106,9 @@ func (uh *UploadHandler) createObjectWriter() (err error) {
 	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, uh.chunkTransferTimeout)
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
-	uh.ctx, uh.cancelFunc = context.WithCancel(context.Background())
-	uh.writer, err = uh.bucket.CreateObjectChunkWriter(uh.ctx, req, int(uh.blockSize), nil)
+	var ctx context.Context
+	ctx, uh.cancelFunc = context.WithCancel(context.Background())
+	uh.writer, err = uh.bucket.CreateObjectChunkWriter(ctx, req, int(uh.blockSize), nil)
 	return
 }
 

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -15,6 +15,7 @@
 package bufferedwrites
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -277,6 +278,14 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 	assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
 	assert.Equal(t.T(), 0, len(t.uh.uploadCh))
 	assertAllBlocksProcessed(t.T(), t.uh)
+}
+
+func (t *UploadHandlerTest) TestUploadHandlerCancelUpload() {
+	t.uh.ctx, t.uh.cancelFunc = context.WithCancel(context.Background())
+
+	t.uh.CancelUpload()
+
+	assert.Equal(t.T(), context.Canceled, t.uh.ctx.Err())
 }
 
 func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectRequestParametersForEmptyGCSObject() {

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -15,7 +15,6 @@
 package bufferedwrites
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -281,11 +280,14 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 }
 
 func (t *UploadHandlerTest) TestUploadHandlerCancelUpload() {
-	t.uh.ctx, t.uh.cancelFunc = context.WithCancel(context.Background())
+	cancelCalled := false
+	t.uh = &UploadHandler{
+		cancelFunc: func() { cancelCalled = true },
+	}
 
 	t.uh.CancelUpload()
 
-	assert.Equal(t.T(), context.Canceled, t.uh.ctx.Err())
+	assert.True(t.T(), cancelCalled)
 }
 
 func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectRequestParametersForEmptyGCSObject() {

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -281,9 +281,7 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 
 func (t *UploadHandlerTest) TestUploadHandlerCancelUpload() {
 	cancelCalled := false
-	t.uh = &UploadHandler{
-		cancelFunc: func() { cancelCalled = true },
-	}
+	t.uh.cancelFunc = func() { cancelCalled = true }
 
 	t.uh.CancelUpload()
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2258,7 +2258,7 @@ func (fs *fileSystem) Unlink(
 	// Fetch the inode.
 	in, isLocalFile := fs.localFileInodes[fileName]
 	if !isLocalFile {
-		in, _ = fs.generationBackedInodes[fileName]
+		in = fs.generationBackedInodes[fileName]
 	}
 
 	fs.mu.Unlock()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2255,7 +2255,12 @@ func (fs *fileSystem) Unlink(
 	parent := fs.dirInodeOrDie(op.Parent)
 	fileName := inode.NewFileName(parent.Name(), op.Name)
 
-	// Fetch the inode.
+	// Get the inode for the given file.
+	// Files must have an associated inode, which can be found in either:
+	//  - localFileInodes: For files created locally.
+	//  - generationBackedInodes: For files backed by an object.
+	// We are not checking implicitDirInodes or folderInodes because
+	// the unlink operation is only applicable to files.
 	in, isLocalFile := fs.localFileInodes[fileName]
 	if !isLocalFile {
 		in = fs.generationBackedInodes[fileName]

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -328,7 +328,6 @@ func (f *FileInode) Unlink() {
 
 	if f.bwh != nil {
 		f.bwh.Unlink()
-		f.bwh = nil
 	}
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -324,12 +324,11 @@ func (f *FileInode) IsUnlinked() bool {
 }
 
 func (f *FileInode) Unlink() {
+	f.unlinked = true
+
 	if f.bwh != nil {
 		f.bwh.Unlink()
 		f.bwh = nil
-	}
-	if f.local {
-		f.unlinked = true
 	}
 }
 
@@ -591,9 +590,8 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 func (f *FileInode) SetMtime(
 	ctx context.Context,
 	mtime time.Time) (err error) {
-	if f.IsLocal() && f.content == nil && f.bwh == nil {
-		// This scenario will happen for unlinked local file.
-		// No need to update mtime on GCS.
+	if f.IsUnlinked() {
+		// No need to update mtime on GCS for unlinked file.
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -324,7 +324,12 @@ func (f *FileInode) IsUnlinked() bool {
 }
 
 func (f *FileInode) Unlink() {
-	f.unlinked = true
+	if f.bwh != nil {
+		f.bwh.Unlink()
+	}
+	if f.local {
+		f.unlinked = true
+	}
 }
 
 // Source returns a record for the GCS object from which this inode is branched. The

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -217,7 +217,6 @@ func (t *FileStreamingWritesTest) TestUnlinkLocalFileBeforeWrite() {
 	t.in.Unlink()
 
 	assert.True(t.T(), t.in.unlinked)
-	assert.Nil(t.T(), t.in.bwh)
 	// Data shouldn't be updated to GCS.
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
 }
@@ -233,7 +232,6 @@ func (t *FileStreamingWritesTest) TestUnlinkLocalFileAfterWrite() {
 	t.in.Unlink()
 
 	assert.True(t.T(), t.in.IsUnlinked())
-	assert.Nil(t.T(), t.in.bwh)
 	// Data shouldn't be updated to GCS.
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
 }
@@ -250,5 +248,4 @@ func (t *FileStreamingWritesTest) TestUnlinkEmptySyncedFile() {
 	t.in.Unlink()
 
 	assert.True(t.T(), t.in.unlinked)
-	assert.Nil(t.T(), t.in.bwh)
 }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -16,7 +16,6 @@ package inode
 
 import (
 	"context"
-	"math"
 	"testing"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const localFile = "local"

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 )
@@ -1046,6 +1047,19 @@ func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.MetaGeneration, m.MetaGeneration)
+}
+
+func (t *FileTest) TestSetMtimeForUnlinkedFileIsNoOp() {
+	t.in.unlinked = true
+	mtime := time.Now().UTC().Add(123 * time.Second)
+
+	// Set mtime.
+	err := t.in.SetMtime(t.ctx, mtime)
+
+	require.Nil(t.T(), err)
+	attr, err := t.in.Attributes(context.Background())
+	require.Nil(t.T(), err)
+	assert.NotEqual(t.T(), mtime, attr.Mtime)
 }
 
 func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1051,15 +1051,18 @@ func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 
 func (t *FileTest) TestSetMtimeForUnlinkedFileIsNoOp() {
 	t.in.unlinked = true
-	mtime := time.Now().UTC().Add(123 * time.Second)
+	beforeUpdateAttr, err := t.in.Attributes(t.ctx)
+	require.Nil(t.T(), err)
+	mtime := beforeUpdateAttr.Mtime.UTC().Add(123 * time.Second)
 
 	// Set mtime.
-	err := t.in.SetMtime(t.ctx, mtime)
+	err = t.in.SetMtime(t.ctx, mtime)
 
 	require.Nil(t.T(), err)
-	attr, err := t.in.Attributes(context.Background())
+	afterUpdateAttr, err := t.in.Attributes(t.ctx)
 	require.Nil(t.T(), err)
-	assert.NotEqual(t.T(), mtime, attr.Mtime)
+	assert.NotEqual(t.T(), mtime, afterUpdateAttr.Mtime)
+	assert.Equal(t.T(), beforeUpdateAttr.Mtime, afterUpdateAttr.Mtime)
 }
 
 func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes() {

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -55,6 +55,9 @@ type Inode interface {
 	//
 	// This method may block. Errors are for logging purposes only.
 	Destroy() (err error)
+
+	// Unlink operation marks the inode as unlinked/deleted.
+	Unlink()
 }
 
 // An inode owned by a gcs bucket.

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -149,3 +149,6 @@ func (s *SymlinkInode) Target() (target string) {
 	target = s.target
 	return
 }
+
+func (s *SymlinkInode) Unlink() {
+}

--- a/internal/fs/streaming_writes_common_test.go
+++ b/internal/fs/streaming_writes_common_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Streaming write tests which are common for both local file and synced empty
+// object.
+
+package fs_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type StreamingWritesCommonTest struct {
+	suite.Suite
+	fsTest
+}
+
+func TestStreamingWritesCommonTest(t *testing.T) {
+	suite.Run(t, new(StreamingWritesCommonTest))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *StreamingWritesCommonTest) TestUnlinkBeforeWrite() {
+	// unlink the file.
+	err := os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is deleted from GCS.
+	err = t.f1.Close()
+	assert.NoError(nil, err)
+	t.f1 = nil
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}
+
+func (t *StreamingWritesCommonTest) TestUnlinkAfterWrite() {
+	// Write content to file.
+	_, err := t.f1.Write([]byte("tacos"))
+	assert.NoError(t.T(), err)
+
+	// unlink the file.
+	err = os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is not created on GCS.
+	err = t.f1.Close()
+	assert.NoError(nil, err)
+	t.f1 = nil
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}

--- a/internal/fs/streaming_writes_common_test.go
+++ b/internal/fs/streaming_writes_common_test.go
@@ -53,15 +53,5 @@ func (t *StreamingWritesCommonTest) TestUnlinkAfterWrite() {
 	_, err := t.f1.Write([]byte("tacos"))
 	assert.NoError(t.T(), err)
 
-	// unlink the file.
-	err = os.Remove(t.f1.Name())
-	assert.NoError(t.T(), err)
-
-	// Stat the file and validate file is deleted.
-	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
-	// Close the file and validate that file is not created on GCS.
-	err = t.f1.Close()
-	assert.NoError(nil, err)
-	t.f1 = nil
-	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+	t.TestUnlinkBeforeWrite()
 }

--- a/internal/fs/streaming_writes_common_test.go
+++ b/internal/fs/streaming_writes_common_test.go
@@ -19,7 +19,6 @@ package fs_test
 
 import (
 	"os"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
@@ -29,10 +28,6 @@ import (
 type StreamingWritesCommonTest struct {
 	suite.Suite
 	fsTest
-}
-
-func TestStreamingWritesCommonTest(t *testing.T) {
-	suite.Run(t, new(StreamingWritesCommonTest))
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/streaming_writes_empty_gcs_object_test.go
+++ b/internal/fs/streaming_writes_empty_gcs_object_test.go
@@ -29,12 +29,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type StreamingWritesEmptyObjectTest struct {
+type StreamingWritesEmptyGCSObjectTest struct {
 	suite.Suite
 	fsTest
 }
 
-func (t *StreamingWritesEmptyObjectTest) SetupSuite() {
+func (t *StreamingWritesEmptyGCSObjectTest) SetupSuite() {
 	t.serverCfg.NewConfig = &cfg.Config{
 		Write: cfg.WriteConfig{
 			BlockSizeMb:                       10,
@@ -47,10 +47,10 @@ func (t *StreamingWritesEmptyObjectTest) SetupSuite() {
 	t.fsTest.SetUpTestSuite()
 }
 
-func (t *StreamingWritesEmptyObjectTest) TearDownSuite() {
+func (t *StreamingWritesEmptyGCSObjectTest) TearDownSuite() {
 	t.fsTest.TearDownTestSuite()
 }
-func (t *StreamingWritesEmptyObjectTest) SetupTest() {
+func (t *StreamingWritesEmptyGCSObjectTest) SetupTest() {
 	// Create an object on bucket.
 	_, err := storageutil.CreateObject(
 		ctx,
@@ -63,19 +63,19 @@ func (t *StreamingWritesEmptyObjectTest) SetupTest() {
 	assert.Equal(t.T(), nil, err)
 }
 
-func (t *StreamingWritesEmptyObjectTest) TearDownTest() {
+func (t *StreamingWritesEmptyGCSObjectTest) TearDownTest() {
 	t.fsTest.TearDown()
 }
 
 func TestStreamingWritesEmptyObjectTest(t *testing.T) {
-	suite.Run(t, new(StreamingWritesEmptyObjectTest))
+	suite.Run(t, new(StreamingWritesEmptyGCSObjectTest))
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *StreamingWritesEmptyObjectTest) TestUnlinkBeforeWrite() {
+func (t *StreamingWritesEmptyGCSObjectTest) TestUnlinkBeforeWrite() {
 	// Validate that file exists on GCS.
 	_, err := storageutil.ReadObject(ctx, bucket, fileName)
 	assert.NoError(t.T(), err)
@@ -93,7 +93,7 @@ func (t *StreamingWritesEmptyObjectTest) TestUnlinkBeforeWrite() {
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
 }
 
-func (t *StreamingWritesEmptyObjectTest) TestUnlinkAfterWrite() {
+func (t *StreamingWritesEmptyGCSObjectTest) TestUnlinkAfterWrite() {
 	// Validate that file exists on GCS.
 	_, err := storageutil.ReadObject(ctx, bucket, fileName)
 	assert.NoError(t.T(), err)

--- a/internal/fs/streaming_writes_empty_object_test.go
+++ b/internal/fs/streaming_writes_empty_object_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests which tests the kernel-list-cache feature, in which
+// directory listing 2nd time is served from kernel page-cache unless not invalidated.
+// Base of all the tests: how to detect if directory listing is served from page-cache
+// or from GCSFuse?
+// (a) GCSFuse file-system ensures different content, when listing happens on the same directory.
+// (b) If two consecutive directory listing for the same directory are same, that means
+//     2nd listing is served from kernel-page-cache.
+// (c) If not then, both 1st and 2nd listing are served from GCSFuse filesystem.
+
+package fs_test
+
+import (
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type StreamingWritesEmptyObjectTest struct {
+	suite.Suite
+	fsTest
+}
+
+func (t *StreamingWritesEmptyObjectTest) SetupSuite() {
+	t.serverCfg.NewConfig = &cfg.Config{
+		Write: cfg.WriteConfig{
+			BlockSizeMb:                       10,
+			CreateEmptyFile:                   false,
+			ExperimentalEnableStreamingWrites: true,
+			GlobalMaxBlocks:                   20,
+			MaxBlocksPerFile:                  10,
+		},
+	}
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *StreamingWritesEmptyObjectTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+func (t *StreamingWritesEmptyObjectTest) SetupTest() {
+	// Create an object on bucket.
+	_, err := storageutil.CreateObject(
+		ctx,
+		bucket,
+		fileName,
+		[]byte("bar"))
+	assert.Equal(t.T(), nil, err)
+	// Open file handle to read or write.
+	t.f1, err = os.OpenFile(path.Join(mntDir, fileName), os.O_RDWR|syscall.O_DIRECT, filePerms)
+	assert.Equal(t.T(), nil, err)
+}
+
+func (t *StreamingWritesEmptyObjectTest) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func TestStreamingWritesEmptyObjectTest(t *testing.T) {
+	suite.Run(t, new(StreamingWritesEmptyObjectTest))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *StreamingWritesEmptyObjectTest) TestUnlinkWritesAreNotInProgress() {
+	// unlink the synced file.
+	err := os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is not created on GCS.
+	err = t.f1.Close()
+	assert.NoError(nil, err)
+	t.f1 = nil
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}
+
+func (t *StreamingWritesEmptyObjectTest) TestUnlinkWhenWritesAreInProgress() {
+	_, err := t.f1.Write([]byte("tacos"))
+	assert.Nil(t.T(), err)
+
+	// unlink the file.
+	err = os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is not created on GCS.
+	err = t.f1.Close()
+	assert.NoError(nil, err)
+	t.f1 = nil
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}

--- a/internal/fs/streaming_writes_empty_object_test.go
+++ b/internal/fs/streaming_writes_empty_object_test.go
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// A collection of tests which tests the kernel-list-cache feature, in which
-// directory listing 2nd time is served from kernel page-cache unless not invalidated.
-// Base of all the tests: how to detect if directory listing is served from page-cache
-// or from GCSFuse?
-// (a) GCSFuse file-system ensures different content, when listing happens on the same directory.
-// (b) If two consecutive directory listing for the same directory are same, that means
-//     2nd listing is served from kernel-page-cache.
-// (c) If not then, both 1st and 2nd listing are served from GCSFuse filesystem.
+// Streaming write tests for synced empty object.
 
 package fs_test
 

--- a/internal/fs/streaming_writes_empty_object_test.go
+++ b/internal/fs/streaming_writes_empty_object_test.go
@@ -75,23 +75,31 @@ func TestStreamingWritesEmptyObjectTest(t *testing.T) {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *StreamingWritesEmptyObjectTest) TestUnlinkWritesAreNotInProgress() {
+func (t *StreamingWritesEmptyObjectTest) TestUnlinkBeforeWrite() {
+	// Validate that file exists on GCS.
+	_, err := storageutil.ReadObject(ctx, bucket, fileName)
+	assert.NoError(t.T(), err)
+
 	// unlink the synced file.
-	err := os.Remove(t.f1.Name())
+	err = os.Remove(t.f1.Name())
 	assert.NoError(t.T(), err)
 
 	// Stat the file and validate file is deleted.
 	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
-	// Close the file and validate that file is not created on GCS.
+	// Close the file and validate that file is deleted from GCS.
 	err = t.f1.Close()
 	assert.NoError(nil, err)
 	t.f1 = nil
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
 }
 
-func (t *StreamingWritesEmptyObjectTest) TestUnlinkWhenWritesAreInProgress() {
-	_, err := t.f1.Write([]byte("tacos"))
-	assert.Nil(t.T(), err)
+func (t *StreamingWritesEmptyObjectTest) TestUnlinkAfterWrite() {
+	// Validate that file exists on GCS.
+	_, err := storageutil.ReadObject(ctx, bucket, fileName)
+	assert.NoError(t.T(), err)
+	// Write content to file.
+	_, err = t.f1.Write([]byte("tacos"))
+	assert.NoError(t.T(), err)
 
 	// unlink the file.
 	err = os.Remove(t.f1.Name())

--- a/internal/fs/streaming_writes_local_file_test.go
+++ b/internal/fs/streaming_writes_local_file_test.go
@@ -122,12 +122,12 @@ func (t *StreamingWritesLocalFileTest) TestRemoveDirectoryContainingLocalAndEmpt
 				path.Join(explicitDirName, nonEmptyFileName): "taco",
 			}))
 	// Write content to local and empty gcs file.
-	_, t.f1 = operations.CreateLocalFile(ctx, t.T(), mntDir, bucket, path.Join(explicitDirName, fileName))
-	_, err := t.f1.WriteString(FileContents)
+	_, f1 := operations.CreateLocalFile(ctx, t.T(), mntDir, bucket, path.Join(explicitDirName, fileName))
+	_, err := f1.WriteString(FileContents)
 	assert.NoError(t.T(), err)
-	t.f2, err = os.OpenFile(path.Join(mntDir, explicitDirName, emptyFileName), os.O_RDWR|syscall.O_DIRECT, filePerms)
+	f2, err := os.OpenFile(path.Join(mntDir, explicitDirName, emptyFileName), os.O_RDWR|syscall.O_DIRECT, filePerms)
 	assert.Equal(t.T(), nil, err)
-	_, err = t.f2.WriteString(FileContents)
+	_, err = f2.WriteString(FileContents)
 	assert.NoError(t.T(), err)
 
 	// Attempt to remove explicit directory.
@@ -139,11 +139,10 @@ func (t *StreamingWritesLocalFileTest) TestRemoveDirectoryContainingLocalAndEmpt
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(explicitDirName, nonEmptyFileName))
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(explicitDirName, fileName))
 	operations.ValidateNoFileOrDirError(t.T(), explicitDirName)
-	err = operations.CloseLocalFile(t.T(), &t.f1)
+	err = operations.CloseLocalFile(t.T(), &f1)
 	assert.NoError(t.T(), err)
-	err = t.f2.Close()
+	err = f2.Close()
 	assert.NoError(t.T(), err)
-	t.f2 = nil
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, emptyFileName))
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, nonEmptyFileName))
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, fileName))

--- a/internal/fs/streaming_writes_local_file_test.go
+++ b/internal/fs/streaming_writes_local_file_test.go
@@ -1,0 +1,149 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests which tests the kernel-list-cache feature, in which
+// directory listing 2nd time is served from kernel page-cache unless not invalidated.
+// Base of all the tests: how to detect if directory listing is served from page-cache
+// or from GCSFuse?
+// (a) GCSFuse file-system ensures different content, when listing happens on the same directory.
+// (b) If two consecutive directory listing for the same directory are same, that means
+//     2nd listing is served from kernel-page-cache.
+// (c) If not then, both 1st and 2nd listing are served from GCSFuse filesystem.
+
+package fs_test
+
+import (
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	fileName = "foo"
+)
+
+type StreamingWritesLocalFileTest struct {
+	suite.Suite
+	fsTest
+}
+
+func (t *StreamingWritesLocalFileTest) SetupSuite() {
+	t.serverCfg.NewConfig = &cfg.Config{
+		Write: cfg.WriteConfig{
+			BlockSizeMb:                       10,
+			CreateEmptyFile:                   false,
+			ExperimentalEnableStreamingWrites: true,
+			GlobalMaxBlocks:                   20,
+			MaxBlocksPerFile:                  10,
+		},
+	}
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *StreamingWritesLocalFileTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+func (t *StreamingWritesLocalFileTest) SetupTest() {
+	// Create a local file.
+	_, t.f1 = operations.CreateLocalFile(ctx, t.T(), mntDir, bucket, fileName)
+}
+
+func (t *StreamingWritesLocalFileTest) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func TestStreamingWritesTestSuite(t *testing.T) {
+	suite.Run(t, new(StreamingWritesLocalFileTest))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *StreamingWritesLocalFileTest) TestUnlinkWhenWritesAreNotInProgress() {
+	// unlink the local file.
+	err := os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the local file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is not created on GCS.
+	err = operations.CloseLocalFile(t.T(), &t.f1)
+	assert.NoError(nil, err)
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}
+
+func (t *StreamingWritesLocalFileTest) TestUnlinkWhenWritesAreInProgress() {
+	_, err := t.f1.Write([]byte("tacos"))
+	assert.Nil(t.T(), err)
+
+	// unlink the local file.
+	err = os.Remove(t.f1.Name())
+	assert.NoError(t.T(), err)
+
+	// Stat the local file and validate file is deleted.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+	// Close the file and validate that file is not created on GCS.
+	err = operations.CloseLocalFile(t.T(), &t.f1)
+	assert.NoError(nil, err)
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+}
+
+func (t *StreamingWritesEmptyObjectTest) TestRemoveDirectoryContainingLocalAndEmptyObject() {
+	// Create explicit directory with one synced and one local file.
+	explicitDirName := "explicit"
+	emptyFileName := "emptyFile"
+	nonEmptyFileName := "nonEmptyFile"
+	assert.Equal(t.T(),
+		nil,
+		t.createObjects(
+			map[string]string{
+				// File
+				explicitDirName + "/":                        "",
+				path.Join(explicitDirName, emptyFileName):    "",
+				path.Join(explicitDirName, nonEmptyFileName): "taco",
+			}))
+	// Write content to local and empty gcs file.
+	_, t.f1 = operations.CreateLocalFile(ctx, t.T(), mntDir, bucket, path.Join(explicitDirName, fileName))
+	_, err := t.f1.WriteString(FileContents)
+	assert.NoError(t.T(), err)
+	t.f2, err = os.OpenFile(path.Join(mntDir, explicitDirName, emptyFileName), os.O_RDWR|syscall.O_DIRECT, filePerms)
+	assert.Equal(t.T(), nil, err)
+	_, err = t.f2.WriteString(FileContents)
+	assert.NoError(t.T(), err)
+
+	// Attempt to remove explicit directory.
+	err = os.RemoveAll(path.Join(mntDir, explicitDirName))
+
+	// Verify rmDir operation succeeds.
+	assert.NoError(t.T(), err)
+	operations.ValidateNoFileOrDirError(t.T(), path.Join(explicitDirName, emptyFileName))
+	operations.ValidateNoFileOrDirError(t.T(), path.Join(explicitDirName, nonEmptyFileName))
+	operations.ValidateNoFileOrDirError(t.T(), path.Join(explicitDirName, fileName))
+	operations.ValidateNoFileOrDirError(t.T(), explicitDirName)
+	// Validate flush file throws IO error and does not create object on GCS
+	// Close the file and validate that file is not created on GCS.
+	err = operations.CloseLocalFile(t.T(), &t.f1)
+	assert.NoError(nil, err)
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, emptyFileName))
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, nonEmptyFileName))
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, path.Join(explicitDirName, fileName))
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, explicitDirName)
+}

--- a/internal/fs/streaming_writes_local_file_test.go
+++ b/internal/fs/streaming_writes_local_file_test.go
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// A collection of tests which tests the kernel-list-cache feature, in which
-// directory listing 2nd time is served from kernel page-cache unless not invalidated.
-// Base of all the tests: how to detect if directory listing is served from page-cache
-// or from GCSFuse?
-// (a) GCSFuse file-system ensures different content, when listing happens on the same directory.
-// (b) If two consecutive directory listing for the same directory are same, that means
-//     2nd listing is served from kernel-page-cache.
-// (c) If not then, both 1st and 2nd listing are served from GCSFuse filesystem.
+// Streaming write tests for local file.
 
 package fs_test
 

--- a/internal/fs/streaming_writes_local_file_test.go
+++ b/internal/fs/streaming_writes_local_file_test.go
@@ -71,7 +71,10 @@ func TestStreamingWritesLocalFileTestSuite(t *testing.T) {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *StreamingWritesLocalFileTest) TestUnlinkWhenWritesAreNotInProgress() {
+func (t *StreamingWritesLocalFileTest) TestUnlinkBeforeWrite() {
+	// Validate that the file is local (not synced).
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+
 	// unlink the local file.
 	err := os.Remove(t.f1.Name())
 	assert.NoError(t.T(), err)
@@ -84,7 +87,10 @@ func (t *StreamingWritesLocalFileTest) TestUnlinkWhenWritesAreNotInProgress() {
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
 }
 
-func (t *StreamingWritesLocalFileTest) TestUnlinkWhenWritesAreInProgress() {
+func (t *StreamingWritesLocalFileTest) TestUnlinkAfterWrite() {
+	// Validate that the file is local (not synced).
+	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
+	// Write content to file.
 	_, err := t.f1.Write([]byte("tacos"))
 	assert.Nil(t.T(), err)
 

--- a/internal/fs/streaming_writes_local_file_test.go
+++ b/internal/fs/streaming_writes_local_file_test.go
@@ -33,8 +33,7 @@ const (
 )
 
 type StreamingWritesLocalFileTest struct {
-	suite.Suite
-	fsTest
+	StreamingWritesCommonTest
 }
 
 func (t *StreamingWritesLocalFileTest) SetupSuite() {
@@ -55,7 +54,8 @@ func (t *StreamingWritesLocalFileTest) TearDownSuite() {
 	t.fsTest.TearDownTestSuite()
 }
 func (t *StreamingWritesLocalFileTest) SetupTest() {
-	// Create a local file.
+	// CreateLocalFile creates a local file and validates that object does not
+	// exist on GCS.
 	_, t.f1 = operations.CreateLocalFile(ctx, t.T(), mntDir, bucket, fileName)
 }
 
@@ -70,41 +70,6 @@ func TestStreamingWritesLocalFileTestSuite(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
-
-func (t *StreamingWritesLocalFileTest) TestUnlinkBeforeWrite() {
-	// Validate that the file is local (not synced).
-	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
-
-	// unlink the local file.
-	err := os.Remove(t.f1.Name())
-	assert.NoError(t.T(), err)
-
-	// Stat the local file and validate file is deleted.
-	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
-	// Close the file and validate that file is not created on GCS.
-	err = operations.CloseLocalFile(t.T(), &t.f1)
-	assert.NoError(nil, err)
-	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
-}
-
-func (t *StreamingWritesLocalFileTest) TestUnlinkAfterWrite() {
-	// Validate that the file is local (not synced).
-	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
-	// Write content to file.
-	_, err := t.f1.Write([]byte("tacos"))
-	assert.Nil(t.T(), err)
-
-	// unlink the local file.
-	err = os.Remove(t.f1.Name())
-	assert.NoError(t.T(), err)
-
-	// Stat the local file and validate file is deleted.
-	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
-	// Close the file and validate that file is not created on GCS.
-	err = operations.CloseLocalFile(t.T(), &t.f1)
-	assert.NoError(nil, err)
-	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, fileName)
-}
 
 func (t *StreamingWritesLocalFileTest) TestRemoveDirectoryContainingLocalAndEmptyObject() {
 	// Create explicit directory with one synced and one local file.

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -40,6 +40,7 @@ func ValidateObjectNotFoundErr(ctx context.Context, t *testing.T, bucket gcs.Buc
 	var notFoundErr *gcs.NotFoundError
 	_, err := storageutil.ReadObject(ctx, bucket, fileName)
 
+	assert.Error(t, err)
 	assert.True(t, errors.As(err, &notFoundErr))
 }
 


### PR DESCRIPTION
### Description
Support Unlink operation when streaming writes are in progress.
Changes include:
- Cancelling ongoing upload's context and freeing up resources.
- File Inode Unlink will be called for both local and generation backed inodes.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
