### PR TITLE
Setting bwh to nil after all fileHandles are closed

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1737,7 +1737,7 @@ func (fs *fileSystem) CreateFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle)
+	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, false)
 	op.Handle = handleID
 
 	fs.mu.Unlock()
@@ -2381,7 +2381,7 @@ func (fs *fileSystem) OpenFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
-	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle)
+	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, op.OpenFlags.IsReadOnly())
 	op.Handle = handleID
 
 	// When we observe object generations that we didn't create, we assign them

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1737,6 +1737,7 @@ func (fs *fileSystem) CreateFile(
 	handleID := fs.nextHandleID
 	fs.nextHandleID++
 
+	// Creating new file is always a write operation, hence passing readOnly as false.
 	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, false)
 	op.Handle = handleID
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2376,6 +2376,14 @@ func (fs *fileSystem) OpenFile(
 
 	// Find the inode.
 	in := fs.fileInodeOrDie(op.Inode)
+	// Follow lock ordering rules to get inode lock.
+	// Inode lock is required to register fileHandle with the inode.
+	fs.mu.Unlock()
+	in.Lock()
+
+	// Get the fs lock again.
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 
 	// Allocate a handle.
 	handleID := fs.nextHandleID

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2373,7 +2373,6 @@ func (fs *fileSystem) OpenFile(
 	ctx context.Context,
 	op *fuseops.OpenFileOp) (err error) {
 	fs.mu.Lock()
-	defer fs.mu.Unlock()
 
 	// Find the inode.
 	in := fs.fileInodeOrDie(op.Inode)
@@ -2381,6 +2380,7 @@ func (fs *fileSystem) OpenFile(
 	// Inode lock is required to register fileHandle with the inode.
 	fs.mu.Unlock()
 	in.Lock()
+	defer in.Unlock()
 
 	// Get the fs lock again.
 	fs.mu.Lock()

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -53,12 +53,8 @@ type FileHandle struct {
 	readOnly bool
 }
 
-func NewFileHandle(
-	inode *inode.FileInode,
-	fileCacheHandler *file.CacheHandler,
-	cacheFileForRangeRead bool,
-	metricHandle common.MetricHandle,
-	readOnly bool) (fh *FileHandle) {
+// LOCKS_REQUIRED(fh.inode.mu)
+func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, readOnly bool) (fh *FileHandle) {
 	fh = &FileHandle{
 		inode:                 inode,
 		fileCacheHandler:      fileCacheHandler,

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -67,6 +67,7 @@ func NewFileHandle(
 		readOnly:              readOnly,
 	}
 
+	fh.inode.RegisterFileHandle(fh.readOnly)
 	fh.mu = syncutil.NewInvariantMutex(fh.checkInvariants)
 
 	return
@@ -75,6 +76,8 @@ func NewFileHandle(
 // Destroy any resources associated with the handle, which must not be used
 // again.
 func (fh *FileHandle) Destroy() {
+	// Deregister the fileHandle with the inode.
+	fh.inode.DeRegisterFileHandle(fh.readOnly)
 	if fh.reader != nil {
 		fh.reader.Destroy()
 	}

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -47,14 +47,24 @@ type FileHandle struct {
 	// will be downloaded for random reads as well too.
 	cacheFileForRangeRead bool
 	metricHandle          common.MetricHandle
+	// For now, we will consider the files which are open in append mode also as write,
+	// as we are not doing anything special for append. When required we will
+	// define an enum instead of boolean to hold the type of open.
+	readOnly bool
 }
 
-func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle) (fh *FileHandle) {
+func NewFileHandle(
+	inode *inode.FileInode,
+	fileCacheHandler *file.CacheHandler,
+	cacheFileForRangeRead bool,
+	metricHandle common.MetricHandle,
+	readOnly bool) (fh *FileHandle) {
 	fh = &FileHandle{
 		inode:                 inode,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
 		metricHandle:          metricHandle,
+		readOnly:              readOnly,
 	}
 
 	fh.mu = syncutil.NewInvariantMutex(fh.checkInvariants)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -94,8 +94,16 @@ type FileInode struct {
 	// Represents if local file has been unlinked.
 	unlinked bool
 
-	bwh              *bufferedwrites.BufferedWriteHandler
-	config           *cfg.Config
+	bwh    *bufferedwrites.BufferedWriteHandler
+	config *cfg.Config
+
+	// Once write is started on the file i.e, bwh is initialized, any fileHandles
+	// opened in write mode before or after this and not yet closed are considered
+	// as writing to the file even though they are not writing.
+	// In case of successful flush, we will set bwh to nil. But in case of error,
+	// we will keep returning that error to all the fileHandles open during that time
+	// and set bwh to nil after all fileHandlers are closed.
+	// writeHandleCount tracks the count of open fileHandles in write mode.
 	writeHandleCount int32
 }
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1327,7 +1327,7 @@ func (t *FileTest) TestWriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), int64(2), attrs.Size)
+	assert.Equal(t.T(), uint64(2), attrs.Size)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 }
 
@@ -1352,7 +1352,7 @@ func (t *FileTest) TestSetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEn
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()
-	assert.Equal(t.T(), 2, writeFileInfo.TotalSize)
+	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -193,7 +193,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Equal(t.T(), nil, err)
+	assert.Nil(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 }
@@ -384,7 +384,7 @@ func (t *FileTest) TestWriteThenSync() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotNil(t.T(), m)
+	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("paco")), m.Size)
@@ -431,7 +431,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	assert.Nil(t.T(), err)
-	assert.NotNil(t.T(), m)
+	assert.NotEqual(t.T(), nil, m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("tacos")), m.Size)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -384,7 +384,7 @@ func (t *FileTest) TestWriteThenSync() {
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("paco")), m.Size)
@@ -431,7 +431,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 	assert.Nil(t.T(), err)
-	assert.NotEqual(t.T(), nil, m)
+	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 	assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 	assert.Equal(t.T(), uint64(len("tacos")), m.Size)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -193,7 +193,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), nil, err)
 
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 }


### PR DESCRIPTION
### Description
Setting bwh to nil after all fileHandles are closed in case of error.
Follow up PR will be raised to clear the buffers

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
