### PR TITLE
fix: Use random bucket name in each CreateTestBucketForDynamicMounting call instead of using  fixed random name.

### DIFF
--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -92,7 +92,10 @@ func (s *remountTest) TestCacheIsNotReusedOnDynamicRemount(t *testing.T) {
 	runTestsOnlyForDynamicMount(t)
 	testBucket1 := setup.TestBucket()
 	testFileName1 := setupFileInTestDir(s.ctx, s.storageClient, testDirName, fileSize, t)
-	testBucket2 := dynamic_mounting.CreateTestBucketForDynamicMounting(ctx, storageClient)
+	testBucket2, err := dynamic_mounting.CreateTestBucketForDynamicMounting(ctx, storageClient)
+	if err != nil {
+		t.Fatalf("Failed to create bucket for dynamic mounting test: %v", err)
+	}
 	defer func() {
 		if err := client.DeleteBucket(ctx, storageClient, testBucket2); err != nil {
 			t.Logf("Failed to delete test bucket %s.Error : %v", testBucket1, err)

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -29,9 +29,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 )
 
-// Adding prefix `golang-grpc-test` to white list the bucket for grpc so that
-// we can run the grpc related e2e test.
-const PrefixBucketForDynamicMountingTest = "golang-grpc-test-gcsfuse-dynamic-mounting-test-"
+const PrefixBucketForDynamicMountingTest = "gcsfuse-dynamic-mounting-test-"
 
 func MountGcsfuseWithDynamicMounting(flags []string) (err error) {
 	defaultArg := []string{"--log-severity=trace",

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -99,10 +99,10 @@ func executeTestsForDynamicMounting(flags [][]string, createdBucket string, m *t
 	return
 }
 
-func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string) {
+func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string, err error) {
 	projectID, err := metadata.ProjectIDWithContext(ctx)
 	if err != nil {
-		log.Printf("Error in fetching project id: %v", err)
+		return "", fmt.Errorf("failed to get project ID of instance: %v", err)
 	}
 
 	// Create bucket handle and attributes
@@ -113,7 +113,7 @@ func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Cli
 	bucketName = PrefixBucketForDynamicMountingTest + setup.GenerateRandomString(5)
 	bucket := client.Bucket(bucketName)
 	if err := bucket.Create(ctx, projectID, storageClassAndLocation); err != nil {
-		log.Fatalf("DynamicBucket(%q).Create: %v", bucketName, err)
+		return "", fmt.Errorf("failed to create bucket: %v", err)
 	}
 	return
 }
@@ -121,7 +121,10 @@ func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Cli
 func RunTests(ctx context.Context, client *storage.Client, flags [][]string, m *testing.M) (successCode int) {
 	log.Println("Running dynamic mounting tests...")
 
-	createdBucket := CreateTestBucketForDynamicMounting(ctx, client)
+	createdBucket, err := CreateTestBucketForDynamicMounting(ctx, client)
+	if err != nil {
+		log.Fatalf("Failed to create bucket for dynamic mounting test: %v", err)
+	}
 
 	successCode = executeTestsForDynamicMounting(flags, createdBucket, m)
 

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -100,7 +100,7 @@ func executeTestsForDynamicMounting(flags [][]string, createdBucket string, m *t
 }
 
 func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string) {
-	projectID, err := metadata.ProjectID()
+	projectID, err := metadata.ProjectIDWithContext(ctx)
 	if err != nil {
 		log.Printf("Error in fetching project id: %v", err)
 	}
@@ -128,7 +128,7 @@ func RunTests(ctx context.Context, client *storage.Client, flags [][]string, m *
 	log.Printf("Test log: %s\n", setup.LogFile())
 
 	if err := client_util.DeleteBucket(ctx, client, createdBucket); err != nil {
-		log.Fatalf("Failed to delete the bucket : %s. Error: %v", createdBucket, err)
+		log.Fatalf("Failed to delete the created bucket for dynamic mounting test: %s. Error: %v", createdBucket, err)
 	}
 
 	return successCode


### PR DESCRIPTION
### Description

Current method can't create multiple random buckets for dynamic mounting if required for parallel execution of tests within same package test. Currently running two tests in a test package in sequential is also not possible if they create dynamic bucket and one of them fails to delete it. Thus other test will see that bucket already exists on GCS. This is part of larger effort in which I am trying to reduce test package run time.

- Use random bucket name in each CreateTestBucketForDynamicMounting call instead of using random fixed name.
- Use `metadata.ProjectIDWithContext(ctx)` instead of `deprecated metadata.ProjectID()`
- Improved error handling.


### Link to the issue in case of a bug fix.
b/413231761

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - run as part of Presubmit run

### Any backward incompatible change? If so, please explain.
