### PR TITLE
Skipping KLC test for kernel version b/w v6.9.x and v6.12.x

### DIFF
--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -36,7 +36,7 @@ func SkipTestForUnsupportedKernelVersion(t *testing.T) {
 	// TODO: b/384648943 make this part of fsTest.SetUpTestSuite() after post fs
 	// tests are fully migrated to stretchr/testify.
 	t.Helper()
-	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.\d{2}\.\d+`}
+	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.10\.\d+`, `^6\.11\.\d+`, `^6\.12\.\d+`}
 
 	kernelVersion := operations.KernelVersion(t)
 	for i := 0; i < len(UnsupportedKernelVersions); i++ {


### PR DESCRIPTION
### Description
Based on https://github.com/GoogleCloudPlatform/gcsfuse/issues/2792#issuecomment-2591559168, the bug should be fixed for kernel version 6.13.0 and onwards.

Hence, skipping the KLC test till 6.12.x.

### Link to the issue in case of a bug fix.
b/380427259

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
