### PR TITLE
Add info log when staged writes are used

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -311,6 +311,9 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 			return err
 		}
 
+		if f.config.Write.EnableStreamingWrites {
+			logger.Infof("Falling back to staged write for '%s'. Streaming write is limited to sequential writes on new/empty files.", f.name)
+		}
 		tf, err := f.contentCache.NewTempFile(rc)
 		if err != nil {
 			err = fmt.Errorf("NewTempFile: %w", err)


### PR DESCRIPTION
### Description
Add info log when staged writes are used.

### Link to the issue in case of a bug fix.
internal bug: b/409341314

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
