### PR TITLE
Make MRDWrapper store copy of MinObject from inode to prevent data race.

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -160,7 +160,7 @@ func NewFileInode(
 		globalMaxWriteBlocksSem: globalMaxBlocksSem,
 	}
 	var err error
-	f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &f.src)
+	f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &minObj)
 	if err != nil {
 		logger.Errorf("NewFileInode: Error in creating MRDWrapper %v", err)
 	}
@@ -905,7 +905,7 @@ func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
 // Updates the min object stored in MRDWrapper corresponding to the inode.
 // Should be called when minObject associated with inode is updated.
 func (f *FileInode) updateMRDWrapper() {
-	err := f.MRDWrapper.SetMinObject(&f.src)
+	err := f.MRDWrapper.SetMinObject(f.Source())
 	if err != nil {
 		logger.Errorf("FileInode::updateMRDWrapper Error in setting minObject %v", err)
 	}

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -443,7 +443,7 @@ func (t *FileTest) TestWriteThenSync() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -532,7 +532,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			assert.Equal(t.T(),
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -595,7 +595,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 			assert.Equal(t.T(), t.in.SourceGeneration().Size, m.Size)
 			assert.Equal(t.T(), uint64(0), m.Size)
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -672,7 +672,7 @@ func (t *FileTest) TestAppendThenSync() {
 			assert.Equal(t.T(),
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -733,7 +733,7 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -805,7 +805,7 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -1101,7 +1101,7 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 				err = t.in.Flush(t.ctx)
 			}
 
-			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
@@ -1231,7 +1231,7 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
-	// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+	// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 	assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 	// Validate MinObject in MRDWrapper is same as the MinObject in inode.
 	assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -442,8 +443,10 @@ func (t *FileTest) TestWriteThenSync() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -529,8 +532,10 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			assert.Equal(t.T(),
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 			require.NoError(t.T(), err)
@@ -590,8 +595,10 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			assert.Equal(t.T(), t.in.SourceGeneration().Metadata, m.MetaGeneration)
 			assert.Equal(t.T(), t.in.SourceGeneration().Size, m.Size)
 			assert.Equal(t.T(), uint64(0), m.Size)
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 			// Validate the mtime.
 			mtimeInBucket, ok := m.Metadata["gcsfuse_mtime"]
 			assert.True(t.T(), ok)
@@ -665,9 +672,10 @@ func (t *FileTest) TestAppendThenSync() {
 			assert.Equal(t.T(),
 				writeTime.UTC().Format(time.RFC3339Nano),
 				m.Metadata["gcsfuse_mtime"])
-
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
@@ -725,8 +733,10 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -795,8 +805,10 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 			// The generation should have advanced.
 			assert.Less(t.T(), t.backingObj.Generation, t.in.SourceGeneration().Object)
 
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -1089,8 +1101,10 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 				err = t.in.Flush(t.ctx)
 			}
 
+			// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 			// Check if the error is a FileClobberedError
 			var fcErr *gcsfuse_errors.FileClobberedError
@@ -1217,8 +1231,10 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
 	m, _, err := t.bucket.StatObject(t.ctx, statReq)
 
+	// Validate MinObject in src and MRDWrapper points to different copy of MinObject.
+	assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 	// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-	assert.Same(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
+	assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
 
 	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -445,8 +444,8 @@ func (t *FileTest) TestWriteThenSync() {
 
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -535,7 +534,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 			require.NoError(t.T(), err)
@@ -597,8 +596,8 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			assert.Equal(t.T(), uint64(0), m.Size)
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 			// Validate the mtime.
 			mtimeInBucket, ok := m.Metadata["gcsfuse_mtime"]
 			assert.True(t.T(), ok)
@@ -674,8 +673,8 @@ func (t *FileTest) TestAppendThenSync() {
 				m.Metadata["gcsfuse_mtime"])
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Read the object's contents.
 			contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
@@ -735,8 +734,8 @@ func (t *FileTest) TestTruncateDownwardThenSync() {
 
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -807,8 +806,8 @@ func (t *FileTest) TestTruncateUpwardThenFlush() {
 
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Stat the current object in the bucket.
 			statReq := &gcs.StatObjectRequest{Name: t.in.Name().GcsObjectName()}
@@ -1103,8 +1102,8 @@ func (t *FileTest) TestSyncFlush_Clobbered() {
 
 			// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 			assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-			// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-			assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+			// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+			assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 			// Check if the error is a FileClobberedError
 			var fcErr *gcsfuse_errors.FileClobberedError
@@ -1233,8 +1232,8 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 
 	// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 	assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
-	// Validate MinObject in MRDWrapper is same as the MinObject in inode.
-	assert.True(t.T(), reflect.DeepEqual(&t.in.src, t.in.MRDWrapper.GetMinObject()))
+	// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
+	assert.Equal(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 
 	require.NoError(t.T(), err)
 	assert.NotNil(t.T(), m)


### PR DESCRIPTION
### Description
Holding a direct reference to an inode's MinObject within MRDWrapper could lead to unsynchronized access and potential data races on inode's minObject mutex-protected fields. To prevent this, MRDWrapper will now store a reference to a separate copy of the MinObject.

### Link to the issue in case of a bug fix.
b/410751316

### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
