### PR TITLE
Unhide prometheus-port flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -493,10 +493,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
-	if err := flagSet.MarkHidden("prometheus-port"); err != nil {
-		return err
-	}
-
 	flagSet.DurationP("read-stall-initial-req-timeout", "", 20000000000*time.Nanosecond, "Initial value of the read-request dynamic timeout.")
 
 	if err := flagSet.MarkHidden("read-stall-initial-req-timeout"); err != nil {

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -612,7 +612,6 @@
   type: "int"
   usage: "Expose Prometheus metrics endpoint on this port and a path of /metrics."
   default: "0"
-  hide-flag: true
 
 - config-path: "metrics.stackdriver-export-interval"
   flag-name: "stackdriver-export-interval"


### PR DESCRIPTION
We plan to publish and document this flag. So, unhide it.

### Description

### Link to the issue in case of a bug fix.
b/400830067

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
