### PR TITLE
[Bug fix] ignore rw option passed as CLI flag during persistent mounting

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -111,7 +111,10 @@ func makeGcsfuseArgs(
 		return s == "o"
 	})
 	nonBoolFlags = append(nonBoolFlags, cfg.ConfigFileFlagName)
-	noopOptions := []string{"user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
+	// 'rw' mount option is implicitly passed as CLI parameter by /etc/fstab
+	// entries and overrides mount options in config file. Ignoring is safe, as
+	// 'rw' is default, so that config file mount options take effect.
+	noopOptions := []string{"rw", "user", "nouser", "auto", "noauto", "_netdev", "no_netdev"}
 
 	// Deal with options.
 	for name, value := range opts {

--- a/tools/mount_gcsfuse/main_test.go
+++ b/tools/mount_gcsfuse/main_test.go
@@ -109,7 +109,7 @@ func TestMakeGcsfuseArgs(t *testing.T) {
 		// Test ignored options
 		{
 			name:          "TestMakeGcsfuseArgs with IgnoredOptions",
-			opts:          map[string]string{"user": "nobody", "_netdev": ""},
+			opts:          map[string]string{"user": "nobody", "_netdev": "", "rw": ""},
 			expectedFlags: []string{},
 		},
 


### PR DESCRIPTION
### Description
When GCSFuse mount entries are added to `/etc/fstab`, the kernel implicitly passes the `-o rw` command-line flag to GCSFuse. This behavior overrides any mount options explicitly defined in the configuration file.

Ignoring this rw flag is acceptable because GCSFuse mounts are created in read-write mode by default.

### Link to the issue in case of a bug fix.
Ref: https://github.com/GoogleCloudPlatform/gcsfuse/discussions/3135
internal bug: b/407781622

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA
4. Manual testing - done to validate that config file settings apply.
config file used in `/etc/fstab` entry:
```
file-system:
  fuse-options: allow_other,rw
```
Before the change, mount options printed in GCSFuse log:
`"FuseOptions":["rw"]`
After the change, mount option printed in GCSFuse log:
`"FuseOptions":["allow_other","rw"]`

also verified that the mount is `rw` even when the flag is not explicitly passed during persistent mounting.

### Any backward incompatible change? If so, please explain.
No
