### PR TITLE
fix panic due to close of already closed channel in upload_handler.go

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -86,6 +86,7 @@ type WriteFileInfo struct {
 
 var ErrOutOfOrderWrite = errors.New("outOfOrder write detected")
 var ErrUploadFailure = errors.New("error while uploading object to GCS")
+var ErrCloseAllFileHandles = "error in streaming writes, please close all file handles pointing to object: %s"
 
 type CreateBWHandlerRequest struct {
 	Object                   *gcs.Object


### PR DESCRIPTION
### Description
Fix panic due to close of already closed channel in upload_handler.go Finalize() method.
Finalize method can be called again in case of failure when writes are performed again.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
