### PR TITLE
Revert "Revert "Add Streaming Writes failure scenario tests for local files.""

### DIFF
--- a/tools/integration_tests/emulator_tests/emulator_tests.sh
+++ b/tools/integration_tests/emulator_tests/emulator_tests.sh
@@ -88,6 +88,14 @@ DOCKER_NETWORK="--net=host"
 # Get the docker image for the testbench
 sudo docker pull $DOCKER_IMAGE
 
+# Remove the docker container if it's already running.
+CONTAINER_ID=$(sudo docker ps -aqf "name=$CONTAINER_NAME")
+if [[ -n "$CONTAINER_ID" ]]; then
+  echo "Container with ID:[$CONTAINER_ID] is already running with name:[$CONTAINER_NAME]"
+  echo "Stoping container...."
+  sudo docker stop $CONTAINER_ID
+fi
+
 # Start the testbench
 sudo docker run --name $CONTAINER_NAME --rm -d $DOCKER_NETWORK $DOCKER_IMAGE
 echo "Running the Cloud Storage testbench: $STORAGE_EMULATOR_HOST"
@@ -112,5 +120,8 @@ curl -X POST --data-binary @test.json \
     "$STORAGE_EMULATOR_HOST/storage/v1/b?project=test-project"
 rm test.json
 
-# Run specific test suite
-go test ./tools/integration_tests/emulator_tests/... --integrationTest -v --testbucket=test-bucket -timeout 10m --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE
+# Run Write Stall Tests.
+go test ./tools/integration_tests/emulator_tests/write_stall/... --integrationTest -v --testbucket=test-bucket -timeout 10m --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE
+
+# Run Streaming Writes Failure Tests.
+go test ./tools/integration_tests/emulator_tests/streaming_writes_failure/... -p 1 -short --integrationTest -v --testbucket=test-bucket --testOnCustomEndpoint=http://localhost:8020 -timeout 10m --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE

--- a/tools/integration_tests/emulator_tests/proxy_server/configs/second_chunk_upload_returns412.yaml
+++ b/tools/integration_tests/emulator_tests/proxy_server/configs/second_chunk_upload_returns412.yaml
@@ -1,0 +1,8 @@
+targetHost: http://localhost:9000
+retryConfig:
+- method: JsonCreate
+  retryInstruction: "return-412"
+  retryCount: 1
+  # Skip count of three is required as first call is used to create the testDir on the GCS and then
+  # second and third call are used in creating resumable upload session uri and first chunk upload.
+  skipCount: 3

