### PR TITLE
Partially Revert "Disable tpc and emulator tests in e2e"

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -28,9 +28,9 @@ BUCKET_LOCATION=$3
 # Pass "true" to run e2e tests on TPC endpoint.
 # The default value will be false.
 RUN_TEST_ON_TPC_ENDPOINT=false
-# if [ $4 != "" ]; then
-  # RUN_TEST_ON_TPC_ENDPOINT=$4
-# fi
+if [ $4 != "" ]; then
+  RUN_TEST_ON_TPC_ENDPOINT=$4
+fi
 INTEGRATION_TEST_TIMEOUT_IN_MINS=90
 
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false


### PR DESCRIPTION
[b/391057586](https://buganizer.corp.google.com/issues/391057586) - Fix and put back TPC and emulator-tests

This partially reverts commit 9d33fa5340017208be465653ee7dc3f10442663c.

This re-enables TPC e2e tests from the code. Instead of this, we'll disable TPC e2e tests from kokoro config which is more efficient.

### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
