### PR TITLE
fix log parsing in cache tests

### DIFF
--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser.go
@@ -47,7 +47,7 @@ func filterAndParseLogLine(logLine string,
 	// Parse the logs based on type.
 	switch {
 	// TODO: change this to regex matching instead of strings.Contains.
-	case strings.Contains(logMessage, "ReadFile"):
+	case strings.Contains(logMessage, "<- ReadFile"):
 		if err := parseReadFileLog(timestampSeconds, timestampNanos, tokenizedLogs, structuredLogs); err != nil {
 			return fmt.Errorf("parseReadFileLog failed: %v", err)
 		}

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
@@ -71,7 +71,7 @@ func TestParseLogFileSuccessful(t *testing.T) {
 {"timestamp": {"seconds": 1704458060, "nanos": 976093794}, "severity": "TRACE", "message": "f41c82a2-c891 <- FileCache(redacted:/smallfile.txt, offset: 0, size: 4096 handle: 29)"}
 {"timestamp": {"seconds": 1704458061, "nanos": 269924363}, "severity": "TRACE", "message": "Job:0xc000aa65b0 (redacted:/smallfile.txt) downloaded till 6 offset."}
 {"timestamp": {"seconds": 1704458061, "nanos": 270075223}, "severity": "TRACE", "message": "f41c82a2-c891 -> OK (isSeq: true, hit: false) (293.935998ms)"}
-{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000182        connection.go:497] -> ReadFile ()"}`),
+{"timestamp": {"seconds": 1704458061, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000182        connection.go:497] -> ReadFile ()"}`),
 			),
 			expected: map[int64]*read_logs.StructuredReadLogEntry{
 				handleId: {

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
@@ -70,7 +70,8 @@ func TestParseLogFileSuccessful(t *testing.T) {
 			reader: bytes.NewReader([]byte(`{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity": "TRACE", "message": "fuse_debug: Op 0x00000182        connection.go:415] <- ReadFile (inode 6, PID 2382526, handle 29, offset 0, 4096 bytes)"}
 {"timestamp": {"seconds": 1704458060, "nanos": 976093794}, "severity": "TRACE", "message": "f41c82a2-c891 <- FileCache(redacted:/smallfile.txt, offset: 0, size: 4096 handle: 29)"}
 {"timestamp": {"seconds": 1704458061, "nanos": 269924363}, "severity": "TRACE", "message": "Job:0xc000aa65b0 (redacted:/smallfile.txt) downloaded till 6 offset."}
-{"timestamp": {"seconds": 1704458061, "nanos": 270075223}, "severity": "TRACE", "message": "f41c82a2-c891 -> OK (isSeq: true, hit: false) (293.935998ms)"}`),
+{"timestamp": {"seconds": 1704458061, "nanos": 270075223}, "severity": "TRACE", "message": "f41c82a2-c891 -> OK (isSeq: true, hit: false) (293.935998ms)"}
+{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000182        connection.go:497] -> ReadFile ()"}`),
 			),
 			expected: map[int64]*read_logs.StructuredReadLogEntry{
 				handleId: {
@@ -119,9 +120,9 @@ func TestParseLogFileSuccessful(t *testing.T) {
 		},
 		{
 			name: "Test file cache logs with no parsable logs",
-			reader: bytes.NewReader([]byte(`{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000182        connection.go:497] -> OK ()"}
+			reader: bytes.NewReader([]byte(`{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000182        connection.go:497] -> ReadFile ()"}
 {"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000184        connection.go:415] <- FlushFile (inode 6, PID 2382526)"}
-{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000184        connection.go:497] -> OK ()"}`),
+{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity":"TRACE","message":"fuse_debug: Op 0x00000184        connection.go:497] -> FlushFile ()"}`),
 			),
 			expected: make(map[int64]*read_logs.StructuredReadLogEntry),
 		},


### PR DESCRIPTION
### Description
Cache tests started running into failures after changes in the logs recently (PR #3009).
Made a quick fix to only parse ReadFile request logs.

### Link to the issue in case of a bug fix.
b/397835673

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
