### PR TITLE
[Random reader refactoring] File cache reader implementation - 1

### DIFF
--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -117,7 +117,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 		if isSequential {
 			readType = util.Sequential
 		}
-		captureFileCacheMetrics(ctx, fc.metricHandle, readType, bytesRead, hit, executionTime)
+		fc.captureFileCacheMetrics(ctx, fc.metricHandle, readType, bytesRead, hit, executionTime)
 	}()
 
 	// Create fileCacheHandle if not already.

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -85,13 +85,12 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 
 	// By default, consider read type random if the offset is non-zero.
 	isSequential := offset == 0
-	requestID := uuid.New()
 
 	var handleID uint64
 	if readOp, ok := ctx.Value(ReadOp).(*fuseops.ReadFileOp); ok {
 		handleID = uint64(readOp.Handle)
 	}
-
+	requestID := uuid.New()
 	logger.Tracef("%.13v <- FileCache(%s:/%s, offset: %d, size: %d, handle: %d)", requestID, fc.bucket.Name(), fc.obj.Name, offset, len(p), handleID)
 
 	startTime := time.Now()
@@ -134,7 +133,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 				isSequential = false
 				return 0, false, nil
 			default:
-				return 0, false, fmt.Errorf("tryReadingFromFileCache: getCacheHandle failed: %w", err)
+				return 0, false, fmt.Errorf("tryReadingFromFileCache: GetCacheHandle failed: %w", err)
 			}
 		}
 	}

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -162,16 +162,6 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 	return 0, false, nil
 }
 
-func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
-	metricHandle.FileCacheReadCount(ctx, 1, []common.MetricAttr{
-		{Key: common.ReadType, Value: readType},
-		{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)},
-	})
-
-	metricHandle.FileCacheReadBytesCount(ctx, int64(readDataSize), []common.MetricAttr{{Key: common.ReadType, Value: readType}})
-	metricHandle.FileCacheReadLatency(ctx, float64(readLatency.Microseconds()), []common.MetricAttr{{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)}})
-}
-
 func (fc *FileCacheReader) ReadAt(ctx context.Context, p []byte, offset int64) (ReaderResponse, error) {
 	var err error
 	readerResponse := ReaderResponse{
@@ -202,4 +192,14 @@ func (fc *FileCacheReader) ReadAt(ctx context.Context, p []byte, offset int64) (
 	// The cache is unable to serve data and requires a fallback to another reader.
 	err = FallbackToAnotherReader
 	return readerResponse, err
+}
+
+func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
+	metricHandle.FileCacheReadCount(ctx, 1, []common.MetricAttr{
+		{Key: common.ReadType, Value: readType},
+		{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)},
+	})
+
+	metricHandle.FileCacheReadBytesCount(ctx, int64(readDataSize), []common.MetricAttr{{Key: common.ReadType, Value: readType}})
+	metricHandle.FileCacheReadLatency(ctx, float64(readLatency.Microseconds()), []common.MetricAttr{{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)}})
 }

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -25,7 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
-	cacheutil "github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
+	cacheUtil "github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
@@ -128,7 +128,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 			case errors.Is(err, lru.ErrInvalidEntrySize):
 				logger.Warnf("tryReadingFromFileCache: while creating CacheHandle: %v", err)
 				return 0, false, nil
-			case errors.Is(err, cacheutil.ErrCacheHandleNotRequiredForRandomRead):
+			case errors.Is(err, cacheUtil.ErrCacheHandleNotRequiredForRandomRead):
 				// Fall back to GCS if it is a random read, cacheFileForRangeRead is
 				// False and there doesn't already exist file in cache.
 				isSequential = false
@@ -147,14 +147,14 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 	bytesRead = 0
 	hit = false
 
