### PR TITLE
Update documentation for  custom-endpoint flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -277,7 +277,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
-	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. The custom endpoint  must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
+	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. The custom endpoint must support the equivalent resources and operations as the GCS JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified, GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -277,7 +277,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
-	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data.   The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
+	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. The custom endpoint  must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -277,7 +277,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
-	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. Should only be used for testing.  The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
+	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data.   The custom endpoint must support the equivalent resources and operations as the GCS  JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified,  GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -293,9 +293,8 @@
   flag-name: "custom-endpoint"
   type: "string"
   usage: >-
-    Specifies an alternative custom endpoint for fetching data.  
-    The custom endpoint must support the equivalent resources
-    and operations as the GCS  JSON endpoint,
+    Specifies an alternative custom endpoint for fetching data. The custom endpoint 
+    must support the equivalent resources and operations as the GCS  JSON endpoint,
     https://storage.googleapis.com/storage/v1. If a custom endpoint is not
     specified,  GCSFuse uses the global GCS JSON API endpoint,
     https://storage.googleapis.com/storage/v1.

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -293,10 +293,10 @@
   flag-name: "custom-endpoint"
   type: "string"
   usage: >-
-    Specifies an alternative custom endpoint for fetching data. The custom endpoint 
-    must support the equivalent resources and operations as the GCS  JSON endpoint,
+    Specifies an alternative custom endpoint for fetching data. The custom endpoint
+    must support the equivalent resources and operations as the GCS JSON endpoint,
     https://storage.googleapis.com/storage/v1. If a custom endpoint is not
-    specified,  GCSFuse uses the global GCS JSON API endpoint,
+    specified, GCSFuse uses the global GCS JSON API endpoint,
     https://storage.googleapis.com/storage/v1.
   default: ""
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -293,8 +293,8 @@
   flag-name: "custom-endpoint"
   type: "string"
   usage: >-
-    Specifies an alternative custom endpoint for fetching data. Should only be
-    used for testing.  The custom endpoint must support the equivalent resources
+    Specifies an alternative custom endpoint for fetching data.  
+    The custom endpoint must support the equivalent resources
     and operations as the GCS  JSON endpoint,
     https://storage.googleapis.com/storage/v1. If a custom endpoint is not
     specified,  GCSFuse uses the global GCS JSON API endpoint,


### PR DESCRIPTION
### Description
We've removed `Should only be used for testing` from the custom endpoint description. This was added previously as the feature was developed for the test-bench server.

Currently, the custom endpoint is being used in the TPC environment, which is not a test server. Therefore, we are updating its description.

I'll also update cloud documentation as well after this.

### Link to the issue in case of a bug fix.
[b/412284502](https://b.corp.google.com/issues/412284502)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
