### PR TITLE
Maintain readType for random reader

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -541,7 +541,6 @@ func (rr *randomReader) getReadInfo(
 	// optimise for random reads. Random reads will read data in chunks of
 	// (average read size in bytes rounded up to the next MB).
 	end = int64(rr.object.Size)
-	rr.readType = util.Sequential
 	if rr.seeks >= minSeeksForRandom {
 		rr.readType = util.Random
 		averageReadBytes := rr.totalReadBytes / rr.seeks

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -119,6 +119,7 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 		limit:                 -1,
 		seeks:                 0,
 		totalReadBytes:        0,
+		readType:              util.Sequential,
 		sequentialReadSizeMb:  sequentialReadSizeMb,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
@@ -149,6 +150,9 @@ type randomReader struct {
 	limit          int64
 	seeks          uint64
 	totalReadBytes uint64
+
+	// ReadType of the reader. Will be sequential by default.
+	readType string
 
 	sequentialReadSizeMb int32
 
@@ -368,22 +372,20 @@ func (rr *randomReader) ReadAt(
 	}
 
 	if rr.reader != nil {
-		// TODO: Passing readType as "unhandled" here for now. Ideally
-		// readType should be stored in and obtained from the previous rr.reader.
-		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, -1, "unhandled")
+		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, -1, rr.readType)
 		return
 	}
 
 	// If we don't have a reader, determine whether to read from NewReader or MRR.
-	readType, end, err := rr.getReadInfo(offset, int64(len(p)))
+	end, err := rr.getReadInfo(offset, int64(len(p)))
 	if err != nil {
 		err = fmt.Errorf("ReadAt: getReaderInfo: %w", err)
 		return
 	}
 
-	readerType := readerType(readType, offset, end, rr.bucket.BucketType())
+	readerType := readerType(rr.readType, offset, end, rr.bucket.BucketType())
 	if readerType == RangeReader {
-		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, end, readType)
+		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, end, rr.readType)
 		return
 	}
 
@@ -507,12 +509,12 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	return
 }
 
-// getReaderInfo provides the readType and the range to query GCS.
+// getReaderInfo determines the readType and provides the range to query GCS.
 // Range here is [start, end]. End is computed using the readType, start offset
 // and size of the data the callers needs.
 func (rr *randomReader) getReadInfo(
 	start int64,
-	size int64) (readType string, end int64, err error) {
+	size int64) (end int64, err error) {
 	// Make sure start and size are legal.
 	if start < 0 || uint64(start) > rr.object.Size || size < 0 {
 		err = fmt.Errorf(
@@ -539,9 +541,9 @@ func (rr *randomReader) getReadInfo(
 	// optimise for random reads. Random reads will read data in chunks of
 	// (average read size in bytes rounded up to the next MB).
 	end = int64(rr.object.Size)
-	readType = util.Sequential
+	rr.readType = util.Sequential
 	if rr.seeks >= minSeeksForRandom {
-		readType = util.Random
+		rr.readType = util.Random
 		averageReadBytes := rr.totalReadBytes / rr.seeks
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MB) + 1) * MB)

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -624,7 +624,6 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 		name              string
 		dataSize          int
 		bucketType        gcs.BucketType
-		initialReadType   string
 		readRanges        [][]int
 		expectedReadTypes []string
 	}{
@@ -632,7 +631,6 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			name:              "SequentialReadFlat",
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
-			initialReadType:   testutil.Sequential,
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
 			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Sequential, testutil.Sequential},
 		},
@@ -640,7 +638,6 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			name:              "SequentialReadZonal",
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
-			initialReadType:   testutil.Sequential,
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
 			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Sequential, testutil.Sequential},
 		},
@@ -648,7 +645,6 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			name:              "RandomReadFlat",
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
-			initialReadType:   testutil.Sequential,
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
 			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Random, testutil.Random, testutil.Random},
 		},
@@ -656,17 +652,8 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			name:              "RandomReadZonal",
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
-			initialReadType:   testutil.Sequential,
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
 			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Random, testutil.Random, testutil.Random},
-		},
-		{
-			name:              "InitialReadTypeRandom",
-			dataSize:          100,
-			bucketType:        gcs.BucketType{Zonal: true},
-			initialReadType:   testutil.Random,
-			readRanges:        [][]int{{10, 20}, {20, 30}, {30, 40}, {40, 50}},
-			expectedReadTypes: []string{testutil.Random, testutil.Random, testutil.Random, testutil.Random},
 		},
 	}
 
@@ -676,7 +663,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.rr.wrapped.seeks = 0
-			t.rr.wrapped.readType = tc.initialReadType
+			t.rr.wrapped.readType = testutil.Sequential
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -113,7 +113,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo() {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			_, _, err := t.rr.wrapped.getReadInfo(tc.start, tc.size)
+			_, err := t.rr.wrapped.getReadInfo(tc.start, tc.size)
 
 			assert.Error(t.T(), err)
 			errorString := fmt.Sprintf(
@@ -138,10 +138,10 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Sequential() {
 	for _, tc := range testCases {
 		t.Run(tc.testName, func() {
 			t.object.Size = tc.objectSize
-			readType, end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
+			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), testutil.Sequential, readType)
+			assert.Equal(t.T(), testutil.Sequential, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -171,10 +171,10 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
 		t.Run(tc.testName, func() {
 			t.object.Size = tc.objectSize
 			t.rr.wrapped.totalReadBytes = tc.totalReadBytes
-			readType, end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
+			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), testutil.Random, readType)
+			assert.Equal(t.T(), testutil.Random, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}


### PR DESCRIPTION
We collect readType as part of our read metrics and hence need to ensure that proper readType value is being maintained and shared for metrics collection.


b/394500505