### PR TITLE
Add flag to guard metric renames

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -217,6 +217,8 @@ type MetricsConfig struct {
 	PrometheusPort int64 `yaml:"prometheus-port"`
 
 	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
+
+	UseNewNames bool `yaml:"use-new-names"`
 }
 
 type MonitoringConfig struct {
@@ -480,6 +482,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.IntP("metadata-cache-negative-ttl-secs", "", 5, "The negative-ttl-secs value in seconds to be used for expiring negative entries in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled negative entries in metadata-cache. Any value set below -1 will throw an error.")
 
 	flagSet.IntP("metadata-cache-ttl-secs", "", 60, "The ttl value in seconds to be used for expiring items in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled metadata-cache. Any value set below -1 will throw an error.")
+
+	flagSet.BoolP("metrics-use-new-names", "", false, "Use the new metric names.")
+
+	if err := flagSet.MarkHidden("metrics-use-new-names"); err != nil {
+		return err
+	}
 
 	flagSet.StringSliceP("o", "", []string{}, "Additional system-specific mount options. Multiple options can be passed as comma separated. For readonly, use --o ro")
 
@@ -829,6 +837,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metadata-cache.ttl-secs", flagSet.Lookup("metadata-cache-ttl-secs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.use-new-names", flagSet.Lookup("metrics-use-new-names")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -613,6 +613,7 @@
   usage: "Expose Prometheus metrics endpoint on this port and a path of /metrics."
   default: "0"
 
+
 - config-path: "metrics.stackdriver-export-interval"
   flag-name: "stackdriver-export-interval"
   type: "duration"
@@ -622,6 +623,13 @@
   default: "0s"
   deprecated: true
   deprecation-warning: "Please use --cloud-metrics-export-interval-secs instead."
+
+- config-path: "metrics.use-new-names"
+  flag-name: "metrics-use-new-names"
+  type: "bool"
+  usage: "Use the new metric names."
+  default: false
+  hide-flag: true
 
 - config-path: "monitoring.experimental-opentelemetry-collector-address"
   flag-name: "experimental-opentelemetry-collector-address"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -925,6 +925,14 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 				EnableOtel:                     true,
 			},
 		},
+		{
+			name: "use_new_metric_names",
+			args: []string{"gcsfuse", "--metrics-use-new-names=true", "abc", "pqr"},
+			expected: &cfg.MetricsConfig{
+				EnableOtel:  true,
+				UseNewNames: true,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
* The hidden flag allows one to switch between the existing metric renames and the new proposed ones.
* This flag is not supposed to be exposed to the end user but will allow to decouple GKE with GCSFuse metrics.

### Link to the issue in case of a bug fix.
b/406112147

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
