### PR TITLE
Close github issues if Cx doesn't response for 2 weeks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,9 +14,9 @@ jobs:
       with:
         only-labels: "pending customer action"
         days-before-issue-stale: -1
-        days-before-issue-close: 30
+        days-before-issue-close: 14
         stale-issue-label: "pending customer action"
-        close-issue-message: "Closing this issue as we haven't received any response in 30 days. Please reopen if you are still experiencing this issue."
+        close-issue-message: "Closing this issue as we haven't received any response in 14 days. Please reopen if you are still experiencing this issue."
         days-before-pr-stale: -1
         days-before-pr-close: -1
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Reduce stale period from 30 days to 14 days for external github issue.

### Link to the issue in case of a bug fix.
b/389558445

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
