### PR TITLE
fix bucket manager unit tests

### DIFF
--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -16,6 +16,7 @@ package gcsx
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -156,7 +157,8 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false, common.NewNoopMetrics())
 
-	ExpectEq("error in iterating through objects: storage: bucket doesn't exist", err.Error())
+	AssertNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))
 	ExpectNe(nil, bucket.Syncer)
 }
 
@@ -180,6 +182,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist_IsMultiB
 
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, true, common.NewNoopMetrics())
 
-	ExpectEq("error in iterating through objects: storage: bucket doesn't exist", err.Error())
+	AssertNe(nil, err)
+	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))
 	ExpectNe(nil, bucket.Syncer)
 }


### PR DESCRIPTION
### Description
Bucket manager tests are asserting the error string to be equal. Changed to check for substring instead as the test is failing on go sdk upgrade.

### Link to the issue in case of a bug fix.
**b/402340996**

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
