### PR TITLE
Adding UTs for negative cases in MRD

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -15,6 +15,7 @@
 package handle
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -124,7 +125,8 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 		var objectData gcsx.ObjectData
 		objectData, err = fh.reader.ReadAt(ctx, dst, offset)
 		switch {
-		case err == io.EOF:
+		case errors.Is(err, io.EOF):
+			err = io.EOF
 			return
 
 		case err != nil:

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -213,11 +213,11 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 	requestId := uuid.New()
 	logger.Tracef("%.13v <- MultiRangeDownloader::Add (%s, [%d, %d))", requestId, mrdWrapper.object.Name, startOffset, endOffset)
 	start := time.Now()
-	mrdWrapper.Wrapped.Add(buffer, startOffset, endOffset-startOffset, func(offsetAddCallback int64, limit int64, e error) {
+	mrdWrapper.Wrapped.Add(buffer, startOffset, endOffset-startOffset, func(offsetAddCallback int64, bytesReadAddCallback int64, e error) {
 		defer func() {
 			mu.Lock()
 			if done != nil {
-				done <- readResult{bytesRead: int(limit), err: e}
+				done <- readResult{bytesRead: int(bytesReadAddCallback), err: e}
 			}
 			mu.Unlock()
 		}()

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -204,7 +204,7 @@ func (t *mrdWrapperTest) Test_Read_EOF() {
 
 	_, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, common.NewNoopMetrics())
 
-	assert.ErrorContains(t.T(), err, "EOF")
+	assert.ErrorIs(t.T(), err, io.EOF)
 }
 
 func (t *mrdWrapperTest) Test_Read_Error() {

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -143,6 +143,11 @@ func (t *mrdWrapperTest) Test_Read() {
 			start: 10,
 			end:   10 + int(t.object.Size)/2,
 		},
+		{
+			name:  "ReadEmpty",
+			start: 10,
+			end:   10,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -156,6 +161,57 @@ func (t *mrdWrapperTest) Test_Read() {
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.end-tc.start, bytesRead)
 			assert.Equal(t.T(), t.objectData[tc.start:tc.end], buf[:bytesRead])
+		})
+	}
+}
+
+func (t *mrdWrapperTest) Test_Read_ErrorHandling() {
+	testCases := []struct {
+		name               string
+		start              int
+		end                int
+		expectedErrKeyword string
+	}{
+		{
+			name:               "ErrorInCreatingMRD",
+			start:              0,
+			end:                100,
+			expectedErrKeyword: "MultiRangeDownloader",
+		},
+		{
+			name:               "TimeoutError",
+			start:              0,
+			end:                100,
+			expectedErrKeyword: "Timeout",
+		},
+		{
+			name:               "ContextCancelled",
+			start:              0,
+			end:                100,
+			expectedErrKeyword: "Context Cancelled",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			ctx := context.Background()
+			buf := make([]byte, tc.end-tc.start)
+			t.mrdWrapper.Wrapped = nil
+			if tc.name == "ErrorInCreatingMRD" {
+				t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Error in creating MRD")).Once()
+			} else if tc.name == "TimeoutError" {
+				t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, t.mrdTimeout+time.Millisecond), nil).Once()
+			} else if tc.name == "ContextCancelled" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(context.Background())
+				cancel()
+				t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond), nil).Once()
+			}
+
+			bytesRead, err := t.mrdWrapper.Read(ctx, buf, int64(tc.start), int64(tc.end), t.mrdTimeout, common.NewNoopMetrics())
+
+			assert.ErrorContains(t.T(), err, tc.expectedErrKeyword)
+			assert.Equal(t.T(), 0, bytesRead)
 		})
 	}
 }

--- a/internal/storage/fake/fake_multi_range_downloader.go
+++ b/internal/storage/fake/fake_multi_range_downloader.go
@@ -27,10 +27,11 @@ import (
 // This struct is an implementation of the gcs.MultiRangeDownloader interface.
 type fakeMultiRangeDownloader struct {
 	gcs.MultiRangeDownloader
-	obj       *fakeObject
-	wg        sync.WaitGroup
-	err       error
-	sleepTime time.Duration // Sleep time to simulate real-world.
+	obj        *fakeObject
+	wg         sync.WaitGroup
+	err        error
+	defaultErr error
+	sleepTime  time.Duration // Sleep time to simulate real-world.
 }
 
 func createFakeObject(obj *gcs.MinObject, data []byte) fakeObject {
@@ -52,16 +53,16 @@ func NewFakeMultiRangeDownloaderWithSleep(obj *gcs.MinObject, data []byte, sleep
 func NewFakeMultiRangeDownloaderWithSleepAndDefaultError(obj *gcs.MinObject, data []byte, sleepTime time.Duration, err error) gcs.MultiRangeDownloader {
 	fakeObj := createFakeObject(obj, data)
 	return &fakeMultiRangeDownloader{
-		obj:       &fakeObj,
-		sleepTime: sleepTime,
-		err:       err,
+		obj:        &fakeObj,
+		sleepTime:  sleepTime,
+		defaultErr: err,
 	}
 }
 
 func (fmrd *fakeMultiRangeDownloader) Add(output io.Writer, offset, length int64, callback func(int64, int64, error)) {
-	if fmrd.err != nil {
+	if fmrd.defaultErr != nil {
 		if callback != nil {
-			callback(offset, 0, fmrd.err)
+			callback(offset, 0, fmrd.defaultErr)
 		}
 		return
 	}


### PR DESCRIPTION
1. Adding UTs for negative cases
2. Updated handling of EOF in file_handle
3. Updated FakeMRD code to return bytes read as the 2nd parameter in the callback. Next release of go-sdk will have the changes from their side in MRD as well
