### PR TITLE
un-support read operations on unfinalized objects

### DIFF
--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -167,10 +167,10 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsTrueAfterWriteForZonalBuckets() {
+func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForZonalBuckets() {
 	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0))
 
-	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
+	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsPromotesInodeToNonLocal() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1518,7 +1519,7 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 
 			assert.Equal(t.T(), 0, n)
 			require.Error(t.T(), err)
-			assert.Equal(t.T(), "cannot read a file when upload in progress", err.Error())
+			assert.ErrorIs(t.T(), err, syscall.ENOTSUP)
 		})
 	}
 }

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unfinalized_object
+
+import (
+	"cloud.google.com/go/storage"
+	"context"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"log"
+	"path"
+	"syscall"
+	"testing"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type unfinalizedObjectReads struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	fileName      string
+	suite.Suite
+}
+
+func (t *unfinalizedObjectReads) SetupTest() {
+	t.testDirPath = client.SetupTestDirectory(t.ctx, t.storageClient, testDirName)
+	t.fileName = path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+}
+
+func (t *unfinalizedObjectReads) TeardownTest() {}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (t *unfinalizedObjectReads) TestUnfinalizedObjectsCantBeRead() {
+	var size int = operations.MiB
+	// Create un-finalized object via same mount.
+	fh := operations.CreateFile(path.Join(t.testDirPath, t.fileName), setup.FilePermission_0600, t.T())
+	operations.WriteWithoutClose(fh, setup.GenerateRandomString(size), t.T())
+	defer operations.CloseFileShouldNotThrowError(t.T(), fh)
+
+	// Read un-finalized object.
+	content, err := operations.ReadFileSequentially(path.Join(t.testDirPath, t.fileName), util.MiB)
+
+	require.Error(t.T(), err)
+	assert.ErrorContains(t.T(), err, syscall.ENOTSUP.Error())
+	assert.Empty(t.T(), content, "expected empty content, but got size: %v", len(content))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestUnfinalizedObjectReadTest(t *testing.T) {
+	ts := &unfinalizedObjectReads{ctx: context.Background()}
+	// Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&ts.ctx, &ts.storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			t.Errorf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		suite.Run(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--enable-streaming-writes=true", "--metadata-cache-ttl-secs=-1"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
+	}
+}

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -15,8 +15,13 @@
 package unfinalized_object
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
+	"log"
+	"path"
+	"syscall"
+	"testing"
+
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
@@ -24,10 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"log"
-	"path"
-	"syscall"
-	"testing"
 )
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
Return unsupported error for reads on unfinalized objects.

### Link to the issue in case of a bug fix.
b/414336188

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - added

### Any backward incompatible change? If so, please explain.
NA
