### PR TITLE
Fixing MinObject related issues in MRDWrapper

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -160,7 +160,7 @@ func NewFileInode(
 		globalMaxWriteBlocksSem: globalMaxBlocksSem,
 	}
 	var err error
-	f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &minObj)
+	f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &f.src)
 	if err != nil {
 		logger.Errorf("NewFileInode: Error in creating MRDWrapper %v", err)
 	}
@@ -705,6 +705,7 @@ func (f *FileInode) SetMtime(
 			minObj = *minObjPtr
 		}
 		f.src = minObj
+		f.updateMRDWrapper()
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -861,7 +861,10 @@ func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
 // Updates the min object stored in MRDWrapper corresponding to the inode.
 // Should be called when minObject associated with inode is updated.
 func (f *FileInode) updateMRDWrapper() {
-	f.MRDWrapper.SetMinObject(&f.src)
+	err := f.MRDWrapper.SetMinObject(&f.src)
+	if err != nil {
+		logger.Errorf("FileInode::updateMRDWrapper Error in setting minObject %v", err)
+	}
 }
 
 // Truncate the file to the specified size.

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -629,7 +629,7 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	// bwh can return a partially synced object along with an error so updating
 	// inode state before returning error.
 	f.updateInodeStateAfterSync(obj)
-	f.updateMRDWrapper(obj)
+	f.updateMRDWrapper()
 	if err != nil {
 		return fmt.Errorf("f.bwh.Flush(): %w", err)
 	}
@@ -808,7 +808,7 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	minObj := storageutil.ConvertObjToMinObject(newObj)
 	// If we wrote out a new object, we need to update our state.
 	f.updateInodeStateAfterSync(minObj)
-	f.updateMRDWrapper(minObj)
+	f.updateMRDWrapper()
 	return
 }
 
@@ -856,10 +856,8 @@ func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
 
 // Updates the min object stored in MRDWrapper corresponding to the inode.
 // Should be called when minObject associated with inode is updated.
-func (f *FileInode) updateMRDWrapper(minObj *gcs.MinObject) {
-	if minObj != nil {
-		f.MRDWrapper.SetMinObject(minObj)
-	}
+func (f *FileInode) updateMRDWrapper() {
+	f.MRDWrapper.SetMinObject(&f.src)
 }
 
 // Truncate the file to the specified size.

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -629,6 +629,7 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	// bwh can return a partially synced object along with an error so updating
 	// inode state before returning error.
 	f.updateInodeStateAfterSync(obj)
+	f.updateMRDWrapper(obj)
 	if err != nil {
 		return fmt.Errorf("f.bwh.Flush(): %w", err)
 	}
@@ -807,6 +808,7 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	minObj := storageutil.ConvertObjToMinObject(newObj)
 	// If we wrote out a new object, we need to update our state.
 	f.updateInodeStateAfterSync(minObj)
+	f.updateMRDWrapper(minObj)
 	return
 }
 
@@ -850,6 +852,14 @@ func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
 	}
 
 	return
+}
+
+// Updates the min object stored in MRDWrapper corresponding to the inode.
+// Should be called when minObject associated with inode is updated.
+func (f *FileInode) updateMRDWrapper(minObj *gcs.MinObject) {
+	if minObj != nil {
+		f.MRDWrapper.SetMinObject(minObj)
+	}
 }
 
 // Truncate the file to the specified size.

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -407,6 +407,9 @@ func (t *FileTest) TestWriteThenSync() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
@@ -489,6 +492,8 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			assert.Equal(t.T(),
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 			assert.Nil(t.T(), err)
@@ -547,6 +552,8 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 			assert.Equal(t.T(), uint64(0), m.Size)
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate the mtime.
 			mtimeInBucket, ok := m.Metadata["gcsfuse_mtime"]
 			assert.True(t.T(), ok)
@@ -620,6 +627,9 @@ func (t *FileTest) TestAppendThenSync() {
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
 
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
@@ -675,6 +685,9 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
+
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -741,6 +754,9 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
+
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -1031,6 +1047,9 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 				err = t.in.Flush(t.ctx)
 			}
 
+			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+
 			// Check if the error is a FileClobberedError
 			var fcErr *gcsfuse_errors.FileClobberedError
 			assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
@@ -1154,6 +1173,9 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	// Now the object in the bucket should have the appropriate mtime.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
+
+	// Validate MinObject in MRDWrapper is same as the MinObject in inode.
+	assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), m)

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -42,6 +42,8 @@ func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinO
 	if object == nil {
 		return MultiRangeDownloaderWrapper{}, fmt.Errorf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
 	}
