### PR TITLE
Revert "Enable OTel metrics by default (#2859)"

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -335,7 +335,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-otel", "", true, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
+	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
 
 	if err := flagSet.MarkHidden("enable-otel"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -589,7 +589,7 @@
   flag-name: "enable-otel"
   type: "bool"
   usage: "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus."
-  default: true
+  default: false
   hide-flag: true
 
 - config-path: "metrics.prometheus-port"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -805,7 +805,6 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 				StackdriverExportInterval:      0,
 				CloudMetricsExportIntervalSecs: 0,
 				PrometheusPort:                 0,
-				EnableOtel:                     true,
 			},
 		},
 		{
@@ -813,7 +812,6 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10,
-				EnableOtel:                     true,
 			},
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -882,7 +882,7 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			name: "default",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
+				EnableOtel: false,
 			},
 		},
 		{
@@ -907,21 +907,14 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "cloud-metrics-export-interval-secs-positive",
-			args: []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				CloudMetricsExportIntervalSecs: 10,
-				EnableOtel:                     true,
-			},
+			name:     "cloud-metrics-export-interval-secs-positive",
+			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},
 		},
 		{
-			name: "stackdriver-export-interval-positive",
-			args: []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				CloudMetricsExportIntervalSecs: 10 * 3600,
-				StackdriverExportInterval:      time.Duration(10) * time.Hour,
-				EnableOtel:                     true,
-			},
+			name:     "stackdriver-export-interval-positive",
+			args:     []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10 * 3600, StackdriverExportInterval: time.Duration(10) * time.Hour},
 		},
 	}
 	for _, tc := range tests {
@@ -953,7 +946,7 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 			name:    "default",
 			cfgFile: "empty.yml",
 			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
+				EnableOtel: false,
 			},
 		},
 		{
@@ -973,16 +966,12 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			cfgFile:  "metrics_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100, EnableOtel: true},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100},
 		},
 		{
-			name:    "stackdriver-export-interval-positive",
-			cfgFile: "stackdriver_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{
-				CloudMetricsExportIntervalSecs: 12 * 3600,
-				StackdriverExportInterval:      12 * time.Hour,
-				EnableOtel:                     true,
-			},
+			name:     "stackdriver-export-interval-positive",
+			cfgFile:  "stackdriver_export_interval_positive.yml",
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 12 * 3600, StackdriverExportInterval: 12 * time.Hour},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
This reverts commit 94c5ebd31c3123513ee73dcea434c8d3b66695a9.

### Description
* This is causing some of the periodic tests  to fail. These tests fetch the metrics using certain attributes that are valid only in the opencensus world. At the moment, I don't have bandwidth to check this. So, reverting it.

### Link to the issue in case of a bug fix.
b/387898221

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
