### PR TITLE
cd script changes to run zb tests only based on flag passed

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -30,7 +30,7 @@ RUN_ON_ZB_ONLY=$(gcloud compute instances describe "$HOSTNAME" --zone="$ZONE_NAM
 echo "RUN_ON_ZB_ONLY flag set to : \"${RUN_ON_ZB_ONLY}\""
 
 # Logging the tests being run on the active GCE VM
-if [[ "$RUN_ON_ZB_ONLY" == "false" ]]; then
+if [[ "$RUN_ON_ZB_ONLY" == "true" ]]; then
   echo "Running integration tests for Zonal bucket only..."
 else
   echo "Running integration tests for non-zonal buckets only..."
@@ -58,12 +58,12 @@ set -e
 # Print commands and their arguments as they are executed.
 set -x
 
-# Export the RUN_E2E_TESTS_FOR_ZB_ONLY variable so that it is available in the environment of the 'starterscriptuser' user.
+# Export the RUN_ON_ZB_ONLY variable so that it is available in the environment of the 'starterscriptuser' user.
 # Since we are running the subsequent script as 'starterscriptuser' using sudo, the environment of 'starterscriptuser' 
-# would not automatically have access to the environment variables set by the original user (i.e. $RUN_E2E_TESTS_FOR_ZB_ONLY).
-# By exporting this variable, we ensure that the value of RUN_E2E_TESTS_FOR_ZB_ONLY is passed into the 'starterscriptuser' script 
+# would not automatically have access to the environment variables set by the original user (i.e. $RUN_ON_ZB_ONLY).
+# By exporting this variable, we ensure that the value of RUN_ON_ZB_ONLY is passed into the 'starterscriptuser' script 
 # and can be used for conditional logic or decisions within that script.
-export RUN_E2E_TESTS_FOR_ZB_ONLY='$RUN_ON_ZB_ONLY'
+export RUN_ON_ZB_ONLY='$RUN_ON_ZB_ONLY'
 
 #Copy details.txt to starterscriptuser home directory and create logs.txt
 cd ~/
@@ -73,7 +73,7 @@ touch logs-hns.txt
 touch logs-zonal.txt
 GENERIC_LOG_FILE='~/logs.txt'
 
-if [[ "$RUN_E2E_TESTS_FOR_ZB_ONLY" == "true" ]]; then
+if [[ "$RUN_ON_ZB_ONLY" == "true" ]]; then
   GENERIC_LOG_FILE='~/logs-zonal.txt'
 fi
   
@@ -394,7 +394,7 @@ function gather_test_logs() {
   done
 }
 
-if [[ "$RUN_E2E_TESTS_FOR_ZB_ONLY" == "true" ]]; then
+if [[ "$RUN_ON_ZB_ONLY" == "true" ]]; then
   echo "Started integration tests for Zonal bucket ..."
   run_e2e_tests_for_zonal_bucket &
   e2e_tests_zonal_bucket_pid=$!

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -363,7 +363,7 @@ function run_e2e_tests_for_zonal_bucket(){
   non_parallel_tests_zonal_group_exit_code=$?
 
   if [ $parallel_tests_zonal_group_exit_code != 0 ] || [ $non_parallel_tests_zonal_group_exit_code != 0 ]; then
-  return 1
+    return 1
   fi
 }
 

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -71,14 +71,14 @@ cp /details.txt .
 touch logs.txt
 touch logs-hns.txt
 touch logs-zonal.txt
-GENERIC_LOG_FILE='~/logs.txt'
+LOG_FILE='~/logs.txt'
 
 if [[ "$RUN_ON_ZB_ONLY" == "true" ]]; then
-  GENERIC_LOG_FILE='~/logs-zonal.txt'
+  LOG_FILE='~/logs-zonal.txt'
 fi
   
-echo "User: $USER" &>> ${GENERIC_LOG_FILE}
-echo "Current Working Directory: $(pwd)"  &>> ${GENERIC_LOG_FILE}
+echo "User: $USER" &>> ${LOG_FILE}
+echo "Current Working Directory: $(pwd)"  &>> ${LOG_FILE}
 
 
 # Based on the os type in detail.txt, run the following commands for setup
@@ -96,7 +96,7 @@ then
 
     # download and install gcsfuse deb package
     gcloud storage cp gs://gcsfuse-release-packages/v$(sed -n 1p details.txt)/gcsfuse_$(sed -n 1p details.txt)_${architecture}.deb .
-    sudo dpkg -i gcsfuse_$(sed -n 1p details.txt)_${architecture}.deb |& tee -a ${GENERIC_LOG_FILE}
+    sudo dpkg -i gcsfuse_$(sed -n 1p details.txt)_${architecture}.deb |& tee -a ${LOG_FILE}
 
     # install wget
     sudo apt install -y wget
@@ -148,12 +148,12 @@ wget -O go_tar.tar.gz https://go.dev/dl/go1.24.0.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file
-gcsfuse --version |& tee -a ${GENERIC_LOG_FILE}
-go version |& tee -a ${GENERIC_LOG_FILE}
+gcsfuse --version |& tee -a ${LOG_FILE}
+go version |& tee -a ${LOG_FILE}
 
 # Clone and checkout gcsfuse repo
 export PATH=${PATH}:/usr/local/go/bin
-git clone https://github.com/googlecloudplatform/gcsfuse |& tee -a ${GENERIC_LOG_FILE}
+git clone https://github.com/googlecloudplatform/gcsfuse |& tee -a ${LOG_FILE}
 cd gcsfuse
 
 # Installation of crcmod is working through pip only on rhel and centos.
@@ -168,7 +168,7 @@ then
     pip3 install --require-hashes -r tools/cd_scripts/requirements.txt --user
 fi
 
-git checkout $(sed -n 2p ~/details.txt) |& tee -a ${GENERIC_LOG_FILE}
+git checkout $(sed -n 2p ~/details.txt) |& tee -a ${LOG_FILE}
 
 #run tests with testbucket flag
 set +e

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -18,6 +18,13 @@ set -x
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# Extract the metadata parameters passed
+# First , we need to extract the GCE VM Zone.
+ZONE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone)
+ZONE_NAME=$(basename $ZONE)
+RUN_E2E_TESTS_FOR_ZB_ONLY=$(gcloud compute instances describe "$HOSTNAME" --zone="$ZONE_NAME" --format='get(metadata.run-on-zb-only)')
+echo "Running tests for zonal buckets only? : $RUN_E2E_TESTS_FOR_ZB_ONLY"
+
 #details.txt file contains the release version and commit hash of the current release.
 gsutil cp  gs://gcsfuse-release-packages/version-detail/details.txt .
 # Writing VM instance name to details.txt (Format: release-test-<os-name>)
