### PR TITLE
append bucket name with architecture in checkpoint tests

### DIFF
--- a/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
+++ b/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
@@ -88,8 +88,8 @@ source .venv/bin/activate
 pip install -r ./perfmetrics/scripts/ml_tests/checkpoint/Jax/requirements.txt
 
 # Run tests in parallel on flat and hns bucket.
-FLAT_BUCKET_NAME="jax-emulated-checkpoint-flat"
-HNS_BUCKET_NAME="jax-emulated-checkpoint-hns"
+FLAT_BUCKET_NAME="jax-emulated-checkpoint-flat-${architecture}"
+HNS_BUCKET_NAME="jax-emulated-checkpoint-hns-${architecture}"
 mount_gcsfuse_and_run_test "${FLAT_BUCKET_NAME}" &
 flat_pid=$!
 mount_gcsfuse_and_run_test "${HNS_BUCKET_NAME}" &

--- a/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
+++ b/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
@@ -61,8 +61,7 @@ function mount_gcsfuse_and_run_test() {
   mkdir -p "${MOUNT_POINT}"
 
   COMMON_FLAGS=(--log-severity=TRACE --enable-streaming-writes --log-file="${KOKORO_ARTIFACTS_DIR}"/gcsfuse_logs/"${BUCKET_NAME}".log)
-  if [[ $BUCKET_NAME == "jax-emulated-checkpoint-flat" ]]
-  then
+  if [[ "$BUCKET_NAME" =~ "flat" ]]; then
     go run . "${COMMON_FLAGS[@]}" --rename-dir-limit=100  "${BUCKET_NAME}" "${MOUNT_POINT}"
   else
     go run . "${COMMON_FLAGS[@]}" "${BUCKET_NAME}" "${MOUNT_POINT}"


### PR DESCRIPTION
### Description
append bucket name with architecture in checkpoint tests to avoid failures due to concurent checkpoints on the same bucket.

### Link to the issue in case of a bug fix.
b/401124062 b/401124902

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
