### PR TITLE
fix bug in csi driver build

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -514,13 +514,6 @@ function ensureGcsFuseCsiDriverCode() {
 }
 
 uuid() {
-  if ! which uuidgen; then
-    # try to install uuidgen
-    sudo apt-get update && sudo apt-get install -y uuid-runtime
-    # confirm that it got installed.
-    which uuidgen
-  fi
-
   echo $(uuidgen) | sed -e "s/\-//g" ;
 }
 
@@ -565,6 +558,12 @@ function createCustomCsiDriverIfNeeded() {
     make generate-spec-yaml
     printf "\nBuilding a new custom CSI driver using the above GCSFuse binary ...\n\n"
     registry=gcr.io/${project_id}/${USER}/${cluster_name}
+    if ! which uuidgen; then
+      # try to install uuidgen
+      sudo apt-get update && sudo apt-get install -y uuid-runtime
+      # confirm that it got installed.
+      which uuidgen
+    fi
     stagingversion=$(uuid)
     make build-image-and-push-multi-arch REGISTRY=${registry} GCSFUSE_PATH=gs://${package_bucket} STAGINGVERSION=${stagingversion}
     printf "\nInstalling the new custom CSI driver built above ...\n\n"


### PR DESCRIPTION
### Description
This fixes a bug unintentionally introduced in #2818 . In that changeset, the bash function `uuid` was printing out some more information other than the uuid value itself because of the installation step. In bash, the printed log becomes the output of a function, hence the installation inside this function was changing the output of the `uuid` function breaking the caller. So, I have moved the installation out to wherever we're invoking this function.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
