### PR TITLE
Update troubleshooting doc for git clone issue

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,10 +172,11 @@ Please note that GCSFuse does not support using `chmod` or similar commands to m
 
 ### Cloning GitHub repository inside mounted bucket is extremely slow
 Ensure your GCS bucket mount configuration does not include `o=sync` or `o=dirsync`. \
-During a Git clone, Git doesn’t just fetch object data—it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
+During a Git clone, Git doesn’t just fetch object data, it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
 
 - Git repeatedly writes and updates .git/config, especially when setting remotes, branches, and defaults.
 - Each update uses Git’s lock-write-rename-delete pattern to ensure consistency.
 
 While using the mount configuration `o=sync,o=dirsync`, all modifications to the config file incur a network call due to enforced synchronous writes, resulting in 
-performance bottleneck.
+performance bottleneck. \
+**Note** : There is no impact of disabling this mount configuration on the user workflow, since we avoid flushing data to GCS on sync( happens multiple times during the course of a Git clone ) , but only on close(), thus ensuring data persistence.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,7 +172,7 @@ Please note that GCSFuse does not support using `chmod` or similar commands to m
 
 ### Cloning github repository inside mounted bucket is extremely slow
 Ensure your GCS bucket mount configuration does not include `o=sync` or `o=dirsync`. \
-During git clone, Git doesn’t just fetch object data—it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
+During a Git clone, Git doesn’t just fetch object data—it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
 
 - Git repeatedly writes and updates .git/config, especially when setting remotes, branches, and defaults.
 - Each update uses Git’s lock-write-rename-delete pattern to ensure consistency.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,3 +168,14 @@ To allow users other than the mounting user to access the bucket, use the `-o al
 Use the `--uid` and `--gid` flags to specify the correct user and group IDs for access.
 
 Please note that GCSFuse does not support using `chmod` or similar commands to manage file access. For more detailed information, refer to the [Permissions and Ownership](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#permissions-and-ownership).
+
+
+### Cloning github repository inside mounted bucket is extremely slow
+Ensure your GCS bucket mount configuration does not include `o=sync` or `o=dirsync`. \
+During git clone, Git doesn’t just fetch object data—it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
+
+- Git repeatedly writes and updates .git/config, especially when setting remotes, branches, and defaults.
+- Each update uses Git’s lock-write-rename-delete pattern to ensure consistency.
+
+While using the mount configuration `o=sync,o=dirsync`, all modifications to the config file incur a network call due to enforced synchronous writes, resulting in 
+performance bottleneck.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -170,7 +170,7 @@ Use the `--uid` and `--gid` flags to specify the correct user and group IDs for 
 Please note that GCSFuse does not support using `chmod` or similar commands to manage file access. For more detailed information, refer to the [Permissions and Ownership](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#permissions-and-ownership).
 
 
-### Cloning github repository inside mounted bucket is extremely slow
+### Cloning GitHub repository inside mounted bucket is extremely slow
 Ensure your GCS bucket mount configuration does not include `o=sync` or `o=dirsync`. \
 During a Git clone, Git doesn’t just fetch object data—it builds out the entire .git directory structure, including initializing config, refs, hooks, and other internals. As part of this setup:
 


### PR DESCRIPTION
### Description
Updating troubleshooting doc for avoiding `o=sync,o=dirsync` options in the mount configuration when trying to clone a repo inside the mounted GCS bucket.

[Ref](https://github.com/GoogleCloudPlatform/gcsfuse/issues/3189)
### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
