### PR TITLE
Add streaming_writes integration tests to run_tests_mounted_directory.sh

### DIFF
--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -605,3 +605,14 @@ sudo umount $MOUNT_DIR
 mount.gcsfuse $TEST_BUCKET_NAME $MOUNT_DIR -o metadata_cache_ttl_secs=0,precondition_errors=true
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/stale_handle/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
 sudo umount $MOUNT_DIR
+
+# Test package: streaming_writes
+# Run streaming_writes tests.
+gcsfuse --rename-dir-limit=3 --enable-streaming-writes=true --write-block-size-mb=1 --write-max-blocks-per-file=2 $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/streaming_writes/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR
+
+# Run write_large_files tests with streaming writes enabled.
+gcsfuse --enable-streaming-writes=true  $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/write_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME
+sudo umount $MOUNT_DIR

--- a/tools/integration_tests/streaming_writes/buffer_size_test.go
+++ b/tools/integration_tests/streaming_writes/buffer_size_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestWritesWithDifferentConfig(t *testing.T) {
+	// Do not run this test with mounted directory flag.
+	if setup.MountedDirectory() != "" {
+		t.SkipNow()
+	}
 	testCases := []struct {
 		name     string
 		flags    []string

--- a/tools/integration_tests/streaming_writes/streaming_writes_test.go
+++ b/tools/integration_tests/streaming_writes/streaming_writes_test.go
@@ -42,12 +42,6 @@ var (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	if setup.MountedDirectory() != "" {
-		// Once streaming writes are enabled by default, we can run all defaultMount tests here.
-		log.Printf("These tests will not run with mounted directory..")
-		return
-	}
-
 	// Create storage client before running tests.
 	ctx = context.Background()
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
@@ -57,6 +51,13 @@ func TestMain(m *testing.M) {
 			log.Fatalf("closeStorageClient failed: %v", err)
 		}
 	}()
+
+	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as operations tests validates content from the bucket.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		rootDir = setup.MountedDirectory()
+		setup.RunTestsForMountedDirectoryFlag(m)
+	}
 
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -54,8 +54,7 @@ func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownl
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	// TODO: remove max-blocks-per-file after the default values are set.
-	flags := [][]string{{"--enable-streaming-writes=true", "--write-max-blocks-per-file=2"}}
+	flags := [][]string{{"--enable-streaming-writes=true"}}
 
 	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 


### PR DESCRIPTION
### Description
This PR adds streaming_writes integration tests to run_tests_mounted_directory.sh.
Both the commands have been manually tested.

### Link to the issue in case of a bug fix.
b/394024245

### Testing details
1. Manual - done
2. Unit tests - NA
3. Integration tests - NA
