### PR TITLE
[Random Reader Refactoring] Create hidden flag to enable new implementation

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -34,6 +34,8 @@ type Config struct {
 
 	EnableHns bool `yaml:"enable-hns"`
 
+	EnableNewReader bool `yaml:"enable-new-reader"`
+
 	FileCache FileCacheConfig `yaml:"file-cache"`
 
 	FileSystem FileSystemConfig `yaml:"file-system"`
@@ -334,6 +336,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
 
 	if err := flagSet.MarkHidden("enable-hns"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-new-reader", "", false, "Enables support for new reader implementation.")
+
+	if err := flagSet.MarkHidden("enable-new-reader"); err != nil {
 		return err
 	}
 
@@ -657,6 +665,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("enable-new-reader", flagSet.Lookup("enable-new-reader")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -85,6 +85,13 @@
   default: true
   hide-flag: true
 
+- config-path: "enable-new-reader"
+  flag-name: "enable-new-reader"
+  type: "bool"
+  usage: "Enables support for new reader implementation."
+  default: false
+  hide-flag: true
+
 - config-path: "file-cache.cache-file-for-range-read"
   flag-name: "file-cache-cache-file-for-range-read"
   type: "bool"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -874,6 +874,38 @@ func TestArgsParsing_EnableAtomicRenameObjectFlag(t *testing.T) {
 	}
 }
 
+func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
+	tests := []struct {
+		name                      string
+		args                      []string
+		expectedEnabledNewReaders bool
+	}{
+		{
+			name:                      "normal",
+			args:                      []string{"gcsfuse", "--enable-new-reader=true", "abc", "pqr"},
+			expectedEnabledNewReaders: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotEnableNewReader bool
+			cmd, err := newRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotEnableNewReader = cfg.EnableNewReader
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedEnabledNewReaders, gotEnableNewReader)
+			}
+		})
+	}
+}
+
 func TestArgsParsing_MetricsFlags(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -899,9 +899,8 @@ func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 
 			err = cmd.Execute()
 
-			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedEnableNewReader, gotEnableNewReader)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedEnableNewReader, gotEnableNewReader)
 		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -876,14 +876,14 @@ func TestArgsParsing_EnableAtomicRenameObjectFlag(t *testing.T) {
 
 func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 	tests := []struct {
-		name                      string
-		args                      []string
-		expectedEnabledNewReaders bool
+		name                     string
+		args                     []string
+		expectedEnableNewReaders bool
 	}{
 		{
-			name:                      "normal",
-			args:                      []string{"gcsfuse", "--enable-new-reader=true", "abc", "pqr"},
-			expectedEnabledNewReaders: true,
+			name:                     "normal",
+			args:                     []string{"gcsfuse", "--enable-new-reader=true", "abc", "pqr"},
+			expectedEnableNewReaders: true,
 		},
 	}
 
@@ -900,7 +900,7 @@ func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 			err = cmd.Execute()
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedEnabledNewReaders, gotEnableNewReader)
+				assert.Equal(t, tc.expectedEnableNewReaders, gotEnableNewReader)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -876,14 +876,14 @@ func TestArgsParsing_EnableAtomicRenameObjectFlag(t *testing.T) {
 
 func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 	tests := []struct {
-		name                     string
-		args                     []string
-		expectedEnableNewReaders bool
+		name                    string
+		args                    []string
+		expectedEnableNewReader bool
 	}{
 		{
-			name:                     "normal",
-			args:                     []string{"gcsfuse", "--enable-new-reader=true", "abc", "pqr"},
-			expectedEnableNewReaders: true,
+			name:                    "normal",
+			args:                    []string{"gcsfuse", "--enable-new-reader=true", "abc", "pqr"},
+			expectedEnableNewReader: true,
 		},
 	}
 
@@ -900,7 +900,7 @@ func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 			err = cmd.Execute()
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedEnableNewReaders, gotEnableNewReader)
+				assert.Equal(t, tc.expectedEnableNewReader, gotEnableNewReader)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
1. Implement a hidden flag to enable the new implementation.
2. The default value is currently false.
3. This flag will be turned on by default in the future.

### Link to the issue in case of a bug fix.
[b/408912993](https://b.corp.google.com/issues/408912993)

### Testing details
1. Manual - Done
4. Unit tests - Updated
5. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
