### PR TITLE
CloseFile should not exit the tests

### DIFF
--- a/internal/fs/stale_file_handle_common_test.go
+++ b/internal/fs/stale_file_handle_common_test.go
@@ -133,7 +133,7 @@ func (t *staleFileHandleCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowErro
 	assert.NoError(t.T(), err)
 
 	operations.SyncFile(t.f1, t.T())
-	operations.CloseFile(t.f1)
+	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.

--- a/tools/integration_tests/emulator_tests/streaming_writes_failure/common_failure_test.go
+++ b/tools/integration_tests/emulator_tests/streaming_writes_failure/common_failure_test.go
@@ -275,7 +275,7 @@ func (t *commonFailureTestSuite) TestStreamingWritesBwhResetsWhenFileHandlesAreO
 	operations.CloseFileShouldThrowError(t.T(), t.fh1)
 	// Opening new file handle and writing to file succeeds when file handles in O_RDONLY mode are open.
 	t.writingAfterBwhReinitializationSucceeds()
-	operations.CloseFileShouldNotThrowError(fh2, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh2)
 	// Close and validate object content found on GCS.
 	CloseFileAndValidateContentFromGCS(t.ctx, t.storageClient, t.fh1, testDirName, FileName1, string(t.data), t.T())
 }

--- a/tools/integration_tests/kernel_list_cache/disabled_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/disabled_kernel_list_cache_test.go
@@ -53,9 +53,9 @@ func (s *disabledKernelListCacheTest) TestKernelListCache_AlwaysCacheMiss(t *tes
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)

--- a/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/finite_kernel_list_cache_test.go
@@ -56,9 +56,9 @@ func (s *finiteKernelListCacheTest) TestKernelListCache_CacheHitWithinLimit_Cach
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_delete_dir_test.go
@@ -49,9 +49,9 @@ func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_ListAndDelete
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// (a) First read served from GCS, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
@@ -77,9 +77,9 @@ func (s *infiniteKernelListCacheDeleteDirTest) TestKernelListCache_DeleteAndList
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	err := os.RemoveAll(targetDir)
 	assert.NoError(t, err)

