### PR TITLE
Fix and enable package implicit_dir in e2e tests for rapid buckets

### DIFF
--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -31,7 +31,7 @@ import (
 func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
@@ -46,7 +46,7 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	subDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory)
 
@@ -63,7 +63,7 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, ExplicitDirInImplicitDir)
 
@@ -84,7 +84,7 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory, ExplicitDirInImplicitSubDir)
 
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, t)
@@ -106,7 +106,7 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
@@ -125,7 +125,7 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory)
 

--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 )
 
@@ -31,7 +32,11 @@ import (
 func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	}
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
@@ -46,7 +51,11 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	}
 
 	subDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory)
 
@@ -63,7 +72,11 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	}
 
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, ExplicitDirInImplicitDir)
 
@@ -84,7 +97,11 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	}
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory, ExplicitDirInImplicitSubDir)
 
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, t)
@@ -106,7 +123,11 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	}
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
@@ -125,7 +146,11 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	}
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory)
 

--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -31,7 +31,7 @@ import (
 func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
@@ -46,7 +46,7 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 
 	subDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory)
 
@@ -63,7 +63,7 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, ExplicitDirInImplicitDir)
 
@@ -84,7 +84,7 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory, ExplicitDirInImplicitSubDir)
 
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, t)

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -39,7 +39,7 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
 
 	err := filepath.WalkDir(testDirPath, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 )
 
