### PR TITLE
add unfinalized object operations tests 

### DIFF
--- a/internal/fs/stale_file_handle_common_test.go
+++ b/internal/fs/stale_file_handle_common_test.go
@@ -105,9 +105,9 @@ func (t *staleFileHandleCommon) TestClobberedFileSyncAndCloseThrowsStaleFileHand
 
 	err = t.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.
 	t.f1 = nil

--- a/internal/fs/stale_file_handle_streaming_writes_common_test.go
+++ b/internal/fs/stale_file_handle_streaming_writes_common_test.go
@@ -73,7 +73,7 @@ func (t *staleFileHandleStreamingWritesCommon) TestWriteFileSyncFileClobberedFlu
 
 	err = t.f1.Close()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.
 	t.f1 = nil

--- a/internal/fs/stale_file_handle_streaming_writes_local_file_test.go
+++ b/internal/fs/stale_file_handle_streaming_writes_local_file_test.go
@@ -53,11 +53,11 @@ func (t *staleFileHandleStreamingWritesLocalFile) TestClobberedWriteFileSyncAndC
 
 	_, err = t.f1.WriteAt(data, 0)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Sync()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.
 	t.f1 = nil

--- a/internal/fs/stale_file_handle_streaming_writes_synced_file_test.go
+++ b/internal/fs/stale_file_handle_streaming_writes_synced_file_test.go
@@ -55,7 +55,7 @@ func (t *staleFileHandleStreamingWritesSyncedFile) TestWriteToClobberedFileThrow
 
 	_, err = t.f1.WriteAt(data, 0)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Sync()
 	assert.NoError(t.T(), err)
 	err = t.f1.Close()
@@ -79,7 +79,7 @@ func (t *staleFileHandleStreamingWritesSyncedFile) TestRenameFileWriteThrowsStal
 
 	_, err = t.f1.WriteAt(data, 0)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Sync()
 	assert.NoError(t.T(), err)
 	err = t.f1.Close()

--- a/internal/fs/stale_file_handle_synced_file_test.go
+++ b/internal/fs/stale_file_handle_synced_file_test.go
@@ -53,7 +53,7 @@ func (t *staleFileHandleSyncedFile) TestClobberedFileReadThrowsStaleFileHandleEr
 	buffer := make([]byte, 6)
 	_, err := t.f1.Read(buffer)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Validate that object is updated with new content.
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
 	assert.NoError(t.T(), err)
@@ -66,7 +66,7 @@ func (t *staleFileHandleSyncedFile) TestClobberedFileFirstWriteThrowsStaleFileHa
 
 	_, err := t.f1.Write([]byte("taco"))
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Attempt to sync to file should not result in error as we first check if the
 	// content has been dirtied before clobbered check in Sync flow.
 	err = t.f1.Sync()
@@ -92,9 +92,9 @@ func (t *staleFileHandleSyncedFile) TestRenamedFileSyncThrowsStaleFileHandleErro
 
 	err = t.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.
 	t.f1 = nil
@@ -118,9 +118,9 @@ func (t *staleFileHandleSyncedFile) TestFileDeletedRemotelySyncAndCloseThrowsSta
 
 	err = t.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	err = t.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Make f1 nil, so that another attempt is not taken in TearDown to close the
 	// file.
 	t.f1 = nil

--- a/tools/integration_tests/local_file/create_file.go
+++ b/tools/integration_tests/local_file/create_file.go
@@ -55,7 +55,7 @@ func (t *CommonLocalFileTestSuite) TestCreateNewFileWhenSameFileExistsOnGCS() {
 	operations.WriteWithoutClose(fh, FileContents, t.T())
 	// Validate closing local file throws error.
 	err := fh.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	//  Ensure that the content on GCS is not overwritten.
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, FileName1, GCSFileContent, t.T())
 }

