### PR TITLE
Improving error conversion logic

### DIFF
--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -22,13 +22,13 @@ import (
 	"syscall"
 
 	"cloud.google.com/go/storage"
-	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -74,12 +74,8 @@ func errno(err error, preconditionErrCfg bool) error {
 		return syscall.EACCES
 	}
 
-	// The control client API returns an RPC error code instead of googleapi code.
-	// Currently, we only have gRPC control client APIs, so we are checking the gRPC status code.
-	// TODO: Add a check for the HTTP status code when the HTTP client is initiated for control client APIs.
-	var apiErr *apierror.APIError
-	if errors.As(err, &apiErr) {
-		switch apiErr.GRPCStatus().Code() {
+	if grpcStatus, ok := status.FromError(err); ok {
+		switch grpcStatus.Code() {
 		case codes.Canceled:
 			return syscall.EINTR
 		case codes.AlreadyExists:


### PR DESCRIPTION
gRPC returns status messages on error (https://google.aip.dev/193#error_model). So, it should be used to handle gRPC errors.

apiError is a wrapper over status & googleApi.Error. So, ideally, we should just be using apiError.Error and then check whether the underlying error was http or gRPC and then proceed (i.e. try to convert error to apiError.Err and if it succeeds, then use appropriately). But the http error that we got returned success when converted to both status as well as googleApi.Error (although with unknown code in converted status). 

Hence, we have to check for both scenarios (http & grpc). So, there is no use of using apiError. Hence, started using status directly for gRPC.

b/392000371