--- a/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
+++ b/tools/integration_tests/kernel_list_cache/infinite_kernel_list_cache_test.go
@@ -54,9 +54,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_AlwaysCacheHit(t *test
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
@@ -96,9 +96,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnAdditionOfF
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
@@ -147,9 +147,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnDeletionOfF
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
@@ -191,9 +191,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnFileRename(
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
@@ -257,11 +257,11 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_EvictCacheEntryOfOnlyD
 	operations.CreateDirectory(subDir, t)
 	// Create test files
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(subDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 	f3 := operations.CreateFile(path.Join(subDir, "file3.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f3)
+	operations.CloseFileShouldNotThrowError(t, f3)
 	// Initial read of parent directory (caches results)
 	f, err := os.Open(targetDir)
 	require.NoError(t, err)
@@ -324,9 +324,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnAdditionOfD
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 	// First read, kernel will cache the dir response.
 	f, err := os.Open(targetDir)
 	require.NoError(t, err)
@@ -367,9 +367,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnDeletionOfD
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 	err := os.Mkdir(path.Join(targetDir, "sub_dir"), setup.DirPermission_0755)
 	require.NoError(t, err)
 	// First read, kernel will cache the dir response.
@@ -412,9 +412,9 @@ func (s *infiniteKernelListCacheTest) TestKernelListCache_CacheMissOnDirectoryRe
 	operations.CreateDirectory(targetDir, t)
 	// Create test data
 	f1 := operations.CreateFile(path.Join(targetDir, "file1.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f1)
+	operations.CloseFileShouldNotThrowError(t, f1)
 	f2 := operations.CreateFile(path.Join(targetDir, "file2.txt"), setup.FilePermission_0600, t)
-	operations.CloseFile(f2)
+	operations.CloseFileShouldNotThrowError(t, f2)
 	err := os.Mkdir(path.Join(targetDir, "sub_dir"), setup.DirPermission_0755)
 	require.NoError(t, err)
 	// First read, kernel will cache the dir response.

--- a/tools/integration_tests/local_file/remove_dir.go
+++ b/tools/integration_tests/local_file/remove_dir.go
@@ -45,7 +45,7 @@ func (t *CommonLocalFileTestSuite) TestRmDirOfDirectoryContainingGCSAndLocalFile
 	// Validate writing content to unlinked local file does not throw error.
 	operations.WriteWithoutClose(fh2, FileContents, t.T())
 	// Validate flush file does not throw error and does not create object on GCS.
-	operations.CloseFileShouldNotThrowError(fh2, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh2)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile, t.T())
 	// Validate synced files are also deleted.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, syncedFile, t.T())
@@ -67,9 +67,9 @@ func (t *CommonLocalFileTestSuite) TestRmDirOfDirectoryContainingOnlyLocalFiles(
 	// Verify rmDir operation succeeds.
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(testDirPath, ExplicitDirName))
 	// Close the local files and validate they are not present on GCS.
-	operations.CloseFileShouldNotThrowError(fh1, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh1)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile1, t.T())
-	operations.CloseFileShouldNotThrowError(fh2, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh2)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, localFile2, t.T())
 	// Validate directory is also deleted.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, ExplicitDirName, t.T())

--- a/tools/integration_tests/local_file/sym_link.go
+++ b/tools/integration_tests/local_file/sym_link.go
@@ -52,7 +52,7 @@ func (t *localFileTestSuite) TestReadSymlinkForDeletedLocalFile() {
 	filePath, symlink, fh := createAndVerifySymLink(t.T())
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(filePath)
-	operations.CloseFileShouldNotThrowError(fh, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 
 	// Reading symlink should fail.

--- a/tools/integration_tests/local_file/unlinked_file.go
+++ b/tools/integration_tests/local_file/unlinked_file.go
@@ -34,7 +34,7 @@ func (t *CommonLocalFileTestSuite) TestStatOnUnlinkedLocalFile() {
 	operations.ValidateNoFileOrDirError(t.T(), path.Join(testDirPath, FileName1))
 
 	// Close the file and validate that file is not created on GCS.
-	operations.CloseFileShouldNotThrowError(fh, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 }
 
@@ -60,7 +60,7 @@ func (t *CommonLocalFileTestSuite) TestReadDirContainingUnlinkedLocalFiles() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh2, testDirName,
 		FileName2, "", t.T())
 	// Verify unlinked file is not written to GCS.
-	operations.CloseFileShouldNotThrowError(fh3, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh3)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName3, t.T())
 }
 
@@ -76,7 +76,7 @@ func (t *CommonLocalFileTestSuite) TestWriteOnUnlinkedLocalFileSucceeds() {
 	operations.WriteWithoutClose(fh, FileContents, t.T())
 
 	// Validate flush file does not throw error.
-	operations.CloseFileShouldNotThrowError(fh, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh)
 	// Validate unlinked file is not written to GCS.
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 }
@@ -95,7 +95,7 @@ func (t *CommonLocalFileTestSuite) TestSyncOnUnlinkedLocalFile() {
 	operations.SyncFile(fh, t.T())
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 	// Close the local file and validate it is not present on GCS.
-	operations.CloseFileShouldNotThrowError(fh, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), fh)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 }
 

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -73,7 +73,7 @@ func createDirectoryStructureForEmptyManagedFoldersTest(t *testing.T) {
 	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), bucket)
 	operations.CreateDirectory(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, SimulatedFolder), t)
 	f := operations.CreateFile(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, File), setup.FilePermission_0600, t)
-	operations.CloseFile(f)
+	operations.CloseFileShouldNotThrowError(t, f)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -117,7 +117,7 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 		log.Fatalf("Failed to clean up test directory: %v", err)
 	}
 	f := operations.CreateFile(path.Join("/tmp", FileInNonEmptyManagedFoldersTest), setup.FilePermission_0600, t)
-	defer operations.CloseFile(f)
+	defer operations.CloseFileShouldNotThrowError(t, f)
 	managedFolder1 := path.Join(testDir, ManagedFolder1)
 	managedFolder2 := path.Join(testDir, ManagedFolder2)
 	simulatedFolderNonEmptyManagedFoldersTest := path.Join(testDir, SimulatedFolderNonEmptyManagedFoldersTest)
@@ -254,7 +254,7 @@ func moveAndCheckErrForViewPermission(src, dest string, t *testing.T) {
 
 func createFileForTest(filePath string, t *testing.T) {
 	file, err := os.Create(filePath)
-	defer operations.CloseFile(file)
+	defer operations.CloseFileShouldNotThrowError(t, file)
 	if err != nil {
 		t.Errorf("Error in creating local file, %v", err)
 	}

--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -59,7 +59,7 @@ func createSrcDirectoryWithObjects(dirPath string, t *testing.T) string {
 	}
 
 	// Closing file at the end
-	defer operations.CloseFile(file)
+	defer operations.CloseFileShouldNotThrowError(t, file)
 
 	return dirPath
 }

--- a/tools/integration_tests/operations/delete_file_test.go
+++ b/tools/integration_tests/operations/delete_file_test.go
@@ -48,7 +48,7 @@ func createFile(filePath string, t *testing.T) {
 	}
 
 	// Closing file at the end
-	operations.CloseFile(file)
+	operations.CloseFileShouldNotThrowError(t, file)
 }
 
 // Remove testBucket/A.txt

