### PR TITLE
fix make command

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -472,7 +472,7 @@ func (job *Job) Download(ctx context.Context, offset int64, waitForDownload bool
 	job.mu.Lock()
 	if int64(job.object.Size) < offset {
 		defer job.mu.Unlock()
-		err = fmt.Errorf(fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", offset, job.object.Size))
+		err = fmt.Errorf("download: the requested offset %d is greater than the size of object %d", offset, job.object.Size)
 		return job.status, err
 	}
 

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -681,7 +681,7 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 	ctx := context.Background()
 	wg := sync.WaitGroup{}
 	offsets := []int64{0, 4 * util.MiB, 16 * util.MiB, 8 * util.MiB, int64(objectSize), int64(objectSize) + 1}
-	expectedErrs := []error{nil, nil, nil, nil, nil, fmt.Errorf(fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", int64(objectSize)+1, int64(objectSize)))}
+	expectedErrs := []error{nil, nil, nil, nil, nil, fmt.Errorf("download: the requested offset %d is greater than the size of object %d", int64(objectSize)+1, int64(objectSize))}
 	downloadFunc := func(expectedOffset int64, expectedErr error) {
 		defer wg.Done()
 		var jobStatus JobStatus

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -631,7 +631,7 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), fmt.Sprintf("Download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
+	AssertTrue(strings.Contains(err.Error(), fmt.Sprintf("download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
 	expectedJobStatus := JobStatus{NotStarted, nil, 0}
 	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
 	AssertFalse(callbackExecuted.Load())

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -148,10 +148,15 @@ func Errorf(format string, v ...interface{}) {
 	defaultLogger.Error(fmt.Sprintf(format, v...))
 }
 
+// Error prints the message with ERROR severity.
+func Error(error string) {
+	defaultLogger.Error(error)
+}
+
 // Fatal prints an error log and exits with non-zero exit code.
 func Fatal(format string, v ...interface{}) {
 	Errorf(format, v...)
-	Errorf(string(debug.Stack()))
+	Error(string(debug.Stack()))
 	os.Exit(1)
 }
 

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -73,7 +73,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 	// Indent for readability
 	jsonData, err := json.MarshalIndent(policy, "", "  ")
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error in marshal the data into JSON format: %v", err))
+		t.Fatalf("Error in marshal the data into JSON format: %v", err)
 	}
 
 	f, err := os.CreateTemp(os.TempDir(), "iam-policy-*.json")
@@ -84,11 +84,11 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 	// Write the JSON to a FileInNonEmptyManagedFoldersTest
 	_, err = f.Write(jsonData)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error in writing iam policy in json FileInNonEmptyManagedFoldersTest : %v", err))
+		t.Fatalf("Error in writing iam policy in json FileInNonEmptyManagedFoldersTest : %v", err)
 	}
 
 	gcloudProvidePermissionCmd := fmt.Sprintf("alpha storage managed-folders set-iam-policy gs://%s/%s %s", bucket, managedFolderPath, f.Name())
-	_, err = operations.ExecuteGcloudCommandf(gcloudProvidePermissionCmd)
+	_, err = operations.ExecuteGcloudCommand(gcloudProvidePermissionCmd)
 	if err != nil {
 		t.Fatalf("Error in providing permission to managed folder: %v", err)
 	}
@@ -97,7 +97,7 @@ func providePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount,
 func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, iamRole string, t *testing.T) {
 	gcloudRevokePermissionCmd := fmt.Sprintf("alpha storage managed-folders remove-iam-policy-binding  gs://%s/%s --member=%s --role=%s", bucket, managedFolderPath, serviceAccount, iamRole)
 
-	_, err := operations.ExecuteGcloudCommandf(gcloudRevokePermissionCmd)
+	_, err := operations.ExecuteGcloudCommand(gcloudRevokePermissionCmd)
 	if err != nil && !strings.Contains(err.Error(), "Policy binding with the specified principal, role, and condition not found!") && !strings.Contains(err.Error(), "The specified managed folder does not exist.") {
 		t.Fatalf("Error in removing permission to managed folder: %v", err)
 	}

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -164,26 +164,26 @@ func DirSizeMiB(dirPath string) (dirSizeMB int64, err error) {
 func DeleteManagedFoldersInBucket(managedFolderPath, bucket string) {
 	gcloudDeleteManagedFolderCmd := fmt.Sprintf("alpha storage rm -r gs://%s/%s", bucket, managedFolderPath)
 
-	_, err := ExecuteGcloudCommandf(gcloudDeleteManagedFolderCmd)
+	_, err := ExecuteGcloudCommand(gcloudDeleteManagedFolderCmd)
 	if err != nil && !strings.Contains(err.Error(), "The following URLs matched no objects or files") {
-		log.Fatalf(fmt.Sprintf("Error while deleting managed folder: %v", err))
+		log.Fatalf("Error while deleting managed folder: %v", err)
 	}
 }
 
 func CreateManagedFoldersInBucket(managedFolderPath, bucket string) {
 	gcloudCreateManagedFolderCmd := fmt.Sprintf("alpha storage managed-folders create gs://%s/%s", bucket, managedFolderPath)
 
-	_, err := ExecuteGcloudCommandf(gcloudCreateManagedFolderCmd)
+	_, err := ExecuteGcloudCommand(gcloudCreateManagedFolderCmd)
 	if err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
-		log.Fatalf(fmt.Sprintf("Error while creating managed folder: %v", err))
+		log.Fatalf("Error while creating managed folder: %v", err)
 	}
 }
 
 func CopyFileInBucket(srcfilePath, destFilePath, bucket string, t *testing.T) {
 	gcloudCopyFileCmd := fmt.Sprintf("alpha storage cp %s gs://%s/%s/", srcfilePath, bucket, destFilePath)
 
-	_, err := ExecuteGcloudCommandf(gcloudCopyFileCmd)
+	_, err := ExecuteGcloudCommand(gcloudCopyFileCmd)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error while copying file in bucket: %v", err))
+		t.Fatalf("Error while copying file in bucket: %v", err)
 	}
 }

--- a/tools/integration_tests/util/operations/operations.go
+++ b/tools/integration_tests/util/operations/operations.go
@@ -46,6 +46,14 @@ func executeToolCommandf(tool string, format string, args ...any) ([]byte, error
 	return runCommand(cmd)
 }
 
+// Executes any given tool (e.g. gsutil/gcloud).
+func executeToolCommand(tool string, command string) ([]byte, error) {
+	cmdArgs := tool + " " + command
+	cmd := exec.Command("/bin/bash", "-c", cmdArgs)
+
+	return runCommand(cmd)
+}
+
 // Executes any given tool (e.g. gsutil/gcloud) with given args in specified directory.
 func ExecuteToolCommandfInDirectory(dirPath, tool, format string, args ...any) ([]byte, error) {
 	cmdArgs := tool + " " + fmt.Sprintf(format, args...)
@@ -70,9 +78,14 @@ func runCommand(cmd *exec.Cmd) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
-// Executes any given gcloud command with given args.
+// ExecuteGcloudCommandf executes any given gcloud command with given args.
 func ExecuteGcloudCommandf(format string, args ...any) ([]byte, error) {
 	return executeToolCommandf("gcloud", format, args...)
+}
+
+// ExecuteGcloudCommand executes any given gcloud command.
+func ExecuteGcloudCommand(command string) ([]byte, error) {
+	return executeToolCommand("gcloud", command)
 }
 
 func KernelVersion(t *testing.T) string {

--- a/tools/prefetch_cache_gcsfuse/prefetch.go
+++ b/tools/prefetch_cache_gcsfuse/prefetch.go
@@ -33,7 +33,7 @@ import (
 const NUM_WORKERS = 10
 
 func downloadFile(ctx context.Context, client *storage.Client, object *storage.ObjectAttrs, cacheDir string) (err error) {
-	log.Printf(fmt.Sprintf("downloading file %v from bucket %v into dir %v", object.Name, object.Bucket, cacheDir))
+	log.Printf("downloading file %v from bucket %v into dir %v", object.Name, object.Bucket, cacheDir)
 
 	// We may want a way to verify the files are fully downloaded
 	// and either resuming the download or discarding and redownloading the file


### PR DESCRIPTION
### Description
`go vet` command was failing with errors like: 
```
non-constant format string in call to github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations.ExecuteGcloudCommandf
```
This PR fixes those errors.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
