### PR TITLE
Move some packages to non-parallel in ZB e2e

### DIFF
--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -121,13 +121,11 @@ TEST_DIR_NON_PARALLEL=(
 # pass for zonal buckets.
 TEST_DIR_PARALLEL_FOR_ZB=(
   "benchmarking"
-  "concurrent_operations"
   "explicit_dir"
   "gzip"
   "implicit_dir"
   "interrupt"
   "kernel_list_cache"
-  "list_large_dir"
   "local_file"
   "log_rotation"
   "monitoring"
@@ -148,8 +146,10 @@ TEST_DIR_PARALLEL_FOR_ZB=(
 # but only those tests which currently
 # pass for zonal buckets.
 TEST_DIR_NON_PARALLEL_FOR_ZB=(
-  "readonly"
+  "concurrent_operations"
+  "list_large_dir"
   "managed_folders"
+  "readonly"
   "readonly_creds"
 )
 


### PR DESCRIPTION
### Description
Move following packages from parallel to non-parallel because their random failures when they are run in parallel with other packages.
- concurrent_operations
- list_large_dir

### Link to the issue in case of a bug fix.
[b/411581896](http://b/411581896)


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