--- a/tools/integration_tests/local_file/read_dir.go
+++ b/tools/integration_tests/local_file/read_dir.go
@@ -175,7 +175,7 @@ func (t *CommonLocalFileTestSuite) TestReadDirWithSameNameLocalAndGCSFile() {
 
 	// Validate closing local file throws error.
 	err = fh1.Close()
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 }
 
 func (t *CommonLocalFileTestSuite) TestConcurrentReadDirAndCreationOfLocalFiles_DoesNotThrowError() {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -141,6 +141,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "stale_handle"
   # "streaming_writes"
   "write_large_files"
+  "unfinalized_object"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,

--- a/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
@@ -47,9 +47,9 @@ func (s *staleFileHandleCommon) TestClobberedFileSyncAndCloseThrowsStaleFileHand
 
 	err = s.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 	err = s.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 }
 
 func (s *staleFileHandleCommon) TestFileDeletedLocallySyncAndCloseDoNotThrowError() {

--- a/tools/integration_tests/stale_handle/stale_file_handle_synced_file_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_synced_file_test.go
@@ -60,7 +60,7 @@ func (s *staleFileHandleSyncedFile) TestClobberedFileReadThrowsStaleFileHandleEr
 	buffer := make([]byte, GCSFileSize)
 	_, err = s.f1.Read(buffer)
 
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 }
 
 func (s *staleFileHandleSyncedFile) TestClobberedFileFirstWriteThrowsStaleFileHandleError() {
@@ -70,7 +70,7 @@ func (s *staleFileHandleSyncedFile) TestClobberedFileFirstWriteThrowsStaleFileHa
 
 	_, err = s.f1.WriteString(Content)
 
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 	// Attempt to sync to file should not result in error as we first check if the
 	// content has been dirtied before clobbered check in Sync flow.
 	operations.SyncFile(s.f1, s.T())
@@ -88,9 +88,9 @@ func (s *staleFileHandleSyncedFile) TestRenamedFileSyncAndCloseThrowsStaleFileHa
 
 	err = s.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 	err = s.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 }
 
 func (s *staleFileHandleSyncedFile) TestFileDeletedRemotelySyncAndCloseThrowsStaleFileHandleError() {
@@ -107,9 +107,9 @@ func (s *staleFileHandleSyncedFile) TestFileDeletedRemotelySyncAndCloseThrowsSta
 
 	err = s.f1.Sync()
 
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 	err = s.f1.Close()
-	operations.ValidateStaleNFSFileHandleError(s.T(), err)
+	operations.ValidateESTALEError(s.T(), err)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_common_test.go
@@ -86,6 +86,6 @@ func (t *staleFileHandleStreamingWritesCommon) TestClosingFileHandleForClobbered
 	// Closing the file/writer returns stale NFS file handle error.
 	err = t.f1.Close()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, FileContents, t.T())
 }

--- a/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
+++ b/tools/integration_tests/stale_handle_streaming_writes/stale_file_handle_streaming_writes_empty_gcs_file_test.go
@@ -59,7 +59,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFirstWriteToClobberedFi
 	// Attempt first write to the file.
 	_, err = t.f1.WriteAt([]byte(t.data), 0)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	operations.SyncFile(t.f1, t.T())
 	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
 }
@@ -75,7 +75,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestWriteOnRenamedFileThrow
 	// Attempt to write to file should give stale NFS file handle erorr.
 	_, err = t.f1.WriteAt([]byte(t.data), int64(n))
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Sync and Close succeeds.
 	operations.SyncFile(t.f1, t.T())
 	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
@@ -98,7 +98,7 @@ func (t *staleFileHandleStreamingWritesEmptyGcsFile) TestFileDeletedRemotelyWrit
 	// Closing the file/writer returns stale NFS file handle error.
 	err = t.f1.Close()
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
 }
 

--- a/tools/integration_tests/streaming_writes/rename_file_test.go
+++ b/tools/integration_tests/streaming_writes/rename_file_test.go
@@ -79,7 +79,7 @@ func (t *defaultMountCommonTest) TestAfterRenameWriteFailsWithStaleNFSFileHandle
 
 	_, err = t.f1.WriteAt(data, operations.MiB*4)
 
