### PR TITLE
[Random Reader Refactoring] Convert error message consts in error variable

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -81,11 +81,9 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	if jobStatus.Err != nil ||
 		jobStatus.Name == downloader.Invalid ||
 		jobStatus.Name == downloader.Failed {
-		err := fmt.Errorf("%w: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob, jobStatus.Name, jobStatus.Err)
-		return err
+		return fmt.Errorf("%w: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob, jobStatus.Name, jobStatus.Err)
 	} else if jobStatus.Offset < requiredOffset {
-		err := fmt.Errorf("%w: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS, jobStatus.Offset, requiredOffset)
-		return err
+		return fmt.Errorf("%w: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS, jobStatus.Offset, requiredOffset)
 	}
 	return err
 }
@@ -112,8 +110,7 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		fileInfo = fch.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	}
 	if fileInfo == nil {
-		err = fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
-		return err
+		return fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 	}
 
 	// The generation check below is required because it may happen that file
@@ -121,12 +118,10 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 	// from local cached file to `dst` buffer.
 	fileInfoData := fileInfo.(data.FileInfo)
 	if fileInfoData.ObjectGeneration != object.Generation {
-		err = fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
-		return err
+		return fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 	}
 	if fileInfoData.Offset < requiredOffset {
-		err = fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
-		return err
+		return fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
 	}
 
 	return nil
@@ -221,14 +216,12 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 			// Ensure that the number of bytes read into dst buffer is equal to what is
 			// requested. It will also help catch cases where file in cache is truncated
 			// externally to size offset + x where x < requestedNumBytes.
-			err = fmt.Errorf("%w, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle, n, requestedNumBytes)
-			return 0, false, err
+			return 0, false, fmt.Errorf("%w, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle, n, requestedNumBytes)
 		}
 		err = nil
 	}
 	if err != nil {
-		err = fmt.Errorf("%w: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandle, offset, err)
-		return 0, false, err
+		return 0, false, fmt.Errorf("%w: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandle, offset, err)
 	}
 
 	// Look up of file being read in file info cache is required to update the LRU

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -16,7 +16,6 @@ package file
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -222,8 +221,8 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 			// Ensure that the number of bytes read into dst buffer is equal to what is
 			// requested. It will also help catch cases where file in cache is truncated
 			// externally to size offset + x where x < requestedNumBytes.
-			errMsg := fmt.Sprintf("%w, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle, n, requestedNumBytes)
-			return 0, false, errors.New(errMsg)
+			err = fmt.Errorf("%w, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle, n, requestedNumBytes)
+			return 0, false, err
 		}
 		err = nil
 	}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -66,11 +66,11 @@ func NewCacheHandle(localFileHandle *os.File, fileDownloadJob *downloader.Job,
 
 func (fch *CacheHandle) validateCacheHandle() error {
 	if fch.fileHandle == nil {
-		return errors.New(util.InvalidFileHandleErrMsg)
+		return util.ErrInvalidFileHandle
 	}
 
 	if fch.fileInfoCache == nil {
-		return errors.New(util.InvalidFileInfoCacheErrMsg)
+		return util.ErrInvalidFileInfoCache
 	}
 
 	return nil
@@ -82,10 +82,10 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	if jobStatus.Err != nil ||
 		jobStatus.Name == downloader.Invalid ||
 		jobStatus.Name == downloader.Failed {
-		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.InvalidFileDownloadJobErrMsg, jobStatus.Name, jobStatus.Err)
+		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob, jobStatus.Name, jobStatus.Err)
 		return err
 	} else if jobStatus.Offset < requiredOffset {
-		err := fmt.Errorf("%s: jobOffset: %d is less than required offset: %d", util.FallbackToGCSErrMsg, jobStatus.Offset, requiredOffset)
+		err := fmt.Errorf("%s: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS.Error(), jobStatus.Offset, requiredOffset)
 		return err
 	}
 	return err
@@ -113,7 +113,7 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		fileInfo = fch.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	}
 	if fileInfo == nil {
-		err = fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
+		err = fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache.Error(), fileInfoKeyName)
 		return err
 	}
 
@@ -122,11 +122,11 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 	// from local cached file to `dst` buffer.
 	fileInfoData := fileInfo.(data.FileInfo)
 	if fileInfoData.ObjectGeneration != object.Generation {
-		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.InvalidFileInfoCacheErrMsg, fileInfoData.ObjectGeneration, object.Generation)
+		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 		return err
 	}
 	if fileInfoData.Offset < requiredOffset {
-		err = fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.InvalidFileInfoCacheErrMsg, fileInfoData.Offset, requiredOffset)
+		err = fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache.Error(), fileInfoData.Offset, requiredOffset)
 		return err
 	}
 
