### PR TITLE
Fix "Already Exist" error code for folder creation

### DIFF
--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -82,6 +82,8 @@ func errno(err error, preconditionErrCfg bool) error {
 		switch apiErr.GRPCStatus().Code() {
 		case codes.Canceled:
 			return syscall.EINTR
+		case codes.AlreadyExists:
+			return syscall.EEXIST
 		case codes.PermissionDenied, codes.Unauthenticated:
 			return syscall.EACCES
 		case codes.NotFound:

--- a/internal/fs/wrappers/error_mapping_test.go
+++ b/internal/fs/wrappers/error_mapping_test.go
@@ -47,6 +47,15 @@ func (testSuite *ErrorMapping) TestPermissionDeniedGrpcApiError() {
 	assert.Equal(testSuite.T(), syscall.EACCES, fsErr)
 }
 
+func (testSuite *ErrorMapping) TestAlreadyExistGrpcApiError() {
+	statusErr := status.New(codes.AlreadyExists, "already exist")
+	apiError, _ := apierror.FromError(statusErr.Err())
+
+	fsErr := errno(apiError, testSuite.preconditionErrCfg)
+
+	assert.Equal(testSuite.T(), syscall.EEXIST, fsErr)
+}
+
 func (testSuite *ErrorMapping) TestNotFoundGrpcApiError() {
 	statusErr := status.New(codes.NotFound, "Not found")
 	apiError, _ := apierror.FromError(statusErr.Err())

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -67,6 +67,24 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 }
 
+func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyExistFolder(t *testing.T) {
+	targetDir := path.Join(testDirPath, "explicit_dir")
+	// Create test directory
+	operations.CreateDirectory(targetDir, t)
+	dir := path.Join(targetDir, "test_dir")
+
+	// Error should be returned as dir does not exist
+	_, err := os.Stat(dir)
+	assert.ErrorContains(t, err, "no such file or directory")
+
+	// Adding the same name folder with control client
+	client.CreateFoldersInBucket(ctx, storageControlClient, path.Join(testDirName, "explicit_dir", "test_dir"))
+
+	// Error should be returned as already exist on trying to create.
+	err = os.Mkdir(dir, setup.DirPermission_0755)
+	assert.ErrorContains(t, err, "file exists")
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -72,13 +72,15 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyE
 	// Create test directory
 	operations.CreateDirectory(targetDir, t)
 	dir := path.Join(targetDir, "test_dir")
+	dirPathOnBucket := path.Join(testDirName, "explicit_dir", "test_dir")
 
 	// Error should be returned as dir does not exist
 	_, err := os.Stat(dir)
 	assert.ErrorContains(t, err, "no such file or directory")
 
 	// Adding the same name folder with control client
-	client.CreateFoldersInBucket(ctx, storageControlClient, path.Join(testDirName, "explicit_dir", "test_dir"))
+	_, err = client.CreateFoldersInBucket(ctx, storageControlClient, dirPathOnBucket)
+	assert.NoError(t, err)
 
 	// Error should be returned as already exist on trying to create.
 	err = os.Mkdir(dir, setup.DirPermission_0755)

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -69,6 +69,10 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing
 }
 
 func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyExistFolder(t *testing.T) {
+	// CreateFolder API is only for HNS buckets and not FLAT.
+	if !setup.IsHierarchicalBucket(ctx, storageClient) {
+		t.SkipNow()
+	}
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	// Create test directory
 	operations.CreateDirectory(targetDir, t)

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -80,7 +80,7 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyE
 	assert.ErrorContains(t, err, "no such file or directory")
 
 	// Adding the same name folder with control client
-	_, err = client.CreateFoldersInBucket(ctx, storageControlClient, dirPathOnBucket)
+	_, err = client.CreateFolderInBucket(ctx, storageControlClient, dirPathOnBucket)
 	assert.NoError(t, err)
 
 	// Error should be returned as already exist on trying to create.

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"syscall"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
@@ -84,7 +85,7 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyE
 
 	// Error should be returned as already exist on trying to create.
 	err = os.Mkdir(dir, setup.DirPermission_0755)
-	assert.ErrorContains(t, err, "file exists")
+	assert.ErrorIs(t, err, syscall.EEXIST)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -69,10 +69,6 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCache(t *testing
 }
 
 func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyExistFolder(t *testing.T) {
-	// CreateFolder API is only for HNS buckets and not FLAT.
-	if !setup.IsHierarchicalBucket(ctx, storageClient) {
-		t.SkipNow()
-	}
 	targetDir := path.Join(testDirPath, "explicit_dir")
 	// Create test directory
 	operations.CreateDirectory(targetDir, t)
@@ -83,8 +79,12 @@ func (s *infiniteNegativeStatCacheTest) TestInfiniteNegativeStatCacheForAlreadyE
 	_, err := os.Stat(dir)
 	assert.ErrorContains(t, err, "no such file or directory")
 
-	// Adding the same name folder with control client
-	_, err = client.CreateFolderInBucket(ctx, storageControlClient, dirPathOnBucket)
+	// Adding the same name folder/dir.
+	if setup.IsHierarchicalBucket(ctx, storageClient) {
+		_, err = client.CreateFolderInBucket(ctx, storageControlClient, dirPathOnBucket)
+	} else {
+		err = client.CreateObjectOnGCS(ctx, storageClient, dirPathOnBucket+"/", "")
+	}
 	assert.NoError(t, err)
 
 	// Error should be returned as already exist on trying to create.

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
@@ -40,9 +41,10 @@ var (
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
-	rootDir       string
-	storageClient *storage.Client
-	ctx           context.Context
+	rootDir              string
+	storageClient        *storage.Client
+	storageControlClient *control.StorageControlClient
+	ctx                  context.Context
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -74,6 +76,13 @@ func TestMain(m *testing.M) {
 		err := closeStorageClient()
 		if err != nil {
 			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+	closeStorageControlClient := client.CreateControlClientWithCancel(&ctx, &storageControlClient)
+	defer func() {
+		err := closeStorageControlClient()
+		if err != nil {
+			log.Fatalf("closeStorageControlClient failed: %v", err)
 		}
 	}()
 

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -29,6 +29,7 @@ import (
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"google.golang.org/grpc/codes"
 )
@@ -109,7 +110,7 @@ func CreateFoldersInBucket(ctx context.Context, client *control.StorageControlCl
 	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 
 	req := &controlpb.CreateFolderRequest{
-		Parent:   fmt.Sprintf("projects/_/buckets/%v", bucket),
+		Parent:   fmt.Sprintf(storage.FullBucketPathHNS, bucket),
 		FolderId: path.Join(rootFolder, folderPath),
 	}
 	f, err := client.CreateFolder(ctx, req)

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -108,11 +108,12 @@ func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 
 func CreateFolderInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) (*controlpb.Folder, error) {
 	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
-
 	req := &controlpb.CreateFolderRequest{
 		Parent:   fmt.Sprintf(storage.FullBucketPathHNS, bucket),
 		FolderId: path.Join(rootFolder, folderPath),
 	}
+
 	f, err := client.CreateFolder(ctx, req)
+
 	return f, err
 }

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -22,12 +22,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path"
 	"strings"
 	"time"
 
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"google.golang.org/grpc/codes"
 )
 
@@ -101,4 +103,15 @@ func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 	if _, err := client.CreateManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
 		log.Fatalf("Error while creating managed folder: %v", err)
 	}
+}
+
+func CreateFoldersInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) (*controlpb.Folder, error) {
+	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+
+	req := &controlpb.CreateFolderRequest{
+		Parent:   fmt.Sprintf("projects/_/buckets/%v", bucket),
+		FolderId: path.Join(rootFolder, folderPath),
+	}
+	f, err := client.CreateFolder(ctx, req)
+	return f, err
 }

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -106,7 +106,7 @@ func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 	}
 }
 
-func CreateFoldersInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) (*controlpb.Folder, error) {
+func CreateFolderInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) (*controlpb.Folder, error) {
 	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 
 	req := &controlpb.CreateFolderRequest{


### PR DESCRIPTION
### Description
On HNS bucket, when metadata cache is enabled and folder creation results into conflict (409), we are returning input/output error. The correct error code should be EEXIST.

This issue occurred on HNS buckets because the control client was returning a different error than the HTTP/gRPC client (a Precondition error), which prevented the conversion to the correct error code.

### Link to the issue in case of a bug fix.
[b/391649826](https://buganizer.corp.google.com/issues/391649826)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
