### PR TITLE
TPC support with HNS buckets

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -268,12 +269,9 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	var controlClient *control.StorageControlClient
 	var clientOpts []option.ClientOption
 
-	// TODO: We will implement an additional check for the HTTP control client protocol once the Go SDK supports HTTP.
 	// Control-client is needed for folder APIs and for getting storage-layout of the bucket.
-	// GetStorageLayout API is not supported for storage-testbench and for TPC, both of which are identified by non-nil custom-endpoint.
-	// Change this check once TPC(custom-endpoint) supports gRPC.
-	// TODO: Enable creation of control-client for preprod endpoint.
-	if clientConfig.EnableHNS && clientConfig.CustomEndpoint == "" {
+	// GetStorageLayout API is not supported for storage-testbench, which are identified by custom-endpoint containing localhost.
+	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "localhost") {
 		clientOpts, err = createClientOptionForGRPCClient(&clientConfig, false)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -281,7 +281,7 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 			return nil, fmt.Errorf("could not create StorageControl Client: %w", err)
 		}
 	} else {
-		logger.Infof("Skipping storage control client creation as control client support is assumed to be unavailable on the local host. This is likely because a custom endpoint for a testbench server (which doesn't support control client) was provided.")
+		logger.Infof("Skipping storage control client creation because custom-endpoint %q was passed, which is assumed to be a storage testbench server because of 'localhost' in it.", clientConfig.CustomEndpoint)
 	}
 
 	sh = &storageClient{

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -280,6 +280,8 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		if err != nil {
 			return nil, fmt.Errorf("could not create StorageControl Client: %w", err)
 		}
+	} else {
+		logger.Infof("Skipping storage control client creation as control client support is assumed to be unavailable on the local host. This is likely because a custom endpoint for a testbench server (which doesn't support control client) was provided.")
 	}
 
 	sh = &storageClient{

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -428,7 +428,7 @@ function run_e2e_tests_for_zonal_bucket(){
 function run_e2e_tests_for_tpc() {
   bucket=$1
   # Clean bucket before testing.
-  gcloud storage rm -r gs://$bucket/**
+  gcloud storage rm -r gs://$bucket/*
 
   # Run Operations e2e tests in TPC to validate all the functionality.
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=$bucket --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
@@ -437,7 +437,7 @@ function run_e2e_tests_for_tpc() {
   set -e
 
   # Delete data after testing.
-  gcloud storage rm -r gs://$bucket/**
+  gcloud storage rm -r gs://$bucket/*
 
   if [ $exit_code != 0 ];
    then

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -428,7 +428,7 @@ function run_e2e_tests_for_zonal_bucket(){
 function run_e2e_tests_for_tpc() {
   bucket=$1
   # Clean bucket before testing.
-  gcloud storage rm -r gs://gcsfuse-e2e-tests-tpc/**
+  gcloud storage rm -r gs://$bucket/**
 
   # Run Operations e2e tests in TPC to validate all the functionality.
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=$bucket --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
@@ -437,13 +437,13 @@ function run_e2e_tests_for_tpc() {
   set -e
 
   # Delete data after testing.
-  gcloud storage rm -r gs://gcsfuse-e2e-tests-tpc/**
+  gcloud storage rm -r gs://$bucket/**
 
   if [ $exit_code != 0 ];
    then
-     echo "The tests failed."
+     return 1
   fi
-  return $exit_code
+  return 0
 }
 
 function run_e2e_tests_for_emulator() {

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -429,7 +429,7 @@ function run_e2e_tests_for_tpc() {
   local bucket=$1
   if [ $bucket == "" ];
   then
-    echo "Bucket name is require"
+    echo "Bucket name is required"
     return 1
   fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -427,7 +427,7 @@ function run_e2e_tests_for_zonal_bucket(){
 
 function run_e2e_tests_for_tpc() {
   local bucket=$1
-  if [ $bucket == "" ];
+  if [ "$bucket" == "" ];
   then
     echo "Bucket name is required"
     return 1

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -434,16 +434,16 @@ function run_e2e_tests_for_tpc() {
   fi
 
   # Clean bucket before testing.
-  gcloud --verbosity=error storage rm -r gs://$bucket/*
+  gcloud --verbosity=error storage rm -r gs://"$bucket"/*
 
   # Run Operations e2e tests in TPC to validate all the functionality.
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=$bucket --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket="$bucket" --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
   exit_code=$?
 
   set -e
 
   # Delete data after testing.
-  gcloud --verbosity=error storage rm -r gs://$bucket/*
+  gcloud --verbosity=error storage rm -r gs://"$bucket"/*
 
   if [ $exit_code != 0 ];
    then

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -426,9 +426,15 @@ function run_e2e_tests_for_zonal_bucket(){
 }
 
 function run_e2e_tests_for_tpc() {
-  bucket=$1
+  local bucket=$1
+  if [ $bucket == "" ];
+  then
+    echo "Bucket name is require."
+    return 1
+  fi
+
   # Clean bucket before testing.
-  gcloud storage rm -r gs://$bucket/*
+  gcloud --verbosity=error storage rm -r gs://$bucket/*
 
   # Run Operations e2e tests in TPC to validate all the functionality.
   GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=$bucket --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
@@ -437,7 +443,7 @@ function run_e2e_tests_for_tpc() {
   set -e
 
   # Delete data after testing.
-  gcloud storage rm -r gs://$bucket/*
+  gcloud --verbosity=error storage rm -r gs://$bucket/*
 
   if [ $exit_code != 0 ];
    then

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -425,12 +425,13 @@ function run_e2e_tests_for_zonal_bucket(){
    return 0
 }
 
-function run_e2e_tests_for_tpc_and_exit() {
+function run_e2e_tests_for_tpc() {
+  bucket=$1
   # Clean bucket before testing.
   gcloud storage rm -r gs://gcsfuse-e2e-tests-tpc/**
 
   # Run Operations e2e tests in TPC to validate all the functionality.
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=gcsfuse-e2e-tests-tpc --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/operations/... --testOnTPCEndPoint=$RUN_TEST_ON_TPC_ENDPOINT $GO_TEST_SHORT_FLAG $PRESUBMIT_RUN_FLAG --zonal=false -p 1 --integrationTest -v --testbucket=$bucket --testInstalledPackage=$RUN_E2E_TESTS_ON_PACKAGE -timeout $INTEGRATION_TEST_TIMEOUT
   exit_code=$?
 
   set -e
@@ -442,7 +443,7 @@ function run_e2e_tests_for_tpc_and_exit() {
    then
      echo "The tests failed."
   fi
-  exit $exit_code
+  return $exit_code
 }
 
 function run_e2e_tests_for_emulator() {
@@ -479,8 +480,30 @@ function main(){
     fi
   else
     # Run tpc test and exit in case RUN_TEST_ON_TPC_ENDPOINT is true.
-    if [ $RUN_TEST_ON_TPC_ENDPOINT == true ]; then
-         run_e2e_tests_for_tpc_and_exit
+    if [ "$RUN_TEST_ON_TPC_ENDPOINT" == true ]; then
+         # Run tests for flat bucket
+         run_e2e_tests_for_tpc gcsfuse-e2e-tests-tpc &
+         e2e_tests_tpc_flat_bucket_pid=$!
+         # Run tests for hns bucket
+         run_e2e_tests_for_tpc gcsfuse-e2e-tests-tpc-hns &
+         e2e_tests_tpc_hns_bucket_pid=$!
+
+         wait $e2e_tests_tpc_flat_bucket_pid
+         e2e_tests_tpc_flat_bucket_status=$?
+
+         wait $e2e_tests_tpc_hns_bucket_pid
+         e2e_tests_tpc_hns_bucket_status=$?
+
+         if [ $e2e_tests_tpc_flat_bucket_status != 0 ];
+         then
+            echo "The e2e tests for flat bucket failed.."
+            exit_code=1
+         fi
+         if [ $e2e_tests_tpc_hns_bucket_status != 0 ];
+         then
+             echo "The e2e tests for hns bucket failed.."
+             exit_code=1
+         fi
     fi
 
     run_e2e_tests_for_hns_bucket &

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -429,7 +429,7 @@ function run_e2e_tests_for_tpc() {
   local bucket=$1
   if [ $bucket == "" ];
   then
-    echo "Bucket name is require."
+    echo "Bucket name is require"
     return 1
   fi
 

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -497,13 +497,15 @@ function main(){
          if [ $e2e_tests_tpc_flat_bucket_status != 0 ];
          then
             echo "The e2e tests for flat bucket failed.."
-            exit_code=1
+            exit 1
          fi
          if [ $e2e_tests_tpc_hns_bucket_status != 0 ];
          then
              echo "The e2e tests for hns bucket failed.."
-             exit_code=1
+             exit 1
          fi
+         # Exit to prevent the following code from executing for TPC.
+         exit 0
     fi
 
     run_e2e_tests_for_hns_bucket &


### PR DESCRIPTION
### Description
Previously, TPC did not support the control client at the time GCSFuse implementation for TPC was developed. However, control client support for TPC has been available since December 2024, necessitating modifications to enable GCSFuse to support TPC with HNS buckets.

Also added automated tests for HNS buckets on TPC.

### Link to the issue in case of a bug fix.
[b/379063794](https://b.corp.google.com/issues/379063794)

### Testing details
1. Manual - Tested on TPC environment
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