@@ -39,7 +40,11 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
+	}
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
 
 	err := filepath.WalkDir(testDirPath, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -39,7 +39,7 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, path.Join(DirForImplicitDirTests, testDirName), t)
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
 
 	err := filepath.WalkDir(testDirPath, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  "benchmarking"
-  # "concurrent_operations"
-  # "explicit_dir"
-  "gzip"
-  # "implicit_dir"
-  "interrupt"
-  "kernel_list_cache"
-  "list_large_dir"
-  "local_file"
-  "log_rotation"
-  "monitoring"
-  "mount_timeout"
-  "mounting"
-  "negative_stat_cache"
-  # "operations"
-  "read_cache"
-  "read_large_files"
-  "rename_dir_limit"
-  "stale_handle"
-  # "streaming_writes"
-  "write_large_files"
+  # "benchmarking"
+  # # "concurrent_operations"
+  # # "explicit_dir"
+  # "gzip"
+  "implicit_dir"
+  # "interrupt"
+  # "kernel_list_cache"
+  # "list_large_dir"
+  # "local_file"
+  # "log_rotation"
+  # "monitoring"
+  # "mount_timeout"
+  # "mounting"
+  # "negative_stat_cache"
+  # # "operations"
+  # "read_cache"
+  # "read_large_files"
+  # "rename_dir_limit"
+  # "stale_handle"
+  # # "streaming_writes"
+  # "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  "readonly"
-  "managed_folders"
-  "readonly_creds"
+  # "readonly"
+  # "managed_folders"
+  # "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -124,7 +124,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   # "concurrent_operations"
   # "explicit_dir"
   "gzip"
-  # "implicit_dir"
+  "implicit_dir"
   "interrupt"
   "kernel_list_cache"
   "list_large_dir"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -449,9 +449,9 @@ function clean_up() {
 function main(){
   set -e
 
-  upgrade_gcloud_version
-
-  install_packages
+  # upgrade_gcloud_version
+#
+  # install_packages
 
   set +e
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  # "benchmarking"
-  # # "concurrent_operations"
-  # # "explicit_dir"
-  # "gzip"
-  "implicit_dir"
-  # "interrupt"
-  # "kernel_list_cache"
-  # "list_large_dir"
-  # "local_file"
-  # "log_rotation"
-  # "monitoring"
-  # "mount_timeout"
-  # "mounting"
-  # "negative_stat_cache"
-  # # "operations"
-  # "read_cache"
-  # "read_large_files"
-  # "rename_dir_limit"
-  # "stale_handle"
-  # # "streaming_writes"
-  # "write_large_files"
+  "benchmarking"
+  # "concurrent_operations"
+  # "explicit_dir"
+  "gzip"
+  # "implicit_dir"
+  "interrupt"
+  "kernel_list_cache"
+  "list_large_dir"
+  "local_file"
+  "log_rotation"
+  "monitoring"
+  "mount_timeout"
+  "mounting"
+  "negative_stat_cache"
+  # "operations"
+  "read_cache"
+  "read_large_files"
+  "rename_dir_limit"
+  "stale_handle"
+  # "streaming_writes"
+  "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  # "readonly"
-  # "managed_folders"
-  # "readonly_creds"
+  "readonly"
+  "managed_folders"
+  "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -449,9 +449,9 @@ function clean_up() {
 function main(){
   set -e
 
-  # upgrade_gcloud_version
-#
-  # install_packages
+  upgrade_gcloud_version
+
+  install_packages
 
   set +e
 

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -80,18 +80,19 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 
 // createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
-// Note: testDir is of the form <bucket>/<object-name>.
-func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
-	var err error
-	idx := strings.Index(testDir, "/")
+// Note: testDirWithBucketName is of the form <bucket>/<object-name>.
+func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDirWithBucketName string, t *testing.T) {
+	t.Helper()
+
+	idx := strings.Index(testDirWithBucketName, "/")
 	if idx <= 0 {
-		t.Errorf("Unexpected testDir: %q. Expected form: <bucket>/<object-name>", testDir)
+		t.Fatalf("Unexpected testDirWithBucketName: %q. Expected form: <bucket>/<object-name>", testDirWithBucketName)
 	}
-	bucketName := testDir[:idx]
-	testDirWithoutBucketName := testDir[idx+1:]
+	bucketName := testDirWithBucketName[:idx]
+	testDirWithoutBucketName := testDirWithBucketName[idx+1:]
 
 	objectName := path.Join(testDirWithoutBucketName, "implicitDirectory", "fileInImplicitDir1")
-	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
+	err := client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
 	if err != nil {
 		t.Fatalf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 	}
@@ -104,6 +105,8 @@ func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient 
 }
 
 func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
+	t.Helper()
+
 	// Implicit Directory Structure
 	// testBucket/testDir/implicitDirectory                                                  -- Dir
 	// testBucket/testDir/implicitDirectory/fileInImplicitDir1                               -- File
@@ -160,6 +163,8 @@ func CreateImplicitDirectoryInExplicitDirectoryStructure(testDir string, t *test
 }
 
 func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
+	t.Helper()
+
 	// testBucket/testDir/explicitDirectory                                                                   -- Dir
 	// testBucket/testDir/explictFile                                                                         -- File
 	// testBucket/testDir/explicitDirectory/fileInExplicitDir1                                                -- File

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -81,7 +81,8 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 // createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDir is of the form <bucket>/<object-name>.
-func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) (err error) {
+func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
+	var err error
 	idx := strings.Index(testDir, "/")
 	if idx <= 0 {
 		t.Errorf("Unexpected testDir: %q. Expected form: <bucket>/<object-name>", testDir)
@@ -102,10 +103,9 @@ func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient 
 		t.Errorf("Failed to create GCS object %q in bucket %q", objectName, bucketName)
 		t.FailNow()
 	}
-	return nil
 }
 
-func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) error {
+func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
 	// Implicit Directory Structure
 	// testBucket/testDir/implicitDirectory                                                  -- Dir
 	// testBucket/testDir/implicitDirectory/fileInImplicitDir1                               -- File
@@ -113,7 +113,7 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, sto
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 
 	// Create implicit directory in bucket for testing.
-	return createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), testDir), t)
+	createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), testDir), t)
 }
 
 func CreateImplicitDirectoryStructure(testDir string) {
@@ -161,7 +161,7 @@ func CreateImplicitDirectoryInExplicitDirectoryStructure(testDir string, t *test
 	setup.RunScriptForTestData("../util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh", dirPathInBucket)
 }
 
-func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) error {
+func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
 	// testBucket/testDir/explicitDirectory                                                                   -- Dir
 	// testBucket/testDir/explictFile                                                                         -- File
 	// testBucket/testDir/explicitDirectory/fileInExplicitDir1                                                -- File
@@ -173,5 +173,5 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 
 	CreateExplicitDirectoryStructure(testDir, t)
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
-	return createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), dirPathInBucket), t)
+	createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), dirPathInBucket), t)
 }

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -176,5 +176,5 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 
 	CreateExplicitDirectoryStructure(testDir, t)
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
-	createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), dirPathInBucket), t)
+	createTestdataObjectsUsingStorageClient(ctx, storageClient, dirPathInBucket, t)
 }

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -93,15 +93,13 @@ func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient 
 	objectName := path.Join(testDirWithoutBucketName, "implicitDirectory", "fileInImplicitDir1")
 	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
 	if err != nil {
-		t.Errorf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
-		t.FailNow()
+		t.Fatalf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 	}
 
 	objectName = path.Join(testDirWithoutBucketName, "implicitDirectory/implicitSubDirectory", "fileInImplicitDir2")
 	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2")
 	if err != nil {
-		t.Errorf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
-		t.FailNow()
+		t.Fatalf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 	}
 }
 

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -81,7 +81,7 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 // createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDirWithBucketName is of the form <bucket>/<object-name>.
-func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDirWithBucketName string, t *testing.T) {
+func createTestdataObjectsUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
 	t.Helper()
 
 	idx := strings.Index(testDirWithBucketName, "/")
@@ -104,7 +104,7 @@ func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient 
 	}
 }
 
