### PR TITLE
Update Semantics doc about changes in GCSFuse behavior after Write Failure Improvements

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -57,7 +57,7 @@ Examples:
 
 **Stale File Handle Errors**
 
-To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE``` error under the following circumstances:
+To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error when an application tries to access stale data. This can occur in the following circumstances:
 
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
 - **Read During Modification**: If one mount is reading a file while another mount modifies and syncs the file, the reader application will encounter this error.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -62,9 +62,9 @@ Examples:
 To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error when an application tries to access stale data. This can occur in the following circumstances:
 
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file descriptors will encounter this error when attempting to sync or close the file.
-- **Read During Modification**:  If an application is reading a file through a GCSFuse mount, and the same object is modified on GCS (by deleting, renaming, or changing its content or metadata), the GCSFuse reader will encounter this error. This is because GCSFuse detects that the file it was accessing has changed.
-- **File Renaming During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
-- **File Deletion During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is deleted on Google Cloud Storage (via different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
+- **Read During Modification**:  When an application is reading a file through a GCSFuse mount, and the same object is modified on GCS (by deleting, renaming, or changing its content or metadata), the GCSFuse reader will encounter this error. This is because GCSFuse detects that the file it was accessing has changed.
+- **File Renaming During Write**: When an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
+- **File Deletion During Write**: When an application is writing to a file through a GCSFuse mount, and the same object is deleted on Google Cloud Storage (via different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
 
 These changes in Cloud Storage FUSE prioritize data integrity and provide users with clear indications of potential conflicts, preventing silent data loss and ensuring a more robust and reliable experience.
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -62,7 +62,7 @@ To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error w
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
 - **Read During Modification**: If one mount is reading a file while another mount modifies and syncs the file, the reader application will encounter this error.
 - **File Deletion or Renaming During Read**: If a mount is reading a file and the file is deleted or renamed by the same or a different mount, the reader application will encounter this error.
-- **File Renaming During Write**: If a mount is writing to a file and the file is renamed by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file.
+- **File Renaming During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
 - **File Deletion During Write**: If a mount is writing to a file and the file is deleted by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file. However, if the file is deleted by the same mount, the writer application will not encounter any error.
 
 These changes in Cloud Storage FUSE prioritize data integrity and provide users with clear indications of potential conflicts, preventing silent data loss and ensuring a more robust and reliable experience.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -43,7 +43,7 @@ when writing large files.
 
 **Concurrency**
 
-Multiple readers can access the same or different objects from the same bucket without issue. Multiple writers can also write to different objects in the same bucket without issue. However, there is no concurrency control for multiple writers to the same file. When multiple writers try to replace a file from the same machine, the last write wins and all previous writes are lost without any user notification of the overwrite. However, in case of different machines the flush from first machine wins and the other machines that had the file open before the first machine synced its changes will get a ```syscall.ESTALE error``` when they try to save their own edits - there is no merging or version control. Therefore, for data integrity it is recommended that multiple sources do not modify the same object.
+Multiple readers can access the same or different objects from the same bucket without issue. Multiple writers can also write to different objects in the same bucket without issue. However, there is no concurrency control for multiple writers to the same file. When multiple writers try to replace a file from the same machine, the last write wins and all previous writes are lost without any user notification of the overwrite. However, in case of different machines the flush from first machine wins and the other machines that had the file open before the first machine synced its changes will get a ```syscall.ESTALE``` error when they try to save their own edits - there is no merging or version control. Therefore, for data integrity it is recommended that multiple sources do not modify the same object.
 
 **Write/Read consistency**
 
@@ -57,7 +57,7 @@ Examples:
 
 **Stale File Handle Errors**
 
-To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE error``` under the following circumstances:
+To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE``` error under the following circumstances:
 
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
 - **Read During Modification**: If one mount is reading a file while another mount modifies and syncs the file, the reader application will encounter this error.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -43,7 +43,7 @@ when writing large files.
 
 **Concurrency**
 
-Multiple readers can access the same or different objects from the same bucket without issue. Multiple writers can also write to different objects in the same bucket without issue. However, there is no concurrency control for multiple writers to the same file. When multiple writers try to replace a file from the same machine, the last write wins and all previous writes are lost without any user notification of the overwrite. However, in case of different machines the flush from first machine wins and the other machines that had the file open before the first machine synced its changes will get a ```syscall.ESTALE``` error when they try to save their own edits - there is no merging or version control. Therefore, for data integrity it is recommended that multiple sources do not modify the same object.
+Multiple readers can access the same or different objects from the same bucket without issue. Multiple writers can also write to different objects in the same bucket without issue. However, there is no concurrency control for multiple writers to the same file. When multiple writers try to replace a file from the same machine, the last write wins and all previous writes are lost without any user notification of the overwrite. However, in case of different machines the flush from first machine wins and the other machines that had the file open before the first machine synced its changes will get a ```syscall.ESTALE error``` when they try to save their own edits - there is no merging or version control. Therefore, for data integrity it is recommended that multiple sources do not modify the same object.
 
 **Write/Read consistency**
 
@@ -57,7 +57,7 @@ Examples:
 
 **Stale File Handle Errors**
 
-To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE``` error under the following circumstances:
+To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE error``` under the following circumstances:
 
 - **Concurrent Writes**: As described above, if multiple machines have the same file open for writing and one machine modifies and syncs the file, other machines with open file handles will encounter this error upon syncing or closing the file.
 - **Read During Modification**: If a machine is reading a file and another machine modifies and syncs the same file, the reader will receive this error.
@@ -429,3 +429,4 @@ Not all of the usual file system features are supported. Most prominently:
 - File and directory permissions and ownership cannot be changed. See the permissions section above.
 - Modification times are not tracked for any inodes except for files.
 - No other times besides modification time are tracked. For example, ctime and atime are not tracked (but will be set to something reasonable). Requests to change them will appear to succeed, but the results are unspecified.
+

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -59,10 +59,11 @@ Examples:
 
 To prevent data corruption and ensure consistency, Cloud Storage FUSE actively detects and handles situations that could lead to stale file handles. This results in a ```syscall.ESTALE error``` under the following circumstances:
 
-- **Concurrent Writes**: As described above, if multiple machines have the same file open for writing and one machine modifies and syncs the file, other machines with open file handles will encounter this error upon syncing or closing the file.
-- **Read During Modification**: If a machine is reading a file and another machine modifies and syncs the same file, the reader will receive this error.
-- **File Deletion or Renaming During Read**: If a machine is reading a file and the file is deleted or renamed from the same or a different machine, the reader will encounter this error.
-- **File Deletion or Renaming During Write**: If a machine is writing to a file and the file is deleted or renamed from the same or a different machine, the writer will receive this error upon syncing or closing the file.
+- **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
+- **Read During Modification**: If one mount is reading a file while another mount modifies and syncs the file, the reader application will encounter this error.
+- **File Deletion or Renaming During Read**: If a mount is reading a file and the file is deleted or renamed by the same or a different mount, the reader application will encounter this error.
+- **File Renaming During Write**: If a mount is writing to a file and the file is renamed by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file.
+- **File Deletion During Write**: If a mount is writing to a file and the file is deleted by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file. However, if the file is deleted by the same mount, the writer application will not encounter any error.
 
 These changes in Cloud Storage FUSE prioritize data integrity and provide users with clear indications of potential conflicts, preventing silent data loss and ensuring a more robust and reliable experience.
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -60,8 +60,7 @@ Examples:
 To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error when an application tries to access stale data. This can occur in the following circumstances:
 
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
-- **Read During Modification**: If one mount is reading a file while another mount modifies and syncs the file, the reader application will encounter this error.
-- **File Deletion or Renaming During Read**: If a mount is reading a file and the file is deleted or renamed by the same or a different mount, the reader application will encounter this error.
+- **Read During Modification**:  If an application is reading a file through a GCSFuse mount, and the same object is modified on GCS (by deleting, renaming, or changing its content or metadata), the GCSFuse reader will encounter this error. This is because GCSFuse detects that the file it was accessing has changed.
 - **File Renaming During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
 - **File Deletion During Write**: If a mount is writing to a file and the file is deleted by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file. However, if the file is deleted by the same mount, the writer application will not encounter any error.
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -43,7 +43,7 @@ when writing large files.
 
 **Concurrency**
 
-Multiple readers can access the same or different objects within a bucket without issue. Likewise, multiple writers modify different objects in the same bucket simultaneously without any issue. Even when multiple writers attempt to replace the same file from the same mount point, the last write wins similar to a native filesystem.
+Multiple readers can access the same or different objects within a bucket without issue. Likewise, multiple writers can modify different objects in the same bucket simultaneously without any issue. Concurrent writes to the same gcs object are supported from the same mount and behave similar to native file system.
 
 However, when different mounts try to write to the same object, the flush from first mount wins. Other mounts that have not updated their local file descriptors after the object is updated will encounter a ```syscall.ESTALE``` error when attempting to save their edits due to precondition checks. Therefore, to ensure data integrity it is strongly recommended that multiple sources do not modify the same object.
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -43,7 +43,9 @@ when writing large files.
 
 **Concurrency**
 
-Multiple readers can access the same or different objects from the same bucket without issue. Multiple writers can also write to different objects in the same bucket without issue. However, there is no concurrency control for multiple writers to the same file. When multiple writers try to replace a file from the same machine, the last write wins and all previous writes are lost without any user notification of the overwrite. However, in case of different machines the flush from first machine wins and the other machines that had the file open before the first machine synced its changes will get a ```syscall.ESTALE``` error when they try to save their own edits - there is no merging or version control. Therefore, for data integrity it is recommended that multiple sources do not modify the same object.
+Multiple readers can access the same or different objects within a bucket without issue. Likewise, multiple writers modify different objects in the same bucket simultaneously without any issue. Even when multiple writers attempt to replace the same file from the same mount point, the last write wins similar to a native filesystem.
+
+However, when different mounts try to write to the same object, the flush from first mount wins. Other mounts that have not updated their local file descriptors after the object is updated will encounter a ```syscall.ESTALE``` error when attempting to save their edits due to precondition checks. Therefore, to ensure data integrity it is strongly recommended that multiple sources do not modify the same object.
 
 **Write/Read consistency**
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -62,7 +62,7 @@ To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error w
 - **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
 - **Read During Modification**:  If an application is reading a file through a GCSFuse mount, and the same object is modified on GCS (by deleting, renaming, or changing its content or metadata), the GCSFuse reader will encounter this error. This is because GCSFuse detects that the file it was accessing has changed.
 - **File Renaming During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
-- **File Deletion During Write**: If a mount is writing to a file and the file is deleted by the same or a different mount, the writer application will encounter this error when attempting to sync or close the file. However, if the file is deleted by the same mount, the writer application will not encounter any error.
+- **File Deletion During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is deleted on Google Cloud Storage (via different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
 
 These changes in Cloud Storage FUSE prioritize data integrity and provide users with clear indications of potential conflicts, preventing silent data loss and ensuring a more robust and reliable experience.
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -45,7 +45,7 @@ when writing large files.
 
 Multiple readers can access the same or different objects within a bucket without issue. Likewise, multiple writers can modify different objects in the same bucket simultaneously without any issue. Concurrent writes to the same gcs object are supported from the same mount and behave similar to native file system.
 
-However, when different mounts try to write to the same object, the flush from first mount wins. Other mounts that have not updated their local file descriptors after the object is updated will encounter a ```syscall.ESTALE``` error when attempting to save their edits due to precondition checks. Therefore, to ensure data integrity it is strongly recommended that multiple sources do not modify the same object.
+However, when different mounts try to write to the same object, the flush from first mount wins. Other mounts that have not updated their local file descriptors after the object is modified will encounter a ```syscall.ESTALE``` error when attempting to save their edits due to precondition checks. Therefore, to ensure data is consistently written, it is strongly recommended that multiple sources do not modify the same object.
 
 **Write/Read consistency**
 

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -61,7 +61,7 @@ Examples:
 
 To ensure consistency, Cloud Storage FUSE returns a ```syscall.ESTALE``` error when an application tries to access stale data. This can occur in the following circumstances:
 
-- **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file handles will encounter this error when the writer application attempts to sync or close the file.
+- **Concurrent Writes**: When multiple mounts have the same file open for writing, and one mount modifies and syncs the file, other mounts with open file descriptors will encounter this error when attempting to sync or close the file.
 - **Read During Modification**:  If an application is reading a file through a GCSFuse mount, and the same object is modified on GCS (by deleting, renaming, or changing its content or metadata), the GCSFuse reader will encounter this error. This is because GCSFuse detects that the file it was accessing has changed.
 - **File Renaming During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is renamed on Google Cloud Storage (via same or different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.
 - **File Deletion During Write**: If an application is writing to a file through a GCSFuse mount, and the same object is deleted on Google Cloud Storage (via different GCSFuse mount or through another interface), the writer will encounter this error when syncing or closing the file.


### PR DESCRIPTION
### Description
This PR updates Semantics doc about the changes in GCSFuse behavior after Write Failure Improvements.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/305012368

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
