### PR TITLE
Update wrapped error while returning FileClobberedError after calling clobbered method

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -730,10 +730,10 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 		return nil, err
 	}
 	if isClobbered {
-        return nil, &gcsfuse_errors.FileClobberedError{
-            Err: fmt.Errorf("file was clobbered"),
-        }
-    }
+		return nil, &gcsfuse_errors.FileClobberedError{
+			Err: fmt.Errorf("file was clobbered"),
+		}
+	}
 	return latestGcsObj, nil
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -730,10 +730,10 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 		return nil, err
 	}
 	if isClobbered {
-		err = &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("file was clobbered"),
-		}
-	}
+        return nil, &gcsfuse_errors.FileClobberedError{
+            Err: fmt.Errorf("file was clobbered"),
+        }
+    }
 	return latestGcsObj, nil
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -727,14 +727,14 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 	// properties.
 	latestGcsObj, isClobbered, err := f.clobbered(ctx, true, true)
 	if err != nil {
-		return latestGcsObj, err
+		return nil, err
 	}
 	if isClobbered {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("file was clobbered"),
 		}
 	}
-	return latestGcsObj, err
+	return latestGcsObj, nil
 }
 
 // Sync writes out contents to GCS.  If this fails due to the generation

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -728,7 +728,7 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 	latestGcsObj, isClobbered, err := f.clobbered(ctx, true, true)
 	if isClobbered {
 		err = &gcsfuse_errors.FileClobberedError{
-			Err: err,
+			Err: fmt.Errorf("clobbered: file was clobbered"),
 		}
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -726,17 +726,14 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 	// default sets the projection to full, which fetches all the object
 	// properties.
 	latestGcsObj, isClobbered, err := f.clobbered(ctx, true, true)
+	if err != nil {
+		return latestGcsObj, err
+	}
 	if isClobbered {
-		if err == nil {
-			err = fmt.Errorf("file was clobbered")
-		} else {
-			err = fmt.Errorf("file was clobbered: %w", err)
-		}
 		err = &gcsfuse_errors.FileClobberedError{
-			Err: err,
+			Err: fmt.Errorf("file was clobbered"),
 		}
 	}
-
 	return latestGcsObj, err
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -727,8 +727,13 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 	// properties.
 	latestGcsObj, isClobbered, err := f.clobbered(ctx, true, true)
 	if isClobbered {
+		if err == nil {
+			err = fmt.Errorf("file was clobbered")
+		} else {
+			err = fmt.Errorf("file was clobbered: %w", err)
+		}
 		err = &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("clobbered: file was clobbered"),
+			Err: err,
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR updates wrapped error while returning FileClobberedError after calling clobbered method as clobbered method return err as nil if file is clobbered.

### Link to the issue in case of a bug fix.
[Bug Link](https://b.corp.google.com/issues/388693349)

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA
