### PR TITLE
Added destroy method to free up the memory buffers

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -272,7 +272,7 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 
 	assert.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 5, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -347,6 +347,18 @@ func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthGreaterT
 
 	assert.Equal(testSuite.T(), testSuite.bwh.truncatedSize, fileInfo.TotalSize)
 }
+func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
+	// Try to write 4 blocks of data.
+	contents := strings.Repeat("A", blockSize*4)
+	err := testSuite.bwh.Write([]byte(contents), 0)
+	require.Nil(testSuite.T(), err)
+
+	err = testSuite.bwh.Destroy()
+
+	require.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
+}
 
 func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {
 	testSuite.bwh.Unlink()

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -174,7 +174,7 @@ func (uh *UploadHandler) Destroy() {
 	for {
 		select {
 		case currBlock, ok := <-uh.uploadCh:
-			// Not ok means channel not closed. Return.
+			// Not ok means channel closed. Return.
 			if !ok {
 				return
 			}

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -186,6 +186,15 @@ func (uh *UploadHandler) Destroy() {
 			uh.wg.Done()
 		}
 	}
+
+	// This code is safer when not executed from multiple go-routines at once.
+	// Since destroy takes a inode lock in fileHandle, this is called by
+	// only one goroutine at once.
+	select {
+	case <-uh.uploadCh:
+	default:
+		close(uh.uploadCh)
+	}
 }
 
 // TODO: Move this method to util and add unit tests.

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
@@ -187,23 +186,5 @@ func (uh *UploadHandler) Destroy() {
 			close(uh.uploadCh)
 			return
 		}
-	}
-}
-
-// TODO: Move this method to util and add unit tests.
-// waitTimeout waits for the waitGroup for the specified max timeout.
-// Returns true if waiting timed out.
-func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-
-	select {
-	case <-c:
-		return false // completed normally
-	case <-time.After(timeout):
-		return true // timed out
 	}
 }

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -171,8 +171,6 @@ func (uh *UploadHandler) AwaitBlocksUpload() {
 }
 
 func (uh *UploadHandler) Destroy() {
-	logger.Debugf("Closing the signalUploadFailure channel to stop the upload")
-	close(uh.signalUploadFailure)
 	// Waiting for upload routine to move all blocks to freeChannel.
 	timedOut := waitTimeout(&uh.wg, 10*time.Second)
 
@@ -180,7 +178,7 @@ func (uh *UploadHandler) Destroy() {
 	// either because upload is stuck in uploading a chunk or the upload
 	// go-routine crashed. Copying all pending blocks to freeBlock channel for cleanup.
 	// We can clean up from uploadChannel also, but to ensure clean up happens
-	// at one place we are copying them to freeBlock channel.
+	// from one place we are copying them to freeBlock channel.
 	if timedOut {
 		for currBlock := range uh.uploadCh {
 			uh.freeBlocksCh <- currBlock
@@ -190,6 +188,7 @@ func (uh *UploadHandler) Destroy() {
 	}
 }
 
+// TODO: Move this method to util and add unit tests.
 // waitTimeout waits for the waitGroup for the specified max timeout.
 // Returns true if waiting timed out.
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
@@ -167,4 +168,41 @@ func (uh *UploadHandler) SignalUploadFailure() chan error {
 
 func (uh *UploadHandler) AwaitBlocksUpload() {
 	uh.wg.Wait()
+}
+
+func (uh *UploadHandler) Destroy() {
+	logger.Debugf("Closing the signalUploadFailure channel to stop the upload")
+	close(uh.signalUploadFailure)
+	// Waiting for upload routine to move all blocks to freeChannel.
+	timedOut := waitTimeout(&uh.wg, 10*time.Second)
+
+	// TimedOut means there are some blocks which are still in uploadChannel,
+	// either because upload is stuck in uploading a chunk or the upload
+	// go-routine crashed. Copying all pending blocks to freeBlock channel for cleanup.
+	// We can clean up from uploadChannel also, but to ensure clean up happens
+	// at one place we are copying them to freeBlock channel.
+	if timedOut {
+		for currBlock := range uh.uploadCh {
+			uh.freeBlocksCh <- currBlock
+			// Marking as wg.Done to ensure any waiters are unblocked.
+			uh.wg.Done()
+		}
+	}
+}
+
+// waitTimeout waits for the waitGroup for the specified max timeout.
+// Returns true if waiting timed out.
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
 }

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -369,7 +369,6 @@ func (t *UploadHandlerTest) TestDestroy() {
 
 	t.uh.Destroy()
 
-	assertUploadFailureSignal(t.T(), t.uh)
 	assertAllBlocksProcessed(t.T(), t.uh)
 	assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
 	assert.Equal(t.T(), 0, len(t.uh.uploadCh))

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -68,13 +68,6 @@ func (t *UploadHandlerTest) SetupSubTest() {
 }
 
 func (t *UploadHandlerTest) TestMultipleBlockUpload() {
-	// Create some blocks.
-	var blocks []block.Block
-	for i := 0; i < 5; i++ {
-		b, err := t.blockPool.Get()
-		require.NoError(t.T(), err)
-		blocks = append(blocks, b)
-	}
 	// CreateObjectChunkWriter -- should be called once.
 	writer := &storagemock.Writer{}
 	mockObj := &gcs.MinObject{}
@@ -82,6 +75,7 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 
 	// Upload the blocks.
+	blocks := t.createBlocks(5)
 	for _, b := range blocks {
 		err := t.uh.Upload(b)
 		require.NoError(t.T(), err)
@@ -193,13 +187,10 @@ func (t *UploadHandlerTest) TestUploadSingleBlockThrowsErrorInCopy() {
 
 func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
 	// Create some blocks.
-	var blocks []block.Block
+	blocks := t.createBlocks(4)
 	for i := 0; i < 4; i++ {
-		b, err := t.blockPool.Get()
+		err := blocks[i].Write([]byte("testdata" + strconv.Itoa(i) + " "))
 		require.NoError(t.T(), err)
-		err = b.Write([]byte("testdata" + strconv.Itoa(i) + " "))
-		require.NoError(t.T(), err)
-		blocks = append(blocks, b)
 	}
 	// CreateObjectChunkWriter -- should be called once.
 	writer := &storagemock.Writer{}
@@ -259,18 +250,11 @@ func TestSignalUploadFailure(t *testing.T) {
 }
 
 func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
-	// Create some blocks.
-	var blocks []block.Block
-	for i := 0; i < 5; i++ {
-		b, err := t.blockPool.Get()
-		require.NoError(t.T(), err)
-		blocks = append(blocks, b)
-	}
 	// CreateObjectChunkWriter -- should be called once.
 	writer := &storagemock.Writer{}
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 	// Upload the blocks.
-	for _, b := range blocks {
+	for _, b := range t.createBlocks(5) {
 		err := t.uh.Upload(b)
 		require.NoError(t.T(), err)
 	}
@@ -371,20 +355,10 @@ func (t *UploadHandlerTest) TestDestroy() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			// Create some blocks.
-			var blocks []block.Block
-			for i := 0; i < 5; i++ {
-				b, err := t.blockPool.Get()
-				require.NoError(t.T(), err)
-				blocks = append(blocks, b)
-			}
-			// CreateObjectChunkWriter -- should be called once.
-			writer := &storagemock.Writer{}
-			t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
-			// Upload the blocks.
-			for _, b := range blocks {
-				err := t.uh.Upload(b)
-				require.NoError(t.T(), err)
+			// Add blocks to uploadCh.
+			for _, b := range t.createBlocks(5) {
+				t.uh.uploadCh <- b
+				t.uh.wg.Add(1)
 			}
 			if tc.uploadChClosed {
 				close(t.uh.uploadCh)
@@ -395,7 +369,7 @@ func (t *UploadHandlerTest) TestDestroy() {
 			assertAllBlocksProcessed(t.T(), t.uh)
 			assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
 			assert.Equal(t.T(), 0, len(t.uh.uploadCh))
-
+			// Check if uploadCh is closed.
 			select {
 			case <-t.uh.uploadCh:
 			default:
@@ -403,4 +377,15 @@ func (t *UploadHandlerTest) TestDestroy() {
 			}
 		})
 	}
+}
+
+func (t *UploadHandlerTest) createBlocks(count int) []block.Block {
+	var blocks []block.Block
+	for i := 0; i < count; i++ {
+		b, err := t.blockPool.Get()
+		require.NoError(t.T(), err)
+		blocks = append(blocks, b)
+	}
+
+	return blocks
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2558,13 +2558,14 @@ func (fs *fileSystem) ReleaseFileHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseFileHandleOp) (err error) {
 	fs.mu.Lock()
-	defer fs.mu.Unlock()
+
+	fileHandle := fs.handles[op.Handle].(*handle.FileHandle)
+	// Update the map. We are okay updating the map before destroy is called.
+	delete(fs.handles, op.Handle)
+	fs.mu.Unlock()
 
 	// Destroy the handle.
-	fs.handles[op.Handle].(*handle.FileHandle).Destroy()
-
-	// Update the map.
-	delete(fs.handles, op.Handle)
+	fileHandle.Destroy()
 
 	return
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2566,6 +2566,8 @@ func (fs *fileSystem) ReleaseFileHandle(
 	fs.mu.Unlock()
 
 	// Destroy the handle.
+	fileHandle.Lock()
+	defer fileHandle.Unlock()
 	fileHandle.Destroy()
 
 	return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2560,7 +2560,8 @@ func (fs *fileSystem) ReleaseFileHandle(
 	fs.mu.Lock()
 
 	fileHandle := fs.handles[op.Handle].(*handle.FileHandle)
-	// Update the map. We are okay updating the map before destroy is called.
+	// Update the map. We are okay updating the map before destroy is called
+	// since destroy is doing only internal cleanup.
 	delete(fs.handles, op.Handle)
 	fs.mu.Unlock()
 

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -71,9 +71,13 @@ func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, 
 
 // Destroy any resources associated with the handle, which must not be used
 // again.
+// LOCK_FUNCTION(fh.inode.mu)
+// UNLOCK_FUNCTION(fh.inode.mu)
 func (fh *FileHandle) Destroy() {
 	// Deregister the fileHandle with the inode.
+	fh.inode.Lock()
 	fh.inode.DeRegisterFileHandle(fh.readOnly)
+	fh.inode.Unlock()
 	if fh.reader != nil {
 		fh.reader.Destroy()
 	}

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -71,6 +71,7 @@ func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, 
 
 // Destroy any resources associated with the handle, which must not be used
 // again.
+// LOCKS_REQUIRED(fh.mu)
 // LOCK_FUNCTION(fh.inode.mu)
 // UNLOCK_FUNCTION(fh.inode.mu)
 func (fh *FileHandle) Destroy() {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -403,7 +403,9 @@ func (f *FileInode) DeRegisterFileHandle(readOnly bool) {
 	f.writeHandleCount--
 
 	// All write fileHandles associated with bwh are closed. So safe to set bwh to nil.
-	if f.writeHandleCount == 0 {
+	if f.writeHandleCount == 0 && f.bwh != nil {
+		err := f.bwh.Destroy()
+		logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
 		f.bwh = nil
 	}
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -405,7 +405,9 @@ func (f *FileInode) DeRegisterFileHandle(readOnly bool) {
 	// All write fileHandles associated with bwh are closed. So safe to set bwh to nil.
 	if f.writeHandleCount == 0 && f.bwh != nil {
 		err := f.bwh.Destroy()
-		logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
+		if err != nil {
+			logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
+		}
 		f.bwh = nil
 	}
 }


### PR DESCRIPTION
### Description
Added destroy method which will clean up the memory buffers when bwh is unInitialized.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
