### PR TITLE
[POC] Modify Sync and Unlink to Destroy Inode Content with Guarantee

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -28,8 +28,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file"
@@ -1116,16 +1114,6 @@ func (fs *fileSystem) lookUpOrCreateChildDirInode(
 func (fs *fileSystem) syncFile(
 	ctx context.Context,
 	f *inode.FileInode) (err error) {
-	// SyncFile can be triggered for unlinked files if the fileHandle is open by
-	// same or another user. This indicates a potential file clobbering scenario:
-	// - The file was deleted (unlinked) while a handle to it was still open.
-	if f.IsLocal() && f.IsUnlinked() {
-		err = &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
-		}
-		return
-	}
-
 	// Sync the inode.
 	err = f.Sync(ctx)
 	if err != nil {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -193,13 +193,13 @@ func (t *fsTest) SetUpTestSuite() {
 	mountCfg := t.mountCfg
 	mountCfg.OpContext = ctx
 
-	//if mountCfg.ErrorLogger == nil {
-	mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse_errors: ")
-	//}
+	if mountCfg.ErrorLogger == nil {
+		mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse_errors: ")
+	}
 
-	//if *fDebug {
-	mountCfg.DebugLogger = logger.NewLegacyLogger(logger.LevelInfo, "fuse: ")
-	//}
+	if *fDebug {
+		mountCfg.DebugLogger = logger.NewLegacyLogger(logger.LevelDebug, "fuse: ")
+	}
 
 	mfs, err = fuse.Mount(mntDir, server, &mountCfg)
 	AssertEq(nil, err)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -193,13 +193,13 @@ func (t *fsTest) SetUpTestSuite() {
 	mountCfg := t.mountCfg
 	mountCfg.OpContext = ctx
 
-	if mountCfg.ErrorLogger == nil {
-		mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse_errors: ")
-	}
+	//if mountCfg.ErrorLogger == nil {
+	mountCfg.ErrorLogger = logger.NewLegacyLogger(logger.LevelError, "fuse_errors: ")
+	//}
 
-	if *fDebug {
-		mountCfg.DebugLogger = logger.NewLegacyLogger(logger.LevelDebug, "fuse: ")
-	}
+	//if *fDebug {
+	mountCfg.DebugLogger = logger.NewLegacyLogger(logger.LevelInfo, "fuse: ")
+	//}
 
 	mfs, err = fuse.Mount(mntDir, server, &mountCfg)
 	AssertEq(nil, err)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -151,7 +151,7 @@ func NewFileInode(
 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) checkInvariants() {
-	if f.destroyed {
+	if f.destroyed || f.unlinked {
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -675,6 +675,7 @@ func (f *FileInode) Sync(ctx context.Context) (err error) {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("tempFile linked to file %s was clobbered, indicating file clobbering", f.Name().LocalName()),
 		}
+		return
 	}
 
 	latestGcsObj, err := f.fetchLatestGcsObject(ctx)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -375,7 +375,6 @@ func (t *FileTest) TestWriteThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -426,7 +425,6 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	err = t.in.Sync(t.ctx)
 
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
@@ -465,7 +463,6 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 	err = t.in.Sync(t.ctx)
 
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
@@ -509,7 +506,6 @@ func (t *FileTest) TestAppendThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -557,7 +553,6 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -601,7 +596,6 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -873,7 +867,7 @@ func (t *FileTest) TestSync_Clobbered() {
 	// Check if the error is a FileClobberedError
 	var fcErr *gcsfuse_errors.FileClobberedError
 	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
-	assert.Nil(t.T(), t.in.content)
+	assert.True(t.T(), t.in.content.IsClobbered())
 	assert.Equal(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 	assert.Equal(t.T(), t.backingObj.MetaGeneration, t.in.SourceGeneration().Metadata)
 
@@ -987,7 +981,6 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -1196,9 +1189,8 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	// Unlink.
 	t.in.Unlink()
 
-	// Verify that fileInode is now unlinked.
+	// Verify that fileInode is now unlinked
 	assert.True(t.T(), t.in.IsUnlinked())
-	assert.Nil(t.T(), t.in.content)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -375,6 +375,7 @@ func (t *FileTest) TestWriteThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -425,6 +426,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 	err = t.in.Sync(t.ctx)
 
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
@@ -463,6 +465,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 	err = t.in.Sync(t.ctx)
 
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 	// Verify that fileInode is no more local
 	assert.False(t.T(), t.in.IsLocal())
 	// Stat the current object in the bucket.
@@ -506,6 +509,7 @@ func (t *FileTest) TestAppendThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -553,6 +557,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -596,6 +601,7 @@ func (t *FileTest) TestTruncateUpwardThenSync() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 
 	// The generation should have advanced.
 	assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
@@ -867,6 +873,7 @@ func (t *FileTest) TestSync_Clobbered() {
 	// Check if the error is a FileClobberedError
 	var fcErr *gcsfuse_errors.FileClobberedError
 	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
+	assert.Nil(t.T(), t.in.content)
 	assert.Equal(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 	assert.Equal(t.T(), t.backingObj.MetaGeneration, t.in.SourceGeneration().Metadata)
 
@@ -980,6 +987,7 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	// Sync.
 	err = t.in.Sync(t.ctx)
 	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -1188,8 +1196,9 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	// Unlink.
 	t.in.Unlink()
 
-	// Verify that fileInode is now unlinked
+	// Verify that fileInode is now unlinked.
 	assert.True(t.T(), t.in.IsUnlinked())
+	assert.Nil(t.T(), t.in.content)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)

--- a/internal/fs/stale_file_handle_local_file_test.go
+++ b/internal/fs/stale_file_handle_local_file_test.go
@@ -107,8 +107,8 @@ func (t *StaleFileHandleLocalFile) TestUnlinkedLocalInode_SyncAndClose_ThrowsSta
 	assert.Equal(t.T(), nil, err)
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(mntDir, FileName))
 	// Write to unlinked local file.
-	_, err = t.f1.WriteString(FileContents)
-	assert.Equal(t.T(), nil, err)
+	_, err = t.f1.Write([]byte(FileContents))
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
 
 	err = t.f1.Sync()
 
@@ -138,7 +138,7 @@ func (t *StaleFileHandleLocalFile) TestUnlinkedDirectoryContainingSyncedAndLocal
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(mntDir, "explicit/foo"))
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(mntDir, "explicit"))
 	// Validate writing content to unlinked local file does not throw error.
-	_, err = t.f1.WriteString(FileContents)
+	_, err = t.f1.Write([]byte(FileContents))
 	assert.Equal(t.T(), nil, err)
 
 	err = operations.CloseLocalFile(t.T(), &t.f1)

--- a/internal/fs/stale_file_handle_synced_file_test.go
+++ b/internal/fs/stale_file_handle_synced_file_test.go
@@ -197,7 +197,7 @@ func (t *StaleFileHandleSyncedFile) TestSyncedObjectDeletedLocally_SyncAndClose_
 	t.f1 = nil
 }
 
-func (t *StaleFileHandleSyncedFile) TestRenamedSyncedObject_Sync_ThrowsStaleFileHandleError() {
+func (t *StaleFileHandleSyncedFile) TestRenamedSyncedObject_SyncAndClose_ThrowsStaleFileHandleError() {
 	// Dirty the file by giving it some contents.
 	n, err := t.f1.Write([]byte("foobar"))
 	assert.Equal(t.T(), nil, err)

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -221,7 +221,9 @@ func (tf *tempFile) CheckInvariants() {
 func (tf *tempFile) Destroy() {
 	tf.state = fileDestroyed
 	// Throw away the file (for anonymous files).
-	tf.f.Close()
+	if tf.f != nil {
+		tf.f.Close()
+	}
 
 	tf.f = nil
 }

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -693,7 +693,7 @@ func CreateLocalFile(ctx context.Context, t *testing.T, mntDir string, bucket gc
 	// Creating a file shouldn't create file on GCS.
 	filePath = path.Join(mntDir, fileName)
 
-	f, err := os.Create(filePath)
+	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, 0666)
 
 	assert.Equal(t, nil, err)
 	ValidateObjectNotFoundErr(ctx, t, bucket, fileName)


### PR DESCRIPTION
### Description
Ensure that the Sync and Unlink methods of FileInode are modified to guarantee the destruction of inode content
This PR fixes the issue where a GCSFuse mount could not be unmounted after encountering a precondition or clobbered error.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Automated
