### PR TITLE
Enable e2e package concurrent_operations for ZB

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -121,7 +121,7 @@ TEST_DIR_NON_PARALLEL=(
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
   "benchmarking"
-  # "concurrent_operations"
+  "concurrent_operations"
   # "explicit_dir"
   "gzip"
   # "implicit_dir"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  "benchmarking"
+  # "benchmarking"
   "concurrent_operations"
-  # "explicit_dir"
-  "gzip"
-  # "implicit_dir"
-  "interrupt"
-  "kernel_list_cache"
-  "list_large_dir"
-  "local_file"
-  "log_rotation"
-  "monitoring"
-  "mount_timeout"
-  "mounting"
-  "negative_stat_cache"
-  # "operations"
-  "read_cache"
-  "read_large_files"
-  "rename_dir_limit"
-  "stale_handle"
-  # "streaming_writes"
-  "write_large_files"
+  # # "explicit_dir"
+  # "gzip"
+  # # "implicit_dir"
+  # # "interrupt"
+  # "kernel_list_cache"
+  # "list_large_dir"
+  # "local_file"
+  # "log_rotation"
+  # "monitoring"
+  # "mount_timeout"
+  # "mounting"
+  # "negative_stat_cache"
+  # # "operations"
+  # "read_cache"
+  # "read_large_files"
+  # "rename_dir_limit"
+  # "stale_handle"
+  # # "streaming_writes"
+  # "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  "readonly"
-  "managed_folders"
-  "readonly_creds"
+  # "readonly"
+  # "managed_folders"
+  # "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -449,9 +449,9 @@ function clean_up() {
 function main(){
   set -e
 
-  upgrade_gcloud_version
-
-  install_packages
+  # upgrade_gcloud_version
+#
+  # install_packages
 
   set +e
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,36 +120,36 @@ TEST_DIR_NON_PARALLEL=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
-  # "benchmarking"
+  "benchmarking"
   "concurrent_operations"
-  # # "explicit_dir"
-  # "gzip"
-  # # "implicit_dir"
-  # # "interrupt"
-  # "kernel_list_cache"
-  # "list_large_dir"
-  # "local_file"
-  # "log_rotation"
-  # "monitoring"
-  # "mount_timeout"
-  # "mounting"
-  # "negative_stat_cache"
-  # # "operations"
-  # "read_cache"
-  # "read_large_files"
-  # "rename_dir_limit"
-  # "stale_handle"
-  # # "streaming_writes"
-  # "write_large_files"
+  # "explicit_dir"
+  "gzip"
+  # "implicit_dir"
+  "interrupt"
+  "kernel_list_cache"
+  "list_large_dir"
+  "local_file"
+  "log_rotation"
+  "monitoring"
+  "mount_timeout"
+  "mounting"
+  "negative_stat_cache"
+  # "operations"
+  "read_cache"
+  "read_large_files"
+  "rename_dir_limit"
+  "stale_handle"
+  # "streaming_writes"
+  "write_large_files"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  # "readonly"
-  # "managed_folders"
-  # "readonly_creds"
+  "readonly"
+  "managed_folders"
+  "readonly_creds"
 )
 
 # Create a temporary file to store the log file name.


### PR DESCRIPTION
### Description
Enable e2e package concurrent_operations for ZB

### Link to the issue in case of a bug fix.
[b/407895631](http://b/407895631)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
