### PR TITLE
Fix context canceled error conversion and add stale file handle tests for streaming writes.

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -160,6 +160,7 @@ TEST_DIR_PARALLEL=(
   "concurrent_operations"
   "mount_timeout"
   "stale_handle"
+  "stale_handle_streaming_writes"
   "negative_stat_cache"
   "streaming_writes"
 )

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -104,6 +104,7 @@ TEST_DIR_PARALLEL=(
   "benchmarking"
   "mount_timeout"
   "stale_handle"
+  "stale_handle_streaming_writes"
   "negative_stat_cache"
   "streaming_writes"
 )

--- a/tools/integration_tests/stale_handle_streaming_writes/setup_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/setup_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stale_handle_streaming_writes
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName = "StaleHandleStreamingWritesTest"
+)
+
+var (
+	flags     []string
+	mountFunc func([]string) error
+	// root directory is the directory to be unmounted.
+	rootDir       string
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	// Create storage client before running tests.
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as operations tests validates content from the bucket.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		rootDir = setup.MountedDirectory()
+		setup.RunTestsForMountedDirectoryFlag(m)
+	}
+
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+	rootDir = setup.MntDir()
+	log.Println("Log File: " + setup.LogFile())
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=1"},
+	}
+	// Run all tests for GRPC.
+	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--client-protocol=grpc", "")
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+
+	var successCode int
+	for i := range flagsSet {
+		log.Printf("Running tests with flags: %v", flagsSet[i])
+		flags = flagsSet[i]
+		successCode = m.Run()
+		if successCode != 0 {
+			break
+		}
+	}
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/stale_handle_streaming_writes/setup_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/setup_test.go
@@ -66,7 +66,6 @@ func TestMain(m *testing.M) {
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucketFlag()
 	rootDir = setup.MntDir()
-	log.Println("Log File: " + setup.LogFile())
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
 		{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=1"},

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -78,11 +78,10 @@ func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobbered
 	// Dirty the file by giving it some contents.
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
-	err = t.f1.Sync()
-	assert.NoError(t.T(), err)
 	// Clobber file by replacing the underlying object with a new generation.
 	err = WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
 	assert.NoError(t.T(), err)
+	operations.SyncFile(t.f1, t.T())
 
 	// Closing the file/writer returns stale NFS file handle error.
 	err = t.f1.Close()

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -84,7 +84,7 @@ func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobbered
 	err = WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
 	assert.NoError(t.T(), err)
 
-    // Closing the file/writer returns stale NFS file handle error.
+	// Closing the file/writer returns stale NFS file handle error.
 	err = t.f1.Close()
 
 	operations.ValidateStaleNFSFileHandleError(t.T(), err)

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stale_handle_streaming_writes
+
+import (
+	"os"
+	"path"
+
+	"cloud.google.com/go/storage"
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// //////////////////////////////////////////////////////////////////////
+// Boilerplate
+// //////////////////////////////////////////////////////////////////////
+
+type staleFileHandleStreamingWritesCommon struct {
+	f1          *os.File
+	data        string
+	testDirPath string
+	fileName    string
+	filePath    string
+	suite.Suite
+}
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func (t *staleFileHandleStreamingWritesCommon) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	t.testDirPath = setup.SetupTestDirectory(testDirName)
+	t.data = setup.GenerateRandomString(operations.MiB * 5)
+}
+
+func (t *staleFileHandleStreamingWritesCommon) TearDownSuite() {
+	setup.UnmountGCSFuse(rootDir)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *staleFileHandleStreamingWritesCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowError() {
+	// Dirty the file by giving it some contents.
+	bytesWrote, err := t.f1.WriteAt([]byte(t.data), 0)
+	assert.NoError(t.T(), err)
+	// Delete the file.
+	operations.RemoveFile(t.f1.Name())
+	// Verify unlink operation succeeds.
+	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
+
+	// Attempt to write to file should give stale NFS file handle erorr.
+	_, err = t.f1.WriteAt([]byte(t.data), int64(bytesWrote))
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.SyncFile(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+}
+
+func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobberedFileReturnsStaleFileHandleError() {
+	// Dirty the file by giving it some contents.
+	_, err := t.f1.WriteAt([]byte(t.data), 0)
+	assert.NoError(t.T(), err)
+	err = t.f1.Sync()
+	assert.NoError(t.T(), err)
+	// Replace the underlying object with a new generation.
+	err = WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
+	assert.NoError(t.T(), err)
+
+    // Closing the file/writer returns stale NFS file handle error.
+	err = t.f1.Close()
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, FileContents, t.T())
+}

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -66,10 +66,10 @@ func (t *staleFileHandleStreamingWritesCommon) TestFileDeletedLocallySyncAndClos
 	// Verify unlink operation succeeds.
 	operations.ValidateNoFileOrDirError(t.T(), t.f1.Name())
 
-	// Attempt to write to file should give stale NFS file handle erorr.
+	// Write should not give an error.
 	_, err = t.f1.WriteAt([]byte(t.data), int64(bytesWrote))
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	assert.NoError(t.T(), err)
 	operations.SyncFile(t.f1, t.T())
 	operations.CloseFileShouldNotThrowError(t.f1, t.T())
 }
@@ -80,7 +80,7 @@ func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobbered
 	assert.NoError(t.T(), err)
 	err = t.f1.Sync()
 	assert.NoError(t.T(), err)
-	// Replace the underlying object with a new generation.
+	// Clobber file by replacing the underlying object with a new generation.
 	err = WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
 	assert.NoError(t.T(), err)
 

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
@@ -52,7 +52,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) SetupTest() {
 ////////////////////////////////////////////////////////////////////////
 
 func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFirstWriteToClobberedFileThrowsStaleFileHandleError() {
-	// Replace the underlying object with a new generation.
+	// Clobber file by replacing the underlying object with a new generation.
 	err := WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
 	assert.NoError(t.T(), err)
 

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stale_handle_streaming_writes
+
+import (
+	"path"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// //////////////////////////////////////////////////////////////////////
+// Boilerplate
+// //////////////////////////////////////////////////////////////////////
+
+type staleFileHandleStreamingWritesEmptyGcsFile struct {
+	staleFileHandleStreamingWritesCommon
+}
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func (t *staleFileHandleStreamingWritesEmptyGcsFile) SetupTest() {
+	t.fileName = setup.GenerateRandomString(5)
+	// Create an empty object on GCS
+	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "", t.T())
+	t.filePath = path.Join(t.testDirPath, t.fileName)
+	t.f1 = operations.OpenFile(t.filePath, t.T())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFirstWriteToClobberedFileThrowsStaleFileHandleError() {
+	// Replace the underlying object with a new generation.
+	err := WriteToObject(ctx, storageClient, path.Join(testDirName, t.fileName), FileContents, storage.Conditions{})
+	assert.NoError(t.T(), err)
+
+	// Attempt first write to the file.
+	_, err = t.f1.WriteAt([]byte(t.data), 0)
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.SyncFile(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+}
+
+func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestWriteOnRenamedFileThrowsStaleFileHandleError() {
+	// Dirty the file by giving it some contents.
+	n, err := t.f1.WriteAt([]byte(t.data), 0)
+	assert.NoError(t.T(), err)
+	newFile := "new" + t.fileName
+	err = operations.RenameFile(t.filePath, path.Join(t.testDirPath, newFile))
+	assert.NoError(t.T(), err)
+
+	// Attempt to write to file should give stale NFS file handle erorr.
+	_, err = t.f1.WriteAt([]byte(t.data), int64(n))
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	// Sync and Close succeeds.
+	operations.SyncFile(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, newFile, t.data, t.T())
+}
+
+func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFileDeletedRemotelyWriteAndSyncDoNoThrowStaleFileHandleError() {
+	// Dirty the file by giving it some contents.
+	n, err := t.f1.WriteAt([]byte(t.data), 0)
+	assert.NoError(t.T(), err)
+	// Delete the file remotely.
+	err = DeleteObjectOnGCS(ctx, storageClient, path.Join(testDirName, t.fileName))
+	assert.NoError(t.T(), err)
+	// Verify unlink operation succeeds.
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
+	_, err = t.f1.WriteAt([]byte(t.data), int64(n))
+	assert.NoError(t.T(), err)
+	operations.SyncFile(t.f1, t.T())
+
+	// Closing the file/writer returns stale NFS file handle error.
+	err = t.f1.Close()
+
+	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestStaleFileHandleStreamingWritesEmptyGcsFileTest(t *testing.T) {
+	suite.Run(t, new(staleFileHandleStreamingWritesEmptyGcsFile))
+}

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_local_file_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_local_file_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stale_handle_streaming_writes
+
+import (
+	"testing"
+
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/suite"
+)
+
+// //////////////////////////////////////////////////////////////////////
+// Boilerplate
+// //////////////////////////////////////////////////////////////////////
+
+type staleFileHandleStreamingWritesLocalFile struct {
+	staleFileHandleStreamingWritesCommon
+}
+
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
+func (t *staleFileHandleStreamingWritesLocalFile) SetupTest() {
+	t.fileName = setup.GenerateRandomString(5)
+	// Create a local file.
+	t.filePath, t.f1 = CreateLocalFileInTestDir(ctx, storageClient, t.testDirPath, t.fileName, t.T())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestStaleFileHandleStreamingWritesLocalFileTest(t *testing.T) {
+	suite.Run(t, new(staleFileHandleStreamingWritesLocalFile))
+}


### PR DESCRIPTION
### Description
Added streaming writes test for stale file handle scenarios and also fixed the error conversion in streaming writes uploader go routine when the unlink operation cancels the context.
### Link to the issue in case of a bug fix.

b/395053734, b/399256056

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Done
