### PR TITLE
Handle write edge case when first write is out of order write

### DIFF
--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -166,13 +166,20 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
 			assert.True(t.T(), t.in.IsLocal())
-			createTime := t.in.mtimeClock.Now()
+			createTime := t.clock.Now()
+			t.clock.AdvanceTime(15 * time.Minute)
+			// Sequential Write at offset 0
 			err := t.in.Write(t.ctx, []byte("taco"), 0)
 			require.Nil(t.T(), err)
 			require.NotNil(t.T(), t.in.bwh)
-			assert.Equal(t.T(), int64(4), t.in.bwh.WriteFileInfo().TotalSize)
+			// validate attributes.
+			attrs, err := t.in.Attributes(t.ctx)
+			require.Nil(t.T(), err)
+			assert.WithinDuration(t.T(), attrs.Mtime, createTime, 0)
+			assert.Equal(t.T(), uint64(4), attrs.Size)
 
 			// Out of order write.
+			mtime := t.clock.Now()
 			err = t.in.Write(t.ctx, []byte("hello"), tc.offset)
 			require.Nil(t.T(), err)
 
@@ -180,10 +187,10 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			assert.Nil(t.T(), t.in.bwh)
 			assert.NotNil(t.T(), t.in.content)
 			// The inode should agree about the new mtime and size.
-			attrs, err := t.in.Attributes(t.ctx)
+			attrs, err = t.in.Attributes(t.ctx)
 			require.Nil(t.T(), err)
 			assert.Equal(t.T(), uint64(len(tc.expectedContent)), attrs.Size)
-			assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
+			assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
 			// sync file and validate content
 			gcsSynced, err := t.in.Sync(t.ctx)
 			require.Nil(t.T(), err)
@@ -194,6 +201,44 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			assert.Equal(t.T(), tc.expectedContent, string(contents))
 		})
 	}
+}
+
+func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
+	assert.True(t.T(), t.in.IsLocal())
+	createTime := t.in.mtimeClock.Now()
+	require.NotNil(t.T(), t.in.bwh)
+	// Out of order write.
+	err := t.in.Write(t.ctx, []byte("taco"), 6)
+	require.Nil(t.T(), err)
+	// Ensure bwh cleared and temp file created.
+	assert.Nil(t.T(), t.in.bwh)
+	assert.NotNil(t.T(), t.in.content)
+	// validate attributes.
+	attrs, err := t.in.Attributes(t.ctx)
+	require.Nil(t.T(), err)
+	assert.WithinDuration(t.T(), attrs.Mtime, createTime, 0)
+	assert.Equal(t.T(), uint64(10), attrs.Size)
+
+	// Ordered write.
+	mtime := t.clock.Now()
+	err = t.in.Write(t.ctx, []byte("hello"), 0)
+	require.Nil(t.T(), err)
+
+	// Ensure bwh not re-created.
+	assert.Nil(t.T(), t.in.bwh)
+	// The inode should agree about the new mtime and size.
+	attrs, err = t.in.Attributes(t.ctx)
+	require.Nil(t.T(), err)
+	assert.Equal(t.T(), uint64(len("hello\x00taco")), attrs.Size)
+	assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
+	// sync file and validate content
+	gcsSynced, err := t.in.Sync(t.ctx)
+	require.Nil(t.T(), err)
+	assert.True(t.T(), gcsSynced)
+	// Read the object's contents.
+	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), "hello\x00taco", string(contents))
 }
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesOnClobberedFileThrowsError() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1592,55 +1592,6 @@ func (t *FileTest) TestRegisterFileHandle() {
 	}
 }
 
-func (t *FileTest) TestDeRegisterFileHandle() {
-	tbl := []struct {
-		name        string
-		readonly    bool
-		currentVal  int32
-		expectedVal int32
-		isBwhNil    bool
-	}{
-		{
-			name:        "ReadOnlyHandle",
-			readonly:    true,
-			currentVal:  10,
-			expectedVal: 10,
-			isBwhNil:    false,
-		},
-		{
-			name:        "NonZeroCurrentValueForWriteHandle",
-			readonly:    false,
-			currentVal:  10,
-			expectedVal: 9,
-			isBwhNil:    false,
-		},
-		{
-			name:        "LastWriteHandleToDeregister",
-			readonly:    false,
-			currentVal:  1,
-			expectedVal: 0,
-			isBwhNil:    true,
-		},
-	}
-	for _, tc := range tbl {
-		t.Run(tc.name, func() {
-			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			t.in.writeHandleCount = tc.currentVal
-			err := t.in.ensureBufferedWriteHandler(t.ctx)
-			require.NoError(t.T(), err)
-
-			t.in.DeRegisterFileHandle(tc.readonly)
-
-			assert.Equal(t.T(), tc.expectedVal, t.in.writeHandleCount)
-			if tc.isBwhNil {
-				assert.Nil(t.T(), t.in.bwh)
-			} else {
-				assert.NotNil(t.T(), t.in.bwh)
-			}
-		})
-	}
-}
-
 func getWriteConfig() *cfg.WriteConfig {
 	return &cfg.WriteConfig{
 		MaxBlocksPerFile:      10,


### PR DESCRIPTION
### Description

Handle write edge case when first write is out of order write followed by write at offset 0.

Issue: when we get out of order write, we flush buffered write handler (to finalize whatever we have) and also set bwh to nil
First out of order write creates a source object of size 0, so even after bwh is cleared, it is recreated during the write call. Later when a write at offset 0 happens, it will go to bwh. Partial writes to bwh and temp file can cause errors.

Solution: If temp file is in use, don't re-create buffered write handler.

### Link to the internal issue
b/391545203

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
