### PR TITLE
Moving MRDWrapper to storage package

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/fuse/fuseops"
@@ -97,9 +98,7 @@ type FileInode struct {
 	// Wrapper object for multi range downloader. Needed as we will create the MRD in
 	// random reader and we can't pass fileInode object to random reader as it
 	// creates a cyclic dependency.
-	// Todo: Investigate if cyclic dependency can be removed by removing some unused
-	// code.
-	MRDWrapper gcsx.MultiRangeDownloaderWrapper
+	MRDWrapper storage.MultiRangeDownloaderWrapper
 
 	bwh    bufferedwrites.BufferedWriteHandler
 	config *cfg.Config
@@ -160,7 +159,7 @@ func NewFileInode(
 		globalMaxWriteBlocksSem: globalMaxBlocksSem,
 	}
 	var err error
-	f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &f.src)
+	f.MRDWrapper, err = storage.NewMultiRangeDownloaderWrapper(bucket, &f.src)
 	if err != nil {
 		logger.Errorf("NewFileInode: Error in creating MRDWrapper %v", err)
 	}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -95,9 +95,7 @@ type FileInode struct {
 	// Represents if local file has been unlinked.
 	unlinked bool
 
-	// Wrapper object for multi range downloader. Needed as we will create the MRD in
-	// random reader and we can't pass fileInode object to random reader as it
-	// creates a cyclic dependency.
+	// Wrapper object for multi range downloader.
 	MRDWrapper storage.MultiRangeDownloaderWrapper
 
 	bwh    bufferedwrites.BufferedWriteHandler

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -30,6 +30,7 @@ import (
 	cacheutil "github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/jacobsa/fuse/fuseops"
@@ -111,7 +112,7 @@ const (
 
 // NewRandomReader create a random reader for the supplied object record that
 // reads using the given bucket.
-func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, mrdWrapper *MultiRangeDownloaderWrapper) RandomReader {
+func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, mrdWrapper *storage.MultiRangeDownloaderWrapper) RandomReader {
 	return &randomReader{
 		object:                o,
 		bucket:                bucket,
@@ -174,7 +175,7 @@ type randomReader struct {
 	readHandle []byte
 
 	// mrdWrapper points to the wrapper object within inode.
-	mrdWrapper *MultiRangeDownloaderWrapper
+	mrdWrapper *storage.MultiRangeDownloaderWrapper
 
 	// boolean variable to determine if MRD is being used or not.
 	isMRDInUse bool

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -666,7 +666,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			t.rr.wrapped.readType = testutil.Sequential
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := storage.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
 			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond))
@@ -713,7 +713,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 			t.rr.wrapped.seeks = minSeeksForRandom + 1
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := storage.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
 			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
@@ -755,7 +755,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadFull() {
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := storage.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
 			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
@@ -790,7 +790,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadChunk() {
 		t.rr.wrapped.reader = nil
 		t.object.Size = uint64(tc.dataSize)
 		testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-		fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+		fakeMRDWrapper, err := storage.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
 		assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 		t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 		t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
@@ -844,7 +844,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ValidateTimeout
 			t.rr.wrapped.isMRDInUse = false
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
+			fakeMRDWrapper, err := storage.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
 			assert.Nil(t.T(), err, "Error in creating MRDWrapper")
 			t.rr.wrapped.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, tc.sleepTime)).Once()

--- a/internal/storage/multi_range_downloader_wrapper.go
+++ b/internal/storage/multi_range_downloader_wrapper.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcsx
+package storage
 
 import (
 	"bytes"

--- a/internal/storage/multi_range_downloader_wrapper_test.go
+++ b/internal/storage/multi_range_downloader_wrapper_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gcsx
+package storage
 
 import (
 	"context"
@@ -24,7 +24,6 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/clock"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
@@ -37,7 +36,7 @@ type mrdWrapperTest struct {
 	suite.Suite
 	object     *gcs.MinObject
 	objectData []byte
-	mockBucket *storage.TestifyMockBucket
+	mockBucket *TestifyMockBucket
 	mrdWrapper MultiRangeDownloaderWrapper
 	mrdTimeout time.Duration
 }
@@ -55,7 +54,7 @@ func (t *mrdWrapperTest) SetupTest() {
 	}
 	t.objectData = testutil.GenerateRandomBytes(int(t.object.Size))
 	// Create the bucket.
-	t.mockBucket = new(storage.TestifyMockBucket)
+	t.mockBucket = new(TestifyMockBucket)
 	t.mrdTimeout = time.Millisecond
 	t.mrdWrapper, err = NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{WaitTime: t.mrdTimeout})
 	assert.Nil(t.T(), err, "Error in creating MRDWrapper")


### PR DESCRIPTION
Moving MRDWrapper to storage package.

Currently MRDWrapper is in gcsx package which is not the proper location for this. MRDWrapper implements the read functionality using MRD interface provided by go sdk. Hence, moving it to the storage package.

There are no additional changes required for this move.