### PR TITLE
Doing flush for pending writes on rename file 

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2053,12 +2053,12 @@ func (fs *fileSystem) Rename(
 		return fs.renameNonHierarchicalDir(ctx, oldParent, op.OldName, newParent, op.NewName)
 	}
 
-	return fs.renameFile(ctx, op, err, child, oldParent, newParent)
+	return fs.renameFile(ctx, op, child, oldParent, newParent)
 }
 
 // LOCKS_EXCLUDED(oldParent)
 // LOCKS_EXCLUDED(newParent)
-func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, err error, child *inode.Core, oldParent inode.DirInode, newParent inode.DirInode) error {
+func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, child *inode.Core, oldParent inode.DirInode, newParent inode.DirInode) error {
 	updatedMinObject, err := fs.flushBeforeRename(ctx, child)
 	if err != nil {
 		return fmt.Errorf("flushBeforeRename error :%v", err)

--- a/tools/integration_tests/local_file/rename.go
+++ b/tools/integration_tests/local_file/rename.go
@@ -41,7 +41,7 @@ func verifyRenameOperationNotSupported(err error, t *testing.T) {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *CommonLocalFileTestSuite) TestRenameOfLocalFileFails() {
+func (t *localFileTestSuite) TestRenameOfLocalFileFails() {
 	testDirPath = setup.SetupTestDirectory(testDirName)
 	// Create local file with some content.
 	_, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t.T())
@@ -89,7 +89,11 @@ func (t *CommonLocalFileTestSuite) TestRenameOfDirectoryWithLocalFileFails() {
 }
 
 func (t *CommonLocalFileTestSuite) TestRenameOfLocalFileSucceedsAfterSync() {
-	t.TestRenameOfLocalFileFails()
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create local file with some content.
+	_, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t.T())
+	WritingToLocalFileShouldNotWriteToGCS(ctx, storageClient, fh, testDirName, FileName1, t.T())
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName, FileName1, FileContents, t.T())
 
 	// Attempt to Rename synced file.
 	err := os.Rename(
@@ -100,8 +104,7 @@ func (t *CommonLocalFileTestSuite) TestRenameOfLocalFileSucceedsAfterSync() {
 	if err != nil {
 		t.T().Fatalf("os.Rename() failed on synced file: %v", err)
 	}
-	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, NewFileName,
-		FileContents+FileContents, t.T())
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, NewFileName, FileContents, t.T())
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 }
 

--- a/tools/integration_tests/streaming_writes/move_file_test.go
+++ b/tools/integration_tests/streaming_writes/move_file_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountEmptyGCSFile) TestMoveBeforeFileIsFlushed() {
+func (t *defaultMountCommonTest) TestMoveBeforeFileIsFlushed() {
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
 	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())

--- a/tools/integration_tests/streaming_writes/move_file_test.go
+++ b/tools/integration_tests/streaming_writes/move_file_test.go
@@ -1,0 +1,29 @@
+package streaming_writes
+
+import (
+	"path"
+
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/require"
+)
+
+func (t *defaultMountEmptyGCSFile) TestMoveBeforeFileIsFlushed() {
+	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
+	err := t.f1.Sync()
+	require.NoError(t.T(), err)
+
+	newFile := "newFile.txt"
+	destDirPath := path.Join(testDirPath, newFile)
+	err = operations.Move(t.filePath, destDirPath)
+
+	// Validate that move didn't throw any error.
+	require.NoError(t.T(), err)
+	// Verify the new object contents.
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, newFile, FileContents+FileContents, t.T())
+	require.NoError(t.T(), t.f1.Close())
+	// Check if old object is deleted.
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
+}

--- a/tools/integration_tests/streaming_writes/move_file_test.go
+++ b/tools/integration_tests/streaming_writes/move_file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package streaming_writes
 
 import (


### PR DESCRIPTION
### Description
Doing this only when streaming writes is enabled to be safe. Will do it later for non-streaming writes.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
