### PR TITLE
Support `enable-per-pid-reader` and `min-sequential-read-size-mb` to accelerate mmap reads

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -178,13 +178,14 @@ type randomReader struct {
 }
 
 // func (rr *randomReader) getBucketReader(offset int64) *bucketReader {
-func (rr *randomReader) getBucketReader(pid uint32) *bucketReader {
+func (rr *randomReader) getBucketReader(pid uint32, offset int64) *bucketReader {
 	for _, br := range rr.bucketReaders {
 		if br.reader == nil {
 			continue
 		}
 		//if br.isWithinRange(offset) {
-		if br.isPidMatched(pid) {
+		// Neet to check both pid and offset as a bucket reader can only read a certain range.
+		if br.isPidMatched(pid) && br.isWithinRange(offset) {
 			return br
 		}
 	}
@@ -350,7 +351,7 @@ func (rr *randomReader) ReadAt(
 		}
 
 		//br := rr.getBucketReader(offset)
-		br := rr.getBucketReader(pid)
+		br := rr.getBucketReader(pid, offset)
 		if br == nil {
 			// TODO: remove stale bucket readers before adding new one.
 			// NOte: it doesn't really prefetch rr.sequentialReadSizeMb that many bytes. It just keeps

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -46,7 +46,7 @@ const minReadSize = MB
 // Max read size in bytes for random reads.
 // If the average read size (between seeks) is below this number, reads will
 // optimised for random access.
-// We will skip forwards in a GCS response at most this many bytes.
+
 // About 6 MB of data is buffered anyway, so 8 MB seems like a good round number.
 const maxReadSize = 8 * MB
 
@@ -97,10 +97,32 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 	}
 }
 
-type reader struct {
-	reader io.ReadCloser
-	start  int64
-	limit  int64
+// bucketReader holds a open stream to a GCS bucket for a given range.
+type bucketReader struct {
+	reader   io.ReadCloser
+	start    int64
+	end      int64
+	lastUsed time.Time
+}
+
+func (br *bucketReader) isWithinRange(offset int64) bool {
+	return offset >= br.start && offset < br.end
+}
+
+func (br *bucketReader) read(offset int64, p []byte) (int, error) {
+	bytesToSkip := int64(offset - br.start)
+	skip := make([]byte, bytesToSkip)
+	n, err := io.ReadFull(br.reader, skip)
+	if err != nil {
+		return 0, err
+	}
+	br.start += int64(n)
+
+	// Actually read the data into the buffer.
+	n, err = io.ReadFull(br.reader, p)
+	br.start += int64(n)
+	br.lastUsed = time.Now()
+	return n, err
 }
 
 type randomReader struct {
@@ -112,8 +134,8 @@ type randomReader struct {
 	// INVARIANT: (reader == nil) == (cancel == nil)
 	reader io.ReadCloser
 	cancel func()
-	
-	readers *reader
+
+	bucketReaders []*bucketReader
 
 	// The range of the object that we expect reader to yield, when reader is
 	// non-nil. When reader is nil, limit is the limit of the previous read
@@ -144,8 +166,13 @@ type randomReader struct {
 	metricHandle    common.MetricHandle
 }
 
-func (rr *randomReader) lookupReader(offset int64) *reader, error {
-	return nil, fmt.Errorf("Not implemented")
+func (rr *randomReader) getBucketReader(offset int64) *bucketReader {
+	for _, br := range rr.bucketReaders {
+		if br.isWithinRange(offset) {
+			return br
+		}
+	}
+	return nil
 }
 
 func (rr *randomReader) CheckInvariants() {
@@ -304,71 +331,24 @@ func (rr *randomReader) ReadAt(
 			err = io.EOF
 			return
 		}
-		
-		reader == rr.lookupReader(offset)
 
-		// When the offset is AFTER the reader position, try to seek forward, within reason.
-		// This happens when the kernel page cache serves some data. It's very common for
-		// concurrent reads, often by only a few 128kB fuse read requests. The aim is to
-		// re-use GCS connection and avoid throwing away already read data.
-		// For parallel sequential reads to a single file, not throwing away the connections
-		// is a 15-20x improvement in throughput: 150-200 MB/s instead of 10 MB/s.
-		if rr.reader != nil && rr.start < offset && offset-rr.start < maxReadSize {
-			bytesToSkip := int64(offset - rr.start)
-			p := make([]byte, bytesToSkip)
-			n, _ := io.ReadFull(rr.reader, p)
-			rr.start += int64(n)
-		}
-
-		// If we have an existing reader but it's positioned at the wrong place,
-		// clean it up and throw it away.
-		if rr.reader != nil && rr.start != offset {
-			rr.reader.Close()
-			rr.reader = nil
-			rr.cancel = nil
-			rr.seeks++
-		}
-
-		// If we don't have a reader, start a read operation.
-		if rr.reader == nil {
-			err = rr.startRead(ctx, offset, int64(len(p)))
+		br := rr.getBucketReader(offset)
+		if br == nil {
+			br, err = rr.newBucketReader(ctx, offset, offset+maxReadSize)
 			if err != nil {
-				err = fmt.Errorf("startRead: %w", err)
+				err = fmt.Errorf("ReadAt: while creating bucket reader: %w", err)
 				return
 			}
-		}
 
-		// Now we have a reader positioned at the correct place. Consume as much from
-		// it as possible.
+			rr.bucketReaders = append(rr.bucketReaders, br)
+		}
 		var tmp int
-		tmp, err = rr.readFull(ctx, p)
+		tmp, err = br.read(ctx, p)
 
 		n += tmp
 		p = p[tmp:]
-		rr.start += int64(tmp)
 		offset += int64(tmp)
 		rr.totalReadBytes += uint64(tmp)
-
-		// Sanity check.
-		if rr.start > rr.limit {
-			err = fmt.Errorf("reader returned %d too many bytes", rr.start-rr.limit)
-
-			// Don't attempt to reuse the reader when it's behaving wackily.
-			rr.reader.Close()
-			rr.reader = nil
-			rr.cancel = nil
-			rr.start = -1
-			rr.limit = -1
-
-			return
-		}
-
-		// Are we finished with this reader now?
-		if rr.start == rr.limit {
-			rr.reader.Close()
-			rr.reader = nil
-			rr.cancel = nil
-		}
 
 		// Handle errors.
 		switch {
@@ -385,9 +365,94 @@ func (rr *randomReader) ReadAt(
 
 		case err != nil:
 			// Propagate other errors.
-			err = fmt.Errorf("readFull: %w", err)
+			err = fmt.Errorf("read error: %w", err)
 			return
 		}
+		// When the offset is AFTER the reader position, try to seek forward, within reason.
+		// This happens when the kernel page cache serves some data. It's very common for
+		// concurrent reads, often by only a few 128kB fuse read requests. The aim is to
+		// re-use GCS connection and avoid throwing away already read data.
+		// For parallel sequential reads to a single file, not throwing away the connections
+		// is a 15-20x improvement in throughput: 150-200 MB/s instead of 10 MB/s.
+		/*
+				if rr.reader != nil && rr.start < offset && offset-rr.start < maxReadSize {
+					bytesToSkip := int64(offset - rr.start)
+					p := make([]byte, bytesToSkip)
+					n, _ := io.ReadFull(rr.reader, p)
+					rr.start += int64(n)
+				}
+
+
+			// If we have an existing reader but it's positioned at the wrong place,
+			// clean it up and throw it away.
+			if rr.reader != nil && rr.start != offset {
+				rr.reader.Close()
+				rr.reader = nil
+				rr.cancel = nil
+				rr.seeks++
+			}
+
+			// If we don't have a reader, start a read operation.
+			if rr.reader == nil {
+				err = rr.startRead(ctx, offset, int64(len(p)))
+				if err != nil {
+					err = fmt.Errorf("startRead: %w", err)
+					return
+				}
+			}
+
+			// Now we have a reader positioned at the correct place. Consume as much from
+			// it as possible.
+			var tmp int
+			tmp, err = rr.readFull(ctx, p)
+
+			n += tmp
+			p = p[tmp:]
+			rr.start += int64(tmp)
+			offset += int64(tmp)
+			rr.totalReadBytes += uint64(tmp)
+
+			// Sanity check.
+			if rr.start > rr.limit {
+				err = fmt.Errorf("reader returned %d too many bytes", rr.start-rr.limit)
+
+				// Don't attempt to reuse the reader when it's behaving wackily.
+				rr.reader.Close()
+				rr.reader = nil
+				rr.cancel = nil
+				rr.start = -1
+				rr.limit = -1
+
+				return
+			}
+
+			// Are we finished with this reader now?
+			if rr.start == rr.limit {
+				rr.reader.Close()
+				rr.reader = nil
+				rr.cancel = nil
+			}
+
+			// Handle errors.
+			switch {
+			case err == io.EOF || err == io.ErrUnexpectedEOF:
+				// For a non-empty buffer, ReadFull returns EOF or ErrUnexpectedEOF only
+				// if the reader peters out early. That's fine, but it means we should
+				// have hit the limit above.
+				if rr.reader != nil {
+					err = fmt.Errorf("reader returned %d too few bytes", rr.limit-rr.start)
+					return
+				}
+
+				err = nil
+
+			case err != nil:
+				// Propagate other errors.
+				err = fmt.Errorf("readFull: %w", err)
+				return
+			}
+
+		*/
 	}
 
 	return
@@ -452,6 +517,47 @@ func (rr *randomReader) readFull(
 	n, err = io.ReadFull(rr.reader, p)
 
 	return
+}
+
+func (rr *randomReader) newBucketReader(
+	ctx context.Context,
+	start int64,
+	end int64) (*bucketReader, error) {
+
+	// Begin the read.
+	ctx, _ = context.WithCancel(context.Background())
+	rc, err := rr.bucket.NewReader(
+		ctx,
+		&gcs.ReadObjectRequest{
+			Name:       rr.object.Name,
+			Generation: rr.object.Generation,
+			Range: &gcs.ByteRange{
+				Start: uint64(start),
+				Limit: uint64(end),
+			},
+			ReadCompressed: rr.object.HasContentEncodingGzip(),
+		})
+
+	// If a file handle is open locally, but the corresponding object doesn't exist
+	// in GCS, it indicates a file clobbering scenario. This likely occurred because:
+	//  - The file was deleted in GCS while a local handle was still open.
+	//  - The file content was modified leading to different generation number.
+	var notFoundError *gcs.NotFoundError
+	if errors.As(err, &notFoundError) {
+		return nil, &gcsfuse_errors.FileClobberedError{
+			Err: fmt.Errorf("NewReader: %w", err),
+		}
+	}
+
+	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, util.Sequential, end-start)
+	p := make([]byte, maxReadSize)
+	n, _ := rc.reader.Read(p)
+
+	return &bucketReader{
+		reader: rc,
+		start:  start,
+		end:    start + int64(n),
+	}, nil
 }
 
 // Ensure that rr.reader is set up for a range for which [start, start+size) is
@@ -544,11 +650,11 @@ func (rr *randomReader) startRead(
 	rr.cancel = cancel
 	rr.start = start
 	rr.limit = end
-		
-	rr.readers = append(rr.readers, &reader{
+
+	rr.rangeCaches = append(rr.rangeCaches, &reader{
 		reader: rc,
 		start:  start,
-		limit:  end,
+		end:    end,
 	})
 
 	requestedDataSize := end - start

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -113,7 +113,7 @@ func (br *bucketReader) isWithinRange(offset int64) bool {
 }
 
 func (br *bucketReader) isPidMatched(pid uint32) bool {
-	return pid > 0 && br.pid == pid
+	return br.reader != nil && pid > 0 && br.pid == pid
 }
 
 func (br *bucketReader) read(offset int64, p []byte) (int, error) {

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -337,6 +337,7 @@ func (rr *randomReader) ReadAt(
 
 		br := rr.getBucketReader(offset)
 		if br == nil {
+			// TODO: remove stale bucket readers before adding new one.
 			br, err = rr.newBucketReader(ctx, offset, offset+maxReadSize)
 			if err != nil {
 				err = fmt.Errorf("ReadAt: while creating bucket reader: %w", err)
@@ -359,7 +360,7 @@ func (rr *randomReader) ReadAt(
 				logger.Tracef("Closing bucketReader: %v", err)
 			}
 
-			// TODO: remove the bucket reader from the list.
+			// TODO: remove this bucket reader from the list.
 			br.reader = nil
 		}
 
@@ -574,9 +575,10 @@ func (rr *randomReader) newBucketReader(
 	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, util.Sequential, end-start)
 
 	return &bucketReader{
-		reader: rc,
-		start:  start,
-		end:    end,
+		reader:   rc,
+		start:    start,
+		end:      end,
+		lastUsed: time.Now(),
 	}, nil
 }
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -106,7 +106,7 @@ type bucketReader struct {
 }
 
 func (br *bucketReader) isWithinRange(offset int64) bool {
-	return offset >= br.start && offset < br.end
+	return br.reader != nil && offset >= br.start && offset < br.end
 }
 
 func (br *bucketReader) read(offset int64, p []byte) (int, error) {


### PR DESCRIPTION
### Description
Support `enable-per-pid-reader` and `min-sequential-read-size-mb` to accelerate mmap reads.

1. For each file handle, creates per pid GCS reader stream and stats (start, limit, read bytes count), so that each pid can seek forward and backward independently without interfering with each other
2. Allow configuring the minimum sequential-read-size-mb so that each GCS stream can have a minimum bytes that it can support.
3. This PR firstly refactored the random_reader to move all the GCS reading logics from `randomReader` to `objectRangeReader` so that each pid can have its own `objectRangeReader` and use it indepently.

Initial manual results show it reduced loading time from 13mins to 1min by setting `perPidReader: true` and `minSequentialReadSizeMb: 200`

Before:
<img width="1029" alt="Screenshot 2024-12-22 at 11 54 19 AM" src="https://github.com/user-attachments/assets/4d415568-369a-430d-94f7-2865c1109adf" />

After:
<img width="866" alt="Screenshot 2024-12-22 at 11 54 27 AM" src="https://github.com/user-attachments/assets/0223cd20-8183-40ad-be71-65543e588986" />


### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/2828

### Testing details
1. Manual - NA
5. Unit tests - TODO
6. Integration tests - TODO