@@ -222,13 +222,13 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 			// Ensure that the number of bytes read into dst buffer is equal to what is
 			// requested. It will also help catch cases where file in cache is truncated
 			// externally to size offset + x where x < requestedNumBytes.
-			errMsg := fmt.Sprintf("%s, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandleMsg, n, requestedNumBytes)
+			errMsg := fmt.Sprintf("%s, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle.Error(), n, requestedNumBytes)
 			return 0, false, errors.New(errMsg)
 		}
 		err = nil
 	}
 	if err != nil {
-		err = fmt.Errorf("%s: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandleMsg, offset, err)
+		err = fmt.Errorf("%s: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandle.Error(), offset, err)
 		return 0, false, err
 	}
 

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -222,7 +222,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 			// Ensure that the number of bytes read into dst buffer is equal to what is
 			// requested. It will also help catch cases where file in cache is truncated
 			// externally to size offset + x where x < requestedNumBytes.
-			errMsg := fmt.Sprintf("%s, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle.Error(), n, requestedNumBytes)
+			errMsg := fmt.Sprintf("%w, number of bytes read from file in cache: %v are not equal to requested: %v", util.ErrInReadingFileHandle, n, requestedNumBytes)
 			return 0, false, errors.New(errMsg)
 		}
 		err = nil

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -82,10 +82,10 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	if jobStatus.Err != nil ||
 		jobStatus.Name == downloader.Invalid ||
 		jobStatus.Name == downloader.Failed {
-		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob.Error(), jobStatus.Name, jobStatus.Err)
+		err := fmt.Errorf("%w: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob, jobStatus.Name, jobStatus.Err)
 		return err
 	} else if jobStatus.Offset < requiredOffset {
-		err := fmt.Errorf("%s: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS.Error(), jobStatus.Offset, requiredOffset)
+		err := fmt.Errorf("%w: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS, jobStatus.Offset, requiredOffset)
 		return err
 	}
 	return err
@@ -113,7 +113,7 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		fileInfo = fch.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	}
 	if fileInfo == nil {
-		err = fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache.Error(), fileInfoKeyName)
+		err = fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 		return err
 	}
 
@@ -122,11 +122,11 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 	// from local cached file to `dst` buffer.
 	fileInfoData := fileInfo.(data.FileInfo)
 	if fileInfoData.ObjectGeneration != object.Generation {
-		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache.Error(), fileInfoData.ObjectGeneration, object.Generation)
+		err = fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 		return err
 	}
 	if fileInfoData.Offset < requiredOffset {
-		err = fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache.Error(), fileInfoData.Offset, requiredOffset)
+		err = fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
 		return err
 	}
 
@@ -228,7 +228,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 		err = nil
 	}
 	if err != nil {
-		err = fmt.Errorf("%s: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandle.Error(), offset, err)
+		err = fmt.Errorf("%w: while reading from %d offset of the local file: %w", util.ErrInReadingFileHandle, offset, err)
 		return 0, false, err
 	}
 

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -82,7 +82,7 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	if jobStatus.Err != nil ||
 		jobStatus.Name == downloader.Invalid ||
 		jobStatus.Name == downloader.Failed {
-		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob, jobStatus.Name, jobStatus.Err)
+		err := fmt.Errorf("%s: jobStatus: %s jobError: %w", util.ErrInvalidFileDownloadJob.Error(), jobStatus.Name, jobStatus.Err)
 		return err
 	} else if jobStatus.Offset < requiredOffset {
 		err := fmt.Errorf("%s: jobOffset: %d is less than required offset: %d", util.ErrFallbackToGCS.Error(), jobStatus.Offset, requiredOffset)
@@ -122,7 +122,7 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 	// from local cached file to `dst` buffer.
 	fileInfoData := fileInfo.(data.FileInfo)
 	if fileInfoData.ObjectGeneration != object.Generation {
-		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
+		err = fmt.Errorf("%v: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache.Error(), fileInfoData.ObjectGeneration, object.Generation)
 		return err
 	}
 	if fileInfoData.Offset < requiredOffset {

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -176,7 +176,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileHandle() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	assert.Equal(cht.T(), util.InvalidFileHandleErrMsg, err.Error())
+	assert.Equal(cht.T(), util.ErrInvalidFileHandle, err)
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileDownloadJob() {
@@ -192,7 +192,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileInfoCache() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	assert.Equal(cht.T(), util.InvalidFileInfoCacheErrMsg, err.Error())
+	assert.True(cht.T(), errors.Is(util.ErrInvalidFileHandle, err))
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNonNilMemberAttributes() {
@@ -274,7 +274,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsNotStarted() 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.True(cht.T(), errors.Is(util.ErrFallbackToGCS, err))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
@@ -285,7 +285,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	assert.True(cht.T(), errors.Is(util.ErrInvalidFileDownloadJob, err))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {
@@ -296,7 +296,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileDownloadJob))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsCompleted() {
@@ -319,7 +319,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetIsLe
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobDownloadedOffsetSameAsRequiredOffset() {
@@ -354,7 +354,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithNonNilJobStatusErr() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.InvalidFileDownloadJobErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileDownloadJob))
 }
 
 func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoPresent() {
@@ -389,7 +389,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent
 	_ = cht.cache.Erase(fileInfoKeyName)
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
+	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileHandle, fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -411,7 +411,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGeneration
 
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.InvalidFileInfoCacheErrMsg, fileInfo.ObjectGeneration)
+	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfo.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -434,7 +434,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLess
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.InvalidFileInfoCacheErrMsg, 10, 11)
+	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, 10, 11)
 	assert.Equal(cht.T(), expectedErr.Error(), err.Error())
 }
 
@@ -549,7 +549,7 @@ func (cht *cacheHandleTest) Test_Read_WithNilFileHandle() {
 	assert.NotNil(cht.T(), err)
 	assert.Equal(cht.T(), 0, n)
 	assert.False(cht.T(), cacheHit)
-	assert.Equal(cht.T(), util.InvalidFileHandleErrMsg, err.Error())
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileHandle))
 }
 
 func (cht *cacheHandleTest) Test_Read_WithNilFileDownloadJobAndCacheMiss() {
@@ -565,7 +565,7 @@ func (cht *cacheHandleTest) Test_Read_WithNilFileDownloadJobAndCacheMiss() {
 	assert.NotNil(cht.T(), err)
 	assert.Equal(cht.T(), 0, n)
 	assert.False(cht.T(), cacheHit)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.InvalidFileInfoCacheErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 }
 
 func (cht *cacheHandleTest) Test_Read_WithNilFileDownloadJobAndCacheHit() {
@@ -604,7 +604,7 @@ func (cht *cacheHandleTest) Test_RandomRead() {
 	assert.Equal(cht.T(), 0, n)
 	assert.False(cht.T(), cacheHit)
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalse() {
@@ -621,7 +621,7 @@ func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalse() {
 	assert.Equal(cht.T(), n, 0)
 	assert.False(cht.T(), cacheHit)
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalseButCacheHit() {
@@ -733,7 +733,7 @@ func (cht *cacheHandleTest) Test_SequentialReadToRandom() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, secondReqOffset, dst)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), strings.Contains(err.Error(), util.FallbackToGCSErrMsg))
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 	assert.False(cht.T(), cacheHit)
 	assert.False(cht.T(), cht.cacheHandle.isSequential)
 	jobStatus = cht.cacheHandle.fileDownloadJob.GetStatus()
@@ -782,7 +782,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.InvalidFileInfoCacheErrMsg, fileInfoKeyName)
+	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }
@@ -814,7 +814,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.InvalidFileInfoCacheErrMsg, fileInfoData.ObjectGeneration)
+	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }
@@ -875,7 +875,7 @@ func (cht *cacheHandleTest) Test_SequentialRead_Parallel_Download_True() {
 	assert.Equal(cht.T(), downloader.Downloading, jobStatus.Name)
 	assert.Equal(cht.T(), 0, n)
 	assert.False(cht.T(), cacheHit)
-	assert.ErrorContains(cht.T(), err, util.FallbackToGCSErrMsg)
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_RandomRead_Parallel_Download_True() {
@@ -910,7 +910,7 @@ func (cht *cacheHandleTest) Test_RandomRead_Parallel_Download_True() {
 	assert.Equal(cht.T(), downloader.Downloading, jobStatus.Name)
 	assert.Equal(cht.T(), 0, n)
 	assert.False(cht.T(), cacheHit)
-	assert.ErrorContains(cht.T(), err, util.FallbackToGCSErrMsg)
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalse_And_ParallelDownloadsEnabled() {
@@ -945,5 +945,5 @@ func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalse_And_ParallelD
 	assert.Less(cht.T(), jobStatus.Offset, offset)
 	assert.Equal(cht.T(), n, 0)
 	assert.False(cht.T(), cacheHit)
-	assert.ErrorContains(cht.T(), err, util.FallbackToGCSErrMsg)
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -176,7 +176,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileHandle() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	assert.Equal(cht.T(), util.ErrInvalidFileHandle, err)
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileHandle))
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileDownloadJob() {
@@ -389,7 +389,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent
 	_ = cht.cache.Erase(fileInfoKeyName)
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileHandle, fileInfoKeyName)
+	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileHandle.Error(), fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -411,7 +411,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGeneration
 
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfo.ObjectGeneration)
+	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache.Error(), fileInfo.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -434,7 +434,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLess
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, 10, 11)
+	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache.Error(), 10, 11)
 	assert.Equal(cht.T(), expectedErr.Error(), err.Error())
 }
 
