### PR TITLE
Enable parallel downloads config

### DIFF
--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -79,8 +79,14 @@ const (
 	MetadataNegativeCacheTTLConfigKey = "metadata-cache.negative-ttl-secs"
 	// StatCacheMaxSizeConfigKey is the Viper configuration key for the maximum
 	//size of the metadata stat cache in megabytes.
-	StatCacheMaxSizeConfigKey      = "metadata-cache.stat-cache-max-size-mb"
-	maxSupportedStatCacheMaxSizeMB = util.MaxMiBsInUint64
+	StatCacheMaxSizeConfigKey = "metadata-cache.stat-cache-max-size-mb"
+	// FileCacheMaxSizeConfigKey is the Viper configuration key for the maximum
+	//size of the file cache in megabytes.
+	FileCacheMaxSizeConfigKey = "file-cache.max-size-mb"
+	// FileCacheParallelDownloadsConfigKey is the Viper configuration key for the
+	//parallel downloads enablement.
+	FileCacheParallelDownloadsConfigKey = "file-cache.enable-parallel-downloads"
+	maxSupportedStatCacheMaxSizeMB      = util.MaxMiBsInUint64
 )
 
 // CacheUtilMinimumAlignSizeForWriting is the minimum buffer size used for memory-aligned

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -80,8 +80,6 @@ const (
 	// StatCacheMaxSizeConfigKey is the Viper configuration key for the maximum
 	//size of the metadata stat cache in megabytes.
 	StatCacheMaxSizeConfigKey = "metadata-cache.stat-cache-max-size-mb"
-	// CacheDir is the Viper configuration key for cache directory.
-	CacheDir = "cache-dir"
 	// FileCacheParallelDownloadsConfigKey is the Viper configuration key for the
 	//parallel-downloads enablement.
 	FileCacheParallelDownloadsConfigKey = "file-cache.enable-parallel-downloads"

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -80,11 +80,10 @@ const (
 	// StatCacheMaxSizeConfigKey is the Viper configuration key for the maximum
 	//size of the metadata stat cache in megabytes.
 	StatCacheMaxSizeConfigKey = "metadata-cache.stat-cache-max-size-mb"
-	// CacheDir is the Viper configuration key for the maximum
-	//size of the file cache in megabytes.
+	// CacheDir is the Viper configuration key for cache directory.
 	CacheDir = "cache-dir"
 	// FileCacheParallelDownloadsConfigKey is the Viper configuration key for the
-	//parallel downloads enablement.
+	//parallel-downloads enablement.
 	FileCacheParallelDownloadsConfigKey = "file-cache.enable-parallel-downloads"
 	maxSupportedStatCacheMaxSizeMB      = util.MaxMiBsInUint64
 )

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -80,9 +80,9 @@ const (
 	// StatCacheMaxSizeConfigKey is the Viper configuration key for the maximum
 	//size of the metadata stat cache in megabytes.
 	StatCacheMaxSizeConfigKey = "metadata-cache.stat-cache-max-size-mb"
-	// FileCacheMaxSizeConfigKey is the Viper configuration key for the maximum
+	// CacheDir is the Viper configuration key for the maximum
 	//size of the file cache in megabytes.
-	FileCacheMaxSizeConfigKey = "file-cache.max-size-mb"
+	CacheDir = "cache-dir"
 	// FileCacheParallelDownloadsConfigKey is the Viper configuration key for the
 	//parallel downloads enablement.
 	FileCacheParallelDownloadsConfigKey = "file-cache.enable-parallel-downloads"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -97,12 +97,11 @@ func resolveCloudMetricsUploadIntervalSecs(m *MetricsConfig) {
 	}
 }
 
-func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig) {
+func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig, c *Config) {
 	// Parallel downloads should be default ON when file cache is enabled, in case
 	// it is explicitly set by the user, use that value.
-	if v.IsSet(CacheDir) && !v.IsSet(FileCacheParallelDownloadsConfigKey) {
+	if IsFileCacheEnabled(c) && !v.IsSet(FileCacheParallelDownloadsConfigKey) {
 		fc.EnableParallelDownloads = true
-		return
 	}
 }
 
@@ -125,7 +124,7 @@ func Rationalize(v isSet, c *Config) error {
 	resolveMetadataCacheTTL(v, &c.MetadataCache)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache)
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
-	resolveParallelDownloadsValue(v, &c.FileCache)
+	resolveParallelDownloadsValue(v, &c.FileCache, c)
 
 	return nil
 }

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -97,13 +97,11 @@ func resolveCloudMetricsUploadIntervalSecs(m *MetricsConfig) {
 	}
 }
 
