### PR TITLE
Marks negative stat cache flag public

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -471,10 +471,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("metadata-cache-negative-ttl-secs", "", 5, "The negative-ttl-secs value in seconds to be used for expiring negative entries in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled negative entries in metadata-cache. Any value set below -1 will throw an error.")
 
-	if err := flagSet.MarkHidden("metadata-cache-negative-ttl-secs"); err != nil {
-		return err
-	}
-
 	flagSet.IntP("metadata-cache-ttl-secs", "", 60, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.")
 
 	flagSet.StringSliceP("o", "", []string{}, "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -563,7 +563,6 @@
     can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled
     negative entries in metadata-cache. Any value set below -1 will throw an error.
   default: "5"
-  hide-flag: true
 
 - config-path: "metadata-cache.stat-cache-max-size-mb"
   flag-name: "stat-cache-max-size-mb"


### PR DESCRIPTION
### Description
Make metadata-cache:negative-ttl-secs as public


### Link to the issue in case of a bug fix.
b/398799346

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA
