### PR TITLE
Create global max blocks semaphore only once at file system level.

### DIFF
--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestDirHandle(t *testing.T) { RunTests(t) }
@@ -105,7 +106,8 @@ func (t *DirHandleTest) createLocalFileInode(name string, id fuseops.InodeID) (i
 		contentcache.New("", &t.clock),
 		&t.clock,
 		true, // localFile
-		&cfg.Config{Write: cfg.WriteConfig{GlobalMaxBlocks: math.MaxInt64}})
+		&cfg.Config{},
+		semaphore.NewWeighted(math.MaxInt64))
 	return
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
@@ -206,7 +207,8 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		contentcache.New("", &t.clock),
 		&t.clock,
 		true, //localFile
-		&cfg.Config{Write: cfg.WriteConfig{GlobalMaxBlocks: math.MaxInt64}})
+		&cfg.Config{},
+		semaphore.NewWeighted(math.MaxInt64))
 	return
 }
 

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -16,6 +16,7 @@ package inode
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/semaphore"
 )
 
 const localFile = "local"
@@ -116,7 +118,8 @@ func (t *FileStreamingWritesTest) createInode(fileName string, fileType string) 
 		contentcache.New("", &t.clock),
 		&t.clock,
 		isLocal,
-		&cfg.Config{})
+		&cfg.Config{},
+		semaphore.NewWeighted(math.MaxInt64))
 
 	// Set buffered write config for created inode.
 	t.in.config = &cfg.Config{Write: cfg.WriteConfig{

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/semaphore"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -148,7 +149,8 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 		contentcache.New("", &t.clock),
 		&t.clock,
 		local,
-		&cfg.Config{Write: cfg.WriteConfig{GlobalMaxBlocks: math.MaxInt64}})
+		&cfg.Config{},
+		semaphore.NewWeighted(math.MaxInt64))
 
 	t.in.Lock()
 }


### PR DESCRIPTION
### Description
global max blocks semaphore limits the total number of blocks used across the files when streaming writes are enabled. This config should be created only once at file system level and re-used across files.

### Link to the issue in case of a bug fix.
b/388184725

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
