### PR TITLE
added stat calls in truncate tests for streaming writes

### DIFF
--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -15,6 +15,7 @@
 package streaming_writes
 
 import (
+	"path"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
@@ -27,15 +28,18 @@ type defaultMountLocalFile struct {
 }
 
 func (t *defaultMountLocalFile) SetupTest() {
-	t.fileName = FileName1 + setup.GenerateRandomString(5)
-	// Create a local file.
-	_, t.f1 = CreateLocalFileInTestDir(ctx, storageClient, testDirPath, t.fileName, t.T())
+	t.createLocalFile()
 }
 
 func (t *defaultMountLocalFile) SetupSubTest() {
+	t.createLocalFile()
+}
+
+func (t *defaultMountLocalFile) createLocalFile() {
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	// Create a local file.
 	_, t.f1 = CreateLocalFileInTestDir(ctx, storageClient, testDirPath, t.fileName, t.T())
+	t.filePath = path.Join(testDirPath, t.fileName)
 }
 
 // Executes all tests that run with single streamingWrites configuration for localFiles.

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -24,6 +24,8 @@ import (
 type defaultMountCommonTest struct {
 	f1       *os.File
 	fileName string
+	// filePath of the above file in the mounted directory.
+	filePath string
 	suite.Suite
 }
 

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -28,6 +28,8 @@ func (t *defaultMountCommonTest) TestTruncate() {
 
 	assert.NoError(t.T(), err)
 	data := make([]byte, truncateSize)
+	// Verify that GCSFuse is returning correct file size before the file is uploaded.
+	operations.VerifyStatFile(t.filePath, int64(truncateSize), FilePerms, t.T())
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, string(data[:]), t.T())
 }
@@ -63,12 +65,15 @@ func (t *defaultMountCommonTest) TestWriteAfterTruncate() {
 			// Perform truncate.
 			err := t.f1.Truncate(int64(truncateSize))
 			require.NoError(t.T(), err)
+			operations.VerifyStatFile(t.filePath, int64(truncateSize), FilePerms, t.T())
 
 			// Triggers writes after truncate.
 			newData := []byte("hi")
 			_, err = t.f1.WriteAt(newData, tc.offset)
 
 			require.NoError(t.T(), err)
+			// Verify that GCSFuse is returning correct file size before the file is uploaded.
+			operations.VerifyStatFile(t.filePath, tc.fileSize, FilePerms, t.T())
 			data[tc.offset] = newData[0]
 			data[tc.offset+1] = newData[1]
 			// Close the file and validate that the file is created on GCS.
@@ -79,13 +84,16 @@ func (t *defaultMountCommonTest) TestWriteAfterTruncate() {
 }
 
 func (t *defaultMountCommonTest) TestWriteAndTruncate() {
-	truncateSize := 20
+	var truncateSize int64 = 20
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.VerifyStatFile(t.filePath, int64(len(FileContents)), FilePerms, t.T())
 
-	err := t.f1.Truncate(int64(truncateSize))
+	err := t.f1.Truncate(truncateSize)
 
 	require.NoError(t.T(), err)
 	data := make([]byte, 10)
+	// Verify that GCSFuse is returning correct file size before the file is uploaded.
+	operations.VerifyStatFile(t.filePath, truncateSize, FilePerms, t.T())
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, FileContents+string(data[:]), t.T())
 }
@@ -95,11 +103,14 @@ func (t *defaultMountCommonTest) TestWriteTruncateWrite() {
 
 	// Write
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.VerifyStatFile(t.filePath, int64(len(FileContents)), FilePerms, t.T())
 	// Perform truncate
 	err := t.f1.Truncate(int64(truncateSize))
 	require.NoError(t.T(), err)
+	operations.VerifyStatFile(t.filePath, int64(truncateSize), FilePerms, t.T())
 	// Write
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.VerifyStatFile(t.filePath, int64(truncateSize), FilePerms, t.T())
 
 	data := make([]byte, 10)
 	// Close the file and validate that the file is created on GCS.
@@ -109,9 +120,11 @@ func (t *defaultMountCommonTest) TestWriteTruncateWrite() {
 func (t *defaultMountCommonTest) TestTruncateToLowerSizeAfterWrite() {
 	// Write
 	operations.WriteWithoutClose(t.f1, FileContents+FileContents, t.T())
+	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
 	// Perform truncate
 	err := t.f1.Truncate(int64(5))
 
 	// Truncating to lower size after writes are not allowed.
 	require.Error(t.T(), err)
+	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
 }


### PR DESCRIPTION
### Description
Using existing tests to verify if bwh is returning file size correctly.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