-	if cacheutil.IsCacheHandleInvalid(err) {
+	if cacheUtil.IsCacheHandleInvalid(err) {
 		logger.Tracef("Closing cacheHandle:%p for object: %s:/%s", fc.fileCacheHandle, fc.bucket.Name(), fc.obj.Name)
 		closeErr := fc.fileCacheHandle.Close()
 		if closeErr != nil {
 			logger.Warnf("tryReadingFromFileCache: close cacheHandle error: %v", closeErr)
 		}
 		fc.fileCacheHandle = nil
-	} else if !errors.Is(err, cacheutil.ErrFallbackToGCS) {
+	} else if !errors.Is(err, cacheUtil.ErrFallbackToGCS) {
 		return 0, false, fmt.Errorf("tryReadingFromFileCache: while reading via cache: %w", err)
 	}
 	err = nil

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -128,9 +128,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 	hit = false
 	// On read error
 	if cacheutil.IsCacheHandleInvalid(err) {
-		logger.Tracef("invalidating cacheHandle:%p for object: %s:/%s",
-			fc.fileCacheHandle, fc.bucket.Name(), fc.obj.Name)
-
+		logger.Tracef("Closing cacheHandle:%p for object: %s:/%s", fc.fileCacheHandle, fc.bucket.Name(), fc.obj.Name)
 		closeErr := fc.fileCacheHandle.Close()
 		if closeErr != nil {
 			logger.Warnf("tryReadingFromFileCache: close cacheHandle error: %v", closeErr)

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -126,7 +126,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 		if err != nil {
 			switch {
 			case errors.Is(err, lru.ErrInvalidEntrySize):
-				logger.Warnf("cache handle creation failed due to size constraints: %v", err)
+				logger.Warnf("tryReadingFromFileCache: while creating CacheHandle: %v", err)
 				return 0, false, nil
 			case errors.Is(err, cacheutil.ErrCacheHandleNotRequiredForRandomRead):
 				// Fall back to GCS if it is a random read, cacheFileForRangeRead is
@@ -155,7 +155,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 		}
 		fc.fileCacheHandle = nil
 	} else if !errors.Is(err, cacheutil.ErrFallbackToGCS) {
-		return 0, false, fmt.Errorf("tryReadingFromFileCache: read failed: %w", err)
+		return 0, false, fmt.Errorf("tryReadingFromFileCache: while reading via cache: %w", err)
 	}
 	err = nil
 

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -52,8 +52,8 @@ type FileCacheReader struct {
 	metricHandle common.MetricHandle
 }
 
-func NewFileCacheReader(o *gcs.MinObject, bucket gcs.Bucket, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle) FileCacheReader {
-	return FileCacheReader{
+func NewFileCacheReader(o *gcs.MinObject, bucket gcs.Bucket, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle) *FileCacheReader {
+	return &FileCacheReader{
 		obj:                   o,
 		bucket:                bucket,
 		fileCacheHandler:      fileCacheHandler,

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -236,8 +236,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 
 	readerResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
 
-	// Assuming start2 offset download in progress
-	// require to fall back on GCS reader
+	// Assuming a download with a start offset of start2 is in progress, a fallback to another reader will be required.
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
 	assert.Zero(t.T(), readerResponse.Size)
 	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -130,7 +130,7 @@ func (t *FileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 }
 
 // Writing unit tests on tryReadingFromFileCache to check if cache hit is getting populated correctly.
-func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
+func (t *FileCacheReaderTest) Test_tryReadingFromFileCache_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
 	t.object.Size = 20 * util.MiB
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -157,7 +157,6 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThan
 	assert.Equal(t.T(), buf2, testContent[start2:end2])
 }
 
-// Writing unit tests on tryReadingFromFileCache to check if cache hit is getting populated correctly.
 func (t *FileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -266,9 +265,10 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	buf2 := make([]byte, end2-start2)
 	// Assuming start2 offset download in progress
 	readerResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
-	// Need to get served from GCS reader
+	// Need to get served from another reader
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
 	assert.Zero(t.T(), readerResponse.Size)
+	// Assuming start3 offset is downloaded
 	start3 := 4 * util.MiB
 	end3 := start3 + util.MiB
 	buf3 := make([]byte, end3-start3)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -70,8 +70,8 @@ func (t *FileCacheReaderTest) SetupTest() {
 	t.cacheDir = path.Join(os.Getenv("HOME"), "test_cache_dir")
 	lruCache := lru.NewCache(CacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, common.NewNoopMetrics())
+	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
-	t.reader.fileCacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 	readOp := &fuseops.ReadFileOp{
 		Handle: fuseops.HandleID(123),
 		Offset: 0,
@@ -303,6 +303,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 }
 
 func (t *FileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
+
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc1)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -52,7 +52,7 @@ type fileCacheReaderTest struct {
 	cacheDir     string
 	jobManager   *downloader.JobManager
 	cacheHandler *file.CacheHandler
-	reader       FileCacheReader
+	reader       *FileCacheReader
 }
 
 func TestFileCacheReaderTestSuite(t *testing.T) {

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -15,18 +15,26 @@
 package gcsx
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+	"github.com/jacobsa/fuse/fuseops"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -39,18 +47,20 @@ const (
 
 type FileCacheReaderTest struct {
 	suite.Suite
+	ctx          context.Context
 	object       *gcs.MinObject
 	mockBucket   *storage.TestifyMockBucket
 	cacheDir     string
 	jobManager   *downloader.JobManager
 	cacheHandler *file.CacheHandler
+	reader       FileCacheReader
 }
 
 func TestFileCacheReaderTestSuite(t *testing.T) {
 	suite.Run(t, new(FileCacheReaderTest))
 }
 
-func (t *FileCacheReaderTest) SetupTestSuite() {
+func (t *FileCacheReaderTest) SetupTest() {
 	t.object = &gcs.MinObject{
 		Name:       TestObject,
 		Size:       17,
@@ -59,15 +69,29 @@ func (t *FileCacheReaderTest) SetupTestSuite() {
 	t.mockBucket = new(storage.TestifyMockBucket)
 	t.cacheDir = path.Join(os.Getenv("HOME"), "test_cache_dir")
 	lruCache := lru.NewCache(CacheMaxSize)
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, nil)
+	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, common.NewNoopMetrics())
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
+	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
+	readOp := &fuseops.ReadFileOp{
+		Handle: fuseops.HandleID(123),
+		Offset: 0,
+		Size:   10,
+	}
+	t.ctx = context.WithValue(context.Background(), ReadOp, readOp)
 }
 
-func (t *FileCacheReaderTest) TearDownSuite() {
+func (t *FileCacheReaderTest) TearDown() {
 	err := os.RemoveAll(t.cacheDir)
 	if err != nil {
 		t.T().Logf("Failed to clean up test cache directory '%s': %v", t.cacheDir, err)
 	}
+}
+
+func (t *FileCacheReaderTest) mockNewReaderWithHandleCallForTestBucket(start uint64, limit uint64, rd gcs.StorageReader) {
+	t.mockBucket.
+		On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(rg *gcs.ReadObjectRequest) bool {
+			return rg != nil && (*rg.Range).Start == start && (*rg.Range).Limit == limit
+		})).Return(rd, nil).Maybe()
 }
 
 func (t *FileCacheReaderTest) TestNewFileCacheReader() {
@@ -80,4 +104,270 @@ func (t *FileCacheReaderTest) TestNewFileCacheReader() {
 	assert.True(t.T(), reader.cacheFileForRangeRead)
 	assert.Nil(t.T(), reader.metricHandle)
 	assert.Nil(t.T(), reader.fileCacheHandle)
+}
+
+func (t *FileCacheReaderTest) TestReadWithNilFileCacheHandler() {
+	reader := NewFileCacheReader(t.object, t.mockBucket, nil, true, nil)
+
+	readerResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 0)
+
+	assert.Error(t.T(), err)
+	assert.Zero(t.T(), readerResponse.Size)
+}
+
+func (t *FileCacheReaderTest) TestReadWith_CacheForRangeReadFalsError() {
+	t.mockBucket.On("Name").Return("test-bucket")
+	reader := NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, false, common.NewNoopMetrics())
+
+	readerResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 10)
+
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+}
+
+func (t *FileCacheReaderTest) TestReadWith_GeneticError() {
+	t.mockBucket.On("Name").Return("test-bucket")
+	reader := NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, false, common.NewNoopMetrics())
+
+	readerResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 10)
+
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+}
+
+// Writing unit tests on tryReadingFromFileCache to check if cache hit is getting populated correctly.
+func (t *FileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	buf := make([]byte, objectSize)
+	// First read will be a cache miss.
+	_, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
+	assert.False(t.T(), cacheHit)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), testContent, buf)
+
+	// Second read will be a cache hit.
+	_, cacheHit, err = t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
+	assert.True(t.T(), cacheHit)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), testContent, buf)
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_SequentialFullObject() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	buf := make([]byte, objectSize)
+	n, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
+
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), cacheHit)
+	assert.Equal(t.T(), n, len(buf))
+
+	n, cacheHit, err = t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
+
+	assert.NoError(t.T(), err)
+	assert.True(t.T(), cacheHit)
+	assert.Equal(t.T(), n, len(buf))
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	start := 0
+	end := 10
+	assert.Less(t.T(), end, int(objectSize))
+	buf := make([]byte, end-start)
+
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent[start:end])
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	t.object.Size = 20 * util.MiB
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	start1 := 0
+	end1 := util.MiB // not included
+	assert.Less(t.T(), end1, int(objectSize))
+	// First call from offset 0 - sequential read
+	buf := make([]byte, end1-start1)
+	_, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, int64(start1))
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), cacheHit)
+	assert.Equal(t.T(), buf, testContent[start1:end1])
+	start2 := 3*util.MiB + 4
+	end2 := start2 + util.MiB
+	buf2 := make([]byte, end2-start2)
+
+	// Assuming start2 offset download in progress
+	_, cacheHit, err = t.reader.tryReadingFromFileCache(t.ctx, buf2, int64(start2))
+
+	assert.NoError(t.T(), err)
+	assert.True(t.T(), cacheHit)
+	assert.Equal(t.T(), buf2, testContent[start2:end2])
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsFalse() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	t.reader.cacheFileForRangeRead = false
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	start := 5
+	end := 10 // not included
+	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
+	t.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rc)
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	buf := make([]byte, end-start)
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+	job := t.jobManager.CreateJobIfNotExists(t.object, t.mockBucket)
+	jobStatus := job.GetStatus()
+	assert.True(t.T(), jobStatus.Name == downloader.NotStarted)
+
+	readerResponse, err = t.reader.ReadAt(t.ctx, buf, int64(start))
+
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsTrue() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	t.reader.cacheFileForRangeRead = true
+	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
+	start := 5
+	end := 10 // not included
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
+	// Mock for random-reader's NewReader call
+	t.mockNewReaderWithHandleCallForTestBucket(uint64(start), t.object.Size, rd)
+	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	// Mock for download job's NewReader call
+	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd1)
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	buf := make([]byte, end-start)
+
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
+	assert.True(t.T(), job == nil || job.GetStatus().Name == downloader.Downloading)
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetMoreThanReadChunkSize() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	t.object.Size = 20 * util.MiB
+	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	// Mock for download job's NewReader call
+	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	start1 := 0
+	end1 := util.MiB // not included
+	assert.Less(t.T(), end1, int(t.object.Size))
+	// First call from offset 0 - sequential read
+	buf := make([]byte, end1-start1)
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start1))
+	// Served from file cache
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent[start1:end1])
+	start2 := 16*util.MiB + 4
+	end2 := start2 + util.MiB
+	rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
+	// Mock for random-reader's NewReader call
+	t.mockNewReaderWithHandleCallForTestBucket(uint64(start2), t.object.Size, rd2)
+	buf2 := make([]byte, end2-start2)
+
+	readerResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
+
+	// Assuming start2 offset download in progress
+	// require to fall back on GCS reader
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThanPrevious() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	t.object.Size = 20 * util.MiB
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	start1 := 0
+	end1 := util.MiB // not included
+	assert.Less(t.T(), end1, int(t.object.Size))
+	// First call from offset 0 - sequential read
+	buf := make([]byte, end1-start1)
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start1))
+	// Served from file cache
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent[start1:end1])
+	start2 := 16*util.MiB + 4
+	end2 := start2 + util.MiB
+	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
+	t.mockNewReaderWithHandleCallForTestBucket(uint64(start2), objectSize, rc2)
+	buf2 := make([]byte, end2-start2)
+	// Assuming start2 offset download in progress
+	readerResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
+	// Need to get served from GCS reader
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
+	start3 := util.MiB
+	end3 := start3 + util.MiB
+	buf3 := make([]byte, end3-start3)
+
+	readerResponse, err = t.reader.ReadAt(t.ctx, buf3, int64(start3))
+
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent[start3:end3])
+}
+
+func (t *FileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
+	t.reader.fileCacheHandler = t.cacheHandler
+	objectSize := t.object.Size
+	testContent := testutil.GenerateRandomBytes(int(objectSize))
+	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc1)
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	buf := make([]byte, objectSize)
+	readerResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
+	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
+	if job != nil {
+		jobStatus := job.GetStatus().Name
+		assert.True(t.T(), jobStatus == downloader.Downloading || jobStatus == downloader.Completed, fmt.Sprintf("the actual status is %v", jobStatus))
+	}
+
+	err = t.reader.fileCacheHandler.InvalidateCache(t.object.Name, t.mockBucket.Name())
+	assert.NoError(t.T(), err)
+
+	readerResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	// As job is invalidated Need to get served from GCS reader
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
+	assert.Zero(t.T(), readerResponse.Size)
 }

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -129,6 +129,7 @@ func (t *FileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	assert.Equal(t.T(), n, len(buf))
 }
 
+// Writing unit tests on tryReadingFromFileCache to check if cache hit is getting populated correctly.
 func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
 	t.object.Size = 20 * util.MiB
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -156,6 +157,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThan
 	assert.Equal(t.T(), buf2, testContent[start2:end2])
 }
 
+// Writing unit tests on tryReadingFromFileCache to check if cache hit is getting populated correctly.
 func (t *FileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -267,7 +269,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	// Need to get served from GCS reader
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
 	assert.Zero(t.T(), readerResponse.Size)
-	start3 := util.MiB
+	start3 := 4 * util.MiB
 	end3 := start3 + util.MiB
 	buf3 := make([]byte, end3-start3)
 

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v2/internal/util"
-	"github.com/jacobsa/fuse/fuseops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -72,12 +71,7 @@ func (t *FileCacheReaderTest) SetupTest() {
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, common.NewNoopMetrics())
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm)
 	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
-	readOp := &fuseops.ReadFileOp{
-		Handle: fuseops.HandleID(123),
-		Offset: 0,
-		Size:   10,
-	}
-	t.ctx = context.WithValue(context.Background(), ReadOp, readOp)
+	t.ctx = context.Background()
 }
 
 func (t *FileCacheReaderTest) TearDown() {
@@ -135,7 +129,6 @@ func (t *FileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 }
 
 func (t *FileCacheReaderTest) Test_ReadAt_SequentialFullObject() {
-
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
@@ -155,9 +148,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialFullObject() {
 }
 
 func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
-
 	t.object.Size = 20 * util.MiB
-
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
@@ -303,7 +294,6 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 }
 
 func (t *FileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
-
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc1)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -212,6 +212,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	assert.Zero(t.T(), readerResponse.Size)
 	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
 	assert.True(t.T(), job == nil || job.GetStatus().Name == downloader.Downloading)
+	assert.NotNil(t.T(), t.reader.fileCacheHandle)
 	t.mockBucket.AssertExpectations(t.T())
 }
 

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -264,9 +264,8 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	start2 := 16*util.MiB + 4
 	end2 := start2 + util.MiB
 	buf2 := make([]byte, end2-start2)
