### PR TITLE
Correcting the periodic test failure for grpc_validation package

### DIFF
--- a/tools/integration_tests/grpc_validation/setup_test.go
+++ b/tools/integration_tests/grpc_validation/setup_test.go
@@ -79,7 +79,7 @@ func findTestExecutionEnvironment(ctx context.Context) (string, error) {
 	if v, exists := attrs.Value("gcp.gce.instance.hostname"); exists && strings.Contains(strings.ToLower(v.AsString()), cloudtopProd) {
 		return cloudtopProd, nil
 	}
-	if v, exists := attrs.Value("cloud.region"); exists {
+	if v, exists := attrs.Value("cloud.availability_zone"); exists {
 		return v.AsString(), nil
 	}
 	return "", nil
@@ -154,7 +154,7 @@ func TestMain(m *testing.M) {
 	}
 	defer client.Close()
 
-	testRegion, err := findTestExecutionEnvironment(ctx)
+	testRegion, err = findTestExecutionEnvironment(ctx)
 	if err != nil {
 		log.Fatalf("Failed to retrieve test VM region: %v", err)
 	}


### PR DESCRIPTION
### Description
This PR fixes a subtle bug where the testRegion variable, intended to be shared across test files, was not being properly initialized due to variable shadowing within TestMain().
Due to this , the regions for the testcases were not being correctly configured , resulting in test failures.
Confirmed successful run manually:
![image](https://github.com/user-attachments/assets/07ef472f-1d40-4cd1-8616-252715d4f018)### Link to the issue in case of a bug fix.


### Testing details
1. Manual - On GCE VM
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
