### PR TITLE
Upgrading fuse for better fuse logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1
 	github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec
-	github.com/jacobsa/fuse v0.0.0-20240607092844-7285af0d05b0
+	github.com/jacobsa/fuse v0.0.0-20240626143436-8a36813dc074
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtEMD2ouh8gOGIeDF9LrgXjo+9Q69RVzI=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20240607092844-7285af0d05b0 h1:IWVMQZZvWN+9FeRwWnZAINYNrsr3yyCWI2BcddQBDvk=
-github.com/jacobsa/fuse v0.0.0-20240607092844-7285af0d05b0/go.mod h1:JYi9iIxdYNgxmMgLwtSHO/hmVnP2kfX1oc+mtx+XWLA=
+github.com/jacobsa/fuse v0.0.0-20240626143436-8a36813dc074 h1:rrmTkL654m7vQTYzi9NpEzAO7t0to5f1/jgkvSorVs8=
+github.com/jacobsa/fuse v0.0.0-20240626143436-8a36813dc074/go.mod h1:JYi9iIxdYNgxmMgLwtSHO/hmVnP2kfX1oc+mtx+XWLA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=


### PR DESCRIPTION
### Description
Bringing [jacobsa/fuse changes](https://github.com/jacobsa/fuse/commit/8a36813dc07424e363c77ef2a4b7a766f819ad56) to improve fuse debug logging.

Currently, it's hard to map request to response for similar operations, we get the operation-id of request and then search to know the matching response.


**Log Before**  
```
time="25/06/2024 03:05:52.093580" severity=TRACE message="fuse_debug: Op 0x00000160        connection.go:420] <- LookUpInode (parent 1, name \"b.txt\", PID 870932)"

time="25/06/2024 03:05:52.093777" severity=TRACE message="fuse_debug: Op 0x00000160        connection.go:513] -> OK (inode 2)"
```


**Log After**
```
time="25/06/2024 03:03:45.288441" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:420] <- LookUpInode (parent 1, name \"b.txt\", PID 869418)"

time="25/06/2024 03:03:45.505412" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:513] -> LookUpInode (inode 3)"
```


### Link to the issue in case of a bug fix.
b/397560634

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - not running automated perf test as the only change is log change. - 
![image](https://github.com/user-attachments/assets/574b4958-f17c-4d88-8c01-aa325f24df67)

