### PR TITLE
Enable more e2e test packages for rapid bucket

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -119,37 +119,37 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  # "benchmarking"
+  "benchmarking"
   # "concurrent_operations"
   # "explicit_dir"
-  # "gzip"
+  "gzip"
   # "implicit_dir"
-  # "interrupt"
-  # "kernel_list_cache"
+  "interrupt"
+  "kernel_list_cache"
   # "list_large_dir"
-  # "local_file"
+  "local_file"
   # "log_content"
   "log_rotation"
-  # "monitoring"
+  "monitoring"
   "mount_timeout"
-  # "mounting"
-  # "negative_stat_cache"
+  "mounting"
+  "negative_stat_cache"
   # "operations"
-  # "read_cache"
-  # "read_large_files"
-  # "rename_dir_limit"
-  # "stale_handle"
+  "read_cache"
+  "read_large_files"
+  "rename_dir_limit"
+  "stale_handle"
   # "streaming_writes"
-  # "write_large_files"
+  "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  # "readonly"
-  # "managed_folders"
-  # "readonly_creds"
+  "readonly"
+  "managed_folders"
+  "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.


### PR DESCRIPTION
### Description
Enable more test packages for e2e test runs on ZB.

This is dependent on #3059 . This PR is dependency for #3065.

### Link to the issue in case of a bug fix.
[b/400360552](http://b/400360552)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - [passed through presubmit](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/5f314bf1-3373-4f17-a98c-95427615a64b/summary)