-	// Assuming start2 offset download in progress
+	// Assuming a download with a start offset of start2 is in progress, a fallback to another reader will be required.
 	readerResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
-	// Need to get served from another reader
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
 	assert.Zero(t.T(), readerResponse.Size)
 	// Assuming start3 offset is downloaded

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -104,7 +104,7 @@ func (t *FileCacheReaderTest) TestReadWithNilFileCacheHandler() {
 
 	readerResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 0)
 
-	assert.Error(t.T(), err)
+	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader))
 	assert.Zero(t.T(), readerResponse.Size)
 }
 
@@ -137,7 +137,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThan
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
 	start1 := 0
-	end1 := util.MiB // not included
+	end1 := util.MiB
 	assert.Less(t.T(), end1, int(t.object.Size))
 	// First call from offset 0 - sequential read
 	buf := make([]byte, end1-start1)
@@ -177,7 +177,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 func (t *FileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsFalse() {
 	t.reader.cacheFileForRangeRead = false
 	start := 5
-	end := 10 // not included
+	end := 10
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	buf := make([]byte, end-start)
@@ -198,7 +198,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	t.reader.cacheFileForRangeRead = true
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	start := 5
-	end := 10 // not included
+	end := 10
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd1)
@@ -223,7 +223,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start1 := 0
-	end1 := util.MiB // not included
+	end1 := util.MiB
 	assert.Less(t.T(), end1, int(t.object.Size))
 	// First call from offset 0 - sequential read
 	buf := make([]byte, end1-start1)
@@ -253,7 +253,7 @@ func (t *FileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start1 := 0
-	end1 := util.MiB // not included
+	end1 := util.MiB
 	assert.Less(t.T(), end1, int(t.object.Size))
 	// First call from offset 0 - sequential read
 	buf := make([]byte, end1-start1)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -99,7 +99,7 @@ func (t *fileCacheReaderTest) TestNewFileCacheReader() {
 	assert.Nil(t.T(), reader.fileCacheHandle)
 }
 
-func (t *fileCacheReaderTest) TestReadWithNilFileCacheHandler() {
+func (t *fileCacheReaderTest) Test_ReadAt_NilFileCacheHandlerThrowFallBackError() {
 	reader := NewFileCacheReader(t.object, t.mockBucket, nil, true, nil)
 
 	readerResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 0)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"strconv"
 	"time"
@@ -216,13 +215,12 @@ func (rr *randomReader) CheckInvariants() {
 // fileHandle to file in cache. So, we will get the correct data from fileHandle
 // because Linux does not delete a file until open fileHandle count for a file is zero.
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
-	p []byte,
-	offset int64) (n int, cacheHit bool, err error) {
+		p []byte,
+		offset int64) (n int, cacheHit bool, err error) {
+
 	if rr.fileCacheHandler == nil {
 		return
 	}
-
-	log.Println("In tryReadingFromFileCache")
 
 	// By default, consider read type random if the offset is non-zero.
 	isSeq := offset == 0
@@ -310,9 +308,9 @@ func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHand
 }
 
 func (rr *randomReader) ReadAt(
-	ctx context.Context,
-	p []byte,
-	offset int64) (objectData ObjectData, err error) {
+		ctx context.Context,
+		p []byte,
+		offset int64) (objectData ObjectData, err error) {
 	objectData = ObjectData{
 		DataBuf:  p,
 		CacheHit: false,
@@ -434,8 +432,8 @@ func (rr *randomReader) Destroy() {
 //
 // REQUIRES: rr.reader != nil
 func (rr *randomReader) readFull(
-	ctx context.Context,
-	p []byte) (n int, err error) {
+		ctx context.Context,
+		p []byte) (n int, err error) {
 	// Start a goroutine that will cancel the read operation we block on below if
 	// the calling context is cancelled, but only if this method has not already
 	// returned (to avoid souring the reader for the next read if this one is
@@ -517,8 +515,8 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 // Range here is [start, end]. End is computed using the readType, start offset
 // and size of the data the callers needs.
 func (rr *randomReader) getReadInfo(
-	start int64,
-	size int64) (end int64, err error) {
+		start int64,
+		size int64) (end int64, err error) {
 	// Make sure start and size are legal.
 	if start < 0 || uint64(start) > rr.object.Size || size < 0 {
 		err = fmt.Errorf(

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -295,16 +294,6 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	err = nil
 
 	return
-}
-
-func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
-	metricHandle.FileCacheReadCount(ctx, 1, []common.MetricAttr{
-		{Key: common.ReadType, Value: readType},
-		{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)},
-	})
-
-	metricHandle.FileCacheReadBytesCount(ctx, int64(readDataSize), []common.MetricAttr{{Key: common.ReadType, Value: readType}})
-	metricHandle.FileCacheReadLatency(ctx, float64(readLatency.Microseconds()), []common.MetricAttr{{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)}})
 }
 
 func (rr *randomReader) ReadAt(

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"strconv"
 	"time"
@@ -217,10 +218,11 @@ func (rr *randomReader) CheckInvariants() {
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 	p []byte,
 	offset int64) (n int, cacheHit bool, err error) {
-
 	if rr.fileCacheHandler == nil {
 		return
 	}
+
+	log.Println("In tryReadingFromFileCache")
 
 	// By default, consider read type random if the offset is non-zero.
 	isSeq := offset == 0

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -215,8 +215,8 @@ func (rr *randomReader) CheckInvariants() {
 // fileHandle to file in cache. So, we will get the correct data from fileHandle
 // because Linux does not delete a file until open fileHandle count for a file is zero.
 func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
-		p []byte,
-		offset int64) (n int, cacheHit bool, err error) {
+	p []byte,
+	offset int64) (n int, cacheHit bool, err error) {
 
 	if rr.fileCacheHandler == nil {
 		return
@@ -308,9 +308,9 @@ func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHand
 }
 
 func (rr *randomReader) ReadAt(
-		ctx context.Context,
-		p []byte,
-		offset int64) (objectData ObjectData, err error) {
+	ctx context.Context,
+	p []byte,
+	offset int64) (objectData ObjectData, err error) {
 	objectData = ObjectData{
 		DataBuf:  p,
 		CacheHit: false,
@@ -432,8 +432,8 @@ func (rr *randomReader) Destroy() {
 //
 // REQUIRES: rr.reader != nil
 func (rr *randomReader) readFull(
-		ctx context.Context,
-		p []byte) (n int, err error) {
+	ctx context.Context,
+	p []byte) (n int, err error) {
 	// Start a goroutine that will cancel the read operation we block on below if
 	// the calling context is cancelled, but only if this method has not already
 	// returned (to avoid souring the reader for the next read if this one is
@@ -515,8 +515,8 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 // Range here is [start, end]. End is computed using the readType, start offset
 // and size of the data the callers needs.
 func (rr *randomReader) getReadInfo(
-		start int64,
-		size int64) (end int64, err error) {
+	start int64,
+	size int64) (end int64, err error) {
 	// Make sure start and size are legal.
 	if start < 0 || uint64(start) > rr.object.Size || size < 0 {
 		err = fmt.Errorf(

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -72,7 +72,7 @@ func (t *RandomReaderStretchrTest) SetupTest() {
 	t.mockBucket = new(storage.TestifyMockBucket)
 
 	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
-	lruCache := lru.NewCache(CacheMaxSize)
+	lruCache := lru.NewCache(cacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{
 		EnableCrc: false,
 	}, nil)

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -175,7 +175,7 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	t.bucket = storage.NewMockBucket(ti.MockController, "bucket")
 
 	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
-	lruCache := lru.NewCache(CacheMaxSize)
+	lruCache := lru.NewCache(cacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{
 		EnableCrc: false,
 	}, common.NewNoopMetrics())


### PR DESCRIPTION
### Description
1. Implemented the ReadAt method for the file cache reader, utilizing the helper function tryReadingFromCache.
2. Unit tests cover the following scenarios:  
   i. Nil file cache handler 
   ii. Cache hit and data population from cache on subsequent reads 
   iii. Cache hit and data population from cache on subsequent reads (next offset from the first read) 
   iv. Sequential range read 
   v. When cacheRangeRead is false, an ErrFallbackToGCS error is returned, triggering a fallback to another reader. 
   vi. When the cacheRangeRead flag is true, the file is downloaded into the cache. 
   vii. Receiving ErrFallbackToGCS error. 
   viii. Receiving ErrInvalidFileDownloadJob error.
   ix. Sequential to Random SubsequentRead Offset less than previous
   x. Sequential to Random SubsequentRead Offset More than ReadChunkSize

**Please note that I will add more unit tests in a follow-up pull request to manage the size of this current PR.**

### Link to the issue in case of a bug fix.
[b/411086522](https://b.corp.google.com/issues/411086522)

### Testing details
1. Manual - NA
4. Unit tests - Added
5. Integration tests - NA

### Any backward incompatible change? If so, please explain.
