### PR TITLE
fix read large file tests

### DIFF
--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -747,7 +747,7 @@ func CreateLocalTempFile(content string, gzipCompress bool) (string, error) {
 // ReadAndCompare reads content from the given file paths and compares them.
 func ReadAndCompare(t *testing.T, filePathInMntDir string, filePathInLocalDisk string, offset int64, chunkSize int64) {
 	t.Helper()
-	mountContents, err := ReadChunkFromFile(filePathInMntDir, chunkSize, offset, os.O_RDONLY)
+	mountContents, err := ReadChunkFromFile(filePathInMntDir, chunkSize, offset, os.O_RDONLY|syscall.O_DIRECT)
 	if err != nil {
 		t.Fatalf("error in read file from mounted directory :%d", err)
 	}


### PR DESCRIPTION
### Description
Read large file tests should use O_DIRECT when reading the file via GCSFuse, otherwise reads get served from page cache.

### Link to the issue in case of a bug fix.
internal bug: b/408343842

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA
