### PR TITLE
Remove setting streaming writes by default for high end machines

### DIFF
--- a/cfg/optimize.go
+++ b/cfg/optimize.go
@@ -77,7 +77,6 @@ var (
 			{
 				name: "high-performance",
 				overrides: map[string]flagOverride{
-					"write.enable-streaming-writes":         {newValue: true},
 					"metadata-cache.negative-ttl-secs":      {newValue: 0},
 					"metadata-cache.ttl-secs":               {newValue: -1},
 					"metadata-cache.stat-cache-max-size-mb": {newValue: 1024},

--- a/cfg/optimize_test.go
+++ b/cfg/optimize_test.go
@@ -392,8 +392,7 @@ func TestOptimize_Success(t *testing.T) {
 	optimizedFlags, err := Optimize(cfg, isSet)
 
 	require.NoError(t, err)
-	assert.True(t, cfg.Write.EnableStreamingWrites)
-	assert.True(t, isFlagPresent(optimizedFlags, "write.enable-streaming-writes"))
+	assert.True(t, isFlagPresent(optimizedFlags, "metadata-cache.negative-ttl-secs"))
 	assert.EqualValues(t, 0, cfg.MetadataCache.NegativeTtlSecs)
 	assert.EqualValues(t, -1, cfg.MetadataCache.TtlSecs)
 	assert.EqualValues(t, 1024, cfg.MetadataCache.StatCacheMaxSizeMb)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -227,7 +227,7 @@ func TestArgsParsing_ImplicitDirsFlag(t *testing.T) {
 		},
 		{
 			name:             "default overriden on high performance machine",
-			args:             []string{"gcsfuse", "--machine-type=a3-highgpu-8g", "--implicit-dirs=false", "abc", "pqr"},
+			args:             []string{"gcsfuse", "--machine-type=a3-highgpu-8g", "--disable-autoconfig=false", "--implicit-dirs=false", "abc", "pqr"},
 			expectedImplicit: false,
 		},
 	}
@@ -331,31 +331,6 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteBlockSizeMB:      32 * util.MiB,
 			expectedWriteGlobalMaxBlocks:  math.MaxInt64,
 			expectedWriteMaxBlocksPerFile: 10,
-		},
-		{
-			name:                          "Test high performance config values with autoconfig enabled.",
-			args:                          []string{"gcsfuse", "--machine-type=a3-highgpu-8g", "--disable-autoconfig=false", "abc", "pqr"},
-			expectedEnableStreamingWrites: true,
-			expectedWriteBlockSizeMB:      32 * util.MiB,
-			expectedWriteGlobalMaxBlocks:  math.MaxInt64,
-		},
-		{
-			name:                          "Test high performance config values with autoconfig disabled.",
-			args:                          []string{"gcsfuse", "--machine-type=a3-highgpu-8g", "--disable-autoconfig=true", "abc", "pqr"},
-			expectedCreateEmptyFile:       false,
-			expectedEnableStreamingWrites: false,
-			expectedWriteBlockSizeMB:      32 * util.MiB,
-			expectedWriteGlobalMaxBlocks:  math.MaxInt64,
-			expectedWriteMaxBlocksPerFile: 1,
-		},
-		{
-			name:                          "Test high performance config values with enable-streaming-writes flag overriden.",
-			args:                          []string{"gcsfuse", "--enable-streaming-writes=false", "abc", "pqr"},
-			expectedCreateEmptyFile:       false,
-			expectedEnableStreamingWrites: false,
-			expectedWriteBlockSizeMB:      32 * util.MiB,
-			expectedWriteGlobalMaxBlocks:  math.MaxInt64,
-			expectedWriteMaxBlocksPerFile: 1,
 		},
 	}
 


### PR DESCRIPTION
### Description
Remove setting streaming writes by default for high end machines as it would be set as true in the future.
Also, spruce up a test case to handle the auto config flag properly and make behavior of the test more predictable.

### Link to the issue in case of a bug fix.
b/402273935

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
NA