### PR TITLE
Fix crash when the file name being statted is just "\n"

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -980,8 +980,7 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 	parent inode.DirInode,
 	childName string) (child inode.Inode, err error) {
 	// First check if the requested child is a localFileInode.
-	child, err = fs.lookUpLocalFileInode(parent, childName)
-	if err != nil {
+	if child, err = fs.lookUpLocalFileInode(parent, childName); err != nil {
 		return child, err
 	}
 	if child != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1039,10 +1039,12 @@ func (fs *fileSystem) lookUpOrCreateChildInode(
 // UNLOCK_FUNCTION(fs.mu)
 // LOCK_FUNCTION(child)
 func (fs *fileSystem) lookUpLocalFileInode(parent inode.DirInode, childName string) (child inode.Inode, err error) {
-	// Trim the suffix assigned to fix conflicting names.
+	// If the path specified is "a/\n", the child would come as \n which is not a valid childname.
+	// In such cases, simply return a file-not-found.
 	if childName == inode.ConflictingFileNameSuffix {
 		return child, syscall.ENOENT
 	}
+	// Trim the suffix assigned to fix conflicting names.
 	childName = strings.TrimSuffix(childName, inode.ConflictingFileNameSuffix)
 	fileName := inode.NewFileName(parent.Name(), childName)
 

--- a/tools/integration_tests/operations/stat_file_test.go
+++ b/tools/integration_tests/operations/stat_file_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations_test
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatWithTrailingNewline(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForOperationTests)
+
+	_, err := os.Stat(testDir + "/\n")
+
+	require.Error(t, err)
+	assert.Equal(t, err.(*os.PathError).Err, syscall.ENOENT)
+}


### PR DESCRIPTION
### Description
GCSFuse crashes when a stat call is made for a path where the file name is just "\n". Instead, return an ENOENT error.

### Link to the issue in case of a bug fix.
b/391795883

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Added.
