### PR TITLE
Start using random port for proxy server and run test packages in parallel.

### DIFF
--- a/tools/integration_tests/emulator_tests/emulator_tests.sh
+++ b/tools/integration_tests/emulator_tests/emulator_tests.sh
@@ -120,5 +120,5 @@ curl -X POST --data-binary @test.json \
     "$STORAGE_EMULATOR_HOST/storage/v1/b?project=test-project"
 rm test.json
 
-# Run all the tests.
-go test ./tools/integration_tests/emulator_tests/... -p 1 --integrationTest -v --testbucket=test-bucket --testOnCustomEndpoint=http://localhost:8020/storage/v1/ -timeout 10m --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE
+# Run all emulator test packages in parallel.
+go test ./tools/integration_tests/emulator_tests/... --integrationTest -v --testbucket=test-bucket -timeout 10m --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE

--- a/tools/integration_tests/emulator_tests/proxy_server/main.go
+++ b/tools/integration_tests/emulator_tests/proxy_server/main.go
@@ -20,28 +20,30 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 )
+
+const PortAndProxyProcessIdInfoLogFormat = "Listening Proxy Server On Port [%s] with Process ID [%d]"
 
 var (
 	// Flag to accept config-file path.
 	fConfigPath = flag.String("config-path", "configs/config.yaml", "Path to the file")
 	// Flag to turn on fDebug logs.
-	// TODO: We can add support for specifying a log path for fDebug logs in a future update.
-	fDebug = flag.Bool("debug", false, "Enable proxy server fDebug logs.")
+	fDebug       = flag.Bool("debug", false, "Enable proxy server fDebug logs.")
+	fLogFilePath = flag.String("log-file", "", "Path to the log file")
 	// Initialized before the server gets started.
 	gConfig    *Config
 	gOpManager *OperationManager
+	// Port number assigned to listener.
+	gPort string
 )
