### PR TITLE
Persist logs in read_cache test

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -210,7 +210,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	}
 
 	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	defer setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
+	defer setup.UnmountGCSFuse(rootDir)
 	setup.SetMntDir(mountDir)
 
 	// Run tests on given {Bucket permission, Managed folder permission}.

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -147,7 +147,7 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 		flags = append(flags, "--key-file="+localKeyFilePath)
 	}
 	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	defer setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
+	defer setup.UnmountGCSFuse(rootDir)
 	setup.SetMntDir(mountDir)
 
 	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 	"path"
+	"strings"
 	"sync"
 	"testing"
 
@@ -51,7 +52,7 @@ func (s *cacheFileForRangeReadFalseTest) Setup(t *testing.T) {
 
 func (s *cacheFileForRangeReadFalseTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -50,6 +50,9 @@ func (s *cacheFileForRangeReadFalseTest) Setup(t *testing.T) {
 }
 
 func (s *cacheFileForRangeReadFalseTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func (s *cacheFileForRangeReadTrueTest) Setup(t *testing.T) {
 
 func (s *cacheFileForRangeReadTrueTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -47,6 +47,9 @@ func (s *cacheFileForRangeReadTrueTest) Setup(t *testing.T) {
 }
 
 func (s *cacheFileForRangeReadTrueTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -17,6 +17,7 @@ package read_cache
 import (
 	"context"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
@@ -47,7 +48,7 @@ func (s *disabledCacheTTLTest) Setup(t *testing.T) {
 
 func (s *disabledCacheTTLTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -46,6 +46,9 @@ func (s *disabledCacheTTLTest) Setup(t *testing.T) {
 }
 
 func (s *disabledCacheTTLTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -51,6 +51,9 @@ func (s *jobChunkTest) Setup(t *testing.T) {
 }
 
 func (s *jobChunkTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 	"path"
+	"strings"
 	"sync"
 	"testing"
 
@@ -52,7 +53,7 @@ func (s *jobChunkTest) Setup(t *testing.T) {
 
 func (s *jobChunkTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -45,6 +45,9 @@ func (s *localModificationTest) Setup(t *testing.T) {
 }
 
 func (s *localModificationTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -46,7 +47,7 @@ func (s *localModificationTest) Setup(t *testing.T) {
 
 func (s *localModificationTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -17,6 +17,7 @@ package read_cache
 import (
 	"context"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
@@ -48,7 +49,7 @@ func (s *rangeReadTest) Setup(t *testing.T) {
 
 func (s *rangeReadTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -47,6 +47,9 @@ func (s *rangeReadTest) Setup(t *testing.T) {
 }
 
 func (s *rangeReadTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -45,6 +45,9 @@ func (s *readOnlyTest) Setup(t *testing.T) {
 }
 
 func (s *readOnlyTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -17,6 +17,7 @@ package read_cache
 import (
 	"context"
 	"log"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -46,7 +47,7 @@ func (s *readOnlyTest) Setup(t *testing.T) {
 
 func (s *readOnlyTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func (s *remountTest) Setup(t *testing.T) {
 
 func (s *remountTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -47,6 +47,9 @@ func (s *remountTest) Setup(t *testing.T) {
 }
 
 func (s *remountTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -49,7 +49,7 @@ func (s *smallCacheTTLTest) Setup(t *testing.T) {
 
 func (s *smallCacheTTLTest) Teardown(t *testing.T) {
 	if t.Failed() {
-		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + strings.Replace(t.Name(), "/", "-", -1))
 	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -48,6 +48,9 @@ func (s *smallCacheTTLTest) Setup(t *testing.T) {
 }
 
 func (s *smallCacheTTLTest) Teardown(t *testing.T) {
+	if t.Failed() {
+		setup.SaveLogFileToKOKOROArtifact("gcsfuse-failed-integration-test-logs-" + t.Name())
+	}
 	setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
 }
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -230,12 +230,16 @@ func SaveLogFileInCaseOfFailure(successCode int) {
 	if successCode != 0 {
 		// Logfile name will be gcsfuse-failed-integration-test-log-xxxxx
 		failedlogsFileName := "gcsfuse-failed-integration-test-logs-" + GenerateRandomString(5)
-		log.Printf("log file is available on kokoro artifacts with file name: %s", failedlogsFileName)
-		logFileInKokoroArtifact := path.Join(os.Getenv("KOKORO_ARTIFACTS_DIR"), failedlogsFileName)
-		err := operations.CopyFile(logFile, logFileInKokoroArtifact)
-		if err != nil {
-			log.Fatalf("Error in coping logfile in kokoro artifact: %v", err)
-		}
+		SaveLogFileToKOKOROArtifact(failedlogsFileName)
+	}
+}
+
+func SaveLogFileToKOKOROArtifact(artifactName string) {
+	log.Printf("log file is available on kokoro artifacts with file name: %s", artifactName)
+	logFileInKokoroArtifact := path.Join(os.Getenv("KOKORO_ARTIFACTS_DIR"), artifactName)
+	err := operations.CopyFile(logFile, logFileInKokoroArtifact)
+	if err != nil {
+		log.Fatalf("Error in coping logfile in kokoro artifact: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Description
Read Cache logs are cleared in teardown for log parsing of next test. We should persist these logs in case of failure for debugging.

### Link to the issue in case of a bug fix.
b/394211437

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
