### PR TITLE
Fix: Handle Intermittent SSH Connection Errors for long haul test VMs

### DIFF
--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -42,7 +42,7 @@ function initialize_ssh_key () {
     retries=5
     while [ $attempt -le $retries ]; do
         echo "Attempting SSH connection (attempt $attempt)..."
-        # Requires running first ssh command with --quiet option to initialize keys.
+        # Requires running ssh command with --quiet option to initialize keys.
         # Otherwise it prompts for yes and no.
         if sudo gcloud compute ssh "$VM_NAME" --zone "$ZONE_NAME" --internal-ip --quiet --command "echo 'Running from VM'"; then
             echo "SSH connection successful."

--- a/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
+++ b/perfmetrics/scripts/continuous_test/ml_tests/run_and_manage_test.sh
@@ -43,7 +43,7 @@ function initialize_ssh_key () {
     while [ $attempt -le $retries ]; do
         echo "Attempting SSH connection (attempt $attempt)..."
         # Requires running ssh command with --quiet option to initialize keys.
-        # Otherwise it prompts for yes and no.
+        # Otherwise it prompts for yes or no.
         if sudo gcloud compute ssh "$VM_NAME" --zone "$ZONE_NAME" --internal-ip --quiet --command "echo 'Running from VM'"; then
             echo "SSH connection successful."
             return 0


### PR DESCRIPTION
### Description
Intermittent failures occur when establishing SSH connections to long haul test VMs, arising from a timing conflict between the removal of OS Login-managed SSH keys and subsequent SSH connection attempts. Specifically, `gcloud compute ssh ` may attempt to connect using a newly generated key before the OS Login key removal has fully propagated.This leads to the VM rejecting the authentication attempt , as a result, kokoro jobs which probe for the test status fail.
The ssh keys removal is necessary due to the size limit on os login profiles: [ref](https://github.com/kyma-project/test-infra/issues/93)

Solution -
Implemented a retry mechanism with exponential backoff for the SSH connection attempt. This allows sufficient time for the OS Login key removal to propagate, significantly reducing the frequency of authentication failures.
### Link to the issue in case of a bug fix.


### Testing details
1. Manual - WAI, ref: 
![image](https://github.com/user-attachments/assets/3845d583-7f08-49f9-b02d-d485be792828)

2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
