### PR TITLE
add error mapping for grpc precondition failure

### DIFF
--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -84,6 +84,8 @@ func errno(err error, preconditionErrCfg bool) error {
 			return syscall.EACCES
 		case codes.NotFound:
 			return syscall.ENOENT
+		case codes.FailedPrecondition:
+			return syscall.ESTALE
 		}
 	}
 	// Translate API errors into an em errno

--- a/internal/fs/wrappers/error_mapping_test.go
+++ b/internal/fs/wrappers/error_mapping_test.go
@@ -65,6 +65,15 @@ func (testSuite *ErrorMapping) TestNotFoundGrpcApiError() {
 	assert.Equal(testSuite.T(), syscall.ENOENT, fsErr)
 }
 
+func (testSuite *ErrorMapping) TestFailedPreconditionGrpcApiError() {
+	statusErr := status.New(codes.FailedPrecondition, "Not found")
+	apiError, _ := apierror.FromError(statusErr.Err())
+
+	fsErr := errno(apiError, testSuite.preconditionErrCfg)
+
+	assert.Equal(testSuite.T(), syscall.ESTALE, fsErr)
+}
+
 func (testSuite *ErrorMapping) TestCanceledGrpcApiError() {
 	statusErr := status.New(codes.Canceled, "Canceled error")
 	apiError, _ := apierror.FromError(statusErr.Err())

--- a/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
@@ -50,5 +50,16 @@ func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
 func TestDefaultMountEmptyGCSFileTest(t *testing.T) {
 	s := new(defaultMountEmptyGCSFile)
 	s.defaultMountCommonTest.TestifySuite = &s.Suite
+
+	flags := []string{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2"}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	testDirPath = setup.SetupTestDirectory(testDirName)
 	suite.Run(t, s)
+	setup.UnmountGCSFuse(rootDir)
+
+	flags = []string{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2", "--client-protocol=grpc"}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	suite.Run(t, s)
+	setup.UnmountGCSFuse(rootDir)
 }

--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -48,5 +48,16 @@ func TestDefaultMountLocalFileTest(t *testing.T) {
 	s := new(defaultMountLocalFile)
 	s.CommonLocalFileTestSuite.TestifySuite = &s.Suite
 	s.defaultMountCommonTest.TestifySuite = &s.Suite
+
+	flags := []string{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2"}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	testDirPath = setup.SetupTestDirectory(testDirName)
 	suite.Run(t, s)
+	setup.UnmountGCSFuse(rootDir)
+
+	flags = []string{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2", "--client-protocol=grpc"}
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	testDirPath = setup.SetupTestDirectory(testDirName)
+	suite.Run(t, s)
+	setup.UnmountGCSFuse(rootDir)
 }

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
 )
 
@@ -35,12 +34,7 @@ func (t *defaultMountCommonTest) SetupSuite() {
 	SetCtx(ctx)
 	SetStorageClient(storageClient)
 	SetTestDirName(testDirName)
-
-	flags := []string{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2"}
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	testDirPath = setup.SetupTestDirectory(testDirName)
 }
 
 func (t *defaultMountCommonTest) TearDownSuite() {
-	setup.UnmountGCSFuse(rootDir)
 }

--- a/tools/integration_tests/streaming_writes/write_test.go
+++ b/tools/integration_tests/streaming_writes/write_test.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streaming_writes
+
+import (
+	"path"
+
+	"cloud.google.com/go/storage"
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/assert"
+)
+
+func (t *defaultMountEmptyGCSFile) TestClobberedFileCloseThrowsStaleFileHandleError() {
+	// Dirty the file by giving it some contents.
+	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	operations.WriteWithoutClose(t.f1, FileContents, t.T())
+	// Replace the underlying object with a new generation.
+	err := WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), GCSFileContent, storage.Conditions{})
+	assert.NoError(t.T(), err)
+
+	err = t.f1.Close()
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+}

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ValidateNoFileOrDirError(t *testing.T, path string) {
@@ -47,8 +48,8 @@ func ValidateObjectNotFoundErr(ctx context.Context, t *testing.T, bucket gcs.Buc
 }
 
 func ValidateStaleNFSFileHandleError(t *testing.T, err error) {
-	assert.NotEqual(t, nil, err)
-	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
+	require.Error(t, err)
+	assert.Regexp(t, syscall.ESTALE.Error()+"|"+syscall.EEXIST.Error(), err.Error())
 }
 
 func CheckErrorForReadOnlyFileSystem(t *testing.T, err error) {


### PR DESCRIPTION
### Description
error mapping for GRPC precondition failure

### Link to the issue in case of a bug fix.
b/395053734

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - Manually ran the modified integration tests
