### PR TITLE
Fix the default value of temp-dir in --help

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -547,7 +547,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)")
+	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: \"/tmp\")")
 
 	flagSet.StringP("token-url", "", "", "A url for getting an access token when the key-file is absent.")
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -222,7 +222,7 @@
   type: "resolvedPath"
   usage: >-
     Path to the temporary directory where writes are staged prior to upload to
-    Cloud Storage. (default: system default, likely /tmp)
+    Cloud Storage. (default: "/tmp")
   default: ""
 
 - config-path: "file-system.uid"


### PR DESCRIPTION
### Description
Fix the default value of temp-dir in --help

Show the default value of temp-dir, which is
"/tmp" in code, rather than keeping it
ambiguous.

### Link to the issue in case of a bug fix.
[b/397660108](http://b/397660108)

### Testing details
1. Manual
   ```sh
   $ git switch master && go run . --help | grep "\/tmp"
         --temp-dir string                              Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)
   $ git switch - && go run . --help | grep "\/tmp"
         --temp-dir string                              Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: "/tmp")
   ```
3. Unit tests - NA
4. Integration tests - NA
