### PR TITLE
Fix kernel cache ttl test failure for GKE

### DIFF
--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -32,19 +32,19 @@ import (
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
-type infiniteKernelListCacheDeletionTest struct {
+type infiniteKernelListCacheDeleteDirTest struct {
 	flags []string
 }
 
-func (s *infiniteKernelListCacheDeletionTest) Setup(t *testing.T) {
+func (s *infiniteKernelListCacheDeleteDirTest) Setup(t *testing.T) {
 	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
 }
 
-func (s *infiniteKernelListCacheDeletionTest) Teardown(t *testing.T) {
+func (s *infiniteKernelListCacheDeleteDirTest) Teardown(t *testing.T) {
 	setup.UnmountGCSFuse(rootDir)
 }
 
-func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
+func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
@@ -72,7 +72,7 @@ func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_ListAndDeleteD
 	assert.NoError(t, err)
 }
 
-func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
+func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
@@ -107,8 +107,8 @@ func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_DeleteAndListD
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestInfiniteKernelListCacheDeletionTest(t *testing.T) {
-	ts := &infiniteKernelListCacheDeletionTest{}
+func TestInfiniteKernelListCacheDeleteDirTest(t *testing.T) {
+	ts := &infiniteKernelListCacheDeleteDirTest{}
 
 	// Run tests for mounted directory if the flag is set.
 	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_list_cache
+
+import (
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"os"
+	"path"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type infiniteKernelListCacheDeletionTest struct {
+	flags []string
+}
+
+func (s *infiniteKernelListCacheDeletionTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, ctx, storageClient, testDirName)
+}
+
+func (s *infiniteKernelListCacheDeletionTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	operations.CreateDirectory(targetDir, t)
+	// Create test data
+	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
+	operations.CloseFile(f1)
+	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
+	operations.CloseFile(f2)
+
+	err := os.RemoveAll(targetDir)
+	assert.NoError(t, err)
+
+	// Adding object to GCS to make sure to change the ReadDir() response.
+	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir")+"/", "")
+	require.NoError(t, err)
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
+	// Read will be served from GCS as removing the directory also deletes the cache.
+	f, err := os.Open(targetDir)
+	assert.NoError(t, err)
+	names1, err := f.Readdirnames(-1)
+	assert.NoError(t, err)
+	require.Equal(t, 1, len(names1))
+	assert.Equal(t, "file3.txt", names1[0])
+	err = f.Close()
+	assert.NoError(t, err)
+
+	// 2nd RemoveAll call will also succeed.
+	err = os.RemoveAll(targetDir)
+	assert.NoError(t, err)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestInfiniteKernelListCacheDeletionTest(t *testing.T) {
+	ts := &infiniteKernelListCacheDeletionTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	// Note: metadata cache is disabled to avoid cache consistency issue between
+	// gcsfuse cache and kernel cache. As gcsfuse cache might hold the entry which
+	// already became stale due to delete operation.
+	// TODO: Replace metadata-cache-ttl-secs with something better
+	flagsSet := [][]string{
+		{"--kernel-list-cache-ttl-secs=-1", "--metadata-cache-ttl-secs=0"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		log.Printf("Running tests with flags: %s", ts.flags)
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
@@ -43,6 +43,34 @@ func (s *infiniteKernelListCacheDeletionTest) Teardown(t *testing.T) {
 	setup.UnmountGCSFuse(rootDir)
 }
 
+func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	operations.CreateDirectory(targetDir, t)
+	// Create test data
+	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
+	operations.CloseFile(f1)
+	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
+	operations.CloseFile(f2)
+
+	// (a) First read served from GCS, kernel will cache the dir response.
+	f, err := os.Open(targetDir)
+	assert.NoError(t, err)
+	names1, err := f.Readdirnames(-1)
+	assert.NoError(t, err)
+	require.Equal(t, 2, len(names1))
+	assert.Equal(t, "file1.txt", names1[0])
+	assert.Equal(t, "file2.txt", names1[1])
+	err = f.Close()
+	assert.NoError(t, err)
+	// Adding one object to make sure to change the ReadDir() response.
+	// All files including file3.txt will be deleted by os.RemoveAll
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
+
+	err = os.RemoveAll(targetDir)
+
+	assert.NoError(t, err)
+}
+
 func (s *infiniteKernelListCacheDeletionTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_deletion_test.go
@@ -15,16 +15,17 @@
 package kernel_list_cache
 
 import (
+	"log"
+	"os"
+	"path"
+	"testing"
+
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"log"
-	"os"
-	"path"
-	"testing"
 )
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -453,34 +453,6 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnDirectoryRe
 	assert.Equal(t, "renamed_sub_dir", names2[3])
 }
 
-func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
-	targetDir := path.Join(testDirPath, "explicit_dir")
-	operations.CreateDirectory(targetDir, t)
-	// Create test data
-	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
-
-	// (a) First read served from GCS, kernel will cache the dir response.
-	f, err := os.Open(targetDir)
-	assert.NoError(t, err)
-	names1, err := f.Readdirnames(-1)
-	assert.NoError(t, err)
-	require.Equal(t, 2, len(names1))
-	assert.Equal(t, "file1.txt", names1[0])
-	assert.Equal(t, "file2.txt", names1[1])
-	err = f.Close()
-	assert.NoError(t, err)
-	// Adding one object to make sure to change the ReadDir() response.
-	// All files including file3.txt will be deleted by os.RemoveAll
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-
-	err = os.RemoveAll(targetDir)
-
-	assert.NoError(t, err)
-}
-
 ////////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -481,37 +481,6 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_ListAndDeleteDirectory
 	assert.NoError(t, err)
 }
 
-func (s *infiniteKernelListCacheTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
-	targetDir := path.Join(testDirPath, "explicit_dir")
-	operations.CreateDirectory(targetDir, t)
-	// Create test data
-	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
-	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
-
-	err := os.RemoveAll(targetDir)
-	assert.NoError(t, err)
-
-	// Adding object to GCS to make sure to change the ReadDir() response.
-	err = client.CreateObjectOnGCS(ctx, storageClient, path.Join(testDirName, "explicit_dir")+"/", "")
-	require.NoError(t, err)
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file3.txt"), "", t)
-	// Read will be served from GCS as removing the directory also deletes the cache.
-	f, err := os.Open(targetDir)
-	assert.NoError(t, err)
-	names1, err := f.Readdirnames(-1)
-	assert.NoError(t, err)
-	require.Equal(t, 1, len(names1))
-	assert.Equal(t, "file3.txt", names1[0])
-	err = f.Close()
-	assert.NoError(t, err)
-
-	// 2nd RemoveAll call will also succeed.
-	err = os.RemoveAll(targetDir)
-	assert.NoError(t, err)
-}
-
 ////////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
@@ -525,13 +494,8 @@ func TestInfiniteKernelListCacheTest(t *testing.T) {
 		return
 	}
 
-	// Define flag set to run the tests.
-	// Note: metadata cache is disabled to avoid cache consistency issue between
-	// gcsfuse cache and kernel cache. As gcsfuse cache might hold the entry which
-	// already became stale due to delete operation.
-	// TODO: Replace metadata-cache-ttl-secs with something better
 	flagsSet := [][]string{
-		{"--kernel-list-cache-ttl-secs=-1", "--metadata-cache-ttl-secs=0"},
+		{"--kernel-list-cache-ttl-secs=-1"},
 	}
 
 	// Run tests.

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -560,7 +560,7 @@ test_cases=(
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnDirectoryRename"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=0 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --kernel-list-cache-ttl-secs=-1  "$TEST_BUCKET_NAME" "$MOUNT_DIR"
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/kernel_list_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
 done
@@ -570,7 +570,7 @@ test_cases=(
   "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_DeleteAndListDirectory"
 )
 for test_case in "${test_cases[@]}"; do
-  gcsfuse --kernel-list-cache-ttl-secs=-1 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  gcsfuse --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=0 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/kernel_list_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
 done

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -558,7 +558,6 @@ test_cases=(
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnAdditionOfDirectory"
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnDeletionOfDirectory"
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnDirectoryRename"
-  "TestInfiniteKernelListCacheTest/TestKernelListCache_ListAndDeleteDirectory"
 )
 for test_case in "${test_cases[@]}"; do
   gcsfuse --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=0 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
@@ -567,6 +566,7 @@ for test_case in "${test_cases[@]}"; do
 done
 
 test_cases=(
+  "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_ListAndDeleteDirectory"
   "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_DeleteAndListDirectory"
 )
 for test_case in "${test_cases[@]}"; do

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -559,10 +559,18 @@ test_cases=(
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnDeletionOfDirectory"
   "TestInfiniteKernelListCacheTest/TestKernelListCache_CacheMissOnDirectoryRename"
   "TestInfiniteKernelListCacheTest/TestKernelListCache_ListAndDeleteDirectory"
-  "TestInfiniteKernelListCacheTest/TestKernelListCache_DeleteAndListDirectory"
 )
 for test_case in "${test_cases[@]}"; do
   gcsfuse --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=0 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/kernel_list_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
+  sudo umount "$MOUNT_DIR"
+done
+
+test_cases=(
+  "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_DeleteAndListDirectory"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --kernel-list-cache-ttl-secs=-1 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/kernel_list_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run "$test_case"
   sudo umount "$MOUNT_DIR"
 done

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -566,8 +566,8 @@ for test_case in "${test_cases[@]}"; do
 done
 
 test_cases=(
-  "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_ListAndDeleteDirectory"
-  "TestInfiniteKernelListCacheDeletionTest/TestKernelListCache_DeleteAndListDirectory"
+  "TestInfiniteKernelListCacheDeleteDirTest/TestKernelListCache_ListAndDeleteDirectory"
+  "TestInfiniteKernelListCacheDeleteDirTest/TestKernelListCache_DeleteAndListDirectory"
 )
 for test_case in "${test_cases[@]}"; do
   gcsfuse --kernel-list-cache-ttl-secs=-1 --metadata-cache-ttl-secs=0 "$TEST_BUCKET_NAME" "$MOUNT_DIR"


### PR DESCRIPTION
### Description
Tests began failing due to execution sequence issues stemming from the addition of a negative cache upon deletion. To address this, the affected tests were moved to a separate file and configured with a metadata cache TTL of 0.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
