### PR TITLE
Avoiding nested panic while lookUpLocalFileInode

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1038,9 +1038,11 @@ func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName stri
 	// Trim the suffix assigned to fix conflicting names.
 	childName = strings.TrimSuffix(childName, inode.ConflictingFileNameSuffix)
 
-	// Panic in inode.NewFileName() leads to another panic in the defer's fs.mu.Unlock()
-	// and leads to loss of actual panic message inside inode.NewFileName(), explicitly
-	// calling fs.mu.Lock() to avoid panic in defer's fs.mu.Unlock().
+	// Panic in inode.NewFileName() leads to another panic in the defer function, because of fs.mu.Unlock()
+	// call over the already unlocked mutex. This eventually results into the loss of actual panic message
+	// inside inode.NewFileName().
+	// Explicitly calling fs.mu.Lock() before inode.NewFileName() to avoid this nested panic and hence original
+	// panic message loss.
 	fs.mu.Lock()
 	fileName := inode.NewFileName(parent.Name(), childName)
 


### PR DESCRIPTION
### Description
Panic in inode.NewFileName() leads to another panic in the defer function, because of fs.mu.Unlock()
call over the already unlocked mutex. This eventually results into the loss of actual panic message
inside inode.NewFileName().
Moving defer function after fs.mu.Lock() to avoid this nested panic and hence original
panic message loss.

After the change, started getting the panic message:
```
{"timestamp":{"seconds":1736229731,"nanos":75546141},"severity":"ERROR","message":"Panic: Inode '' cannot have child file ''"}
{"timestamp":{"seconds":1736229731,"nanos":75724827},"severity":"ERROR","message":"goroutine 178 [running]:\nruntime/debug.Stack()\n\t/home/princer_google_com/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/logger.Fatal({0x18dfb0e?, 0xc000e00700?}, {0xc000170850?, 0xc000170827?, 0xc000170878?})\n\t/home/princer_google_com/dev/gcsfuse/internal/logger/logger.go:159 +0x25\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/wrappers.(*errorMapping).handlePanic(0x0?)\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/wrappers/error_mapping.go:123 +0x45\npanic({0x151d6e0?, 0xc000b80020?})\n\t/home/princer_google_com/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/panic.go:785 +0x132\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/inode.NewFileName({{0x0, 0x0}, {0x0, 0x0}}, {0x0, 0x0})\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/inode/name.go:58 +0x108\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs.(*fileSystem).lookUpLocalFileInode(0xc000626200, {0x1c19318, 0xc000c20640}, {0xc0008a6d70?, 0xa?})\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/fs.go:1048 +0x138\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs.(*fileSystem).lookUpOrCreateChildInode(0xc000626200, {0x1c02bb0, 0xc001212050}, {0x1c19318, 0xc000c20640}, {0xc0008a6d70, 0xa})\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/fs.go:974 +0x66\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs.(*fileSystem).LookUpInode(0xc000626200, {0x1c02b78?, 0xc000b86fc0?}, 0xc0007cc960)\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/fs.go:1451 +0x146\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/wrappers.(*errorMapping).LookUpInode(0xc0009ec468, {0x1c02b78?, 0xc000b86fc0?}, 0x4ebd2f?)\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/wrappers/error_mapping.go:155 +0x63\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/wrappers.(*monitoring).LookUpInode.func1({0x1c02b78?, 0xc000b86fc0?})\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/wrappers/monitoring.go:274 +0x36\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/wrappers.(*monitoring).invokeWrapped(0xc0009f4260, {0x1c02b78, 0xc000b86fc0}, {0x18e2c00, 0xb}, 0xc000528ef0)\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/wrappers/monitoring.go:264 +0x78\ngithub.com/googlecloudplatform/gcsfuse/v2/internal/fs/wrappers.(*monitoring).LookUpInode(0x0?, {0x1c02b78?, 0xc000b86fc0?}, 0x0?)\n\t/home/princer_google_com/dev/gcsfuse/internal/fs/wrappers/monitoring.go:274 +0x45\ngithub.com/jacobsa/fuse/fuseutil.(*fileSystemServer).handleOp(0xc0009f4280, 0xc000c4cc30, {0x1c02b78, 0xc000b86fc0}, {0x14de1e0?, 0xc0007cc960})\n\t/home/princer_google_com/go/pkg/mod/github.com/jacobsa/fuse@v0.0.0-20240607092844-7285af0d05b0/fuseutil/file_system.go:144 +0x203\
```

### Link to the issue in case of a bug fix.
See: b/388147397

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
