### PR TITLE
Exclude config.go from code coverage computation

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "tools"
   - "benchmarks"
+  - "cfg/config.go"
 coverage:
   round: down
   precision: 2

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ignore:
   - "tools"
   - "benchmarks"
+  - "perfmetrics"
   - "cfg/config.go"
 coverage:
   round: down


### PR DESCRIPTION
### Description
config.go is auto-generated. Excluding it from code-coverage computation.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
