### PR TITLE
Run monitoring tests in installed_package mode

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -142,6 +142,7 @@ git checkout $(sed -n 2p ~/details.txt) |& tee -a ~/logs.txt
 set +e
 # Test directory arrays
 TEST_DIR_PARALLEL=(
+  "monitoring"
   "local_file"
   "log_rotation"
   "mounting"

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -118,10 +118,6 @@ func (testSuite *PromTest) TearDownTest() {
 	assert.NoError(testSuite.T(), err)
 }
 
-func (testSuite *PromTest) TearDownSuite() {
-	os.RemoveAll(setup.TestDir())
-}
-
 func (testSuite *PromTest) mount(bucketName string) error {
 	testSuite.T().Helper()
 	if portAvailable := isPortOpen(prometheusPort); !portAvailable {
@@ -258,15 +254,9 @@ func (testSuite *PromTest) TestReadMetrics() {
 }
 
 func TestPromOCSuite(t *testing.T) {
-	if setup.TestInstalledPackage() {
-		t.Skip("Skipping since testing on installed package")
-	}
 	suite.Run(t, &PromTest{enableOTEL: false})
 }
 
 func TestPromOTELSuite(t *testing.T) {
-	if setup.TestInstalledPackage() {
-		t.Skip("Skipping since testing on installed package")
-	}
 	suite.Run(t, &PromTest{enableOTEL: true})
 }


### PR DESCRIPTION
### Description

* The monitoring tests are currently skipped in installed_package mode of test runs. This will be changed and monitoring tests will be run in the installed package mode as well.
* Don't clear the test directory post test run. This is to ensure that logs remain available and can be collected post run.

### Link to the issue in case of a bug fix.
b/391754854

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
