### PR TITLE
re-enable disabled UT

### DIFF
--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -954,23 +954,23 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse()
 }
 
 func (dt *downloaderTest) Test_validateCRC_WheContextIsCancelled() {
-	// objectName := "path/in/gcs/file2.txt"
-	// objectSize := 10 * util.MiB
-	// objectContent := testutil.GenerateRandomBytes(objectSize)
-	// dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
-	// // Start download
-	// offset := int64(10 * util.MiB)
-	// _, err := dt.job.Download(context.Background(), offset, true)
-	// AssertEq(nil, err)
-	// AssertTrue((dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
-	// AssertEq(nil, dt.job.status.Err)
-	// AssertGe(dt.job.status.Offset, offset)
+	objectName := "path/in/gcs/file2.txt"
+	objectSize := 10 * util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
+	// Start download
+	offset := int64(10 * util.MiB)
+	_, err := dt.job.Download(context.Background(), offset, true)
+	AssertEq(nil, err)
+	AssertTrue((dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
+	AssertEq(nil, dt.job.status.Err)
+	AssertGe(dt.job.status.Offset, offset)
 
-	// dt.job.cancelFunc()
-	// dt.waitForCrcCheckToBeCompleted()
+	dt.job.cancelFunc()
+	dt.waitForCrcCheckToBeCompleted()
 
-	// AssertEq(Invalid, dt.job.status.Name)
-	// dt.verifyInvalidError(dt.job.status.Err)
+	AssertEq(Invalid, dt.job.status.Name)
+	dt.verifyInvalidError(dt.job.status.Err)
 }
 
 func (dt *downloaderTest) Test_handleError_SetStatusAsInvalidWhenContextIsCancelled() {


### PR DESCRIPTION
### Description
Re-enabling a unit-test that was disabled during rapid-bucket development because it was failing at the time. I have re-enabled it here because it is now passing. More details in the issue ticket below.

### Link to the issue in case of a bug fix.
[b/390578338](http://b/390578338)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