--- a/tools/integration_tests/emulator_tests/streaming_writes_failure/local_file_failure_test.go
+++ b/tools/integration_tests/emulator_tests/streaming_writes_failure/local_file_failure_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streaming_writes_failure
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	emulator_tests "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/emulator_tests/util"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// //////////////////////////////////////////////////////////////////////
+// Boilerplate
+// //////////////////////////////////////////////////////////////////////
+
+type defaultFailureTestSuite struct {
+	suite.Suite
+	configPath         string
+	flags              []string
+	testDirPath        string
+	filePath           string
+	fh1                *os.File
+	storageClient      *storage.Client // Storage Client based on proxy server.
+	closeStorageClient func() error
+	ctx                context.Context
+	data               []byte
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+
+func (t *defaultFailureTestSuite) SetupSuite() {
+	t.configPath = "../proxy_server/configs/second_chunk_upload_returns412.yaml"
+	t.flags = []string{"--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=1", "--custom-endpoint=" + proxyEndpoint}
+	// Generate 5 MB random data.
+	data, err := operations.GenerateRandomData(5 * operations.MiB)
+	t.data = data
+	require.NoError(t.T(), err)
+	log.Printf("Running tests with flags: %v", t.flags)
+}
+
+func (t *defaultFailureTestSuite) SetupTest() {
+	// Start proxy server for each test to ensure the config is initialized per test.
+	emulator_tests.StartProxyServer(t.configPath)
+	// Create storage client before running tests.
+	t.ctx = context.Background()
+	t.closeStorageClient = client.CreateStorageClientWithCancel(&t.ctx, &t.storageClient)
+	setup.MountGCSFuseWithGivenMountFunc(t.flags, mountFunc)
+	// Setup test directory for testing.
+	t.testDirPath = setup.SetupTestDirectory(testDirName)
+	// Create a local file.
+	t.filePath, t.fh1 = CreateLocalFileInTestDir(t.ctx, t.storageClient, t.testDirPath, FileName1, t.T())
+}
+
+func (t *defaultFailureTestSuite) TearDownTest() {
+	// CleanUp MntDir before unmounting GCSFuse.
+	setup.CleanUpDir(rootDir)
+	setup.UnmountGCSFuse(rootDir)
+	assert.NoError(t.T(), t.closeStorageClient())
+	assert.NoError(t.T(), emulator_tests.KillProxyServerProcess(port))
+}
+
+func (t *defaultFailureTestSuite) writingWithNewFileHandleAlsoFails(data []byte, off int64) {
+	t.T().Helper()
+	// Opening a new file handle succeeds.
+	fh := operations.OpenFile(t.filePath, t.T())
+	// Writes with this file handle fails.
+	_, err := fh.WriteAt(data, off)
+	assert.Error(t.T(), err)
+	// Closing the file handle returns error.
+	operations.CloseFileShouldThrowError(t.T(), fh)
+}
+
+func (t *defaultFailureTestSuite) writingAfterBwhReinitializationSucceeds() {
+	t.T().Helper()
+	// Verify that Object is not found on GCS.
+	ValidateObjectNotFoundErrOnGCS(t.ctx, t.storageClient, testDirName, FileName1, t.T())
+	// Opening new file handle and writing to file succeeds.
+	t.fh1 = operations.CreateFile(t.filePath, FilePerms, t.T())
+	_, err := t.fh1.WriteAt(t.data, 0)
+	assert.NoError(t.T(), err)
+	// Sync succeeds.
+	err = t.fh1.Sync()
+	assert.NoError(t.T(), err)
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Tests
+// //////////////////////////////////////////////////////////////////////
+
+func (t *defaultFailureTestSuite) TestStreamingWritesFailsOnSecondChunkUploadFailure() {
+	// Write first 2 MB (say A,B) block to file succeeds but async upload of block B will result in error.
+	// Fuse:[B] -> Go-SDK:[A] -> GCS[]
+	_, err := t.fh1.WriteAt(t.data[:2*operations.MiB], 0)
+	assert.NoError(t.T(), err)
+	// Write again 2MB (C, D) will trigger B upload.
+	// Fuse:[D] -> Go-SDK:[C] -> GCS[A, B -> upload fails]
+	_, _ = t.fh1.WriteAt(t.data[2*operations.MiB:4*operations.MiB], 2*operations.MiB)
+
+	// Write 5th 1MB results in errors.
+	_, err = t.fh1.WriteAt(t.data[4*operations.MiB:5*operations.MiB], 4*operations.MiB)
+
+	require.Error(t.T(), err)
+	t.writingWithNewFileHandleAlsoFails(t.data[4*operations.MiB:5*operations.MiB], 4*operations.MiB)
+	// Close file handle to reinitialize bwh.
+	operations.CloseFileShouldThrowError(t.T(), t.fh1)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Close and validate object content found on GCS.
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
+}
+
+func (t *defaultFailureTestSuite) TestStreamingWritesTruncateSmallerFailsOnSecondChunkUploadFailure() {
+	// Write first 2 MB (say A,B) block to file succeeds but async upload of block B will result in error.
+	// Fuse:[B] -> Go-SDK:[A] -> GCS[]
+	_, err := t.fh1.WriteAt(t.data[:2*operations.MiB], 0)
+	assert.NoError(t.T(), err)
+	// Write again 2MB (C, D) will trigger B upload.
+	// Fuse:[D] -> Go-SDK:[C] -> GCS[A, B -> upload fails]
+	_, _ = t.fh1.WriteAt(t.data[2*operations.MiB:4*operations.MiB], 2*operations.MiB)
+
+	// Write 5th 1MB results in errors.
+	_, err = t.fh1.WriteAt(t.data[4*operations.MiB:5*operations.MiB], 4*operations.MiB)
+
+	require.Error(t.T(), err)
+	// Truncate to smaller size fails.
+	err = t.fh1.Truncate(1 * operations.MiB)
+	assert.Error(t.T(), err)
+	t.writingWithNewFileHandleAlsoFails(t.data[4*operations.MiB:5*operations.MiB], 4*operations.MiB)
+	// Close file handle to reinitialize bwh.
+	operations.CloseFileShouldThrowError(t.T(), t.fh1)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Close and validate object content found on GCS.
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
+}
+
+func (t *defaultFailureTestSuite) TestStreamingWritesTruncateBiggerSucceedsOnSecondChunkUploadFailure() {
+	// Write first 2 MB (say A,B) block to file succeeds but async upload of block B will result in error.
+	// Fuse:[B] -> Go-SDK:[A] -> GCS[]
+	_, err := t.fh1.WriteAt(t.data[:2*operations.MiB], 0)
+	assert.NoError(t.T(), err)
+	// Write again 2MB (C, D) will trigger B upload.
+	// Fuse:[D] -> Go-SDK:[C] -> GCS[A, B -> upload fails]
+	_, _ = t.fh1.WriteAt(t.data[2*operations.MiB:4*operations.MiB], 2*operations.MiB)
+
+	// Write 5th 1MB results in errors.
+	_, err = t.fh1.WriteAt(t.data[4*operations.MiB:5*operations.MiB], 4*operations.MiB)
+
+	require.Error(t.T(), err)
+	// Opening new file handle succeeds.
+	fh2 := operations.OpenFile(t.filePath, t.T())
+	// Truncate to bigger size succeeds.
+	err = fh2.Truncate(5 * operations.MiB)
+	assert.NoError(t.T(), err)
+	// Closing all file handles to reinitialize bwh.
+	operations.CloseFileShouldThrowError(t.T(), fh2)
+	operations.CloseFileShouldThrowError(t.T(), t.fh1)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Truncate to bigger size succeeds.
+	err = t.fh1.Truncate(6 * operations.MiB)
+	assert.NoError(t.T(), err)
+	// Close and validate object content found on GCS.
+	emptyBytes := make([]byte, operations.MiB)
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data)+string(emptyBytes), t.T())
+}
+
+func (t *defaultFailureTestSuite) TestStreamingWritesSyncFailsOnSecondChunkUploadFailure() {
+	// Write first 2 MB (say A,B) block to file succeeds but async upload of block B will result in error.
+	// Fuse:[B] -> Go-SDK:[A] -> GCS[]
+	_, err := t.fh1.WriteAt(t.data[:2*operations.MiB], 0)
+	assert.NoError(t.T(), err)
+	// Sync file succeeds as the block B is only passed to Go-SDK for upload.
+	// Fuse:[] -> Go-SDK:[B]-> GCS[A]
+	operations.SyncFile(t.fh1, t.T())
+
+	// Write next 1 MB block C may succeed based on the status of block B.
+	// Fuse:[C] -> Go-SDK:[B]-> GCS[A]
+	_, _ = t.fh1.WriteAt(t.data[2*operations.MiB:3*operations.MiB], 2*operations.MiB)
+
+	// Sync now reports failure from B block upload.
+	// Fuse:[] -> Go-SDK:[C]-> GCS[A, B -> upload fails]
+	operations.SyncFileShouldThrowError(t.T(), t.fh1)
+	// Close file handle to reinitialize bwh.
+	operations.CloseFileShouldThrowError(t.T(), t.fh1)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Close and validate object content found on GCS.
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
+}
+
+func (t *defaultFailureTestSuite) TestStreamingWritesCloseFailsOnSecondChunkUploadFailure() {
+	// Write first 2 MB (say A,B) block to file succeeds but async upload of block B will result in error.
+	// Fuse:[B] -> Go-SDK:[A] -> GCS[]
+	_, err := t.fh1.WriteAt(t.data[:2*operations.MiB], 0)
+	assert.NoError(t.T(), err)
+
+	// Close fails as it sees error from B block upload.
+	err = t.fh1.Close()
+
+	require.Error(t.T(), err)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Close and validate object content found on GCS.
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
+}
+
+func (t *defaultFailureTestSuite) TestStreamingWritesWhenFinalizeObjectFailure() {
+	// Write 1 MB data to file succeeds and async upload of block will also succeed.
+	_, err := t.fh1.WriteAt(t.data[:operations.MiB], 0)
+	assert.NoError(t.T(), err)
+
+	// Close fails as it sees error on the finalize.
+	err = t.fh1.Close()
+
+	require.Error(t.T(), err)
+	// Opening new file handle and writing to file succeeds.
+	t.writingAfterBwhReinitializationSucceeds()
+	// Close and validate object content found on GCS.
+	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
+}
+
+func TestUploadFailureTestSuite(t *testing.T) {
+	suite.Run(t, new(defaultFailureTestSuite))
+}