@@ -45,9 +52,15 @@ cd ~/
 cp /details.txt .
 touch logs.txt
 touch logs-hns.txt
+touch logs-zonal.txt
 
-echo User: $USER &>> ~/logs.txt
-echo Current Working Directory: $(pwd)  &>> ~/logs.txt
+if [[ "$RUN_E2E_TESTS_FOR_ZB_ONLY" == "true" ]]; then
+  echo User: $USER &>> ~/logs-zonal.txt
+  echo Current Working Directory: $(pwd)  &>> ~/logs-zonal.txt
+else 
+  echo User: $USER &>> ~/logs.txt
+  echo Current Working Directory: $(pwd)  &>> ~/logs.txt
+fi
 
 # Based on the os type in detail.txt, run the following commands for setup
 
@@ -173,6 +186,37 @@ TEST_DIR_NON_PARALLEL=(
   "list_large_dir"
 )
 
+# For Zonal buckets : Test directory arrays
+TEST_DIR_PARALLEL_ZONAL=(
+  #"local_file"
+  "log_rotation"
+  #"mounting"
+  #"read_cache"
+  #"gzip"
+  #"write_large_files"
+  #"rename_dir_limit"
+  #"read_large_files"
+  #"explicit_dir"
+  #"implicit_dir"
+  #"interrupt"
+  #"operations"
+  #"log_content"
+  #"kernel_list_cache"
+  #"concurrent_operations"
+  "mount_timeout"
+  #"stale_handle"
+  #"negative_stat_cache"
+  #"streaming_writes"
+  #"list_large_dir"
+)
+
+#For Zonal Buckets :  These tests never become parallel as they are changing bucket permissions.
+TEST_DIR_NON_PARALLEL_ZONAL=(
+  #"readonly"
+  #"managed_folders"
+  #"readonly_creds"
+)
+
 # Create a temporary file to store the log file name.
 TEST_LOGS_FILE=$(mktemp)
 
