### PR TITLE
Replace `--debug_*` with `--log-severity=trace` in e2e tests

### DIFF
--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -36,9 +36,7 @@ const PrefixBucketForDynamicMountingTest = "golang-grpc-test-gcsfuse-dynamic-mou
 var testBucketForDynamicMounting = PrefixBucketForDynamicMountingTest + setup.GenerateRandomString(5)
 
 func MountGcsfuseWithDynamicMounting(flags []string) (err error) {
-	defaultArg := []string{"--debug_gcs",
-		"--debug_fs",
-		"--debug_fuse",
+	defaultArg := []string{"--log-severity=trace",
 		"--log-file=" + setup.LogFile(),
 		setup.MntDir()}
 

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -28,9 +28,7 @@ import (
 func MountGcsfuseWithOnlyDir(flags []string) (err error) {
 	defaultArg := []string{"--only-dir",
 		setup.OnlyDirMounted(),
-		"--debug_gcs",
-		"--debug_fs",
-		"--debug_fuse",
+		"--log-severity=trace",
 		"--log-file=" + setup.LogFile(),
 		setup.TestBucket(),
 		setup.MntDir()}

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -43,7 +43,7 @@ func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
 	defaultArg := []string{setup.TestBucket(),
 		setup.MntDir(),
 		"-o",
-		"--log-severity=trace",
+		"log_severity=trace",
 		"-o",
 		"log_file=" + setup.LogFile(),
 	}

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -24,15 +24,15 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-// make e.g --debug_gcs in debug_gcs
+// Change e.g --log_severity=trace to log_severity=trace
 func makePersistentMountingArgs(flags []string) (args []string, err error) {
 	var s string
 	for i := range flags {
 		// We are already passing flags with -o flag.
 		s = strings.Replace(flags[i], "--o=", "", -1)
-		// e.g. Convert --debug_gcs to __debug_gcs
+		// e.g. Convert --log-severity=trace to __log_severity=trace
 		s = strings.Replace(s, "-", "_", -1)
-		// e.g. Convert __debug_gcs to debug_gcs
+		// e.g. Convert __log_severity=trace to log_severity=trace
 		s = strings.Replace(s, "__", "", -1)
 		args = append(args, s)
 	}
@@ -43,11 +43,7 @@ func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
 	defaultArg := []string{setup.TestBucket(),
 		setup.MntDir(),
 		"-o",
-		"debug_gcs",
-		"-o",
-		"debug_fs",
-		"-o",
-		"debug_fuse",
+		"--log-severity=trace",
 		"-o",
 		"log_file=" + setup.LogFile(),
 	}

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -30,9 +30,7 @@ func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 			"--key-file=/tmp/sa.key.json")
 	}
 
-	defaultArg = append(defaultArg, "--debug_gcs",
-		"--debug_fs",
-		"--debug_fuse",
+	defaultArg = append(defaultArg, "--log-severity=trace",
 		"--log-file="+setup.LogFile(),
 		setup.TestBucket(),
 		setup.MntDir())


### PR DESCRIPTION
### Description
This is to avoid unnecessary error logs in e2e runs.

### Link to the issue in case of a bug fix.
[b/405912004](http://b/405912004)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - tested through presubmit