-func resolveParallelDownloadsValue(v isSet, c *FileCacheConfig) {
-	// Parallel downloads should be default ON when file cache is enabled, unless
-	// explicitly set by user.
-	if v.IsSet(FileCacheMaxSizeConfigKey) && !v.IsSet(FileCacheParallelDownloadsConfigKey) {
-		if c.MaxSizeMb > 0 || c.MaxSizeMb == -1 {
-			c.EnableParallelDownloads = true
-		}
+func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig) {
+	// Parallel downloads should be default ON when file cache is enabled, in case
+	// it is explicitly set by the user, use that value.
+	if v.IsSet(CacheDir) && !v.IsSet(FileCacheParallelDownloadsConfigKey) {
+		fc.EnableParallelDownloads = true
 		return
 	}
 }

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -97,6 +97,17 @@ func resolveCloudMetricsUploadIntervalSecs(m *MetricsConfig) {
 	}
 }
 
+func resolveParallelDownloadsValue(v isSet, c *FileCacheConfig) {
+	// Parallel downloads should be default ON when file cache is enabled, unless
+	// explicitly set by user.
+	if v.IsSet(FileCacheMaxSizeConfigKey) && !v.IsSet(FileCacheParallelDownloadsConfigKey) {
+		if c.MaxSizeMb > 0 || c.MaxSizeMb == -1 {
+			c.EnableParallelDownloads = true
+		}
+		return
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v isSet, c *Config) error {
 	var err error

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -127,6 +127,7 @@ func Rationalize(v isSet, c *Config) error {
 	resolveMetadataCacheTTL(v, &c.MetadataCache)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache)
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
+	resolveParallelDownloadsValue(v, &c.FileCache)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -430,3 +430,38 @@ func TestRationalizeMetricsConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		flags                     flagSet
+		config                    *Config
+		expectedParallelDownloads bool
+	}{
+		{
+			name:  "valid_config_file_cache_enabled",
+			flags: flagSet{"file-cache.max-size-mb": true},
+			config: &Config{
+				FileCache: FileCacheConfig{
+					MaxSizeMb: 500,
+				},
+			},
+			expectedParallelDownloads: true,
+		},
+		{
+			name:                      "valid_config_file_cache_disabled",
+			config:                    &Config{},
+			expectedParallelDownloads: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := Rationalize(tc.flags, tc.config)
+
+			if assert.NoError(t, actualErr) {
+				assert.Equal(t, tc.expectedParallelDownloads, tc.config.FileCache.EnableParallelDownloads)
+			}
+		})
+	}
+}

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -439,10 +439,12 @@ func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
 		expectedParallelDownloads bool
 	}{
 		{
-			name:  "valid_config_file_cache_enabled",
-			flags: flagSet{"cache-dir": true},
+			name: "valid_config_file_cache_enabled",
 			config: &Config{
 				CacheDir: ResolvedPath("/some-path"),
+				FileCache: FileCacheConfig{
+					MaxSizeMb: 500,
+				},
 			},
 			expectedParallelDownloads: true,
 		},
@@ -452,9 +454,19 @@ func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
 			expectedParallelDownloads: false,
 		},
 		{
-			name:  "valid_config_cache_dir_not_set_and_max_size_mb_set",
-			flags: flagSet{"file-cache.max-size-mb": true},
+			name: "valid_config_cache_dir_not_set_and_max_size_mb_set",
 			config: &Config{
+				FileCache: FileCacheConfig{
+					MaxSizeMb: 500,
+				},
+			},
+			expectedParallelDownloads: false,
+		},
+		{
+			name:  "valid_config_parallel_download_explicit_false",
+			flags: flagSet{"file-cache.enable-parallel-downloads": true},
+			config: &Config{
+				CacheDir: ResolvedPath("/some-path"),
 				FileCache: FileCacheConfig{
 					MaxSizeMb: 500,
 				},

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -477,9 +477,9 @@ func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualErr := Rationalize(tc.flags, tc.config)
+			err := Rationalize(tc.flags, tc.config)
 
-			if assert.NoError(t, actualErr) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expectedParallelDownloads, tc.config.FileCache.EnableParallelDownloads)
 			}
 		})

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -440,17 +440,25 @@ func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
 	}{
 		{
 			name:  "valid_config_file_cache_enabled",
-			flags: flagSet{"file-cache.max-size-mb": true},
+			flags: flagSet{"cache-dir": true},
 			config: &Config{
-				FileCache: FileCacheConfig{
-					MaxSizeMb: 500,
-				},
+				CacheDir: ResolvedPath("/some-path"),
 			},
 			expectedParallelDownloads: true,
 		},
 		{
 			name:                      "valid_config_file_cache_disabled",
 			config:                    &Config{},
+			expectedParallelDownloads: false,
+		},
+		{
+			name:  "valid_config_cache_dir_not_set_and_max_size_mb_set",
+			flags: flagSet{"file-cache.max-size-mb": true},
+			config: &Config{
+				FileCache: FileCacheConfig{
+					MaxSizeMb: 500,
+				},
+			},
 			expectedParallelDownloads: false,
 		},
 	}

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -463,7 +463,9 @@ func TestRationalize_ParallelDownloadsConfig(t *testing.T) {
 			expectedParallelDownloads: false,
 		},
 		{
-			name:  "valid_config_parallel_download_explicit_false",
+			name: "valid_config_parallel_download_explicit_false",
+			// flagset here is representing viper config, value true is not actual value of the flag
+			// it just means flag is SET by the user
 			flags: flagSet{"file-cache.enable-parallel-downloads": true},
 			config: &Config{
 				CacheDir: ResolvedPath("/some-path"),

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -239,7 +239,7 @@ func (testSuite *PromTest) TestReadMetrics() {
 	require.NoError(testSuite.T(), err)
 	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "cache_hit", "false")
 	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "read_type", "Sequential")
-	assertNonZeroCountMetric(testSuite, "file_cache_read_bytes_count", "read_type", "Sequential")
+	assertNonZeroCountMetric(testSuite, "file_cache_read_bytes_count", "read_type", "Parallel")
 	assertNonZeroHistogramMetric(testSuite, "file_cache_read_latencies", "cache_hit", "false")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "OpenFile")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "ReadFile")

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -240,7 +240,6 @@ func (testSuite *PromTest) TestReadMetrics() {
 
 	require.NoError(testSuite.T(), err)
 	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "cache_hit", "false")
-	//assertNonZeroCountMetric(testSuite, "file_cache_read_count", "read_type", "Sequential")
 	assertNonZeroHistogramMetric(testSuite, "file_cache_read_latencies", "cache_hit", "false")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "OpenFile")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "ReadFile")

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -240,6 +240,7 @@ func (testSuite *PromTest) TestReadMetrics() {
 
 	require.NoError(testSuite.T(), err)
 	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "cache_hit", "false")
+	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "read_type", "Sequential")
 	assertNonZeroHistogramMetric(testSuite, "file_cache_read_latencies", "cache_hit", "false")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "OpenFile")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "ReadFile")

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -174,7 +174,9 @@ func assertNonZeroCountMetric(testSuite *PromTest, metricName, labelName, labelV
 		}
 
 	}
-	assert.Fail(testSuite.T(), "Didn't find the metric with name: %s, labelName: %s and labelValue: %s", metricName, labelName, labelValue)
+	assert.Fail(testSuite.T(), fmt.Sprintf("Didn't find the metric with name: %s, labelName: %s and labelValue: %s",
+		metricName, labelName, labelValue))
+	//assert.Fail(testSuite.T(), "Didn't find the metric with name: %s, labelName: %s and labelValue: %s", metricName, labelName, labelValue)
 }
 
 // assertNonZeroHistogramMetric asserts that the specified histogram metric is present and is positive for at least one of the buckets in the Prometheus export.

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -251,6 +251,7 @@ func (testSuite *PromTest) TestReadMetrics() {
 	assertNonZeroCountMetric(testSuite, "gcs_download_bytes_count", "", "")
 	assertNonZeroCountMetric(testSuite, "gcs_read_bytes_count", "", "")
 	assertNonZeroHistogramMetric(testSuite, "gcs_request_latencies", "gcs_method", "NewReader")
+	//TODO: file_cache_read_bytes_count should be added once with waitForDownload is true same as sequential for default pd,
 }
 
 func TestPromOCSuite(t *testing.T) {

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -240,8 +240,7 @@ func (testSuite *PromTest) TestReadMetrics() {
 
 	require.NoError(testSuite.T(), err)
 	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "cache_hit", "false")
-	assertNonZeroCountMetric(testSuite, "file_cache_read_count", "read_type", "Sequential")
-	assertNonZeroCountMetric(testSuite, "file_cache_read_bytes_count", "read_type", "Parallel")
+	//assertNonZeroCountMetric(testSuite, "file_cache_read_count", "read_type", "Sequential")
 	assertNonZeroHistogramMetric(testSuite, "file_cache_read_latencies", "cache_hit", "false")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "OpenFile")
 	assertNonZeroCountMetric(testSuite, "fs_ops_count", "fs_op", "ReadFile")
