### PR TITLE
streaming writes flush and sync flow

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1108,41 +1108,17 @@ func (fs *fileSystem) lookUpOrCreateChildDirInode(
 	return child, nil
 }
 
-// Synchronize the supplied file inode to GCS, updating the index as
-// appropriate.
+// promoteToGenerationBacked updates the file system maps for the given file inode
+// after it has been synced to GCS.
+// The inode is removed from the localFileInodes map and added to the
+// generationBackedInodes map.
 //
 // LOCKS_EXCLUDED(fs.mu)
 // LOCKS_REQUIRED(f)
-func (fs *fileSystem) syncFile(
-	ctx context.Context,
-	f *inode.FileInode) (err error) {
-	// SyncFile can be triggered for unlinked files if the fileHandle is open by
-	// same or another user. This indicates a potential file clobbering scenario:
-	// - The file was deleted (unlinked) while a handle to it was still open.
-	if f.IsLocal() && f.IsUnlinked() {
-		err = &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
-		}
-		return
-	}
-
-	// Sync the inode.
-	err = f.Sync(ctx)
-	if err != nil {
-		err = fmt.Errorf("FileInode.Sync: %w", err)
-		// If the inode was local file inode, treat it as unlinked.
-		fs.mu.Lock()
-		delete(fs.localFileInodes, f.Name())
-		fs.mu.Unlock()
-		return
-	}
-
-	// Once the inode is synced to GCS, it is no longer an localFileInode.
-	// Delete the entry from localFileInodes map and add it to generationBackedInodes.
+func (fs *fileSystem) promoteToGenerationBacked(f *inode.FileInode) {
 	fs.mu.Lock()
 	delete(fs.localFileInodes, f.Name())
-	_, ok := fs.generationBackedInodes[f.Name()]
-	if !ok {
+	if _, ok := fs.generationBackedInodes[f.Name()]; !ok {
 		fs.generationBackedInodes[f.Name()] = f
 	}
 	fs.mu.Unlock()
@@ -1156,8 +1132,75 @@ func (fs *fileSystem) syncFile(
 	//
 	// In other words, either this inode is still in the index or it has been
 	// clobbered and *should* be anonymous.
+}
 
-	return
+// Flushes the supplied file inode to GCS, updating the index as
+// appropriate.
+//
+// LOCKS_EXCLUDED(fs.mu)
+// LOCKS_REQUIRED(f)
+func (fs *fileSystem) flushFile(
+	ctx context.Context,
+	f *inode.FileInode) error {
+	// SyncFile can be triggered for unlinked files if the fileHandle is open by
+	// same or another user. This indicates a potential file clobbering scenario:
+	// - The file was deleted (unlinked) while a handle to it was still open.
+	if f.IsLocal() && f.IsUnlinked() {
+		return &gcsfuse_errors.FileClobberedError{
+			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
+		}
+	}
+
+	// Flush the inode.
+	err := f.Flush(ctx)
+	if err != nil {
+		err = fmt.Errorf("FileInode.Sync: %w", err)
+		// If the inode was local file inode, treat it as unlinked.
+		fs.mu.Lock()
+		delete(fs.localFileInodes, f.Name())
+		fs.mu.Unlock()
+		return err
+	}
+
+	// Promote the inode to generationBackedInodes in fs maps.
+	fs.promoteToGenerationBacked(f)
+	return nil
+}
+
+// Synchronizes the supplied file inode to GCS, updating the index as
+// appropriate.
+//
+// LOCKS_EXCLUDED(fs.mu)
+// LOCKS_REQUIRED(f)
+func (fs *fileSystem) syncFile(
+	ctx context.Context,
+	f *inode.FileInode) error {
+	// SyncFile can be triggered for unlinked files if the fileHandle is open by
+	// same or another user. This indicates a potential file clobbering scenario:
+	// - The file was deleted (unlinked) while a handle to it was still open.
+	if f.IsLocal() && f.IsUnlinked() {
+		return &gcsfuse_errors.FileClobberedError{
+			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
+		}
+	}
+
+	// Sync the inode.
+	gcsSynced, err := f.Sync(ctx)
+	if err != nil {
+		err = fmt.Errorf("FileInode.Sync: %w", err)
+		// If the inode was local file inode, treat it as unlinked.
+		fs.mu.Lock()
+		delete(fs.localFileInodes, f.Name())
+		fs.mu.Unlock()
+		return err
+	}
+
+	// If gcsSynced is true, it means the inode was fully synced to GCS In this
+	// case, we need to promote the inode to generationBackedInodes in fs maps.
+	if gcsSynced {
+		fs.promoteToGenerationBacked(f)
+	}
+	return nil
 }
 
 // Decrement the supplied inode's lookup count, destroying it if the inode says
@@ -2546,7 +2589,7 @@ func (fs *fileSystem) FlushFile(
 	defer in.Unlock()
 
 	// Sync it.
-	if err := fs.syncFile(ctx, in); err != nil {
+	if err := fs.flushFile(ctx, in); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Description
This PR includes code changes to:
-  separate out flush and sync flow.
- file inode test to test for both sync and flush.
- integrate flush file and sync file for streaming writes and associated refactoring.


### Link to the issue in case of a bug fix.
b/385064030

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
