### PR TITLE
Make OTel the default for metrics

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -327,7 +327,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
+	flagSet.BoolP("enable-otel", "", true, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
 
 	if err := flagSet.MarkHidden("enable-otel"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -582,7 +582,7 @@
   flag-name: "enable-otel"
   type: "bool"
   usage: "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus."
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "metrics.prometheus-port"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -804,6 +804,7 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 				StackdriverExportInterval:      0,
 				CloudMetricsExportIntervalSecs: 0,
 				PrometheusPort:                 0,
+				EnableOtel:                     true,
 			},
 		},
 		{
@@ -811,6 +812,7 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10,
+				EnableOtel:                     true,
 			},
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -849,7 +849,7 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			name: "default",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
+				EnableOtel: true,
 			},
 		},
 		{
@@ -874,14 +874,21 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			},
 		},
 		{
-			name:     "cloud-metrics-export-interval-secs-positive",
-			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},
+			name: "cloud-metrics-export-interval-secs-positive",
+			args: []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 10,
+				EnableOtel:                     true,
+			},
 		},
 		{
-			name:     "stackdriver-export-interval-positive",
-			args:     []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10 * 3600, StackdriverExportInterval: time.Duration(10) * time.Hour},
+			name: "stackdriver-export-interval-positive",
+			args: []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 10 * 3600,
+				StackdriverExportInterval:      time.Duration(10) * time.Hour,
+				EnableOtel:                     true,
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -913,7 +920,7 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 			name:    "default",
 			cfgFile: "empty.yml",
 			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
+				EnableOtel: true,
 			},
 		},
 		{
@@ -933,12 +940,16 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			cfgFile:  "metrics_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100, EnableOtel: true},
 		},
 		{
-			name:     "stackdriver-export-interval-positive",
-			cfgFile:  "stackdriver_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 12 * 3600, StackdriverExportInterval: 12 * time.Hour},
+			name:    "stackdriver-export-interval-positive",
+			cfgFile: "stackdriver_export_interval_positive.yml",
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 12 * 3600,
+				StackdriverExportInterval:      12 * time.Hour,
+				EnableOtel:                     true,
+			},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
### Description
Use OTel for metrics by default. One can override the behavior to use OpenCensus instead by setting --enable-otel flag to false.
### Link to the issue in case of a bug fix.
b/387898221

Perf impact:
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 452.23MiB/s  | 1.16MiB/s  |  63.39MiB/s  |  1.29MiB/s   |
|   PR   |  0.25MiB   | 465.06MiB/s  | 1.33MiB/s  |  65.42MiB/s  |  1.29MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3757.51MiB/s | 77.25MiB/s | 1176.68MiB/s |  79.37MiB/s  |
|   PR   | 48.828MiB  | 3832.38MiB/s | 80.22MiB/s | 1209.13MiB/s |  81.02MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 3906.58MiB/s | 29.89MiB/s | 443.78MiB/s  |  33.62MiB/s  |
|   PR   | 976.562MiB | 3897.71MiB/s | 33.91MiB/s | 573.08MiB/s  |  32.56MiB/s  |
|        |            |              |            |              |              |

### Testing details
1. Manual - Tested the Prometheus endpoint.
2. Unit tests - NA
3. Integration tests - Covered by existing tests