--- a/tools/integration_tests/operations/move_file_test.go
+++ b/tools/integration_tests/operations/move_file_test.go
@@ -42,7 +42,7 @@ func createSrcDirectoryAndFile(dirPath string, filePath string, t *testing.T) {
 	}
 
 	// Closing file at the end.
-	defer operations.CloseFile(file)
+	defer operations.CloseFileShouldNotThrowError(t, file)
 
 	err = operations.WriteFile(file.Name(), MoveFileContent)
 	if err != nil {

--- a/tools/integration_tests/operations/read_test.go
+++ b/tools/integration_tests/operations/read_test.go
@@ -39,7 +39,7 @@ func TestReadAfterWrite(t *testing.T) {
 		}
 
 		// Closing file at the end
-		operations.CloseFile(tmpFile)
+		operations.CloseFileShouldNotThrowError(t, tmpFile)
 
 		fileName := tmpFile.Name()
 

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -162,7 +162,7 @@ func TestWriteAtRandom(t *testing.T) {
 		t.Errorf("WriteString-Random: %v", err)
 	}
 	// Closing file at the end
-	operations.CloseFile(f)
+	operations.CloseFileShouldNotThrowError(t, f)
 
 	setup.CompareFileContents(t, fileName, "line 1\nline 5\n")
 	// Validate that extended object attributes are non nil/ non-empty.
@@ -216,7 +216,7 @@ func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 		t.Errorf("Could not open file %s after creation.", fileName)
 	}
 	operations.WriteAt(tempFileContent+appendContent, 0, fh, t)
-	operations.CloseFile(fh)
+	operations.CloseFileShouldNotThrowError(t, fh)
 	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
 
 	// Validate object attributes are as expected.

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -101,9 +101,9 @@ func (s *cacheFileForRangeReadFalseTest) TestReadIsTreatedNonSequentialAfterFile
 	randomReadChunkCount := fileSizeSameAsCacheCapacity / chunkSizeToRead
 	readTillChunk := randomReadChunkCount / 2
 	fh1 := operations.OpenFile(path.Join(testDirPath, testFileNames[0]), t)
-	defer operations.CloseFile(fh1)
+	defer operations.CloseFileShouldNotThrowError(t, fh1)
 	fh2 := operations.OpenFile(path.Join(testDirPath, testFileNames[1]), t)
-	defer operations.CloseFile(fh2)
+	defer operations.CloseFileShouldNotThrowError(t, fh2)
 
 	// Use file handle 1 to read file 1 partially.
 	expectedOutcome[0] = readFileBetweenOffset(t, fh1, 0, int64(readTillChunk*chunkSizeToRead))