@@ -782,7 +782,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
+	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache.Error(), fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }
@@ -814,7 +814,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration)
+	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache.Error(), fileInfoData.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -192,7 +192,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileInfoCache() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileHandle))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNonNilMemberAttributes() {
@@ -389,7 +389,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent
 	_ = cht.cache.Erase(fileInfoKeyName)
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
-	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileHandle, fileInfoKeyName)
+	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -389,7 +389,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent
 	_ = cht.cache.Erase(fileInfoKeyName)
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileHandle.Error(), fileInfoKeyName)
+	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileHandle, fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -411,7 +411,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGeneration
 
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache.Error(), fileInfo.ObjectGeneration)
+	expectedErr := fmt.Errorf("%w: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfo.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 }
 
@@ -434,7 +434,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLess
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache.Error(), 10, 11)
+	expectedErr := fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, 10, 11)
 	assert.Equal(cht.T(), expectedErr.Error(), err.Error())
 }
 
@@ -782,7 +782,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache.Error(), fileInfoKeyName)
+	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }
@@ -814,7 +814,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%v: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache.Error(), fileInfoData.ObjectGeneration)
+	expectedErr := fmt.Errorf("%w: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration)
 	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
 	assert.False(cht.T(), cacheHit)
 }

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -192,7 +192,7 @@ func (cht *cacheHandleTest) Test_validateCacheHandle_WithNilFileInfoCache() {
 
 	err := cht.cacheHandle.validateCacheHandle()
 
-	assert.True(cht.T(), errors.Is(util.ErrInvalidFileHandle, err))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileHandle))
 }
 
 func (cht *cacheHandleTest) Test_validateCacheHandle_WithNonNilMemberAttributes() {
@@ -274,7 +274,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsNotStarted() 
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), errors.Is(util.ErrFallbackToGCS, err))
+	assert.True(cht.T(), errors.Is(err, util.ErrFallbackToGCS))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
@@ -285,7 +285,7 @@ func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsFailed() {
 	err := cht.cacheHandle.shouldReadFromCache(&jobStatus, requiredOffset)
 
 	assert.NotNil(cht.T(), err)
-	assert.True(cht.T(), errors.Is(util.ErrInvalidFileDownloadJob, err))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileDownloadJob))
 }
 
 func (cht *cacheHandleTest) Test_shouldReadFromCache_WithJobStateIsInvalid() {

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"os"
@@ -389,8 +388,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoNotPresent
 	_ = cht.cache.Erase(fileInfoKeyName)
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 0, false)
 
-	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
-	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 }
 
 func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGenerationChanged() {
@@ -411,8 +409,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoGeneration
 
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, cht.object.Size-1, true)
 
-	expectedErr := fmt.Errorf("%w: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfo.ObjectGeneration)
-	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 }
 
 func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLessThanRequired() {
@@ -434,8 +431,7 @@ func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_FileInfoOffsetLess
 	err = cht.cacheHandle.validateEntryInFileInfoCache(cht.bucket, cht.object, 11, true)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, 10, 11)
-	assert.Equal(cht.T(), expectedErr.Error(), err.Error())
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 }
 
 func (cht *cacheHandleTest) Test_validateEntryInFileInfoCache_changeCacheOrderIsTrue() {
@@ -782,8 +778,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
-	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 	assert.False(cht.T(), cacheHit)
 }
 
@@ -814,8 +809,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
-	expectedErr := fmt.Errorf("%w: generation of cached object: %v is different from required generation: ", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration)
-	assert.True(cht.T(), strings.Contains(err.Error(), expectedErr.Error()))
+	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
 	assert.False(cht.T(), cacheHit)
 }
 

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -128,7 +128,7 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		filePath := util.GetDownloadPath(chr.cacheDir, util.GetObjectPath(bucket.Name(), object.Name))
 		_, err := os.Stat(filePath)
 		if err != nil && os.IsNotExist(err) {
-			return fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s: %s", util.FileNotPresentInCacheErrMsg, filePath)
+			return fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s: %s", util.ErrFileNotPresentInCache.Error(), filePath)
 		}
 
 		// Evict object in cache if the generation of object in cache is different
