### PR TITLE
Save gcsfuse logs for streaming writes package for easier debugging.

### DIFF
--- a/tools/integration_tests/streaming_writes/buffer_size_test.go
+++ b/tools/integration_tests/streaming_writes/buffer_size_test.go
@@ -58,6 +58,7 @@ func TestWritesWithDifferentConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			setup.MountGCSFuseWithGivenMountFunc(tc.flags, mountFunc)
+			defer setup.SaveGCSFuseLogFileInCaseOfFailure(t)
 			defer setup.UnmountGCSFuse(rootDir)
 			testDirPath = setup.SetupTestDirectory(testDirName)
 			// Create a local file.

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -46,6 +46,7 @@ func (t *defaultMountCommonTest) SetupSuite() {
 
 func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.UnmountGCSFuse(rootDir)
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t.T())
 }
 
 func (t *defaultMountCommonTest) validateReadCall(filePath string) {

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -259,7 +259,7 @@ func SaveLogFileAsArtifact(logFile, artifactName string) {
 // KOKORO artifacts directory if test ran on KOKORO
 // or saves to TestDir if test ran on local.
 func SaveGCSFuseLogFileInCaseOfFailure(tb testing.TB) {
-	if !tb.Failed() {
+	if !tb.Failed() || MountedDirectory() != "" {
 		return
 	}
 	SaveLogFileAsArtifact(LogFile(), GCSFuseLogFilePrefix+strings.ReplaceAll(tb.Name(), "/", "_")+GenerateRandomString(5))


### PR DESCRIPTION
### Description
Save gcsfuse logs for failed integration tests to ensure logs are available for debug.
Also made a small fix to not save LogFile in case of mountedDirectory is not nil.

### Link to the issue in case of a bug fix.
b/412190425

### Testing details
1. Manual - Tested log file saving code: http://gpaste/5768501689843712
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit tests.

### Any backward incompatible change? If so, please explain.
