### PR TITLE
Changes in mount_timeout package for ZB E2E

### DIFF
--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -41,10 +41,10 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSCentral1A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket:   zonalUSCentral1ABucket,
-				crossZoneBucket:  zonalUSWest4ABucket,
-				sameZoneTimeout:  zonalSameZoneExpectedMountTime,
-				crossZoneTimeout: zonalCrossZoneExpectedMountTime,
+				sameRegionZonalBucket:   zonalUSCentral1ABucket,
+				crossRegionZonalBucket:  zonalUSWest4ABucket,
+				sameRegionMountTimeout:  zonalSameRegionExpectedMountTime,
+				crossRegionMountTimeout: zonalCrossRegionExpectedMountTime,
 			}
 			t.Log("Running tests with region based timeout values since the GCE VM is located in us-central...\n")
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
@@ -52,10 +52,10 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSWEST4A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket:   zonalUSWest4ABucket,
-				crossZoneBucket:  zonalUSCentral1ABucket,
-				sameZoneTimeout:  relaxedExpectedMountTime,
-				crossZoneTimeout: relaxedExpectedMountTime,
+				sameRegionZonalBucket:   zonalUSWest4ABucket,
+				crossRegionZonalBucket:  zonalUSCentral1ABucket,
+				sameRegionMountTimeout:  relaxedExpectedMountTime,
+				crossRegionMountTimeout: relaxedExpectedMountTime,
 			}
 			t.Logf("Running tests with relaxed timeout of %f sec for all scenarios since the GCE VM is not located in us-central...\n", relaxedExpectedMountTime.Seconds())
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
@@ -108,10 +108,10 @@ type RegionWiseTimeouts struct {
 }
 
 type ZBMountTimeoutTestCaseConfig struct {
-	sameZoneBucket   string
-	crossZoneBucket  string
-	sameZoneTimeout  time.Duration
-	crossZoneTimeout time.Duration
+	sameRegionZonalBucket   string
+	crossRegionZonalBucket  string
+	sameRegionMountTimeout  time.Duration
+	crossRegionMountTimeout time.Duration
 }
 
 type MountTimeoutTest struct {
@@ -352,33 +352,15 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeo
 }
 
 func (testSuite *ZBMountTimeoutTest) TestMountSameRegionZonalBucketWithTimeout() {
-	testCases := []struct {
-		name string
-	}{
-		{
-			name: "sameRegionZonalBucket",
-		},
-	}
-	for _, tc := range testCases {
-		setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, tc.name))
+	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "SameRegionZonalBucket"))
 
-		err := testSuite.mountOrTimeout(testSuite.config.sameZoneBucket, testSuite.dir, cfg.GRPC, testSuite.config.sameZoneTimeout)
-		assert.NoError(testSuite.T(), err)
-	}
+	err := testSuite.mountOrTimeout(testSuite.config.sameRegionZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.sameRegionMountTimeout)
+	assert.NoError(testSuite.T(), err)
 }
 
 func (testSuite *ZBMountTimeoutTest) TestMountCrossRegionZonalBucketWithTimeout() {
-	testCases := []struct {
-		name string
-	}{
-		{
-			name: "crossRegionZonalBucket",
-		},
-	}
-	for _, tc := range testCases {
-		setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, tc.name))
+	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "CrossRegionZonalBucket"))
 
-		err := testSuite.mountOrTimeout(testSuite.config.crossZoneBucket, testSuite.dir, cfg.GRPC, testSuite.config.crossZoneTimeout)
-		assert.NoError(testSuite.T(), err)
-	}
+	err := testSuite.mountOrTimeout(testSuite.config.crossRegionZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.crossRegionMountTimeout)
+	assert.NoError(testSuite.T(), err)
 }

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -46,7 +46,7 @@ func TestMountTimeout(t *testing.T) {
 				sameZoneTimeout:  zonalSameZoneExpectedMountTime,
 				crossZoneTimeout: zonalCrossZoneExpectedMountTime,
 			}
-			t.Logf("Running tests with zone %q ...\n", zone)
+			t.Log("Running tests with region based timeout values since the GCE VM is located in us-central...\n")
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
 			break
 		case testEnvZoneGCEUSWEST4A:
@@ -57,12 +57,12 @@ func TestMountTimeout(t *testing.T) {
 				sameZoneTimeout:  relaxedExpectedMountTime,
 				crossZoneTimeout: relaxedExpectedMountTime,
 			}