@@ -217,7 +217,7 @@ func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket
 
 		fileInfo := chr.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 		if fileInfo == nil {
-			return nil, fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s", util.CacheHandleNotRequiredForRandomReadErrMsg)
+			return nil, fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s", util.ErrCacheHandleNotRequiredForRandomRead.Error())
 		}
 	}
 

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -128,7 +128,7 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		filePath := util.GetDownloadPath(chr.cacheDir, util.GetObjectPath(bucket.Name(), object.Name))
 		_, err := os.Stat(filePath)
 		if err != nil && os.IsNotExist(err) {
-			return fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s: %s", util.ErrFileNotPresentInCache.Error(), filePath)
+			return fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %w: %s", util.ErrFileNotPresentInCache, filePath)
 		}
 
 		// Evict object in cache if the generation of object in cache is different

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -217,7 +217,7 @@ func (chr *CacheHandler) GetCacheHandle(object *gcs.MinObject, bucket gcs.Bucket
 
 		fileInfo := chr.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 		if fileInfo == nil {
-			return nil, fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %s", util.ErrCacheHandleNotRequiredForRandomRead.Error())
+			return nil, fmt.Errorf("addFileInfoEntryAndCreateDownloadJob: %w", util.ErrCacheHandleNotRequiredForRandomRead)
 		}
 	}
 

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -17,6 +17,7 @@ package file
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"os"
 	"path"
 	"strconv"
@@ -332,7 +333,7 @@ func Test_addFileInfoEntryAndCreateDownloadJob_IfLocalFileGetsDeleted(t *testing
 	// Hence, this will return error containing util.FileNotPresentInCacheErrMsg.
 	err = chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chTestArgs.object, chTestArgs.bucket)
 
