### PR TITLE
Remove chunk retry timeout for buffered writes writer

### DIFF
--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -103,7 +103,8 @@ func (uh *UploadHandler) Upload(block block.Block) error {
 
 // createObjectWriter creates a GCS object writer.
 func (uh *UploadHandler) createObjectWriter() (err error) {
-	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, uh.chunkTransferTimeout)
+	// TODO: b/381479965: Dynamically set chunkTransferTimeoutSecs based on chunk size. 0 here means no timeout.
+	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, 0)
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
 	var ctx context.Context

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -298,7 +298,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 				*req.MetaGenerationPrecondition == t.uh.obj.MetaGeneration &&
 				req.ContentEncoding == t.uh.obj.ContentEncoding &&
 				req.ContentType == t.uh.obj.ContentType &&
-				req.ChunkTransferTimeoutSecs == chunkTransferTimeoutSecs
+				req.ChunkTransferTimeoutSecs == 0
 		}),
 		mock.Anything,
 		mock.Anything).Return(writer, nil)
@@ -324,7 +324,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 			return req.Name == t.uh.objectName &&
 				*req.GenerationPrecondition == 0 &&
 				req.MetaGenerationPrecondition == nil &&
-				req.ChunkTransferTimeoutSecs == chunkTransferTimeoutSecs
+				req.ChunkTransferTimeoutSecs == 0
 		}),
 		mock.Anything,
 		mock.Anything).Return(writer, nil)


### PR DESCRIPTION
### Description
This is a temporary change to set no chunk retry timeout for buffered writes writer.

### Link to the issue in case of a bug fix.
b/393112604

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
