### PR TITLE
Fix and enable package explicit_dir in zb e2e tests

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -29,18 +29,22 @@ import (
 
 const DirForExplicitDirTests = "dirForExplicitDirTests"
 
+var (
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	var storageClient *storage.Client
 	// Create storage client before running tests.
-	ctx := context.Background()
-	storageClient, err := client.CreateStorageClient(ctx)
-	if err != nil {
-		log.Printf("Error creating storage client: %v\n", err)
-		os.Exit(1)
-	}
-
-	defer storageClient.Close()
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
 
 	// These tests will not run on HNS buckets because the "--implicit-dirs=false" flag does not function similarly to how it does on FLAT buckets.
 	// Note that HNS buckets do not have the concept of implicit directories.

--- a/tools/integration_tests/explicit_dir/list_test.go
+++ b/tools/integration_tests/explicit_dir/list_test.go
@@ -38,7 +38,7 @@ func TestListOnlyExplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(DirForExplicitDirTests)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, DirForExplicitDirTests)
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(DirForExplicitDirTests, t)
 
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/explicit_dir/list_test.go
+++ b/tools/integration_tests/explicit_dir/list_test.go
@@ -38,6 +38,7 @@ func TestListOnlyExplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir2                               -- File
 
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, DirForExplicitDirTests)
 	} else {

--- a/tools/integration_tests/explicit_dir/list_test.go
+++ b/tools/integration_tests/explicit_dir/list_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ func TestListOnlyExplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, DirForExplicitDirTests)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, DirForExplicitDirTests, t)
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(DirForExplicitDirTests, t)
 
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/explicit_dir/list_test.go
+++ b/tools/integration_tests/explicit_dir/list_test.go
@@ -38,7 +38,11 @@ func TestListOnlyExplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForExplicitDirTests/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, storageClient, DirForExplicitDirTests, t)
+	if setup.IsZonalBucketRun() {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, DirForExplicitDirTests)
+	} else {
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(DirForExplicitDirTests)
+	}
 	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(DirForExplicitDirTests, t)
 
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -32,6 +32,7 @@ import (
 func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
@@ -51,6 +52,7 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
@@ -72,6 +74,7 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
@@ -97,6 +100,7 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
@@ -123,6 +127,7 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
@@ -146,6 +151,7 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -40,6 +40,7 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
+	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -104,22 +104,11 @@ func checkIfObjNameIsCorrect(t *testing.T, objName string, prefix string, maxNum
 	}
 }
 
-func splitBucketNameAndDirPath(t *testing.T, bucketNameWithDirPath string) (bucketName, dirPathInBucket string) {
-	t.Helper()
-
-	var found bool
-	if bucketName, dirPathInBucket, found = strings.Cut(bucketNameWithDirPath, "/"); !found {
-		t.Fatalf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
-	}
-	return
-}
-
-// This function is equivalent to testdata/upload_files_to_bucket.sh to replace gcloud with storage-client
 // This is needed for ZB which is not supported by gcloud storage cp command yet.
 func testdataUploadFilesToBucket(ctx context.Context, t *testing.T, storageClient *storage.Client, bucketNameWithDirPath, dirWith12KFiles, filesPrefix string) {
 	t.Helper()
 
-	bucketName, dirPathInBucket := splitBucketNameAndDirPath(t, bucketNameWithDirPath)
+	bucketName, dirPathInBucket := operations.SplitBucketNameAndDirPath(t, bucketNameWithDirPath)
 
 	dirWith12KFilesFullPathPrefix := filepath.Join(dirWith12KFiles, filesPrefix)
 	matches, err := filepath.Glob(dirWith12KFilesFullPathPrefix + "*")
@@ -226,7 +215,7 @@ func listDirTime(t *testing.T, dirPath string, expectExplicitDirs bool, expectIm
 func testdataCreateImplicitDir(ctx context.Context, t *testing.T, storageClient *storage.Client, bucketNameWithDirPath, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int) {
 	t.Helper()
 
-	bucketName, dirPathInBucket := splitBucketNameAndDirPath(t, bucketNameWithDirPath)
+	bucketName, dirPathInBucket := operations.SplitBucketNameAndDirPath(t, bucketNameWithDirPath)
 
 	testFile, err := operations.CreateLocalTempFile("", false)
 	if err != nil {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -122,7 +122,7 @@ TEST_DIR_NON_PARALLEL=(
 TEST_DIR_PARALLEL_FOR_ZB=(
   "benchmarking"
   "concurrent_operations"
-  # "explicit_dir"
+  "explicit_dir"
   "gzip"
   "implicit_dir"
   "interrupt"

--- a/tools/integration_tests/util/operations/string_operations.go
+++ b/tools/integration_tests/util/operations/string_operations.go
@@ -45,3 +45,13 @@ func GetRandomName(t *testing.T) string {
 	}
 	return id.String()
 }
+
+func SplitBucketNameAndDirPath(t *testing.T, bucketNameWithDirPath string) (bucketName, dirPathInBucket string) {
+	t.Helper()
+
+	var found bool
+	if bucketName, dirPathInBucket, found = strings.Cut(bucketNameWithDirPath, "/"); !found {
+		t.Fatalf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
+	}
+	return
+}

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	storage "cloud.google.com/go/storage"
@@ -78,18 +77,13 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 	}
 }
 
-// createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
+// testdataCreateObjects is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDirWithBucketName is of the form <bucket>/<object-name>.
-func createTestdataObjectsUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
+func testdataCreateObjects(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
 	t.Helper()
 
-	idx := strings.Index(testDirWithBucketName, "/")
-	if idx <= 0 {
-		t.Fatalf("Unexpected testDirWithBucketName: %q. Expected form: <bucket>/<object-name>", testDirWithBucketName)
-	}
-	bucketName := testDirWithBucketName[:idx]
-	testDirWithoutBucketName := testDirWithBucketName[idx+1:]
+	bucketName, testDirWithoutBucketName := operations.SplitBucketNameAndDirPath(t, testDirWithBucketName)
 
 	objectName := path.Join(testDirWithoutBucketName, "implicitDirectory", "fileInImplicitDir1")
 	err := client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
@@ -114,7 +108,7 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 
 	// Create implicit directory in bucket for testing.
-	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
+	testdataCreateObjects(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
 }
 
 func CreateImplicitDirectoryStructure(testDir string) {
@@ -180,5 +174,5 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 	CreateExplicitDirectoryStructure(testDir, t)
 
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
-	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, dirPathInBucket)
+	testdataCreateObjects(ctx, t, storageClient, dirPathInBucket)
 }

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -78,7 +78,6 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 	}
 }
 
-// createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDirWithBucketName is of the form <bucket>/<object-name>.
 func createTestdataObjectsUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
@@ -115,17 +114,6 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *
 
 	// Create implicit directory in bucket for testing.
 	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
-}
-
-func CreateImplicitDirectoryStructure(testDir string) {
-	// Implicit Directory Structure
-	// testBucket/testDir/implicitDirectory                                                  -- Dir
-	// testBucket/testDir/implicitDirectory/fileInImplicitDir1                               -- File
-	// testBucket/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
-	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
-
-	// Create implicit directory in bucket for testing.
-	setup.RunScriptForTestData("../util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh", path.Join(setup.TestBucket(), testDir))
 }
 
 func CreateExplicitDirectoryStructure(testDir string, t *testing.T) {

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -78,6 +78,7 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 	}
 }
 
