### PR TITLE
Remove enable-otel flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -216,8 +216,6 @@ type MetadataCacheConfig struct {
 type MetricsConfig struct {
 	CloudMetricsExportIntervalSecs int64 `yaml:"cloud-metrics-export-interval-secs"`
 
-	EnableOtel bool `yaml:"enable-otel"`
-
 	PrometheusPort int64 `yaml:"prometheus-port"`
 
 	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
@@ -354,12 +352,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
-
-	flagSet.BoolP("enable-otel", "", true, "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus.")
-
-	if err := flagSet.MarkHidden("enable-otel"); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("enable-read-stall-retry", "", false, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
@@ -685,10 +677,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metadata-cache.enable-nonexistent-type-cache", flagSet.Lookup("enable-nonexistent-type-cache")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("metrics.enable-otel", flagSet.Lookup("enable-otel")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -613,13 +613,6 @@
   usage: "Specifies the interval at which the metrics are uploaded to cloud monitoring"
   default: 0
 
-- config-path: "metrics.enable-otel"
-  flag-name: "enable-otel"
-  type: "bool"
-  usage: "Specifies whether to use OpenTelemetry for capturing and exporting metrics. If false, use OpenCensus."
-  default: true
-  hide-flag: true
-
 - config-path: "metrics.prometheus-port"
   flag-name: "prometheus-port"
   type: "int"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -806,7 +806,6 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 				StackdriverExportInterval:      0,
 				CloudMetricsExportIntervalSecs: 0,
 				PrometheusPort:                 0,
-				EnableOtel:                     true,
 			},
 		},
 		{
@@ -814,7 +813,6 @@ func TestValidateConfigFile_MetricsConfigSuccessful(t *testing.T) {
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10,
-				EnableOtel:                     true,
 			},
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -909,39 +909,10 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 		expected *cfg.MetricsConfig
 	}{
 		{
-			name: "default",
-			args: []string{"gcsfuse", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
-			},
-		},
-		{
-			name: "enable_otel_normal",
-			args: []string{"gcsfuse", "--enable-otel", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
-			},
-		},
-		{
-			name: "enable_otel_false",
-			args: []string{"gcsfuse", "--enable-otel=false", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
-			},
-		},
-		{
-			name: "enable_otel_false",
-			args: []string{"gcsfuse", "--enable-otel=true", "abc", "pqr"},
-			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
-			},
-		},
-		{
 			name: "cloud-metrics-export-interval-secs-positive",
 			args: []string{"gcsfuse", "--cloud-metrics-export-interval-secs=10", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10,
-				EnableOtel:                     true,
 			},
 		},
 		{
@@ -950,7 +921,6 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 			expected: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 10 * 3600,
 				StackdriverExportInterval:      time.Duration(10) * time.Hour,
-				EnableOtel:                     true,
 			},
 		},
 	}
@@ -980,30 +950,14 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 		expected *cfg.MetricsConfig
 	}{
 		{
-			name:    "default",
-			cfgFile: "empty.yml",
-			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
-			},
-		},
-		{
-			name:    "enable_otel_true",
-			cfgFile: "enable_otel_true.yml",
-			expected: &cfg.MetricsConfig{
-				EnableOtel: true,
-			},
-		},
-		{
-			name:    "enable_otel_false",
-			cfgFile: "enable_otel_false.yml",
-			expected: &cfg.MetricsConfig{
-				EnableOtel: false,
-			},
+			name:     "default",
+			cfgFile:  "empty.yml",
+			expected: &cfg.MetricsConfig{},
 		},
 		{
 			name:     "cloud-metrics-export-interval-secs-positive",
 			cfgFile:  "metrics_export_interval_positive.yml",
-			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100, EnableOtel: true},
+			expected: &cfg.MetricsConfig{CloudMetricsExportIntervalSecs: 100},
 		},
 		{
 			name:    "stackdriver-export-interval-positive",
@@ -1011,7 +965,6 @@ func TestArgsParsing_MetricsViewConfig(t *testing.T) {
 			expected: &cfg.MetricsConfig{
 				CloudMetricsExportIntervalSecs: 12 * 3600,
 				StackdriverExportInterval:      12 * time.Hour,
-				EnableOtel:                     true,
 			},
 		},
 	}

--- a/cmd/testdata/metrics_config/enable_otel_false.yml
+++ b/cmd/testdata/metrics_config/enable_otel_false.yml
@@ -1,2 +1,0 @@
-metrics:
-  enable-otel: false

--- a/cmd/testdata/metrics_config/enable_otel_true.yml
+++ b/cmd/testdata/metrics_config/enable_otel_true.yml
@@ -1,2 +1,0 @@
-metrics:
-  enable-otel: true

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -78,8 +78,6 @@ type PromTest struct {
 	// A temporary directory into which a file system may be mounted. Removed in
 	// TearDown.
 	mountPoint string
-
-	enableOTEL bool
 }
 
 // isHNSTestRun returns true if the bucket is an HNS bucket.
@@ -128,11 +126,6 @@ func (testSuite *PromTest) mount(bucketName string) error {
 	testSuite.T().Cleanup(func() { _ = os.RemoveAll(cacheDir) })
 
 	flags := []string{fmt.Sprintf("--prometheus-port=%d", prometheusPort), "--cache-dir", cacheDir}
-	if testSuite.enableOTEL {
-		flags = append(flags, "--enable-otel=true")
-	} else {
-		flags = append(flags, "--enable-otel=false")
-	}
 	args := append(flags, bucketName, testSuite.mountPoint)
 
 	if err := mounting.MountGcsfuse(testSuite.gcsfusePath, args); err != nil {
@@ -254,10 +247,6 @@ func (testSuite *PromTest) TestReadMetrics() {
 	//TODO: file_cache_read_bytes_count should be added once with waitForDownload is true same as sequential for default pd,
 }
 
-func TestPromOCSuite(t *testing.T) {
-	suite.Run(t, &PromTest{enableOTEL: false})
-}
-
 func TestPromOTELSuite(t *testing.T) {
-	suite.Run(t, &PromTest{enableOTEL: true})
+	suite.Run(t, new(PromTest))
 }


### PR DESCRIPTION
### Description
Remove enable-otel flag.
### Link to the issue in case of a bug fix.
b/408033151

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

enable-otel has always been a hidden flag. So, it's safe to remove.