### PR TITLE
Use new writer flush before reads for zonal buckets with streaming writes.

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -108,10 +108,11 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
 	fh.inode.Lock()
-	err = fh.inode.SyncUsingBufferedWriteHandler()
+	// Ensure all pending writes to Zonal Buckets are flushed before issuing a read.
+	err = fh.inode.SyncPendingBufferedWrites()
 	if err != nil {
 		fh.inode.Unlock()
-		err = fmt.Errorf("fh.inode.SyncUsingBufferedWriteHandler: %w", err)
+		err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)
 		return
 	}
 	err = fh.tryEnsureReader(ctx, sequentialReadSizeMb)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -108,6 +108,12 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
 	fh.inode.Lock()
+	err = fh.inode.SyncUsingBufferedWriteHandler()
+	if err != nil {
+		fh.inode.Unlock()
+		err = fmt.Errorf("fh.inode.SyncUsingBufferedWriteHandler: %w", err)
+		return
+	}
 	err = fh.tryEnsureReader(ctx, sequentialReadSizeMb)
 	if err != nil {
 		fh.inode.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -378,9 +378,9 @@ func (f *FileInode) Source() *gcs.MinObject {
 func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
-	//   2.  The bucket is zonal and there is no pending content write and
-	// 		 SyncUsingBufferedWriteHandler has been called on the fileInode
-	// 		 if using streaming writes.
+	//   2.  The bucket is zonal and there is no pending content write.
+	// 	 3.  The bucket is zonal with streaming writes and SyncUsingBufferedWriteHandler
+	// 		 has been called on f within same Inode lock.
 	// TODO(b/406160290): Check if this can be improved.
 	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().Zonal && f.content == nil)
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -378,9 +378,8 @@ func (f *FileInode) Source() *gcs.MinObject {
 func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
-	//   2.  The bucket is zonal and there is no pending content write.
-	// 	 3.  The bucket is zonal with streaming writes and SyncUsingBufferedWriteHandler
-	// 		 has been called on f within same Inode lock.
+	//   2.  The bucket is zonal with non-streaming writes and there is no pending content write.
+	// 	 3.  The bucket is zonal with streaming writes and SyncUsingBufferedWriteHandler has been called on f within same Inode lock.
 	// TODO(b/406160290): Check if this can be improved.
 	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().Zonal && f.content == nil)
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -646,10 +646,10 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	return nil
 }
 
-// SyncPendingBufferedWrites flushed any pending writes on the bwh to GCS.
+// SyncPendingBufferedWrites flushes any pending writes on the bwh to GCS.
 // It is a no-op when bwh is nil.
 //
-// LOCKS_REQUIRED((f.mu)
+// LOCKS_REQUIRED(f.mu)
 func (f *FileInode) SyncPendingBufferedWrites() error {
 	if f.bwh == nil {
 		return nil

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -378,7 +378,9 @@ func (f *FileInode) Source() *gcs.MinObject {
 func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
-	//   2.  The bucket is zonal and there is no pending content write and SyncUsingBufferedWriteHandler has been called on the f.
+	//   2.  The bucket is zonal and there is no pending content write and
+	// 		 SyncUsingBufferedWriteHandler has been called on the fileInode
+	// 		 if using streaming writes.
 	// TODO(b/406160290): Check if this can be improved.
 	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().Zonal && f.content == nil)
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -379,7 +379,7 @@ func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
 	//   2.  The bucket is zonal with non-streaming writes and there is no pending content write.
-	// 	 3.  The bucket is zonal with streaming writes and SyncUsingBufferedWriteHandler has been called on f within same Inode lock.
+	//   3.  The bucket is zonal with streaming writes and SyncUsingBufferedWriteHandler has been called on f within same Inode lock.
 	// TODO(b/406160290): Check if this can be improved.
 	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().Zonal && f.content == nil)
 }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -186,8 +186,9 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncUsingBufferedWritesForZonal
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("pizza"), 0))
 
 	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
-	_, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	content, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), "pizza", string(content))
 }
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempFile() {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -177,7 +177,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 
 	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
 	content, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), "pizza", string(content))
 }
 
