### PR TITLE
making sure that benchmarking tests are run for periodic tests only

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -65,6 +65,8 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 ////////////////////////////////////////////////////////////////////////
 
 func Benchmark_Delete(b *testing.B) {
+	setup.IgnoreTestIfPresubmitFlagIsSet(b)
+
 	ts := &benchmarkDeleteTest{}
 
 	flagsSet := [][]string{

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -65,6 +65,8 @@ func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 ////////////////////////////////////////////////////////////////////////
 
 func Benchmark_Rename(b *testing.B) {
+	setup.IgnoreTestIfPresubmitFlagIsSet(b)
+
 	ts := &benchmarkRenameTest{}
 	flagsSet := [][]string{
 		{"--stat-cache-ttl=0", "--enable-atomic-rename-object=true"}, {"--client-protocol=grpc", "--stat-cache-ttl=0", "--enable-atomic-rename-object=true"},

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -74,6 +74,8 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 ////////////////////////////////////////////////////////////////////////
 
 func Benchmark_Stat(b *testing.B) {
+	setup.IgnoreTestIfPresubmitFlagIsSet(b)
+
 	ts := &benchmarkStatTest{}
 	flagsSet := [][]string{
 		{"--stat-cache-ttl=0"}, {"--client-protocol=grpc", "--stat-cache-ttl=0"},

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -294,6 +294,14 @@ func IgnoreTestIfIntegrationTestFlagIsNotSet(t *testing.T) {
 	}
 }
 
+func IgnoreTestIfPresubmitFlagIsSet(b *testing.B) {
+	flag.Parse()
+
+	if *isPresubmitRun {
+		b.SkipNow()
+	}
+}
+
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {
 	ParseSetUpFlags()
 


### PR DESCRIPTION
### Description
* Tests in the benchmarking test package will be skipped in case the presubmit flag is turned on.
* Clean up for the cd scripts.
* In a follow-up PR, I will adjust the thresholds value based on periodic test region which is now us-west4.
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated
