### PR TITLE
Improve logging of default values in --help

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -253,11 +253,11 @@ type WriteConfig struct {
 
 func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
-	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
+	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
 
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
 
-	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\".")
+	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
 
 	flagSet.StringP("cache-dir", "", "", "Enables file-caching. Specifies the directory to use for file-cache.")
 
@@ -429,15 +429,15 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value is 0, which indicates no timeout.")
+	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
 
-	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
+	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations. (default: true)")
 
 	flagSet.BoolP("implicit-dirs", "", false, "Implicitly define directories based on content. See files and directories in docs/semantics for more information")
 
 	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
 
-	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. If left unset, Google application default credentials are used.")
+	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
 
 	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
 
@@ -447,7 +447,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
 
-	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. When value is set to 0, all backup files are retained.")
+	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
 
 	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
@@ -455,11 +455,11 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
-	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. A value of 0 indicates no limit on TCP connections (limited by the machine specifications).")
+	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value is 0, which indicates no limit.")
+	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value 0 indicates no limit.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -253,11 +253,11 @@ type WriteConfig struct {
 
 func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
-	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
+	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
 
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
 
-	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
+	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\".")
 
 	flagSet.StringP("cache-dir", "", "", "Enables file-caching. Specifies the directory to use for file-cache.")
 
@@ -429,15 +429,15 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
+	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value is 0, which indicates no timeout.")
 
-	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations. (default: true)")
+	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
 
 	flagSet.BoolP("implicit-dirs", "", false, "Implicitly define directories based on content. See files and directories in docs/semantics for more information")
 
 	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
 
-	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
+	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. If left unset, Google application default credentials are used.")
 
 	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
 
@@ -447,7 +447,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
 
-	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
+	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. When value is set to 0, all backup files are retained.")
 
 	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
@@ -455,11 +455,11 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
-	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
+	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. A value of 0 indicates no limit on TCP connections (limited by the machine specifications).")
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value 0 indicates no limit.")
+	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value is 0, which indicates no limit.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -253,15 +253,15 @@ type WriteConfig struct {
 
 func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
-	flagSet.BoolP("anonymous-access", "", false, "Authentication is enabled by default. This flag disables authentication")
+	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
 
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
 
-	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\". (The default is none)")
+	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\".")
 
 	flagSet.StringP("cache-dir", "", "", "Enables file-caching. Specifies the directory to use for file-cache.")
 
-	flagSet.IntP("chunk-transfer-timeout-secs", "", 10, "We send larger file uploads in 16 MiB chunks. This flag controls the duration  that the HTTP client will wait for a response after making a request to upload a chunk.  The default value of 10s indicates that the client will wait 10 seconds for upload completion;  otherwise, it cancels the request and retries for that chunk till chunkRetryDeadline(32s). 0 means no timeout.")
+	flagSet.IntP("chunk-transfer-timeout-secs", "", 10, "We send larger file uploads in 16 MiB chunks. This flag controls the duration  that the HTTP client will wait for a response after making a request to upload a chunk.  As an example, a value of 10 indicates that the client will wait 10 seconds for upload completion;  otherwise, it cancels the request and retries for that chunk till chunkRetryDeadline(32s). 0 means no timeout.")
 
 	if err := flagSet.MarkHidden("chunk-transfer-timeout-secs"); err != nil {
 		return err
@@ -429,15 +429,15 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. The default value 0 indicates no timeout.")
+	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. A value of 0 indicates no timeout.")
 
-	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations. (default: true)")
+	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
 
 	flagSet.BoolP("implicit-dirs", "", false, "Implicitly define directories based on content. See files and directories in docs/semantics for more information")
 
 	flagSet.IntP("kernel-list-cache-ttl-secs", "", 0, "How long the directory listing (output of ls <dir>) should be cached in the kernel page cache. If a particular directory cache entry is kept by kernel for longer than TTL, then it will be sent for invalidation by gcsfuse on next opendir (comes in the start, as part of next listing) call. 0 means no caching. Use -1 to cache for lifetime (no ttl). Negative value other than -1 will throw error.")
 
-	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)")
+	flagSet.StringP("key-file", "", "", "Absolute path to JSON key file for use with GCS. If this flag is left unset, Google application default credentials are used.")
 
 	flagSet.Float64P("limit-bytes-per-sec", "", -1, "Bandwidth limit for reading data, measured over a 30-second window. (use -1 for no limit)")
 
@@ -447,7 +447,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-format", "", "json", "The format of the log file: 'text' or 'json'.")
 
-	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. The default value is 10. When value is set to 0, all backup files are retained.")
+	flagSet.IntP("log-rotate-backup-file-count", "", 10, "The maximum number of backup log files to retain after they have been rotated. A value of 0 indicates all backup files are retained.")
 
 	flagSet.BoolP("log-rotate-compress", "", true, "Controls whether the rotated log files should be compressed using gzip.")
 
@@ -455,11 +455,11 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("log-severity", "", "info", "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]")
 
