### PR TITLE
Ignore both .vscode/ folder and .vscode symlink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ _testmain.go
 
 # Editors
 .idea/
-.vscode/
+.vscode
 
 # External folders
 vendor/


### PR DESCRIPTION
### Description

Changing `.vscode/` to `.vscode` to ignore both the `.vscode/` folder and `.vscode` symlink. Currently, If the `.vscode/` folder is backed by symlink then gitignore doesn't ignore it.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
