### PR TITLE
Start running streaming_writes package for ZB.

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -366,14 +366,6 @@ func (f *FileInode) Unlink() {
 func (f *FileInode) Source() *gcs.MinObject {
 	// Make a copy, since we modify f.src.
 	o := f.src
-	// Use bwh size if it's not nil as f.src.Size is not updated.
-	if f.bwh != nil {
-		writeFileInfo := f.bwh.WriteFileInfo()
-		o.Size = uint64(writeFileInfo.TotalSize)
-		if f.bucket.BucketType().Zonal && f.local && o.Size > 0 {
-			o.Name = f.Name().objectName
-		}
-	}
 	return &o
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -366,6 +366,14 @@ func (f *FileInode) Unlink() {
 func (f *FileInode) Source() *gcs.MinObject {
 	// Make a copy, since we modify f.src.
 	o := f.src
+	// Use bwh size if it's not nil as f.src.Size is not updated.
+	if f.bwh != nil {
+		writeFileInfo := f.bwh.WriteFileInfo()
+		o.Size = uint64(writeFileInfo.TotalSize)
+		if f.bucket.BucketType().Zonal && f.local && o.Size > 0 {
+			o.Name = f.Name().objectName
+		}
+	}
 	return &o
 }
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -139,7 +139,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "read_large_files"
   "rename_dir_limit"
   "stale_handle"
-  # "streaming_writes"
+  "streaming_writes"
   "write_large_files"
 )
 

--- a/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
@@ -15,15 +15,12 @@
 package streaming_writes
 
 import (
-	"os"
 	"path"
-	"syscall"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -46,9 +43,7 @@ func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
 	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "", t.T())
 	t.filePath = path.Join(testDirPath, t.fileName)
-	var err error
-	t.f1, err = os.OpenFile(path.Join(testDirPath, t.fileName), os.O_RDWR|syscall.O_DIRECT, operations.FilePermission_0600)
-	require.NoError(t.T(), err)
+	t.f1 = operations.OpenFileWithODirect(t.T(), t.filePath)
 }
 
 // Executes all tests that run with single streamingWrites configuration for empty GCS Files.

--- a/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_empty_gcs_file_test.go
@@ -15,12 +15,15 @@
 package streaming_writes
 
 import (
+	"os"
 	"path"
+	"syscall"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -43,7 +46,9 @@ func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
 	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "", t.T())
 	t.filePath = path.Join(testDirPath, t.fileName)
-	t.f1 = operations.OpenFile(t.filePath, t.T())
+	var err error
+	t.f1, err = os.OpenFile(path.Join(testDirPath, t.fileName), os.O_RDWR|syscall.O_DIRECT, operations.FilePermission_0600)
+	require.NoError(t.T(), err)
 }
 
 // Executes all tests that run with single streamingWrites configuration for empty GCS Files.

