### PR TITLE
Use grpc client always for zonal buckets in e2e tests

### DIFF
--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -75,7 +75,7 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
-		writer, err := client.NewWriterExt(ctx, object, storageClient)
+		writer, err := client.NewWriterWithSupportForZB(ctx, object, storageClient)
 		if err != nil {
 			return fmt.Errorf("Error opening writer for object %s: %w\n", file.filePath, err)
 		}

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -74,7 +74,7 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
-		writer := object.NewWriter(ctx)
+		writer := client.NewWriterExt(ctx, object, storageClient)
 
 		// Write the text to the object
 		if _, err := writer.Write([]byte(file.fileContent + "\n")); err != nil {

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -75,7 +75,7 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
-		writer, err := client.NewWriterWithSupportForZB(ctx, object, storageClient)
+		writer, err := client.NewWriter(ctx, object, storageClient)
 		if err != nil {
 			return fmt.Errorf("Error opening writer for object %s: %w\n", file.filePath, err)
 		}

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -130,10 +130,12 @@ func ReadChunkFromGCS(ctx context.Context, client *storage.Client, object string
 
 func NewWriterExt(ctx context.Context, o *storage.ObjectHandle, client *storage.Client) *storage.Writer {
 	wc := o.NewWriter(ctx)
-	if setup.IsZonalBucketRun() {
-		attrs, _ := client.Bucket(o.BucketName()).Attrs(ctx)
-		if attrs.StorageClass == "RAPID" {
+	attrs, _ := client.Bucket(o.BucketName()).Attrs(ctx)
+	if attrs.StorageClass == "RAPID" {
+		if setup.IsZonalBucketRun() {
 			wc.Append = true
+		} else {
+			panic(fmt.Sprintf("Found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName()))
 		}
 	}
 	return wc

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -305,6 +305,9 @@ func UploadGcsObject(ctx context.Context, client *storage.Client, localPath, buc
 	// Create a writer to upload the object.
 	obj := client.Bucket(bucketName).Object(objectName)
 	w, err := NewWriterWithSupportForZB(ctx, obj, client)
+	if err != nil {
+		return fmt.Errorf("Failed to open writer for GCS object gs://%s/%s: %w", bucketName, objectName, err)
+	}
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -139,7 +139,10 @@ func WriteToObject(ctx context.Context, client *storage.Client, object, content 
 	// Upload an object with storage.Writer.
 	wc := o.NewWriter(ctx)
 	if setup.IsZonalBucketRun() {
-		wc.Append = true // setting true for zonal buckets
+		attrs, _ := client.Bucket(setup.TestBucket()).Attrs(ctx)
+		if attrs.StorageClass == "RAPID" {
+			wc.Append = true
+		}
 	}
 	if _, err := io.WriteString(wc, content); err != nil {
 		return fmt.Errorf("io.WriteSTring: %w", err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -154,7 +154,7 @@ func WriteToObject(ctx context.Context, client *storage.Client, object, content 
 	}
 
 	// Upload an object with storage.Writer.
-	wc, err := NewWriterExt(ctx, o, client)
+	wc, err := NewWriterWithSupportForZB(ctx, o, client)
 	if err != nil {
 		return fmt.Errorf("Failed to open writer for object %q: %w", o.ObjectName(), err)
 	}
@@ -304,7 +304,7 @@ func StatObject(ctx context.Context, client *storage.Client, object string) (*st
 func UploadGcsObject(ctx context.Context, client *storage.Client, localPath, bucketName, objectName string, uploadGzipEncoded bool) error {
 	// Create a writer to upload the object.
 	obj := client.Bucket(bucketName).Object(objectName)
-	w, err := NewWriterExt(ctx, obj, client)
+	w, err := NewWriterWithSupportForZB(ctx, obj, client)
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)


### PR DESCRIPTION
### Description
* Always use client-type grpc for zonal bucket in e2e tests
* Always set append flag in the storage writer objects for zonal bucket in e2e tests

### Link to the issue in case of a bug fix.
[b/393050972](http://b/393050972) - Create and pass test flag for zonal bucket

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Enabled through presubmit