-			t.Logf("Running tests with zone %q ...\n", zone)
+			t.Logf("Running tests with relaxed timeout of %f sec for all scenarios since the GCE VM is not located in us-central...\n", relaxedExpectedMountTime.Seconds())
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
 			break
 		default:
 			// Skip the tests if the testing environment is not GCE VM.
-			t.Logf("Skipping tests since the testing environment zone (%q) is not a ZB supported zone...\n", zone)
+			t.Logf("Skipping tests since the testing environment (%q) is not a ZB supported region...\n", zone)
 			t.Skip()
 		}
 	} else {
@@ -173,7 +173,6 @@ func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientPr
 			return err
 		}
 		mountTime := time.Since(start)
-		fmt.Println("time taken to mount bucket ", bucketName, ": ", mountTime)
 
 		minMountTime = time.Duration(math.Min(float64(minMountTime), float64(mountTime)))
 
@@ -352,12 +351,12 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeo
 	}
 }
 
-func (testSuite *ZBMountTimeoutTest) TestMountSameZoneBucketWithTimeout() {
+func (testSuite *ZBMountTimeoutTest) TestMountSameRegionZonalBucketWithTimeout() {
 	testCases := []struct {
 		name string
 	}{
 		{
-			name: "sameZoneBucket",
+			name: "sameRegionZonalBucket",
 		},
 	}
 	for _, tc := range testCases {
@@ -368,12 +367,12 @@ func (testSuite *ZBMountTimeoutTest) TestMountSameZoneBucketWithTimeout() {
 	}
 }
 
-func (testSuite *ZBMountTimeoutTest) TestMountCrossZoneBucketWithTimeout() {
+func (testSuite *ZBMountTimeoutTest) TestMountCrossRegionZonalBucketWithTimeout() {
 	testCases := []struct {
 		name string
 	}{
 		{
-			name: "crossZoneBucket",
+			name: "crossRegionZonalBucket",
 		},
 	}
 	for _, tc := range testCases {

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -44,9 +44,9 @@ func TestMountTimeout(t *testing.T) {
 				sameZoneBucket:   zonalUSCentral1ABucket,
 				crossZoneBucket:  zonalUSWest4ABucket,
 				sameZoneTimeout:  zonalSameZoneExpectedMountTime,
-				crossZoneTimeout: relaxedExpectedMountTime,
+				crossZoneTimeout: zonalCrossZoneExpectedMountTime,
 			}
-			t.Log("Running tests with zone %q ...\n", zone)
+			t.Logf("Running tests with zone %q ...\n", zone)
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
 			break
 		case testEnvZoneGCEUSWEST4A:
@@ -57,12 +57,12 @@ func TestMountTimeout(t *testing.T) {
 				sameZoneTimeout:  relaxedExpectedMountTime,
 				crossZoneTimeout: relaxedExpectedMountTime,
 			}
-			t.Log("Running tests with zone %q ...\n", zone)
+			t.Logf("Running tests with zone %q ...\n", zone)
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
 			break
 		default:
 			// Skip the tests if the testing environment is not GCE VM.
-			t.Log("Skipping tests since the testing environment zone (%q) is not a ZB supported zone...\n", zone)
+			t.Logf("Skipping tests since the testing environment zone (%q) is not a ZB supported zone...\n", zone)
 			t.Skip()
 		}
 	} else {

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -48,7 +48,6 @@ func TestMountTimeout(t *testing.T) {
 			}
 			t.Log("Running tests with region based timeout values since the GCE VM is located in us-central...\n")
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
-			break
 		case testEnvZoneGCEUSWEST4A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
@@ -59,7 +58,6 @@ func TestMountTimeout(t *testing.T) {
 			}
 			t.Logf("Running tests with relaxed timeout of %f sec for all scenarios since the GCE VM is not located in us-central...\n", relaxedExpectedMountTime.Seconds())
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
-			break
 		default:
 			// Skip the tests if the testing environment is not GCE VM.
 			t.Logf("Skipping tests since the testing environment (%q) is not a ZB supported region...\n", zone)

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -41,20 +41,20 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSCentral1A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameRegionZonalBucket:   zonalUSCentral1ABucket,
-				crossRegionZonalBucket:  zonalUSWest4ABucket,
-				sameRegionMountTimeout:  zonalSameRegionExpectedMountTime,
-				crossRegionMountTimeout: zonalCrossRegionExpectedMountTime,
+				sameZoneZonalBucket:   zonalUSCentral1ABucket,
+				crossZoneZonalBucket:  zonalUSWest4ABucket,
+				sameZoneMountTimeout:  zonalSameZoneExpectedMountTime,
+				crossZoneMountTimeout: zonalCrossZoneExpectedMountTime,
 			}
 			t.Log("Running tests with region based timeout values since the GCE VM is located in us-central...\n")
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
 		case testEnvZoneGCEUSWEST4A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameRegionZonalBucket:   zonalUSWest4ABucket,
-				crossRegionZonalBucket:  zonalUSCentral1ABucket,
-				sameRegionMountTimeout:  relaxedExpectedMountTime,
-				crossRegionMountTimeout: relaxedExpectedMountTime,
+				sameZoneZonalBucket:   zonalUSWest4ABucket,
+				crossZoneZonalBucket:  zonalUSCentral1ABucket,
+				sameZoneMountTimeout:  relaxedExpectedMountTime,
+				crossZoneMountTimeout: relaxedExpectedMountTime,
 			}
 			t.Logf("Running tests with relaxed timeout of %f sec for all scenarios since the GCE VM is not located in us-central...\n", relaxedExpectedMountTime.Seconds())
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
@@ -106,10 +106,10 @@ type RegionWiseTimeouts struct {
 }
 
 type ZBMountTimeoutTestCaseConfig struct {
-	sameRegionZonalBucket   string
-	crossRegionZonalBucket  string
-	sameRegionMountTimeout  time.Duration
-	crossRegionMountTimeout time.Duration
+	sameZoneZonalBucket   string
+	crossZoneZonalBucket  string
+	sameZoneMountTimeout  time.Duration
+	crossZoneMountTimeout time.Duration
 }
 
 type MountTimeoutTest struct {
@@ -349,16 +349,16 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeo
 	}
 }
 
-func (testSuite *ZBMountTimeoutTest) TestMountSameRegionZonalBucketWithTimeout() {
-	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "SameRegionZonalBucket"))
+func (testSuite *ZBMountTimeoutTest) TestMountSameZoneZonalBucketWithTimeout() {
+	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "SameZoneZonalBucket"))
 
