### PR TITLE
Fix and enable package list_large_dir in ZB e2e tests

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -118,12 +118,12 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 			return fmt.Errorf("Failed to walk at path=%q: %w", path, err)
 		}
 		if !d.IsDir() && strings.HasPrefix(path, dirWithTwelveThousandFilesFullPathPrefix) {
-			fmt.Printf("Copying file %q to gs://%s/%s/%s ...\n", path, bucketName, testDirWithoutBucketName, d.Name())
+			//fmt.Printf("Copying file %q to gs://%s/%s/%s ...\n", path, bucketName, testDirWithoutBucketName, d.Name())
 			client.CopyFileInBucket(ctx, storageClient, path, filepath.Join(testDirWithoutBucketName, d.Name()), bucketName)
 		}
 		return nil
 	})
-	fmt.Printf("Going to rm -rf %q ...\n", dirWithTwelveThousandFiles)
+	//fmt.Printf("Going to rm -rf %q ...\n", dirWithTwelveThousandFiles)
 	os.RemoveAll(dirWithTwelveThousandFiles)
 }
 

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -126,7 +126,7 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 	numChannels := 16
 	channels := make([]chan copyRequest, numChannels)
 	counter := 0
-	perChannelCapacity:=int(math.Ceil(float64(numberOfFilesInDirectoryWithTwelveThousandFiles)/float64(numChannels)))
+	perChannelCapacity := int(math.Ceil(float64(numberOfFilesInDirectoryWithTwelveThousandFiles) / float64(numChannels)))
 	for i := 0; i < numChannels; i++ {
 		channels[i] = make(chan copyRequest, perChannelCapacity)
 	}

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -17,6 +17,7 @@ package list_large_dir
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"path"
@@ -105,11 +106,15 @@ func checkIfObjNameIsCorrect(t *testing.T, objName string, prefix string, maxNum
 
 func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Client, testBucket, dirWithTwelveThousandFiles, filesPrefix string, t *testing.T) {
 	t.Helper()
-	filepath.Walk(path.Join(dirWithTwelveThousandFiles, filesPrefix), func(path string, info os.FileInfo, err error) error {
+	//filepath.Walk(path.Join(dirWithTwelveThousandFiles, filesPrefix), func(path string, info os.FileInfo, err error) error {
+	//filepath.Walk(dirWithTwelveThousandFiles, func(path string, info os.FileInfo, err error) error {
+	filepath.WalkDir(dirWithTwelveThousandFiles, func(path string, d DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("Failed to walk at path=%q: %w", path, err)
 		}
-		fmt.Printf("Need to copy file %q to gs://%s/", path, testBucket)
+		if strings.HasPrefix(path, filesPrefix) {
+			fmt.Printf("Need to copy file %q to gs://%s/", path, testBucket)
+		}
 		return nil
 	})
 	fmt.Printf("Going to rm -rf %q ...\n", path.Join(dirWithTwelveThousandFiles, filesPrefix))
@@ -219,8 +224,10 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
 
-	assert.Less(t.T(), secondListTime, firstListTime)
-	assert.Less(t.T(), 2*secondListTime, firstListTime)
+	//assert.Less(t.T(), secondListTime, firstListTime)
+	//assert.Less(t.T(), 2*secondListTime, firstListTime)
+	assert.Greater(t.T(), firstListTime, time.Duration(0))
+	assert.Greater(t.T(), secondListTime, time.Duration(0))
 }
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
@@ -228,8 +235,10 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplici
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
 
-	assert.Less(t.T(), secondListTime, firstListTime)
-	assert.Less(t.T(), 2*secondListTime, firstListTime)
+	//assert.Less(t.T(), secondListTime, firstListTime)
+	//assert.Less(t.T(), 2*secondListTime, firstListTime)
+	assert.Greater(t.T(), firstListTime, time.Duration(0))
+	assert.Greater(t.T(), secondListTime, time.Duration(0))
 }
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir() {
@@ -237,8 +246,10 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplici
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, true)
 
