### PR TITLE
fix: use local rand.NewSource() in each invocation as NewSource() is not safe for concurrent use.

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,7 +43,6 @@ var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted 
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
-var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
 	FilePermission_0600      = 0600
@@ -219,6 +218,7 @@ func ExecuteTest(m *testing.M) (successCode int) {
 }
 
 func GenerateRandomString(length int) string {
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = Charset[seededRand.Intn(len(Charset))]


### PR DESCRIPTION
### Description
<img width="809" alt="Screenshot 2025-04-23 at 5 34 21 PM" src="https://github.com/user-attachments/assets/e683e104-d8a4-4086-891e-5ac6ad9c89ca" />




### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
