### PR TITLE
Negative cache integration tests

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -161,6 +161,7 @@ TEST_DIR_PARALLEL=(
   "benchmarking"
   "mount_timeout"
   "stale_handle"
+  "negative_stat_cache"
 )
 
 # These tests never become parallel as they are changing bucket permissions.

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -120,7 +120,6 @@ func TestInfiniteKernelListCacheDeleteDirTest(t *testing.T) {
 	// Note: metadata cache is disabled to avoid cache consistency issue between
 	// gcsfuse cache and kernel cache. As gcsfuse cache might hold the entry which
 	// already became stale due to delete operation.
-	// TODO: Replace metadata-cache-ttl-secs with something better
 	flagsSet := [][]string{
 		{"--kernel-list-cache-ttl-secs=-1", "--metadata-cache-ttl-secs=0", "--metadata-cache-negative-ttl-secs=0"},
 	}

--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -57,7 +57,7 @@ func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, targetFile, "some-content", t)
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, "explicit_dir/file1.txt", "some-content", t)
 
 	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
 	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
@@ -56,8 +57,7 @@ func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	f1 := operations.CreateFile(targetFile, setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, targetFile, "some-content", t)
 
 	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
 	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package negative_stat_cache
+
+import (
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+)
+
+type disabledNegativeStatCacheTest struct {
+	flags []string
+}
+
+func (s *disabledNegativeStatCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+}
+
+func (s *disabledNegativeStatCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	// Create test directory
+	operations.CreateDirectory(targetDir, t)
+	targetFile := path.Join(targetDir, "file1.txt")
+
+	// Error should be returned as file does not exist
+	_, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	assert.NotNil(t, err)
+	// Assert the underlying error is File Not Exist
+	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
+
+	// Adding the object with same name
+	f1 := operations.CreateFile(targetFile, setup.FilePermission_0600, t)
+	operations.CloseFile(f1)
+
+	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
+	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	//Assert File is found
+	assert.NoError(t, err)
+	assert.Contains(t, f.Name(), "explicit_dir/file1.txt")
+	assert.Nil(t, f.Close())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestDisabledNegativeStatCacheTest(t *testing.T) {
+	ts := &disabledNegativeStatCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := []string{"--metadata-cache-negative-ttl-secs=0"}
+
+	// Run tests.
+	ts.flags = flagsSet
+	log.Printf("Running tests with flags: %s", ts.flags)
+	test_setup.RunTests(t, ts)
+}

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package negative_stat_cache
+
+import (
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+)
+
+type finiteNegativeStatCacheTest struct {
+	flags []string
+}
+
+func (s *finiteNegativeStatCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+}
+
+func (s *finiteNegativeStatCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *finiteNegativeStatCacheTest) TestFiniteNegativeStatCache(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	// Create test directory
+	operations.CreateDirectory(targetDir, t)
+	targetFile := path.Join(targetDir, "file1.txt")
+
+	// Error should be returned as file does not exist
+	_, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	assert.NotNil(t, err)
+	// Assert the underlying error is File Not Exist
+	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
+
+	// Adding the object with same name
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file1.txt"), "some-content", t)
+
+	// Error should be returned again, as call will not be served from GCS due to finite gcsfuse stat cache
+	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	assert.NotNil(t, err)
+	// Assert the underlying error is File Not Exist
+	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
+
+	//Wait for Cache to expire
+	time.Sleep(3 * time.Second)
+
+	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
+	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	//Assert File is found
+	assert.NoError(t, err)
+	assert.Contains(t, f.Name(), "explicit_dir/file1.txt")
+	assert.Nil(t, f.Close())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestFiniteNegativeStatCacheTest(t *testing.T) {
+	ts := &finiteNegativeStatCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := []string{"--metadata-cache-negative-ttl-secs=2"}
+
+	// Run tests.
+	ts.flags = flagsSet
+	log.Printf("Running tests with flags: %s", ts.flags)
+	test_setup.RunTests(t, ts)
+}

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -58,7 +58,7 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, targetFile, "some-content", t)
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, "explicit_dir/file1.txt", "some-content", t)
 
 	// Error should be returned again, as call will not be served from GCS due to infinite gcsfuse stat cache
 	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -1,5 +1,4 @@
-// Copyright 2025
-//Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package negative_stat_cache
+
+import (
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+)
+
+type infiniteNegativeStatCacheTest struct {
+	flags []string
+}
+
+func (s *infiniteNegativeStatCacheTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+}
+
+func (s *infiniteNegativeStatCacheTest) Teardown(t *testing.T) {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	// Create test directory
+	operations.CreateDirectory(targetDir, t)
+	targetFile := path.Join(targetDir, "file1.txt")
+
+	// Error should be returned as file does not exist
+	_, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	assert.NotNil(t, err)
+	// Assert the underlying error is File Not Exist
+	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
+
+	// Adding the object with same name
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file1.txt"), "some-content", t)
+
+	// Error should be returned again, as call will not be served from GCS due to infinite gcsfuse stat cache
+	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))
+
+	assert.NotNil(t, err)
+	// Assert the underlying error is File Not Exist
+	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestInfiniteNegativeStatCacheTest(t *testing.T) {
+	ts := &infiniteNegativeStatCacheTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := []string{"--metadata-cache-negative-ttl-secs=-1"}
+
+	// Run tests.
+	ts.flags = flagsSet
+	log.Printf("Running tests with flags: %s", ts.flags)
+	test_setup.RunTests(t, ts)
+}

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -1,4 +1,5 @@
-// Copyright 2025 Google LLC
+// Copyright 2025
+//Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file1.txt"), "some-content", t)
+	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, targetFile, "some-content", t)
 
 	// Error should be returned again, as call will not be served from GCS due to infinite gcsfuse stat cache
 	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package negative_stat_cache
+
+import (
+	"context"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName    = "NegativeStatCacheTest"
+	onlyDirMounted = "OnlyDirMountNegativeStatCache"
+)
+
+var (
+	testDirPath string
+	mountFunc   func([]string) error
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir       string
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
+	// When tests are running in GKE environment, use the mounted directory provided as test flag.
+	if setup.MountedDirectory() != "" {
+		mountDir = setup.MountedDirectory()
+	}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	setup.SetMntDir(mountDir)
+	testDirPath = setup.SetupTestDirectory(testDirName)
+}
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	// Create common storage client to be used in test.
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// If Mounted Directory flag is set, run tests for mounted directory.
+	setup.RunTestsForMountedDirectoryFlag(m)
+	// Else run tests for testBucket.
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	// Save mount and root directory variables.
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+
+	if successCode == 0 {
+		log.Println("Running dynamic mounting tests...")
+		// Save mount directory variable to have path of bucket to run tests.
+		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		successCode = m.Run()
+	}
+
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(onlyDirMounted + "/")
+		mountDir = rootDir
+		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		successCode = m.Run()
+		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+	}
+
+	// Clean up test directory created.
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -84,6 +84,7 @@ TEST_DIR_PARALLEL=(
   "benchmarking"
   "mount_timeout"
   "stale_handle"
+  "negative_stat_cache"
 )
 
 # These tests never become parallel as it is changing bucket permissions.


### PR DESCRIPTION
### Description
This PR adds e2e integration tests for negative stat cache, scenarios include:
1. Happy path - TTL set to a finite positive integer.
2. Disabled Cache - TTL set to 0
3. Infinite Cache - TTL set to -1

### Link to the issue in case of a bug fix.
b/387905752

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Done