### PR TITLE
Fixing the truncate test for empty GCS file in streaming writes flow

### DIFF
--- a/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
@@ -41,8 +41,8 @@ func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
 	// Create an empty file on GCS.
 	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "", t.T())
-	filePath := path.Join(testDirPath, t.fileName)
-	t.f1 = operations.OpenFile(filePath, t.T())
+	t.filePath = path.Join(testDirPath, t.fileName)
+	t.f1 = operations.OpenFile(t.filePath, t.T())
 }
 
 // Executes all tests that run with single streamingWrites configuration for empty GCS Files.


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
