### PR TITLE
relaxing thresholds for delete and stat benchmark

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	expectedDeleteLatency time.Duration = 675 * time.Millisecond
+	expectedDeleteLatency time.Duration = 1000 * time.Millisecond
 )
 
 type benchmarkDeleteTest struct{}

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -29,7 +29,7 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 const (
-	expectedStatLatency time.Duration = 390 * time.Millisecond
+	expectedStatLatency time.Duration = 700 * time.Millisecond
 )
 
 type benchmarkStatTest struct{}


### PR DESCRIPTION
### Description
Since we saw failures for delete benchmark test in louhi pipeline ([b/383948519](b/383948519)), due to very strict thresholds, increasing to ~1.5x of average observed for both delete and stat.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
