### PR TITLE
Fix: Handle gRPC precondition failures while creating object

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -92,8 +92,8 @@ func (bh *bucketHandle) BucketType() gcs.BucketType {
 }
 
 func (bh *bucketHandle) NewReader(
-		ctx context.Context,
-		req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
+	ctx context.Context,
+	req *gcs.ReadObjectRequest) (io.ReadCloser, error) {
 	// Initialising the starting offset and the length to be read by the reader.
 	start := int64(0)
 	length := int64(-1)
@@ -161,7 +161,7 @@ func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectR
 }
 
 func (bh *bucketHandle) StatObject(ctx context.Context,
-		req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 	var attrs *storage.ObjectAttrs
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = bh.bucket.Object(req.Name).Attrs(ctx)
@@ -256,7 +256,6 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 				return
 			}
 		}
-
 		err = fmt.Errorf("error in closing writer : %w", err)
 		return
 	}

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	defer storageClient.Close()
 
 	flags := [][]string{{"--rename-dir-limit=3", "--implicit-dirs"}, {"--rename-dir-limit=3"}}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flags, "--client-protocol=grpc")
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flags, "", "--client-protocol=grpc")
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
 		flags = [][]string{hnsFlagSet}
 	}

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -62,6 +62,7 @@ func TestMain(m *testing.M) {
 	defer storageClient.Close()
 
 	flags := [][]string{{"--rename-dir-limit=3", "--implicit-dirs"}, {"--rename-dir-limit=3"}}
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flags, "--client-protocol=grpc")
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
 		flags = [][]string{hnsFlagSet}
 	}


### PR DESCRIPTION
### Description
This change addresses an issue identified in [b/378625027](https://b.corp.google.com/issues/378625027) where gRPC precondition failures were not being handled correctly.

Previously, error handling only checked for HTTP status codes, but gRPC uses error code 9 for precondition failures. This update adds explicit handling for gRPC error code 9 to ensure proper detection and management of precondition failures in gRPC calls.

Additionally, gRPC tests are enabled for the rename_dir_limit test package to improve test coverage .

Note: Handling of rpc codes for the different flows will be taken seperately.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