-	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. The default value 0 indicates no limit on TCP connections (limited by the machine specifications).")
+	flagSet.IntP("max-conns-per-host", "", 0, "The max number of TCP connections allowed per server. This is effective when client-protocol is set to 'http1'. A value of 0 indicates no limit on TCP connections (limited by the machine specifications).")
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. The default value 0 indicates no limit.")
+	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. A value of 0 indicates no limit.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
 
@@ -531,7 +531,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("sequential-read-size-mb", "", 200, "File chunk size to read from GCS in one call. Need to specify the value in MB. ChunkSize less than 1MB is not supported")
 
-	flagSet.DurationP("stackdriver-export-interval", "", 0*time.Nanosecond, "Export metrics to stackdriver with this interval. The default value 0 indicates no exporting.")
+	flagSet.DurationP("stackdriver-export-interval", "", 0*time.Nanosecond, "Export metrics to stackdriver with this interval. A value of 0 indicates no exporting.")
 
 	if err := flagSet.MarkDeprecated("stackdriver-export-interval", "Please use --cloud-metrics-export-interval-secs instead."); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -186,7 +186,7 @@
   usage: >-
     Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered
     by Ctrl+C). This prevents those signals from immediately terminating gcsfuse
-    inflight operations. (default: true)
+    inflight operations.
   default: true
 
 - config-path: "file-system.kernel-list-cache-ttl-secs"
@@ -240,13 +240,13 @@
 - config-path: "gcs-auth.anonymous-access"
   flag-name: "anonymous-access"
   type: "bool"
-  usage: "Authentication is enabled by default. This flag disables authentication"
+  usage: "This flag disables authentication."
   default: false
 
 - config-path: "gcs-auth.key-file"
   flag-name: "key-file"
   type: "resolvedPath"
-  usage: "Absolute path to JSON key file for use with GCS. (The default is none, Google application default credentials used)"
+  usage: "Absolute path to JSON key file for use with GCS. If this flag is left unset, Google application default credentials are used."
 
 - config-path: "gcs-auth.reuse-token-from-url"
   flag-name: "reuse-token-from-url"
@@ -265,7 +265,7 @@
   type: "string"
   usage: >-
     Project to use for billing when accessing a bucket enabled with "Requester
-    Pays". (The default is none)
+    Pays".
   default: ""
 
 - config-path: "gcs-connection.client-protocol"
@@ -312,7 +312,7 @@
   type: "duration"
   usage: >-
     The time duration that http client will wait to get response from the
-    server. The default value 0 indicates no timeout.
+    server. A value of 0 indicates no timeout.
   default: "0s"
 
 - config-path: "gcs-connection.limit-bytes-per-sec"
@@ -332,7 +332,7 @@
   type: "int"
   usage: >-
     The max number of TCP connections allowed per server. This is effective when
-    client-protocol is set to 'http1'. The default value 0 indicates no limit on
+    client-protocol is set to 'http1'. A value of 0 indicates no limit on
     TCP connections (limited by the machine specifications).
   default: "0"
 
@@ -354,7 +354,7 @@
   usage: >-
     We send larger file uploads in 16 MiB chunks. This flag controls the duration 
     that the HTTP client will wait for a response after making a request to upload a chunk. 
-    The default value of 10s indicates that the client will wait 10 seconds for upload completion; 
+    As an example, a value of 10 indicates that the client will wait 10 seconds for upload completion; 
     otherwise, it cancels the request and retries for that chunk till chunkRetryDeadline(32s). 0 means no timeout.
   default: "10"
   hide-flag: true
@@ -364,7 +364,7 @@
   type: "int"
   usage: >-
     It sets a limit on the number of times an operation will be retried if it
-    fails, preventing endless retry loops. The default value 0 indicates no limit.
+    fails, preventing endless retry loops. A value of 0 indicates no limit.
   default: "0"
 
 - config-path: "gcs-retries.max-retry-sleep"
@@ -465,8 +465,7 @@
   type: "int"
   usage: >-
     The maximum number of backup log files to retain after they have been
-    rotated. The default value is 10. When value is set to 0, all backup files are
-    retained.
+    rotated. A value of 0 indicates all backup files are retained.
   default: "10"
 
 - config-path: "logging.log-rotate.compress"
@@ -613,7 +612,7 @@
   flag-name: "stackdriver-export-interval"
   type: "duration"
   usage: >-
-    Export metrics to stackdriver with this interval. The default value 0
+    Export metrics to stackdriver with this interval. A value of 0
     indicates no exporting.
   default: "0s"
   deprecated: true


### PR DESCRIPTION
### Description
Improves how default values are printed in `gcsfuse --help` .

This PR still doesn't address the following issues:
1. For flags of type string, the default value isn't printed if it's "", similarly the default values of ints, bools aren't printed if they are 0, and false respectively.
2. For flags of type bool, the type isn't printed.
3. `--temp-dir should give the actual default (you're a program! you know what the system default is!) not a description of what it might be`

### Link to the issue in case of a bug fix.
[b/397660108](http://b/397660108)

### Testing details
1. Manual - <img width="1549" alt="20250220-150207-gcsfuse-help-defaults" src="https://github.com/user-attachments/assets/62cbf140-91a8-4441-ba03-befc818ef361" />
4. Unit tests - NA
5. Integration tests - NA