-	operations.ValidateStaleNFSFileHandleError(t.T(), err)
+	operations.ValidateESTALEError(t.T(), err)
 	// Verify the new object contents.
 	ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, newFile, string(data), t.T())
 	require.NoError(t.T(), t.f1.Close())

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	testDirName    = "UnfinalizedObjectTest"
-	onlyDirMounted = "OnlyDirMountedUnfinalizedObject"
+	testDirName = "UnfinalizedObjectTest"
 )
 
 var (

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unfinalized_object
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName    = "UnfinalizedObjectTest"
+	onlyDirMounted = "OnlyDirMountedUnfinalizedObject"
+)
+
+var (
+	mountFunc func([]string) error
+)
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as operations tests validates content from the bucket.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		setup.RunTestsForMountedDirectoryFlag(m)
+	}
+
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unfinalized_object
+
+import (
+	"context"
+	"log"
+	"path"
+	"syscall"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type unfinalizedObjectOperations struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	suite.Suite
+}
+
+func (t *unfinalizedObjectOperations) SetupTest() {
+	t.testDirPath = client.SetupTestDirectory(t.ctx, t.storageClient, testDirName)
+}
+
+func (t *unfinalizedObjectOperations) TeardownTest() {}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedOutsideOfMountReports0Size() {
+	fileName := path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	var size int64 = operations.MiB
+	writer := client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, fileName), size)
+
+	statRes, err := operations.StatFile(path.Join(t.testDirPath, fileName))
+
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), fileName, (*statRes).Name())
+	assert.EqualValues(t.T(), 0, (*statRes).Size())
+	// After object is finalized, correct size should be reported.
+	err = writer.Close()
+	require.NoError(t.T(), err)
+	statRes, err = operations.StatFile(path.Join(t.testDirPath, fileName))
+	require.NoError(t.T(), err)
+	assert.EqualValues(t.T(), size, (*statRes).Size())
+}
+
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedFromSameMountReportsCorrectSize() {
+	fileName := path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	size := operations.MiB
+	// Create un-finalized object via same mount.
+	fh := operations.CreateFile(path.Join(t.testDirPath, fileName), setup.FilePermission_0600, t.T())
+	operations.WriteWithoutClose(fh, setup.GenerateRandomString(size), t.T())
+	operations.SyncFile(fh, t.T())
+
+	statRes, err := operations.StatFile(path.Join(t.testDirPath, fileName))
+
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), fileName, (*statRes).Name())
+	assert.EqualValues(t.T(), size, (*statRes).Size())
+	// Write more data to the object and finalize.
+	operations.WriteWithoutClose(fh, setup.GenerateRandomString(size), t.T())
+	err = fh.Close()
+	require.NoError(t.T(), err)
+	// After object is finalized, correct size should be reported.
+	statRes, err = operations.StatFile(path.Join(t.testDirPath, fileName))
+	require.NoError(t.T(), err)
+	assert.EqualValues(t.T(), 2*size, (*statRes).Size())
+}
+
+func (t *unfinalizedObjectOperations) TestOverWritingUnfinalizedObjectsReturnsESTALE() {
+	fileName := path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	var size int64 = operations.MiB
+	_ = client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, fileName), size)
+	fh := operations.OpenFile(path.Join(t.testDirPath, fileName), t.T())
+
+	// Overwrite unfinalized object.
+	operations.WriteWithoutClose(fh, setup.GenerateRandomString(int(size)), t.T())
+	err := fh.Close()
+
+	operations.ValidateESTALEError(t.T(), err)
+}
+
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCanBeRenamedIfCreatedFromSameMount() {
+	fileName := path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	size := operations.MiB
+	content := setup.GenerateRandomString(size)
+	newFileName := "new" + fileName
+	// Create un-finalized object via same mount.
+	fh := operations.CreateFile(path.Join(t.testDirPath, fileName), setup.FilePermission_0600, t.T())
+	operations.WriteWithoutClose(fh, content, t.T())
+	operations.SyncFile(fh, t.T())
+
+	err := operations.RenameFile(path.Join(t.testDirPath, fileName), path.Join(t.testDirPath, newFileName))
+
+	require.NoError(t.T(), err)
+	client.ValidateObjectNotFoundErrOnGCS(t.ctx, t.storageClient, testDirName, fileName, t.T())
+	client.ValidateObjectContentsFromGCS(t.ctx, t.storageClient, testDirName, newFileName, content, t.T())
+	// validate writing to the renamed file via stale file handle returns ESTALE error.
+	_, err = fh.Write([]byte(content))
+	operations.ValidateESTALEError(t.T(), err)
+}
+
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCantBeRenamedIfCreatedFromDifferentMount() {
+	fileName := path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	var size int64 = operations.MiB
+	_ = client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, fileName), size)
+
+	// Overwrite unfinalized object.
+	err := operations.RenameFile(path.Join(t.testDirPath, fileName), path.Join(t.testDirPath, "New"+fileName))
+
+	require.Error(t.T(), err)
+	assert.ErrorContains(t.T(), err, syscall.EIO.Error())
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestUnfinalizedObjectOperationTest(t *testing.T) {
+	ts := &unfinalizedObjectOperations{ctx: context.Background()}
+	// Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&ts.ctx, &ts.storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			t.Errorf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		suite.Run(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--enable-streaming-writes=true", "--metadata-cache-ttl-secs=0"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
+	}
+}

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -170,9 +170,9 @@ func CreateUnfinalizedObject(ctx context.Context, t *testing.T, client *storage.
 	writer, err := AppendableWriter(ctx, client, object, storage.Conditions{})
 	require.NoError(t, err)
 
-	writeOffset, err := writer.Write([]byte(setup.GenerateRandomString(int(size))))
+	bytesWritten, err := writer.Write([]byte(setup.GenerateRandomString(int(size))))
 	require.NoError(t, err)
-	assert.EqualValues(t, size, writeOffset)
+	assert.EqualValues(t, size, bytesWritten)
 
 	flushOffset, err := writer.Flush()
 	require.NoError(t, err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -410,3 +410,19 @@ func DeleteBucket(ctx context.Context, client *storage.Client, bucketName string
 	}
 	return nil
 }
+
+func AppendableWriter(ctx context.Context, client *storage.Client, object string, precondition storage.Conditions) (*storage.Writer, error) {
+	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
+
+	o := client.Bucket(bucket).Object(object)
+	if !reflect.DeepEqual(precondition, storage.Conditions{}) {
+		o = o.If(precondition)
+	}
+
+	// Upload an object with storage.Writer.
+	wc, err := NewWriter(ctx, o, client)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to open writer for object %q: %w", o.ObjectName(), err)
+	}
+	return wc, nil
+}

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -422,7 +422,7 @@ func AppendableWriter(ctx context.Context, client *storage.Client, object string
 	// Upload an object with storage.Writer.
 	wc, err := NewWriter(ctx, o, client)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open writer for object %q: %w", o.ObjectName(), err)
+		return nil, fmt.Errorf("failed to open writer for object %q: %w", o.ObjectName(), err)
 	}
 	return wc, nil
 }

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ValidateNoFileOrDirError(t *testing.T, path string) {
@@ -46,8 +47,8 @@ func ValidateObjectNotFoundErr(ctx context.Context, t *testing.T, bucket gcs.Buc
 	assert.True(t, errors.As(err, &notFoundErr))
 }
 
-func ValidateStaleNFSFileHandleError(t *testing.T, err error) {
-	assert.NotEqual(t, nil, err)
+func ValidateESTALEError(t *testing.T, err error) {
+	require.Error(t, err)
 	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
 }
 


### PR DESCRIPTION
### Description
Add e2e tests for operations on unfinalized object.
This PR is copy of PR #3139

### Link to the issue in case of a bug fix.
b/407959986

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - added

### Any backward incompatible change? If so, please explain.
No
