### PR TITLE
fix TestReadIsTreatedNonSequentialAfterFileIsRemovedFromCache on arm64 architecture

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -130,14 +130,17 @@ func (s *cacheFileForRangeReadFalseTest) TestReadIsTreatedNonSequentialAfterFile
 	require.Equal(t, 2, len(structuredReadLogs))
 	validate(expectedOutcome[0], structuredReadLogs[0], true, false, randomReadChunkCount, t)
 	validate(expectedOutcome[1], structuredReadLogs[1], true, false, randomReadChunkCount, t)
-	// Validate after cache eviction, read was considered non-sequential and cache hit false for first file.
-	assert.False(t, structuredReadLogs[0].Chunks[readTillChunk+1].IsSequential)
-	assert.False(t, structuredReadLogs[0].Chunks[readTillChunk+1].CacheHit)
+	// Validate after cache eviction, read was considered non-sequential and cache
+	// hit false for first file.
+	// Checking for the last chunk, not readTillChunk+1, due to potential kernel
+	// over-reads on some architectures.
+	assert.False(t, structuredReadLogs[0].Chunks[randomReadChunkCount-1].IsSequential)
+	assert.False(t, structuredReadLogs[0].Chunks[randomReadChunkCount-1].CacheHit)
 	// Validate for 2nd file read was considered sequential because of no cache eviction.
-	assert.True(t, structuredReadLogs[1].Chunks[readTillChunk+1].IsSequential)
+	assert.True(t, structuredReadLogs[1].Chunks[randomReadChunkCount-1].IsSequential)
 	if !s.isParallelDownloadsEnabled {
 		// When parallel downloads are enabled, we can't concretely say that the read will be cache Hit.
-		assert.True(t, structuredReadLogs[1].Chunks[readTillChunk+1].CacheHit)
+		assert.True(t, structuredReadLogs[1].Chunks[randomReadChunkCount-1].CacheHit)
 	}
 
 	validateFileIsNotCached(testFileNames[0], t)


### PR DESCRIPTION
### Description
On arm64 architecture, we see that kernel sends read request for a few extra chunks which is resulting in test failure. 

![3Nj6TkR9bw6KUKn (1)](https://github.com/user-attachments/assets/541f29cc-d20c-403a-a448-415569106189)

Fix: check for last chunk instead of immediate next chunk.

### Link to the issue in case of a bug fix.
b/399540438

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
