### PR TITLE
Adding INFO log for successful gRPC connection

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -334,7 +334,7 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		if sh.directPathDetector != nil {
 			if err := sh.directPathDetector.isDirectPathPossible(ctx, bucketName); err != nil {
 				logger.Warnf("Direct path connectivity unavailable for %s, reason: %v", bucketName, err)
-			}else {
+			} else {
 				logger.Infof("Successfully connected over gRPC DirectPath for %s", bucketName)
 			}
 		}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -334,6 +334,8 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		if sh.directPathDetector != nil {
 			if err := sh.directPathDetector.isDirectPathPossible(ctx, bucketName); err != nil {
 				logger.Warnf("Direct path connectivity unavailable for %s, reason: %v", bucketName, err)
+			}else {
+				logger.Infof("Successfully connected over gRPC DirectPath for %s", bucketName)
 			}
 		}
 	}


### PR DESCRIPTION
### Description
Added info log for successful gRPC connection over directpath.This will be used for e2e tests for validation for gRPC activation (e2e tests will be included in a follow-up PR).
Example logs for success case:
```
{"timestamp":{"seconds":1741243229,"nanos":31380851},"severity":"INFO","message":"GetStorageLayout <- (anushkadhn-grpc-validation)"}
{"timestamp":{"seconds":1741243229,"nanos":79429877},"severity":"INFO","message":"GetStorageLayout -> (anushkadhn-grpc-validation) 48 msec"}
{"timestamp":{"seconds":1741243229,"nanos":439687090},"severity":"INFO","message":"Successfully connected over gRPC DirectPath for anushkadhn-grpc-validation"}
```

Motivation:  Currently we only show a warning log if directpath connection is not possible. To validate for success cases, this was required.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Tested manually on a GCE VM  for both success and failure cases for grpc connection (using buckets which are 
colocated with the test GCE VM , and with out of region bucket )
3. Unit tests - NA
4. Integration tests - NA
