### PR TITLE
fix: promote zonal object to generation backed inode on sync

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -109,7 +109,7 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// because the inode is dirty).
 	fh.inode.Lock()
 	// Ensure all pending writes to Zonal Buckets are flushed before issuing a read.
-	err = fh.inode.SyncPendingBufferedWrites()
+	_, err = fh.inode.SyncPendingBufferedWrites()
 	if err != nil {
 		fh.inode.Unlock()
 		err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -109,6 +109,8 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// because the inode is dirty).
 	fh.inode.Lock()
 	// Ensure all pending writes to Zonal Buckets are flushed before issuing a read.
+	// Updating inode state is not required here because inode state for Zonal Buckets will
+	// be updated at time of BWH creation.
 	_, err = fh.inode.SyncPendingBufferedWrites()
 	if err != nil {
 		fh.inode.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -653,7 +653,9 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	if err != nil {
 		return fmt.Errorf("f.bwh.Flush(): %w", err)
 	}
-
+	// Set BWH to nil as as object has been finalized.
+	f.bwh = nil
+	// If we finalized the object, we need to update our state.
 	f.updateInodeStateAfterSync(obj)
 	return nil
 }
@@ -662,24 +664,28 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 // It is a no-op when bwh is nil.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) SyncPendingBufferedWrites() error {
+func (f *FileInode) SyncPendingBufferedWrites() (gcsSynced bool, err error) {
 	if f.bwh == nil {
-		return nil
+		return
 	}
-	_, err := f.bwh.Sync()
+	minObj, err := f.bwh.Sync()
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
-		return &gcsfuse_errors.FileClobberedError{
+		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("f.bwh.Sync(): %w", err),
 		}
+		return
 	}
 	if err != nil {
-		return fmt.Errorf("f.bwh.Sync(): %w", err)
+		err = fmt.Errorf("f.bwh.Sync(): %w", err)
+		return
 	}
-	// Update the f.src.Size to the current Size of object
-	// on GCS after flushing pending buffers.
-	f.src.Size = uint64(f.bwh.WriteFileInfo().TotalSize)
-	return nil
+	// We return gcsSynced as true when we get minObject from Sync() for Zonal Buckets.
+	// For Non-Zonal Buckets minObj is always nil.
+	gcsSynced = minObj != nil
+	// If we flushed out object, we need to update our state.
+	f.updateInodeStateAfterSync(minObj)
+	return
 }
 
 // Set the mtime for this file. May involve a round trip to GCS.
@@ -813,9 +819,8 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 	}
 
 	if f.bwh != nil {
-		// SyncPendingBufferedWrites does not finalize the upload,
-		// so return gcsSynced as false.
-		err = f.SyncPendingBufferedWrites()
+		// SyncPendingBufferedWrites returns gcsSynced as true for Zonal Buckets.
+		gcsSynced, err = f.SyncPendingBufferedWrites()
 		if err != nil {
 			err = fmt.Errorf("could not sync what has been written so far: %w", err)
 		}
@@ -900,12 +905,7 @@ func (f *FileInode) updateInodeStateAfterSync(minObj *gcs.MinObject) {
 			f.content.Destroy()
 			f.content = nil
 		}
-		if f.bwh != nil {
-			f.bwh = nil
-		}
 	}
-
-	return
 }
 
 // Updates the min object stored in MRDWrapper corresponding to the inode.

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -223,7 +223,6 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.True(t.T(), t.in.IsLocal())
-
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
 }
 

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -226,7 +226,7 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
 }
 
-func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesUpdateSrcSize() {
+func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotUpdateSrcSize() {
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0))
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
@@ -234,7 +234,7 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
-	assert.Equal(t.T(), uint64(6), t.in.src.Size)
+	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 }
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempFile() {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -173,10 +173,14 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBuckets() {
+func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsPromotesInodeToNonLocal() {
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("pizza"), 0))
 
-	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
+	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+
+	require.NoError(t.T(), err)
+	assert.True(t.T(), gcsSynced)
+	assert.False(t.T(), t.in.IsLocal())
 	content, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), "pizza", string(content))
