### PR TITLE
Clean up buckets on e2e failure

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -178,13 +178,6 @@ function delete_buckets_listed_in_file() {
 	fi
 }
 
-# Clean-up for this program, which is called whenever this program exits.
-# Args: None.
-function clean_up() {
-	local bucketNamesFile=${1}
-	delete_buckets_listed_in_file "${bucketNamesFile}"
-}
-
 function upgrade_gcloud_version() {
   sudo apt-get update
   # Upgrade gcloud version.
@@ -461,7 +454,7 @@ function main(){
   # buckets to be cleaned-up while exiting this program.
   bucketNamesFile=$(realpath ./bucketNames)"-"$(tr -dc 'a-z0-9' < /dev/urandom | head -c $RANDOM_STRING_LENGTH)
   # Delete all these buckets when the program exits.
-  trap "clean_up ${bucketNamesFile}" EXIT
+  trap "delete_buckets_listed_in_file ${bucketNamesFile}" EXIT
 
   set -e
 


### PR DESCRIPTION
### Description
It addresses two problems.
1. Deletion of buckets created by E2E run script. The code is there in place, but it doesn't fully work in the following ways
   - It deletes objects but not the bucket itself, at least not if the test run fails, as I have many times gone back and deleted buckets manually afterwards.
3. The deletion code doesn't get called if the script terminates early because of some test or environment issue causing a crash.

It also logs the bucket deletions if and when they are deleted.

### Link to the issue in case of a bug fix.
[b/409363794](http://b/409363794)

### Testing details
1. Manual - NA
4. Unit tests - NA
5. Integration tests - NA

### Any backward incompatible change? If so, please explain.
