### PR TITLE
skip kernel list cache tests for kernel version 6.10+

### DIFF
--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -36,7 +36,7 @@ func SkipTestForUnsupportedKernelVersion(t *testing.T) {
 	// TODO: b/384648943 make this part of fsTest.SetUpTestSuite() after post fs
 	// tests are fully migrated to stretchr/testify.
 	t.Helper()
-	UnsupportedKernelVersions := []string{`^6\.9\.\d+`}
+	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.\d{2}\.\d+`}
 
 	kernelVersion := operations.KernelVersion(t)
 	for i := 0; i < len(UnsupportedKernelVersions); i++ {


### PR DESCRIPTION
### Description
skip kernel list cache tests for kernel version 6.10+.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