-	err := testSuite.mountOrTimeout(testSuite.config.sameRegionZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.sameRegionMountTimeout)
+	err := testSuite.mountOrTimeout(testSuite.config.sameZoneZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.sameZoneMountTimeout)
 	assert.NoError(testSuite.T(), err)
 }
 
-func (testSuite *ZBMountTimeoutTest) TestMountCrossRegionZonalBucketWithTimeout() {
-	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "CrossRegionZonalBucket"))
+func (testSuite *ZBMountTimeoutTest) TestMountCrossZoneZonalBucketWithTimeout() {
+	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "CrossZoneZonalBucket"))
 
-	err := testSuite.mountOrTimeout(testSuite.config.crossRegionZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.crossRegionMountTimeout)
+	err := testSuite.mountOrTimeout(testSuite.config.crossZoneZonalBucket, testSuite.dir, cfg.GRPC, testSuite.config.crossZoneMountTimeout)
 	assert.NoError(testSuite.T(), err)
 }

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -41,8 +41,8 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSCentral1A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket: zonalUSCentral1ABucket
-				crossZoneBucket: zonalUSWest4ABucket
+				sameZoneBucket: zonalUSCentral1ABucket,
+				crossZoneBucket: zonalUSWest4ABucket,
 				sameZoneTimeout:  zonalSameZoneExpectedMountTime,
 				zonalCrossZoneTimeout: relaxedExpectedMountTime,
 			}
@@ -52,8 +52,8 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSWEST4A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket: zonalUSWest4ABucket
-				crossZoneBucket: zonalUSCentral1ABucket
+				sameZoneBucket: zonalUSWest4ABucket,
+				crossZoneBucket: zonalUSCentral1ABucket,
 				sameZoneTimeout:  relaxedExpectedMountTime,
 				zonalCrossZoneTimeout: relaxedExpectedMountTime,
 			}
@@ -186,6 +186,13 @@ func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientPr
 		return fmt.Errorf("[Client Protocol: %s] Mounting failed due to timeout (exceeding %f seconds). Time taken for mounting %s: %f sec", clientProtocol, expectedMountTime.Seconds(), bucketName, minMountTime.Seconds())
 	}
 	return nil
