### PR TITLE
Support GCE_METADATA_HOST in background mode

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -310,6 +310,13 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 		if p, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
 			env = append(env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", p))
 		}
+
+		// Pass along GCE_MEATADATA_HOST, since it is supported by google-cloud-go
+		// https://github.com/googleapis/google-cloud-go/blob/main/compute/metadata/metadata.go
+		if p, ok := os.LookupEnv("GCE_METADATA_HOST"); ok {
+			env = append(env, fmt.Sprintf("GCE_METADATA_HOST=%s", p))
+		}
+		
 		// Pass through the https_proxy/http_proxy environment variable,
 		// in case the host requires a proxy server to reach the GCS endpoint.
 		// https_proxy has precedence over http_proxy, in case both are set


### PR DESCRIPTION
### Description
`GCE_METADATA_HOST` is supported by google sdks to bypass GCE metadata service endpoint, for some cases (eg, container)
Documented in `https://github.com/googleapis/google-cloud-go/blob/main/compute/metadata/metadata.go`
And `google-cloud-go` is a dependency of `gcsfuse`, which means `GCE_METADATA_HOST` should be supported by `gcsfuse`.

However, only --foreground mode supports `GCE_METADATA_HOST`.
In background mode, the env does not check and include `GCE_METADATA_HOST`
It is a bug to me and this PR fixes it.


### Link to the issue in case of a bug fix.


### Testing details
1. Manual - OK
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No