### PR TITLE
[Move Object] Bucket handle integration

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -593,18 +593,14 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 
 	// If storage object does not exist, httpclient is returning ErrObjectNotExist error instead of googleapi error
 	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/cloud.google.com/go/storage/http_client.go#L516
-	if err != nil {
-		if ok, preCondErr := isPreconditionFailed(err); ok {
-			err = preCondErr
-		} else if errors.Is(err, storage.ErrObjectNotExist) {
-			err = &gcs.NotFoundError{Err: storage.ErrObjectNotExist}
-		} else {
-			err = fmt.Errorf("error in moving object: %w", err)
-		}
-		return nil, err
+	if ok, preCondErr := isPreconditionFailed(err); ok {
+		err = preCondErr
+	} else if errors.Is(err, storage.ErrObjectNotExist) {
+		err = &gcs.NotFoundError{Err: storage.ErrObjectNotExist}
+	} else {
+		err = fmt.Errorf("error in moving object: %w", err)
 	}
-
-	return o, nil
+	return nil, err
 }
 
 func (bh *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -537,8 +537,48 @@ func (bh *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (er
 }
 
 func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectRequest) (*gcs.Object, error) {
-	// TODO: Implement it.
-	return nil, nil
+	var o *gcs.Object
+	var err error
+
+	obj := bh.bucket.Object(req.SrcName)
+
+	// Switching to the requested generation of source object.
+	if req.SrcGeneration != 0 {
+		obj = obj.Generation(req.SrcGeneration)
+	}
+
+	// Putting a condition that the metaGeneration of source should match *req.SrcMetaGenerationPrecondition for copy operation to occur.
+	if req.SrcMetaGenerationPrecondition != nil {
+		obj = obj.If(storage.Conditions{MetagenerationMatch: *req.SrcMetaGenerationPrecondition})
+	}
+
+	dstMoveObject := storage.MoveObjectDestination{
+		Object:     req.DstName,
+		Conditions: nil,
+	}
+
+	attrs, err := obj.Move(ctx, dstMoveObject)
+	if err == nil {
+		// Converting objAttrs to type *Object
+		o = storageutil.ObjectAttrsToBucketObject(attrs)
+	}
+
+	// If storage object does not exist, httpclient is returning ErrObjectNotExist error instead of googleapi error
+	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/vendor/cloud.google.com/go/storage/http_client.go#L516
+	switch ee := err.(type) {
+	case *googleapi.Error:
+		if ee.Code == http.StatusPreconditionFailed {
+			err = &gcs.PreconditionError{Err: ee}
+		}
+	default:
+		if err == storage.ErrObjectNotExist {
+			err = &gcs.NotFoundError{Err: storage.ErrObjectNotExist}
+		} else {
+			err = fmt.Errorf("error in updating object: %w", err)
+		}
+	}
+
+	return o, nil
 }
 
 func (bh *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -588,6 +588,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 	if err == nil {
 		// Converting objAttrs to type *Object
 		o = storageutil.ObjectAttrsToBucketObject(attrs)
+		return o, nil
 	}
 
 	// If storage object does not exist, httpclient is returning ErrObjectNotExist error instead of googleapi error
@@ -598,7 +599,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 		} else if errors.Is(err, storage.ErrObjectNotExist) {
 			err = &gcs.NotFoundError{Err: storage.ErrObjectNotExist}
 		} else {
-			err = fmt.Errorf("error in updating object: %w", err)
+			err = fmt.Errorf("error in moving object: %w", err)
 		}
 		return nil, err
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -547,7 +547,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 		obj = obj.Generation(req.SrcGeneration)
 	}
 
-	// Putting a condition that the metaGeneration of source should match *req.SrcMetaGenerationPrecondition for copy operation to occur.
+	// Putting a condition that the metaGeneration of source should match *req.SrcMetaGenerationPrecondition for move operation to occur.
 	if req.SrcMetaGenerationPrecondition != nil {
 		obj = obj.If(storage.Conditions{MetagenerationMatch: *req.SrcMetaGenerationPrecondition})
 	}

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1572,7 +1572,7 @@ func TestIsPreconditionFailed(t *testing.T) {
 				t.Errorf("Expected isPrecond to be %v, got %v", tc.expectPreCond, isPreCond)
 			}
 
