### PR TITLE
Fix flaky parallel dirOps e2e tests

### DIFF
--- a/tools/integration_tests/emulator_tests/emulator_test.go
+++ b/tools/integration_tests/emulator_tests/emulator_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-
 const port = 8020
 
 var (

--- a/tools/integration_tests/emulator_tests/emulator_test.go
+++ b/tools/integration_tests/emulator_tests/emulator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
+
 const port = 8020
 
 var (

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -199,6 +199,7 @@ func TestParallelLookUpAndDeleteSameDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 	// Assert either dir is looked up first or deleted first
 	if lookUpErr == nil {
+		assert.NotNil(t, statInfo, "statInfo should not be nil when lookUpErr is nil")
 		assert.Contains(t, statInfo.Name(), "explicitDir1")
 		assert.True(t, statInfo.IsDir())
 	} else {
@@ -331,6 +332,7 @@ func TestParallelLookUpAndDeleteSameFile(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 	// Assert either file is looked up first or deleted first
 	if lookUpErr == nil {
+		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
 		assert.Equal(t, int64(5), fileInfo.Size())
 		assert.Contains(t, fileInfo.Name(), "file1.txt")
 		assert.False(t, fileInfo.IsDir())
@@ -373,6 +375,7 @@ func TestParallelLookUpAndRenameSameFile(t *testing.T) {
 	assert.Equal(t, int64(5), newFileInfo.Size())
 	// Assert either file is renamed first or looked up first
 	if lookUpErr == nil {
+		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
 		assert.Equal(t, int64(5), fileInfo.Size())
 		assert.Contains(t, fileInfo.Name(), "file1.txt")
 		assert.False(t, fileInfo.IsDir())

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -243,7 +243,7 @@ func TestParallelLookUpsForDifferentFiles(t *testing.T) {
 	wg = sync.WaitGroup{}
 	wg.Add(2)
 	go lookUpFunc(&wg, filePath1, &stat1, &err1)
-	go lookUpFunc(&wg, filePath1, &stat2, &err2)
+	go lookUpFunc(&wg, filePath2, &stat2, &err2)
 	wg.Wait()
 
 	// Assert both stats passed and give correct information

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -428,6 +428,7 @@ func TestParallelLookUpAndMkdirSameDir(t *testing.T) {
 	go mkdirFunc(&wg, dirPath, &mkdirErr)
 	wg.Wait()
 
+	// Assert either directory is created first or looked up first
 	assert.NoError(t, mkdirErr, "mkdirFunc should not fail")
 
 	if lookUpErr == nil {


### PR DESCRIPTION
### Description
**Potential Problems:**
1. Data Race: The update to statInfo and lookUpErr in the goroutine may not be visible to the main thread immediately.
This can lead to a situation where lookUpErr == nil, but statInfo still appears nil in the main thread and cause panic.
2. Improper Synchronization: Even though we're using sync.WaitGroup to wait for goroutines to finish, there is no explicit guarantee that statInfo and lookUpErr are synchronized across goroutines and the main thread.

**Applied Fixes:**
1. Use pointers to pass results (statInfo, lookUpErr, etc.) directly to avoid shared variable conflicts.
2. Avoid Shared Variables: Each goroutine updates its respective variables, ensuring no concurrent writes to shared memory.
3. Thread-Safe Updates: By passing pointers, the main thread accesses fully updated variables after wg.Wait().


### Link to the issue in case of a bug fix.
1. [b/387209276](https://b.corp.google.com/issues/387209276)
2. [b/383948909](https://b.corp.google.com/issues/383948909)
3. [b/386583075](https://b.corp.google.com/issues/386583075)

### Testing details
1. Manual - NA
4. Unit tests - NA
5. Integration tests - Automated
