### PR TITLE
Enable e2e package concurrent_operations for ZB

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -121,7 +121,7 @@ TEST_DIR_NON_PARALLEL=(
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
   "benchmarking"
-  # "concurrent_operations"
+  "concurrent_operations"
   # "explicit_dir"
   "gzip"
   "implicit_dir"


### PR DESCRIPTION
### Description
Enable e2e package concurrent_operations for ZB

### Link to the issue in case of a bug fix.
[b/407895631](http://b/407895631)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Run as part of presubmit - [log](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/1d340073-5e4f-468c-bcc8-1e1978920e56/summary)

### Any backward incompatible change? If so, please explain.