-			if err != nil {
+			if tc.expectPreCond && err != nil {
 				var preCondErr *gcs.PreconditionError
 				if !errors.As(err, &preCondErr) {
 					t.Errorf("Expected err to be of type *gcs.PreconditionError, got %T", err)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1578,6 +1578,10 @@ func TestIsPreconditionFailed(t *testing.T) {
 					t.Errorf("Expected err to be of type *gcs.PreconditionError, got %T", err)
 				}
 			}
+
+			if !tc.expectPreCond {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1531,43 +1531,36 @@ func TestIsPreconditionFailed(t *testing.T) {
 		name          string
 		err           error
 		expectPreCond bool
-		expectErr     bool
 	}{
 		{
 			name:          "googleapi.Error with PreconditionFailed",
 			err:           &googleapi.Error{Code: http.StatusPreconditionFailed},
 			expectPreCond: true,
-			expectErr:     true,
 		},
 		{
 			name:          "googleapi.Error with other code",
 			err:           &googleapi.Error{Code: http.StatusNotFound},
 			expectPreCond: false,
-			expectErr:     false,
 		},
 		{
 			name:          "apierror.APIError with FailedPrecondition",
 			err:           preCondApiError,
 			expectPreCond: true,
-			expectErr:     true,
 		},
 		{
 			name:          "apierror.APIError with other code",
 			err:           notFoundApiError,
 			expectPreCond: false,
-			expectErr:     false,
 		},
 		{
 			name:          "nil error",
 			err:           nil,
 			expectPreCond: false,
-			expectErr:     false,
 		},
 		{
 			name:          "generic error",
 			err:           errors.New("generic error"),
 			expectPreCond: false,
-			expectErr:     false,
 		},
 	}
 
@@ -1579,11 +1572,7 @@ func TestIsPreconditionFailed(t *testing.T) {
 				t.Errorf("Expected isPrecond to be %v, got %v", tc.expectPreCond, isPreCond)
 			}
 
-			if (err != nil) != tc.expectErr {
-				t.Errorf("Expected err to be %v, got %v", tc.expectErr, err != nil)
-			}
-
-			if tc.expectErr && err != nil {
+			if err != nil {
 				var preCondErr *gcs.PreconditionError
 				if !errors.As(err, &preCondErr) {
 					t.Errorf("Expected err to be of type *gcs.PreconditionError, got %T", err)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1527,7 +1527,8 @@ func (testSuite *BucketHandleTest) TestCreateFolderWithGivenName() {
 func TestIsPreconditionFailed(t *testing.T) {
 	preCondApiError, _ := apierror.FromError(status.New(codes.FailedPrecondition, "Precondition error").Err())
 	notFoundApiError, _ := apierror.FromError(status.New(codes.NotFound, "Not Found error").Err())
-	testCases := []struct {
+
+	tests := []struct {
 		name          string
 		err           error
 		expectPreCond bool
@@ -1564,22 +1565,15 @@ func TestIsPreconditionFailed(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			isPreCond, err := isPreconditionFailed(tc.err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isPreCond, err := isPreconditionFailed(tt.err)
+			assert.Equal(t, tt.expectPreCond, isPreCond)
 
-			if isPreCond != tc.expectPreCond {
-				t.Errorf("Expected isPrecond to be %v, got %v", tc.expectPreCond, isPreCond)
-			}
-
-			if tc.expectPreCond && err != nil {
+			if tt.expectPreCond {
 				var preCondErr *gcs.PreconditionError
-				if !errors.As(err, &preCondErr) {
-					t.Errorf("Expected err to be of type *gcs.PreconditionError, got %T", err)
-				}
-			}
-
-			if !tc.expectPreCond {
+				assert.ErrorAs(t, err, &preCondErr)
+			} else {
 				assert.NoError(t, err)
 			}
 		})

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1383,9 +1383,9 @@ func (testSuite *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstO
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-			Return(&controlpb.StorageLayout{
-				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-			}, nil)
+		Return(&controlpb.StorageLayout{
+			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		}, nil)
 
 	testSuite.bucketHandle.BucketType()
 
@@ -1394,9 +1394,9 @@ func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() 
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceFalse() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-			Return(&controlpb.StorageLayout{
-				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
-			}, nil)
+		Return(&controlpb.StorageLayout{
+			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
+		}, nil)
 
 	testSuite.bucketHandle.BucketType()
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1383,9 +1383,9 @@ func (testSuite *BucketHandleTest) TestComposeObjectMethodWithOneSrcObjectIsDstO
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-		Return(&controlpb.StorageLayout{
-			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		}, nil)
+			Return(&controlpb.StorageLayout{
+				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+			}, nil)
 
 	testSuite.bucketHandle.BucketType()
 
@@ -1394,9 +1394,9 @@ func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceTrue() 
 
 func (testSuite *BucketHandleTest) TestBucketTypeForHierarchicalNameSpaceFalse() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
-		Return(&controlpb.StorageLayout{
-			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
-		}, nil)
+			Return(&controlpb.StorageLayout{
+				HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: false},
+			}, nil)
 
 	testSuite.bucketHandle.BucketType()
 
@@ -1568,8 +1568,8 @@ func TestIsPreconditionFailed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			isPreCond, err := isPreconditionFailed(tt.err)
-			assert.Equal(t, tt.expectPreCond, isPreCond)
 
+			assert.Equal(t, tt.expectPreCond, isPreCond)
 			if tt.expectPreCond {
 				var preCondErr *gcs.PreconditionError
 				assert.ErrorAs(t, err, &preCondErr)


### PR DESCRIPTION
### Description
- MoveObject bucket handle integration
- Unit tests are not covered as we're currently using a fake storage server for the rest of our storage client API unit tests. To add unit tests for the MoveObject function, we have two options:
  1. Add a moveObject API to the [fake GCS server repository](https://github.com/fsouza/fake-gcs-server/blob/main/fakestorage/object.go,). This would involve extending the fake server's functionality to include support for the move operation. This seems like a more complex solution and time consuming.
  2. Mock the MoveObject API. Mocking is not possible because the MoveObject function takes a [private](https://github.com/googleapis/google-cloud-go/blob/main/storage/http_client.go#L596) struct from storage library as an argument.  

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