@@ -307,7 +307,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	assert.True(t.T(), gcsSynced)
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), "hello\x00taco", string(contents))
 }
 
@@ -328,7 +328,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesOnClobberedFileThrowsError
 	// Validate Object on GCS not updated.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	objGot, _, err := t.bucket.StatObject(t.ctx, statReq)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), storageutil.ConvertObjToMinObject(objWritten), objGot)
 }
 
@@ -410,13 +410,13 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndFlush() {
 			assert.False(t.T(), t.in.IsLocal())
 			// Check attributes.
 			attrs, err := t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
 			assert.Equal(t.T(), t.clock.Now().UTC(), attrs.Mtime.UTC())
 			// Validate Object on GCS.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -424,7 +424,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndFlush() {
 			// Mtime metadata is not written for buffered writes.
 			assert.Equal(t.T(), "", m.Metadata["gcsfuse_mtime"])
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "tacos", string(contents))
 		})
 	}
@@ -466,7 +466,7 @@ func (t *FileStreamingWritesTest) TestFlushEmptyFile() {
 			assert.False(t.T(), t.in.IsLocal())
 			// Check attributes.
 			attrs, err := t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 			// For synced file, mtime is updated by SetInodeAttributes call.
 			if tc.isLocal {
@@ -475,7 +475,7 @@ func (t *FileStreamingWritesTest) TestFlushEmptyFile() {
 			// Validate Object on GCS.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -483,7 +483,7 @@ func (t *FileStreamingWritesTest) TestFlushEmptyFile() {
 			// Mtime metadata is not written for buffered writes.
 			assert.Equal(t.T(), "", m.Metadata["gcsfuse_mtime"])
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "", string(contents))
 		})
 	}
@@ -576,7 +576,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndSync() {
 				var notFoundErr *gcs.NotFoundError
 				assert.ErrorAs(t.T(), err, &notFoundErr)
 			} else {
-				assert.NoError(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.NotNil(t.T(), m)
 				assert.Equal(t.T(), uint64(0), m.Size)
 			}
@@ -611,7 +611,7 @@ func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreate
 	assert.True(t.T(), gcsSynced)
 	// Read the object's contents.
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), "\x00\x00taco\x00\x00\x00\x00", string(contents))
 }
 

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -160,13 +160,13 @@ func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFals
 }
 
 func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForNonZonalBuckets() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesTest) TestSyncUsingBufferedWritesForNonZonalBuckets() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
 	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
@@ -177,13 +177,13 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsTrueAfterWriteForZonalBuckets() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncUsingBufferedWritesForZonalBuckets() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("pizza"), 0))
 
 	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
 	_, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -185,20 +185,20 @@ func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
 
 func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreamingWrites() {
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), t.initialContents, string(contents))
-	assert.Nil(t.T(), err)
 
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("bar"), 0))
 	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
 
 	contents, err = storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), t.initialContents, string(contents))
-	assert.Nil(t.T(), err)
 }
 
 func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len(t.initialContents)), attrs.Size)
 	assert.Equal(t.T(), uint32(1), attrs.Nlink)
@@ -223,7 +223,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 }
@@ -241,7 +241,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gsutil() {
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime.UTC(), mtime)
 }
@@ -262,7 +262,7 @@ func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_GcsfuseOutranks
 
 	// Ask it for its attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), attrs.Mtime, canonicalMtime)
 }
@@ -347,7 +347,7 @@ func (t *FileTest) TestWrite() {
 
 	// Check attributes.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("pacoburrito")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, writeTime)
@@ -381,7 +381,7 @@ func (t *FileTest) TestTruncate() {
 
 	// Check attributes.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 
 	assert.Equal(t.T(), uint64(len("ta")), attrs.Size)
 	assert.Equal(t.T(), attrs.Mtime, truncateTime)
@@ -420,7 +420,7 @@ func (t *FileTest) TestWriteThenSync() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -437,7 +437,7 @@ func (t *FileTest) TestWriteThenSync() {
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -449,12 +449,12 @@ func (t *FileTest) TestWriteThenSync() {
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "paco", string(contents))
 
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 
 			assert.Equal(t.T(), uint64(len("paco")), attrs.Size)
 			assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
@@ -495,7 +495,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -507,7 +507,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -519,11 +519,11 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "tacos", string(contents))
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
 			assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
 		})
