### PR TITLE
Stopping use of timer based cleanup logic for MRD

### DIFF
--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -32,7 +32,7 @@ import (
 
 // Timeout value which determines when the MultiRangeDownloader will be closed after
 // it's refcount reaches 0.
-// TODO b/391508479 : Reset it back to an appropriate value
+// TODO (b/391508479): Reset it back to an appropriate value & rename it to multiRangeDownloaderCleanupTimeout.
 const multiRangeDownloaderTimeout = 0
 
 func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject) MultiRangeDownloaderWrapper {
@@ -117,10 +117,9 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) cleanupMultiRangeDownloader() {
 	closeMRD := func(ctx context.Context) {
 		select {
 		case <-mrdWrapper.clock.After(multiRangeDownloaderTimeout):
-			/* TODO b/391508479: Restore locks when closeMRD is called asynchronously
-			mrdWrapper.mu.Lock()
-			defer mrdWrapper.mu.Unlock()
-			*/
+			// TODO (b/391508479): Restore locks when closeMRD is called asynchronously.
+			// mrdWrapper.mu.Lock()
+			// defer mrdWrapper.mu.Unlock()
 
 			if mrdWrapper.refCount == 0 && mrdWrapper.Wrapped != nil {
 				mrdWrapper.Wrapped.Close()
@@ -132,11 +131,10 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) cleanupMultiRangeDownloader() {
 		}
 	}
 
-	/* TODO b/391508479: Start using cancelCleanup function & call closeMRD asynchronously
-	ctx, cancel := context.WithCancel(context.Background())
-	mrdWrapper.cancelCleanup = cancel
-	go closeMRD(ctx)
-	*/
+	// TODO (b/391508479): Start using cancelCleanup function & call closeMRD asynchronously.
+	// ctx, cancel := context.WithCancel(context.Background())
+	// mrdWrapper.cancelCleanup = cancel
+	// go closeMRD(ctx)
 	closeMRD(context.Background())
 }
 

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -135,7 +135,6 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) cleanupMultiRangeDownloader() {
 	ctx, cancel := context.WithCancel(context.Background())
 	mrdWrapper.cancelCleanup = cancel
 	go closeMRD(ctx)
-	closeMRD(context.Background())
 }
 
 // Ensures that MultiRangeDownloader exists, creating it if it does not exist.

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -80,14 +80,12 @@ func (t *mrdWrapperTest) Test_IncrementRefCount_CancelCleanup() {
 	err := t.mrdWrapper.DecrementRefCount()
 
 	assert.Nil(t.T(), err)
-	assert.NotNil(t.T(), t.mrdWrapper.cancelCleanup)
-	assert.NotNil(t.T(), t.mrdWrapper.Wrapped)
+	assert.Nil(t.T(), t.mrdWrapper.Wrapped)
 
 	t.mrdWrapper.IncrementRefCount()
 
 	assert.Equal(t.T(), finalRefCount, t.mrdWrapper.refCount)
 	assert.Nil(t.T(), t.mrdWrapper.cancelCleanup)
-	assert.NotNil(t.T(), t.mrdWrapper.Wrapped)
 }
 
 func (t *mrdWrapperTest) Test_DecrementRefCount_ParallelUpdates() {
@@ -115,8 +113,7 @@ func (t *mrdWrapperTest) Test_DecrementRefCount_ParallelUpdates() {
 	wg.Wait()
 
 	assert.Equal(t.T(), finalRefCount, t.mrdWrapper.GetRefCount())
-	assert.NotNil(t.T(), t.mrdWrapper.Wrapped)
-	assert.NotNil(t.T(), t.mrdWrapper.cancelCleanup)
+	assert.Nil(t.T(), t.mrdWrapper.Wrapped)
 	// Waiting for the cleanup to be done.
 	time.Sleep(t.mrdTimeout + time.Millisecond)
 	assert.Nil(t.T(), t.mrdWrapper.Wrapped)


### PR DESCRIPTION
Making changes to stop using timer based cleanup function for MRD (Created b/391508479 to track restoring it).

Making this change against b/388177094