--- a/tools/integration_tests/emulator_tests/streaming_writes_failure/streaming_writes_failure_test.go
+++ b/tools/integration_tests/emulator_tests/streaming_writes_failure/streaming_writes_failure_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package emulator_tests
+package streaming_writes_failure
 
 import (
 	"fmt"
@@ -24,29 +24,30 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-const port = 8020
+const (
+	testDirName = "StreamingWritesFailureTest"
+	port        = 8020
+)
 
 var (
-	testDirPath string
-	mountFunc   func([]string) error
-	// root directory is the directory to be unmounted.
-	rootDir       string
 	proxyEndpoint = fmt.Sprintf("http://localhost:%d/storage/v1/b?project=test-project", port)
+	mountFunc     func([]string) error
+	// root directory is the directory to be unmounted.
+	rootDir string
 )
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	if setup.MountedDirectory() != "" {
-		log.Printf("These tests will not run with mounted directory..")
+		log.Printf("These tests will not run with mounted directory.")
 		return
 	}
 
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()
-
 	rootDir = setup.MntDir()
-
+	log.Printf("Test log: %s\n", setup.LogFile())
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
 	successCode := m.Run()

--- a/tools/integration_tests/emulator_tests/util/test_helper.go
+++ b/tools/integration_tests/emulator_tests/util/test_helper.go
@@ -35,7 +35,7 @@ import (
 // It launches the proxy server with the specified configuration and port, logs its output to a file.
 func StartProxyServer(configPath string) {
 	// Start the proxy in the background
-	cmd := exec.Command("go", "run", "./proxy_server/.", "--config-path="+configPath)
+	cmd := exec.Command("go", "run", "../proxy_server/.", "--config-path="+configPath)
 	logFileForProxyServer, err := os.Create(path.Join(os.Getenv("KOKORO_ARTIFACTS_DIR"), "proxy-"+setup.GenerateRandomString(5)))
 	if err != nil {
 		log.Fatal("Error in creating log file for proxy server.")
@@ -64,7 +64,8 @@ func KillProxyServerProcess(port int) error {
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines[1:] {
 		fields := strings.Fields(line)
-		if len(fields) > 1 {
+		// Kill only the process directly listening on the port.
+		if len(fields) > 1 && strings.Contains(line, "LISTEN") {
 			pidStr := fields[1]
 			pid, err := strconv.Atoi(pidStr)
 			if err != nil {

--- a/tools/integration_tests/emulator_tests/write_stall/write_stall_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/write_stall_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package write_stall
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const port = 8020
+
+var (
+	testDirPath string
+	mountFunc   func([]string) error
+	// root directory is the directory to be unmounted.
+	rootDir       string
+	proxyEndpoint = fmt.Sprintf("http://localhost:%d/storage/v1/b?project=test-project", port)
+)
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	if setup.MountedDirectory() != "" {
+		log.Printf("These tests will not run with mounted directory..")
+		return
+	}
+
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	rootDir = setup.MntDir()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package emulator_tests
+package write_stall
 
 import (
 	"fmt"
@@ -41,7 +41,7 @@ type chunkTransferTimeoutInfinity struct {
 }
 
 func (s *chunkTransferTimeoutInfinity) Setup(t *testing.T) {
-	configPath := "./proxy_server/configs/write_stall_40s.yaml"
+	configPath := "../proxy_server/configs/write_stall_40s.yaml"
 	emulator_tests.StartProxyServer(configPath)
 	setup.MountGCSFuseWithGivenMountFunc(s.flags, mountFunc)
 }
@@ -103,14 +103,14 @@ func TestChunkTransferTimeout(t *testing.T) {
 	}{
 		{
 			name:       "SingleStall",
-			configPath: "./proxy_server/configs/write_stall_40s.yaml",
+			configPath: "../proxy_server/configs/write_stall_40s.yaml",
 			expectedTimeout: func(chunkTransferTimeoutSecs int) time.Duration {
 				return time.Duration(chunkTransferTimeoutSecs) * time.Second
 			},
 		},
 		{
 			name:       "MultipleStalls",
-			configPath: "./proxy_server/configs/write_stall_twice_40s.yaml", // 2 stalls
+			configPath: "../proxy_server/configs/write_stall_twice_40s.yaml", // 2 stalls
 			// Expect total time to be greater than the timeout multiplied by the number of stalls (2 in this case).
 			expectedTimeout: func(chunkTransferTimeoutSecs int) time.Duration {
 				return time.Duration(chunkTransferTimeoutSecs*2) * time.Second

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -50,6 +50,8 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 			return nil, fmt.Errorf("unable to fetch token-source for TPC: %w", err)
 		}
 		client, err = storage.NewClient(ctx, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithTokenSource(ts))
+	} else if setup.TestOnCustomEndpoint() != "" {
+		client, err = storage.NewClient(ctx, option.WithEndpoint(setup.TestOnCustomEndpoint()))
 	} else {
 		if setup.IsZonalBucketRun() {
 			client, err = storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -579,12 +579,26 @@ func CloseFileShouldNotThrowError(file *os.File, t *testing.T) {
 	}
 }
 
+func CloseFileShouldThrowError(t *testing.T, file *os.File) {
+	t.Helper()
+	if err := file.Close(); err == nil {
+		t.Fatalf("file.Close() for file %s should throw an error: %v", file.Name(), err)
+	}
+}
+
 func SyncFile(fh *os.File, t *testing.T) {
 	err := fh.Sync()
 
 	// Verify fh.Sync operation succeeds.
 	if err != nil {
 		t.Fatalf("%s.Sync(): %v", fh.Name(), err)
+	}
+}
+
+func SyncFileShouldThrowError(t *testing.T, file *os.File) {
+	t.Helper()
+	if err := file.Sync(); err == nil {
+		t.Fatalf("file.Close() for file %s should throw an error: %v", file.Name(), err)
 	}
 }
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,6 +43,7 @@ var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted 
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
+var testOnCustomEndpoint = flag.String("testOnCustomEndpoint", "", "Run tests on custom endpoint only when the flag value is set. Required for tests requiring proxy server.")
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
@@ -95,6 +96,10 @@ func TestInstalledPackage() bool {
 
 func TestOnTPCEndPoint() bool {
 	return *testOnTPCEndPoint
+}
+
+func TestOnCustomEndpoint() string {
+	return *testOnCustomEndpoint
 }
 
 func MountedDirectory() string {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcsfuse#3007

The previous revert attempt aimed to simplify the commit history on the master branch. However, instead of removing the unwanted commits, it introduced a new "revert" commit that undid the changes of those commits, effectively adding to the history rather than cleaning it up.