### PR TITLE
Fix flaky TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -116,7 +116,9 @@ func (s *cacheFileForRangeReadFalseTest) TestReadIsTreatedNonSequentialAfterFile
 	randomReadChunkCount := fileSizeSameAsCacheCapacity / chunkSizeToRead
 	readTillChunk := randomReadChunkCount / 2
 	fh1 := operations.OpenFile(path.Join(testDirPath, testFileNames[0]), t)
+	defer operations.CloseFile(fh1)
 	fh2 := operations.OpenFile(path.Join(testDirPath, testFileNames[1]), t)
+	defer operations.CloseFile(fh2)
 
 	// Use file handle 1 to read file 1 partially.
 	expectedOutcome[0] = readFileBetweenOffset(t, fh1, 0, int64(readTillChunk*chunkSizeToRead))

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -16,7 +16,6 @@ package read_cache
 
 import (
 	"context"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -74,19 +73,8 @@ func readFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffSet i
 		expected.BucketName = setup.DynamicBucketMounted()
 	}
 
-	chunkRead := make([]byte, chunkSizeToRead)
-	var readData []byte
-	for startOffset < endOffSet {
-		_, err := file.ReadAt(chunkRead, startOffset)
-		if err != nil && err != io.EOF {
-			t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
-		}
-		readData = append(readData, chunkRead...)
-		startOffset = startOffset + chunkSizeToRead
-	}
-
+	expected.content = operations.ReadFileBetweenOffset(t, file, startOffset, endOffSet, chunkSizeToRead)
 	expected.EndTimeStampSeconds = time.Now().Unix()
-	expected.content = string(readData)
 	return expected
 }
 

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -110,9 +110,12 @@ func (s *cacheFileForRangeReadFalseTest) TestReadIsTreatedNonSequentialAfterFile
 
 	// Use file handle 1 to read file 1 partially.
 	expectedOutcome[0] = readFileBetweenOffset(t, fh1, 0, int64(readTillChunk*chunkSizeToRead))
-	// Use file handle 2 to read file 2 partially. This wiill evict file 1 from cache due to cache capacity constraints.
+	// Use file handle 2 to read file 2 partially. This will evict file 1 from
+	// cache due to cache capacity constraints.
 	expectedOutcome[1] = readFileBetweenOffset(t, fh2, 0, int64(readTillChunk*chunkSizeToRead))
-	// Read remaining file 1.
+	// Read remaining file 1. File 2 remains cached. Cache eviction happens on
+	// cache handler creation, which is tied to the file handle. Since the handle
+	// isn't recreated, eviction doesn't occur.
 	expectedOutcome[2] = readFileBetweenOffset(t, fh1, int64(readTillChunk*chunkSizeToRead)+1, fileSizeSameAsCacheCapacity)
 	// Read remaining file 2.
 	expectedOutcome[3] = readFileBetweenOffset(t, fh2, int64(readTillChunk*chunkSizeToRead)+1, fileSizeSameAsCacheCapacity)

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -73,8 +73,8 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, readFullFile bo
 	return expected
 }
 
-func validate(expected *Expected, logEntry *read_logs.StructuredReadLogEntry,
-	isSeq, cacheHit bool, chunkCount int, t *testing.T) {
+func validate(expected *Expected, logEntry *read_logs.StructuredReadLogEntry, isSeq, cacheHit bool, chunkCount int, t *testing.T) {
+	t.Helper()
 	if logEntry.StartTimeSeconds < expected.StartTimeStampSeconds {
 		t.Errorf("start time in logs %d less than actual start time %d.", logEntry.StartTimeSeconds, expected.StartTimeStampSeconds)
 	}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -316,6 +316,25 @@ func ReadChunkFromFile(filePath string, chunkSize int64, offset int64, flag int)
 	return
 }
 
+func ReadFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffset, chunkSize int64) string {
+	t.Helper()
+	chunk := make([]byte, chunkSize)
+	var readData []byte
+
+	for startOffset < endOffset {
+		readSize := min(chunkSize, endOffset-startOffset)
+
+		n, err := file.ReadAt(chunk[:readSize], startOffset)
+		if err != nil && err != io.EOF {
+			t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
+		}
+		readData = append(readData, chunk[:n]...)
+		startOffset += int64(n)
+	}
+
+	return string(readData)
+}
+
 // Returns the stats of a file.
 // Fails if the passed input is a directory.
 func StatFile(file string) (*fs.FileInfo, error) {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -325,8 +325,17 @@ func ReadFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffset, 
 		readSize := min(chunkSize, endOffset-startOffset)
 
 		n, err := file.ReadAt(chunk[:readSize], startOffset)
-		if err != nil && err != io.EOF {
-			t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
+		if err != nil {
+			if err == io.EOF && startOffset < endOffset {
+				// Reached EOF before endOffset.
+				if n > 0 {
+					readData = append(readData, chunk[:n]...)
+				}
+				break
+			} else if err != io.EOF {
+				t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
+				return "" //Return empty string on error.
+			}
 		}
 		readData = append(readData, chunk[:n]...)
 		startOffset += int64(n)

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -325,17 +325,12 @@ func ReadFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffset, 
 		readSize := min(chunkSize, endOffset-startOffset)
 
 		n, err := file.ReadAt(chunk[:readSize], startOffset)
-		if err != nil {
-			if err == io.EOF && startOffset < endOffset {
-				// Reached EOF before endOffset.
-				if n > 0 {
-					readData = append(readData, chunk[:n]...)
-				}
-				break
-			} else if err != io.EOF {
-				t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
-				return "" //Return empty string on error.
-			}
+		if err == io.EOF {
+			readData = append(readData, chunk[:n]...)
+			break
+		} else if err != nil {
+			t.Errorf("Failed to read file chunk at offset %d: %v", startOffset, err)
+			return ""
 		}
 		readData = append(readData, chunk[:n]...)
 		startOffset += int64(n)


### PR DESCRIPTION
### Description
This PR addresses flaky `TestConcurrentReads_ReadIsTreatedNonSequentialAfterFileIsRemovedFromCache` test, which verifies GCSFuse's cache eviction behavior under concurrent read scenarios. Previously, concurrent reads triggered unpredictable situations like:
1. premature file removal from the cache, even before the initial read operation completed. 
2. logs order inconsistency.
This made the test flaky and unreliable.

To resolve this, the PR modifies the test to perform sequential partial reads one by one. By eliminating concurrent operations, we ensure a deterministic execution flow, allowing the cache to operate as expected. 

### Link to the issue in case of a bug fix.
b/390309943

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