-	assert.ErrorContains(t, err, util.FileNotPresentInCacheErrMsg)
+	assert.ErrorContains(t, err, util.ErrFileNotPresentInCache.Error())
 }
 
 func Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasCompleted(t *testing.T) {
@@ -530,7 +531,7 @@ func Test_GetCacheHandle_IfLocalFileGetsDeleted(t *testing.T) {
 
 	cacheHandle, err := chTestArgs.cacheHandler.GetCacheHandle(chTestArgs.object, chTestArgs.bucket, false, 0)
 
-	assert.ErrorContains(t, err, util.FileNotPresentInCacheErrMsg)
+	assert.True(t, errors.Is(err, util.ErrFileNotPresentInCache))
 	assert.Nil(t, cacheHandle)
 	// Check file info and download job are not removed
 	assert.True(t, isEntryInFileInfoCache(t, chTestArgs.cache, chTestArgs.object.Name, chTestArgs.bucket.Name()))
@@ -577,7 +578,7 @@ func Test_GetCacheHandle_CacheForRangeRead(t *testing.T) {
 
 			assert.NoError(t, err1)
 			assert.Nil(t, cacheHandle1.validateCacheHandle())
-			assert.ErrorContains(t, err2, util.CacheHandleNotRequiredForRandomReadErrMsg)
+			assert.True(t, errors.Is(err2, util.ErrCacheHandleNotRequiredForRandomRead))
 			assert.Nil(t, cacheHandle2)
 			assert.NoError(t, err3)
 			assert.Nil(t, cacheHandle3.validateCacheHandle())

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -333,7 +333,7 @@ func Test_addFileInfoEntryAndCreateDownloadJob_IfLocalFileGetsDeleted(t *testing
 	// Hence, this will return error containing util.FileNotPresentInCacheErrMsg.
 	err = chTestArgs.cacheHandler.addFileInfoEntryAndCreateDownloadJob(chTestArgs.object, chTestArgs.bucket)
 
-	assert.ErrorContains(t, err, util.ErrFileNotPresentInCache.Error())
+	assert.True(t, errors.Is(err, util.ErrFileNotPresentInCache))
 }
 
 func Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasCompleted(t *testing.T) {

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -22,7 +22,6 @@ import (
 	"io/fs"
 	"os"
 	"reflect"
-	"strings"
 	"syscall"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -440,7 +439,7 @@ func (job *Job) downloadObjectAsync() {
 		// downloading. If the entry is deleted in between which is expected
 		// to happen at the time of eviction, then the job should be
 		// marked Invalid instead of Failed.
-		if strings.Contains(err.Error(), lru.EntryNotExistErrMsg) {
+		if errors.Is(err, lru.ErrEntryNotExist) {
 			job.updateStatusAndNotifySubscribers(Invalid, err)
 			return
 		}

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -581,7 +581,7 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	// Verify that jobStatus is failed
 	AssertEq(Failed, jobStatus.Name)
 	AssertGe(jobStatus.Offset, 0)
-	AssertTrue(errors.Is(err, lru.ErrInvalidUpdateEntrySize))
+	AssertTrue(errors.Is(jobStatus.Err, lru.ErrInvalidUpdateEntrySize))
 	// Verify callback is executed
 	AssertTrue(callbackExecuted.Load())
 }

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -81,7 +81,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 }
 
 func (dt *downloaderTest) verifyInvalidError(err error) {
-	AssertTrue((nil == err) || (errors.Is(err, context.Canceled)) || (strings.Contains(err.Error(), lru.EntryNotExistErrMsg)),
+	AssertTrue((nil == err) || (errors.Is(err, context.Canceled)) || errors.Is(err, lru.ErrEntryNotExist),
 		fmt.Sprintf("actual error:%v is not as expected", err))
 }
 
@@ -287,7 +287,7 @@ func (dt *downloaderTest) Test_updateStatusOffset_InsertNew() {
 	err = dt.job.updateStatusOffset(10)
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
+	AssertTrue(errors.Is(err, lru.ErrEntryNotExist))
 	// Confirm job's status offset
 	AssertEq(0, dt.job.status.Offset)
 }
@@ -313,7 +313,7 @@ func (dt *downloaderTest) Test_updateStatusOffset_Fail() {
 	err = dt.job.updateStatusOffset(15)
 
 	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertTrue(errors.Is(err, lru.ErrInvalidUpdateEntrySize))
 	// Confirm job's status offset
 	AssertEq(0, dt.job.status.Offset)
 }
@@ -581,7 +581,7 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	// Verify that jobStatus is failed
 	AssertEq(Failed, jobStatus.Name)
 	AssertGe(jobStatus.Offset, 0)
-	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertTrue(errors.Is(err, lru.ErrInvalidUpdateEntrySize))
 	// Verify callback is executed
 	AssertTrue(callbackExecuted.Load())
 }
@@ -592,7 +592,7 @@ func (dt *downloaderTest) Test_Download_AlreadyFailed() {
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 	dt.job.mu.Lock()
-	dt.job.status = JobStatus{Failed, fmt.Errorf(lru.InvalidUpdateEntrySizeErrorMsg), 8}
+	dt.job.status = JobStatus{Failed, lru.ErrInvalidUpdateEntrySize, 8}
 	dt.job.mu.Unlock()
 
 	// Requesting again from download job which is in failed state
@@ -600,7 +600,7 @@ func (dt *downloaderTest) Test_Download_AlreadyFailed() {
 
 	AssertEq(nil, err)
 	AssertEq(Failed, jobStatus.Name)
-	AssertTrue(strings.Contains(jobStatus.Err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	AssertTrue(errors.Is(jobStatus.Err, lru.ErrInvalidUpdateEntrySize))
 }
 
 func (dt *downloaderTest) Test_Download_AlreadyInvalid() {

--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -25,11 +25,11 @@ import (
 )
 
 // Predefined error messages returned by the Cache.
-const (
-	InvalidEntrySizeErrorMsg       = "size of the entry is more than the cache's maxSize"
-	InvalidEntryErrorMsg           = "nil values are not supported"
-	InvalidUpdateEntrySizeErrorMsg = "size of entry to be updated is not same as existing size"
-	EntryNotExistErrMsg            = "entry with given key does not exist"
+var (
+	ErrInvalidEntrySize       = errors.New("size of the entry is more than the cache's maxSize")
+	ErrInvalidEntry           = errors.New("nil values are not supported")
+	ErrInvalidUpdateEntrySize = errors.New("size of entry to be updated is not same as existing size")
+	ErrEntryNotExist          = errors.New("entry with given key does not exist")
 )
 
 // Cache is a LRU cache for any lru.ValueType indexed by string keys.
@@ -149,12 +149,12 @@ func (c *Cache) Insert(
 	key string,
 	value ValueType) ([]ValueType, error) {
 	if value == nil {
-		return nil, errors.New(InvalidEntryErrorMsg)
+		return nil, ErrInvalidEntry
 	}
 
 	valueSize := value.Size()
 	if valueSize > c.maxSize {
-		return nil, errors.New(InvalidEntrySizeErrorMsg)
+		return nil, ErrInvalidEntrySize
 	}
 
 	c.mu.Lock()
@@ -248,7 +248,7 @@ func (c *Cache) UpdateWithoutChangingOrder(
 	key string,
 	value ValueType) error {
 	if value == nil {
-		return errors.New(InvalidEntryErrorMsg)
+		return ErrInvalidEntry
 	}
 
 	c.mu.Lock()
@@ -256,11 +256,11 @@ func (c *Cache) UpdateWithoutChangingOrder(
 
 	e, ok := c.index[key]
 	if !ok {
-		return errors.New(EntryNotExistErrMsg)
+		return ErrEntryNotExist
 	}
 
 	if value.Size() != e.Value.(entry).Value.Size() {
-		return errors.New(InvalidUpdateEntrySizeErrorMsg)
+		return ErrInvalidUpdateEntrySize
 	}
 
 	e.Value = entry{key, value}

--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -24,7 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
 )
 
-// Predefined error messages returned by the Cache.
+// Predefined errors returned by the Cache.
 var (
 	ErrInvalidEntrySize       = errors.New("size of the entry is more than the cache's maxSize")
 	ErrInvalidEntry           = errors.New("nil values are not supported")

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -17,7 +17,6 @@ package lru_test
 import (
 	"errors"
 	"math/rand"
-	"strings"
 	"sync"
 	"testing"
 
@@ -81,7 +80,7 @@ func (t *CacheTest) LookUpInEmptyCache() {
 }
 
 func (t *CacheTest) InsertNilValue() {
-	t.insertAndAssert("taco", nil, []int64{}, errors.New(lru.InvalidEntryErrorMsg))
+	t.insertAndAssert("taco", nil, []int64{}, lru.ErrInvalidEntry)
 }
 
 func (t *CacheTest) LookUpUnknownKey() {
@@ -155,7 +154,7 @@ func (t *CacheTest) TestWhenEntrySizeMoreThanCacheMaxSize() {
 	t.insertAndAssert("burrito", testData{Value: 23, DataSize: 4}, []int64{}, nil)
 
 	// Insert entry with size greater than maxSize of cache.
-	t.insertAndAssert("taco", testData{Value: 26, DataSize: MaxSize + 1}, []int64{}, errors.New(lru.InvalidEntrySizeErrorMsg))
+	t.insertAndAssert("taco", testData{Value: 26, DataSize: MaxSize + 1}, []int64{}, lru.ErrInvalidEntrySize)
 
 	ExpectEq(23, t.cache.LookUp("burrito").(testData).Value)
 }
@@ -242,7 +241,7 @@ func (t *CacheTest) TestUpdateWhenKeyNotPresent() {
 	err := t.cache.UpdateWithoutChangingOrder(key, data)
 
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), lru.EntryNotExistErrMsg))
+	ExpectTrue(errors.Is(err, lru.ErrEntryNotExist))
 }
 
 func (t *CacheTest) TestUpdateWhenSizeIsDifferent() {
@@ -254,7 +253,7 @@ func (t *CacheTest) TestUpdateWhenSizeIsDifferent() {
 	err := t.cache.UpdateWithoutChangingOrder(key, newData)
 
 	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), lru.InvalidUpdateEntrySizeErrorMsg))
+	ExpectTrue(errors.Is(err, lru.ErrInvalidUpdateEntrySize))
 }
 
 func (t *CacheTest) TestUpdateNotChangeOrder() {

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"unsafe"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -31,15 +30,15 @@ import (
 	"github.com/jacobsa/fuse/fsutil"
 )
 
-const (
-	InvalidFileHandleErrMsg                   = "invalid file handle"
-	InvalidFileDownloadJobErrMsg              = "invalid download job"
-	InvalidFileInfoCacheErrMsg                = "invalid file info cache"
-	ErrInSeekingFileHandleMsg                 = "error while seeking file handle"
-	ErrInReadingFileHandleMsg                 = "error while reading file handle"
-	FallbackToGCSErrMsg                       = "read via gcs"
-	FileNotPresentInCacheErrMsg               = "file is not present in cache"
-	CacheHandleNotRequiredForRandomReadErrMsg = "cacheFileForRangeRead is false, read type random read and fileInfo entry is absent"
+var (
+	ErrInvalidFileHandle                   = errors.New("invalid file handle")
+	ErrInvalidFileDownloadJob              = errors.New("invalid download job")
+	ErrInvalidFileInfoCache                = errors.New("invalid file info cache")
+	ErrInSeekingFileHandle                 = errors.New("error while seeking file handle")
+	ErrInReadingFileHandle                 = errors.New("error while reading file handle")
+	ErrFallbackToGCS                       = errors.New("read via gcs")
+	ErrFileNotPresentInCache               = errors.New("file is not present in cache")
+	ErrCacheHandleNotRequiredForRandomRead = errors.New("cacheFileForRangeRead is false, read type random read and fileInfo entry is absent")
 )
 
 const (
@@ -99,11 +98,11 @@ func GetDownloadPath(cacheDir string, objectPath string) string {
 // If it's invalid then we should close that cacheHandle and create new cacheHandle
 // for next call onwards.
 func IsCacheHandleInvalid(readErr error) bool {
-	return strings.Contains(readErr.Error(), InvalidFileHandleErrMsg) ||
-		strings.Contains(readErr.Error(), InvalidFileDownloadJobErrMsg) ||
-		strings.Contains(readErr.Error(), InvalidFileInfoCacheErrMsg) ||
-		strings.Contains(readErr.Error(), ErrInSeekingFileHandleMsg) ||
-		strings.Contains(readErr.Error(), ErrInReadingFileHandleMsg)
+	return errors.Is(readErr, ErrInvalidFileHandle) ||
+		errors.Is(readErr, ErrInvalidFileDownloadJob) ||
+		errors.Is(readErr, ErrInvalidFileInfoCache) ||
+		errors.Is(readErr, ErrInSeekingFileHandle) ||
+		errors.Is(readErr, ErrInReadingFileHandle)
 }
 
 // CreateCacheDirectoryIfNotPresentAt Creates directory at given path with

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -242,13 +242,13 @@ func (ut *utilTest) Test_IsCacheHandleValid_True() {
 }
 
 func (ut *utilTest) Test_IsCacheHandleValid_False() {
-	errMessages := []string{
-		ErrFallbackToGCS.Error() + "test",
-		"random error message",
+	errs := []error{
+		fmt.Errorf("%w: %s", ErrFallbackToGCS, "test"),
+		fmt.Errorf("random error message"),
 	}
 
-	for _, errMsg := range errMessages {
-		ExpectFalse(IsCacheHandleInvalid(errors.New(errMsg)))
+	for _, err := range errs {
+		ExpectFalse(IsCacheHandleInvalid(err))
 	}
 }
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -228,16 +228,16 @@ func (ut *utilTest) Test_getDownloadPath() {
 }
 
 func (ut *utilTest) Test_IsCacheHandleValid_True() {
-	errMessages := []string{
-		ErrInvalidFileHandle.Error() + "test",
-		ErrInvalidFileDownloadJob.Error() + "test",
-		ErrInvalidFileInfoCache.Error() + "test",
-		ErrInSeekingFileHandle.Error() + "test",
-		ErrInReadingFileHandle.Error() + "test",
+	errs := []error{
+		fmt.Errorf("%w: %s", ErrInvalidFileHandle, "test"),
+		fmt.Errorf("%w: %s", ErrInvalidFileDownloadJob, "test"),
+		fmt.Errorf("%w: %s", ErrInvalidFileInfoCache, "test"),
+		fmt.Errorf("%w: %s", ErrInSeekingFileHandle, "test"),
+		fmt.Errorf("%w: %s", ErrInReadingFileHandle, "test"),
 	}
 
-	for _, errMsg := range errMessages {
-		ExpectTrue(IsCacheHandleInvalid(errors.New(errMsg)))
+	for _, err := range errs {
+		ExpectTrue(IsCacheHandleInvalid(err))
 	}
 }
 

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -229,11 +229,11 @@ func (ut *utilTest) Test_getDownloadPath() {
 
 func (ut *utilTest) Test_IsCacheHandleValid_True() {
 	errMessages := []string{
-		InvalidFileHandleErrMsg + "test",
-		InvalidFileDownloadJobErrMsg + "test",
-		InvalidFileInfoCacheErrMsg + "test",
-		ErrInSeekingFileHandleMsg + "test",
-		ErrInReadingFileHandleMsg + "test",
+		ErrInvalidFileHandle.Error() + "test",
+		ErrInvalidFileDownloadJob.Error() + "test",
+		ErrInvalidFileInfoCache.Error() + "test",
+		ErrInSeekingFileHandle.Error() + "test",
+		ErrInReadingFileHandle.Error() + "test",
 	}
 
 	for _, errMsg := range errMessages {
@@ -243,7 +243,7 @@ func (ut *utilTest) Test_IsCacheHandleValid_True() {
 
 func (ut *utilTest) Test_IsCacheHandleValid_False() {
 	errMessages := []string{
-		FallbackToGCSErrMsg + "test",
+		ErrFallbackToGCS.Error() + "test",
 		"random error message",
 	}
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -288,7 +288,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 			logger.Warnf("tryReadingFromFileCache: while closing fileCacheHandle: %v", err)
 		}
 		rr.fileCacheHandle = nil
-	} else if !errors.Is(err, cacheutil.ErrFallbackToGCS) {
+	} else if errors.Is(err, cacheutil.ErrFallbackToGCS) {
 		err = fmt.Errorf("tryReadingFromFileCache: while reading via cache: %w", err)
 		return
 	}

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -288,7 +288,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 			logger.Warnf("tryReadingFromFileCache: while closing fileCacheHandle: %v", err)
 		}
 		rr.fileCacheHandle = nil
-	} else if errors.Is(err, cacheutil.ErrFallbackToGCS) {
+	} else if !errors.Is(err, cacheutil.ErrFallbackToGCS) {
 		err = fmt.Errorf("tryReadingFromFileCache: while reading via cache: %w", err)
 		return
 	}

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -907,7 +907,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	_, err = t.rr.ReadAt(buf, 0)
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), util.FileNotPresentInCacheErrMsg))
+	AssertTrue(errors.Is(err, util.ErrFileNotPresentInCache))
 }
 
 func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen() {


### PR DESCRIPTION
### Description
Comparing error strings is fragile because error messages can change. `errors.Is` checks if an error wraps a specific target error, providing a robust and type-safe way to verify error identity regardless of the exact message.   

As part of the random reader refactoring project, this thing is being updated to align with best practices. Note that these changes are specific to the reader scenario and are not being applied to the entire codebase.

### Link to the issue in case of a bug fix.
[b/409482191](https://b.corp.google.com/issues/409482191)

### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