-
-// Host address of the proxy server.
-// TODO: Allow this value to be configured via a command-line flag.
-const Port = "8020"
 
 type ProxyHandler struct {
 	http.Handler
@@ -130,7 +132,7 @@ func (ph ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		u.Host = "localhost:" + Port
+		u.Host = "localhost:" + gPort
 		resp.Header.Set("Location", u.String())
 	}
 
@@ -157,40 +159,46 @@ func (ph ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // ProxyServer represents a simple proxy server over GCS storage based API endpoint.
 type ProxyServer struct {
-	port     string
 	server   *http.Server
 	shutdown chan os.Signal
 }
 
 // NewProxyServer creates a new ProxyServer instance
-func NewProxyServer(port string) *ProxyServer {
+func NewProxyServer() *ProxyServer {
 	return &ProxyServer{
-		port:     port,
 		shutdown: make(chan os.Signal, 1),
 	}
 }
 
 // Start starts the proxy server.
 func (ps *ProxyServer) Start() {
+	//  Create a listener on random available port.
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		log.Fatalf("Error on listening: %v", err)
+	}
+	gPort = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	// Log port number and proxy process Id for the proxy server.
+	log.Printf(PortAndProxyProcessIdInfoLogFormat, gPort, os.Getpid())
 	ps.server = &http.Server{
-		Addr:    ":" + ps.port,
+		Addr:    ":" + gPort,
 		Handler: ProxyHandler{},
 	}
 
 	// Start the server in a new goroutine
 	go func() {
-		log.Printf("Proxy server started on port %s\n", ps.port)
-		if err := ps.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := ps.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Server error: %v", err)
 		}
 	}()
 
 	// Handle graceful shutdown
 	signal.Notify(ps.shutdown, syscall.SIGINT, syscall.SIGTERM)
+	// Blocks until one of the Signal is recieved.
 	<-ps.shutdown
 	log.Println("Shutting down proxy server...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := ps.server.Shutdown(ctx); err != nil {
@@ -211,12 +219,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *fLogFilePath == "" {
+		log.Println("No log file path for proxy server provided.")
+		os.Exit(1)
+	}
+	logFile, err := os.OpenFile(*fLogFilePath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		log.Printf("Error opening log file: %v\n", err)
+		os.Exit(1)
+	}
+	defer logFile.Close()
+	log.SetOutput(logFile)
+
 	if *fDebug {
 		log.Printf("%+v\n", gConfig)
 	}
 
 	gOpManager = NewOperationManager(*gConfig)
 
-	ps := NewProxyServer(Port)
+	ps := NewProxyServer()
 	ps.Start()
 }

--- a/tools/integration_tests/emulator_tests/read_stall/setup_test.go
+++ b/tools/integration_tests/emulator_tests/read_stall/setup_test.go
@@ -15,7 +15,6 @@
 package read_stall
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -24,14 +23,11 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-const port = 8020
-
 var (
 	testDirPath string
 	mountFunc   func([]string) error
 	// root directory is the directory to be unmounted.
-	rootDir       string
-	proxyEndpoint = fmt.Sprintf("http://localhost:%d/storage/v1/b?project=test-project", port)
+	rootDir string
 )
 
 func TestMain(m *testing.M) {

--- a/tools/integration_tests/emulator_tests/streaming_writes_failure/streaming_writes_failure_test.go
+++ b/tools/integration_tests/emulator_tests/streaming_writes_failure/streaming_writes_failure_test.go
@@ -15,7 +15,6 @@
 package streaming_writes_failure
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -26,12 +25,10 @@ import (
 
 const (
 	testDirNamePrefix = "StreamingWritesFailureTest"
-	port              = 8020
 )
 
 var (
-	proxyEndpoint = fmt.Sprintf("http://localhost:%d/storage/v1/b?project=test-project", port)
-	mountFunc     func([]string) error
+	mountFunc func([]string) error
 	// root directory is the directory to be unmounted.
 	rootDir     string
 	testDirName string

--- a/tools/integration_tests/emulator_tests/write_stall/write_stall_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/write_stall_test.go
@@ -15,7 +15,6 @@
 package write_stall
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -24,14 +23,11 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-const port = 8020
-
 var (
 	testDirPath string
 	mountFunc   func([]string) error
 	// root directory is the directory to be unmounted.
-	rootDir       string
-	proxyEndpoint = fmt.Sprintf("http://localhost:%d/storage/v1/b?project=test-project", port)
+	rootDir string
 )
 
 func TestMain(m *testing.M) {

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -37,18 +38,23 @@ const (
 )
 
 type chunkTransferTimeoutInfinity struct {
-	flags []string
+	port           int
+	proxyProcessId int
+	flags          []string
 }
 
 func (s *chunkTransferTimeoutInfinity) Setup(t *testing.T) {
 	configPath := "../proxy_server/configs/write_stall_40s.yaml"
-	emulator_tests.StartProxyServer(configPath)
+	var err error
+	s.port, s.proxyProcessId, err = emulator_tests.StartProxyServer(configPath, setup.CreateProxyServerLogFile(t))
+	require.NoError(t, err)
+	setup.AppendProxyEndpointToFlagSet(&s.flags, s.port)
 	setup.MountGCSFuseWithGivenMountFunc(s.flags, mountFunc)
 }
 
 func (s *chunkTransferTimeoutInfinity) Teardown(t *testing.T) {
 	setup.UnmountGCSFuse(rootDir)
-	assert.NoError(t, emulator_tests.KillProxyServerProcess(port))
+	assert.NoError(t, emulator_tests.KillProxyServerProcess(s.proxyProcessId))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -79,7 +85,7 @@ func TestChunkTransferTimeoutInfinity(t *testing.T) {
 	ts := &chunkTransferTimeoutInfinity{}
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
-		{"--custom-endpoint=" + proxyEndpoint, "--chunk-transfer-timeout-secs=0"},
+		{"--chunk-transfer-timeout-secs=0"},
 	}
 
 	// Run tests.
@@ -92,8 +98,8 @@ func TestChunkTransferTimeoutInfinity(t *testing.T) {
 
 func TestChunkTransferTimeout(t *testing.T) {
 	flagSets := [][]string{
-		{"--custom-endpoint=" + proxyEndpoint},
-		{"--custom-endpoint=" + proxyEndpoint, "--chunk-transfer-timeout-secs=5"},
+		{},
+		{"--chunk-transfer-timeout-secs=5"},
 	}
 
 	stallScenarios := []struct {
@@ -127,12 +133,14 @@ func TestChunkTransferTimeout(t *testing.T) {
 		t.Run(fmt.Sprintf("Flags_%v", flags), func(t *testing.T) {
 			for _, scenario := range stallScenarios {
 				t.Run(scenario.name, func(t *testing.T) {
-					emulator_tests.StartProxyServer(scenario.configPath)
+					port, proxyProcessId, err := emulator_tests.StartProxyServer(scenario.configPath, setup.CreateProxyServerLogFile(t))
+					require.NoError(t, err)
+					setup.AppendProxyEndpointToFlagSet(&flags, port)
 					setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
 
 					defer func() { // Defer unmount and  killing the server.
 						setup.UnmountGCSFuse(rootDir)
-						assert.NoError(t, emulator_tests.KillProxyServerProcess(port))
+						assert.NoError(t, emulator_tests.KillProxyServerProcess(proxyProcessId))
 					}()
 
 					testDir := scenario.name + setup.GenerateRandomString(3)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -50,8 +50,6 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 			return nil, fmt.Errorf("unable to fetch token-source for TPC: %w", err)
 		}
 		client, err = storage.NewClient(ctx, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithTokenSource(ts))
-	} else if setup.TestOnCustomEndpoint() != "" {
-		client, err = storage.NewClient(ctx, option.WithEndpoint(setup.TestOnCustomEndpoint()))
 	} else {
 		if setup.IsZonalBucketRun() {
 			client, err = storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,7 +43,6 @@ var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted 
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
-var testOnCustomEndpoint = flag.String("testOnCustomEndpoint", "", "Run tests on custom endpoint only when the flag value is set. Required for tests requiring proxy server.")
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
@@ -96,10 +95,6 @@ func TestInstalledPackage() bool {
 
 func TestOnTPCEndPoint() bool {
 	return *testOnTPCEndPoint
-}
-
-func TestOnCustomEndpoint() string {
-	return *testOnCustomEndpoint
 }
 
 func MountedDirectory() string {
@@ -575,4 +570,17 @@ func CreateFileOnDiskAndCopyToMntDir(t *testing.T, filePathInLocalDisk string, f
 	if err != nil {
 		t.Errorf("Error in copying file:%v", err)
 	}
+}
+
+func CreateProxyServerLogFile(t *testing.T) string {
+	proxyServerLogFile := path.Join(TestDir(), "proxy-server-log-"+GenerateRandomString(5))
+	_, err := os.Create(proxyServerLogFile)
+	if err != nil {
+		t.Fatalf("Error in creating log file for proxy server: %v", err)
+	}
+	return proxyServerLogFile
+}
+
+func AppendProxyEndpointToFlagSet(flagSet *[]string, port int) {
+	*flagSet = append(*flagSet, "--custom-endpoint="+fmt.Sprintf("http://localhost:%d/storage/v1/", port))
 }


### PR DESCRIPTION
### Description
* Start using random Proxy Server Ports for emulator tests.
* Use logFilePath for logging proxy server logs. We log Port and ProxyProcessId in a pre-defined format which can be read back in tests with the same format. This removes using hard-coded port and also removes uses of `lsof` which seems to hang if any of the NFS mounts become unresponsive (Crash GCSFuse mounts).
* Running all emulator tests packages in parallel by removing `-p 1` flag. 
* Removed `--TestOnCustomEndpoint` as we have a more elegant way to create storage client for [emulators](https://cloud.google.com/go/docs/reference/cloud.google.com/go/storage/latest#hdr-Creating_a_Client)
### Link to the issue in case of a bug fix.
[b/398808494](http://b/398808494)

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Done
