### PR TITLE
Skipping Kernel List Cache E2E Test on the Unsupported Kernel Version

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -33,7 +33,7 @@ func GetKernelVersion() (string, error) {
 
 // kernelVersion is just a wrapper over GetKernelVersion. This
 // allows us to mock it in the unit test of ShouldSkipKernelListCacheTest.
-var kernelVersionForTest = func() (string, error) {
+var kernelVersionToTest = func() (string, error) {
 	return GetKernelVersion()
 }
 
@@ -43,7 +43,7 @@ var kernelVersionForTest = func() (string, error) {
 func IsKLCacheEvictionUnSupported() (bool, error) {
 	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.10\.\d+`, `^6\.11\.\d+`, `^6\.12\.\d+`}
 
-	kernelVersion, err := kernelVersionForTest()
+	kernelVersion, err := kernelVersionToTest()
 	if err != nil {
 		return false, err
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -16,8 +16,8 @@ package common
 
 import (
 	"os/exec"
-	"strings"
 	"regexp"
+	"strings"
 )
 
 // GetKernelVersion returns the kernel version.
@@ -31,7 +31,7 @@ func GetKernelVersion() (string, error) {
 	return kernelVersion, nil
 }
 
-// kernelVersion is just a wrapper over GetKernelVersion. This 
+// kernelVersion is just a wrapper over GetKernelVersion. This
 // allows us to mock it in the unit test of ShouldSkipKernelListCacheTest.
 var kernelVersionForTest = func() (string, error) {
 	return GetKernelVersion()

--- a/common/util.go
+++ b/common/util.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os/exec"
+	"strings"
+	"regexp"
+)
+
+// GetKernelVersion returns the kernel version.
+func GetKernelVersion() (string, error) {
+	cmd := exec.Command("uname", "-r")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	kernelVersion := strings.TrimSpace(string(out))
+	return kernelVersion, nil
+}
+
+// kernelVersion is just a wrapper over GetKernelVersion. This 
+// allows us to mock it in the unit test of ShouldSkipKernelListCacheTest.
+var kernelVersionForTest = func() (string, error) {
+	return GetKernelVersion()
+}
+
+// IsKLCacheEvictionUnSupported returns true if Kernel List Cache Eviction is not supported
+// for the current linux version.
+// In case of any non-nil error it returns false.
+func IsKLCacheEvictionUnSupported() (bool, error) {
+	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.10\.\d+`, `^6\.11\.\d+`, `^6\.12\.\d+`}
+
+	kernelVersion, err := kernelVersionForTest()
+	if err != nil {
+		return false, err
+	}
+
+	for i := 0; i < len(UnsupportedKernelVersions); i++ {
+		matched, err := regexp.MatchString(UnsupportedKernelVersions[i], kernelVersion)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKLCacheEvictionUnSupported(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockKernelVersion string
+		expectedSkip      bool
+	}{
+		{
+			name:              "Cloudtop Supported",
+			mockKernelVersion: "4.19.0-17-amd64",
+			expectedSkip:      false,
+		},
+		{
+			name: 			   "Cloudtop Unsupported",
+			mockKernelVersion: "6.10.11-1rodete2-amd64",
+			expectedSkip:      true,
+		},
+		{
+			name:              "GCP Linux Kernel Version, supported",
+			mockKernelVersion: "6.8.0-1020-gcp",
+			expectedSkip:      false,
+		},
+		{
+			name:              "GCP Linux Kernel Version, unsupported",
+			mockKernelVersion: "6.9.0-1020-gcp",
+			expectedSkip:      true,
+		},
+		{
+			name:              "GCP Linux Kernel Version, unsupported",
+			mockKernelVersion: "6.9.0-1020-gcp",
+			expectedSkip:      true,
+		},
+		{
+			name:              "GCP Linux Kernel Version, unsupported",
+			mockKernelVersion: "6.10.0-1020-gcp",
+			expectedSkip:      true,
+		},
+		{
+			name:              "GCP Linux Kernel Version, unsupported",
+			mockKernelVersion: "6.11.0-1020-gcp",
+			expectedSkip:      true,
+		},
+		{
+			name:              "Another Unsupported Kernel Version",
+			mockKernelVersion: "6.10.0-1-amd64",
+			expectedSkip:      true,
+		},
+		{
+			name:              "GCP Linux Kernel Version, unsupported",
+			mockKernelVersion: "6.12.0-1020-gcp",
+			expectedSkip:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalKernelVersion := kernelVersionForTest
+			kernelVersionForTest = func() (string, error) { return tc.mockKernelVersion, nil }
+			defer func() { kernelVersionForTest = originalKernelVersion }()
+
+			skip, err := IsKLCacheEvictionUnSupported()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			assert.Equal(t, tc.expectedSkip, skip)
+		})
+	}
+}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -31,7 +31,7 @@ func TestIsKLCacheEvictionUnSupported(t *testing.T) {
 			expectedSkip:      false,
 		},
 		{
-			name: 			   "Cloudtop Unsupported",
+			name:              "Cloudtop Unsupported",
 			mockKernelVersion: "6.10.11-1rodete2-amd64",
 			expectedSkip:      true,
 		},

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsKLCacheEvictionUnSupported(t *testing.T) {
@@ -26,62 +27,55 @@ func TestIsKLCacheEvictionUnSupported(t *testing.T) {
 		expectedSkip      bool
 	}{
 		{
-			name:              "Cloudtop Supported",
+			name:              "Cloudtop_Supported",
 			mockKernelVersion: "4.19.0-17-amd64",
 			expectedSkip:      false,
 		},
 		{
-			name:              "Cloudtop Unsupported",
+			name:              "Cloudtop_Unsupported",
 			mockKernelVersion: "6.10.11-1rodete2-amd64",
 			expectedSkip:      true,
 		},
 		{
-			name:              "GCP Linux Kernel Version, supported",
+			name:              "GCP_Supported",
 			mockKernelVersion: "6.8.0-1020-gcp",
 			expectedSkip:      false,
 		},
 		{
-			name:              "GCP Linux Kernel Version, unsupported",
+			name:              "GCP_Unsupported_6.9.x",
 			mockKernelVersion: "6.9.0-1020-gcp",
 			expectedSkip:      true,
 		},
 		{
-			name:              "GCP Linux Kernel Version, unsupported",
-			mockKernelVersion: "6.9.0-1020-gcp",
-			expectedSkip:      true,
-		},
-		{
-			name:              "GCP Linux Kernel Version, unsupported",
+			name:              "GCP_Unsupported_6.10.x",
 			mockKernelVersion: "6.10.0-1020-gcp",
 			expectedSkip:      true,
 		},
 		{
-			name:              "GCP Linux Kernel Version, unsupported",
+			name:              "GCP_Unsupported_6.11.x",
 			mockKernelVersion: "6.11.0-1020-gcp",
 			expectedSkip:      true,
 		},
 		{
-			name:              "Another Unsupported Kernel Version",
-			mockKernelVersion: "6.10.0-1-amd64",
+			name:              "GCP_Unsupported_6.12.x",
+			mockKernelVersion: "6.12.0-1020-gcp",
 			expectedSkip:      true,
 		},
 		{
-			name:              "GCP Linux Kernel Version, unsupported",
-			mockKernelVersion: "6.12.0-1020-gcp",
+			name:              "Amd64_Unsupported_6.10.x",
+			mockKernelVersion: "6.10.0-1-amd64",
 			expectedSkip:      true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			originalKernelVersion := kernelVersionForTest
-			kernelVersionForTest = func() (string, error) { return tc.mockKernelVersion, nil }
-			defer func() { kernelVersionForTest = originalKernelVersion }()
+			originalKernelVersion := kernelVersionToTest
+			kernelVersionToTest = func() (string, error) { return tc.mockKernelVersion, nil }
+			defer func() { kernelVersionToTest = originalKernelVersion }()
 
 			skip, err := IsKLCacheEvictionUnSupported()
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedSkip, skip)
 		})
 	}

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -36,7 +36,7 @@ func SkipTestForUnsupportedKernelVersion(t *testing.T) {
 	// TODO: b/384648943 make this part of fsTest.SetUpTestSuite() after post fs
 	// tests are fully migrated to stretchr/testify.
 	t.Helper()
-	UnsupportedKernelVersions := []string{`^6\.9\.\d+`, `^6\.10\.\d+`, `^6\.11\.\d+`, `^6\.12\.\d+`}
+	UnsupportedKernelVersions := []string{`^6\.9\.\d+-.*`, `^6\.10\.\d+-.*`, `^6\.11\.\d+-.*`, `^6\.12\.\d+-.*`}
 
 	kernelVersion := operations.KernelVersion(t)
 	for i := 0; i < len(UnsupportedKernelVersions); i++ {

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -20,13 +20,11 @@ import (
 	"errors"
 	"os"
 	"path"
-	"regexp"
 	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -36,15 +34,10 @@ func SkipTestForUnsupportedKernelVersion(t *testing.T) {
 	// TODO: b/384648943 make this part of fsTest.SetUpTestSuite() after post fs
 	// tests are fully migrated to stretchr/testify.
 	t.Helper()
-	UnsupportedKernelVersions := []string{`^6\.9\.\d+-.*`, `^6\.10\.\d+-.*`, `^6\.11\.\d+-.*`, `^6\.12\.\d+-.*`}
-
-	kernelVersion := operations.KernelVersion(t)
-	for i := 0; i < len(UnsupportedKernelVersions); i++ {
-		matched, err := regexp.MatchString(UnsupportedKernelVersions[i], kernelVersion)
-		assert.NoError(t, err)
-		if matched {
-			t.SkipNow()
-		}
+	unsupported, err := common.IsKLCacheEvictionUnSupported()
+	assert.NoError(t, err)
+	if unsupported {
+		t.SkipNow()
 	}
 }
 

--- a/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
@@ -51,7 +51,7 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 
 func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
 	operations.SkipKLCTestForUnsupportedKernelVersion(t)
-	
+
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data

--- a/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
@@ -50,6 +50,8 @@ func (s *finiteKernelListCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_CacheMissAfterLimit(t *testing.T) {
+	operations.SkipKLCTestForUnsupportedKernelVersion(t)
+	
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -45,8 +45,6 @@ func (s *infiniteKernelListCacheDeleteDirTest) Teardown(t *testing.T) {
 }
 
 func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
-	operations.SkipKLCTestForUnsupportedKernelVersion(t)
-
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
@@ -75,8 +73,6 @@ func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDelete
 }
 
 func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
-	operations.SkipKLCTestForUnsupportedKernelVersion(t)
-
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
@@ -112,6 +108,8 @@ func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_DeleteAndList
 ////////////////////////////////////////////////////////////////////////
 
 func TestInfiniteKernelListCacheDeleteDirTest(t *testing.T) {
+	operations.SkipKLCTestForUnsupportedKernelVersion(t)
+
 	ts := &infiniteKernelListCacheDeleteDirTest{}
 
 	// Run tests for mounted directory if the flag is set.

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -45,6 +45,8 @@ func (s *infiniteKernelListCacheDeleteDirTest) Teardown(t *testing.T) {
 }
 
 func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDeleteDirectory(t *testing.T) {
+	operations.SkipKLCTestForUnsupportedKernelVersion(t)
+
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -73,6 +73,8 @@ func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDelete
 }
 
 func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_DeleteAndListDirectory(t *testing.T) {
+	operations.SkipKLCTestForUnsupportedKernelVersion(t)
+
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	operations.CreateDirectory(targetDir, t)
 	// Create test data

--- a/tools/integration_tests/util/operations/operations.go
+++ b/tools/integration_tests/util/operations/operations.go
@@ -20,11 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
-	"strings"
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // GenerateRandomData generates random data that can be used to write to a file.
@@ -88,12 +84,4 @@ func ExecuteGcloudCommand(command string) ([]byte, error) {
 	return executeToolCommand("gcloud", command)
 }
 
-func KernelVersion(t *testing.T) string {
-	t.Helper()
 
-	cmd := exec.Command("uname", "-r")
-	out, err := cmd.Output()
-	assert.NoError(t, err)
-	kernelVersion := strings.TrimSpace(string(out))
-	return kernelVersion
-}

--- a/tools/integration_tests/util/operations/operations.go
+++ b/tools/integration_tests/util/operations/operations.go
@@ -83,5 +83,3 @@ func ExecuteGcloudCommandf(format string, args ...any) ([]byte, error) {
 func ExecuteGcloudCommand(command string) ([]byte, error) {
 	return executeToolCommand("gcloud", command)
 }
-
-

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
@@ -59,4 +60,13 @@ func CheckErrorForReadOnlyFileSystem(t *testing.T, err error) {
 		return
 	}
 	t.Errorf("Incorrect error for readonly file system: %v", err.Error())
+}
+
+func SkipKLCTestForUnsupportedKernelVersion(t *testing.T) {
+	t.Helper()
+	unsupported, err := common.IsKLCacheEvictionUnSupported()
+	assert.NoError(t, err)
+	if unsupported {
+		t.SkipNow()
+	}
 }


### PR DESCRIPTION
### Description
1. Refactoring - moving the common utility b/w gcsfuse/internal and e2e tests in common package.
2. Added check to skip the e2e kernel list cache test for unsupported kernel version.

### Link to the issue in case of a bug fix.
Ref: https://github.com/GoogleCloudPlatform/gcsfuse/issues/2792

### Testing details
1. Manual - Tested manually on unsupported kernel version.
4. Unit tests - Automation
5. Integration tests - Automation
