### PR TITLE
Add streaming writes config to useragent

### DIFF
--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -55,8 +55,3 @@ func ListCacheTTLSecsToDuration(secs int64) time.Duration {
 func IsMetricsEnabled(c *MetricsConfig) bool {
 	return c.CloudMetricsExportIntervalSecs > 0 || c.PrometheusPort > 0
 }
-
-// AreStreamingWritesEnabled returns true if streaming writes are enabled.
-func AreStreamingWritesEnabled(c *Config) bool {
-	return c.Write.EnableStreamingWrites
-}

--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -55,3 +55,8 @@ func ListCacheTTLSecsToDuration(secs int64) time.Duration {
 func IsMetricsEnabled(c *MetricsConfig) bool {
 	return c.CloudMetricsExportIntervalSecs > 0 || c.PrometheusPort > 0
 }
+
+// AreStreamingWritesEnabled returns true if streaming writes are enabled.
+func AreStreamingWritesEnabled(c *Config) bool {
+	return c.Write.EnableStreamingWrites
+}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -113,7 +113,11 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	if cfg.IsParallelDownloadsEnabled(mountConfig) {
 		isParallelDownloadsEnabled = "1"
 	}
-	return fmt.Sprintf("%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled)
+	areStreamingWritesEnabled := "0"
+	if cfg.AreStreamingWritesEnabled(mountConfig) {
+		areStreamingWritesEnabled = "1"
+	}
+	return fmt.Sprintf("%s:%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled, areStreamingWritesEnabled)
 }
 func createStorageHandle(newConfig *cfg.Config, userAgent string) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -114,7 +114,7 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 		isParallelDownloadsEnabled = "1"
 	}
 	areStreamingWritesEnabled := "0"
-	if cfg.AreStreamingWritesEnabled(mountConfig) {
+	if mountConfig.Write.EnableStreamingWrites {
 		areStreamingWritesEnabled = "1"
 	}
 	return fmt.Sprintf("%s:%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled, areStreamingWritesEnabled)

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -69,7 +69,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 
 	mountConfig := &cfg.Config{}
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) (Cfg:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0)", common.GetVersion()))
 
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
@@ -77,7 +77,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
 	mountConfig := &cfg.Config{}
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion()))
 
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
@@ -85,7 +85,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
 func (t *MainTest) TestGetUserAgentConfigWithNoFileCache() {
 	mountConfig := &cfg.Config{}
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion()))
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
 
@@ -103,7 +103,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: 0,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache disabled where maxsize is set but cache dir is not set.",
@@ -112,7 +112,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: -1,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache enabled but random read disabled.",
@@ -122,7 +122,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: -1,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache and random read enabled.",
@@ -133,7 +133,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					CacheFileForRangeRead: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache disabled and enable parallel downloads set.",
@@ -144,7 +144,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache and parallel downloads enabled.",
@@ -155,7 +155,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache, random reads and parallel downloads enabled.",
@@ -167,7 +167,33 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:1)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:1:0)", common.GetVersion())),
+		},
+		{
+			name: "streaming_writes_enabled",
+			mountConfig: &cfg.Config{
+				CacheDir: "/cache/path",
+				FileCache: cfg.FileCacheConfig{
+					MaxSizeMb:               -1,
+					CacheFileForRangeRead:   false,
+					EnableParallelDownloads: true,
+				},
+				Write: cfg.WriteConfig{EnableStreamingWrites: true},
+			},
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:1)", common.GetVersion())),
+		},
+		{
+			name: "streaming_writes_disabled",
+			mountConfig: &cfg.Config{
+				CacheDir: "/cache/path",
+				FileCache: cfg.FileCacheConfig{
+					MaxSizeMb:               -1,
+					CacheFileForRangeRead:   true,
+					EnableParallelDownloads: false,
+				},
+				Write: cfg.WriteConfig{EnableStreamingWrites: false},
+			},
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0)", common.GetVersion())),
 		},
 	}
 
@@ -185,7 +211,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSe
 
 	mountConfig := &cfg.Config{}
 	userAgent := getUserAgent("", getConfigForUserAgent(mountConfig))
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) (Cfg:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0)", common.GetVersion()))
 
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }


### PR DESCRIPTION
### Description
To track usage of streaming writes config, added bitset for streaming writes to user agent. This is a temporary change until we find a better way to track usage.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
