### PR TITLE
Streaming writes config validation changes

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -575,13 +575,13 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("write-global-max-blocks", "", -1, "Specifies the maximum number of blocks to be used by all files for streaming writes. The value should be >= 2 or -1 (for infinite blocks).")
+	flagSet.IntP("write-global-max-blocks", "", -1, "Specifies the maximum number of blocks to be used by all files for streaming writes. The value should be >= 0 (1 block per file is not counted  towards this limit) or -1 (for infinite blocks).")
 
 	if err := flagSet.MarkHidden("write-global-max-blocks"); err != nil {
 		return err
 	}
 
-	flagSet.IntP("write-max-blocks-per-file", "", -1, "Specifies the maximum number of blocks to be used by a single file for  streaming writes. The value should be >= 2 or -1 (for infinite blocks).")
+	flagSet.IntP("write-max-blocks-per-file", "", -1, "Specifies the maximum number of blocks to be used by a single file for  streaming writes. The value should be >= 1 or -1 (for infinite blocks).")
 
 	if err := flagSet.MarkHidden("write-max-blocks-per-file"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -675,7 +675,8 @@
   type: "int"
   usage: >-
     Specifies the maximum number of blocks to be used by all files for
-    streaming writes. The value should be >= 2 or -1 (for infinite blocks).
+    streaming writes. The value should be >= 0 (1 block per file is not counted 
+    towards this limit) or -1 (for infinite blocks).
   default: -1 #TODO: revisit default value after perf testing.
   hide-flag: true
 
@@ -684,7 +685,7 @@
   type: "int"
   usage: >-
     Specifies the maximum number of blocks to be used by a single file for 
-    streaming writes. The value should be >= 2 or -1 (for infinite blocks).
+    streaming writes. The value should be >= 1 or -1 (for infinite blocks).
   default: -1 #TODO: revisit default value after perf testing.
   hide-flag: true
 

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -85,7 +85,9 @@ func resolveStreamingWriteConfig(w *WriteConfig) {
 	}
 
 	if w.MaxBlocksPerFile == -1 {
-		w.MaxBlocksPerFile = math.MaxInt64
+		// Setting a reasonable value here because if enough heap space is not
+		// available, make channel results in panic.
+		w.MaxBlocksPerFile = math.MaxInt16
 	}
 
 	if w.GlobalMaxBlocks < w.MaxBlocksPerFile {

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -332,7 +332,7 @@ func TestRationalize_WriteConfig(t *testing.T) {
 				},
 			},
 			expectedCreateEmptyFile:  false,
-			expectedMaxBlocksPerFile: math.MaxInt64,
+			expectedMaxBlocksPerFile: math.MaxInt16,
 			expectedBlockSizeMB:      10 * 1024 * 1024,
 		},
 		{

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -169,11 +169,11 @@ func isValidWriteStreamingConfig(wc *WriteConfig) error {
 	if wc.BlockSizeMb <= 0 || wc.BlockSizeMb > util.MaxMiBsInInt64 {
 		return fmt.Errorf("invalid value of write-block-size-mb; can't be less than 1 or more than %d", util.MaxMiBsInInt64)
 	}
-	if !(wc.MaxBlocksPerFile == -1 || wc.MaxBlocksPerFile >= 2) {
-		return fmt.Errorf("invalid value of write-max-blocks-per-file: %d; should be >=2 or -1 (for infinite)", wc.MaxBlocksPerFile)
+	if !(wc.MaxBlocksPerFile == -1 || wc.MaxBlocksPerFile >= 1) {
+		return fmt.Errorf("invalid value of write-max-blocks-per-file: %d; should be >=1 or -1 (for infinite)", wc.MaxBlocksPerFile)
 	}
-	if !(wc.GlobalMaxBlocks == -1 || wc.GlobalMaxBlocks >= 2) {
-		return fmt.Errorf("invalid value of write-global-max-blocks: %d; should be >=2 or -1 (for infinite)", wc.GlobalMaxBlocks)
+	if wc.GlobalMaxBlocks < -1 {
+		return fmt.Errorf("invalid value of write-global-max-blocks: %d; should be >=0 or -1 (for infinite)", wc.GlobalMaxBlocks)
 	}
 	return nil
 }

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -473,20 +473,6 @@ func Test_isValidWriteStreamingConfig_ErrorScenarios(t *testing.T) {
 			GlobalMaxBlocks:       -2,
 			MaxBlocksPerFile:      -1,
 		}},
-		{"0_global_max_blocks", WriteConfig{
-			BlockSizeMb:           10,
-			CreateEmptyFile:       false,
-			EnableStreamingWrites: true,
-			GlobalMaxBlocks:       0,
-			MaxBlocksPerFile:      -1,
-		}},
-		{"1_global_max_blocks", WriteConfig{
-			BlockSizeMb:           10,
-			CreateEmptyFile:       false,
-			EnableStreamingWrites: true,
-			GlobalMaxBlocks:       1,
-			MaxBlocksPerFile:      -1,
-		}},
 		{"-2_max_blocks_per_file", WriteConfig{
 			BlockSizeMb:           10,
 			CreateEmptyFile:       false,
@@ -500,13 +486,6 @@ func Test_isValidWriteStreamingConfig_ErrorScenarios(t *testing.T) {
 			EnableStreamingWrites: true,
 			GlobalMaxBlocks:       20,
 			MaxBlocksPerFile:      0,
-		}},
-		{"1_max_blocks_per_file", WriteConfig{
-			BlockSizeMb:           10,
-			CreateEmptyFile:       false,
-			EnableStreamingWrites: true,
-			GlobalMaxBlocks:       20,
-			MaxBlocksPerFile:      1,
 		}},
 	}
 
@@ -556,6 +535,27 @@ func Test_isValidWriteStreamingConfig_SuccessScenarios(t *testing.T) {
 			EnableStreamingWrites: true,
 			GlobalMaxBlocks:       40,
 			MaxBlocksPerFile:      20,
+		}},
+		{"0_global_max_blocks", WriteConfig{
+			BlockSizeMb:           10,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       0,
+			MaxBlocksPerFile:      -1,
+		}},
+		{"1_global_max_blocks", WriteConfig{
+			BlockSizeMb:           10,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       1,
+			MaxBlocksPerFile:      -1,
+		}},
+		{"1_max_blocks_per_file", WriteConfig{
+			BlockSizeMb:           10,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       20,
+			MaxBlocksPerFile:      1,
 		}},
 	}
 

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -302,11 +302,11 @@ func TestValidateConfigFile_InvalidConfigThrowsError(t *testing.T) {
 		},
 		{
 			name:       "small_global_max_blocks",
-			configFile: "testdata/write_config/invalid_write_config_due_to_small_global_max_blocks.yaml",
+			configFile: "testdata/write_config/invalid_write_config_due_to_invalid_global_max_blocks.yaml",
 		},
 		{
 			name:       "small_max_blocks_per_file",
-			configFile: "testdata/write_config/invalid_write_config_due_to_small_max_blocks_per_file.yaml",
+			configFile: "testdata/write_config/invalid_write_config_due_to_zero_max_blocks_per_file.yaml",
 		},
 		{
 			name:       "negative req_increase_rate",

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -194,7 +194,7 @@ func TestValidateConfigFile_WriteConfig(t *testing.T) {
 					BlockSizeMb:           64 * util.MiB,
 					EnableStreamingWrites: false,
 					GlobalMaxBlocks:       math.MaxInt64,
-					MaxBlocksPerFile:      math.MaxInt64},
+					MaxBlocksPerFile:      math.MaxInt16},
 			},
 		},
 		{

--- a/cmd/testdata/write_config/invalid_write_config_due_to_invalid_global_max_blocks.yaml
+++ b/cmd/testdata/write_config/invalid_write_config_due_to_invalid_global_max_blocks.yaml
@@ -1,6 +1,6 @@
 write:
   create-empty-file: true
   enable-streaming-writes: true
-  global-max-blocks: 20
+  global-max-blocks: -2
   block-size-mb: 10
-  max-blocks-per-file: 1
+  max-blocks-per-file: 2

--- a/cmd/testdata/write_config/invalid_write_config_due_to_zero_max_blocks_per_file.yaml
+++ b/cmd/testdata/write_config/invalid_write_config_due_to_zero_max_blocks_per_file.yaml
@@ -1,6 +1,6 @@
 write:
   create-empty-file: true
   enable-streaming-writes: true
-  global-max-blocks: 0
+  global-max-blocks: 20
   block-size-mb: 10
-  max-blocks-per-file: 2
+  max-blocks-per-file: 0

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1714,6 +1714,9 @@ func (fs *fileSystem) createLocalFile(ctx context.Context, parentID fuseops.Inod
 
 	defer func() {
 		if err != nil {
+			if child == nil {
+				return
+			}
 			// fs.mu lock is already taken
 			delete(fs.localFileInodes, child.Name())
 		}


### PR DESCRIPTION
### Description
Change global max blocks config to allow for 0 blocks.
Set a reasonable value for max blocks per file when it is set to -1.

### Link to the issue in case of a bug fix.
b/392549199

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - NA