@@ -558,7 +558,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -570,7 +570,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -584,11 +584,11 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			assert.WithinDuration(t.T(), mtime, creationTime, Delta)
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "", string(contents))
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 		})
 	}
@@ -627,7 +627,7 @@ func (t *FileTest) TestAppendThenSync() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -641,7 +641,7 @@ func (t *FileTest) TestAppendThenSync() {
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -656,12 +656,12 @@ func (t *FileTest) TestAppendThenSync() {
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), "tacoburrito", string(contents))
 
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 
 			assert.Equal(t.T(), uint64(len("tacoburrito")), attrs.Size)
 			assert.Equal(t.T(), attrs.Mtime, writeTime.UTC())
@@ -699,7 +699,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -716,7 +716,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
@@ -727,7 +727,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 
 			assert.Equal(t.T(), uint64(2), attrs.Size)
 			assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
@@ -768,7 +768,7 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 
 			if tc.callSync {
 				gcsSynced, err := t.in.Sync(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.True(t.T(), gcsSynced)
 			} else {
 				err = t.in.Flush(t.ctx)
@@ -784,19 +784,19 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
+
+			require.NoError(t.T(), err)
+			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(),
 				truncateTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
-
-			assert.Nil(t.T(), err)
-			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), t.in.SourceGeneration().Object, m.Generation)
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 			assert.Equal(t.T(), uint64(6), m.Size)
 
 			// Check attributes.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 
 			assert.Equal(t.T(), uint64(6), attrs.Size)
 			assert.Equal(t.T(), attrs.Mtime, truncateTime.UTC())
@@ -813,7 +813,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	assert.Nil(t.T(), err)
 	// Fetch the attributes and check if the file is empty.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(0), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 6)
@@ -821,12 +821,12 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	assert.Nil(t.T(), err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(6), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotNil(t.T(), err)
+	require.Error(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -842,7 +842,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	assert.Nil(t.T(), err)
 	// Validate the new data is written correctly.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(7), attrs.Size)
 
 	err = t.in.Truncate(t.ctx, 2)
@@ -850,12 +850,12 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	assert.Nil(t.T(), err)
 	// The inode should return the new size.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(2), attrs.Size)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotNil(t.T(), err)
+	require.Error(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -884,7 +884,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 
 			if tc.performWrite {
@@ -893,7 +893,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 				assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 				// Fetch the attributes and check if the file size reflects the write.
 				attrs, err := t.in.Attributes(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.Equal(t.T(), uint64(2), attrs.Size)
 			}
 
@@ -902,12 +902,12 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 			assert.Nil(t.T(), err)
 			// The inode should return the new size.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(10), attrs.Size)
 			// Data shouldn't be updated to GCS.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			_, _, err = t.bucket.StatObject(t.ctx, statReq)
-			assert.NotNil(t.T(), err)
+			require.Error(t.T(), err)
 			assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 		})
 	}
@@ -934,7 +934,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 			assert.Nil(t.T(), t.in.bwh)
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 
 			if tc.performWrite {
@@ -943,7 +943,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 				assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 				// Fetch the attributes and check if the file size reflects the write.
 				attrs, err := t.in.Attributes(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.Equal(t.T(), uint64(2), attrs.Size)
 			}
 
@@ -952,12 +952,12 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 			assert.Nil(t.T(), err)
 			// The inode should return the new size.
 			attrs, err = t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(10), attrs.Size)
 			// Data shouldn't be updated to GCS.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			minObject, _, err := t.bucket.StatObject(t.ctx, statReq)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), minObject.Size)
 		})
 	}
@@ -1007,7 +1007,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 			assert.Nil(t.T(), t.in.bwh)
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 
 			if tc.performWrite {
@@ -1016,13 +1016,13 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
 				// Fetch the attributes and check if the file size reflects the write.
 				attrs, err := t.in.Attributes(t.ctx)
-				assert.Nil(t.T(), err)
+				require.NoError(t.T(), err)
 				assert.Equal(t.T(), uint64(7), attrs.Size)
 			}
 
 			err = t.in.Truncate(t.ctx, tc.truncateSize)
 
