### PR TITLE
Reducing the number of metric updates

### DIFF
--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -213,26 +213,6 @@ func recordReader(ctx context.Context, metricHandle common.MetricHandle, ioMetho
 	metricHandle.GCSReaderCount(ctx, 1, []common.MetricAttr{{Key: common.IOMethod, Value: ioMethod}})
 }
 
-type gcsFullReadCloser struct {
-	wrapped gcs.StorageReader
-}
-
-func newGCSFullReadCloser(reader gcs.StorageReader) gcs.StorageReader {
-	return gcsFullReadCloser{wrapped: reader}
-}
-
-func (frc gcsFullReadCloser) Read(p []byte) (n int, err error) {
-	return io.ReadFull(frc.wrapped, p)
-}
-
-func (frc gcsFullReadCloser) ReadHandle() (rh storagev2.ReadHandle) {
-	return frc.wrapped.ReadHandle()
-}
-
-func (frc gcsFullReadCloser) Close() (err error) {
-	return frc.wrapped.Close()
-}
-
 // Monitoring on the object reader
 func newMonitoringReadCloser(ctx context.Context, object string, rc gcs.StorageReader, metricHandle common.MetricHandle) gcs.StorageReader {
 	recordReader(ctx, metricHandle, "opened")

--- a/internal/monitor/full_read_closer.go
+++ b/internal/monitor/full_read_closer.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"io"
+
+	storagev2 "cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+)
+
+// gcsFullReadCloser wraps a gcs.StorageReader and ensures that the Read call returns:
+// if size of the buffer is more than the response, then the entire response is returned,
+// or if size of the buffer is less than or equal to the response, then the entire buffer is filled,
+// or an error is encountered.
+type gcsFullReadCloser struct {
+	wrapped gcs.StorageReader
+}
+
+func newGCSFullReadCloser(reader gcs.StorageReader) gcs.StorageReader {
+	return gcsFullReadCloser{wrapped: reader}
+}
+
+// Read reads exactly len(buf) bytes from the wrapped StorageReader into buf.
+// It returns the number of bytes copied and an error if fewer bytes were read.
+// The error is EOF only if no bytes were read.
+// If an EOF happens after reading some but not all the bytes, Read returns ErrUnexpectedEOF.
+// On return, n == len(buf) if and only if err == nil.
+// If StorageReader returns an error having read at least len(buf) bytes, the error is dropped.
+func (frc gcsFullReadCloser) Read(buf []byte) (n int, err error) {
+	return io.ReadFull(frc.wrapped, buf)
+}
+
+func (frc gcsFullReadCloser) ReadHandle() (rh storagev2.ReadHandle) {
+	return frc.wrapped.ReadHandle()
+}
+
+func (frc gcsFullReadCloser) Close() (err error) {
+	return frc.wrapped.Close()
+}

--- a/internal/monitor/full_read_closer.go
+++ b/internal/monitor/full_read_closer.go
@@ -21,10 +21,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 )
 
-// gcsFullReadCloser wraps a gcs.StorageReader and ensures that the Read call returns:
-// 1. entire response, if buffer size > response size
-// 2. entire buffer is filled, if buffer size <= response size
-// 3. error
+// gcsFullReadCloser wraps a gcs.StorageReader and ensures that the Read call reads the entire response up to the buffer size even if the wrapped read returns data in smaller chunks.
 type gcsFullReadCloser struct {
 	wrapped gcs.StorageReader
 }

