### PR TITLE
[testing-on-gke] Dump bucket_name, machine_type in FIO output file

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -147,6 +147,8 @@ spec:
         echo "{{ .Values.gcsfuse.mountOptions }}" > ${output_dir}/gcsfuse_mount_options
         {{ end }}
         echo "{{ .Values.podName }}" > ${output_dir}/pod_name
+        echo "{{ .Values.nodeType }}" > ${output_dir}/machine_type
+        echo "{{ .Values.bucketName }}" > ${output_dir}/bucket_name
 
         for i in $(seq $epoch); do
           echo "[Epoch ${i}] start time:" `date +%s`


### PR DESCRIPTION
### Description
Dump new fields `bucket_name`, `machine_type` in the output csv file from the pods. These will be useful for dashboard for filtering out data based on more dimensions.

This PR is dependent on PR #3127 .

### Link to the issue in case of a bug fix.
[b/412912760](http://b/412912760)

### Testing details
1. Manual - Tested locally. It generated the following csv file content
   ```
   File Size,Read Type,Scenario,Epoch,Duration (s),Throughput (MB/s),IOPS,Throughput over Local SSD (%),GCSFuse Lowest Memory (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU (core),GCSFuse Highest CPU (core),Pod,Start,End,GcsfuseMoutOptions,BlockSize,FilesPerThread,NumThreads,InstanceID,e2e_latency_ns_max,e2e_latency_ns_p50,e2e_latency_ns_p90,e2e_latency_ns_p99,e2e_latency_ns_p99.9,bucket_name,machine_type
   1M,randread,gcsfuse-generic,1,1,75,603,NA,108.0,108.0,0.00285,0.00285,fio-tester-gcsfuse-rr-1m-5331607609046042386,2025-04-23 09:06:30 UTC,2025-04-23 09:06:31 UTC,"implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true",128K,8,10,gargnitin_google_com-20250423-090500,140747827,1832,436224,52690944,141557760,***,n2-standard-96
   1M,randread,gcsfuse-generic,2,0,2857,22857,NA,108.0,108.0,0.00442,0.00442,fio-tester-gcsfuse-rr-1m-5331607609046042386,2025-04-23 09:06:52 UTC,2025-04-23 09:06:52 UTC,"implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true",128K,8,10,gargnitin_google_com-20250423-090500,3025767,1192,708608,2473984,3031040,***,n2-standard-96
   1M,randread,gcsfuse-generic,3,0,2666,21333,NA,108.0,108.0,0.00598,0.00598,fio-tester-gcsfuse-rr-1m-5331607609046042386,2025-04-23 09:07:12 UTC,2025-04-23 09:07:13 UTC,"implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true",128K,8,10,gargnitin_google_com-20250423-090500,2927873,1464,987136,2473984,2932736,***,n2-standard-96
   1M,randread,gcsfuse-generic,4,0,2962,23703,NA,212.0,212.0,0.00682,0.00682,fio-tester-gcsfuse-rr-1m-5331607609046042386,2025-04-23 09:07:33 UTC,2025-04-23 09:07:33 UTC,"implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:type-cache-max-size-mb:-1,metadata-cache:stat-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true",128K,8,10,gargnitin_google_com-20250423-090500,3016322,1064,716800,2473984,3031040,***,n2-standard-96
   ```
3. Unit tests - NA
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
