### PR TITLE
[Move Object] Rename benchmark e2e perf test

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -45,7 +45,6 @@ func (s *benchmarkRenameTest) TeardownB(b *testing.B) {}
 func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 	createFiles(b)
 	b.ResetTimer()
-	log.Println("N: ", b.N)
 	for i := 0; i < b.N; i++ {
 		if err := os.Rename(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), path.Join(testDirPath, fmt.Sprintf("b%d.txt", i))); err != nil {
 			b.Errorf("testing error: %v", err)

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package benchmarking
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"testing"
@@ -25,33 +26,34 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
+type benchmarkRenameTest struct{}
+
 const (
-	expectedDeleteLatency time.Duration = 675 * time.Millisecond
+	expectedRenameLatency time.Duration = 700 * time.Millisecond
 )
 
-type benchmarkDeleteTest struct{}
-
-func (s *benchmarkDeleteTest) SetupB(b *testing.B) {
+func (s *benchmarkRenameTest) SetupB(b *testing.B) {
 	testDirPath = setup.SetupTestDirectory(testDirName)
 }
 
-func (s *benchmarkDeleteTest) TeardownB(b *testing.B) {}
+func (s *benchmarkRenameTest) TeardownB(b *testing.B) {}
 
 ////////////////////////////////////////////////////////////////////////
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
+func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 	createFiles(b)
 	b.ResetTimer()
+	log.Println("N: ", b.N)
 	for i := 0; i < b.N; i++ {
-		if err := os.Remove(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))); err != nil {
+		if err := os.Rename(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), path.Join(testDirPath, fmt.Sprintf("b%d.txt", i))); err != nil {
 			b.Errorf("testing error: %v", err)
 		}
 	}
-	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
-	if averageDeleteLatency > expectedDeleteLatency {
-		b.Errorf("DeleteFile took more time (%d msec) than expected (%d msec)", averageDeleteLatency.Milliseconds(), expectedDeleteLatency.Milliseconds())
+	averageRenameLatency := time.Duration(int(b.Elapsed()) / b.N)
+	if averageRenameLatency > expectedRenameLatency {
+		b.Errorf("RenameFile took more time (%d msec) than expected (%d msec)", averageRenameLatency.Milliseconds(), expectedRenameLatency.Milliseconds())
 	}
 }
 
@@ -59,7 +61,7 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func Benchmark_Delete(b *testing.B) {
-	ts := &benchmarkDeleteTest{}
+func Benchmark_Rename(b *testing.B) {
+	ts := &benchmarkRenameTest{}
 	benchmark_setup.RunBenchmarks(b, ts)
 }

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -67,7 +67,7 @@ func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 func Benchmark_Rename(b *testing.B) {
 	ts := &benchmarkRenameTest{}
 	flagsSet := [][]string{
-		{"--stat-cache-ttl=0"}, {"--client-protocol=grpc", "--stat-cache-ttl=0"},
+		{"--stat-cache-ttl=0", "--enable-atomic-rename-object=true"}, {"--client-protocol=grpc", "--stat-cache-ttl=0", "--enable-atomic-rename-object=true"},
 	}
 
 	// Run tests.

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -16,7 +16,6 @@ package benchmarking
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"testing"

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -76,9 +76,8 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 func Benchmark_Stat(b *testing.B) {
 	ts := &benchmarkStatTest{}
 	flagsSet := [][]string{
-		{"--stat-cache-ttl=0", "--enable-atomic-rename-object=true"}, {"--client-protocol=grpc", "--stat-cache-ttl=0", "--enable-atomic-rename-object=true"},
+		{"--stat-cache-ttl=0"}, {"--client-protocol=grpc", "--stat-cache-ttl=0"},
 	}
-
 
 	// Run tests.
 	for _, flags := range flagsSet {

--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -16,6 +16,7 @@ package benchmarking
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -24,6 +25,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
@@ -36,6 +38,14 @@ var (
 	ctx           context.Context
 	testDirPath   string
 )
+
+// createFiles creates the below objects in the bucket.
+// benchmarking/a{i}.txt where i is a counter based on the benchtime value.
+func createFiles(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		operations.CreateFileOfSize(5, path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), b)
+	}
+}
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
@@ -58,8 +68,8 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 
 	flagsSet := [][]string{
-		{"--stat-cache-ttl=0"},
-		{"--client-protocol=grpc", "--stat-cache-ttl=0"},
+		{"--stat-cache-ttl=0", "--enable-atomic-rename-object=true"},
+		{"--client-protocol=grpc", "--stat-cache-ttl=0", "--enable-atomic-rename-object=true"},
 	}
 	successCode := static_mounting.RunTests(flagsSet, m)
 


### PR DESCRIPTION
### Description
- Adding rename tests in benchmarking e2e tests to validate execution time for rename operation.

### Link to the issue in case of a bug fix.
[b/388391082](https://b.corp.google.com/issues/388391082)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
