### PR TITLE
Lock bundler version

### DIFF
--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -19,7 +19,7 @@
 
 FROM golang:1.23.4 as builder
 
-RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler
+RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm && gem install --no-document bundler -v "2.4.12"
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
### Description

builds using 'package_gcsfuse_docker/Dockerfile' fail without specifying 'bundler' version to match 'tools/gem_dependency/Gemfile.lock'

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
