### PR TITLE
Recreate MRD in case of any error

### DIFF
--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -45,10 +45,10 @@ func NewMultiRangeDownloaderWrapperWithClock(bucket gcs.Bucket, object *gcs.MinO
 	// In case of a local inode, MRDWrapper would be created with an empty minObject (i.e. with a minObject without any information)
 	// and when the object is actually created, MRDWrapper would be updated using SetMinObject method.
 	return MultiRangeDownloaderWrapper{
-		clock:         clock,
-		bucket:        bucket,
-		object:        object,
-		needsCreation: true,
+		clock:     clock,
+		bucket:    bucket,
+		object:    object,
+		createMRD: true,
 	}, nil
 }
 
@@ -74,10 +74,10 @@ type MultiRangeDownloaderWrapper struct {
 	cancelCleanup context.CancelFunc
 	// Used for waiting for timeout (helps us in mocking the functionality).
 	clock clock.Clock
-	// Used to determine whether we should recreate MRD.
-	needsCreation bool
-	// Mutex to synchronize access over needsCreation variable.
-	muCreation sync.Mutex
+	// Used to determine whether we should create MRD.
+	createMRD bool
+	// Mutex to synchronize access over createMRD.
+	muCreateMRD sync.Mutex
 }
 
 // Sets the gcs.MinObject stored in the wrapper to passed value, only if it's non nil.
@@ -162,28 +162,27 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) cleanupMultiRangeDownloader() {
 	go closeMRD(ctx)
 }
 
-// Ensures that MultiRangeDownloader exists, creating it if it does not exist or if it needs to be recreated.
+// Ensures that MultiRangeDownloader exists, creating it if needed.
 func (mrdWrapper *MultiRangeDownloaderWrapper) ensureMultiRangeDownloader() (err error) {
-	mrdWrapper.muCreation.Lock()
-	defer mrdWrapper.muCreation.Unlock()
+	mrdWrapper.muCreateMRD.Lock()
+	defer mrdWrapper.muCreateMRD.Unlock()
 
-	if !mrdWrapper.needsCreation {
+	if !mrdWrapper.createMRD {
 		return
 	}
+
 	if mrdWrapper.object == nil || mrdWrapper.bucket == nil {
 		return fmt.Errorf("ensureMultiRangeDownloader error: Missing minObject or bucket")
 	}
-
 	mrdWrapper.Wrapped, err = mrdWrapper.bucket.NewMultiRangeDownloader(context.Background(), &gcs.MultiRangeDownloaderRequest{
 		Name:           mrdWrapper.object.Name,
 		Generation:     mrdWrapper.object.Generation,
 		ReadCompressed: mrdWrapper.object.HasContentEncodingGzip(),
 	})
-	if err != nil {
-		mrdWrapper.needsCreation = true
-		return
+	// In case of successful creation of MRD, setting createMRD to false. It will remain true otherwise.
+	if err == nil {
+		mrdWrapper.createMRD = false
 	}
-	mrdWrapper.needsCreation = false
 	return
 }
 
@@ -199,7 +198,6 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 	err = mrdWrapper.ensureMultiRangeDownloader()
 	if err != nil {
 		err = fmt.Errorf("MultiRangeDownloaderWrapper::Read: Error in creating MultiRangeDownloader:  %v", err)
-		mrdWrapper.needsCreation = true
 		return
 	}
 
@@ -234,9 +232,9 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 
 		if e != nil && e != io.EOF {
 			e = fmt.Errorf("Error in Add Call: %w", e)
-			mrdWrapper.muCreation.Lock()
-			mrdWrapper.needsCreation = true
-			mrdWrapper.muCreation.Unlock()
+			mrdWrapper.muCreateMRD.Lock()
+			mrdWrapper.createMRD = true
+			mrdWrapper.muCreateMRD.Unlock()
 		}
 	})
 

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -148,7 +148,7 @@ func (t *mrdWrapperTest) Test_Read() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
 			buf := make([]byte, tc.end-tc.start)
-			t.mrdWrapper.Wrapped = nil
+			t.mrdWrapper.createMRD = true
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond))
 
 			bytesRead, err := t.mrdWrapper.Read(context.Background(), buf, int64(tc.start), int64(tc.end), time.Millisecond, common.NewNoopMetrics())
@@ -256,16 +256,17 @@ func (t *mrdWrapperTest) Test_EnsureMultiRangeDownloader() {
 		t.Run(tc.name, func() {
 			t.mrdWrapper.bucket = tc.bucket
 			t.mrdWrapper.object = tc.obj
-			t.mrdWrapper.Wrapped = nil
+			t.mrdWrapper.createMRD = true
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond))
 			err := t.mrdWrapper.ensureMultiRangeDownloader()
 			if tc.err == nil {
 				assert.NoError(t.T(), err)
 				assert.NotNil(t.T(), t.mrdWrapper.Wrapped)
+				assert.False(t.T(), t.mrdWrapper.createMRD)
 			} else {
 				assert.Error(t.T(), err)
 				assert.EqualError(t.T(), err, tc.err.Error())
-				assert.Nil(t.T(), t.mrdWrapper.Wrapped)
+				assert.True(t.T(), t.mrdWrapper.createMRD)
 			}
 		})
 	}


### PR DESCRIPTION
Changes to ensure MRD is recreated if any error is thrown from the Add call as well. Currently, after successful  recreation of MRD, we are not recreating it.

Using a new variable to determine creation of MRD (instead of setting it to nil) to simplify the code (i.e. to prevent an additional mutex lock before calling add)

Performance testing: Tested random read with 50 threads for 1M/128K block size and there is no regression. Also tested the parallel read scenario (50 threads randomly reading from the same file) and there's no regression in this scenario as well.

b/394500981