### PR TITLE
skip kernel list cache test for unsupported kernel version

### DIFF
--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -20,15 +20,19 @@ import (
 	"errors"
 	"os"
 	"path"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+const UnsupportedKernelVersion = `^6\.9\.\d+`
 
 type KernelListCacheTestWithInfiniteTtl struct {
 	suite.Suite
@@ -52,6 +56,12 @@ func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestInfiniteTtlSuite(t *testing.T) {
+	kernelVersion := operations.KernelVersion(t)
+	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
+	assert.NoError(t, err)
+	if matched {
+		t.SkipNow()
+	}
 	suite.Run(t, new(KernelListCacheTestWithInfiniteTtl))
 }
 

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -32,7 +32,21 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const UnsupportedKernelVersion = `^6\.9\.\d+`
+func SkipTestForUnsupportedKernelVersion(t *testing.T) {
+	// TODO: b/384648943 make this part of fsTest.SetUpTestSuite() after post fs
+	// tests are fully migrated to stretchr/testify.
+	t.Helper()
+	UnsupportedKernelVersions := []string{`^6\.9\.\d+`}
+
+	kernelVersion := operations.KernelVersion(t)
+	for i := 0; i < len(UnsupportedKernelVersions); i++ {
+		matched, err := regexp.MatchString(UnsupportedKernelVersions[i], kernelVersion)
+		assert.NoError(t, err)
+		if matched {
+			t.SkipNow()
+		}
+	}
+}
 
 type KernelListCacheTestWithInfiniteTtl struct {
 	suite.Suite
@@ -56,12 +70,7 @@ func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestInfiniteTtlSuite(t *testing.T) {
-	kernelVersion := operations.KernelVersion(t)
-	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
-	assert.NoError(t, err)
-	if matched {
-		t.SkipNow()
-	}
+	SkipTestForUnsupportedKernelVersion(t)
 	suite.Run(t, new(KernelListCacheTestWithInfiniteTtl))
 }
 

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -26,6 +26,7 @@ package fs_test
 import (
 	"os"
 	"path"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -120,6 +122,12 @@ func (t *KernelListCacheTestWithPositiveTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestWithPositiveTtlSuite(t *testing.T) {
+	kernelVersion := operations.KernelVersion(t)
+	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
+	assert.NoError(t, err)
+	if matched {
+		t.SkipNow()
+	}
 	suite.Run(t, new(KernelListCacheTestWithPositiveTtl))
 }
 

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -26,7 +26,6 @@ package fs_test
 import (
 	"os"
 	"path"
-	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -34,7 +33,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -122,12 +120,7 @@ func (t *KernelListCacheTestWithPositiveTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestWithPositiveTtlSuite(t *testing.T) {
-	kernelVersion := operations.KernelVersion(t)
-	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
-	assert.NoError(t, err)
-	if matched {
-		t.SkipNow()
-	}
+	SkipTestForUnsupportedKernelVersion(t)
 	suite.Run(t, new(KernelListCacheTestWithPositiveTtl))
 }
 

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -19,10 +19,12 @@ package fs_test
 import (
 	"os"
 	"path"
+	"regexp"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -50,6 +52,12 @@ func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestZeroTtlSuite(t *testing.T) {
+	kernelVersion := operations.KernelVersion(t)
+	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
+	assert.NoError(t, err)
+	if matched {
+		t.SkipNow()
+	}
 	suite.Run(t, new(KernelListCacheTestWithZeroTtl))
 }
 

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -19,12 +19,10 @@ package fs_test
 import (
 	"os"
 	"path"
-	"regexp"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -52,12 +50,7 @@ func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
 }
 
 func TestKernelListCacheTestZeroTtlSuite(t *testing.T) {
-	kernelVersion := operations.KernelVersion(t)
-	matched, err := regexp.MatchString(UnsupportedKernelVersion, kernelVersion)
-	assert.NoError(t, err)
-	if matched {
-		t.SkipNow()
-	}
+	SkipTestForUnsupportedKernelVersion(t)
 	suite.Run(t, new(KernelListCacheTestWithZeroTtl))
 }
 

--- a/tools/integration_tests/util/operations/operations.go
+++ b/tools/integration_tests/util/operations/operations.go
@@ -20,7 +20,11 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
+	"strings"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // GenerateRandomData generates random data that can be used to write to a file.
@@ -69,4 +73,14 @@ func runCommand(cmd *exec.Cmd) ([]byte, error) {
 // Executes any given gcloud command with given args.
 func ExecuteGcloudCommandf(format string, args ...any) ([]byte, error) {
 	return executeToolCommandf("gcloud", format, args...)
+}
+
+func KernelVersion(t *testing.T) string {
+	t.Helper()
+
+	cmd := exec.Command("uname", "-r")
+	out, err := cmd.Output()
+	assert.NoError(t, err)
+	kernelVersion := strings.TrimSpace(string(out))
+	return kernelVersion
 }


### PR DESCRIPTION
### Description
skip kernel list cache test for unsupported kernel version 6.9.x - Ref issue #2792

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
