### PR TITLE
fix re-flush for streaming writes

### DIFF
--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Note: All the write operations take inode lock in fs.go, hence we don't need
+// any locks here as we will get calls to these methods serially.
+
 package bufferedwrites
 
 import (

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -616,21 +616,17 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	obj, err := f.bwh.Flush()
-
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		return &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("f.bwh.Flush(): %w", err),
 		}
 	}
-
-	// bwh can return a partially synced object along with an error so updating
-	// inode state before returning error.
-	f.updateInodeStateAfterSync(obj)
 	if err != nil {
 		return fmt.Errorf("f.bwh.Flush(): %w", err)
 	}
 
+	f.updateInodeStateAfterSync(obj)
 	return nil
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -600,6 +600,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 
 	// Fall back to temp file for Out-Of-Order Writes.
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
+		logger.Infof("Out-of-order write detected. Falling back to temporary file on disk.")
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler()
 		if err != nil {


### PR DESCRIPTION
### Description
- A panic was happening due to close of already closed channel in upload_handler.go Finalize() method.
We should not allow finalize after the upload has failed once.
- During write, we should flush partially written object for out of order writes only. For all other cases, we will wait for file handle to send flush call to finalize the object.

### Link to the issue in case of a bug fix.
b/393120278

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
