### PR TITLE
[WIP] ensure min object is reflects current GCS Object for Zonal Buckets for streaming writes.

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -455,16 +455,12 @@ func (testSuite *BufferedWriteTest) TestUnlinkBeforeAnyWriteThenFurtherWriteSucc
 	testSuite.bwh.Unlink()
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.NotNil(testSuite.T(), bwhImpl.uploadHandler.cancelFunc)
-	buffer, err := operations.GenerateRandomData(blockSize)
+	buffer, err := operations.GenerateRandomData(2 * blockSize)
 	assert.NoError(testSuite.T(), err)
 
-	for i := 0; i < 5; i++ {
-		err := testSuite.bwh.Write(buffer, int64(blockSize*i))
-		require.Nil(testSuite.T(), err)
-	}
+	err = testSuite.bwh.Write(buffer, int64(0))
 
-	assert.Equal(testSuite.T(), 5, len(bwhImpl.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	require.Nil(testSuite.T(), err)
 }
 
 func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -328,12 +328,13 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 		testSuite.T().Run(tc.name, func(t *testing.T) {
 			testSuite.setupTestWithBucketType(tc.bucketType)
 			buffer, err := operations.GenerateRandomData(int64(blockSize * tc.numBlocks))
-			assert.NoError(t, err)
+			assert.NoError(testSuite.T(), err)
 			err = testSuite.bwh.Write(buffer, 0)
-			require.Nil(t, err)
+			require.Nil(testSuite.T(), err)
 
 			// Wait for 3 blocks to upload successfully.
 			err = testSuite.bwh.Sync()
+
 			assert.NoError(t, err)
 			assert.NoError(testSuite.T(), err)
 			bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -84,6 +84,8 @@ func newUploadHandler(req *CreateUploadHandlerRequest) (*UploadHandler, error) {
 		blockSize:            req.BlockSize,
 		chunkTransferTimeout: req.ChunkTransferTimeoutSecs,
 	}
+	// createObjectWriter can only fail here due to throttling, so we will not
+	// handle this error explicitly or fall back to temp file flow.
 	err := uh.createObjectWriter()
 	if err != nil {
 		return nil, fmt.Errorf("createObjectWriter: %w", err)
@@ -104,7 +106,7 @@ func (uh *UploadHandler) Upload(block block.Block) {
 	uh.uploadCh <- block
 }
 
-// createObjectWriter creates a GCS object writer...
+// createObjectWriter creates a GCS object writer.
 func (uh *UploadHandler) createObjectWriter() (err error) {
 	// TODO: b/381479965: Dynamically set chunkTransferTimeoutSecs based on chunk size. 0 here means no timeout.
 	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, 0)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -194,6 +194,8 @@ func (fh *FileHandle) tryEnsureReader(ctx context.Context, sequentialReadSizeMb 
 	// can use it. Otherwise we must throw it away.
 	if fh.reader != nil {
 		if fh.reader.Object().Generation == fh.inode.SourceGeneration().Object {
+			// Update reader object size to source object size.
+			fh.reader.Object().Size = fh.inode.SourceGeneration().Size
 			return
 		}
 		fh.reader.Destroy()

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -722,6 +722,9 @@ func (t *FakeBufferedWriteHandler) SetMtime(_ time.Time)   {}
 func (t *FakeBufferedWriteHandler) Truncate(_ int64) error { return nil }
 func (t *FakeBufferedWriteHandler) Destroy() error         { return nil }
 func (t *FakeBufferedWriteHandler) Unlink()                {}
+func (t *FakeBufferedWriteHandler) UpdatedMinObjectFromUploadHandler() *gcs.MinObject {
+	return nil
+}
 
 func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
 	err := t.in.CreateBufferedOrTempWriter(t.ctx)

--- a/tools/integration_tests/streaming_writes/default_mount_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,12 +50,11 @@ func (t *defaultMountCommonTest) TearDownSuite() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(t.T())
 }
 
-func (t *defaultMountCommonTest) validateReadCall(filePath string) {
-	_, err := os.ReadFile(filePath)
+func (t *defaultMountCommonTest) validateReadCall(filePath, expectedContent string) {
+	readContent, err := os.ReadFile(filePath)
 	if setup.IsZonalBucketRun() {
-		// TODO(b/410698332): Remove skip condition once reads start working.
-		t.T().Skip("Skipping Zonal Bucket Read tests.")
 		require.NoError(t.T(), err)
+		assert.Equal(t.T(), expectedContent, string(readContent))
 	} else {
 		require.Error(t.T(), err)
 	}

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -30,7 +30,7 @@ func (t *defaultMountCommonTest) TestReadFileAfterSync() {
 	// Sync File to ensure buffers are flushed to GCS.
 	operations.SyncFile(t.f1, t.T())
 
-	t.validateReadCall(t.f1.Name())
+	t.validateReadCall(t.f1.Name(), t.data)
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -34,7 +34,7 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileAndReadFromSymlink
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
 	// Validate read file from symlink.
-	t.validateReadCall(symlink)
+	t.validateReadCall(symlink, t.data)
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
@@ -50,7 +50,7 @@ func (t *defaultMountCommonTest) TestReadingFromSymlinkForDeletedLocalFile() {
 	operations.VerifyReadLink(t.filePath, symlink, t.T())
 
 	// Validate read from symlink.
-	t.validateReadCall(symlink)
+	t.validateReadCall(symlink, t.data)
 
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -106,8 +106,8 @@ func CreateLocalFileInTestDir(ctx context.Context, storageClient *storage.Client
 	testDirPath, fileName string, t *testing.T) (string, *os.File) {
 	filePath := path.Join(testDirPath, fileName)
 	fh := operations.CreateFile(filePath, FilePerms, t)
-	testDirName := GetDirName(testDirPath)
-	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
+	// testDirName := GetDirName(testDirPath)
+	// ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, fileName, t)
 	return filePath, fh
 }
 

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -143,6 +143,7 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 		if setup.IsZonalBucketRun() {
 			// Zonal bucket writers require append-flag to be set.
 			wc.Append = true
+			wc.FinalizeOnClose = true
 		} else {
 			return nil, fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())
 		}


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