-func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
+func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDir string) {
 	t.Helper()
 
 	// Implicit Directory Structure
@@ -114,7 +114,7 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, sto
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 
 	// Create implicit directory in bucket for testing.
-	createTestdataObjectsUsingStorageClient(ctx, storageClient, path.Join(setup.TestBucket(), testDir), t)
+	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
 }
 
 func CreateImplicitDirectoryStructure(testDir string) {
@@ -162,7 +162,7 @@ func CreateImplicitDirectoryInExplicitDirectoryStructure(testDir string, t *test
 	setup.RunScriptForTestData("../util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh", dirPathInBucket)
 }
 
-func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx context.Context, storageClient *storage.Client, testDir string, t *testing.T) {
+func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDir string) {
 	t.Helper()
 
 	// testBucket/testDir/explicitDirectory                                                                   -- Dir
@@ -176,5 +176,5 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 
 	CreateExplicitDirectoryStructure(testDir, t)
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
-	createTestdataObjectsUsingStorageClient(ctx, storageClient, dirPathInBucket, t)
+	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, dirPathInBucket)
 }

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -93,14 +93,14 @@ func createTestdataObjectsUsingStorageClient(ctx context.Context, storageClient 
 	objectName := path.Join(testDirWithoutBucketName, "implicitDirectory", "fileInImplicitDir1")
 	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
 	if err != nil {
-		t.Errorf("Failed to create GCS object %q in bucket %q", objectName, bucketName)
+		t.Errorf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 		t.FailNow()
 	}
 
 	objectName = path.Join(testDirWithoutBucketName, "implicitDirectory/implicitSubDirectory", "fileInImplicitDir2")
 	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2")
 	if err != nil {
-		t.Errorf("Failed to create GCS object %q in bucket %q", objectName, bucketName)
+		t.Errorf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
### Description
* Uses storage-client instead of gcloud for input object creations in `implicit_dir` test package for test specific to ZB. 
  - It leaves non-ZB untouched to avoid causing need for validating non-ZB buckets again, and also the reduce the surface area of impact if there is something wrong in the change.
* Enables package `implicit_dir` in run_e2e_tests.sh
* It is followed up in PR #3144 .

A dependent change on this is the fix for explicit_dir package, which is in #3144 .

### Link to the issue in case of a bug fix.
[b/407894792](http://b/407894792)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Run as part of presubmit - [log](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/94e7d815-93df-4b98-b9cd-973a6a27768c/log).

### Any backward incompatible change? If so, please explain.
