### PR TITLE
Fix and enable package log_content in ZB e2e

### DIFF
--- a/tools/integration_tests/log_content/file_upload_log_test.go
+++ b/tools/integration_tests/log_content/file_upload_log_test.go
@@ -96,7 +96,9 @@ func TestSmallFileUploadLog(t *testing.T) {
 		unexpectedLogSubstrings := []string{"bytes uploaded so far"}
 		operations.VerifyUnexpectedSubstrings(t, logString, unexpectedLogSubstrings)
 	} else {
-		// For zonal buckets, a single log for the full file-size will come.
+		// For zonal buckets, for file-size too small (<16 MB), a single progress log for the
+		// full file-size will come. This is because of a known difference in
+		// implementation of object-write in GCS for zonal buckets.
 		expectedSubstrings := []string{fmt.Sprintf("%d bytes uploaded so far", SmallFileSize)}
 		operations.VerifyExpectedSubstrings(t, logString, expectedSubstrings)
 	}

--- a/tools/integration_tests/log_content/file_upload_log_test.go
+++ b/tools/integration_tests/log_content/file_upload_log_test.go
@@ -90,8 +90,14 @@ func TestBigFileUploadLog(t *testing.T) {
 func TestSmallFileUploadLog(t *testing.T) {
 	logString := uploadFileAndReturnLogs(t, DirForSmallFileUploadLogTest, SmallFileSize)
 
-	// The file being uploaded is too small (<16 MB) for progress logs
-	// to be printed.
-	unexpectedLogSubstrings := []string{"bytes uploaded so far"}
-	operations.VerifyUnexpectedSubstrings(t, logString, unexpectedLogSubstrings)
+	if !setup.IsZonalBucketRun() {
+		// The file being uploaded is too small (<16 MB) for progress logs
+		// to be printed.
+		unexpectedLogSubstrings := []string{"bytes uploaded so far"}
+		operations.VerifyUnexpectedSubstrings(t, logString, unexpectedLogSubstrings)
+	} else {
+		// For zonal buckets, a single log for the full file-size will come.
+		expectedSubstrings := []string{fmt.Sprintf("%d bytes uploaded so far", SmallFileSize)}
+		operations.VerifyExpectedSubstrings(t, logString, expectedSubstrings)
+	}
 }

--- a/tools/integration_tests/log_content/file_upload_log_test.go
+++ b/tools/integration_tests/log_content/file_upload_log_test.go
@@ -36,7 +36,7 @@ const (
 func uploadFile(t *testing.T, dirNamePrefix string, fileSize int64) {
 	testDir, err := os.MkdirTemp(setup.MntDir(), dirNamePrefix+"-*")
 	if err != nil || testDir == "" {
-		t.Fatalf("Error in creating test-directory:%v", err)
+		t.Fatalf("Error in creating test-directory: %v", err)
 	}
 	// Clean up.
 	defer operations.RemoveDir(testDir)

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -129,7 +129,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "kernel_list_cache"
   # "list_large_dir"
   "local_file"
-  # "log_content"
+  "log_content"
   "log_rotation"
   "monitoring"
   "mount_timeout"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -450,9 +450,9 @@ function clean_up() {
 function main(){
   set -e
 
-  # upgrade_gcloud_version
-# 
-  # install_packages
+  upgrade_gcloud_version
+
+  install_packages
 
   set +e
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,37 +120,37 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  # "benchmarking"
-  # # "concurrent_operations"
-  # # "explicit_dir"
-  # "gzip"
-  # # "implicit_dir"
-  # "interrupt"
-  # "kernel_list_cache"
-  # # "list_large_dir"
-  # "local_file"
-  "log_content"
-  # "log_rotation"
-  # "monitoring"
-  # "mount_timeout"
-  # "mounting"
-  # "negative_stat_cache"
-  # # "operations"
-  # "read_cache"
-  # "read_large_files"
-  # "rename_dir_limit"
-  # "stale_handle"
-  # # "streaming_writes"
-  # "write_large_files"
+  "benchmarking"
+  # "concurrent_operations"
+  # "explicit_dir"
+  "gzip"
+  # "implicit_dir"
+  "interrupt"
+  "kernel_list_cache"
+  # "list_large_dir"
+  "local_file"
+  # "log_content"
+  "log_rotation"
+  "monitoring"
+  "mount_timeout"
+  "mounting"
+  "negative_stat_cache"
+  # "operations"
+  "read_cache"
+  "read_large_files"
+  "rename_dir_limit"
+  "stale_handle"
+  # "streaming_writes"
+  "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  # "readonly"
-  # "managed_folders"
-  # "readonly_creds"
+  "readonly"
+  "managed_folders"
+  "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,37 +120,37 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  "benchmarking"
-  # "concurrent_operations"
-  # "explicit_dir"
-  "gzip"
-  # "implicit_dir"
-  "interrupt"
-  "kernel_list_cache"
-  # "list_large_dir"
-  "local_file"
-  # "log_content"
-  "log_rotation"
-  "monitoring"
-  "mount_timeout"
-  "mounting"
-  "negative_stat_cache"
-  # "operations"
-  "read_cache"
-  "read_large_files"
-  "rename_dir_limit"
-  "stale_handle"
-  # "streaming_writes"
-  "write_large_files"
+  # "benchmarking"
+  # # "concurrent_operations"
+  # # "explicit_dir"
+  # "gzip"
+  # # "implicit_dir"
+  # "interrupt"
+  # "kernel_list_cache"
+  # # "list_large_dir"
+  # "local_file"
+  "log_content"
+  # "log_rotation"
+  # "monitoring"
+  # "mount_timeout"
+  # "mounting"
+  # "negative_stat_cache"
+  # # "operations"
+  # "read_cache"
+  # "read_large_files"
+  # "rename_dir_limit"
+  # "stale_handle"
+  # # "streaming_writes"
+  # "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  "readonly"
-  "managed_folders"
-  "readonly_creds"
+  # "readonly"
+  # "managed_folders"
+  # "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -450,9 +450,9 @@ function clean_up() {
 function main(){
   set -e
 
-  upgrade_gcloud_version
-
-  install_packages
+  # upgrade_gcloud_version
+# 
+  # install_packages
 
   set +e
 


### PR DESCRIPTION
### Description
* Fixes failure in package `log_content` in run_e2e_tests.sh
* Enables package `log_content` in run_e2e_tests.sh

### Link to the issue in case of a bug fix.
[b/407894736](http://b/407894736)


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
