### PR TITLE
[testing-on-gke] Add e2e-latency output metrics

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
@@ -105,8 +105,7 @@ class DlioWorkload:
   (essentially the data needed to create a job file for DLIO run).
 
   Members:
-  1. scenario (string): One of "local-ssd", "gcsfuse-generic",
-  "gcsfuse-file-cache" and "gcsfuse-no-file-cache".
+  1. scenario (string): One of "local-ssd", "gcsfuse-generic".
   2. numFilesTrain (int): DLIO numFilesTrain argument e.g. 500000 etc.
   3. recordLength (int): DLIO recordLength argument e.g. 100, 1000000 etc.
   4. bucket (str): Name of a GCS bucket to read input files from.

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -97,8 +97,6 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
         "records":
             "local-ssd": [record1, record2, record3, ...]
             "gcsfuse-generic": [record1, record2, record3, ...]
-            "gcsfuse-file-cache": [record1, record2, record3, ...]
-            "gcsfuse-no-file-cache": [record1, record2, record3, ...]
   """
 
   output = {}
@@ -145,8 +143,6 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
               "records": {
                   "local-ssd": [],
                   "gcsfuse-generic": [],
-                  "gcsfuse-file-cache": [],
-                  "gcsfuse-no-file-cache": [],
               },
           }
 

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -131,26 +131,4 @@ spec:
       volumeAttributes:
         bucketName: {{ .Values.bucketName }}
         mountOptions: "{{ .Values.gcsfuse.mountOptions }}"
-  {{- else if eq .Values.scenario "gcsfuse-file-cache" }}
-    csi:
-      driver: gcsfuse.csi.storage.gke.io
-      volumeAttributes:
-        bucketName: {{ .Values.bucketName }}
-        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
-        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
-        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
-        fileCacheCapacity: "{{ .Values.gcsfuse.fileCacheCapacity }}"
-        fileCacheForRangeRead: "{{ .Values.gcsfuse.fileCacheForRangeRead }}"
-        gcsfuseLoggingSeverity: "debug"
-        mountOptions: implicit-dirs
-  {{- else }}
-    csi:
-      driver: gcsfuse.csi.storage.gke.io
-      volumeAttributes:
-        bucketName: {{ .Values.bucketName }}
-        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
-        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
-        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
-        gcsfuseLoggingSeverity: "debug"
-        mountOptions: implicit-dirs
   {{- end }}

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/unet3d-loading-test/values.yaml
@@ -19,7 +19,7 @@
 
 image: jiaxun/dlio:v1.2.0
 bucketName: gke-dlio-test-data
-# scenario controls the kind of storage that is used for the load testing. local-ssd means directly on LSSD; gcsfuse-generic means on a gcsfuse mount with gcsfuse.mountOptions sent from the caller; gcsfuse-no-file-cache and gcsfuse-file-cache mean as their name suggests.
+# scenario controls the kind of storage that is used for the load testing. local-ssd means directly on LSSD; gcsfuse-generic means on a gcsfuse mount with gcsfuse.mountOptions sent from the caller.
 scenario: local-ssd
 nodeType: n2-standard-96
 instanceId: ldap-yyyymmdd-hhmmss

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -110,8 +110,7 @@ class FioWorkload:
   (essentially the data needed to create a job file for FIO run).
 
   Members:
-  1. scenario (string): One of "local-ssd", "gcsfuse-generic",
-  "gcsfuse-file-cache" and "gcsfuse-no-file-cache".
+  1. scenario (string): One of "local-ssd", "gcsfuse-generic".
   2. fileSize (string): fio filesize field in string format e.g. '100', '10K',
   '10M' etc.
   3. blockSize (string): equivalent of bs field in fio job file e.g. '8K',

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -191,26 +191,4 @@ spec:
       volumeAttributes:
         bucketName: {{ .Values.bucketName }}
         mountOptions: "{{ .Values.gcsfuse.mountOptions }}"
-  {{- else if eq .Values.scenario "gcsfuse-file-cache" }}
-    csi:
-      driver: gcsfuse.csi.storage.gke.io
-      volumeAttributes:
-        bucketName: {{ .Values.bucketName }}
-        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
-        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
-        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
-        fileCacheCapacity: "{{ .Values.gcsfuse.fileCacheCapacity }}"
-        fileCacheForRangeRead: "true"
-        gcsfuseLoggingSeverity: "debug"
-        mountOptions: implicit-dirs
-  {{- else }}
-    csi:
-      driver: gcsfuse.csi.storage.gke.io
-      volumeAttributes:
-        bucketName: {{ .Values.bucketName }}
-        metadataCacheTTLSeconds: "{{ .Values.gcsfuse.metadataCacheTTLSeconds }}"
-        metadataTypeCacheCapacity: "{{ .Values.gcsfuse.metadataTypeCacheCapacity }}"
-        metadataStatCacheCapacity: "{{ .Values.gcsfuse.metadataStatCacheCapacity }}"
-        gcsfuseLoggingSeverity: "debug"
-        mountOptions: implicit-dirs
   {{- end }}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -19,7 +19,7 @@
 
 image: ubuntu:24.04
 bucketName: gke-dlio-test-data
-# scenario controls the kind of storage that is used for the load testing. local-ssd means directly on LSSD; gcsfuse-generic means on a gcsfuse mount with gcsfuse.mountOptions sent from the caller; gcsfuse-no-file-cache and gcsfuse-file-cache mean as their name suggests.
+# scenario controls the kind of storage that is used for the load testing. local-ssd means directly on LSSD; gcsfuse-generic means on a gcsfuse mount with gcsfuse.mountOptions sent from the caller.
 scenario: local-ssd
 nodeType: n2-standard-96
 instanceId: ldap-yyyymmdd-hhmmss

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -51,6 +51,11 @@ record = {
     "blockSize": "",
     "filesPerThread": 0,
     "numThreads": 0,
+    "e2e_latency_ns_max": 0,
+    "e2e_latency_ns_p50": 0,
+    "e2e_latency_ns_p90": 0,
+    "e2e_latency_ns_p99": 0,
+    "e2e_latency_ns_p99.9": 0,
 }
 
 
@@ -250,6 +255,13 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
       r["blockSize"] = bs
       r["filesPerThread"] = nrfiles
       r["numThreads"] = numjobs
+      clat_ns = per_epoch_output_data["jobs"][0]["read"]["clat_ns"]
+      r["e2e_latency_ns_max"] = clat_ns["max"]
+      clat_ns_percentile = clat_ns["percentile"]
+      r["e2e_latency_ns_p50"] = clat_ns_percentile["50.000000"]
+      r["e2e_latency_ns_p90"] = clat_ns_percentile["90.000000"]
+      r["e2e_latency_ns_p99"] = clat_ns_percentile["99.000000"]
+      r["e2e_latency_ns_p99.9"] = clat_ns_percentile["99.900000"]
 
       # This print is for debugging in case something goes wrong.
       pprint.pprint(r)
@@ -274,7 +286,9 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
         " Lowest"
         " Memory (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU"
         " (core),GCSFuse Highest CPU"
-        " (core),Pod,Start,End,GcsfuseMoutOptions,BlockSize,FilesPerThread,NumThreads,InstanceID\n"
+        " (core),Pod,Start,End,GcsfuseMoutOptions,BlockSize,FilesPerThread,NumThreads,InstanceID,"
+        "e2e_latency_ns_max,e2e_latency_ns_p50,e2e_latency_ns_p90,e2e_latency_ns_p99,e2e_latency_ns_p99.9"  #
+        "\n"
     )
 
     for key in output:
@@ -312,7 +326,10 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
             continue
 
           output_file_fwr.write(
-              f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mb_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.instance_id}\n"
+              f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mb_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.instance_id},"
+          )
+          output_file_fwr.write(
+              f"{r['e2e_latency_ns_max']},{r['e2e_latency_ns_p50']},{r['e2e_latency_ns_p90']},{r['e2e_latency_ns_p99']},{r['e2e_latency_ns_p99.9']}\n"
           )
 
     output_file_fwr.close()

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -102,8 +102,6 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
         "records":
             "local-ssd": [record1, record2, record3, ...]
             "gcsfuse-generic": [record1, record2, record3, ...]
-            "gcsfuse-file-cache": [record1, record2, record3, ...]
-            "gcsfuse-no-file-cache": [record1, record2, record3, ...]
   """
 
   output = {}
@@ -191,8 +189,6 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
             "records": {
                 "local-ssd": [],
                 "gcsfuse-generic": [],
-                "gcsfuse-file-cache": [],
-                "gcsfuse-no-file-cache": [],
             },
         }
 

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -23,8 +23,6 @@ from typing import Tuple
 SUPPORTED_SCENARIOS = [
     "local-ssd",
     "gcsfuse-generic",
-    "gcsfuse-no-file-cache",
-    "gcsfuse-file-cache",
 ]
 
 


### PR DESCRIPTION
### Description
Add new columns in output table for e2e-latency. The values added are as following:
- max of e2e-latency
- P50 of e2e-latency
- P90 of e2e-latency
- P99 of e2e-latency
- P99.9 of e2e-latency

This also removes the obsolete gcsfuse scenarios `gcsfuse-file-cache` and `gcsfuse-no-file-cache` .

### Link to the issue in case of a bug fix.
[b/400360265](http://b/400360265)

### Testing details
1. Manual - Tested manually with the output generated as follows:
   ![image](https://github.com/user-attachments/assets/b9260e79-f8a4-4a02-be53-c35cee5a2b63)
3. Unit tests - NA
4. Integration tests - NA
