### PR TITLE
do not do force stat for local files during flush

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -781,12 +781,13 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 // object, syncs the content and updates the inode state.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
+func (f *FileInode) syncUsingContent(ctx context.Context) error {
 	var latestGcsObj *gcs.Object
 	if !f.local {
+		var err error
 		latestGcsObj, err = f.fetchLatestGcsObject(ctx)
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -797,21 +798,19 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
-		err = &gcsfuse_errors.FileClobberedError{
+		return &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("SyncObject: %w", err),
 		}
-		return
 	}
 
 	// Propagate other errors.
 	if err != nil {
-		err = fmt.Errorf("SyncObject: %w", err)
-		return
+		return fmt.Errorf("SyncObject: %w", err)
 	}
 	minObj := storageutil.ConvertObjToMinObject(newObj)
 	// If we wrote out a new object, we need to update our state.
 	f.updateInodeStateAfterSync(minObj)
-	return
+	return nil
 }
 
 // Flush writes out contents to GCS. If this fails due to the generation

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -782,9 +782,12 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
-	latestGcsObj, err := f.fetchLatestGcsObject(ctx)
-	if err != nil {
-		return
+	var latestGcsObj *gcs.Object
+	if !f.local {
+		latestGcsObj, err = f.fetchLatestGcsObject(ctx)
+		if err != nil {
+			return
+		}
 	}
 
 	// Write out the contents if they are dirty.

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package inode
 
 import (

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -1,0 +1,141 @@
+package inode
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/contentcache"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	storagemock "github.com/googlecloudplatform/gcsfuse/v2/internal/storage/mock"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/syncutil"
+	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/semaphore"
+)
+
+type FileMockBucketTest struct {
+	suite.Suite
+	ctx        context.Context
+	bucket     *storagemock.TestifyMockBucket
+	clock      timeutil.SimulatedClock
+	backingObj *gcs.MinObject
+	in         *FileInode
+}
+
+func TestFileMockBucketTestSuite(t *testing.T) {
+	suite.Run(t, new(FileMockBucketTest))
+}
+
+func (t *FileMockBucketTest) SetupTest() {
+	// Enabling invariant check for all tests.
+	syncutil.EnableInvariantChecking()
+	t.ctx = context.Background()
+	t.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
+	t.bucket = new(storagemock.TestifyMockBucket)
+	t.bucket.On("BucketType").Return(gcs.BucketType{Hierarchical: false, Zonal: false})
+
+	// Create the inode.
+	t.createInode(fileName, localFile)
+}
+
+func (t *FileMockBucketTest) TearDownTest() {
+	t.in.Unlock()
+}
+
+func (t *FileMockBucketTest) SetupSubTest() {
+	t.SetupTest()
+}
+
+func (t *FileMockBucketTest) createInode(fileName string, fileType string) {
+	if fileType != emptyGCSFile && fileType != localFile {
+		t.T().Errorf("fileType should be either local or empty")
+	}
+
+	name := NewFileName(
+		NewRootName(""),
+		fileName,
+	)
+	syncerBucket := gcsx.NewSyncerBucket(
+		1, // Append threshold
+		ChunkTransferTimeoutSecs,
+		".gcsfuse_tmp/",
+		t.bucket)
+
+	isLocal := false
+	if fileType == localFile {
+		t.backingObj = nil
+		isLocal = true
+	}
+
+	if fileType == emptyGCSFile {
+		object, err := storageutil.CreateObject(
+			t.ctx,
+			t.bucket,
+			fileName,
+			[]byte{})
+		t.backingObj = storageutil.ConvertObjToMinObject(object)
+
+		assert.Nil(t.T(), err)
+	}
+
+	t.in = NewFileInode(
+		fileInodeID,
+		name,
+		t.backingObj,
+		fuseops.InodeAttributes{
+			Uid:  uid,
+			Gid:  gid,
+			Mode: fileMode,
+		},
+		&syncerBucket,
+		false, // localFileCache
+		contentcache.New("", &t.clock),
+		&t.clock,
+		isLocal,
+		&cfg.Config{},
+		semaphore.NewWeighted(math.MaxInt64))
+
+	// Create write handler for the local inode created above.
+	err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	assert.Nil(t.T(), err)
+
+	t.in.Lock()
+}
+
+func (t *FileMockBucketTest) TestFlushLocalFileDoesNotForceFetchObjectFromGCS() {
+	assert.True(t.T(), t.in.IsLocal())
+	// Expect only CreateObject call on bucket.
+	t.bucket.On("CreateObject", t.ctx, mock.AnythingOfType("*gcs.CreateObjectRequest")).
+		Return(&gcs.Object{Name: fileName}, nil)
+
+	err := t.in.Flush(t.ctx)
+
+	require.NoError(t.T(), err)
+	t.bucket.AssertExpectations(t.T())
+}
+
+func (t *FileMockBucketTest) TestFlushSyncedFileForceFetchObjectFromGCS() {
+	t.bucket.On("CreateObject", t.ctx, mock.AnythingOfType("*gcs.CreateObjectRequest")).
+		Return(&gcs.Object{Name: fileName}, nil)
+	t.createInode(fileName, emptyGCSFile)
+	assert.False(t.T(), t.in.IsLocal())
+	// Expect both StatObject and CreateObject call on bucket.
+	t.bucket.On("StatObject", t.ctx, mock.AnythingOfType("*gcs.StatObjectRequest")).
+		Return(&gcs.MinObject{Name: fileName}, &gcs.ExtendedObjectAttributes{}, nil)
+	t.bucket.On("CreateObject", t.ctx, mock.AnythingOfType("*gcs.CreateObjectRequest")).
+		Return(&gcs.Object{Name: fileName}, nil)
+
+	err := t.in.Flush(t.ctx)
+
+	require.NoError(t.T(), err)
+	t.bucket.AssertExpectations(t.T())
+}


### PR DESCRIPTION
### Description
During Flush, we make a stat call to fetch all the attributes of an object which are required by create object call. For local files, this call can be avoided.

### Link to the issue in case of a bug fix.
b/394759110

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - via KOKORO
4. Perf tests -
![5RPYpZFGwbMcpkX](https://github.com/user-attachments/assets/13d23e91-1d1f-430a-8e18-216528ef9425)

