### PR TITLE
Fix error handing with gcsFullReadCloser

### DIFF
--- a/internal/monitor/full_read_closer.go
+++ b/internal/monitor/full_read_closer.go
@@ -31,9 +31,8 @@ func newGCSFullReadCloser(reader gcs.StorageReader) gcs.StorageReader {
 }
 
 // Read reads exactly len(buf) bytes from the wrapped StorageReader into buf.
-// 1. the number of bytes copied and an ErrUnexpectedEOF if response size < buffer size
-// 2. EOF only if no bytes were read.
-// 3. n == len(buf) if and only if err == nil.
+// 1. the number of bytes copied and an EOF if response size < buffer size
+// 2. n == len(buf) if and only if err == nil.
 func (frc gcsFullReadCloser) Read(buf []byte) (n int, err error) {
 	n, err = io.ReadFull(frc.wrapped, buf)
 	if err == io.ErrUnexpectedEOF {

--- a/internal/monitor/full_read_closer.go
+++ b/internal/monitor/full_read_closer.go
@@ -35,7 +35,11 @@ func newGCSFullReadCloser(reader gcs.StorageReader) gcs.StorageReader {
 // 2. EOF only if no bytes were read.
 // 3. n == len(buf) if and only if err == nil.
 func (frc gcsFullReadCloser) Read(buf []byte) (n int, err error) {
-	return io.ReadFull(frc.wrapped, buf)
+	n, err = io.ReadFull(frc.wrapped, buf)
+	if err == io.ErrUnexpectedEOF {
+		err = io.EOF
+	}
+	return n, err
 }
 
 func (frc gcsFullReadCloser) ReadHandle() (rh storagev2.ReadHandle) {

--- a/internal/monitor/full_read_closer.go
+++ b/internal/monitor/full_read_closer.go
@@ -37,6 +37,9 @@ func newGCSFullReadCloser(reader gcs.StorageReader) gcs.StorageReader {
 func (frc gcsFullReadCloser) Read(buf []byte) (n int, err error) {
 	n, err = io.ReadFull(frc.wrapped, buf)
 	if err == io.ErrUnexpectedEOF {
+		// if an EOF is encountered before reading the full length of the buffer,
+		// ReadFull returns an ErrUnexpectedEOF error. This needs to be convered
+		// to EOF in order to have a consistent behavior (error) with and without gcsFullReadCloser.
 		err = io.EOF
 	}
 	return n, err

--- a/internal/monitor/full_read_closer_test.go
+++ b/internal/monitor/full_read_closer_test.go
@@ -59,7 +59,7 @@ func TestFullReaderCloser(t *testing.T) {
 			data:         []byte("0123"),
 			bufSize:      5,
 			expectedData: []byte("0123"),
-			expectedErr:  io.ErrUnexpectedEOF,
+			expectedErr:  io.EOF,
 		},
 		{
 			name:         "small_buffer",


### PR DESCRIPTION
### Description
If an EOF is encountered before reading the full length of the buffer, ReadFull returns an ErrUnexpectedEOF error. This needs to be convered to EOF in order to have a consistent behavior (error) with and without gcsFullReadCloser.

### Link to the issue in case of a bug fix.
b/413109300


### Testing details
1. Manual - NA
2. Unit tests - Updated
3. Integration tests - Executed after enabling metrics

### Any backward incompatible change? If so, please explain.
