### PR TITLE
Skip monitoring tests from cd

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -142,7 +142,6 @@ git checkout $(sed -n 2p ~/details.txt) |& tee -a ~/logs.txt
 set +e
 # Test directory arrays
 TEST_DIR_PARALLEL=(
-  "monitoring"
   "local_file"
   "log_rotation"
   "mounting"

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -157,7 +157,6 @@ TEST_DIR_PARALLEL=(
   "log_content"
   "kernel_list_cache"
   "concurrent_operations"
-  "benchmarking"
   "mount_timeout"
   "stale_handle"
   "negative_stat_cache"


### PR DESCRIPTION
### Description
Monitoring tests fail with installed_package. So, skip them from cd. They are already covered by ci tests.
### Link to the issue in case of a bug fix.
b/391097316

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
