### PR TITLE
fix install test for patch release

### DIFF
--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -20,6 +20,7 @@ set -x
 gsutil cp  gs://gcsfuse-release-packages/version-detail/details.txt .
 # Writing VM instance name to details.txt (Format: release-test-<os-name>)
 vm_instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google")
+to_release_version=$(sed '1q' details.txt | tr -d '\n')
 echo $vm_instance_name >> details.txt
 touch ~/logs.txt
 
@@ -51,8 +52,8 @@ then
     fi
 
     sudo apt-get update
-    # Install latest released gcsfuse version
-    sudo apt-get install -y gcsfuse
+    # Install to be released gcsfuse version
+    sudo apt-get install -y gcsfuse="$to_release_version" >> ~/logs.txt
 else
 #  For rhel and centos
     sudo yum install fuse
@@ -72,20 +73,20 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-sudo yum install -y gcsfuse
+sudo yum install -y gcsfuse-"$to_release_version" >> ~/logs.txt
 fi
 
 # Verify gcsfuse version (successful installation)
 gcsfuse --version |& tee version.txt
 installed_version=$(echo $(sed -n 1p version.txt) | cut -d' ' -f3)
 if grep -q $installed_version details.txt; then
-    echo "GCSFuse latest version installed correctly." &>> ~/logs.txt
+    echo "GCSFuse to be released version installed correctly." &>> ~/logs.txt
 else
-    echo "Failure detected in latest gcsfuse version installation." &>> ~/logs.txt
+    echo "Failure detected in to be released gcsfuse version installation." &>> ~/logs.txt
 fi
 
 
-# Uninstall gcsfuse latest version and install old version
+# Uninstall gcsfuse and install old version.
 if grep -q ubuntu details.txt || grep -q debian details.txt;
 then
   sudo apt-get remove -y gcsfuse |& tee -a ~/logs.txt
@@ -104,7 +105,7 @@ else
   echo "Failure detected in GCSFuse old version installation." &>> ~/logs.txt
 fi
 
-# Upgrade gcsfuse to latest version
+# Upgrade gcsfuse to latest version.
 if grep -q ubuntu details.txt || grep -q debian details.txt;
 then
     sudo apt-get install --only-upgrade gcsfuse |& tee -a ~/logs.txt
@@ -114,10 +115,10 @@ fi
 
 gcsfuse --version |& tee version.txt
 installed_version=$(echo $(sed -n 1p version.txt) | cut -d' ' -f3)
-if grep -q $installed_version details.txt; then
-    echo "GCSFuse successfully upgraded to latest version $installed_version." &>> ~/logs.txt
+if [[ "$(printf '%s\n%s\n' "$to_release_version" "$installed_version" | sort -V | tail -n 1)" == "$installed_version" ]]; then
+  echo "GCSFuse successfully upgraded to latest version: installed_version ($installed_version), to_release_version: ($to_release_version)" &>> ~/logs.txt
 else
-    echo "Failure detected in upgrading to latest gcsfuse version." &>> ~/logs.txt
+  echo "Failure detected in upgrading to latest gcsfuse version: installed_version ($installed_version), to_release_version: ($to_release_version)" &>> ~/logs.txt
 fi
 
 if grep -q Failure ~/logs.txt; then


### PR DESCRIPTION
### Description
Installation tests were failing when running against patch releases. This was because the test script assumed the version being released was the most recent.
This PR updates the test script to no longer rely on the release version being the absolute latest, making it compatible with patch releases.

### Link to the issue in case of a bug fix.
internal bug : b/409958930

### Testing details
1. Manual - manually ran on CD pipeline
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
