### PR TITLE
Trigger shadow reviewer workflow only when PR is opened

### DIFF
--- a/.github/workflows/shadow.yml
+++ b/.github/workflows/shadow.yml
@@ -3,7 +3,7 @@ name: "Shadow reviews"
 on:
   pull_request:
     types: 
-    - review_requested
+    - opened
     branches:
       - master
 


### PR DESCRIPTION
### Description
Changing the trigger action from `review_requested` to `opened` as currently, the action triggers when a review is requested, but it also requests a review itself—creating a potentially endless loop.





### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