--- a/tools/integration_tests/read_gcs_algo/concurrent_read_same_file_test.go
+++ b/tools/integration_tests/read_gcs_algo/concurrent_read_same_file_test.go
@@ -53,7 +53,7 @@ func readAndCompare(t *testing.T, filePathInMntDir string, filePathInLocalDisk s
 	if err != nil {
 		t.Fatalf("error in opening file from mounted directory :%d", err)
 	}
-	defer operations.CloseFile(mountedFile)
+	defer operations.CloseFileShouldNotThrowError(t, mountedFile)
 
 	// Perform 5 reads on each file.
 	numberOfReads := 5

--- a/tools/integration_tests/rename_dir_limit/move_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/move_dir_test.go
@@ -78,7 +78,7 @@ func createSrcDirectoryWithObjectsForMoveDirTest(dirPath string, t *testing.T) {
 	}
 
 	// Closing file at the end
-	defer operations.CloseFile(file)
+	defer operations.CloseFileShouldNotThrowError(t, file)
 
 	err = operations.WriteFile(file.Name(), SrcMoveFileContent)
 	if err != nil {

--- a/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
@@ -64,5 +64,5 @@ func (s *staleFileHandleCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowErro
 	operations.WriteWithoutClose(s.f1, Content2, s.T())
 
 	operations.SyncFile(s.f1, s.T())
-	operations.CloseFile(s.f1)
+	operations.CloseFileShouldNotThrowError(s.T(), s.f1)
 }

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -71,7 +71,7 @@ func (t *staleFileHandleStreamingWritesCommon) TestFileDeletedLocallySyncAndClos
 
 	assert.NoError(t.T(), err)
 	operations.SyncFile(t.f1, t.T())
-	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 }
 
 func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobberedFileReturnsStaleFileHandleError() {

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
@@ -61,7 +61,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFirstWriteToClobberedFi
 
 	operations.ValidateStaleNFSFileHandleError(t.T(), err)
 	operations.SyncFile(t.f1, t.T())
-	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 }
 
 func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestWriteOnRenamedFileThrowsStaleFileHandleError() {
@@ -78,7 +78,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestWriteOnRenamedFileThrow
 	operations.ValidateStaleNFSFileHandleError(t.T(), err)
 	// Sync and Close succeeds.
 	operations.SyncFile(t.f1, t.T())
-	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, newFile, t.data, t.T())
 }
 

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -56,7 +56,7 @@ func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFails() {
 	assert.Error(t.T(), err)
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)
-	operations.CloseFileShouldNotThrowError(t.f1, t.T())
+	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
 	// Reading symlink should fail.
 	_, err = os.Stat(symlink)

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -96,7 +96,7 @@ func ValidateObjectChunkFromGCS(ctx context.Context, storageClient *storage.Clie
 
 func CloseFileAndValidateContentFromGCS(ctx context.Context, storageClient *storage.Client,
 	fh *os.File, testDirName, fileName, content string, t *testing.T) {
-	operations.CloseFileShouldNotThrowError(fh, t)
+	operations.CloseFileShouldNotThrowError(t, fh)
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, fileName, content, t)
 }
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -213,7 +213,7 @@ func DownloadObjectFromGCS(gcsFile string, destFileName string, t *testing.T) er
 		}
 	}()
 	f := operations.CreateFile(destFileName, setup.FilePermission_0600, t)
-	defer operations.CloseFile(f)
+	defer operations.CloseFileShouldNotThrowError(t, f)
 
 	rc, err := storageClient.Bucket(bucket).Object(gcsFile).NewReader(ctx)
 	if err != nil {

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -106,7 +106,7 @@ func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string,
 		}
 
 		// Closing file at the end.
-		CloseFile(file)
+		CloseFileShouldNotThrowError(t, file)
 	}
 }
 

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -180,6 +180,7 @@ func CloseFiles(t *testing.T, files []*os.File) {
 	}
 }
 
+// Deprecated: please use CloseFileShouldNotThrowError instead.
 func CloseFile(file *os.File) {
 	if err := file.Close(); err != nil {
 		log.Fatalf("error in closing: %v", err)
@@ -601,10 +602,9 @@ func WriteAt(content string, offset int64, fh *os.File, t testing.TB) {
 	}
 }
 
-func CloseFileShouldNotThrowError(file *os.File, t *testing.T) {
-	if err := file.Close(); err != nil {
-		t.Fatalf("file.Close() for file %s: %v", file.Name(), err)
-	}
+func CloseFileShouldNotThrowError(t testing.TB, file *os.File) {
+	err := file.Close()
+	assert.NoError(t, err)
 }
 
 func CloseFileShouldThrowError(t *testing.T, file *os.File) {
@@ -630,11 +630,10 @@ func SyncFileShouldThrowError(t *testing.T, file *os.File) {
 	}
 }
 
-func CreateFileWithContent(filePath string, filePerms os.FileMode,
-	content string, t testing.TB) {
+func CreateFileWithContent(filePath string, filePerms os.FileMode, content string, t testing.TB) {
 	fh := CreateFile(filePath, filePerms, t)
 	WriteAt(content, 0, fh, t)
-	CloseFile(fh)
+	CloseFileShouldNotThrowError(t, fh)
 }
 
 // CreateFileOfSize creates a file of given size with random data.

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -144,7 +144,7 @@ func CreateExplicitDirectoryStructure(testDir string, t *testing.T) {
 	}
 
 	// Closing file at the end.
-	defer operations.CloseFile(file)
+	defer operations.CloseFileShouldNotThrowError(t, file)
 }
 
 func CreateImplicitDirectoryInExplicitDirectoryStructure(testDir string, t *testing.T) {


### PR DESCRIPTION
### Description
CloseFile test helper logs a fatal error in case of failure which exits the tests. Due to this, sometimes GCSFuse failure logs are also not retained. Changing to use assert library instead so that logs are retained.

### Link to the issue in case of a bug fix.
b/406133834

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA