### PR TITLE
Increasing the wait time for cache population

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -60,7 +60,7 @@ func (s *cacheFileForRangeReadTrueTest) TestRangeReadsWithCacheHit(t *testing.T)
 	// Do a random read on file and validate from gcs.
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset5000, t)
 	// Wait for the cache to propagate the updates before proceeding to get cache hit.
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 	// Read file again from zeroOffset 1000 and validate from gcs.
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset1000, t)
 


### PR DESCRIPTION
### Description
2sec for the file to download is not getting sufficient for certain vm types in cd pipeline. Doubling it.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