@@ -249,7 +248,7 @@ func (testSuite *PromTest) TestReadMetrics() {
 	assertNonZeroCountMetric(testSuite, "gcs_request_count", "gcs_method", "NewReader")
 	assertNonZeroCountMetric(testSuite, "gcs_reader_count", "io_method", "opened")
 	assertNonZeroCountMetric(testSuite, "gcs_reader_count", "io_method", "closed")
-	assertNonZeroCountMetric(testSuite, "gcs_read_count", "read_type", "Sequential")
+	assertNonZeroCountMetric(testSuite, "gcs_read_count", "read_type", "Parallel")
 	assertNonZeroCountMetric(testSuite, "gcs_download_bytes_count", "", "")
 	assertNonZeroCountMetric(testSuite, "gcs_read_bytes_count", "", "")
 	assertNonZeroHistogramMetric(testSuite, "gcs_request_latencies", "gcs_method", "NewReader")

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -176,7 +176,6 @@ func assertNonZeroCountMetric(testSuite *PromTest, metricName, labelName, labelV
 	}
 	assert.Fail(testSuite.T(), fmt.Sprintf("Didn't find the metric with name: %s, labelName: %s and labelValue: %s",
 		metricName, labelName, labelValue))
-	//assert.Fail(testSuite.T(), "Didn't find the metric with name: %s, labelName: %s and labelValue: %s", metricName, labelName, labelValue)
 }
 
 // assertNonZeroHistogramMetric asserts that the specified histogram metric is present and is positive for at least one of the buckets in the Prometheus export.


### PR DESCRIPTION
### Description
This PR adds the logic rationalize.go to enable parallel downloads whenever cache dir is set.
This is first PR is making parallel downloads default ON for file cache customers.
Fixed the error string in prom test, was not printing metrics variables correctly - [error](https://screenshot.googleplex.com/9DX8uTJN3r4LGwn)

[Perf test results](https://screenshot.googleplex.com/4Q3j4dq6hfJXVDS)

### Link to the issue in case of a bug fix.
b/404435879

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - Done