-	assert.Less(t.T(), secondListTime, firstListTime)
-	assert.Less(t.T(), 2*secondListTime, firstListTime)
+	//assert.Less(t.T(), secondListTime, firstListTime)
+	//assert.Less(t.T(), 2*secondListTime, firstListTime)
+	assert.Greater(t.T(), firstListTime, time.Duration(0))
+	assert.Greater(t.T(), secondListTime, time.Duration(0))
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -233,27 +233,27 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 // Tests
 // //////////////////////////////////////////////////////////////////////
 
-func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
-	dirPath := prepareTestDirectory(t.T(), false, false)
-
-	firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
-
-	//assert.Less(t.T(), secondListTime, firstListTime)
-	//assert.Less(t.T(), 2*secondListTime, firstListTime)
-	assert.Greater(t.T(), firstListTime, time.Duration(0))
-	assert.Greater(t.T(), secondListTime, time.Duration(0))
-}
-
-func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
-	dirPath := prepareTestDirectory(t.T(), true, false)
-
-	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
-
-	//assert.Less(t.T(), secondListTime, firstListTime)
-	//assert.Less(t.T(), 2*secondListTime, firstListTime)
-	assert.Greater(t.T(), firstListTime, time.Duration(0))
-	assert.Greater(t.T(), secondListTime, time.Duration(0))
-}
+//func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
+	//dirPath := prepareTestDirectory(t.T(), false, false)
+//
+	//firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
+//
+	////assert.Less(t.T(), secondListTime, firstListTime)
+	////assert.Less(t.T(), 2*secondListTime, firstListTime)
+	//assert.Greater(t.T(), firstListTime, time.Duration(0))
+	//assert.Greater(t.T(), secondListTime, time.Duration(0))
+//}
+//
+//func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
+	//dirPath := prepareTestDirectory(t.T(), true, false)
+//
+	//firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
+//
+	////assert.Less(t.T(), secondListTime, firstListTime)
+	////assert.Less(t.T(), 2*secondListTime, firstListTime)
+	//assert.Greater(t.T(), firstListTime, time.Duration(0))
+	//assert.Greater(t.T(), secondListTime, time.Duration(0))
+//}
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir() {
 	dirPath := prepareTestDirectory(t.T(), true, true)

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -108,8 +108,7 @@ func splitBucketNameAndDirPath(t *testing.T, bucketNameWithDirPath string) (buck
 	t.Helper()
 
 	var found bool
-	bucketName, dirPathInBucket, found = strings.Cut(bucketNameWithDirPath, "/")
-	if !found {
+	if bucketName, dirPathInBucket, found = strings.Cut(bucketNameWithDirPath, "/"); !found {
 		t.Fatalf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
 	}
 	return
@@ -150,7 +149,7 @@ func testdataUploadFilesToBucket(ctx context.Context, t *testing.T, storageClien
 	// Copy request consumers.
 	numCopyGoroutines := 16
 	var wg sync.WaitGroup
-	for copyGoroutine := 0; copyGoroutine < numCopyGoroutines; copyGoroutine++ {
+	for range numCopyGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -216,7 +216,7 @@ func listDirTime(t *testing.T, dirPath string, expectExplicitDirs bool, expectIm
 	return firstListTime, minSecondListTime
 }
 
-func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageClient *storage.Client, bucketNameWithDirPath, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
+func testdataCreateImplicitDir(ctx context.Context, storageClient *storage.Client, bucketNameWithDirPath, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
 	t.Helper()
 
 	bucketName, dirPathInBucket := splitBucketNameAndDirPath(bucketNameWithDirPath, t)
@@ -250,7 +250,7 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 
 	if withImplicitDirs {
 		if setup.IsZonalBucketRun() {
-			testdataCreateImplicitDirUsingStorageClient(ctx, storageClient, testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, numberOfImplicitDirsInDirectoryWithTwelveThousandFiles, t)
+			testdataCreateImplicitDir(ctx, storageClient, testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, numberOfImplicitDirsInDirectoryWithTwelveThousandFiles, t)
 		} else {
 			setup.RunScriptForTestData("testdata/create_implicit_dir.sh", testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, strconv.Itoa(numberOfImplicitDirsInDirectoryWithTwelveThousandFiles))
 		}

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -117,16 +117,10 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 	if err != nil {
 		t.Fatalf("Failed to get files of pattern %s*: %v", dirWithTwelveThousandFilesFullPathPrefix, err)
 	}
-	counter := 0
-	start := time.Now()
 	for _, match := range matches {
 		_,fileName:=filepath.Split(match)
-		if len(fileName)>0 {
-			client.CopyFileInBucket(ctx, storageClient, match, filepath.Join(dirPathInBucket,fileName), bucketName)
-			counter++
-			if counter%100 == 0 {
-				fmt.Printf("Completed copying %d objects. Time taken so far = %v\n", counter, time.Since(start))
-			}
+		if len(fileName) > 0 {
+			client.CopyFileInBucket(ctx, storageClient, match, filepath.Join(dirPathInBucket, fileName), bucketName)
 		}
 	}
 }

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -110,7 +110,7 @@ func splitBucketNameAndDirPath(t *testing.T, bucketNameWithDirPath string) (buck
 	var found bool
 	bucketName, dirPathInBucket, found = strings.Cut(bucketNameWithDirPath, "/")
 	if !found {
-		t.Errorf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
+		t.Fatalf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
 	}
 	return
 }

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -238,10 +238,8 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
 
-	//assert.Less(t.T(), secondListTime, firstListTime)
-	//assert.Less(t.T(), 2*secondListTime, firstListTime)
-	assert.Greater(t.T(), firstListTime, time.Duration(0))
-	assert.Greater(t.T(), secondListTime, time.Duration(0))
+	assert.Less(t.T(), secondListTime, firstListTime)
+	assert.Less(t.T(), 2*secondListTime, firstListTime)
 }
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
@@ -249,10 +247,8 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplici
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
 
-	//assert.Less(t.T(), secondListTime, firstListTime)
-	//assert.Less(t.T(), 2*secondListTime, firstListTime)
-	assert.Greater(t.T(), firstListTime, time.Duration(0))
-	assert.Greater(t.T(), secondListTime, time.Duration(0))
+	assert.Less(t.T(), secondListTime, firstListTime)
+	assert.Less(t.T(), 2*secondListTime, firstListTime)
 }
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir() {
@@ -260,10 +256,8 @@ func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplici
 
 	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, true)
 
-	//assert.Less(t.T(), secondListTime, firstListTime)
-	//assert.Less(t.T(), 2*secondListTime, firstListTime)
-	assert.Greater(t.T(), firstListTime, time.Duration(0))
-	assert.Greater(t.T(), secondListTime, time.Duration(0))
+	assert.Less(t.T(), secondListTime, firstListTime)
+	assert.Less(t.T(), 2*secondListTime, firstListTime)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -171,8 +171,11 @@ func listDirTime(t *testing.T, dirPath string, expectExplicitDirs bool, expectIm
 	return firstListTime, minSecondListTime
 }
 
-func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageClient *storge.Client, testBucket, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
+func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageClient *storage.Client, testBucket, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
 	testFile, err := operations.CreateLocalTempFile("", false)
+	if err != nil {
+		t.Fatalf("Failed to local file for creating copies ...")
+	}
 	for a := 1; a <= numberOfImplicitDirsInDirectory; a++ {
 		client.CopyFileInBucket(ctx, storageClient, testFile, testBucket, path.Join(prefixExplicitDirInLargeDirListTest, fmt.Sprintf("%d", a)))
 	}
@@ -198,7 +201,7 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 
 	if withImplicitDirs {
 		if setup.IsZonalBucketRun() {
-			testdataCreateImplicitDirUsingStorageClient(testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, strconv.Itoa(numberOfImplicitDirsInDirectoryWithTwelveThousandFiles))
+			testdataCreateImplicitDirUsingStorageClient(ctx, storageClient, testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, numberOfImplicitDirsInDirectoryWithTwelveThousandFiles, t)
 		} else {
 			setup.RunScriptForTestData("testdata/create_implicit_dir.sh", testDirPathOnBucket, prefixImplicitDirInLargeDirListTest, strconv.Itoa(numberOfImplicitDirsInDirectoryWithTwelveThousandFiles))
 		}

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -233,27 +233,27 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 // Tests
 // //////////////////////////////////////////////////////////////////////
 
-//func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
-	//dirPath := prepareTestDirectory(t.T(), false, false)
-//
-	//firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
-//
-	////assert.Less(t.T(), secondListTime, firstListTime)
-	////assert.Less(t.T(), 2*secondListTime, firstListTime)
-	//assert.Greater(t.T(), firstListTime, time.Duration(0))
-	//assert.Greater(t.T(), secondListTime, time.Duration(0))
-//}
-//
-//func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
-	//dirPath := prepareTestDirectory(t.T(), true, false)
-//
-	//firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
-//
-	////assert.Less(t.T(), secondListTime, firstListTime)
-	////assert.Less(t.T(), 2*secondListTime, firstListTime)
-	//assert.Greater(t.T(), firstListTime, time.Duration(0))
-	//assert.Greater(t.T(), secondListTime, time.Duration(0))
-//}
+func (t *listLargeDir) TestListDirectoryWithTwelveThousandFiles() {
+	dirPath := prepareTestDirectory(t.T(), false, false)
+
+	firstListTime, secondListTime := listDirTime(t.T(), dirPath, false, false)
+
+	//assert.Less(t.T(), secondListTime, firstListTime)
+	//assert.Less(t.T(), 2*secondListTime, firstListTime)
+	assert.Greater(t.T(), firstListTime, time.Duration(0))
+	assert.Greater(t.T(), secondListTime, time.Duration(0))
+}
+
+func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDir() {
+	dirPath := prepareTestDirectory(t.T(), true, false)
+
+	firstListTime, secondListTime := listDirTime(t.T(), dirPath, true, false)
+
+	//assert.Less(t.T(), secondListTime, firstListTime)
+	//assert.Less(t.T(), 2*secondListTime, firstListTime)
+	assert.Greater(t.T(), firstListTime, time.Duration(0))
+	assert.Greater(t.T(), secondListTime, time.Duration(0))
+}
 
 func (t *listLargeDir) TestListDirectoryWithTwelveThousandFilesAndHundredExplicitDirAndHundredImplicitDir() {
 	dirPath := prepareTestDirectory(t.T(), true, true)

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -122,7 +122,6 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 	bucketName, dirPathInBucket := splitBucketNameAndDirPath(bucketNameWithDirPath, t)
 
 	dirWithTwelveThousandFilesFullPathPrefix := filepath.Join(dirWithTwelveThousandFiles, filesPrefix)
-	fmt.Printf("Copying files from %q to gs://%s/%s/ ...\n", dirWithTwelveThousandFiles, bucketName, dirPathInBucket)
 	matches, err := filepath.Glob(dirWithTwelveThousandFilesFullPathPrefix + "*")
 	if err != nil {
 		t.Fatalf("Failed to get files of pattern %s*: %v", dirWithTwelveThousandFilesFullPathPrefix, err)
@@ -166,7 +165,6 @@ func createFilesAndUpload(t *testing.T, dirPath string) {
 	t.Helper()
 
 	localDirPath := path.Join(os.Getenv("HOME"), directoryWithTwelveThousandFiles)
-	fmt.Printf("Creating %d files in %q with prefix %q ...\n", numberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, prefixFileInDirectoryWithTwelveThousandFiles)
 	operations.CreateDirectoryWithNFiles(numberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, prefixFileInDirectoryWithTwelveThousandFiles, t)
 	defer os.RemoveAll(localDirPath)
 

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -106,12 +106,14 @@ func checkIfObjNameIsCorrect(t *testing.T, objName string, prefix string, maxNum
 
 func splitBucketNameAndDirPath(bucketNameWithDirPath string, t *testing.T) (bucketName, dirPathInBucket string) {
 	t.Helper()
+
 	idx := strings.Index(bucketNameWithDirPath, "/")
 	if idx <= 0 {
 		t.Errorf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
 	}
 	bucketName = bucketNameWithDirPath[:idx]
 	dirPathInBucket = bucketNameWithDirPath[idx+1:]
+	return
 }
 
 func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Client, bucketNameWithDirPath, dirWithTwelveThousandFiles, filesPrefix string, t *testing.T) {

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -111,19 +111,17 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 		t.Errorf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
 	}
 	bucketName := bucketNameWithDirPath[:idx]
-	testDirWithoutBucketName := bucketNameWithDirPath[idx+1:]
+	dirPathInBucket := bucketNameWithDirPath[idx+1:]
 	dirWithTwelveThousandFilesFullPathPrefix := filepath.Join(dirWithTwelveThousandFiles, filesPrefix)
 	filepath.WalkDir(dirWithTwelveThousandFiles, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("Failed to walk at path=%q: %w", path, err)
 		}
 		if !d.IsDir() && strings.HasPrefix(path, dirWithTwelveThousandFilesFullPathPrefix) {
-			//fmt.Printf("Copying file %q to gs://%s/%s/%s ...\n", path, bucketName, testDirWithoutBucketName, d.Name())
-			client.CopyFileInBucket(ctx, storageClient, path, filepath.Join(testDirWithoutBucketName, d.Name()), bucketName)
+			client.CopyFileInBucket(ctx, storageClient, path, filepath.Join(dirPathInBucket, d.Name()), bucketName)
 		}
 		return nil
 	})
-	//fmt.Printf("Going to rm -rf %q ...\n", dirWithTwelveThousandFiles)
 	os.RemoveAll(dirWithTwelveThousandFiles)
 }
 
@@ -189,14 +187,13 @@ func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageCli
 		t.Errorf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
 	}
 	bucketName := bucketNameWithDirPath[:idx]
-	testDirWithoutBucketName := bucketNameWithDirPath[idx+1:]
+	dirPathInBucket := bucketNameWithDirPath[idx+1:]
 	testFile, err := operations.CreateLocalTempFile("", false)
 	if err != nil {
 		t.Fatalf("Failed to local file for creating copies ...")
 	}
 	for a := 1; a <= numberOfImplicitDirsInDirectory; a++ {
-		//fmt.Printf("Copying %q to %q in gs://%s ...\n",  testFile, path.Join(testDirWithoutBucketName, prefixImplicitDirInLargeDirListTest+fmt.Sprintf("%d", a), testFile), bucketName)
-		client.CopyFileInBucket(ctx, storageClient, testFile, path.Join(testDirWithoutBucketName, prefixImplicitDirInLargeDirListTest+fmt.Sprintf("%d", a), testFile), bucketName)
+		client.CopyFileInBucket(ctx, storageClient, testFile, path.Join(dirPathInBucket, prefixImplicitDirInLargeDirListTest+fmt.Sprintf("%d", a), testFile), bucketName)
 	}
 }
 

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -182,13 +182,21 @@ func listDirTime(t *testing.T, dirPath string, expectExplicitDirs bool, expectIm
 	return firstListTime, minSecondListTime
 }
 
-func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageClient *storage.Client, testBucket, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
+func testdataCreateImplicitDirUsingStorageClient(ctx context.Context, storageClient *storage.Client, bucketNameWithDirPath, prefixImplicitDirInLargeDirListTest string, numberOfImplicitDirsInDirectory int, t *testing.T) {
+	t.Helper()
+	idx := strings.Index(bucketNameWithDirPath, "/")
+	if idx <= 0 {
+		t.Errorf("Unexpected bucketNameWithDirPath: %q. Expected form: <bucket>/<object-name>", bucketNameWithDirPath)
+	}
+	bucketName := bucketNameWithDirPath[:idx]
+	testDirWithoutBucketName := bucketNameWithDirPath[idx+1:]
 	testFile, err := operations.CreateLocalTempFile("", false)
 	if err != nil {
 		t.Fatalf("Failed to local file for creating copies ...")
 	}
 	for a := 1; a <= numberOfImplicitDirsInDirectory; a++ {
-		client.CopyFileInBucket(ctx, storageClient, testFile, testBucket, path.Join(prefixExplicitDirInLargeDirListTest, fmt.Sprintf("%d", a)))
+		//fmt.Printf("Copying %q to %q in gs://%s ...\n",  testFile, path.Join(testDirWithoutBucketName, prefixImplicitDirInLargeDirListTest+fmt.Sprintf("%d", a), testFile), bucketName)
+		client.CopyFileInBucket(ctx, storageClient, testFile, path.Join(testDirWithoutBucketName, prefixImplicitDirInLargeDirListTest+fmt.Sprintf("%d", a), testFile), bucketName)
 	}
 }
 

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -118,7 +118,7 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 		t.Fatalf("Failed to get files of pattern %s*: %v", dirWithTwelveThousandFilesFullPathPrefix, err)
 	}
 	for _, match := range matches {
-		_,fileName:=filepath.Split(match)
+		_, fileName := filepath.Split(match)
 		if len(fileName) > 0 {
 			client.CopyFileInBucket(ctx, storageClient, match, filepath.Join(dirPathInBucket, fileName), bucketName)
 		}

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -154,17 +154,12 @@ func testdataUploadFilesToBucket(ctx context.Context, t *testing.T, storageClien
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// It is needed to have an explicit variable to break out from this for-loop as the break statement inside
-			// the select statement applies only to the select statement, and not to the surrounding for-loop.
-			for stop := false; !stop; {
-				select {
-				case copyRequest, ok := <-channel:
-					if !ok {
-						stop = true
-						break
-					}
-					client.CopyFileInBucket(ctx, storageClient, copyRequest.srcLocalFilePath, copyRequest.dstGCSObjectPath, bucketName)
+			for {
+				copyRequest, ok := <-channel
+				if !ok {
+					break
 				}
+				client.CopyFileInBucket(ctx, storageClient, copyRequest.srcLocalFilePath, copyRequest.dstGCSObjectPath, bucketName)
 			}
 		}()
 	}

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -113,6 +113,7 @@ func testdataUploadFilesToBucket(ctx context.Context, storageClient *storage.Cli
 	bucketName := bucketNameWithDirPath[:idx]
 	dirPathInBucket := bucketNameWithDirPath[idx+1:]
 	dirWithTwelveThousandFilesFullPathPrefix := filepath.Join(dirWithTwelveThousandFiles, filesPrefix)
+	fmt.Printf("Copying files from %q to gs://%s/%s/ ...\n", dirWithTwelveThousandFiles, bucketName, dirPathInBucket)
 	err := filepath.WalkDir(dirWithTwelveThousandFiles, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("Failed to walk at path=%q: %w", path, err)
@@ -132,6 +133,7 @@ func createFilesAndUpload(t *testing.T, dirPath string) {
 	t.Helper()
 
 	localDirPath := path.Join(os.Getenv("HOME"), directoryWithTwelveThousandFiles)
+	fmt.Printf("Creating %d files in %q with prefix %q ...\n", numberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, prefixFileInDirectoryWithTwelveThousandFiles)
 	operations.CreateDirectoryWithNFiles(numberOfFilesInDirectoryWithTwelveThousandFiles, localDirPath, prefixFileInDirectoryWithTwelveThousandFiles, t)
 	defer os.RemoveAll(localDirPath)
 

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -54,7 +54,9 @@ func TestMain(m *testing.M) {
 	}()
 
 	flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"}}
-	if !testing.Short() {
+	// Don't run for grpc if -short flat is passed.
+	// Don't run for grpc for zonal bucket as zonal buckets by default use grpc.
+	if !testing.Short() && !setup.IsZonalBucketRun() {
 		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"})
 	}
 

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -30,9 +30,11 @@ import (
 const prefixFileInDirectoryWithTwelveThousandFiles = "fileInDirectoryWithTwelveThousandFiles"
 const prefixExplicitDirInLargeDirListTest = "explicitDirInLargeDirListTest"
 const prefixImplicitDirInLargeDirListTest = "implicitDirInLargeDirListTest"
-const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
-const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 100
-const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
+
+// const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
+const numberOfFilesInDirectoryWithTwelveThousandFiles = 1
+const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 1
+const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 1
 
 var (
 	directoryWithTwelveThousandFiles = "directoryWithTwelveThousandFiles" + setup.GenerateRandomString(5)

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -30,9 +30,7 @@ import (
 const prefixFileInDirectoryWithTwelveThousandFiles = "fileInDirectoryWithTwelveThousandFiles"
 const prefixExplicitDirInLargeDirListTest = "explicitDirInLargeDirListTest"
 const prefixImplicitDirInLargeDirListTest = "implicitDirInLargeDirListTest"
-
 const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
-//const numberOfFilesInDirectoryWithTwelveThousandFiles = 5
 const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 100
 const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -31,10 +31,10 @@ const prefixFileInDirectoryWithTwelveThousandFiles = "fileInDirectoryWithTwelveT
 const prefixExplicitDirInLargeDirListTest = "explicitDirInLargeDirListTest"
 const prefixImplicitDirInLargeDirListTest = "implicitDirInLargeDirListTest"
 
-// const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
-const numberOfFilesInDirectoryWithTwelveThousandFiles = 5
-const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 1
-const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 1
+const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
+//const numberOfFilesInDirectoryWithTwelveThousandFiles = 5
+const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 100
+const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 
 var (
 	directoryWithTwelveThousandFiles = "directoryWithTwelveThousandFiles" + setup.GenerateRandomString(5)

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -32,7 +32,7 @@ const prefixExplicitDirInLargeDirListTest = "explicitDirInLargeDirListTest"
 const prefixImplicitDirInLargeDirListTest = "implicitDirInLargeDirListTest"
 
 // const numberOfFilesInDirectoryWithTwelveThousandFiles = 12000
-const numberOfFilesInDirectoryWithTwelveThousandFiles = 1
+const numberOfFilesInDirectoryWithTwelveThousandFiles = 5
 const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 1
 const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 1
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  # "benchmarking"
-  # # "concurrent_operations"
-  # # "explicit_dir"
-  # "gzip"
-  # # "implicit_dir"
-  # "interrupt"
-  # "kernel_list_cache"
-  "list_large_dir"
-  # "local_file"
-  # "log_rotation"
-  # "monitoring"
-  # "mount_timeout"
-  # "mounting"
-  # "negative_stat_cache"
-  # # "operations"
-  # "read_cache"
-  # "read_large_files"
-  # "rename_dir_limit"
-  # "stale_handle"
-  # # "streaming_writes"
-  # "write_large_files"
+  "benchmarking"
+  # "concurrent_operations"
+  # "explicit_dir"
+  "gzip"
+  # "implicit_dir"
+  "interrupt"
+  "kernel_list_cache"
+  # "list_large_dir"
+  "local_file"
+  "log_rotation"
+  "monitoring"
+  "mount_timeout"
+  "mounting"
+  "negative_stat_cache"
+  # "operations"
+  "read_cache"
+  "read_large_files"
+  "rename_dir_limit"
+  "stale_handle"
+  # "streaming_writes"
+  "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  # "readonly"
-  # "managed_folders"
-  # "readonly_creds"
+  "readonly"
+  "managed_folders"
+  "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -449,9 +449,9 @@ function clean_up() {
 function main(){
   set -e
 
-  upgrade_gcloud_version
-
-  install_packages
+  # upgrade_gcloud_version
+# 
+  # install_packages
 
   set +e
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -127,7 +127,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   # "implicit_dir"
   "interrupt"
   "kernel_list_cache"
-  # "list_large_dir"
+  "list_large_dir"
   "local_file"
   "log_rotation"
   "monitoring"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  "benchmarking"
-  # "concurrent_operations"
-  # "explicit_dir"
-  "gzip"
-  # "implicit_dir"
-  "interrupt"
-  "kernel_list_cache"
-  # "list_large_dir"
-  "local_file"
-  "log_rotation"
-  "monitoring"
-  "mount_timeout"
-  "mounting"
-  "negative_stat_cache"
-  # "operations"
-  "read_cache"
-  "read_large_files"
-  "rename_dir_limit"
-  "stale_handle"
-  # "streaming_writes"
-  "write_large_files"
+  # "benchmarking"
+  # # "concurrent_operations"
+  # # "explicit_dir"
+  # "gzip"
+  # # "implicit_dir"
+  # "interrupt"
+  # "kernel_list_cache"
+  "list_large_dir"
+  # "local_file"
+  # "log_rotation"
+  # "monitoring"
+  # "mount_timeout"
+  # "mounting"
+  # "negative_stat_cache"
+  # # "operations"
+  # "read_cache"
+  # "read_large_files"
+  # "rename_dir_limit"
+  # "stale_handle"
+  # # "streaming_writes"
+  # "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  "readonly"
-  "managed_folders"
-  "readonly_creds"
+  # "readonly"
+  # "managed_folders"
+  # "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -449,9 +449,9 @@ function clean_up() {
 function main(){
   set -e
 
-  # upgrade_gcloud_version
-# 
-  # install_packages
+  upgrade_gcloud_version
+
+  install_packages
 
   set +e
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -30,7 +30,6 @@ import (
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/storage/experimental"
 	"github.com/googleapis/gax-go/v2"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -147,49 +146,6 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 		} else {
 			return nil, fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())
 		}
-	}
-
-	return
-}
-
-// MoveObject is a one-shot wrapper over storage-client functionalities to move a
-// GCS object to another object-name which works for zonal buckets and for non-zonal hierarchical buckets.
-func MoveObject(ctx context.Context, client *storage.Client, srcObject, dstObject string) (err error) {
-	defer func() {
-		err = gcs.GetGCSError(err)
-	}()
-
-	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(srcObject)
-
-	o := client.Bucket(bucket).Object(object)
-
-	// Fail for non-zonal and non-hierarchial buckets.
-	var attrs *storage.BucketAttrs
-	attrs, err = client.Bucket(o.BucketName()).Attrs(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get attributes for bucket %q: %w", o.BucketName(), err)
-	}
-	if attrs.StorageClass == "RAPID" {
-		if !setup.IsZonalBucketRun() {
-			return fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())
-		} else {
-			fmt.Printf("Received request for moving object in zonal bucket gs://%s/%s to %s\n", bucket.BucketName(), object.ObjectName(), dstObject)
-		}
-	} else if !attrs.HierarchicalNamespace.Enabled {
-		return fmt.Errorf("Move not support for non-zonal non-hierarchical bucket %q", o.BucketName())
-	} else {
-		fmt.Printf("Received request for moving object in HNS bucket gs://%s/%s to %s\n", bucket.BucketName(), object.ObjectName(), dstObject)
-	}
-
-	dstMoveObject := storage.MoveObjectDestination{
-		Object:     dstObject,
-		Conditions: nil,
-	}
-
-	_, err = o.Move(ctx, dstMoveObject)
-	if err != nil {
-		err = fmt.Errorf("error in moving object %q to %q in bucket %q: %w", o.ObjectName(), dstObject, o.BucketName(), err)
-		return
 	}
 
 	return

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -378,7 +378,7 @@ func ClearCacheControlOnGcsObject(ctx context.Context, client *storage.Client, o
 func CopyFileInBucket(ctx context.Context, storageClient *storage.Client, srcfilePath, destFilePath, bucket string) {
 	err := UploadGcsObject(ctx, storageClient, srcfilePath, bucket, destFilePath, false)
 	if err != nil {
-		log.Fatalf("Error while copying file in bucket: %v", err)
+		log.Fatalf("Error while copying file %q to GCS object \"gs://%s/%s\" : %v", srcfilePath, bucket, destFilePath, err)
 	}
 }
 


### PR DESCRIPTION
### Description
* Create the 12k files and 100 implicit directories and 100 explicit directories for testing in ZB using storage-client instead of using gcloud (as `gcloud storage cp` doesn't work for ZB)
  - No change in use of gcloud for non-ZB. This is for speed as creating/copying files in bulk using gcloud (which is highly parallelized) is faster than using storage-client, so leaving part that as it is. We can switch easily for non-ZB later if it makes sense.
* Disable GRPC-specific test for zonal-bucket case, as it's a duplicate, as ZB by default work over GRPC.
* Enable list_large_dir e2e test package for ZB.

### Link to the issue in case of a bug fix.
[b/407894658](http://b/407894658)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - through presubmit - [Passed ZB run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/1727612b-d05b-4af3-8643-1d715c2f7761/summary), [Passed non-ZB run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/cea37703-8d4e-4264-84c7-c2bd2498426e/summary).

### Any backward incompatible change? If so, please explain.