-			assert.NotNil(t.T(), err)
+			require.Error(t.T(), err)
 			assert.ErrorContains(t.T(), err, "cannot truncate")
 		})
 	}
@@ -1064,6 +1064,7 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 				var gcsSynced bool
 				// Sync. The call should not succeed, and we expect a FileClobberedError.
 				gcsSynced, err = t.in.Sync(t.ctx)
+				require.Error(t.T(), err)
 				assert.False(t.T(), gcsSynced)
 			} else {
 				// Flush. The call should not succeed, and we expect a FileClobberedError.
@@ -1083,7 +1084,7 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 			m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-			assert.Nil(t.T(), err)
+			require.NoError(t.T(), err)
 			assert.NotNil(t.T(), m)
 			assert.Equal(t.T(), newObj.Generation, m.Generation)
 			assert.Equal(t.T(), newObj.Size, m.Size)
@@ -1123,14 +1124,14 @@ func (t *FileTest) TestSetMtime_ContentNotFaultedIn() {
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -1154,14 +1155,14 @@ func (t *FileTest) TestSetMtime_ContentClean() {
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// The inode should have added the mtime to the backing object's metadata.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -1185,12 +1186,12 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 
 	// Sync.
 	gcsSynced, err := t.in.Sync(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.True(t.T(), gcsSynced)
 
 	// Now the object in the bucket should have the appropriate mtime.
@@ -1200,7 +1201,7 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 	assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(),
 		mtime.UTC().Format(time.RFC3339Nano),
@@ -1228,7 +1229,7 @@ func (t *FileTest) TestSetMtime_SourceObjectGenerationChanged() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), 0, len(m.Metadata))
@@ -1257,7 +1258,7 @@ func (t *FileTest) TestSetMtime_SourceObjectMetaGenerationChanged() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)
 	assert.Equal(t.T(), newObj.Generation, m.Generation)
 	assert.Equal(t.T(), newObj.MetaGeneration, m.MetaGeneration)
@@ -1274,7 +1275,7 @@ func (t *FileTest) TestSetMtimeForUnlinkedFileIsNoOp() {
 
 	require.Nil(t.T(), err)
 	afterUpdateAttr, err := t.in.Attributes(t.ctx)
-	require.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.NotEqual(t.T(), mtime, afterUpdateAttr.Mtime)
 	assert.Equal(t.T(), beforeUpdateAttr.Mtime, afterUpdateAttr.Mtime)
 }
@@ -1290,7 +1291,7 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	assert.Nil(t.T(), err)
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 
 	// Set mtime.
@@ -1300,14 +1301,14 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 	assert.Equal(t.T(), attrs.Ctime, mtime)
 	assert.Equal(t.T(), attrs.Atime, mtime)
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotNil(t.T(), err)
+	require.Error(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -1328,7 +1329,7 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err = t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 	assert.Equal(t.T(), attrs.Ctime, mtime)
 	assert.Equal(t.T(), attrs.Atime, mtime)
@@ -1380,7 +1381,7 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 	assert.NotNil(t.T(), t.in.content)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
@@ -1406,7 +1407,7 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFile
 	assert.Nil(t.T(), t.in.bwh)
 	// Validate that file size is 0.
 	sr, err := t.in.content.Stat()
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
@@ -1427,7 +1428,7 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	// Data shouldn't be updated to GCS.
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	_, _, err = t.bucket.StatObject(t.ctx, statReq)
-	assert.NotNil(t.T(), err)
+	require.Error(t.T(), err)
 	assert.Equal(t.T(), "gcs.NotFoundError: object test not found", err.Error())
 }
 
@@ -1480,7 +1481,7 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 			n, err := t.in.Read(t.ctx, data, 0)
 
 			assert.Equal(t.T(), 0, n)
-			assert.NotNil(t.T(), err)
+			require.Error(t.T(), err)
 			assert.Equal(t.T(), "cannot read a file when upload in progress", err.Error())
 		})
 	}
