### PR TITLE
Remove unnecessary allocation of memory in random reader

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -350,9 +350,8 @@ func (rr *randomReader) ReadAt(
 	// is a 15-20x improvement in throughput: 150-200 MB/s instead of 10 MB/s.
 	if rr.reader != nil && rr.start < offset && offset-rr.start < maxReadSize {
 		bytesToSkip := offset - rr.start
-		p := make([]byte, bytesToSkip)
-		n, _ := io.ReadFull(rr.reader, p)
-		rr.start += int64(n)
+		discardedBytes, _ := io.CopyN(io.Discard, rr.reader, int64(bytesToSkip))
+		rr.start += discardedBytes
 	}
 
 	// If we have an existing reader, but it's positioned at the wrong place,


### PR DESCRIPTION
### Description
If a fileHandle has a reader from [8MiB,100MiB), and application request comes from [13MiB, 14MiB):
GCSFuse skips the [8MiB, 13MiB) content by reading from the reader. GCSFuse allocates a temporary memory buffer up to 8 MiB to read the content from the reader, which can be avoided by discarding the content.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