+// createTestdataObjectsUsingStorageClient is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDirWithBucketName is of the form <bucket>/<object-name>.
 func createTestdataObjectsUsingStorageClient(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
@@ -114,6 +115,17 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *
 
 	// Create implicit directory in bucket for testing.
 	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
+}
+
+func CreateImplicitDirectoryStructure(testDir string) {
+	// Implicit Directory Structure
+	// testBucket/testDir/implicitDirectory                                                  -- Dir
+	// testBucket/testDir/implicitDirectory/fileInImplicitDir1                               -- File
+	// testBucket/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
+	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
+
+	// Create implicit directory in bucket for testing.
+	setup.RunScriptForTestData("../util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh", path.Join(setup.TestBucket(), testDir))
 }
 
 func CreateExplicitDirectoryStructure(testDir string, t *testing.T) {

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -85,13 +85,13 @@ func testdataCreateObjects(ctx context.Context, t *testing.T, storageClient *sto
 
 	bucketName, testDirWithoutBucketName := operations.SplitBucketNameAndDirPath(t, testDirWithBucketName)
 
-	objectName := path.Join(testDirWithoutBucketName, "implicitDirectory", "fileInImplicitDir1")
+	objectName := path.Join(testDirWithoutBucketName, ImplicitDirectory, FileInImplicitDirectory)
 	err := client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
 	if err != nil {
 		t.Fatalf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)
 	}
 
-	objectName = path.Join(testDirWithoutBucketName, "implicitDirectory/implicitSubDirectory", "fileInImplicitDir2")
+	objectName = path.Join(testDirWithoutBucketName, path.Join(ImplicitDirectory, ImplicitSubDirectory), FileInImplicitSubDirectory)
 	err = client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory implicitDirectory/implicitSubDirectory file fileInImplicitDir2")
 	if err != nil {
 		t.Fatalf("Failed to create GCS object %q in bucket %q: %v", objectName, bucketName, err)

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -157,7 +157,9 @@ func CreateImplicitDirectoryInExplicitDirectoryStructure(testDir string, t *test
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
 
+	// CreateExplicitDirectoryStructure writes files using GCSFuse.
 	CreateExplicitDirectoryStructure(testDir, t)
+
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
 	setup.RunScriptForTestData("../util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh", dirPathInBucket)
 }
@@ -174,7 +176,9 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
 
+	// CreateExplicitDirectoryStructure writes files using GCSFuse.
 	CreateExplicitDirectoryStructure(testDir, t)
+
 	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
 	createTestdataObjectsUsingStorageClient(ctx, t, storageClient, dirPathInBucket)
 }


### PR DESCRIPTION
### Description
* Uses storage-client instead of gcloud for input object creations in explicit_dir test package.
  - leaves non-ZB tests untouched.
* Enables package `explicit_dir` in run_e2e_tests.sh

This is on top of PR #3143  .

### Link to the issue in case of a bug fix.
[b/407896339](http://b/407896339), [b/407894792](http://b/407894792)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Run as part of presubmit: [log](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/94e7d815-93df-4b98-b9cd-973a6a27768c/log), [log](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/daa39f5f-e0ed-4a9b-8cf5-daa1a60ffe86/summary)

### Any backward incompatible change? If so, please explain.
