### PR TITLE
fix write large file tests

### DIFF
--- a/tools/integration_tests/log_content/file_upload_log_test.go
+++ b/tools/integration_tests/log_content/file_upload_log_test.go
@@ -44,10 +44,7 @@ func uploadFile(t *testing.T, dirNamePrefix string, fileSize int64) {
 	filePath := path.Join(testDir, FileName)
 
 	// Sequentially write the data in file.
-	err = operations.WriteFileSequentially(filePath, fileSize, fileSize)
-	if err != nil {
-		t.Fatalf("Error in writing file: %v", err)
-	}
+	operations.WriteFilesSequentially(t, []string{filePath}, fileSize, fileSize)
 }
 
 func extractRelevantLogsFromLogFile(t *testing.T, logFile string, logFileOffset int64) (logString string) {

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -16,15 +16,11 @@
 package write_large_files
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
-
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
@@ -33,23 +29,6 @@ const (
 	OneMiB               = 1024 * 1024
 	WritePermission_0200 = 0200
 )
-
-func compareFileFromGCSBucketAndMntDir(gcsFile, mntDirFile, localFilePathToDownloadGcsFile string, t *testing.T) error {
-	err := client.DownloadObjectFromGCS(gcsFile, localFilePathToDownloadGcsFile, t)
-	if err != nil {
-		return fmt.Errorf("Error in downloading object: %v", err)
-	}
-
-	// Remove file after testing.
-	defer operations.RemoveFile(localFilePathToDownloadGcsFile)
-
-	identical, err := operations.AreFilesIdentical(mntDirFile, localFilePathToDownloadGcsFile)
-	if !identical {
-		return fmt.Errorf("Download of GCS object %s didn't match the Mounted local file (%s): %v", localFilePathToDownloadGcsFile, mntDirFile, err)
-	}
-
-	return nil
-}
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()


### PR DESCRIPTION
### Description
The large file write tests were flawed: they were comparing the content read through GCSFuse after write operations with the original content residing in the bucket, rather than verifying the consistency of the data written and read through GCSFuse. 
This PR modifies the test logic to ensure that the content written via GCSFuse is identical to the content read back from GCSFuse, providing accurate validation of write operations.

### Link to the issue in case of a bug fix.
b/392292871

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