--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -15,11 +15,16 @@
 package streaming_writes
 
 import (
+	"os"
+	"path"
+	"syscall"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -39,8 +44,11 @@ func (t *defaultMountLocalFile) SetupSubTest() {
 
 func (t *defaultMountLocalFile) createLocalFile() {
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
+	t.filePath = path.Join(testDirPath, t.fileName)
 	// Create a local file.
-	t.filePath, t.f1 = CreateLocalFileInTestDir(ctx, storageClient, testDirPath, t.fileName, t.T())
+	var err error
+	t.f1, err = os.OpenFile(path.Join(testDirPath, t.fileName), os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
+	require.NoError(t.T(), err)
 }
 
 // Executes all tests that run with single streamingWrites configuration for localFiles.

--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -15,16 +15,13 @@
 package streaming_writes
 
 import (
-	"os"
 	"path"
-	"syscall"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -45,10 +42,8 @@ func (t *defaultMountLocalFile) SetupSubTest() {
 func (t *defaultMountLocalFile) createLocalFile() {
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	t.filePath = path.Join(testDirPath, t.fileName)
-	// Create a local file.
-	var err error
-	t.f1, err = os.OpenFile(path.Join(testDirPath, t.fileName), os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
-	require.NoError(t.T(), err)
+	// Create a local file with O_DIRECT.
+	t.f1 = operations.OpenFileWithODirect(t.T(), t.filePath)
 }
 
 // Executes all tests that run with single streamingWrites configuration for localFiles.

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -48,7 +48,7 @@ func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.UnmountGCSFuse(rootDir)
 }
 
-func (t *defaultMountCommonTest) validateReadSucceedsForZB(filePath string) {
+func (t *defaultMountCommonTest) validateReadCall(filePath string) {
 	_, err := os.ReadFile(filePath)
 	if setup.IsZonalBucketRun() {
 		// TODO(b/410698332): Remove skip condition once reads start working.

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,9 +49,12 @@ func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.UnmountGCSFuse(rootDir)
 }
 
-func (t *defaultMountCommonTest) validateReadSucceedsForZB(err error) {
+func (t *defaultMountCommonTest) validateReadSucceedsForZB(filePath, expectedContent string) {
+	readContent, err := os.ReadFile(filePath)
 	if setup.IsZonalBucketRun() {
+		t.T().Skip("Skipping Zonal Bucket Read tests.")
 		require.NoError(t.T(), err)
+		assert.Equal(t.T(), expectedContent, string(readContent))
 	} else {
 		require.Error(t.T(), err)
 	}

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,13 +48,12 @@ func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.UnmountGCSFuse(rootDir)
 }
 
-func (t *defaultMountCommonTest) validateReadSucceedsForZB(filePath, expectedContent string) {
-	readContent, err := os.ReadFile(filePath)
+func (t *defaultMountCommonTest) validateReadSucceedsForZB(filePath string) {
+	_, err := os.ReadFile(filePath)
 	if setup.IsZonalBucketRun() {
 		// TODO(b/410698332): Remove skip condition once reads start working.
 		t.T().Skip("Skipping Zonal Bucket Read tests.")
 		require.NoError(t.T(), err)
-		assert.Equal(t.T(), expectedContent, string(readContent))
 	} else {
 		require.Error(t.T(), err)
 	}

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -17,9 +17,11 @@ package streaming_writes
 import (
 	"os"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 type defaultMountCommonTest struct {
@@ -27,6 +29,7 @@ type defaultMountCommonTest struct {
 	fileName string
 	// filePath of the above file in the mounted directory.
 	filePath string
+	data     string
 	test_suite.TestifySuite
 }
 
@@ -38,8 +41,17 @@ func (t *defaultMountCommonTest) SetupSuite() {
 
 	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
 	testDirPath = setup.SetupTestDirectory(testDirName)
+	t.data = setup.GenerateRandomString(5 * util.MiB)
 }
 
 func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.UnmountGCSFuse(rootDir)
+}
+
+func (t *defaultMountCommonTest) validateReadSucceedsForZB(err error) {
+	if setup.IsZonalBucketRun() {
+		require.NoError(t.T(), err)
+	} else {
+		require.Error(t.T(), err)
+	}
 }

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -52,6 +52,7 @@ func (t *defaultMountCommonTest) TearDownSuite() {
 func (t *defaultMountCommonTest) validateReadSucceedsForZB(filePath, expectedContent string) {
 	readContent, err := os.ReadFile(filePath)
 	if setup.IsZonalBucketRun() {
+		// TODO(b/410698332): Remove skip condition once reads start working.
 		t.T().Skip("Skipping Zonal Bucket Read tests.")
 		require.NoError(t.T(), err)
 		assert.Equal(t.T(), expectedContent, string(readContent))

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -30,7 +30,7 @@ func (t *defaultMountCommonTest) TestReadFileSucceedsForZB() {
 	// Sync File to ensure buffers are flushed to GCS.
 	operations.SyncFile(t.f1, t.T())
 
-	t.validateReadSucceedsForZB(t.f1.Name(), t.data)
+	t.validateReadSucceedsForZB(t.f1.Name())
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountCommonTest) TestReadFileSucceedsForZB() {
+func (t *defaultMountCommonTest) TestReadFileAfterSync() {
 	// Write some content to the file.
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
 	// Sync File to ensure buffers are flushed to GCS.
 	operations.SyncFile(t.f1, t.T())
 
-	t.validateReadSucceedsForZB(t.f1.Name())
+	t.validateReadCall(t.f1.Name())
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -30,17 +30,8 @@ func (t *defaultMountCommonTest) TestReadFileSucceedsForZB() {
 	// Sync File to ensure buffers are flushed to GCS.
 	operations.SyncFile(t.f1, t.T())
 
-	statRes, err := operations.StatFile(t.filePath)
+	t.validateReadSucceedsForZB(t.f1.Name(), t.data)
 
-	require.NoError(t.T(), err)
-	assert.Equal(t.T(), t.fileName, (*statRes).Name())
-	assert.EqualValues(t.T(), len(t.data), (*statRes).Size())
-
-	// Reading the file contents.
-	buf := make([]byte, len(t.data))
-	_, err = t.f1.ReadAt(buf, 0)
-
-	t.validateReadSucceedsForZB(err)
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -23,49 +23,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountCommonTest) TestReadLocalFileFails() {
-	// Write some content to local file.
-	_, err := t.f1.WriteAt([]byte(FileContents), 0)
+func (t *defaultMountCommonTest) TestReadFileSucceedsForZB() {
+	// Write some content to the file.
+	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
+	// Sync File to ensure buffers are flushed to GCS.
+	operations.SyncFile(t.f1, t.T())
 
-	// Reading the local file content fails.
-	buf := make([]byte, len(FileContents))
+	statRes, err := operations.StatFile(t.filePath)
+
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), t.fileName, (*statRes).Name())
+	assert.EqualValues(t.T(), len(t.data), (*statRes).Size())
+
+	// Reading the file contents.
+	buf := make([]byte, len(t.data))
 	_, err = t.f1.ReadAt(buf, 0)
-	assert.Error(t.T(), err)
 
+	t.validateReadSucceedsForZB(err)
 	// Close the file and validate that the file is created on GCS.
-	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, FileContents, t.T())
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
 func (t *defaultMountCommonTest) TestReadBeforeFileIsFlushed() {
-	testContent := "testContent"
 	// Write data to file.
-	operations.WriteAt(testContent, 0, t.f1, t.T())
+	operations.WriteAt(t.data, 0, t.f1, t.T())
 
 	// Try to read the file.
 	_, err := t.f1.Seek(0, 0)
 	require.NoError(t.T(), err)
-	buf := make([]byte, 10)
+	buf := make([]byte, len(t.data))
 	_, err = t.f1.Read(buf)
 
 	require.Error(t.T(), err, "input/output error")
 	// Validate if correct content is uploaded to GCS after read error.
-	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, testContent, t.T())
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
 func (t *defaultMountCommonTest) TestReadAfterFlush() {
-	testContent := "testContent"
 	// Write data to file and flush.
-	operations.WriteAt(testContent, 0, t.f1, t.T())
-	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, testContent, t.T())
+	operations.WriteAt(t.data, 0, t.f1, t.T())
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 
 	// Perform read and validate the contents.
 	var err error
 	t.f1, err = operations.OpenFileAsReadonly(path.Join(testDirPath, t.fileName))
 	require.NoError(t.T(), err)
-	buf := make([]byte, len(testContent))
+	buf := make([]byte, len(t.data))
 	_, err = t.f1.Read(buf)
 
 	require.NoError(t.T(), err)
-	require.Equal(t.T(), string(buf), testContent)
+	require.Equal(t.T(), string(buf), t.data)
 }

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFileSucceedsForZB() {
+func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileAndReadFromSymlink() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
@@ -33,14 +33,14 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFileSucceedsFo
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
-	// Reading file from symlink succeeds for ZB.
-	t.validateReadSucceedsForZB(symlink)
+	// Validate read file from symlink.
+	t.validateReadCall(symlink)
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
-func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFileReadFileSucceedsForZB() {
+func (t *defaultMountCommonTest) TestReadingFromSymlinkForDeletedLocalFile() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
@@ -49,8 +49,8 @@ func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFileReadFileS
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
-	// Reading file from symlink succeeds for ZB.
-	t.validateReadSucceedsForZB(symlink)
+	// Validate read from symlink.
+	t.validateReadCall(symlink)
 
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
+func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFileSucceedsForZB() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
@@ -40,7 +40,7 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
-func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFails() {
+func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFileReadFileSucceedsForZB() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -34,7 +34,7 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
 	// Reading file from symlink succeeds for ZB.
-	t.validateReadSucceedsForZB(symlink, t.data)
+	t.validateReadSucceedsForZB(symlink)
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
@@ -50,7 +50,7 @@ func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFails() {
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
 	// Reading file from symlink succeeds for ZB.
-	t.validateReadSucceedsForZB(symlink, t.data)
+	t.validateReadSucceedsForZB(symlink)
 
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -28,7 +28,7 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
-	_, err := t.f1.WriteAt([]byte(FileContents), 0)
+	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
@@ -38,14 +38,14 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
 
 	assert.Error(t.T(), err)
 	// Close the file and validate that the file is created on GCS.
-	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, FileContents, t.T())
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
 func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFails() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
-	_, err := t.f1.WriteAt([]byte(FileContents), 0)
+	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -33,10 +33,9 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileReadFails() {
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
-	// Reading file from symlink fails.
-	_, err = os.ReadFile(symlink)
+	// Reading file from symlink succeeds for ZB.
+	t.validateReadSucceedsForZB(symlink, t.data)
 
-	assert.Error(t.T(), err)
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
@@ -50,10 +49,9 @@ func (t *defaultMountCommonTest) TestReadSymlinkForDeletedLocalFileFails() {
 	// Verify read link.
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
-	// Reading the file from symlink fails.
-	_, err = os.ReadFile(symlink)
+	// Reading file from symlink succeeds for ZB.
+	t.validateReadSucceedsForZB(symlink, t.data)
 
-	assert.Error(t.T(), err)
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)
 	operations.CloseFileShouldNotThrowError(t.T(), t.f1)

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -519,6 +519,16 @@ func OpenFile(filePath string, t *testing.T) (f *os.File) {
 	return
 }
 
+func OpenFileWithODirect(t *testing.T, filePath string) (f *os.File) {
+	t.Helper()
+	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, FilePermission_0600)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	return
+
+}
+
 func CreateSymLink(filePath, symlink string, t *testing.T) {
 	err := os.Symlink(filePath, symlink)
 


### PR DESCRIPTION
### Description
Start running streaming writes package for ZB. Currently read tests are skipped as reads are not working on unfinalized Objects. Added a TODO bug to remove skip conditions.

Note: `execute-integration-tests` and `execute-integration-tests-on-zb` passed on commit #5fb608a removing labels to ensure no re-runs during review comments.

### Link to the issue in case of a bug fix.
b/407894714

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