@@ -1494,6 +1495,7 @@ func (t *FileTest) TestReadEmptyGCSFileWhenStreamingWritesAreNotInProgress() {
 	n, err := t.in.Read(t.ctx, data, 0)
 
 	assert.Equal(t.T(), 0, n)
+	require.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "EOF")
 }
 
@@ -1505,7 +1507,7 @@ func (t *FileTest) TestWriteToLocalFileWithInvalidConfigWhenStreamingWritesAreEn
 
 	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
-	assert.NotNil(t.T(), err)
+	require.Error(t.T(), err)
 	assert.True(t.T(), strings.Contains(err.Error(), "invalid configuration"))
 }
 
@@ -1540,7 +1542,7 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 	assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(7), attrs.Size)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 }
@@ -1559,7 +1561,7 @@ func (t *FileTest) TestWriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	assert.Equal(t.T(), int64(2), writeFileInfo.TotalSize)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), uint64(2), attrs.Size)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, Delta)
 }
@@ -1594,7 +1596,7 @@ func (t *FileTest) TestSetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEn
 	assert.Nil(t.T(), err)
 	// The inode should agree about the new mtime.
 	attrs, err := t.in.Attributes(t.ctx)
-	assert.Nil(t.T(), err)
+	require.NoError(t.T(), err)
 	assert.Equal(t.T(), attrs.Mtime, mtime)
 	assert.Equal(t.T(), attrs.Ctime, mtime)
 	assert.Equal(t.T(), attrs.Atime, mtime)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -183,10 +183,17 @@ func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileTest) TestSyncUsingBufferedWriteHandlerReturnsNilForNonStreamingWrites() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+func (t *FileTest) TestSyncUsingBufferedWriteHandlerReturnsNilAndNoOpForNonStreamingWrites() {
+	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Equal(t.T(), t.initialContents, string(contents))
+	assert.Nil(t.T(), err)
 
+	t.in.Write(t.ctx, []byte("bar"), 0)
 	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
+
+	contents, err = storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
+	assert.Equal(t.T(), t.initialContents, string(contents))
+	assert.Nil(t.T(), err)
 }
 
 func (t *FileTest) TestInitialAttributes() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -183,13 +183,13 @@ func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileTest) TestSyncUsingBufferedWriteHandlerReturnsNilAndNoOpForNonStreamingWrites() {
+func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreamingWrites() {
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	assert.Equal(t.T(), t.initialContents, string(contents))
 	assert.Nil(t.T(), err)
 
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("bar"), 0))
-	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
+	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
 
 	contents, err = storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	assert.Equal(t.T(), t.initialContents, string(contents))

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -178,7 +178,7 @@ func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsTrue() {
 }
 
 func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
-	t.in.Write(t.ctx, []byte("taco"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -188,7 +188,7 @@ func (t *FileTest) TestSyncUsingBufferedWriteHandlerReturnsNilAndNoOpForNonStrea
 	assert.Equal(t.T(), t.initialContents, string(contents))
 	assert.Nil(t.T(), err)
 
-	t.in.Write(t.ctx, []byte("bar"), 0)
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("bar"), 0))
 	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
 
 	contents, err = storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -173,6 +173,22 @@ func (t *FileTest) TestInitialSourceGeneration() {
 	assert.Equal(t.T(), t.backingObj.MetaGeneration, sg.Metadata)
 }
 
+func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsTrue() {
+	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
+}
+
+func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
+	t.in.Write(t.ctx, []byte("taco"), 0)
+
+	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
+}
+
+func (t *FileTest) TestSyncUsingBufferedWriteHandlerReturnsNilForNonStreamingWrites() {
+	t.in.Write(t.ctx, []byte("taco"), 0)
+
+	assert.NoError(t.T(), t.in.SyncUsingBufferedWriteHandler())
+}
+
 func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx)
 	assert.Nil(t.T(), err)


### PR DESCRIPTION
### Description
Implicitly Call Zonal Bucket writer.Flush() before read operation to ensure writes using streaming_writes are available for read from zonal buckets.

### Link to the issue in case of a bug fix.
http://b/406160016

### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - NA
