### PR TITLE
Fix typo RUN_TESTS_FOR_ZONAL_BUCKET -> RUN_TESTS_WITH_ZONAL_BUCKET

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -35,8 +35,9 @@ if [ $# -gt 0 ]; then
     >&2 echo "$0: ZONAL_BUCKET_ARG (\$1) passed as $1 . Expected: true or false"
     exit  1
   fi
-elif test -n ${RUN_TESTS_FOR_ZONAL_BUCKET}; then
-  ZONAL_BUCKET_ARG=${RUN_TESTS_FOR_ZONAL_BUCKET}
+elif test -n "${RUN_TESTS_WITH_ZONAL_BUCKET}" && ${RUN_TESTS_WITH_ZONAL_BUCKET}; then
+  echo "Running for zonal bucket(s) ...";
+  ZONAL_BUCKET_ARG=${RUN_TESTS_WITH_ZONAL_BUCKET}
 fi
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -28,7 +28,7 @@ readonly BUCKET_LOCATION="u-us-prp1"
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 # This flag, if set true, will indicate to underlying script to also run for zonal buckets.
-readonly RUN_TESTS_FOR_ZONAL_BUCKET=false
+readonly RUN_TESTS_WITH_ZONAL_BUCKET=false
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
@@ -63,7 +63,7 @@ gcloud config set project $PROJECT_ID
 
 set +e
 # $1 argument is refering to value of testInstalledPackage
-./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG ${RUN_TESTS_FOR_ZONAL_BUCKET}
+./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG ${RUN_TESTS_WITH_ZONAL_BUCKET}
 exit_code=$?
 set -e
 


### PR DESCRIPTION
### Description
The e2e tests bottom script and kokoro
configs use the env var RUN_TESTS_WITH_ZONAL_BUCKET, while the top level e2e test script uses RUN_TESTS_FOR_ZONAL_BUCKET instead. Changing all instances of RUN_TESTS_FOR_ZONAL_BUCKET to RUN_TESTS_WITH_ZONAL_BUCKET in this change for consistency.

This is to fix the mismatch that caused [e2e zonal bucket run](https://fusion2.corp.google.com/ci;prev=s/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fperiodic%2Fe2e_tests%2Fsubjobs%2Fe2e-tests-amd64-master-zb/activity/fe1c06b1-ca3f-478c-aedf-0d1e60d69519/log?q=gcsfuse&s=p) to run on non-zonal bucket.

### Link to the issue in case of a bug fix.
[b/400360552](http://b/400360552)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
