### PR TITLE
Fixing reader growth logic & logging errors in MRD::Read

### DIFF
--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -191,15 +191,15 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 		}()
 
 		if e != nil && e != io.EOF {
-			e = fmt.Errorf("MultiRangeDownloaderWrapper::Read: Error in Add Call: %w", e)
+			e = fmt.Errorf("Error in Add Call: %w", e)
 		}
 	})
 
 	select {
 	case <-time.After(timeout):
-		err = fmt.Errorf("MultiRangeDownloaderWrapper::Read: Timeout")
+		err = fmt.Errorf("Timeout")
 	case <-ctx.Done():
-		err = fmt.Errorf("MultiRangeDownloaderWrapper::Read: Context Cancelled: %w", ctx.Err())
+		err = fmt.Errorf("Context Cancelled: %w", ctx.Err())
 	case res := <-done:
 		bytesRead = res.bytesRead
 		err = res.err
@@ -209,6 +209,8 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 	errDesc := "OK"
 	if err != nil {
 		errDesc = err.Error()
+		err = fmt.Errorf("MultiRangeDownloaderWrapper::Read: %w", err)
+		logger.Errorf("%v", err)
 	}
 	logger.Tracef("%.13v -> MultiRangeDownloader::Add (%s, [%d, %d)) (%v): %v", requestId, mrdWrapper.object.Name, startOffset, endOffset, duration, errDesc)
 	return

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -361,7 +361,7 @@ func (rr *randomReader) ReadAt(
 		rr.cancel = nil
 		if rr.start != offset {
 			// We should only increase the seek count if we have to discard the reader when it's
-			// positioned at wrong place. Discarding it if can't serve the entire require would
+			// positioned at wrong place. Discarding it if can't serve the entire request would
 			// result in reader size not growing for random reads scenario.
 			rr.seeks++
 		}

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -359,7 +359,12 @@ func (rr *randomReader) ReadAt(
 		rr.closeReader()
 		rr.reader = nil
 		rr.cancel = nil
-		rr.seeks++
+		if rr.start != offset {
+			// We should only increase the seek count if we have to discard the reader when it's
+			// positioned at wrong place. Discarding it if can't serve the entire require would
+			// result in reader size not growing for random reads scenario.
+			rr.seeks++
+		}
 	}
 
 	if rr.reader != nil {


### PR DESCRIPTION
1. Changes to ensure reader size does not stop growing in random reads scenario.
2. Logging error in MRD::Read

b/390543202, b/391753515
