### PR TITLE
Support directpath for StorageControl

### DIFF
--- a/internal/storage/storageutil/control_client.go
+++ b/internal/storage/storageutil/control_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc/codes"
 )
 
@@ -58,7 +59,8 @@ func CreateGRPCControlClient(ctx context.Context, clientOpts []option.ClientOpti
 		logger.Fatal("error setting direct path env var: %v", err)
 	}
 
-	controlClient, err = control.NewStorageControlClient(ctx, clientOpts...)
+	opts := append(clientOpts, internaloption.EnableDirectPath(true), internaloption.AllowNonDefaultServiceAccount(true), internaloption.EnableDirectPathXds())
+	controlClient, err = control.NewStorageControlClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("NewStorageControlClient: %w", err)
 	}


### PR DESCRIPTION
### Description
This allows the StorageControl client to use directpath/xDS endpoints. These mirror the default gRPC options in package cloud.google/com/go/storage.

See https://github.com/googleapis/google-cloud-go/blob/main/storage/grpc_client.go#L105-L109

### Related issues
[b/412688930](http://b/412688930)

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Ran through presubmit

### Any backward incompatible change? If so, please explain.