--- a/internal/monitor/full_read_closer_test.go
+++ b/internal/monitor/full_read_closer_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	storagev2 "cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyStorageReader struct {
+	buf      *bytes.Buffer
+	maxBytes int
+}
+
+func (frc dummyStorageReader) ReadHandle() (rh storagev2.ReadHandle) {
+	return nil
+}
+
+func (frc dummyStorageReader) Close() (err error) {
+	return nil
+}
+
+func (frc dummyStorageReader) Read(b []byte) (n int, err error) {
+	bufLen := min(len(b), frc.maxBytes)
+	temp := make([]byte, bufLen)
+	n, err = frc.buf.Read(temp)
+	copy(b, temp)
+	return n, err
+}
+
+func TestFullReaderCloser(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                 string
+		bufSize              int
+		data                 []byte
+		maxReadBytes         int
+		expectedData         []byte
+		expectedErr          error
+		expectedNumBytesRead int
+	}{
+		{
+			name:                 "large_buffer",
+			data:                 []byte("0123"),
+			bufSize:              5,
+			maxReadBytes:         10,
+			expectedData:         []byte("0123"),
+			expectedErr:          io.ErrUnexpectedEOF,
+			expectedNumBytesRead: 4,
+		},
+		{
+			name:                 "small_buffer",
+			data:                 []byte("0123"),
+			bufSize:              2,
+			maxReadBytes:         10,
+			expectedData:         []byte("01"),
+			expectedErr:          nil,
+			expectedNumBytesRead: 2,
+		},
+		{
+			name:                 "equal_buffer",
+			data:                 []byte("0123"),
+			bufSize:              4,
+			maxReadBytes:         10,
+			expectedData:         []byte("0123"),
+			expectedErr:          nil,
+			expectedNumBytesRead: 4,
+		},
+		{
+			name:                 "partial_read_full_data_returned",
+			data:                 []byte("0123"),
+			bufSize:              10,
+			maxReadBytes:         2,
+			expectedData:         []byte("0123"),
+			expectedErr:          io.ErrUnexpectedEOF,
+			expectedNumBytesRead: 4,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			storageReader := dummyStorageReader{
+				maxBytes: tc.maxReadBytes,
+				buf:      new(bytes.Buffer),
+			}
+			storageReader.buf.Write(tc.data)
+			fullReadCloser := newGCSFullReadCloser(storageReader)
+			buffer := make([]byte, tc.bufSize)
+
+			n, err := fullReadCloser.Read(buffer)
+
+			assert.Equal(t, tc.expectedNumBytesRead, n)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedData[:n], buffer[:n])
+		})
+	}
+}

--- a/internal/monitor/full_read_closer_test.go
+++ b/internal/monitor/full_read_closer_test.go
@@ -23,23 +23,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type dummyStorageReader struct {
+// partialStorageReader reads at most maxBytes from the buffer in one go.
+type partialStorageReader struct {
 	buf      *bytes.Buffer
 	maxBytes int
 }
 
-func (frc dummyStorageReader) ReadHandle() (rh storagev2.ReadHandle) {
+func (psr partialStorageReader) ReadHandle() (rh storagev2.ReadHandle) {
 	return nil
 }
 
-func (frc dummyStorageReader) Close() (err error) {
+func (psr partialStorageReader) Close() (err error) {
 	return nil
 }
 
-func (frc dummyStorageReader) Read(b []byte) (n int, err error) {
-	bufLen := min(len(b), frc.maxBytes)
+func (psr partialStorageReader) Read(b []byte) (n int, err error) {
+	bufLen := min(len(b), psr.maxBytes)
 	temp := make([]byte, bufLen)
-	n, err = frc.buf.Read(temp)
+	n, err = psr.buf.Read(temp)
 	copy(b, temp)
 	return n, err
 }
@@ -96,7 +97,7 @@ func TestFullReaderCloser(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			storageReader := dummyStorageReader{
+			storageReader := partialStorageReader{
 				maxBytes: tc.maxReadBytes,
 				buf:      new(bytes.Buffer),
 			}

--- a/internal/monitor/full_read_closer_test.go
+++ b/internal/monitor/full_read_closer_test.go
@@ -51,7 +51,6 @@ func TestFullReaderCloser(t *testing.T) {
 		name         string
 		bufSize      int
 		data         []byte
-		maxReadBytes int
 		expectedData []byte
 		expectedErr  error
 	}{
@@ -75,14 +74,6 @@ func TestFullReaderCloser(t *testing.T) {
 			bufSize:      4,
 			expectedData: []byte("0123"),
 			expectedErr:  nil,
-		},
-		{
-			name:         "partial_read_full_data_returned",
-			data:         []byte("0123"),
-			bufSize:      10,
-			maxReadBytes: 2,
-			expectedData: []byte("0123"),
-			expectedErr:  io.ErrUnexpectedEOF,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
* Wait for the entire buffer to be filled up before updating the metrics. This helps reduce the number of updates to the gcs/read_bytes_count metric by a factor of 1000 there by improving performance and reducing CPU and memory usage.

### Description

### Link to the issue in case of a bug fix.
b/386226641

### Testing details
1. Manual - Verified reader behavior by checking that the md5 checksum of a file doesn't change when copied into a GCSFuse bucket.
2. Unit tests - Added
3. Integration tests - NA
