### PR TITLE
[Refactoring] Common method to wrap error as Precondition or NotFound

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -115,9 +115,9 @@ func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectR
 	}
 
 	err := obj.Delete(ctx)
-	var converted bool
-	err, converted = gcs.WrapGCSFuseError(err)
-	if err != nil && !converted {
+	var wrapped bool
+	err, wrapped = gcs.WrapGCSFuseError(err)
+	if err != nil && !wrapped {
 		err = fmt.Errorf("error in deleting object: %w", err)
 	}
 	return err
@@ -129,10 +129,10 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 	// Retrieving object attrs through Go Storage Client.
 	attrs, err = bh.bucket.Object(req.Name).Attrs(ctx)
 
-	var converted bool
-	err, converted = gcs.WrapGCSFuseError(err)
+	var wrapped bool
+	err, wrapped = gcs.WrapGCSFuseError(err)
 	if err != nil {
-		if !converted {
+		if !wrapped {
 			err = fmt.Errorf("error in fetching object attributes: %w", err)
 		}
 		return
@@ -202,9 +202,9 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// We can't use defer to close the writer, because we need to close the
 	// writer successfully before calling Attrs() method of writer.
 	if err = wc.Close(); err != nil {
-		var converted bool
-		err, converted = gcs.WrapGCSFuseError(err)
-		if !converted {
+		var wrapped bool
+		err, wrapped = gcs.WrapGCSFuseError(err)
+		if !wrapped {
 			err = fmt.Errorf("error in closing writer : %w", err)
 		}
 		return
@@ -235,9 +235,9 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {
 	if err = w.Close(); err != nil {
-		var converted bool
-		err, converted = gcs.WrapGCSFuseError(err)
-		if !converted {
+		var wrapped bool
+		err, wrapped = gcs.WrapGCSFuseError(err)
+		if !wrapped {
 			err = fmt.Errorf("error in closing writer : %w", err)
 		}
 		return
@@ -266,9 +266,9 @@ func (bh *bucketHandle) CopyObject(ctx context.Context, req *gcs.CopyObjectReque
 	objAttrs, err := dstObj.CopierFrom(srcObj).Run(ctx)
 
 	if err != nil {
-		var converted bool
-		err, converted = gcs.WrapGCSFuseError(err)
-		if !converted {
+		var wrapped bool
+		err, wrapped = gcs.WrapGCSFuseError(err)
+		if !wrapped {
 			err = fmt.Errorf("error in copying object: %w", err)
 		}
 		return
@@ -405,9 +405,9 @@ func (bh *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectR
 		return
 	}
 
-	var converted bool
-	err, converted = gcs.WrapGCSFuseError(err)
-	if !converted {
+	var wrapped bool
+	err, wrapped = gcs.WrapGCSFuseError(err)
+	if !wrapped {
 		err = fmt.Errorf("error in updating object: %w", err)
 	}
 
@@ -453,9 +453,9 @@ func (bh *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObje
 	// Composing Source Objects to Destination Object using Composer created through Go Storage Client.
 	attrs, err := dstObj.ComposerFrom(srcObjList...).Run(ctx)
 	if err != nil {
-		var converted bool
-		err, converted = gcs.WrapGCSFuseError(err)
-		if !converted {
+		var wrapped bool
+		err, wrapped = gcs.WrapGCSFuseError(err)
+		if !wrapped {
 			err = fmt.Errorf("error in composing object: %w", err)
 		}
 		return
@@ -505,9 +505,9 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 		return o, nil
 	}
 
-	var converted bool
-	err, converted = gcs.WrapGCSFuseError(err)
-	if !converted {
+	var wrapped bool
+	err, wrapped = gcs.WrapGCSFuseError(err)
+	if !wrapped {
 		err = fmt.Errorf("error in moving object: %w", err)
 	}
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -95,7 +95,7 @@ func (bh *bucketHandle) NewReaderWithReadHandle(
 
 	// NewRangeReader creates a "storage.Reader" object which is also io.ReadCloser since it contains both Read() and Close() methods present in io.ReadCloser interface.
 	r, err := obj.NewRangeReader(ctx, start, length)
-	err, _ = gcs.WrapGCSFuseError(err)
+	err, _ = gcs.WrapUnderCommonGCSError(err)
 
 	return r, err
 }
@@ -116,7 +116,7 @@ func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectR
 
 	err := obj.Delete(ctx)
 	var wrapped bool
-	err, wrapped = gcs.WrapGCSFuseError(err)
+	err, wrapped = gcs.WrapUnderCommonGCSError(err)
 	if err != nil && !wrapped {
 		err = fmt.Errorf("error in deleting object: %w", err)
 	}
@@ -130,7 +130,7 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 	attrs, err = bh.bucket.Object(req.Name).Attrs(ctx)
 
 	var wrapped bool
-	err, wrapped = gcs.WrapGCSFuseError(err)
+	err, wrapped = gcs.WrapUnderCommonGCSError(err)
 	if err != nil {
 		if !wrapped {
 			err = fmt.Errorf("error in fetching object attributes: %w", err)
@@ -203,7 +203,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// writer successfully before calling Attrs() method of writer.
 	if err = wc.Close(); err != nil {
 		var wrapped bool
-		err, wrapped = gcs.WrapGCSFuseError(err)
+		err, wrapped = gcs.WrapUnderCommonGCSError(err)
 		if !wrapped {
 			err = fmt.Errorf("error in closing writer : %w", err)
 		}
@@ -236,7 +236,7 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {
 	if err = w.Close(); err != nil {
 		var wrapped bool
-		err, wrapped = gcs.WrapGCSFuseError(err)
+		err, wrapped = gcs.WrapUnderCommonGCSError(err)
 		if !wrapped {
 			err = fmt.Errorf("error in closing writer : %w", err)
 		}
@@ -267,7 +267,7 @@ func (bh *bucketHandle) CopyObject(ctx context.Context, req *gcs.CopyObjectReque
 
 	if err != nil {
 		var wrapped bool
-		err, wrapped = gcs.WrapGCSFuseError(err)
+		err, wrapped = gcs.WrapUnderCommonGCSError(err)
 		if !wrapped {
 			err = fmt.Errorf("error in copying object: %w", err)
 		}
@@ -406,7 +406,7 @@ func (bh *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectR
 	}
 
 	var wrapped bool
-	err, wrapped = gcs.WrapGCSFuseError(err)
+	err, wrapped = gcs.WrapUnderCommonGCSError(err)
 	if !wrapped {
 		err = fmt.Errorf("error in updating object: %w", err)
 	}
@@ -454,7 +454,7 @@ func (bh *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObje
 	attrs, err := dstObj.ComposerFrom(srcObjList...).Run(ctx)
 	if err != nil {
 		var wrapped bool
-		err, wrapped = gcs.WrapGCSFuseError(err)
+		err, wrapped = gcs.WrapUnderCommonGCSError(err)
 		if !wrapped {
 			err = fmt.Errorf("error in composing object: %w", err)
 		}
@@ -506,7 +506,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 	}
 
 	var wrapped bool
-	err, wrapped = gcs.WrapGCSFuseError(err)
+	err, wrapped = gcs.WrapUnderCommonGCSError(err)
 	if !wrapped {
 		err = fmt.Errorf("error in moving object: %w", err)
 	}
@@ -555,7 +555,7 @@ func (bh *bucketHandle) GetFolder(ctx context.Context, folderName string) (*gcs.
 
 	if err != nil {
 		err = fmt.Errorf("error getting metadata for folder: %s, %w", folderName, err)
-		err, _ = gcs.WrapGCSFuseError(err)
+		err, _ = gcs.WrapUnderCommonGCSError(err)
 		return nil, err
 	}
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -95,7 +95,7 @@ func (bh *bucketHandle) NewReaderWithReadHandle(
 
 	// NewRangeReader creates a "storage.Reader" object which is also io.ReadCloser since it contains both Read() and Close() methods present in io.ReadCloser interface.
 	r, err := obj.NewRangeReader(ctx, start, length)
-	return r, gcs.WrapUnderCommonGCSError(err)
+	return r, gcs.GetGCSError(err)
 }
 
 func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectRequest) error {
@@ -116,14 +116,14 @@ func (bh *bucketHandle) DeleteObject(ctx context.Context, req *gcs.DeleteObjectR
 	if err != nil {
 		err = fmt.Errorf("error in deleting object: %w", err)
 	}
-	return gcs.WrapUnderCommonGCSError(err)
+	return gcs.GetGCSError(err)
 }
 
 func (bh *bucketHandle) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
 
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	var attrs *storage.ObjectAttrs
@@ -177,7 +177,7 @@ func (bh *bucketHandle) getObjectHandleWithPreconditionsSet(req *gcs.CreateObjec
 
 func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
@@ -231,12 +231,8 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 }
 
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {
-	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
-	}()
-
 	if err = w.Close(); err != nil {
-		err = fmt.Errorf("error in closing writer : %w", err)
+		err = fmt.Errorf("error in closing writer : %w", gcs.GetGCSError(err))
 		return
 	}
 
@@ -248,7 +244,7 @@ func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gc
 
 func (bh *bucketHandle) CopyObject(ctx context.Context, req *gcs.CopyObjectRequest) (o *gcs.Object, err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	srcObj := bh.bucket.Object(req.SrcName)
@@ -358,7 +354,7 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 
 func (bh *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectRequest) (o *gcs.Object, err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	obj := bh.bucket.Object(req.Name)
@@ -412,7 +408,7 @@ func (bh *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectR
 
 func (bh *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObjectsRequest) (o *gcs.Object, err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	dstObj := bh.bucket.Object(req.DstName)
@@ -465,7 +461,7 @@ func (bh *bucketHandle) ComposeObjects(ctx context.Context, req *gcs.ComposeObje
 
 func (bh *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	var callOptions []gax.CallOption
@@ -482,7 +478,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 	var err error
 
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	obj := bh.bucket.Object(req.SrcName)
@@ -515,7 +511,7 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 
 func (bh *bucketHandle) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (folder *gcs.Folder, err error) {
 	defer func() {
-		err = gcs.WrapUnderCommonGCSError(err)
+		err = gcs.GetGCSError(err)
 	}()
 
 	var controlFolder *controlpb.Folder
@@ -557,7 +553,7 @@ func (bh *bucketHandle) GetFolder(ctx context.Context, folderName string) (*gcs.
 	}, callOptions...)
 
 	if err != nil {
-		err = gcs.WrapUnderCommonGCSError(fmt.Errorf("error getting metadata for folder: %s, %w", folderName, err))
+		err = gcs.GetGCSError(fmt.Errorf("error getting metadata for folder: %s, %w", folderName, err))
 		return nil, err
 	}
 
@@ -574,7 +570,7 @@ func (bh *bucketHandle) CreateFolder(ctx context.Context, folderName string) (*g
 
 	clientFolder, err := bh.controlClient.CreateFolder(ctx, req)
 	if err != nil {
-		return nil, gcs.WrapUnderCommonGCSError(err)
+		return nil, gcs.GetGCSError(err)
 	}
 
 	folder := gcs.GCSFolder(bh.bucketName, clientFolder)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -413,13 +413,13 @@ func (bh *bucketHandle) UpdateObject(ctx context.Context, req *gcs.UpdateObjectR
 
 	attrs, err := obj.Update(ctx, updateQuery)
 
-	if err == nil {
-		// Converting objAttrs to type *Object
-		o = storageutil.ObjectAttrsToBucketObject(attrs)
+	if err != nil {
+		err = fmt.Errorf("error in updating object: %w", err)
 		return
 	}
 
-	err = fmt.Errorf("error in updating object: %w", err)
+	// Converting objAttrs to type *Object
+	o = storageutil.ObjectAttrsToBucketObject(attrs)
 	return
 }
 
@@ -511,13 +511,13 @@ func (bh *bucketHandle) MoveObject(ctx context.Context, req *gcs.MoveObjectReque
 	}
 
 	attrs, err := obj.Move(ctx, dstMoveObject)
-	if err == nil {
-		// Converting objAttrs to type *Object
-		o = storageutil.ObjectAttrsToBucketObject(attrs)
+	if err != nil {
+		err = fmt.Errorf("error in moving object: %w", err)
 		return
 	}
 
-	err = fmt.Errorf("error in moving object: %w", err)
+	// Converting objAttrs to type *Object
+	o = storageutil.ObjectAttrsToBucketObject(attrs)
 	return
 }
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -313,7 +313,7 @@ func (testSuite *BucketHandleTest) TestDeleteObjectMethodWithMissingObject() {
 			MetaGenerationPrecondition: nil,
 		})
 
-	assert.Equal(testSuite.T(), "gcs.NotFoundError: storage: object doesn't exist", err.Error())
+	assert.NotNil(testSuite.T(), err)
 }
 
 func (testSuite *BucketHandleTest) TestDeleteObjectMethodWithMissingGeneration() {

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,14 +26,12 @@ import (
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
-	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -1632,60 +1629,4 @@ func (testSuite *BucketHandleTest) TestCreateFolderWithGivenName() {
 	testSuite.mockClient.AssertExpectations(testSuite.T())
 	assert.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), gcs.GCSFolder(TestBucketName, &mockFolder), folder)
-}
-
-func TestIsPreconditionFailed(t *testing.T) {
-	preCondApiError, _ := apierror.FromError(status.New(codes.FailedPrecondition, "Precondition error").Err())
-	notFoundApiError, _ := apierror.FromError(status.New(codes.NotFound, "Not Found error").Err())
-
-	tests := []struct {
-		name          string
-		err           error
-		expectPreCond bool
-	}{
-		{
-			name:          "googleapi.Error with PreconditionFailed",
-			err:           &googleapi.Error{Code: http.StatusPreconditionFailed},
-			expectPreCond: true,
-		},
-		{
-			name:          "googleapi.Error with other code",
-			err:           &googleapi.Error{Code: http.StatusNotFound},
-			expectPreCond: false,
-		},
-		{
-			name:          "apierror.APIError with FailedPrecondition",
-			err:           preCondApiError,
-			expectPreCond: true,
-		},
-		{
-			name:          "apierror.APIError with other code",
-			err:           notFoundApiError,
-			expectPreCond: false,
-		},
-		{
-			name:          "nil error",
-			err:           nil,
-			expectPreCond: false,
-		},
-		{
-			name:          "generic error",
-			err:           errors.New("generic error"),
-			expectPreCond: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isPreCond, err := isPreconditionFailed(tt.err)
-
-			assert.Equal(t, tt.expectPreCond, isPreCond)
-			if tt.expectPreCond {
-				var preCondErr *gcs.PreconditionError
-				assert.ErrorAs(t, err, &preCondErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }

--- a/internal/storage/gcs/errors.go
+++ b/internal/storage/gcs/errors.go
@@ -47,7 +47,7 @@ func (pe *PreconditionError) Error() string {
 }
 
 // WrapGCSFuseError converts an error returned by go-sdk into gcsfuse specific gcs error.
-// It returns converted error and a boolean indicating whether a conversion occured or not.
+// It returns wrapped error and a boolean indicating whether a conversion occured or not.
 func WrapGCSFuseError(err error) (error, bool) {
 	if err == nil {
 		return nil, false

--- a/internal/storage/gcs/errors.go
+++ b/internal/storage/gcs/errors.go
@@ -45,8 +45,8 @@ func (pe *PreconditionError) Error() string {
 	return fmt.Sprintf("gcs.PreconditionError: %v", pe.Err)
 }
 
-// WrapUnderCommonGCSError converts an error returned by go-sdk into gcsfuse specific common gcs error.
-func WrapUnderCommonGCSError(err error) error {
+// GetGCSError converts an error returned by go-sdk into gcsfuse specific common gcs error.
+func GetGCSError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -73,6 +73,7 @@ func WrapUnderCommonGCSError(err error) error {
 	}
 
 	// If storage object doesn't exist, go-sdk returns as ErrObjectNotExist.
+	// Important to note: currently go-sdk doesn't format/convert error coming from the control-client.
 	// Ref: http://shortn/_CY9Jyqf2wF
 	if errors.Is(err, storage.ErrObjectNotExist) {
 		return &NotFoundError{Err: err}

--- a/internal/storage/gcs/errors.go
+++ b/internal/storage/gcs/errors.go
@@ -14,7 +14,17 @@
 
 package gcs
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 // A *NotFoundError value is an error that indicates an object name or a
 // particular generation for that name were not found.
@@ -34,4 +44,51 @@ type PreconditionError struct {
 // Returns pe.Err.Error().
 func (pe *PreconditionError) Error() string {
 	return fmt.Sprintf("gcs.PreconditionError: %v", pe.Err)
+}
+
+// WrapGCSFuseError converts an error returned by go-sdk into gcsfuse specific gcs error.
+// It returns converted error and a boolean indicating whether a conversion occured or not.
+func WrapGCSFuseError(err error) (error, bool) {
+	if err == nil {
+		return nil, false
+	}
+
+	// Http client error.
+	var gErr *googleapi.Error
+	if errors.As(err, &gErr) {
+		switch gErr.Code {
+		case http.StatusNotFound:
+			return &NotFoundError{Err: err}, true
+		case http.StatusPreconditionFailed:
+			return &PreconditionError{Err: err}, true
+		}
+
+	}
+
+	// Control client error.
+	var apiErr *apierror.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.GRPCStatus().Code() {
+		case codes.NotFound:
+			return &NotFoundError{Err: err}, true
+		case codes.FailedPrecondition:
+			return &PreconditionError{Err: err}, true
+		}
+	}
+
+	// RPC error.
+	if rpcErr, ok := status.FromError(err); ok {
+		switch rpcErr.Code() {
+		case codes.NotFound:
+			return &NotFoundError{Err: err}, true
+		case codes.FailedPrecondition:
+			return &PreconditionError{Err: err}, true
+		}
+	}
+
+	if err == storage.ErrObjectNotExist {
+		return &NotFoundError{Err: err}, true
+	}
+
+	return err, false
 }

--- a/internal/storage/gcs/errors.go
+++ b/internal/storage/gcs/errors.go
@@ -46,9 +46,9 @@ func (pe *PreconditionError) Error() string {
 	return fmt.Sprintf("gcs.PreconditionError: %v", pe.Err)
 }
 
-// WrapGCSFuseError converts an error returned by go-sdk into gcsfuse specific gcs error.
-// It returns wrapped error and a boolean indicating whether a conversion occured or not.
-func WrapGCSFuseError(err error) (error, bool) {
+// WrapUnderCommonGCSError converts an error returned by go-sdk into gcsfuse specific common gcs error.
+// It returns wrapped error and a boolean indicating whether a wrapped or not.
+func WrapUnderCommonGCSError(err error) (error, bool) {
 	if err == nil {
 		return nil, false
 	}

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcs
+
+import (
+	"net/http"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"errors"
+)
+
+func TestWrapGCSFuseError(t *testing.T) {
+	preconditionAPIErr, ok := apierror.FromError(status.Error(codes.FailedPrecondition, codes.FailedPrecondition.String()))
+	assert.True(t, ok)
+
+	notFoundAPIErr, ok := apierror.FromError(status.Error(codes.NotFound, codes.NotFound.String()))
+	assert.True(t, ok)
+
+	otherAPIErr, ok := apierror.FromError(status.Error(codes.Internal, codes.Internal.String()))
+	assert.True(t, ok)
+
+	testCases := []struct {
+		name            string
+		inputErr        error
+		expectedErr     error
+		expectedConvert bool
+	}{
+		{
+			name:            "nil_error",
+			inputErr:        nil,
+			expectedErr:     nil,
+			expectedConvert: false,
+		},
+		{
+			name:            "googleapi.Error_NotFound",
+			inputErr:        &googleapi.Error{Code: http.StatusNotFound},
+			expectedErr:     &NotFoundError{Err: &googleapi.Error{Code: http.StatusNotFound}},
+			expectedConvert: true,
+		},
+		{
+			name:            "googleapi.Error_PreconditionFailed",
+			inputErr:        &googleapi.Error{Code: http.StatusPreconditionFailed},
+			expectedErr:     &PreconditionError{Err: &googleapi.Error{Code: http.StatusPreconditionFailed}},
+			expectedConvert: true,
+		},
+		{
+			name:            "googleapi.Error_other_code",
+			inputErr:        &googleapi.Error{Code: http.StatusBadRequest},
+			expectedErr:     &googleapi.Error{Code: http.StatusBadRequest},
+			expectedConvert: false,
+		},
+		{
+			name:            "grpc_status_NotFound",
+			inputErr:        status.Error(codes.NotFound, "not found"),
+			expectedErr:     &NotFoundError{Err: status.Error(codes.NotFound, "not found")},
+			expectedConvert: true,
+		},
+		{
+			name:            "grpc_status_FailedPrecondition",
+			inputErr:        status.Error(codes.FailedPrecondition, "failed precondition"),
+			expectedErr:     &PreconditionError{Err: status.Error(codes.FailedPrecondition, "failed precondition")},
+			expectedConvert: true,
+		},
+		{
+			name:            "grpc_status_other_code",
+			inputErr:        status.Error(codes.Internal, "internal error"),
+			expectedErr:     status.Error(codes.Internal, "internal error"),
+			expectedConvert: false,
+		},
+		{
+			name:            "other_error",
+			inputErr:        errors.New("some error"),
+			expectedErr:     errors.New("some error"),
+			expectedConvert: false,
+		},
+		{
+			name:            "GCS_Precondition_error",
+			inputErr:        &PreconditionError{Err: errors.New("precondition error")},
+			expectedErr:     &PreconditionError{Err: errors.New("precondition error")},
+			expectedConvert: false,
+		},
+		{
+			name:            "GCS_NotFound_error",
+			inputErr:        &NotFoundError{Err: errors.New("not found error")},
+			expectedErr:     &NotFoundError{Err: errors.New("not found error")},
+			expectedConvert: false,
+		},
+		{
+			name:            "Storage_object_not_exist",
+			inputErr:        storage.ErrObjectNotExist,
+			expectedErr:     &NotFoundError{Err: storage.ErrObjectNotExist},
+			expectedConvert: true,
+		},
+		{
+			name:            "precondition_apierror",
+			inputErr:        preconditionAPIErr,
+			expectedErr:     &PreconditionError{Err: preconditionAPIErr},
+			expectedConvert: true,
+		},
+		{
+			name:            "notfound_apierror",
+			inputErr:        notFoundAPIErr,
+			expectedErr:     &NotFoundError{Err: notFoundAPIErr},
+			expectedConvert: true,
+		},
+		{
+			name:            "other_apierror",
+			inputErr:        otherAPIErr,
+			expectedErr:     otherAPIErr,
+			expectedConvert: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, converted := WrapGCSFuseError(tc.inputErr)
+			assert.Equal(t, tc.expectedConvert, converted)
+			assert.Equal(t, tc.expectedErr, got)
+
+		})
+	}
+}

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -29,7 +29,7 @@ import (
 	"errors"
 )
 
-func TestWrapUnderCommonGCSError(t *testing.T) {
+func TestGetGCSError(t *testing.T) {
 	preconditionAPIErr, ok := apierror.FromError(status.Error(codes.FailedPrecondition, codes.FailedPrecondition.String()))
 	assert.True(t, ok)
 
@@ -142,7 +142,7 @@ func TestWrapUnderCommonGCSError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := WrapUnderCommonGCSError(tc.inputErr)
+			got := GetGCSError(tc.inputErr)
 			assert.Equal(t, tc.expectedErr, got)
 		})
 	}

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -132,7 +132,7 @@ func TestWrapGCSFuseError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, converted := WrapGCSFuseError(tc.inputErr)
+			got, wrapped := WrapGCSFuseError(tc.inputErr)
 			assert.Equal(t, tc.expectedConvert, converted)
 			assert.Equal(t, tc.expectedErr, got)
 

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -42,98 +42,98 @@ func TestWrapGCSFuseError(t *testing.T) {
 		name            string
 		inputErr        error
 		expectedErr     error
-		expectedConvert bool
+		expectedWrapped bool
 	}{
 		{
 			name:            "nil_error",
 			inputErr:        nil,
 			expectedErr:     nil,
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "googleapi.Error_NotFound",
 			inputErr:        &googleapi.Error{Code: http.StatusNotFound},
 			expectedErr:     &NotFoundError{Err: &googleapi.Error{Code: http.StatusNotFound}},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "googleapi.Error_PreconditionFailed",
 			inputErr:        &googleapi.Error{Code: http.StatusPreconditionFailed},
 			expectedErr:     &PreconditionError{Err: &googleapi.Error{Code: http.StatusPreconditionFailed}},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "googleapi.Error_other_code",
 			inputErr:        &googleapi.Error{Code: http.StatusBadRequest},
 			expectedErr:     &googleapi.Error{Code: http.StatusBadRequest},
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "grpc_status_NotFound",
 			inputErr:        status.Error(codes.NotFound, "not found"),
 			expectedErr:     &NotFoundError{Err: status.Error(codes.NotFound, "not found")},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "grpc_status_FailedPrecondition",
 			inputErr:        status.Error(codes.FailedPrecondition, "failed precondition"),
 			expectedErr:     &PreconditionError{Err: status.Error(codes.FailedPrecondition, "failed precondition")},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "grpc_status_other_code",
 			inputErr:        status.Error(codes.Internal, "internal error"),
 			expectedErr:     status.Error(codes.Internal, "internal error"),
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "other_error",
 			inputErr:        errors.New("some error"),
 			expectedErr:     errors.New("some error"),
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "GCS_Precondition_error",
 			inputErr:        &PreconditionError{Err: errors.New("precondition error")},
 			expectedErr:     &PreconditionError{Err: errors.New("precondition error")},
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "GCS_NotFound_error",
 			inputErr:        &NotFoundError{Err: errors.New("not found error")},
 			expectedErr:     &NotFoundError{Err: errors.New("not found error")},
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 		{
 			name:            "Storage_object_not_exist",
 			inputErr:        storage.ErrObjectNotExist,
 			expectedErr:     &NotFoundError{Err: storage.ErrObjectNotExist},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "precondition_apierror",
 			inputErr:        preconditionAPIErr,
 			expectedErr:     &PreconditionError{Err: preconditionAPIErr},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "notfound_apierror",
 			inputErr:        notFoundAPIErr,
 			expectedErr:     &NotFoundError{Err: notFoundAPIErr},
-			expectedConvert: true,
+			expectedWrapped: true,
 		},
 		{
 			name:            "other_apierror",
 			inputErr:        otherAPIErr,
 			expectedErr:     otherAPIErr,
-			expectedConvert: false,
+			expectedWrapped: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, wrapped := WrapGCSFuseError(tc.inputErr)
-			assert.Equal(t, tc.expectedConvert, converted)
+			assert.Equal(t, tc.expectedWrapped, wrapped)
 			assert.Equal(t, tc.expectedErr, got)
 
 		})

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -39,7 +39,9 @@ func TestGetGCSError(t *testing.T) {
 	otherAPIErr, ok := apierror.FromError(status.Error(codes.Internal, codes.Internal.String()))
 	assert.True(t, ok)
 
-	// TODO: to check - why does wrapped_grpc_status_NotFound test fails without same error in input and output?
+	// TODO: to directly create the error for "wrapped_grpc_status_NotFound" sub-test, if below issue is fixed.
+	// Currently, test fails because status.FromError(err) appends extra message to the input err, if error is created directly.
+	// Details: https://github.com/grpc/grpc-go/issues/8102
 	grpcNotFoundErr := status.Error(codes.NotFound, "not found")
 	assert.True(t, ok)
 

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -28,7 +28,7 @@ import (
 	"errors"
 )
 
-func TestWrapGCSFuseError(t *testing.T) {
+func TestWrapUnderCommonGCSError(t *testing.T) {
 	preconditionAPIErr, ok := apierror.FromError(status.Error(codes.FailedPrecondition, codes.FailedPrecondition.String()))
 	assert.True(t, ok)
 
@@ -132,7 +132,7 @@ func TestWrapGCSFuseError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, wrapped := WrapGCSFuseError(tc.inputErr)
+			got, wrapped := WrapUnderCommonGCSError(tc.inputErr)
 			assert.Equal(t, tc.expectedWrapped, wrapped)
 			assert.Equal(t, tc.expectedErr, got)
 

--- a/internal/storage/gcs/errors_test.go
+++ b/internal/storage/gcs/errors_test.go
@@ -39,9 +39,8 @@ func TestGetGCSError(t *testing.T) {
 	otherAPIErr, ok := apierror.FromError(status.Error(codes.Internal, codes.Internal.String()))
 	assert.True(t, ok)
 
-	// TODO: to directly create the error for "wrapped_grpc_status_NotFound" sub-test, if below issue is fixed.
-	// Currently, test fails because status.FromError(err) appends extra message to the input err, if error is created directly.
-	// Details: https://github.com/grpc/grpc-go/issues/8102
+	// TODO: to directly create the error for "wrapped_grpc_status_NotFound" sub-test, when the following issue is resolved.
+	// Ref: https://github.com/grpc/grpc-go/issues/8102
 	grpcNotFoundErr := status.Error(codes.NotFound, "not found")
 	assert.True(t, ok)
 


### PR DESCRIPTION
### Description
- Created a single method which wraps the error returned by go-sdk under gcs.NotFound or gcs.PreconditionFailed. This takes care of error coming from http, grpc and control client.
- Updated all the methods of bucket_handle.go to use the new method for conversion.
- I'll enable the streaming write test for GRPC protocol as a separate PR (with more test-packages).

### Link to the issue in case of a bug fix.
b/395511337

### Testing details
1. Manual - Tested the streaming write test manually by enabling that for gRPC. `GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/streaming_writes/... -p 1 --integrationTest -v --testbucket=<bucket_name> -run=TestDefaultMountLocalFileTest/TestCreateNewFileWhenSameFileExistsOnGCS`
2. Unit tests - NA
3. Integration tests - NA
