### PR TITLE
Refactor: ValidateStaleNFSFileHandleError for ARM64 Compatibility

### DIFF
--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -46,7 +47,7 @@ func ValidateObjectNotFoundErr(ctx context.Context, t *testing.T, bucket gcs.Buc
 
 func ValidateStaleNFSFileHandleError(t *testing.T, err error) {
 	assert.NotEqual(t, nil, err)
-	assert.Regexp(t, "stale NFS file handle", err.Error())
+	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
 }
 
 func CheckErrorForReadOnlyFileSystem(t *testing.T, err error) {


### PR DESCRIPTION
### Description
Updated the ValidateStaleNFSFileHandleError function to dynamically fetch the error message associated with syscall.ESTALE. This change ensures that the function correctly identifies stale file handle errors across different architectures, including ARM64 and AMD64, which may return different error messages for the same syscall error.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