+}
+
+func (testSuite *NonZBMountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientProtocol string, expectedMountTime time.Duration) error {
+	return testSuite.MountTimeoutTest.mountOrTimeout(bucketName, mountDir, clientProtocol, expectedMountTime)
+}
+func (testSuite *ZBMountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientProtocol string, expectedMountTime time.Duration) error {
+	return testSuite.MountTimeoutTest.mountOrTimeout(bucketName, mountDir, clientProtocol, expectedMountTime)
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountMultiRegionUSBucketWithTimeout() {

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -173,6 +173,7 @@ func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, mountDir, clientPr
 			return err
 		}
 		mountTime := time.Since(start)
+		fmt.Println("time taken to mount bucket ", bucketName, ": ", mountTime)
 
 		minMountTime = time.Duration(math.Min(float64(minMountTime), float64(mountTime)))
 

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -36,7 +36,7 @@ const (
 
 func TestMountTimeout(t *testing.T) {
 	if setup.IsZonalBucketRun() {
-		zone := os.Getenv("TEST_ENV_ZONE")
+		zone := os.Getenv("TEST_ENV")
 		switch zone {
 		case testEnvZoneGCEUSCentral1A:
 			// Set strict zone-based config values.

--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -41,10 +41,10 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSCentral1A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket: zonalUSCentral1ABucket,
-				crossZoneBucket: zonalUSWest4ABucket,
+				sameZoneBucket:   zonalUSCentral1ABucket,
+				crossZoneBucket:  zonalUSWest4ABucket,
 				sameZoneTimeout:  zonalSameZoneExpectedMountTime,
-				zonalCrossZoneTimeout: relaxedExpectedMountTime,
+				crossZoneTimeout: relaxedExpectedMountTime,
 			}
 			t.Log("Running tests with zone %q ...\n", zone)
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
@@ -52,10 +52,10 @@ func TestMountTimeout(t *testing.T) {
 		case testEnvZoneGCEUSWEST4A:
 			// Set strict zone-based config values.
 			config := ZBMountTimeoutTestCaseConfig{
-				sameZoneBucket: zonalUSWest4ABucket,
-				crossZoneBucket: zonalUSCentral1ABucket,
+				sameZoneBucket:   zonalUSWest4ABucket,
+				crossZoneBucket:  zonalUSCentral1ABucket,
 				sameZoneTimeout:  relaxedExpectedMountTime,
-				zonalCrossZoneTimeout: relaxedExpectedMountTime,
+				crossZoneTimeout: relaxedExpectedMountTime,
 			}
 			t.Log("Running tests with zone %q ...\n", zone)
 			suite.Run(t, &ZBMountTimeoutTest{config: config})
@@ -108,10 +108,10 @@ type RegionWiseTimeouts struct {
 }
 
 type ZBMountTimeoutTestCaseConfig struct {
-	sameZoneBucket string
-	crossZoneBucket string
+	sameZoneBucket   string
+	crossZoneBucket  string
 	sameZoneTimeout  time.Duration
-	zonalCrossZoneTimeout time.Duration
+	crossZoneTimeout time.Duration
 }
 
 type MountTimeoutTest struct {
@@ -354,32 +354,32 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeo
 
 func (testSuite *ZBMountTimeoutTest) TestMountSameZoneBucketWithTimeout() {
 	testCases := []struct {
-		name           string
+		name string
 	}{
 		{
-			name:           "sameZoneBucket",
+			name: "sameZoneBucket",
 		},
 	}
 	for _, tc := range testCases {
 		setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, tc.name))
 
-		err := testSuite.mountOrTimeout(testSuite.config.sameZoneBucket, testSuite.dir, string(tc.clientProtocol), testSuite.config.sameZoneTimeout)
+		err := testSuite.mountOrTimeout(testSuite.config.sameZoneBucket, testSuite.dir, cfg.GRPC, testSuite.config.sameZoneTimeout)
 		assert.NoError(testSuite.T(), err)
 	}
 }
 
 func (testSuite *ZBMountTimeoutTest) TestMountCrossZoneBucketWithTimeout() {
 	testCases := []struct {
-		name           string
+		name string
 	}{
 		{
-			name:           "crossZoneBucket",
+			name: "crossZoneBucket",
 		},
 	}
 	for _, tc := range testCases {
 		setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, tc.name))
 
-		err := testSuite.mountOrTimeout(testSuite.config.crossZoneBucket, testSuite.dir, config.GRC, testSuite.config.crossZoneTimeout)
+		err := testSuite.mountOrTimeout(testSuite.config.crossZoneBucket, testSuite.dir, cfg.GRPC, testSuite.config.crossZoneTimeout)
 		assert.NoError(testSuite.T(), err)
 	}
 }

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -63,19 +63,24 @@ const (
 	zonalUSCentral1ABucket         string        = "mount_timeout_test_bucket_zb_usc1a"
 	zonalUSWest4ABucket            string        = "mount_timeout_test_bucket_zb_usw4a"
 	zonalSameZoneExpectedMountTime time.Duration = 2500 * time.Millisecond
+	zonalCrossZoneExpectedMountTime time.Duration = 5000 * time.Millisecond
 	// Commont constants.
 	relaxedExpectedMountTime time.Duration = 8000 * time.Millisecond
 	logfilePathPrefix        string        = "/tmp/gcsfuse_mount_timeout_"
 )
 
-// findTestExecutionEnvironment determines the environment in which the tests are running.
+// findTestExecutionEnvironment determines the environment (region, zone) in which the tests are running.
 // It uses the GCP resource detector to identify the environment.
 //
 // If the tests are running on a GCE instance with a hostname containing non-gce.
 // it returns testEnvNonGCE since it implies that the tests are being run on cloudtop.
 //
-// If the tests are running on a VM in the "us-central" region, it returns gce-us-central .
+// If the tests are running on a VM in the "us-central" region, it returns gce-us-central.
 // Otherwise, if running in any other region, it returns gce-non-us-central.
+///
+// If the tests are specifically running in us-central1, it returns zone as gce-zone-us-central1-a.
+// If the tests are specifically running in us-west4, it returns zone as gce-zone-us-west4-a.
+// Otherwise, if running in any other region, it returns zone as gce-zone-other.
 //
 // For all other cases, it returns non-gce.
 func findTestExecutionEnvironment(ctx context.Context) (string, string) {
@@ -89,7 +94,7 @@ func findTestExecutionEnvironment(ctx context.Context) (string, string) {
 	}
 	if v, exists := attrs.Value("cloud.region"); exists {
 		region := strings.ToLower(v.AsString())
-		// The above method only returns region of the VM, and not the zone. So, assuming here that when region is us-central1, then zone is us-central1-a, which may not be true always.
+		// The above method only ever returns region of the VM, and not the zone. So, I am assuming that when region is us-central1, then zone is us-central1-a, which may not be true always.
 		switch region {
 		case "us-central1":
 			return testEnvGCEUSCentral, testEnvZoneGCEUSCentral1A

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -62,8 +62,8 @@ const (
 	testEnvZoneGCEOther               string        = "gce-zone-other"
 	zonalUSCentral1ABucket            string        = "mount_timeout_test_bucket_zb_usc1a"
 	zonalUSWest4ABucket               string        = "mount_timeout_test_bucket_zb_usw4a"
-	zonalSameRegionExpectedMountTime  time.Duration = 2500 * time.Millisecond
-	zonalCrossRegionExpectedMountTime time.Duration = 5000 * time.Millisecond
+	zonalSameZoneExpectedMountTime  time.Duration = 2500 * time.Millisecond
+	zonalCrossZoneExpectedMountTime time.Duration = 5000 * time.Millisecond
 	// Commont constants.
 	relaxedExpectedMountTime time.Duration = 8000 * time.Millisecond
 	logfilePathPrefix        string        = "/tmp/gcsfuse_mount_timeout_"

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -57,11 +57,11 @@ const (
 	dualRegionAsiaExpectedMountTime        time.Duration = 6250 * time.Millisecond
 	singleRegionUSCentralExpectedMountTime time.Duration = 2500 * time.Millisecond
 	// Constants specific to ZB E2E runs.
-	testEnvZoneGCEUSCentral1A         string        = "gce-zone-us-central1-a"
-	testEnvZoneGCEUSWEST4A            string        = "gce-zone-us-west4a-a"
-	testEnvZoneGCEOther               string        = "gce-zone-other"
-	zonalUSCentral1ABucket            string        = "mount_timeout_test_bucket_zb_usc1a"
-	zonalUSWest4ABucket               string        = "mount_timeout_test_bucket_zb_usw4a"
+	testEnvZoneGCEUSCentral1A       string        = "gce-zone-us-central1-a"
+	testEnvZoneGCEUSWEST4A          string        = "gce-zone-us-west4a-a"
+	testEnvZoneGCEOther             string        = "gce-zone-other"
+	zonalUSCentral1ABucket          string        = "mount_timeout_test_bucket_zb_usc1a"
+	zonalUSWest4ABucket             string        = "mount_timeout_test_bucket_zb_usw4a"
 	zonalSameZoneExpectedMountTime  time.Duration = 2500 * time.Millisecond
 	zonalCrossZoneExpectedMountTime time.Duration = 5000 * time.Millisecond
 	// Commont constants.

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -57,13 +57,13 @@ const (
 	dualRegionAsiaExpectedMountTime        time.Duration = 6250 * time.Millisecond
 	singleRegionUSCentralExpectedMountTime time.Duration = 2500 * time.Millisecond
 	// Constants specific to ZB E2E runs.
-	testEnvZoneGCEUSCentral1A      string        = "gce-zone-us-central1-a"
-	testEnvZoneGCEUSWEST4A         string        = "gce-zone-us-west4a-a"
-	testEnvZoneGCEOther            string        = "gce-zone-other"
-	zonalUSCentral1ABucket         string        = "mount_timeout_test_bucket_zb_usc1a"
-	zonalUSWest4ABucket            string        = "mount_timeout_test_bucket_zb_usw4a"
-	zonalSameZoneExpectedMountTime time.Duration = 2500 * time.Millisecond
-	zonalCrossZoneExpectedMountTime time.Duration = 5000 * time.Millisecond
+	testEnvZoneGCEUSCentral1A         string        = "gce-zone-us-central1-a"
+	testEnvZoneGCEUSWEST4A            string        = "gce-zone-us-west4a-a"
+	testEnvZoneGCEOther               string        = "gce-zone-other"
+	zonalUSCentral1ABucket            string        = "mount_timeout_test_bucket_zb_usc1a"
+	zonalUSWest4ABucket               string        = "mount_timeout_test_bucket_zb_usw4a"
+	zonalSameRegionExpectedMountTime  time.Duration = 2500 * time.Millisecond
+	zonalCrossRegionExpectedMountTime time.Duration = 5000 * time.Millisecond
 	// Commont constants.
 	relaxedExpectedMountTime time.Duration = 8000 * time.Millisecond
 	logfilePathPrefix        string        = "/tmp/gcsfuse_mount_timeout_"
@@ -77,7 +77,7 @@ const (
 //
 // If the tests are running on a VM in the "us-central" region, it returns gce-us-central.
 // Otherwise, if running in any other region, it returns gce-non-us-central.
-///
+// /
 // If the tests are specifically running in us-central1, it returns zone as gce-zone-us-central1-a.
 // If the tests are specifically running in us-west4, it returns zone as gce-zone-us-west4-a.
 // Otherwise, if running in any other region, it returns zone as gce-zone-other.

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -85,14 +85,15 @@ func findTestExecutionEnvironment(ctx context.Context) (string, string) {
 	}
 	attrs := detectedAttrs.Set()
 	if v, exists := attrs.Value("gcp.gce.instance.hostname"); exists && strings.Contains(strings.ToLower(v.AsString()), "cloudtop-prod") {
-		return testEnvNonGCE
+		return testEnvNonGCE, testEnvZoneGCEOther
 	}
 	if v, exists := attrs.Value("cloud.region"); exists {
-		zone := strings.ToLower(v.AsString())
-		switch zone {
-		case "us-central1-a":
+		region := strings.ToLower(v.AsString())
+		// The above method only returns region of the VM, and not the zone. So, assuming here that when region is us-central1, then zone is us-central1-a, which may not be true always.
+		switch region {
+		case "us-central1":
 			return testEnvGCEUSCentral, testEnvZoneGCEUSCentral1A
-		case "us-west4-a":
+		case "us-west4":
 			return testEnvGCENonUSCentral, testEnvZoneGCEUSWEST4A
 		default:
 			if strings.Contains(strings.ToLower(v.AsString()), "us-central") {
@@ -102,7 +103,7 @@ func findTestExecutionEnvironment(ctx context.Context) (string, string) {
 			}
 		}
 	}
-	return testEnvNonGCE
+	return testEnvNonGCE, testEnvZoneGCEOther
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
### Description
- Splits the existing MountTimeoutTest class to NonZBMountTimeoutTest and ZBMountTimeoutTest. 
- Creates and adds new ZBs for mount_timeout tests and mounts them in the test
- Disables the tests for mounting of non-ZB out of the E2E ZB runs
- Adds new tests for mounting the ZBs during the E2E ZB runs .

### Link to the issue in case of a bug fix.
[b/411578929](http://b/411578929) , [b/410500613](http://b/410500613)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - as part of presubmit - [logs](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/a369417f-6667-4e9b-b529-e200bc260385/summary)

### Any backward incompatible change? If so, please explain.
