### PR TITLE
Add new build config for e2e daily run on ZB

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/zonal/e2e-tests-master.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/zonal/e2e-tests-master.cfg
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+action {
+  define_artifacts {
+    regex: "gcsfuse-failed-integration-test-logs-*"
+    strip_prefix: "github/gcsfuse/perfmetrics/scripts"
+    regex: "proxy*"
+  }
+}
+
+env_vars {
+  key: "RUN_TESTS_WITH_ZONAL_BUCKET"
+  value: "true"
+}
+
+build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh"


### PR DESCRIPTION
### Description
Add new build config for e2e daily run on ZB . This new build is consumed by the new kokoro job being created in [cl/735704462](http://cl/735704462) .

This is dependent on #3064 .

### Link to the issue in case of a bug fix.
[b/400360552](http://b/400360552)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
