### PR TITLE
Reduce number of iterations for flake-detector

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -32,7 +32,7 @@ jobs:
         run: go mod download
 
       - name: Test all
-        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 5 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
 
       - name: Cache RaceDetector Test
-        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 20 ./internal/cache/...
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 5 ./internal/cache/...


### PR DESCRIPTION
### Description
* Flake detector runs the same set of tests 20 times which times out since the tests are no longer running in parallel. Reduce the number of times to 5 to make it pass.

### Link to the issue in case of a bug fix.
b/380798155

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
