### PR TITLE
Finalize object for any error in buffered writes flow

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -29,9 +29,37 @@ import (
 // Note: All the write operations take inode lock in fs.go, hence we don't need any locks here
 // as we will get write operations serially.
 
-// BufferedWriteHandler is responsible for filling up the buffers with the data
+type BufferedWriteHandler interface {
+	// Write writes the given data to the buffer. It writes to an existing buffer if
+	// the capacity is available otherwise writes to a new buffer.
+	Write(data []byte, offset int64) (err error)
+
+	// Sync uploads all the pending full buffers to GCS.
+	Sync() (err error)
+
+	// Flush finalizes the upload.
+	Flush() (*gcs.MinObject, error)
+
+	// SetMtime stores the mtime with the bufferedWriteHandler.
+	SetMtime(mtime time.Time)
+
+	// Truncate allows truncating the file to a larger size.
+	Truncate(size int64) error
+
+	// WriteFileInfo returns the file info i.e, how much data has been buffered so far
+	// and the mtime.
+	WriteFileInfo() WriteFileInfo
+
+	// Destroy destroys the upload handler and then free up the buffers.
+	Destroy() error
+
+	// Unlink cancels the ongoing upload and free up the buffers.
+	Unlink()
+}
+
+// BufferedWriteHandlerImpl is responsible for filling up the buffers with the data
 // as it receives and handing over to uploadHandler which uploads to GCS.
-type BufferedWriteHandler struct {
+type BufferedWriteHandlerImpl struct {
 	current       block.Block
 	blockPool     *block.BlockPool
 	uploadHandler *UploadHandler
@@ -70,13 +98,13 @@ type CreateBWHandlerRequest struct {
 }
 
 // NewBWHandler creates the bufferedWriteHandler struct.
-func NewBWHandler(req *CreateBWHandlerRequest) (bwh *BufferedWriteHandler, err error) {
+func NewBWHandler(req *CreateBWHandlerRequest) (bwh BufferedWriteHandler, err error) {
 	bp, err := block.NewBlockPool(req.BlockSize, req.MaxBlocksPerFile, req.GlobalMaxBlocksSem)
 	if err != nil {
 		return
 	}
 
-	bwh = &BufferedWriteHandler{
+	bwh = &BufferedWriteHandlerImpl{
 		current:   nil,
 		blockPool: bp,
 		uploadHandler: newUploadHandler(&CreateUploadHandlerRequest{
@@ -95,9 +123,7 @@ func NewBWHandler(req *CreateBWHandlerRequest) (bwh *BufferedWriteHandler, err e
 	return
 }
 
-// Write writes the given data to the buffer. It writes to an existing buffer if
-// the capacity is available otherwise writes to a new buffer.
-func (wh *BufferedWriteHandler) Write(data []byte, offset int64) (err error) {
+func (wh *BufferedWriteHandlerImpl) Write(data []byte, offset int64) (err error) {
 	// Fail early if the uploadHandler has failed.
 	select {
 	case <-wh.uploadHandler.SignalUploadFailure():
@@ -123,7 +149,7 @@ func (wh *BufferedWriteHandler) Write(data []byte, offset int64) (err error) {
 	return wh.appendBuffer(data)
 }
 
-func (wh *BufferedWriteHandler) appendBuffer(data []byte) (err error) {
+func (wh *BufferedWriteHandlerImpl) appendBuffer(data []byte) (err error) {
 	dataWritten := 0
 	for dataWritten < len(data) {
 		if wh.current == nil {
@@ -156,8 +182,7 @@ func (wh *BufferedWriteHandler) appendBuffer(data []byte) (err error) {
 	return
 }
 
-// Sync uploads all the pending full buffers to GCS.
-func (wh *BufferedWriteHandler) Sync() (err error) {
+func (wh *BufferedWriteHandlerImpl) Sync() (err error) {
 	// Upload all the pending buffers and release the buffers.
 	wh.uploadHandler.AwaitBlocksUpload()
 	err = wh.blockPool.ClearFreeBlockChannel()
@@ -175,7 +200,7 @@ func (wh *BufferedWriteHandler) Sync() (err error) {
 }
 
 // Flush finalizes the upload.
-func (wh *BufferedWriteHandler) Flush() (*gcs.MinObject, error) {
+func (wh *BufferedWriteHandlerImpl) Flush() (*gcs.MinObject, error) {
 	// In case it is a truncated file, upload empty blocks as required.
 	err := wh.writeDataForTruncatedSize()
 	if err != nil {
@@ -212,12 +237,11 @@ func (wh *BufferedWriteHandler) Flush() (*gcs.MinObject, error) {
 	return obj, nil
 }
 
-// SetMtime stores the mtime with the bufferedWriteHandler.
-func (wh *BufferedWriteHandler) SetMtime(mtime time.Time) {
+func (wh *BufferedWriteHandlerImpl) SetMtime(mtime time.Time) {
 	wh.mtime = mtime
 }
 
-func (wh *BufferedWriteHandler) Truncate(size int64) error {
+func (wh *BufferedWriteHandlerImpl) Truncate(size int64) error {
 	if size < wh.totalSize {
 		return fmt.Errorf("cannot truncate to lesser size when upload is in progress")
 	}
@@ -226,22 +250,19 @@ func (wh *BufferedWriteHandler) Truncate(size int64) error {
 	return nil
 }
 
-// WriteFileInfo returns the file info i.e, how much data has been buffered so far
-// and the mtime.
-func (wh *BufferedWriteHandler) WriteFileInfo() WriteFileInfo {
+func (wh *BufferedWriteHandlerImpl) WriteFileInfo() WriteFileInfo {
 	return WriteFileInfo{
 		TotalSize: int64(math.Max(float64(wh.totalSize), float64(wh.truncatedSize))),
 		Mtime:     wh.mtime,
 	}
 }
 
-func (wh *BufferedWriteHandler) Destroy() error {
-	// Destroy the upload handler and then free up the buffers.
+func (wh *BufferedWriteHandlerImpl) Destroy() error {
 	wh.uploadHandler.Destroy()
 	return wh.blockPool.ClearFreeBlockChannel()
 }
 
-func (wh *BufferedWriteHandler) writeDataForTruncatedSize() error {
+func (wh *BufferedWriteHandlerImpl) writeDataForTruncatedSize() error {
 	// If totalSize is greater than truncatedSize, that means user has
 	// written more data than they actually truncated in the beginning.
 	if wh.totalSize >= wh.truncatedSize {
@@ -263,7 +284,7 @@ func (wh *BufferedWriteHandler) writeDataForTruncatedSize() error {
 	return nil
 }
 
-func (wh *BufferedWriteHandler) Unlink() {
+func (wh *BufferedWriteHandlerImpl) Unlink() {
 	wh.uploadHandler.CancelUpload()
 	err := wh.blockPool.ClearFreeBlockChannel()
 	if err != nil {

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -69,7 +69,7 @@ func (testSuite *BufferedWriteTest) TestWrite() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(2), fileInfo.TotalSize)
 }
@@ -79,7 +79,7 @@ func (testSuite *BufferedWriteTest) TestWriteWithEmptyBuffer() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(0), fileInfo.TotalSize)
 }
@@ -92,7 +92,7 @@ func (testSuite *BufferedWriteTest) TestWriteEqualToBlockSize() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(size), fileInfo.TotalSize)
 }
@@ -105,7 +105,7 @@ func (testSuite *BufferedWriteTest) TestWriteDataSizeGreaterThanBlockSize() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(size), fileInfo.TotalSize)
 }
@@ -120,7 +120,7 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsGreaterThanExpected
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(2), fileInfo.TotalSize)
 }
@@ -135,7 +135,7 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsLessThanExpected() 
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(5), fileInfo.TotalSize)
 }
@@ -148,7 +148,7 @@ func (testSuite *BufferedWriteTest) TestMultipleWrites() {
 	require.Nil(testSuite.T(), err)
 
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(13), fileInfo.TotalSize)
 }
@@ -157,7 +157,7 @@ func (testSuite *BufferedWriteTest) TestWriteWithSignalUploadFailureInBetween() 
 	err := testSuite.bwh.Write([]byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(5), fileInfo.TotalSize)
 
@@ -173,7 +173,7 @@ func (testSuite *BufferedWriteTest) TestWriteAtTruncatedOffset() {
 	// Truncate
 	err := testSuite.bwh.Truncate(2)
 	require.NoError(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Equal(testSuite.T(), int64(2), bwhImpl.truncatedSize)
 
 	// Write at offset = truncatedSize
@@ -188,7 +188,7 @@ func (testSuite *BufferedWriteTest) TestWriteAtTruncatedOffset() {
 func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
 	err := testSuite.bwh.Write([]byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Equal(testSuite.T(), int64(5), bwhImpl.totalSize)
 	// Truncate
 	err = testSuite.bwh.Truncate(20)
@@ -211,7 +211,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 	obj, err := testSuite.bwh.Flush()
 
 	require.NoError(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), nil, bwhImpl.current)
 	// Validate object.
 	assert.NotNil(testSuite.T(), obj)
@@ -221,7 +221,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Nil(testSuite.T(), bwhImpl.current)
 
 	obj, err := testSuite.bwh.Flush()
@@ -235,7 +235,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
 func (testSuite *BufferedWriteTest) TestFlushWithSignalUploadFailureDuringWrite() {
 	err := testSuite.bwh.Write([]byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 
 	// Close the channel to simulate failure in uploader.
 	close(bwhImpl.uploadHandler.SignalUploadFailure())
@@ -254,7 +254,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithMultiBlockWritesAndSignalUpload
 	// Upload and sync 5 blocks.
 	testSuite.TestSync5InProgressBlocks()
 	// Close the channel to simulate failure in uploader.
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	close(bwhImpl.uploadHandler.SignalUploadFailure())
 	// Write 5 more blocks.
 	for i := 0; i < 5; i++ {
@@ -285,7 +285,7 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	err = testSuite.bwh.Sync()
 
 	assert.NoError(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 }
@@ -299,7 +299,7 @@ func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
 		require.Nil(testSuite.T(), err)
 	}
 	// Close the channel to simulate failure in uploader.
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	close(bwhImpl.uploadHandler.SignalUploadFailure())
 
 	err = testSuite.bwh.Sync()
@@ -309,7 +309,7 @@ func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNonZeroTruncatedLengthForEmptyObject() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Nil(testSuite.T(), bwhImpl.current)
 	bwhImpl.truncatedSize = 10
 
@@ -322,7 +322,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonZeroTruncatedLengthForEmptyO
 func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjectSize() {
 	err := testSuite.bwh.Write([]byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.truncatedSize = 10
 
 	_, err = testSuite.bwh.Flush()
@@ -332,7 +332,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjec
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.totalSize = 10
 
 	err := testSuite.bwh.Truncate(2)
@@ -341,7 +341,7 @@ func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithSizeGreaterThanCurrentObjectSize() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.totalSize = 10
 
 	err := testSuite.bwh.Truncate(12)
@@ -351,7 +351,7 @@ func (testSuite *BufferedWriteTest) TestTruncateWithSizeGreaterThanCurrentObject
 }
 
 func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthLessThanTotalSize() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.totalSize = 10
 	bwhImpl.truncatedSize = 5
 
@@ -361,7 +361,7 @@ func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthLessThan
 }
 
 func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthGreaterThanTotalSize() {
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.totalSize = 10
 	bwhImpl.truncatedSize = 20
 
@@ -378,7 +378,7 @@ func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 	err = testSuite.bwh.Destroy()
 
 	require.Nil(testSuite.T(), err)
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
 }
@@ -386,7 +386,7 @@ func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {
 	testSuite.bwh.Unlink()
 
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Nil(testSuite.T(), bwhImpl.uploadHandler.cancelFunc)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
@@ -401,7 +401,7 @@ func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
 		require.Nil(testSuite.T(), err)
 	}
 	cancelCalled := false
-	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.uploadHandler.cancelFunc = func() { cancelCalled = true }
 
 	testSuite.bwh.Unlink()

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -32,7 +32,7 @@ import (
 const chunkTransferTimeoutSecs int64 = 10
 
 type BufferedWriteTest struct {
-	bwh *BufferedWriteHandler
+	bwh BufferedWriteHandler
 	suite.Suite
 }
 
@@ -69,7 +69,8 @@ func (testSuite *BufferedWriteTest) TestWrite() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(2), fileInfo.TotalSize)
 }
 
@@ -78,7 +79,8 @@ func (testSuite *BufferedWriteTest) TestWriteWithEmptyBuffer() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(0), fileInfo.TotalSize)
 }
 
@@ -90,7 +92,8 @@ func (testSuite *BufferedWriteTest) TestWriteEqualToBlockSize() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(size), fileInfo.TotalSize)
 }
 
@@ -102,7 +105,8 @@ func (testSuite *BufferedWriteTest) TestWriteDataSizeGreaterThanBlockSize() {
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(size), fileInfo.TotalSize)
 }
 
@@ -116,7 +120,8 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsGreaterThanExpected
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(2), fileInfo.TotalSize)
 }
 
@@ -130,7 +135,8 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsLessThanExpected() 
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(5), fileInfo.TotalSize)
 }
 
@@ -142,7 +148,8 @@ func (testSuite *BufferedWriteTest) TestMultipleWrites() {
 	require.Nil(testSuite.T(), err)
 
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(13), fileInfo.TotalSize)
 }
 
@@ -150,11 +157,12 @@ func (testSuite *BufferedWriteTest) TestWriteWithSignalUploadFailureInBetween() 
 	err := testSuite.bwh.Write([]byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(5), fileInfo.TotalSize)
 
 	// Close the channel to simulate failure in uploader.
-	close(testSuite.bwh.uploadHandler.SignalUploadFailure())
+	close(bwhImpl.uploadHandler.SignalUploadFailure())
 
 	err = testSuite.bwh.Write([]byte("hello"), 5)
 	require.Error(testSuite.T(), err)
@@ -165,32 +173,34 @@ func (testSuite *BufferedWriteTest) TestWriteAtTruncatedOffset() {
 	// Truncate
 	err := testSuite.bwh.Truncate(2)
 	require.NoError(testSuite.T(), err)
-	require.Equal(testSuite.T(), int64(2), testSuite.bwh.truncatedSize)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	require.Equal(testSuite.T(), int64(2), bwhImpl.truncatedSize)
 
 	// Write at offset = truncatedSize
 	err = testSuite.bwh.Write([]byte("hello"), 2)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
-	assert.Equal(testSuite.T(), testSuite.bwh.mtime, fileInfo.Mtime)
+	assert.Equal(testSuite.T(), bwhImpl.mtime, fileInfo.Mtime)
 	assert.Equal(testSuite.T(), int64(7), fileInfo.TotalSize)
 }
 
 func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
 	err := testSuite.bwh.Write([]byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), int64(5), testSuite.bwh.totalSize)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	require.Equal(testSuite.T(), int64(5), bwhImpl.totalSize)
 	// Truncate
 	err = testSuite.bwh.Truncate(20)
 	require.NoError(testSuite.T(), err)
-	require.Equal(testSuite.T(), int64(20), testSuite.bwh.truncatedSize)
+	require.Equal(testSuite.T(), int64(20), bwhImpl.truncatedSize)
 	require.Equal(testSuite.T(), int64(20), testSuite.bwh.WriteFileInfo().TotalSize)
 
 	// Write at offset=bwh.totalSize
 	err = testSuite.bwh.Write([]byte("abcde"), 5)
 
 	require.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), int64(10), testSuite.bwh.totalSize)
+	assert.Equal(testSuite.T(), int64(10), bwhImpl.totalSize)
 	assert.Equal(testSuite.T(), int64(20), testSuite.bwh.WriteFileInfo().TotalSize)
 }
 
@@ -201,16 +211,18 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 	obj, err := testSuite.bwh.Flush()
 
 	require.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), nil, testSuite.bwh.current)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), nil, bwhImpl.current)
 	// Validate object.
 	assert.NotNil(testSuite.T(), obj)
 	assert.Equal(testSuite.T(), uint64(2), obj.Size)
 	// Validate that all blocks have been freed up.
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
-	require.Nil(testSuite.T(), testSuite.bwh.current)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	require.Nil(testSuite.T(), bwhImpl.current)
 
 	obj, err := testSuite.bwh.Flush()
 
@@ -223,9 +235,10 @@ func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
 func (testSuite *BufferedWriteTest) TestFlushWithSignalUploadFailureDuringWrite() {
 	err := testSuite.bwh.Write([]byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
 
 	// Close the channel to simulate failure in uploader.
-	close(testSuite.bwh.uploadHandler.SignalUploadFailure())
+	close(bwhImpl.uploadHandler.SignalUploadFailure())
 
 	obj, err := testSuite.bwh.Flush()
 	require.Error(testSuite.T(), err)
@@ -241,7 +254,8 @@ func (testSuite *BufferedWriteTest) TestFlushWithMultiBlockWritesAndSignalUpload
 	// Upload and sync 5 blocks.
 	testSuite.TestSync5InProgressBlocks()
 	// Close the channel to simulate failure in uploader.
-	close(testSuite.bwh.uploadHandler.SignalUploadFailure())
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	close(bwhImpl.uploadHandler.SignalUploadFailure())
 	// Write 5 more blocks.
 	for i := 0; i < 5; i++ {
 		err := testSuite.bwh.Write(buffer, int64(blockSize*(i+5)))
@@ -271,8 +285,9 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	err = testSuite.bwh.Sync()
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
@@ -284,7 +299,8 @@ func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
 		require.Nil(testSuite.T(), err)
 	}
 	// Close the channel to simulate failure in uploader.
-	close(testSuite.bwh.uploadHandler.SignalUploadFailure())
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	close(bwhImpl.uploadHandler.SignalUploadFailure())
 
 	err = testSuite.bwh.Sync()
 
@@ -293,28 +309,31 @@ func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNonZeroTruncatedLengthForEmptyObject() {
-	require.Nil(testSuite.T(), testSuite.bwh.current)
-	testSuite.bwh.truncatedSize = 10
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	require.Nil(testSuite.T(), bwhImpl.current)
+	bwhImpl.truncatedSize = 10
 
 	_, err := testSuite.bwh.Flush()
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), testSuite.bwh.truncatedSize, testSuite.bwh.totalSize)
+	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjectSize() {
 	err := testSuite.bwh.Write([]byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
-	testSuite.bwh.truncatedSize = 10
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.truncatedSize = 10
 
 	_, err = testSuite.bwh.Flush()
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), testSuite.bwh.truncatedSize, testSuite.bwh.totalSize)
+	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {
-	testSuite.bwh.totalSize = 10
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.totalSize = 10
 
 	err := testSuite.bwh.Truncate(2)
 
@@ -322,30 +341,33 @@ func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithSizeGreaterThanCurrentObjectSize() {
-	testSuite.bwh.totalSize = 10
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.totalSize = 10
 
 	err := testSuite.bwh.Truncate(12)
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), int64(12), testSuite.bwh.truncatedSize)
+	assert.Equal(testSuite.T(), int64(12), bwhImpl.truncatedSize)
 }
 
 func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthLessThanTotalSize() {
-	testSuite.bwh.totalSize = 10
-	testSuite.bwh.truncatedSize = 5
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.totalSize = 10
+	bwhImpl.truncatedSize = 5
 
 	fileInfo := testSuite.bwh.WriteFileInfo()
 
-	assert.Equal(testSuite.T(), testSuite.bwh.totalSize, fileInfo.TotalSize)
+	assert.Equal(testSuite.T(), bwhImpl.totalSize, fileInfo.TotalSize)
 }
 
 func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthGreaterThanTotalSize() {
-	testSuite.bwh.totalSize = 10
-	testSuite.bwh.truncatedSize = 20
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.totalSize = 10
+	bwhImpl.truncatedSize = 20
 
 	fileInfo := testSuite.bwh.WriteFileInfo()
 
-	assert.Equal(testSuite.T(), testSuite.bwh.truncatedSize, fileInfo.TotalSize)
+	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, fileInfo.TotalSize)
 }
 func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 	// Try to write 4 blocks of data.
@@ -356,16 +378,18 @@ func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 	err = testSuite.bwh.Destroy()
 
 	require.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
 }
 
 func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {
 	testSuite.bwh.Unlink()
 
-	assert.Nil(testSuite.T(), testSuite.bwh.uploadHandler.cancelFunc)
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	assert.Nil(testSuite.T(), bwhImpl.uploadHandler.cancelFunc)
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 }
 
 func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
@@ -377,11 +401,12 @@ func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
 		require.Nil(testSuite.T(), err)
 	}
 	cancelCalled := false
-	testSuite.bwh.uploadHandler.cancelFunc = func() { cancelCalled = true }
+	bwhImpl := testSuite.bwh.(*BufferedWriteHandlerImpl)
+	bwhImpl.uploadHandler.cancelFunc = func() { cancelCalled = true }
 
 	testSuite.bwh.Unlink()
 
 	assert.True(testSuite.T(), cancelCalled)
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(testSuite.bwh.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -619,7 +619,7 @@ func (t *TestBufferedWriteHandler) WriteFileInfo() bufferedwrites.WriteFileInfo 
 }
 
 func (t *TestBufferedWriteHandler) Sync() (err error)      { return nil }
-func (t *TestBufferedWriteHandler) SetMtime(_ time.Time)   { return }
+func (t *TestBufferedWriteHandler) SetMtime(_ time.Time)   {}
 func (t *TestBufferedWriteHandler) Truncate(_ int64) error { return nil }
 func (t *TestBufferedWriteHandler) Destroy() error         { return nil }
 func (t *TestBufferedWriteHandler) Unlink()                {}

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -591,38 +591,38 @@ func (t *FileStreamingWritesTest) TestDeRegisterFileHandle() {
 	}
 }
 
-// TestBufferedWriteHandler is a test double for BufferedWriteHandler.
-type TestBufferedWriteHandler struct {
+// FakeBufferedWriteHandler is a test double for BufferedWriteHandler.
+type FakeBufferedWriteHandler struct {
 	WriteFunc func(data []byte, offset int64) error
 	FlushFunc func() (*gcs.MinObject, error)
 }
 
-func (t *TestBufferedWriteHandler) Write(data []byte, offset int64) error {
+func (t *FakeBufferedWriteHandler) Write(data []byte, offset int64) error {
 	if t.WriteFunc != nil {
 		return t.WriteFunc(data, offset)
 	}
 	return nil
 }
 
-func (t *TestBufferedWriteHandler) Flush() (*gcs.MinObject, error) {
+func (t *FakeBufferedWriteHandler) Flush() (*gcs.MinObject, error) {
 	if t.FlushFunc != nil {
 		return t.FlushFunc()
 	}
 	return nil, nil
 }
 
-func (t *TestBufferedWriteHandler) WriteFileInfo() bufferedwrites.WriteFileInfo {
+func (t *FakeBufferedWriteHandler) WriteFileInfo() bufferedwrites.WriteFileInfo {
 	return bufferedwrites.WriteFileInfo{
 		TotalSize: 0,
 		Mtime:     time.Time{},
 	}
 }
 
-func (t *TestBufferedWriteHandler) Sync() (err error)      { return nil }
-func (t *TestBufferedWriteHandler) SetMtime(_ time.Time)   {}
-func (t *TestBufferedWriteHandler) Truncate(_ int64) error { return nil }
-func (t *TestBufferedWriteHandler) Destroy() error         { return nil }
-func (t *TestBufferedWriteHandler) Unlink()                {}
+func (t *FakeBufferedWriteHandler) Sync() (err error)      { return nil }
+func (t *FakeBufferedWriteHandler) SetMtime(_ time.Time)   {}
+func (t *FakeBufferedWriteHandler) Truncate(_ int64) error { return nil }
+func (t *FakeBufferedWriteHandler) Destroy() error         { return nil }
+func (t *FakeBufferedWriteHandler) Unlink()                {}
 
 func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesErrorScenarios() {
 	assert.True(t.T(), t.in.IsLocal())
@@ -650,7 +650,7 @@ func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesErrorScenarios() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			t.in.bwh = &TestBufferedWriteHandler{
+			t.in.bwh = &FakeBufferedWriteHandler{
 				WriteFunc: func(data []byte, offset int64) error {
 					return tc.writeErr
 				},


### PR DESCRIPTION
### Description
We were finalizing only for upload failure and out of order writes but it makes sense to finalize the object in case of any failure.

### Link to the issue in case of a bug fix.
b/392834488

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