@@ -182,15 +226,16 @@ function run_non_parallel_tests() {
   local exit_code=0
   local -n test_array=$1
   local BUCKET_NAME=$2
+  local zonal=$3
   for test_dir_np in "${test_array[@]}"
   do
     test_path_non_parallel="./tools/integration_tests/$test_dir_np"
-    # To make it clear whether tests are running on a flat or HNS bucket, We kept the log file naming
+    # To make it clear whether tests are running on a flat or HNS or zonal bucket, We kept the log file naming
     # convention to include the bucket name as a suffix (e.g., package_name_bucket_name).
     local log_file="/tmp/${test_dir_np}_${BUCKET_NAME}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
+    GODEBUG=asyncpreemptoff=1 go test $test_path_non_parallel -p 1 --zonal=${zonal} --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1
     exit_code_non_parallel=$?
     if [ $exit_code_non_parallel != 0 ]; then
       exit_code=$exit_code_non_parallel
@@ -203,6 +248,7 @@ function run_parallel_tests() {
   local exit_code=0
   local -n test_array=$1
   local BUCKET_NAME=$2
+  local zonal=$3
   local pids=()
   local benchmark_flags=""
 
@@ -220,7 +266,7 @@ function run_parallel_tests() {
     local log_file="/tmp/${test_dir_p}_${BUCKET_NAME}.log"
     echo $log_file >> $TEST_LOGS_FILE
     # Executing integration tests
-    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $benchmark_flags -p 1 --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
+    GODEBUG=asyncpreemptoff=1 go test $test_path_parallel $benchmark_flags -p 1 --zonal=${zonal} --integrationTest -v --testbucket=$BUCKET_NAME --testInstalledPackage=true -timeout $INTEGRATION_TEST_TIMEOUT > "$log_file" 2>&1 &
     pid=$!  # Store the PID of the background process
     pids+=("$pid")  # Optionally add the PID to an array for later
   done
@@ -243,11 +289,11 @@ function run_e2e_tests_for_flat_bucket() {
   echo "Flat Bucket name to run tests parallelly: "$flat_bucket_name_parallel
 
   echo "Running parallel tests..."
-  run_parallel_tests TEST_DIR_PARALLEL "$flat_bucket_name_parallel" &
+  run_parallel_tests TEST_DIR_PARALLEL "$flat_bucket_name_parallel" false &
   parallel_tests_pid=$!
 
  echo "Running non parallel tests ..."
- run_non_parallel_tests TEST_DIR_NON_PARALLEL "$flat_bucket_name_non_parallel" &
+ run_non_parallel_tests TEST_DIR_NON_PARALLEL "$flat_bucket_name_non_parallel" false &
  non_parallel_tests_pid=$!
 
  # Wait for all tests to complete.
@@ -271,9 +317,9 @@ function run_e2e_tests_for_hns_bucket(){
   echo "HNS Bucket name to run tests parallelly: "$hns_bucket_name_parallel
 
    echo "Running tests for HNS bucket"
-   run_parallel_tests TEST_DIR_PARALLEL "$hns_bucket_name_parallel" &
+   run_parallel_tests TEST_DIR_PARALLEL "$hns_bucket_name_parallel" false &
    parallel_tests_hns_group_pid=$!
-   run_non_parallel_tests TEST_DIR_NON_PARALLEL "$hns_bucket_name_non_parallel" &
+   run_non_parallel_tests TEST_DIR_NON_PARALLEL "$hns_bucket_name_non_parallel" false &
    non_parallel_tests_hns_group_pid=$!
 
    # Wait for all tests to complete.
@@ -289,6 +335,33 @@ function run_e2e_tests_for_hns_bucket(){
    return 0
 }
 
+function run_e2e_tests_for_zonal_bucket(){
+  zonal_bucket_name_non_parallel=$(sed -n 3p ~/details.txt)-zonal
+  echo "Zonal Bucket name to run tests sequentially: "$zonal_bucket_name_non_parallel
+
+  zonal_bucket_name_parallel=$(sed -n 3p ~/details.txt)-zonal-parallel
+  echo "Zonal Bucket name to run tests parallely: "$zonal_bucket_name_parallel
+
+  echo "Running tests for Zonal bucket"
+  run_parallel_tests TEST_DIR_PARALLEL_ZONAL "$zonal_bucket_name_parallel" true &
+  parallel_tests_zonal_group_pid=$!
+  run_non_parallel_tests TEST_DIR_NON_PARALLEL_ZONAL "$zonal_bucket_name_non_parallel" true &
+  non_parallel_tests_zonal_group_pid=$!
+
+  # Wait for all tests to complete.
+  wait $parallel_tests_zonal_group_pid
+  parallel_tests_zonal_group_exit_code=$?
+  wait $non_parallel_tests_zonal_group_pid
+  non_parallel_tests_zonal_group_exit_code=$?
+
+  if [ $parallel_tests_zonal_group_exit_code != 0 ] || [ $non_parallel_tests_zonal_group_exit_code != 0 ];
+  then
+  return 1
+  fi
+  return 0
+}
+
+
 function run_e2e_tests_for_emulator() {
   ./tools/integration_tests/emulator_tests/emulator_tests.sh true > ~/logs-emulator.txt
 }
@@ -302,6 +375,8 @@ function gather_test_logs() {
     if [ -f "$log_file" ]; then
       if [[ "$test_log_file" == *"hns"* ]]; then
         output_file="$HOME/logs-hns.txt"
+      elif [[ "$test_log_file" == *"zonal"* ]]; then
+        output_file="$HOME/logs-zonal.txt"
       else
         output_file="$HOME/logs.txt"
       fi
@@ -313,53 +388,75 @@ function gather_test_logs() {
   done
 }
 
-echo "Running integration tests for HNS bucket..."
-run_e2e_tests_for_hns_bucket &
-e2e_tests_hns_bucket_pid=$!
+if [[ "$RUN_E2E_TESTS_FOR_ZB_ONLY" == "true" ]]; then
+  echo "Running integration tests for Zonal bucket only..."
+  run_e2e_tests_for_zonal_bucket &
+  e2e_tests_zonal_bucket_pid=$!
 
-echo "Running integration tests for FLAT bucket..."
-run_e2e_tests_for_flat_bucket &
-e2e_tests_flat_bucket_pid=$!
+  wait $e2e_tests_zonal_bucket_pid
+  e2e_tests_zonal_bucket_status=$?
 
-run_e2e_tests_for_emulator &
-e2e_tests_emulator_pid=$!
+  gather_test_logs
+  
+  if [ $e2e_tests_zonal_bucket_status != 0 ];
+  then
+      echo "Test failures detected in Zonal bucket." &>> ~/logs-zonal.txt
+  else
+      touch success-zonal.txt
+      gsutil cp success-zonal.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  fi
 
-wait $e2e_tests_emulator_pid
-e2e_tests_emulator_status=$?
-
-wait $e2e_tests_flat_bucket_pid
-e2e_tests_flat_bucket_status=$?
-
-wait $e2e_tests_hns_bucket_pid
-e2e_tests_hns_bucket_status=$?
-
-gather_test_logs
-
-if [ $e2e_tests_flat_bucket_status != 0 ]
-then
-    echo "Test failures detected in FLAT bucket." &>> ~/logs.txt
+  gsutil cp ~/logs-zonal.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
 else
-    touch success.txt
-    gsutil cp success.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
-fi
-gsutil cp ~/logs.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  echo "Running integration tests for HNS bucket..."
+  run_e2e_tests_for_hns_bucket &
+  e2e_tests_hns_bucket_pid=$!
 
-if [ $e2e_tests_hns_bucket_status != 0 ];
-then
-    echo "Test failures detected in HNS bucket." &>> ~/logs-hns.txt
-else
-    touch success-hns.txt
-    gsutil cp success-hns.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
-fi
-gsutil cp ~/logs-hns.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  echo "Running integration tests for FLAT bucket..."
+  run_e2e_tests_for_flat_bucket &
+  e2e_tests_flat_bucket_pid=$!
 
-if [ $e2e_tests_emulator_status != 0 ];
-then
-    echo "Test failures detected in emulator based tests." &>> ~/logs-emulator.txt
-else
-    touch success-emulator.txt
-    gsutil cp success-emulator.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
-fi
+  run_e2e_tests_for_emulator &
+  e2e_tests_emulator_pid=$!
 
-gsutil cp ~/logs-emulator.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  wait $e2e_tests_emulator_pid
+  e2e_tests_emulator_status=$?
+
+  wait $e2e_tests_flat_bucket_pid
+  e2e_tests_flat_bucket_status=$?
+
+  wait $e2e_tests_hns_bucket_pid
+  e2e_tests_hns_bucket_status=$?
+
+  gather_test_logs
+
+  if [ $e2e_tests_flat_bucket_status != 0 ]
+  then
+      echo "Test failures detected in FLAT bucket." &>> ~/logs.txt
+  else
+      touch success.txt
+      gsutil cp success.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  fi
+  gsutil cp ~/logs.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+
+  if [ $e2e_tests_hns_bucket_status != 0 ];
+  then
+      echo "Test failures detected in HNS bucket." &>> ~/logs-hns.txt
+  else
+      touch success-hns.txt
+      gsutil cp success-hns.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  fi
+  gsutil cp ~/logs-hns.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+
+  if [ $e2e_tests_emulator_status != 0 ];
+  then
+      echo "Test failures detected in emulator based tests." &>> ~/logs-emulator.txt
+  else
+      touch success-emulator.txt
+      gsutil cp success-emulator.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+  fi
+
+  gsutil cp ~/logs-emulator.txt gs://gcsfuse-release-packages/v$(sed -n 1p ~/details.txt)/$(sed -n 3p ~/details.txt)/
+fi
+  
 '


### PR DESCRIPTION
### Description
Added `RUN_ON_ZB_ONLY` flag to run integration tests only for ZB via this script.

Follow up CL:
* Changes in louhi pipeline to setup stages for the zb-only tests


### Motivation
ZB integration tests cannot be run in parallel with flat or HNS buckets. Hence, in our release pipeline , we are going to run these tests on a seperate VM altogether. To ensure this targeted test execution, we pass this field as a VM metadata argument , which is consumed the same VM's starter script (e2e_test.sh)


### Link to the issue in case of a bug fix.
[b/405035152](http://b/405035152)

### Testing details
1. Manual - Checked script in cloned louhi pipeline. WAI.
2. Unit tests - NA
3. Integration tests - NA
