### PR TITLE
Fix: grpc_validation test suite should be skipped in presubmits

### DIFF
--- a/tools/integration_tests/grpc_validation/setup_test.go
+++ b/tools/integration_tests/grpc_validation/setup_test.go
@@ -137,12 +137,12 @@ func createTestBucket(testBucketRegion, testBucketName string) (err error) {
 
 func TestMain(m *testing.M) {
 	// Parse flags from the setup.
+	var err error
+	setup.ParseSetUpFlags()
 	if setup.IsPresubmitRun() {
 		log.Println("Skipping test package : grpc_validation since this is a presubmit test run")
 		os.Exit(0)
 	}
-	var err error
-	setup.ParseSetUpFlags()
 	if err := setup.SetUpTestDir(); err != nil {
 		log.Fatalf("Failed to setup GCSFuse package. Error: %v", err)
 	}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -785,7 +785,6 @@ func CheckLogFileForMessage(t *testing.T, expectedLog, logFile string) bool {
 	file, err := os.Open(logFile)
 	require.NoError(t, err, "Failed to open log file")
 	defer file.Close()
-	t.Logf("logfile name %s expectedLog %s", logFile, expectedLog)
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if strings.Contains(scanner.Text(), expectedLog) {


### PR DESCRIPTION
### Description
Validated that it is indeed getting skipped
![image](https://github.com/user-attachments/assets/a94c55e8-9c7e-415d-8ee0-eb19b54ccd72)

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
