### PR TITLE
Enhance error handling by replacing direct err checks with errors.Is for EOF error

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -16,6 +16,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -211,7 +212,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	// dst buffer has fixed size of 1 MiB even when the offset is such that
 	// offset + 1 MiB > object size. In that case, io.ErrUnexpectedEOF is thrown
 	// which should be ignored.
-	if err == io.EOF || err == io.ErrUnexpectedEOF {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		if n != requestedNumBytes {
 			// Ensure that the number of bytes read into dst buffer is equal to what is
 			// requested. It will also help catch cases where file in cache is truncated

--- a/internal/cache/util/util.go
+++ b/internal/cache/util/util.go
@@ -142,10 +142,10 @@ func calculateCRC32(ctx context.Context, reader io.Reader) (uint32, error) {
 		case <-ctx.Done():
 			return 0, fmt.Errorf("CRC computation is cancelled: %w", ctx.Err())
 		default:
-			switch n, err := reader.Read(buf); err {
-			case nil:
+			switch n, err := reader.Read(buf); {
+			case err == nil:
 				checksum = crc32.Update(checksum, table, buf[:n])
-			case io.EOF:
+			case errors.Is(err, io.EOF):
 				return checksum, nil
 			default:
 				return 0, err

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -612,7 +612,7 @@ func Test_CopyUsingMemoryAlignedBuffer(t *testing.T) {
 					_ = readFile.Close()
 				})
 				_, err = readFile.ReadAt(buf, tc.writeOffset)
-				if err != nil && err != io.EOF {
+				if err != nil && errors.Is(err, io.EOF) {
 					t.Errorf("error (%v) while reading contents at the time of assertion for: %v", err, tc.name)
 				}
 				assert.True(t, reflect.DeepEqual(string(content[:sizeToMatch]), string(buf)))

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -21,6 +21,7 @@ package fs_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"os"
@@ -553,7 +554,7 @@ func (t *ForeignModsTest) ReadFromFile_Large() {
 		size := randSrc.Intn(int(contentLen - offset))
 
 		n, err := f.ReadAt(buf[:size], offset)
-		if offset+int64(size) == contentLen && err == io.EOF {
+		if offset+int64(size) == contentLen && errors.Is(err, io.EOF) {
 			err = nil
 		}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2553,7 +2553,7 @@ func (fs *fileSystem) ReadFile(
 	op.Dst, op.BytesRead, err = fh.Read(ctx, op.Dst, op.Offset, fs.sequentialReadSizeMb)
 
 	// As required by fuse, we don't treat EOF as an error.
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = nil
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -560,7 +560,7 @@ func (f *FileInode) Read(
 	// Read from the local content, propagating io.EOF.
 	n, err = f.content.ReadAt(dst, offset)
 	switch {
-	case err == io.EOF:
+	case errors.Is(err, io.EOF):
 		return
 
 	case err != nil:

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -319,7 +319,7 @@ func (t *FileTest) TestRead() {
 		data = data[:n]
 
 		// Ignore EOF.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			err = nil
 		}
 
@@ -350,7 +350,7 @@ func (t *FileTest) TestWrite() {
 	var buf [1024]byte
 	n, err := t.in.Read(t.ctx, buf[:], 0)
 
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = nil
 	}
 
@@ -384,7 +384,7 @@ func (t *FileTest) TestTruncate() {
 	var buf [1024]byte
 	n, err := t.in.Read(t.ctx, buf[:], 0)
 
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = nil
 	}
 

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -1526,7 +1526,7 @@ func (t *FileTest) WriteAtDoesntChangeOffset_AppendMode() {
 }
 
 func validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAttributes,
-		minObject1, minObject2 *gcs.MinObject) {
+	minObject1, minObject2 *gcs.MinObject) {
 	AssertNe(nil, extendedAttr1)
 	AssertNe(nil, extendedAttr2)
 	AssertNe(nil, minObject1)

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -767,7 +767,7 @@ func (t *ModesTest) AppendMode_SeekAndWrite() {
 	buf := make([]byte, 1024)
 	n, err := t.f1.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq(contents+"222", string(buf[:n]))
 
 	// Read the full contents with another file handle.
@@ -815,7 +815,7 @@ func (t *ModesTest) AppendMode_WriteAt() {
 	buf := make([]byte, 1024)
 	n, err := t.f1.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq("taco111ritoenchilada", string(buf[:n]))
 
 	// Read the full contents with another file handle.
@@ -1526,7 +1526,7 @@ func (t *FileTest) WriteAtDoesntChangeOffset_AppendMode() {
 }
 
 func validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAttributes,
-	minObject1, minObject2 *gcs.MinObject) {
+		minObject1, minObject2 *gcs.MinObject) {
 	AssertNe(nil, extendedAttr1)
 	AssertNe(nil, extendedAttr2)
 	AssertNe(nil, minObject1)
@@ -1625,19 +1625,19 @@ func (t *FileTest) ReadsPastEndOfFile() {
 
 	// Read a range overlapping EOF.
 	n, err = t.f1.ReadAt(buf[:4], 2)
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq(2, n)
 	ExpectEq("co", string(buf[:n]))
 
 	// Read a range starting at EOF.
 	n, err = t.f1.ReadAt(buf[:4], 4)
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq(0, n)
 	ExpectEq("", string(buf[:n]))
 
 	// Read a range starting past EOF.
 	n, err = t.f1.ReadAt(buf[:4], 100)
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq(0, n)
 	ExpectEq("", string(buf[:n]))
 }
@@ -1748,7 +1748,7 @@ func (t *FileTest) Seek() {
 
 	// Read full the contents of the file.
 	n, err = t.f1.ReadAt(buf, 0)
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	ExpectEq("txxo", string(buf[:n]))
 }
 
@@ -1903,7 +1903,7 @@ func (t *FileTest) UnlinkFile_StillOpen() {
 	buf := make([]byte, 1024)
 	n, err = f.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
+	AssertTrue(errors.Is(err, io.EOF))
 	AssertEq(4, n)
 	ExpectEq("taco", string(buf[:4]))
 

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -16,6 +16,7 @@
 package fs_test
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -498,7 +499,7 @@ func (t *FileCacheTest) ConcurrentReadsFromSameFileHandle() {
 		_, err := file.Seek(offset, 0)
 		ExpectEq(nil, err)
 		_, err = file.Read(buf)
-		ExpectTrue(err == nil || err == io.EOF)
+		ExpectTrue(err == nil || errors.Is(err, io.EOF))
 		// we can't compare the data as seek is of same file and can be changed by
 		// concurrent go routines.
 	}

--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -166,7 +166,7 @@ func (t *IntegrationTest) ReadThenSync() {
 	buf := make([]byte, 1024)
 	n, err := t.tf.ReadAt(buf, 0)
 
-	AssertThat(err, AnyOf(io.EOF, nil))
+	AssertTrue(errors.Is(err, io.EOF) || err == nil)
 	ExpectEq(len("taco"), n)
 	ExpectEq("taco", string(buf[:n]))
 
@@ -539,7 +539,7 @@ func (t *IntegrationTest) MultipleInteractions() {
 		// Read the contents of the temp file.
 		_, err = t.tf.ReadAt(buf, 0)
 
-		AssertThat(err, AnyOf(nil, io.EOF))
+		AssertTrue(errors.Is(err, io.EOF) || err == nil)
 		if !bytes.Equal(buf, expectedContents) {
 			AddFailure("Contents mismatch for %s", desc)
 			AbortTest()
@@ -564,7 +564,7 @@ func (t *IntegrationTest) MultipleInteractions() {
 		// Compare contents again.
 		_, err = t.tf.ReadAt(buf, 0)
 
-		AssertThat(err, AnyOf(nil, io.EOF))
+		AssertTrue(errors.Is(err, io.EOF) || err == nil)
 		if !bytes.Equal(buf, expectedContents) {
 			AddFailure("Contents mismatch for %s", desc)
 			AbortTest()
@@ -589,7 +589,7 @@ func (t *IntegrationTest) MultipleInteractions() {
 		// Compare contents again.
 		_, err = t.tf.ReadAt(buf, 0)
 
-		AssertThat(err, AnyOf(nil, io.EOF))
+		AssertTrue(errors.Is(err, io.EOF) || err == nil)
 		if !bytes.Equal(buf, expectedContents) {
 			AddFailure("Contents mismatch for %s", desc)
 			AbortTest()
@@ -606,7 +606,7 @@ func (t *IntegrationTest) MultipleInteractions() {
 		// Compare contents again.
 		_, err = t.tf.ReadAt(buf, 0)
 
-		AssertThat(err, AnyOf(nil, io.EOF))
+		AssertTrue(errors.Is(err, io.EOF) || err == nil)
 		if !bytes.Equal(buf, expectedContents) {
 			AddFailure("Contents mismatch for %s", desc)
 			AbortTest()

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -16,6 +16,7 @@ package gcsx
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sync"

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -222,7 +222,7 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 			mu.Unlock()
 		}()
 
-		if e != nil && e != io.EOF {
+		if e != nil && !errors.Is(err, io.EOF) {
 			e = fmt.Errorf("Error in Add Call: %w", e)
 		}
 	})

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -610,7 +610,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 
 	// Handle errors.
 	switch {
-	case err == io.EOF || err == io.ErrUnexpectedEOF:
+	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
 		// For a non-empty buffer, ReadFull returns EOF or ErrUnexpectedEOF only
 		// if the reader peters out early. That's fine, but it means we should
 		// have hit the limit above.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -222,7 +222,7 @@ func (t *RandomReaderTest) ReadAtEndOfObject() {
 	objectData, err := t.rr.ReadAt(buf, int64(t.object.Size))
 
 	ExpectEq(0, objectData.Size)
-	ExpectEq(io.EOF, err)
+	ExpectTrue(errors.Is(err, io.EOF))
 }
 
 func (t *RandomReaderTest) ReadPastEndOfObject() {
@@ -232,7 +232,7 @@ func (t *RandomReaderTest) ReadPastEndOfObject() {
 
 	ExpectFalse(objectData.CacheHit)
 	ExpectEq(0, objectData.Size)
-	ExpectEq(io.EOF, err)
+	ExpectTrue(errors.Is(err, io.EOF))
 }
 
 func (t *RandomReaderTest) NoExistingReader() {
@@ -1035,7 +1035,7 @@ func (t *RandomReaderTest) Test_ReadAt_OffsetEqualToObjectSize() {
 
 	// nothing should be read
 	ExpectFalse(objectData.CacheHit)
-	ExpectEq(io.EOF, err)
+	ExpectTrue(errors.Is(err, io.EOF))
 	ExpectEq(0, objectData.Size)
 }
 

--- a/internal/gcsx/temp_file.go
+++ b/internal/gcsx/temp_file.go
@@ -15,6 +15,7 @@
 package gcsx
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -341,7 +342,7 @@ func (tf *tempFile) ensure(limit int64) error {
 			n = minCopyLength
 		}
 		n, err = io.CopyN(tf.f, tf.source, n)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			tf.source.Close()
 			tf.dirtyThreshold = size + n
 			tf.state = fileComplete

--- a/internal/gcsx/temp_file_test.go
+++ b/internal/gcsx/temp_file_test.go
@@ -15,6 +15,7 @@
 package gcsx_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -174,7 +175,7 @@ func (t *TempFileTest) ReadAt() {
 
 	n, err = t.tf.ReadAt(buf[:], int64(initialContentSize)-1)
 	ExpectEq(1, n)
-	ExpectEq(io.EOF, err)
+	ExpectTrue(errors.Is(err, io.EOF))
 	ExpectEq(
 		initialContent[initialContentSize-1:initialContentSize],
 		string(buf[0:n]),

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -100,7 +101,7 @@ func (dr *debugReader) Read(p []byte) (n int, err error) {
 	n, err = dr.wrapped.Read(p)
 
 	// Don't log EOF errors, which are par for the course.
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		dr.bucket.requestLogf(dr.requestID, "-> Read error: %v", err)
 	}
 

--- a/tools/integration_tests/emulator_tests/util/test_helper.go
+++ b/tools/integration_tests/emulator_tests/util/test_helper.go
@@ -154,7 +154,7 @@ func ReadFirstByte(t *testing.T, filePath string) (time.Duration, error) {
 
 	startTime := time.Now()
 	_, err = file.Read(buffer)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return 0, err
 	}
 

--- a/tools/integration_tests/read_gcs_algo/concurrent_read_same_file_test.go
+++ b/tools/integration_tests/read_gcs_algo/concurrent_read_same_file_test.go
@@ -16,6 +16,7 @@ package read_gcs_algo
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"math/rand/v2"
 	"os"
@@ -61,7 +62,7 @@ func readAndCompare(t *testing.T, filePathInMntDir string, filePathInLocalDisk s
 		mountContents := make([]byte, chunkSize)
 		// Reading chunk size randomly from the file.
 		_, err = mountedFile.ReadAt(mountContents, offset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			err = nil
 		}
 		if err != nil {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -207,7 +207,7 @@ func ReadFileSequentially(filePath string, chunkSize int64) (content []byte, err
 	// Closing the file at the end.
 	defer CloseFile(file)
 
-	for err != io.EOF {
+	for !errors.Is(err, io.EOF) {
 		var numberOfBytes int
 
 		// Reading 200 MB chunk sequentially from the file.

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -212,7 +213,7 @@ func ReadFileSequentially(filePath string, chunkSize int64) (content []byte, err
 		// Reading 200 MB chunk sequentially from the file.
 		numberOfBytes, err = file.ReadAt(chunk, offset)
 		// If the file reaches the end, write the remaining content in the buffer and return.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 
 			for i := offset; i < offset+int64(numberOfBytes); i++ {
 				// Adding remaining bytes.
@@ -303,7 +304,7 @@ func ReadChunkFromFile(filePath string, chunkSize int64, offset int64, flag int)
 
 	// Reading chunk size randomly from the file.
 	numberOfBytes, err = file.ReadAt(chunk, offset)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		err = nil
 	}
 	if err != nil {
@@ -327,7 +328,7 @@ func ReadFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffset, 
 		readSize := min(chunkSize, endOffset-startOffset)
 
 		n, err := file.ReadAt(chunk[:readSize], startOffset)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			readData = append(readData, chunk[:n]...)
 			break
 		} else if err != nil {


### PR DESCRIPTION
### Description
This pull request addresses an issue where runs encounter an unexpected `ReadFile: input/output error` with an EOF message from GCSFuse.

The root cause is that GCSFuse's code uses direct equality checks (`err == io.EOF`) when handling EOF errors. This approach fails to correctly identify `io.EOF` in cases where the error has been wrapped with additional context.

To resolve this, this PR replaces all instances of `err == io.EOF` with `errors.Is(err, io.EOF)`. The `errors.Is` function correctly traverses the chain of wrapped errors to determine if the underlying error is `io.EOF`.

### Link to the issue in case of a bug fix.
[b/406196625](b/406196625)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