+	// In case of a local inode, MRDWrapper would be created with an empty minObject (i.e. with a minObject without any information)
+	// and when the object is actually created, MRDWrapper would be updated using SetMinObject method.
 	return MultiRangeDownloaderWrapper{
 		clock:  clock,
 		bucket: bucket,
@@ -80,6 +82,10 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) SetMinObject(minObj *gcs.MinObjec
 	}
 	mrdWrapper.object = minObj
 	return nil
+}
+
+func (mrdWrapper *MultiRangeDownloaderWrapper) GetMinObject() *gcs.MinObject {
+	return mrdWrapper.object
 }
 
 // Returns current refcount.

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -84,6 +84,7 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) SetMinObject(minObj *gcs.MinObjec
 	return nil
 }
 
+// Returns the minObject stored in MultiRangeDownloaderWrapper. Used only for unit testing.
 func (mrdWrapper *MultiRangeDownloaderWrapper) GetMinObject() *gcs.MinObject {
 	return mrdWrapper.object
 }

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -40,7 +40,7 @@ func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject) Mu
 
 func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinObject, clock clock.Clock) MultiRangeDownloaderWrapper {
 	if object == nil {
-		logger.Errorf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
+		logger.Warnf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
 	}
 	return MultiRangeDownloaderWrapper{
 		clock:  clock,

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -39,6 +39,9 @@ func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject) Mu
 }
 
 func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinObject, clock clock.Clock) MultiRangeDownloaderWrapper {
+	if object == nil {
+		logger.Errorf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
+	}
 	return MultiRangeDownloaderWrapper{
 		clock:  clock,
 		bucket: bucket,
@@ -70,9 +73,11 @@ type MultiRangeDownloaderWrapper struct {
 	clock clock.Clock
 }
 
-// Sets the gcs.MinObject stored in the wrapper to passed value.
+// Sets the gcs.MinObject stored in the wrapper to passed value, only if it's non nil.
 func (mrdWrapper *MultiRangeDownloaderWrapper) SetMinObject(minObj *gcs.MinObject) {
-	mrdWrapper.object = minObj
+	if minObj != nil {
+		mrdWrapper.object = minObj
+	}
 }
 
 // Returns current refcount.

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -34,19 +34,19 @@ import (
 // it's refcount reaches 0.
 const multiRangeDownloaderTimeout = 60 * time.Second
 
-func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject) MultiRangeDownloaderWrapper {
+func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject) (MultiRangeDownloaderWrapper, error) {
 	return NewMultiRangeDownloaderWrapperWithClock(bucket, object, clock.RealClock{})
 }
 
-func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinObject, clock clock.Clock) MultiRangeDownloaderWrapper {
+func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinObject, clock clock.Clock) (MultiRangeDownloaderWrapper, error) {
 	if object == nil {
-		logger.Warnf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
+		return MultiRangeDownloaderWrapper{}, fmt.Errorf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject")
 	}
 	return MultiRangeDownloaderWrapper{
 		clock:  clock,
 		bucket: bucket,
 		object: object,
-	}
+	}, nil
 }
 
 type readResult struct {
@@ -74,10 +74,12 @@ type MultiRangeDownloaderWrapper struct {
 }
 
 // Sets the gcs.MinObject stored in the wrapper to passed value, only if it's non nil.
-func (mrdWrapper *MultiRangeDownloaderWrapper) SetMinObject(minObj *gcs.MinObject) {
-	if minObj != nil {
-		mrdWrapper.object = minObj
+func (mrdWrapper *MultiRangeDownloaderWrapper) SetMinObject(minObj *gcs.MinObject) error {
+	if minObj == nil {
+		return fmt.Errorf("MultiRangeDownloaderWrapper::SetMinObject: Missing MinObject")
 	}
+	mrdWrapper.object = minObj
+	return nil
 }
 
 // Returns current refcount.

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -16,6 +16,7 @@ package gcsx
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -158,6 +159,71 @@ func (t *mrdWrapperTest) Test_Read() {
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.end-tc.start, bytesRead)
 			assert.Equal(t.T(), t.objectData[tc.start:tc.end], buf[:bytesRead])
+		})
+	}
+}
+
+func (t *mrdWrapperTest) Test_NewMultiRangeDownloaderWrapper() {
+	testCases := []struct {
+		name   string
+		bucket gcs.Bucket
+		obj    *gcs.MinObject
+		err    error
+	}{
+		{
+			name:   "ValidParameters",
+			bucket: t.mockBucket,
+			obj:    t.object,
+			err:    nil,
+		},
+		{
+			name:   "NilMinObject",
+			bucket: t.mockBucket,
+			obj:    nil,
+			err:    fmt.Errorf("NewMultiRangeDownloaderWrapperWithClock: Missing MinObject"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			_, err := NewMultiRangeDownloaderWrapper(tc.bucket, tc.obj)
+			if tc.err == nil {
+				assert.NoError(t.T(), err)
+			} else {
+				assert.Error(t.T(), err)
+				assert.EqualError(t.T(), err, tc.err.Error())
+			}
+		})
+	}
+}
+
+func (t *mrdWrapperTest) Test_SetMinObject() {
+	testCases := []struct {
+		name string
+		obj  *gcs.MinObject
+		err  error
+	}{
+		{
+			name: "ValidMinObject",
+			obj:  t.object,
+			err:  nil,
+		},
+		{
+			name: "NilMinObject",
+			obj:  nil,
+			err:  fmt.Errorf("MultiRangeDownloaderWrapper::SetMinObject: Missing MinObject"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			err := t.mrdWrapper.SetMinObject(tc.obj)
+			if tc.err == nil {
+				assert.NoError(t.T(), err)
+			} else {
+				assert.Error(t.T(), err)
+				assert.EqualError(t.T(), err, tc.err.Error())
+			}
 		})
 	}
 }

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -45,6 +45,7 @@ func TestMRDWrapperTestSuite(t *testing.T) {
 }
 
 func (t *mrdWrapperTest) SetupTest() {
+	var err error
 	t.object = &gcs.MinObject{
 		Name:       "foo",
 		Size:       100,
@@ -54,7 +55,8 @@ func (t *mrdWrapperTest) SetupTest() {
 	// Create the bucket.
 	t.mockBucket = new(storage.TestifyMockBucket)
 	t.mrdTimeout = time.Millisecond
-	t.mrdWrapper = NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{WaitTime: t.mrdTimeout})
+	t.mrdWrapper, err = NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{WaitTime: t.mrdTimeout})
+	assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 	t.mrdWrapper.Wrapped = fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond)
 	t.mrdWrapper.refCount = 0
 }

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -259,6 +259,7 @@ func (t *mrdWrapperTest) Test_EnsureMultiRangeDownloader() {
 		t.Run(tc.name, func() {
 			t.mrdWrapper.bucket = tc.bucket
 			t.mrdWrapper.object = tc.obj
+			t.mrdWrapper.Wrapped = nil
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond))
 			err := t.mrdWrapper.ensureMultiRangeDownloader()
 			if tc.err == nil {
@@ -267,6 +268,7 @@ func (t *mrdWrapperTest) Test_EnsureMultiRangeDownloader() {
 			} else {
 				assert.Error(t.T(), err)
 				assert.EqualError(t.T(), err, tc.err.Error())
+				assert.Nil(t.T(), t.mrdWrapper.Wrapped)
 			}
 		})
 	}

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -642,7 +642,6 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.rr.wrapped.seeks = minSeeksForRandom + 1
@@ -686,7 +685,6 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadFull() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)
@@ -723,7 +721,6 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadChunk() {
 	}
 
 	for _, tc := range testCases {
-		var err error
 		t.rr.wrapped.reader = nil
 		t.object.Size = uint64(tc.dataSize)
 		testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -763,7 +760,6 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ValidateTimeout
 
 	for i, tc := range testCases {
 		t.Run(tc.name, func() {
-			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -642,12 +642,14 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
+			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.rr.wrapped.seeks = minSeeksForRandom + 1
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
@@ -684,11 +686,13 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadFull() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
+			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
@@ -719,10 +723,12 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadChunk() {
 	}
 
 	for _, tc := range testCases {
+		var err error
 		t.rr.wrapped.reader = nil
 		t.object.Size = uint64(tc.dataSize)
 		testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-		fakeMRDWrapper := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+		fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+		assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 		t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 		t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
 		t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
@@ -757,11 +763,13 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ValidateTimeout
 
 	for i, tc := range testCases {
 		t.Run(tc.name, func() {
+			var err error
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, tc.sleepTime)).Times(1)
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)


### PR DESCRIPTION
1. Ensure MRD's minObject is updated when inode's minObject is updated.

2. Ensure that we set MRD to nil if there were any errors while creating it. (We observed that NewMultiRangeDownloader returned a non nil value for MRD even in case of error)

b/391534052