### PR TITLE
Empty_gcs_file tests under streaming_writes package

### DIFF
--- a/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
@@ -1,0 +1,37 @@
+package streaming_writes
+
+import (
+	"path"
+	"testing"
+
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/suite"
+)
+
+type defaultMountEmptyGCSFile struct {
+	defaultMountCommonTest
+}
+
+func (t *defaultMountEmptyGCSFile) SetupTest() {
+	t.createEmptyGCSFile()
+}
+
+func (t *defaultMountEmptyGCSFile) SetupSubTest() {
+	t.createEmptyGCSFile()
+}
+
+func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
+	t.fileName = FileName1 + setup.GenerateRandomString(5)
+	// Create an empty file on GCS.
+	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "", t.T())
+	filePath := path.Join(testDirPath, t.fileName)
+	t.f1 = operations.OpenFile(filePath, t.T())
+}
+
+// Executes all tests that run with single streamingWrites configuration for empty GCS Files.
+func TestDefaultMountEmptyGCSFileTest(t *testing.T) {
+	suite.Run(t, new(defaultMountEmptyGCSFile))
+}

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -67,6 +67,7 @@ func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 
 	successCode = executeTestsForStaticMounting(flagsSet, m)
 
+	fmt.Println(setup.LogFile())
 	log.Printf("Test log: %s\n", setup.LogFile())
 
 	return successCode

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -476,6 +476,14 @@ func CreateFile(filePath string, filePerms os.FileMode, t testing.TB) (f *os.Fil
 	return
 }
 
+func OpenFile(filePath string, t testing.TB) (f *os.File) {
+	f, err := os.OpenFile(filePath, os.O_RDWR, FilePermission_0777)
+	if err != nil {
+		t.Fatalf("OpenFile(%s): %v", filePath, err)
+	}
+	return
+}
+
 func CreateSymLink(filePath, symlink string, t *testing.T) {
 	err := os.Symlink(filePath, symlink)
 

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -54,7 +54,8 @@ func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownl
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{"--implicit-dirs"}}
+	// TODO: remove max-blocks-per-file after the default values are set.
+	flags := [][]string{{"--enable-streaming-writes=true", "--write-max-blocks-per-file=2"}}
 
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 


### PR DESCRIPTION
### Description

- Made existing tests under streaming_writes package to run for empty_gcs_file flow
- Running write_large_file package for streaming_writes

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
