### PR TITLE
Enable metrics while running perf tests

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -63,7 +63,7 @@ git fetch origin -q
 
 function execute_perf_test() {
   mkdir -p gcs
-  GCSFUSE_FLAGS="--implicit-dirs"
+  GCSFUSE_FLAGS="--implicit-dirs --prometheus-port=48341"
   BUCKET_NAME=presubmit-perf-tests
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.


### PR DESCRIPTION
### Description
In order to ensure that metrics enablement doesn't cause performance degradation, let's enable metrics as part of performance tests.

Perf:
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 565.81MiB/s  | 1.09MiB/s  |  80.33MiB/s  |  1.21MiB/s   |
|   PR   |  0.25MiB   | 576.78MiB/s  | 1.32MiB/s  |  78.64MiB/s  |  1.19MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3866.66MiB/s | 87.37MiB/s | 1559.47MiB/s |  86.65MiB/s  |
|   PR   | 48.828MiB  | 3855.06MiB/s | 87.2MiB/s  | 1521.87MiB/s |  83.73MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 3804.34MiB/s | 79.34MiB/s | 641.55MiB/s  |  32.04MiB/s  |
|   PR   | 976.562MiB | 3903.54MiB/s | 79.06MiB/s | 1102.62MiB/s |  29.2MiB/s   |

### Link to the issue in case of a bug fix.
b/404727384

### Testing details
1. Manual - Verified from the build logs that the PrometheusPort flag was being set.
2. Unit tests - NA
3. Integration tests - NA
