### PR TITLE
[testing-on-gke] Support for rapid buckets

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -339,10 +339,11 @@ if __name__ == "__main__":
   args = parse_arguments()
   ensure_directory_exists(_LOCAL_LOGS_LOCATION)
 
-  fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
-      args.workload_config
-  )
-  downloadFioOutputs(fioWorkloads, args.instance_id)
+  if not args.predownloaded_output_files:
+    fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
+        args.workload_config
+    )
+    downloadFioOutputs(fioWorkloads, args.instance_id)
 
   mash_installed = is_mash_installed()
   if not mash_installed:

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -790,7 +790,7 @@ function areThereAnyDLIOWorkloads() {
 function fetchAndParseFioOutputs() {
   printf "\nFetching and parsing fio outputs ...\n\n"
   cd "${gke_testing_dir}"/examples/fio
-  parse_logs_args="--project-number=${project_number} --workload-config \"${workload_config}\" --instance-id ${instance_id} --output-file \"${output_dir}/fio/output.csv\" --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace}"
+  parse_logs_args="--project-number=${project_number} --workload-config ${workload_config} --instance-id ${instance_id} --output-file ${output_dir}/fio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace}"
   if ${zonal}; then
     python3 parse_logs.py ${parse_logs_args} --predownloaded-output-files
   else

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -97,7 +97,7 @@ function printHelp() {
   echo "workload_config=<path/to/workload/configuration/file e.g. /a/b/c.json >"
   echo "output_dir=</absolute/path/to/output/dir, output files will be written at output_dir/fio/output.csv and output_dir/dlio/output.csv>"
   echo "force_update_gcsfuse_code=<true|false, to force-update the gcsfuse-code to given branch if gcsfuse_src_dir has been set. Default=\"${DEFAULT_FORCE_UPDATE_GCSFUSE_CODE}\">"
-  echo "zonal=<true|false, to convey that at least some of the buckets in the given workload configuration are zonal buckets which can't be read/written using gcloud. Default=\"${DEFAULT_ZONAL}\"> "
+  echo "zonal=<true|false, to convey that at least one of the buckets in the given workload configuration is a zonal bucket which can't be read/written using gcloud. Default=\"${DEFAULT_ZONAL}\"> "
   echo ""
   echo ""
   echo ""
@@ -726,6 +726,8 @@ function downloadFioOutputsFromZonalBucket() {
         echo "Mounting \"${bucket}\" ... "
         cd $gcsfuse_src_dir
         if ! go run $gcsfuse_src_dir --implicit-dirs --log-severity=trace --log-file=$mountpath.log --log-format=text --metadata-cache-ttl-secs=-1 --stat-cache-max-size-mb=-1 --type-cache-max-size-mb=-1 --enable-nonexistent-type-cache=false $bucket $mountpath > /dev/null ; then
+            cd - >/dev/null
+
             exitWithError "Failed to mount bucket ${bucket} to ${mountpath}."
         else
             cd - >/dev/null

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -479,6 +479,8 @@ function ensureGkeCluster() {
     fi
     cluster_updation_command="gcloud container clusters update ${cluster_name} --project=${project_id} --location=${zone}"
     ${cluster_updation_command} --workload-pool=${project_id}.svc.id.goog
+    # Separating in two update calls as gcloud doesn't support updating these
+    # two fields in a single call.
     if ${zonal}; then
       ${cluster_updation_command} --private-ipv6-google-access-type=bidirectional
     fi
@@ -748,7 +750,7 @@ function downloadFioOutputsFromBucket() {
   if test -d "${src_dir}" ; then
     mkdir -pv "${dst_dir}"
     echo "Copying files from \"${src_dir}\" to \"${dst_dir}/\" ... "
-    cp -rfv "${src_dir}"/* "${dst_dir}"/
+    cp -rfvu "${src_dir}"/* "${dst_dir}"/
   fi
 
   echo "  Unmounting \"${bucket}\" from \"${mountpath}\" ... "

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -801,7 +801,7 @@ if test -z ${only_parse} || ! ${only_parse} ; then
   validateMachineConfig ${machine_type} ${num_nodes} ${num_ssd}
 
   if ${zonal} && $(areThereAnyDLIOWorkloads); then
-    exitWithError "DLIO workloads are not supported with zona buckets as of now."
+    exitWithError "DLIO workloads are not supported with zonal buckets as of now."
   fi
 
   # GCP configuration

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -114,7 +114,6 @@ def parse_arguments() -> object:
   )
   parser.add_argument(
       "--predownloaded-output-files",
-      # metavar="Whether the output files have already been downloaded",
       help="If true, output files will not be downloaded. False by default.",
       required=False,
       default=False,

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -112,4 +112,12 @@ def parse_arguments() -> object:
       help="File path of the output metrics (in CSV format)",
       default="output.csv",
   )
+  parser.add_argument(
+      "--predownloaded-output-files",
+      # metavar="Whether the output files have already been downloaded",
+      help="If true, output files will not be downloaded. False by default.",
+      required=False,
+      default=False,
+      action="store_true",
+  )
   return parser.parse_args()


### PR DESCRIPTION
### Description
1. This is a fix in synthetic AI/ML test tool to support rapid (aka zonal) bucket scenarios, especially for output parsing. The tool needs to read fio outputs from bucket(s) specified for the workload(s). For this, the tool traditionally used `gcloud`, but reading/writing objects in rapid buckets using `gcloud` isn't supported as of today. As an alternative, the tool will mount the bucket(s) using gcsfuse and read the output files using the mounted directory. This is required to unblock testing on rapid buckets.

2. Additionally, this changes the underlying cluster's properties to use ipv6 access-type to bidirectional, which is required to connect to direct-path for rapid buckets, as of today.

**Note**:  These are both workarounds, and will be removed later when no longer needed.

### Link to the issue in case of a bug fix.
[b/388667681](http://b/388667681)

### Testing details
1. Manual - NA
2. Unit tests - NA
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
