### PR TITLE
Enable OTel by default

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -337,7 +337,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-otel", "", false, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
+	flagSet.BoolP("enable-otel", "", true, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
 
 	if err := flagSet.MarkHidden("enable-otel"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -599,7 +599,7 @@
   flag-name: "enable-otel"
   type: "bool"
   usage: "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus."
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "metrics.prometheus-port"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -807,6 +807,7 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 				StackdriverExportInterval:      0,
 				CloudMetricsExportIntervalSecs: 0,
 				PrometheusPort:                 0,
+				EnableOtel:                     true,
 			},
 		},
 		{
@@ -814,6 +815,7 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10,
+				EnableOtel:                     true,
 			},
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -882,7 +882,7 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			name: "default",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
+				EnableOtel: true,
 			},
 		},
 		{
@@ -907,14 +907,21 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			},
 		},
 		{
-			name:     "cloud-metrics-export-interval-secs-positive",
-			args:     []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10},
+			name: "cloud-metrics-export-interval-secs-positive",
+			args: []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 10,
+				EnableOtel:                     true,
+			},
 		},
 		{
-			name:     "stackdriver-export-interval-positive",
-			args:     []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 10 * 3600, StackdriverExportInterval: time.Duration(10) * time.Hour},
+			name: "stackdriver-export-interval-positive",
+			args: []string{"gcsfuse", "--stackdriver-export-interval=10h", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 10 * 3600,
+				StackdriverExportInterval:      time.Duration(10) * time.Hour,
+				EnableOtel:                     true,
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -946,7 +953,7 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 			name:    "default",
 			cfgFile: "empty.yml",
 			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
+				EnableOtel: true,
 			},
 		},
 		{
@@ -966,12 +973,16 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			cfgFile:  "metrics_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100, EnableOtel: true},
 		},
 		{
-			name:     "stackdriver-export-interval-positive",
-			cfgFile:  "stackdriver_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 12 * 3600, StackdriverExportInterval: 12 * time.Hour},
+			name:    "stackdriver-export-interval-positive",
+			cfgFile: "stackdriver_export_interval_positive.yml",
+			expected: &cfg.MetricsConfig{
+				CloudMetricsExportIntervalSecs: 12 * 3600,
+				StackdriverExportInterval:      12 * time.Hour,
+				EnableOtel:                     true,
+			},
 		},
 	}
 	for _, tc := range tests {

--- a/perfmetrics/scripts/vm_metrics/vm_metrics.py
+++ b/perfmetrics/scripts/vm_metrics/vm_metrics.py
@@ -187,8 +187,8 @@ def _get_metric_filter(type, metric_type, instance, extra_filter):
             metric_type=metric_type, instance_name=instance)
   elif (type == 'custom'):
     metric_filter = (
-        'metric.type = "{metric_type}" AND metric.labels.opencensus_task = '
-        'ends_with("{instance_name}")').format(
+        'metric.type = "{metric_type}" AND metadata.system_labels.name = '
+        '"{instance_name}"').format(
         metric_type=metric_type, instance_name=instance)
   elif (type == 'agent'):
     # Fetch the instance ID here

--- a/perfmetrics/scripts/vm_metrics/vm_metrics_test.py
+++ b/perfmetrics/scripts/vm_metrics/vm_metrics_test.py
@@ -288,7 +288,7 @@ class TestVmmetricsTest(unittest.TestCase):
   def test_get_metric_filter_custom(self):
     metric_type = "metric_type"
     extra_filter = "extra_filter"
-    expected_metric_filter = 'metric.type = "{}" AND metric.labels.opencensus_task = ends_with("{}") AND {}'.format(metric_type, TEST_INSTANCE, extra_filter)
+    expected_metric_filter = 'metric.type = "{}" AND metadata.system_labels.name = "{}" AND {}'.format(metric_type, TEST_INSTANCE, extra_filter)
     self.assertEqual(vm_metrics._get_metric_filter('custom', metric_type, TEST_INSTANCE, extra_filter), expected_metric_filter)
 
   @patch('vm_metrics._get_instance_id')


### PR DESCRIPTION
### Description
Use OTel for metrics by default. One can override the behavior to use OpenCensus instead by setting --enable-otel flag to false.

Perf:

| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 480.23MiB/s  | 1.28MiB/s  |  67.36MiB/s  |  1.24MiB/s   |
|   PR   |  0.25MiB   | 489.49MiB/s  | 1.21MiB/s  |  68.74MiB/s  |  1.32MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3535.15MiB/s | 81.58MiB/s | 1250.43MiB/s |  82.85MiB/s  |
|   PR   | 48.828MiB  | 3428.55MiB/s | 81.17MiB/s | 1231.22MiB/s |  81.53MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 3420.17MiB/s | 30.88MiB/s | 412.77MiB/s  |  33.81MiB/s  |
|   PR   | 976.562MiB | 3489.39MiB/s | 33.64MiB/s | 482.15MiB/s  |  32.29MiB/s  |

### Link to the issue in case of a bug fix.
b/387898221

### Testing details
1. Manual - yes
2. Unit tests - NA
3. Integration tests - Already tested vi existing CI tests