@@ -186,8 +190,10 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0))
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
+	gcsSynced, err := t.in.SyncPendingBufferedWrites()
 
+	require.NoError(t.T(), err)
+	assert.True(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(6), t.in.src.Size)
 }
 
@@ -209,10 +215,15 @@ func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFals
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBuckets() {
+func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotPromoteInodeToNonLocal() {
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
-	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
+	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+	assert.True(t.T(), t.in.IsLocal())
+
 	operations.ValidateObjectNotFoundErr(t.ctx, t.T(), t.bucket, t.in.Name().GcsObjectName())
 }
 
@@ -220,8 +231,10 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0))
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
+	gcsSynced, err := t.in.SyncPendingBufferedWrites()
 
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(6), t.in.src.Size)
 }
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -201,8 +201,10 @@ func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreaming
 	assert.Equal(t.T(), t.initialContents, string(contents))
 
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("bar"), 0))
-	assert.NoError(t.T(), t.in.SyncPendingBufferedWrites())
+	gcsSynced, err := t.in.SyncPendingBufferedWrites()
 
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	contents, err = storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), t.initialContents, string(contents))

--- a/tools/integration_tests/streaming_writes/rename_file_test.go
+++ b/tools/integration_tests/streaming_writes/rename_file_test.go
@@ -19,15 +19,10 @@ import (
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
-	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/require"
 )
 
 func (t *defaultMountCommonTest) TestRenameBeforeFileIsFlushed() {
-	if setup.IsZonalBucketRun() {
-		//TODO (b/413296959): Re-enable after update inode state changes are merged.
-		t.T().Skip("Skipping Zonal Bucket Rename tests until inode state is fixed.")
-	}
 	operations.WriteWithoutClose(t.f1, t.data, t.T())
 	operations.WriteWithoutClose(t.f1, t.data, t.T())
 	operations.VerifyStatFile(t.filePath, int64(2*len(t.data)), FilePerms, t.T())
@@ -48,10 +43,6 @@ func (t *defaultMountCommonTest) TestRenameBeforeFileIsFlushed() {
 }
 
 func (t *defaultMountCommonTest) TestSyncAfterRenameSucceeds() {
-	if setup.IsZonalBucketRun() {
-		//TODO (b/413296959): Re-enable after update inode state changes are merged.
-		t.T().Skip("Skipping Zonal Bucket Rename tests until inode state is fixed.")
-	}
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	require.NoError(t.T(), err)
 	operations.VerifyStatFile(t.filePath, int64(len(t.data)), FilePerms, t.T())
@@ -73,10 +64,6 @@ func (t *defaultMountCommonTest) TestSyncAfterRenameSucceeds() {
 }
 
 func (t *defaultMountCommonTest) TestAfterRenameWriteFailsWithStaleNFSFileHandleError() {
-	if setup.IsZonalBucketRun() {
-		//TODO (b/413296959): Re-enable after update inode state changes are merged.
-		t.T().Skip("Skipping Zonal Bucket Rename tests until inode state is fixed.")
-	}
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	require.NoError(t.T(), err)
 	operations.VerifyStatFile(t.filePath, int64(len(t.data)), FilePerms, t.T())


### PR DESCRIPTION
### Description
Promote zonal bucket objects to generation backed inodes as soon as the Sync() is called for local inodes which does a implicit flush on zonal buckets and upload pending buffers for non-zonal buckets. In case of non-zonal buckets they are only updated to generation backed inodes once the Close() has been called on them which finalizes the object.
Note: Start running tests which were skipped as part of b/413296959
**Note: A follow up PR will be send to promote Zonal Object to generation backed Inode as soon as BWH is initialized.**

### Link to the issue in case of a bug fix.
b/413296959
b/413587897

### Testing details
1. Manual - Tested skipped tests from b/413296959
2. Unit tests - Updated unit tests and tested.
3. Integration tests - Run as part of presubmit tests.

### Any backward incompatible change? If so, please explain.
