### PR TITLE
Write Failure Improvements - Do not deviate from local file system when file is unlinked from the same mount

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -28,7 +28,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -1152,13 +1151,11 @@ func (fs *fileSystem) promoteToGenerationBacked(f *inode.FileInode) {
 func (fs *fileSystem) flushFile(
 	ctx context.Context,
 	f *inode.FileInode) error {
-	// SyncFile can be triggered for unlinked files if the fileHandle is open by
-	// same or another user. This indicates a potential file clobbering scenario:
-	// - The file was deleted (unlinked) while a handle to it was still open.
-	if f.IsLocal() && f.IsUnlinked() {
-		return &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
-		}
+	// FlushFile mirrors the behavior of native filesystems by not returning an error
+	// when syncing files that have been unlinked from the same mount. This applies
+	// to both local and synced files.
+	if f.IsUnlinked() {
+		return nil
 	}
 
 	// Flush the inode.
@@ -1185,13 +1182,11 @@ func (fs *fileSystem) flushFile(
 func (fs *fileSystem) syncFile(
 	ctx context.Context,
 	f *inode.FileInode) error {
-	// SyncFile can be triggered for unlinked files if the fileHandle is open by
-	// same or another user. This indicates a potential file clobbering scenario:
-	// - The file was deleted (unlinked) while a handle to it was still open.
-	if f.IsLocal() && f.IsUnlinked() {
-		return &gcsfuse_errors.FileClobberedError{
-			Err: fmt.Errorf("file %s was unlinked while it was still open, indicating file clobbering", f.Name().LocalName()),
-		}
+	// SyncFile mirrors the behavior of native filesystems by not returning an error
+	// when syncing files that have been unlinked from the same mount. This applies
+	// to both local and synced files.
+	if f.IsUnlinked() {
+		return nil
 	}
 
 	// Sync the inode.

--- a/internal/fs/stale_file_handle_common_test.go
+++ b/internal/fs/stale_file_handle_common_test.go
@@ -64,7 +64,7 @@ func (t *staleFileHandleCommon) TestClobberedFileSyncAndCloseThrowsStaleFileHand
 	assert.Equal(t.T(), "foobar", string(contents))
 }
 
-func (t *staleFileHandleCommon) TestDeletedFileSyncAndCloseThrowsStaleFileHandleError() {
+func (t *staleFileHandleCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowError() {
 	// Dirty the file by giving it some contents.
 	n, err := t.f1.Write([]byte("foobar"))
 	assert.NoError(t.T(), err)
@@ -79,14 +79,8 @@ func (t *staleFileHandleCommon) TestDeletedFileSyncAndCloseThrowsStaleFileHandle
 	assert.Equal(t.T(), 4, n)
 	assert.NoError(t.T(), err)
 
-	err = t.f1.Sync()
+	operations.SyncFile(t.f1, t.T())
+	operations.CloseFile(t.f1)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
-	err = t.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
-	// Make f1 nil, so that another attempt is not taken in TearDown to close the
-	// file.
-	t.f1 = nil
-	// Verify unlinked file is not present on GCS.
 	operations.ValidateObjectNotFoundErr(ctx, t.T(), bucket, "foo")
 }

--- a/tools/integration_tests/local_file/remove_dir_test.go
+++ b/tools/integration_tests/local_file/remove_dir_test.go
@@ -41,9 +41,8 @@ func TestRmDirOfDirectoryContainingGCSAndLocalFiles(t *testing.T) {
 	operations.ValidateNoFileOrDirError(t, path.Join(testDirPath, ExplicitDirName))
 	// Validate writing content to unlinked local file does not throw error.
 	operations.WriteWithoutClose(fh2, FileContents, t)
-	// Validate flush file throws error and does not create object on GCS.
-	err := fh2.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Validate flush file does not throw error and does not create object on GCS.
+	operations.CloseFileShouldNotThrowError(fh2, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile, t)
 	// Validate synced files are also deleted.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, syncedFile, t)
@@ -64,12 +63,10 @@ func TestRmDirOfDirectoryContainingOnlyLocalFiles(t *testing.T) {
 
 	// Verify rmDir operation succeeds.
 	operations.ValidateNoFileOrDirError(t, path.Join(testDirPath, ExplicitDirName))
-	// Validate that closing local files throws error and they are not present on GCS.
-	err := fh1.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Close the local files and validate they are not present on GCS.
+	operations.CloseFileShouldNotThrowError(fh1, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile1, t)
-	err = fh2.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	operations.CloseFileShouldNotThrowError(fh2, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile2, t)
 	// Validate directory is also deleted.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, ExplicitDirName, t)

--- a/tools/integration_tests/local_file/unlinked_file_test.go
+++ b/tools/integration_tests/local_file/unlinked_file_test.go
@@ -34,9 +34,8 @@ func TestStatOnUnlinkedLocalFile(t *testing.T) {
 	// Stat the local file and validate error.
 	operations.ValidateNoFileOrDirError(t, path.Join(testDirPath, FileName1))
 
-	// Validate closing local file throws error and does not create file on GCS.
-	err := fh.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Close the file and validate that file is not created on GCS.
+	operations.CloseFileShouldNotThrowError(fh, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
 }
 
@@ -61,9 +60,8 @@ func TestReadDirContainingUnlinkedLocalFiles(t *testing.T) {
 		FileName1, "", t)
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh2, testDirName,
 		FileName2, "", t)
-	// Verify closing unlinked local file throws error and does not write to GCS.
-	err := fh3.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Verify unlinked file is not written to GCS.
+	operations.CloseFileShouldNotThrowError(fh3, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName3, t)
 }
 
@@ -78,9 +76,8 @@ func TestWriteOnUnlinkedLocalFileSucceeds(t *testing.T) {
 	// Write to unlinked local file.
 	operations.WriteWithoutClose(fh, FileContents, t)
 
-	// Validate flush file throws error.
-	err := fh.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Validate flush file does not throw error.
+	operations.CloseFileShouldNotThrowError(fh, t)
 	// Validate unlinked file is not written to GCS.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
 }
@@ -95,11 +92,10 @@ func TestSyncOnUnlinkedLocalFile(t *testing.T) {
 
 	// Verify unlink operation succeeds.
 	operations.ValidateNoFileOrDirError(t, path.Join(testDirPath, FileName1))
-	// Validate sync and close operations throws error and do not write to GCS after unlink.
-	err := fh.Sync()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Validate sync operation does not write to GCS after unlink.
+	operations.SyncFile(fh, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
-	err = fh.Close()
-	operations.ValidateStaleNFSFileHandleError(t, err)
+	// Close the local file and validate it is not present on GCS.
+	operations.CloseFileShouldNotThrowError(fh, t)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
 }

--- a/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
@@ -52,7 +52,7 @@ func (s *staleFileHandleCommon) TestClobberedFileSyncAndCloseThrowsStaleFileHand
 	operations.ValidateStaleNFSFileHandleError(s.T(), err)
 }
 
-func (s *staleFileHandleCommon) TestDeletedFileSyncAndCloseThrowsStaleFileHandleError() {
+func (s *staleFileHandleCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowError() {
 	// Dirty the file by giving it some contents.
 	_, err := s.f1.WriteString(Content)
 	assert.NoError(s.T(), err)
@@ -63,9 +63,6 @@ func (s *staleFileHandleCommon) TestDeletedFileSyncAndCloseThrowsStaleFileHandle
 	// Attempt to write to file should not give any error.
 	operations.WriteWithoutClose(s.f1, Content2, s.T())
 
-	err = s.f1.Sync()
-
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
-	err = s.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.SyncFile(s.f1, s.T())
+	operations.CloseFile(s.f1)
 }

--- a/tools/integration_tests/stale_handle/stale_file_handle_local_file_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_local_file_test.go
@@ -15,18 +15,12 @@
 package stale_handle
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // //////////////////////////////////////////////////////////////////////
@@ -41,29 +35,6 @@ func (s *staleFileHandleLocalFile) SetupTest() {
 	testDirPath := setup.SetupTestDirectory(s.T().Name())
 	// Create a local file.
 	_, s.f1 = CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, s.T())
-}
-
-////////////////////////////////////////////////////////////////////////
-// Tests
-////////////////////////////////////////////////////////////////////////
-
-func (s *staleFileHandleLocalFile) TestUnlinkedDirectoryContainingSyncedAndLocalFilesCloseThrowsStaleFileHandleError() {
-	explicitDir := path.Join(setup.MntDir(), s.T().Name(), ExplicitDirName)
-	// Create explicit directory with one synced and one local file.
-	operations.CreateDirectory(explicitDir, s.T())
-	CreateObjectInGCSTestDir(ctx, storageClient, path.Join(s.T().Name(), ExplicitDirName), ExplicitFileName1, "", s.T())
-	_, f2 := CreateLocalFileInTestDir(ctx, storageClient, explicitDir, ExplicitLocalFileName1, s.T())
-	err := os.RemoveAll(explicitDir)
-	assert.NoError(s.T(), err)
-	operations.ValidateNoFileOrDirError(s.T(), explicitDir+"/")
-	operations.ValidateNoFileOrDirError(s.T(), path.Join(explicitDir, ExplicitFileName1))
-	operations.ValidateNoFileOrDirError(s.T(), path.Join(explicitDir, ExplicitLocalFileName1))
-	// Validate writing content to unlinked local file does not throw error.
-	operations.WriteWithoutClose(f2, FileContents, s.T())
-
-	err = f2.Close()
-
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
This PR fixes GCSFuse behavior for Sync and Flush of files that have been deleted from same mount.

### Link to the issue in case of a bug fix.
[Bug Link](https://buganizer.corp.google.com/issues/388998716)

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated
