### PR TITLE
Sync file Inode at the time of BWH initialization

### DIFF
--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -123,6 +123,7 @@ func (uh *UploadHandler) UploadError() (err error) {
 func (uh *UploadHandler) uploader() {
 	for currBlock := range uh.uploadCh {
 		if uh.UploadError() != nil {
+			uh.freeBlocksCh <- currBlock
 			uh.wg.Done()
 			continue
 		}

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -122,19 +122,21 @@ func (uh *UploadHandler) UploadError() (err error) {
 // uploader is the single-threaded goroutine that uploads blocks.
 func (uh *UploadHandler) uploader() {
 	for currBlock := range uh.uploadCh {
-		if uh.UploadError() == nil {
-			_, err := io.Copy(uh.writer, currBlock.Reader())
-			if errors.Is(err, context.Canceled) {
-				// Context canceled error indicates that the file was deleted from the
-				// same mount. In this case, we suppress the error to match local
-				// filesystem behavior.
-				err = nil
-			}
-			if err != nil {
-				logger.Errorf("buffered write upload failed for object %s: error in io.Copy: %v", uh.objectName, err)
-				err = gcs.GetGCSError(err)
-				uh.uploadError.Store(&err)
-			}
+		if uh.UploadError() != nil {
+			uh.wg.Done()
+			continue
+		}
+		_, err := io.Copy(uh.writer, currBlock.Reader())
+		if errors.Is(err, context.Canceled) {
+			// Context canceled error indicates that the file was deleted from the
+			// same mount. In this case, we suppress the error to match local
+			// filesystem behavior.
+			err = nil
+		}
+		if err != nil {
+			logger.Errorf("buffered write upload failed for object %s: error in io.Copy: %v", uh.objectName, err)
+			err = gcs.GetGCSError(err)
+			uh.uploadError.Store(&err)
 		}
 		// Put back the uploaded block on the freeBlocksChannel for re-use.
 		uh.freeBlocksCh <- currBlock

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -260,7 +260,7 @@ func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
 
 	assertUploadFailureError(t.T(), t.uh)
 	assertAllBlocksProcessed(t.T(), t.uh)
-	assert.Equal(t.T(), 4, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 2, len(t.uh.freeBlocksCh))
 }
 
 func assertUploadFailureError(t *testing.T, handler *UploadHandler) {

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -260,7 +260,7 @@ func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
 
 	assertUploadFailureError(t.T(), t.uh)
 	assertAllBlocksProcessed(t.T(), t.uh)
-	assert.Equal(t.T(), 2, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 4, len(t.uh.freeBlocksCh))
 }
 
 func assertUploadFailureError(t *testing.T, handler *UploadHandler) {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1214,7 +1214,7 @@ func (fs *fileSystem) syncFile(
 	return nil
 }
 
-// Initializes Buffered Write Handler if Eligible and synchronizes the file inode to GCS if initialized succeds.
+// Initializes Buffered Write Handler if Eligible and synchronizes the file inode to GCS if initialization succeeds.
 //
 // LOCKS_EXCLUDED(fs.mu)
 // LOCKS_REQUIRED(f.mu)
@@ -2629,7 +2629,6 @@ func (fs *fileSystem) WriteFile(
 	in.Lock()
 	defer in.Unlock()
 
-	// Initialize BWH if eligible and Sync file inode.
 	err = fs.initBufferedWriteHandlerAndSyncFileIfEligible(ctx, in)
 	if err != nil {
 		return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1782,10 +1782,12 @@ func (fs *fileSystem) createLocalFile(ctx context.Context, parentID fuseops.Inod
 	fileInode.Lock()
 	err = fs.initBufferedWriteHandlerAndSyncFileIfEligible(ctx, fileInode)
 	if err != nil {
+		fileInode.Unlock()
 		return
 	}
 	err = fileInode.CreateEmptyTempFile(ctx)
 	if err != nil {
+		fileInode.Unlock()
 		return
 	}
 	fileInode.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -952,7 +952,11 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	return
 }
 
-func (f *FileInode) CreateBufferedOrTempWriter(ctx context.Context) (err error) {
+func (f *FileInode) CreateBufferedOrTempWriter(ctx context.Context) (initialized bool, err error) {
+	initialized, err = f.InitBufferedWriteHandlerIfEligible(ctx)
+	if err != nil {
+		return
+	}
 	// Skip creating empty file when streaming writes are enabled.
 	if f.bwh != nil {
 		return

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -969,23 +969,24 @@ func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 
 // Initializes Buffered Write Handler if the file inode is eligible and returns
 // initialized as true when the new instance of buffered writer handler is created.
-func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (initalized bool, err error) {
+func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (bool, error) {
 	// bwh already initialized, do nothing.
 	if f.bwh != nil {
-		return
+		return false, nil
 	}
 
 	tempFileInUse := f.content != nil
 	if f.src.Size != 0 || !f.config.Write.EnableStreamingWrites || tempFileInUse {
 		// bwh should not be initialized under these conditions.
-		return
+		return false, nil
 	}
 
 	var latestGcsObj *gcs.Object
+	var err error
 	if !f.local {
 		latestGcsObj, err = f.fetchLatestGcsObject(ctx)
 		if err != nil {
-			return
+			return false, err
 		}
 	}
 
@@ -1005,5 +1006,5 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (ini
 		f.bwh.SetMtime(f.mtimeClock.Now())
 		return true, nil
 	}
-	return
+	return false, nil
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -953,9 +953,12 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 
 // CreateEmptyTempFile creates an empty file with no contents when
 // streaming writes are not in enabled.
+//
+// LOCKS_REQUIRED(f.mu)
 func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
-	// Skip creating empty file when streaming writes are enabled.
-	if f.bwh != nil {
+	// Skip creating empty temp file when streaming writes are enabled
+	// or temp file is already created.
+	if f.bwh != nil || f.content != nil {
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -951,8 +951,8 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	return
 }
 
-// CreateEmptyTempFile creates an empty file with no contents and skips
-// creating empty file when streaming writes are enabled.
+// CreateEmptyTempFile creates an empty file with no contents when
+// streaming writes are not in enabled.
 func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 	// Skip creating empty file when streaming writes are enabled.
 	if f.bwh != nil {
@@ -968,7 +968,7 @@ func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 }
 
 // Initializes Buffered Write Handler if the file inode is eligible and returns
-// initialized as true if the new instance of buffered writer handler is created.
+// initialized as true when the new instance of buffered writer handler is created.
 func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (initalized bool, err error) {
 	// bwh already initialized, do nothing.
 	if f.bwh != nil {
@@ -1000,12 +1000,10 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (ini
 			ChunkTransferTimeoutSecs: f.config.GcsRetries.ChunkTransferTimeoutSecs,
 		})
 		if err != nil {
-			err = fmt.Errorf("failed to create bufferedWriteHandler: %w", err)
-			return
+			return false, fmt.Errorf("failed to create bufferedWriteHandler: %w", err)
 		}
 		f.bwh.SetMtime(f.mtimeClock.Now())
-		initalized = true
-		return
+		return true, nil
 	}
 	return
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -951,6 +951,8 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	return
 }
 
+// CreateEmptyTempFile creates an empty file with no contents and skips
+// creating empty file when streaming writes are enabled.
 func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 	// Skip creating empty file when streaming writes are enabled.
 	if f.bwh != nil {
@@ -965,6 +967,8 @@ func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 	return
 }
 
+// Initializes Buffered Write Handler if the file inode is eligible and returns
+// initialized as true if the new instance of buffered writer handler is created.
 func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context) (initalized bool, err error) {
 	// bwh already initialized, do nothing.
 	if f.bwh != nil {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -951,11 +951,7 @@ func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	return
 }
 
-func (f *FileInode) CreateBufferedOrTempWriter(ctx context.Context) (initialized bool, err error) {
-	initialized, err = f.InitBufferedWriteHandlerIfEligible(ctx)
-	if err != nil {
-		return
-	}
+func (f *FileInode) CreateEmptyTempFile(ctx context.Context) (err error) {
 	// Skip creating empty file when streaming writes are enabled.
 	if f.bwh != nil {
 		return

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"strconv"
 	"strings"
 	"syscall"

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -114,7 +114,7 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64))
 
-	// Create write handler for the local inode created above.
+	// Create empty file for local inode created above.
 	err := t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -115,7 +115,7 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		semaphore.NewWeighted(math.MaxInt64))
 
 	// Create write handler for the local inode created above.
-	err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
 	assert.Nil(t.T(), err)
 
 	t.in.Lock()

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -115,7 +115,7 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		semaphore.NewWeighted(math.MaxInt64))
 
 	// Create write handler for the local inode created above.
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 
 	t.in.Lock()

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -695,11 +695,7 @@ func (t *FileStreamingWritesTest) TestDeRegisterFileHandle() {
 	}
 	for _, tc := range tbl {
 		t.Run(tc.name, func() {
-			t.in.config = &cfg.Config{Write: *getWriteConfig()}
 			t.in.writeHandleCount = tc.currentVal
-			_, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-			require.NoError(t.T(), err)
-			require.NotNil(t.T(), t.in.bwh)
 
 			t.in.DeRegisterFileHandle(tc.readonly)
 
@@ -747,8 +743,6 @@ func (t *FakeBufferedWriteHandler) Destroy() error                { return nil }
 func (t *FakeBufferedWriteHandler) Unlink()                       {}
 
 func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
-	err := t.in.CreateEmptyTempFile(t.ctx)
-	assert.NoError(t.T(), err)
 	assert.True(t.T(), t.in.IsLocal())
 	require.NotNil(t.T(), t.in.bwh)
 	writeErr := errors.New("write error")
@@ -758,7 +752,7 @@ func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
 		},
 	}
 
-	err = t.in.Write(context.Background(), []byte("hello"), 0)
+	err := t.in.Write(context.Background(), []byte("hello"), 0)
 
 	require.Error(t.T(), err)
 	assert.Regexp(t.T(), writeErr.Error(), err.Error())

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -151,6 +151,7 @@ func (t *FileStreamingWritesCommon) createInode(fileName string, fileType string
 		EnableStreamingWrites: true,
 		GlobalMaxBlocks:       10,
 	}}
+	// Initialize BWH for inode created above.
 	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initialized)

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -151,7 +151,8 @@ func (t *FileStreamingWritesCommon) createInode(fileName string, fileType string
 		EnableStreamingWrites: true,
 		GlobalMaxBlocks:       10,
 	}}
-
+	_, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+	require.NoError(t.T(), err)
 	t.in.Lock()
 }
 
@@ -704,7 +705,7 @@ func (t *FileStreamingWritesTest) TestDeRegisterFileHandle() {
 		t.Run(tc.name, func() {
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
 			t.in.writeHandleCount = tc.currentVal
-			err := t.in.initBufferedWriteHandlerIfEligible(t.ctx)
+			_, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			require.NotNil(t.T(), t.in.bwh)
 

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -201,6 +201,31 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 	assert.Equal(t.T(), uint64(6), t.in.src.Size)
 }
 
+func (t *FileStreamingWritesZonalBucketTest) TestflushUsingBufferedWriteHandlerForZonalBucketsOnZeroSizeRecreatesBwhOnInitAgain() {
+	err := t.in.flushUsingBufferedWriteHandler()
+	require.NoError(t.T(), err)
+	assert.Nil(t.T(), t.in.bwh)
+
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initialized)
+	assert.NotNil(t.T(), t.in.bwh)
+}
+
+func (t *FileStreamingWritesZonalBucketTest) TestflushUsingBufferedWriteHandlerForZonalBucketsOnNonZeroSizeDoesNotRecreatesBwhOnInitAgain() {
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0))
+	err := t.in.flushUsingBufferedWriteHandler()
+	require.NoError(t.T(), err)
+	assert.Nil(t.T(), t.in.bwh)
+
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+
+	require.NoError(t.T(), err)
+	assert.False(t.T(), initialized)
+	assert.Nil(t.T(), t.in.bwh)
+}
+
 // //////////////////////////////////////////////////////////////////////
 // Tests (Non Zonal Bucket)
 // //////////////////////////////////////////////////////////////////////
@@ -239,6 +264,31 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
+}
+
+func (t *FileStreamingWritesTest) TestflushUsingBufferedWriteHandlerOnZeroSizeRecreatesBwhOnInitAgain() {
+	err := t.in.flushUsingBufferedWriteHandler()
+	require.NoError(t.T(), err)
+	assert.Nil(t.T(), t.in.bwh)
+
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initialized)
+	assert.NotNil(t.T(), t.in.bwh)
+}
+
+func (t *FileStreamingWritesTest) TestflushUsingBufferedWriteHandlerOnNonZeroSizeDoesNotRecreatesBwhOnInitAgain() {
+	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0))
+	err := t.in.flushUsingBufferedWriteHandler()
+	require.NoError(t.T(), err)
+	assert.Nil(t.T(), t.in.bwh)
+
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+
+	require.NoError(t.T(), err)
+	assert.False(t.T(), initialized)
+	assert.Nil(t.T(), t.in.bwh)
 }
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempFile() {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -167,8 +167,8 @@ func TestFileStreamingWritesWithZonalBucketTestSuite(t *testing.T) {
 	suite.Run(t, new(FileStreamingWritesZonalBucketTest))
 }
 
-func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsTrueForZonalBuckets() {
-	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
+func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsFalseForZonalBuckets() {
+	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForZonalBuckets() {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -266,7 +266,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func() {
-			_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+			err := t.in.CreateEmptyTempFile(t.ctx)
 			assert.Nil(t.T(), err)
 			assert.True(t.T(), t.in.IsLocal())
 			createTime := t.clock.Now()
@@ -307,7 +307,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 }
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	assert.True(t.T(), t.in.IsLocal())
 	createTime := t.in.mtimeClock.Now()
@@ -489,7 +489,7 @@ func (t *FileStreamingWritesTest) TestFlushEmptyFile() {
 				assert.False(t.T(), t.in.IsLocal())
 			}
 			t.clock.AdvanceTime(10 * time.Second)
-			_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+			err := t.in.CreateEmptyTempFile(t.ctx)
 			assert.NoError(t.T(), err)
 
 			err = t.in.Flush(t.ctx)
@@ -547,7 +547,7 @@ func (t *FileStreamingWritesTest) TestFlushClobberedFile() {
 				t.createInode(fileName, emptyGCSFile)
 				assert.False(t.T(), t.in.IsLocal())
 			}
-			_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+			err := t.in.CreateEmptyTempFile(t.ctx)
 			assert.NoError(t.T(), err)
 			t.clock.AdvanceTime(10 * time.Second)
 			// Clobber the file.
@@ -644,7 +644,7 @@ func (t *FileStreamingWritesTest) TestSourceGenerationSizeForSyncedFileIsReflect
 }
 
 func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreatesBWH() {
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 	assert.NoError(t.T(), err)
 	assert.True(t.T(), t.in.IsLocal())
 	require.NotNil(t.T(), t.in.bwh)
@@ -758,7 +758,7 @@ func (t *FakeBufferedWriteHandler) Destroy() error                { return nil }
 func (t *FakeBufferedWriteHandler) Unlink()                       {}
 
 func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 	assert.NoError(t.T(), err)
 	assert.True(t.T(), t.in.IsLocal())
 	require.NotNil(t.T(), t.in.bwh)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1614,6 +1614,7 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for local inode created above.
 	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initalized)
@@ -1638,6 +1639,7 @@ func (t *FileTest) TestWriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 	createTime := t.in.mtimeClock.Now()
+	// Initialize BWH for inode created above.
 	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initalized)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1370,6 +1370,7 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for local inode created above.
 	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initalized)
@@ -1427,7 +1428,7 @@ func (t *FileTest) TestTestCheckInvariantsShouldNotThrowExceptionForLocalFiles()
 	assert.NotNil(t.T(), t.in)
 }
 
-func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
+func (t *FileTest) TestCreateEmptyTempFileShouldCreateFile() {
 	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
@@ -1436,6 +1437,36 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 	sr, err := t.in.content.Stat()
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), int64(0), sr.Size)
+}
+
+func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForInodeWhenStreamingWritesAreEnabled() {
+	t.createInodeWithEmptyObject()
+	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for inode created above.
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initialized)
+	assert.NotNil(t.T(), t.in.bwh)
+
+	err = t.in.CreateEmptyTempFile(t.ctx)
+
+	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
+}
+
+func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForLocalInodeWhenStreamingWritesAreEnabled() {
+	t.createInodeWithLocalParam("test", true)
+	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for local inode created above.
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initialized)
+	assert.NotNil(t.T(), t.in.bwh)
+
+	err = t.in.CreateEmptyTempFile(t.ctx)
+
+	assert.Nil(t.T(), err)
+	assert.Nil(t.T(), t.in.content)
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamingWritesAreEnabled() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -157,6 +157,14 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 	t.in.Lock()
 }
 
+func (t *FileTest) createBufferedWriteHandler() {
+	// Initialize BWH for local inode created above.
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initialized)
+	assert.NotNil(t.T(), t.in.bwh)
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
@@ -912,12 +920,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 			// Create a local file inode.
 			t.createInodeWithLocalParam("test", true)
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			// Initialize BWH for local inode created above.
-			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-			require.NoError(t.T(), err)
-			assert.True(t.T(), initialized)
-			assert.NotNil(t.T(), t.in.bwh)
-
+			t.createBufferedWriteHandler()
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
 			require.NoError(t.T(), err)
@@ -967,11 +970,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 		t.Run(tc.name, func() {
 			t.createInodeWithEmptyObject()
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			// Initialize BWH for inode created above.
-			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-			require.NoError(t.T(), err)
-			assert.True(t.T(), initialized)
-			assert.NotNil(t.T(), t.in.bwh)
+			t.createBufferedWriteHandler()
 
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
@@ -1045,11 +1044,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				t.createInodeWithEmptyObject()
 			}
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			// Initialize BWH for inode created above.
-			initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-			require.NoError(t.T(), err)
-			assert.True(t.T(), initalized)
-			assert.NotNil(t.T(), t.in.bwh)
+			t.createBufferedWriteHandler()
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
 			require.NoError(t.T(), err)
@@ -1370,11 +1365,7 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for local inode created above.
-	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initalized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)
@@ -1442,13 +1433,9 @@ func (t *FileTest) TestCreateEmptyTempFileShouldCreateFile() {
 func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForInodeWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for inode created above.
-	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initialized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
-	err = t.in.CreateEmptyTempFile(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
 	assert.Nil(t.T(), t.in.content)
@@ -1457,13 +1444,9 @@ func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForInodeWhenStreami
 func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForLocalInodeWhenStreamingWritesAreEnabled() {
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for local inode created above.
-	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initialized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
-	err = t.in.CreateEmptyTempFile(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
 	assert.Nil(t.T(), t.in.content)
@@ -1533,21 +1516,13 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 				// Create a local file inode.
 				t.createInodeWithLocalParam("test", true)
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
-				// Initialize BWH for local inode created above.
-				initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-				require.NoError(t.T(), err)
-				assert.True(t.T(), initalized)
-				assert.NotNil(t.T(), t.in.bwh)
+				t.createBufferedWriteHandler()
 			}
 
 			if tc.fileType == EmptyGCSFile {
 				t.createInodeWithEmptyObject()
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
-				// Initialize BWH for inode created above.
-				initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-				require.NoError(t.T(), err)
-				assert.True(t.T(), initialized)
-				assert.NotNil(t.T(), t.in.bwh)
+				t.createBufferedWriteHandler()
 			}
 
 			if tc.performWrite {
@@ -1595,13 +1570,9 @@ func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for local inode created above.
-	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initialized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
-	err = t.in.Write(t.ctx, []byte("hi"), 0)
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
@@ -1614,13 +1585,9 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for local inode created above.
-	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initalized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
-	err = t.in.Write(t.ctx, []byte("hi"), 0)
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1639,13 +1606,9 @@ func (t *FileTest) TestWriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 	createTime := t.in.mtimeClock.Now()
-	// Initialize BWH for inode created above.
-	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initalized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 
-	err = t.in.Write(t.ctx, []byte("hi"), 0)
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
@@ -1673,13 +1636,9 @@ func (t *FileTest) TestSetMtimeOnEmptyGCSFileWhenStreamingWritesAreEnabled() {
 func (t *FileTest) TestSetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	// Initialize BWH for inode created above.
-	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	require.NoError(t.T(), err)
-	assert.True(t.T(), initalized)
-	assert.NotNil(t.T(), t.in.bwh)
+	t.createBufferedWriteHandler()
 	// Initiate write call.
-	err = t.in.Write(t.ctx, []byte("hi"), 0)
+	err := t.in.Write(t.ctx, []byte("hi"), 0)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
 	writeFileInfo := t.in.bwh.WriteFileInfo()

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1433,18 +1433,7 @@ func (t *FileTest) TestCreateEmptyTempFile() {
 	assert.Equal(t.T(), int64(0), sr.Size)
 }
 
-func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForInodeWhenStreamingWritesAreEnabled() {
-	t.createInodeWithEmptyObject()
-	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	t.createBufferedWriteHandler(true)
-
-	err := t.in.CreateEmptyTempFile(t.ctx)
-
-	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
-}
-
-func (t *FileTest) TestCreateEmptyTempFileDoesNotWhenBWHIsNotNil() {
+func (t *FileTest) TestCreateEmptyTempFileWhenBWHIsNotNil() {
 	testCases := []struct {
 		name    string
 		isLocal bool
@@ -1475,6 +1464,17 @@ func (t *FileTest) TestCreateEmptyTempFileDoesNotWhenBWHIsNotNil() {
 			assert.Nil(t.T(), t.in.content)
 		})
 	}
+}
+
+func (t *FileTest) TestInitBufferedWriteHandlerIfEligibleShouldNotCreateBWHNonEmptySyncedFile() {
+	// Enabling buffered writes.
+	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+
+	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+
+	assert.NoError(t.T(), err)
+	assert.Nil(t.T(), t.in.bwh)
+	assert.False(t.T(), initialized)
 }
 
 func (t *FileTest) TestUnlinkLocalFile() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -502,7 +502,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			// Create a local file inode.
 			t.createInodeWithLocalParam("test", true)
 			// Create a temp file for the local inode created above.
-			_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+			err = t.in.CreateEmptyTempFile(t.ctx)
 			assert.Nil(t.T(), err)
 			// Write some content to temp file.
 			t.clock.AdvanceTime(time.Second)
@@ -574,7 +574,7 @@ func (t *FileTest) TestSyncEmptyLocalFile() {
 			t.createInodeWithLocalParam("test", true)
 			creationTime := t.clock.Now()
 			// Create a temp file for the local inode created above.
-			_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+			err = t.in.CreateEmptyTempFile(t.ctx)
 			assert.Nil(t.T(), err)
 
 			if tc.callSync {
@@ -841,7 +841,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
-	_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Fetch the attributes and check if the file is empty.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -867,7 +867,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
-	_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Write some data to the local file.
 	err = t.in.Write(t.ctx, []byte("burrito"), 0)
@@ -910,9 +910,8 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 			// Create a local file inode.
 			t.createInodeWithLocalParam("test", true)
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			initialized, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+			err := t.in.CreateEmptyTempFile(t.ctx)
 			require.NoError(t.T(), err)
-			assert.True(t.T(), initialized)
 			assert.NotNil(t.T(), t.in.bwh)
 
 			// Fetch the attributes and check if the file is empty.
@@ -1041,9 +1040,8 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				t.createInodeWithEmptyObject()
 			}
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			initialized, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+			err := t.in.CreateEmptyTempFile(t.ctx)
 			require.NoError(t.T(), err)
-			assert.True(t.T(), initialized)
 			assert.NotNil(t.T(), t.in.bwh)
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
@@ -1332,7 +1330,7 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
-	_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Validate the attributes on an empty file.
 	attrs, err = t.in.Attributes(t.ctx)
@@ -1364,7 +1362,7 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 
 	// Set mtime.
@@ -1420,7 +1418,7 @@ func (t *FileTest) TestTestCheckInvariantsShouldNotThrowExceptionForLocalFiles()
 }
 
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.content)
@@ -1434,7 +1432,7 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamin
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
 	assert.Nil(t.T(), t.in.content)
@@ -1445,7 +1443,7 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFile
 	// Enabling buffered writes.
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 
-	_, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.content)
@@ -1462,7 +1460,7 @@ func (t *FileTest) TestUnlinkLocalFile() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	// Create a temp file for the local inode created above.
-	_, err = t.in.CreateBufferedOrTempWriter(t.ctx)
+	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 
 	// Unlink.
@@ -1505,9 +1503,8 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 				// Create a local file inode.
 				t.createInodeWithLocalParam("test", true)
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
-				initialized, err := t.in.CreateBufferedOrTempWriter(t.ctx)
+				err := t.in.CreateEmptyTempFile(t.ctx)
 				require.NoError(t.T(), err)
-				assert.True(t.T(), initialized)
 				assert.NotNil(t.T(), t.in.bwh)
 			}
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -967,7 +967,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 		t.Run(tc.name, func() {
 			t.createInodeWithEmptyObject()
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			// Initialize BWH for local inode created above.
+			// Initialize BWH for inode created above.
 			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			assert.True(t.T(), initialized)
@@ -1045,7 +1045,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				t.createInodeWithEmptyObject()
 			}
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			// Initialize BWH for local inode created above.
+			// Initialize BWH for inode created above.
 			initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			assert.True(t.T(), initalized)
@@ -1469,18 +1469,7 @@ func (t *FileTest) TestCreateEmptyTempFileShouldNotCreateFileForLocalInodeWhenSt
 	assert.Nil(t.T(), t.in.content)
 }
 
-func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamingWritesAreEnabled() {
-	t.createInodeWithLocalParam("test", true)
-	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
-	err := t.in.CreateEmptyTempFile(t.ctx)
-
-	assert.Nil(t.T(), err)
-	assert.Nil(t.T(), t.in.content)
-	assert.NotNil(t.T(), t.in.bwh)
-}
-
-func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateFileForNonLocalFilesForStreamingWrites() {
+func (t *FileTest) TestCreateEmptyTempFileShouldCreateFileForNonLocalFilesForStreamingWrites() {
 	// Enabling buffered writes.
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 
@@ -1544,6 +1533,7 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 				// Create a local file inode.
 				t.createInodeWithLocalParam("test", true)
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
+				// Initialize BWH for local inode created above.
 				initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 				require.NoError(t.T(), err)
 				assert.True(t.T(), initalized)
@@ -1553,6 +1543,7 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 			if tc.fileType == EmptyGCSFile {
 				t.createInodeWithEmptyObject()
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
+				// Initialize BWH for inode created above.
 				initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 				require.NoError(t.T(), err)
 				assert.True(t.T(), initialized)
@@ -1588,10 +1579,11 @@ func (t *FileTest) TestReadEmptyGCSFileWhenStreamingWritesAreNotInProgress() {
 	assert.Contains(t.T(), err.Error(), "EOF")
 }
 
-func (t *FileTest) TestWriteToLocalFileWithInvalidConfigWhenStreamingWritesAreEnabled() {
+func (t *FileTest) TestInitBufferedWriteHandlerWithInvalidConfigWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: true}}
+
 	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 
 	assert.True(t.T(), strings.Contains(err.Error(), "invalid configuration"))
@@ -1603,6 +1595,7 @@ func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for local inode created above.
 	initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initialized)
@@ -1678,6 +1671,7 @@ func (t *FileTest) TestSetMtimeOnEmptyGCSFileWhenStreamingWritesAreEnabled() {
 func (t *FileTest) TestSetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEnabled() {
 	t.createInodeWithEmptyObject()
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
+	// Initialize BWH for inode created above.
 	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	require.NoError(t.T(), err)
 	assert.True(t.T(), initalized)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -841,6 +841,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileShouldUpdateLocalFileAttributes
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
+	// Create a temp file for the local inode created above.
 	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Fetch the attributes and check if the file is empty.
@@ -867,6 +868,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	var attrs fuseops.InodeAttributes
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
+	// Create a temp file for the local inode created above.
 	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Write some data to the local file.
@@ -910,6 +912,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 			// Create a local file inode.
 			t.createInodeWithLocalParam("test", true)
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
+			// Initialize BWH for local inode created above.
 			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			assert.True(t.T(), initialized)
@@ -964,6 +967,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 		t.Run(tc.name, func() {
 			t.createInodeWithEmptyObject()
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
+			// Initialize BWH for local inode created above.
 			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			assert.True(t.T(), initialized)
@@ -1041,6 +1045,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				t.createInodeWithEmptyObject()
 			}
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
+			// Initialize BWH for local inode created above.
 			initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
 			assert.True(t.T(), initalized)
@@ -1332,6 +1337,7 @@ func (t *FileTest) TestTestSetMtimeForLocalFileShouldUpdateLocalFileAttributes()
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	createTime := t.in.mtimeClock.Now()
+	// Create a temp file for the local inode created above.
 	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Validate the attributes on an empty file.
@@ -1364,8 +1370,10 @@ func (t *FileTest) TestSetMtimeForLocalFileWhenStreamingWritesAreEnabled() {
 	// Create a local file inode.
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-	err = t.in.CreateEmptyTempFile(t.ctx)
-	assert.Nil(t.T(), err)
+	initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), initalized)
+	assert.NotNil(t.T(), t.in.bwh)
 
 	// Set mtime.
 	mtime := time.Now().UTC().Add(123 * time.Second)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -910,8 +910,9 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 			// Create a local file inode.
 			t.createInodeWithLocalParam("test", true)
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			err := t.in.CreateEmptyTempFile(t.ctx)
+			initialized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
+			assert.True(t.T(), initialized)
 			assert.NotNil(t.T(), t.in.bwh)
 
 			// Fetch the attributes and check if the file is empty.
@@ -1040,8 +1041,9 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 				t.createInodeWithEmptyObject()
 			}
 			t.in.config = &cfg.Config{Write: *getWriteConfig()}
-			err := t.in.CreateEmptyTempFile(t.ctx)
+			initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 			require.NoError(t.T(), err)
+			assert.True(t.T(), initalized)
 			assert.NotNil(t.T(), t.in.bwh)
 			// Fetch the attributes and check if the file is empty.
 			attrs, err := t.in.Attributes(t.ctx)
@@ -1431,7 +1433,7 @@ func (t *FileTest) TestCreateBufferedOrTempWriterShouldCreateEmptyFile() {
 func (t *FileTest) TestCreateBufferedOrTempWriterShouldNotCreateFileWhenStreamingWritesAreEnabled() {
 	t.createInodeWithLocalParam("test", true)
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
-
+	t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 	err := t.in.CreateEmptyTempFile(t.ctx)
 
 	assert.Nil(t.T(), err)
@@ -1503,8 +1505,9 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 				// Create a local file inode.
 				t.createInodeWithLocalParam("test", true)
 				t.in.config = &cfg.Config{Write: *getWriteConfig()}
-				err := t.in.CreateEmptyTempFile(t.ctx)
+				initalized, err := t.in.InitBufferedWriteHandlerIfEligible(t.ctx)
 				require.NoError(t.T(), err)
+				assert.True(t.T(), initalized)
 				assert.NotNil(t.T(), t.in.bwh)
 			}
 

--- a/tools/integration_tests/streaming_writes/buffer_size_test.go
+++ b/tools/integration_tests/streaming_writes/buffer_size_test.go
@@ -15,6 +15,7 @@
 package streaming_writes
 
 import (
+	"path"
 	"testing"
 
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
@@ -62,7 +63,13 @@ func TestWritesWithDifferentConfig(t *testing.T) {
 			defer setup.UnmountGCSFuse(rootDir)
 			testDirPath = setup.SetupTestDirectory(testDirName)
 			// Create a local file.
-			_, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t)
+			fh := operations.CreateFile(path.Join(testDirPath, FileName1), FilePerms, t)
+			testDirName := GetDirName(testDirPath)
+			if setup.IsZonalBucketRun() {
+				ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, FileName1, "", t)
+			} else {
+				ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t)
+			}
 			data, err := operations.GenerateRandomData(tc.fileSize)
 			if err != nil {
 				t.Fatalf("Error in generating data: %v", err)

--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"testing"
 
-	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
@@ -27,7 +26,6 @@ import (
 
 type defaultMountLocalFile struct {
 	defaultMountCommonTest
-	CommonLocalFileTestSuite
 	suite.Suite
 }
 
@@ -49,7 +47,6 @@ func (t *defaultMountLocalFile) createLocalFile() {
 // Executes all tests that run with single streamingWrites configuration for localFiles.
 func TestDefaultMountLocalFileTest(t *testing.T) {
 	s := new(defaultMountLocalFile)
-	s.CommonLocalFileTestSuite.TestifySuite = &s.Suite
 	s.defaultMountCommonTest.TestifySuite = &s.Suite
 	suite.Run(t, s)
 }

--- a/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
+++ b/tools/integration_tests/streaming_writes/default_mount_local_file_test.go
@@ -18,26 +18,34 @@ import (
 	"path"
 	"testing"
 
+	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/local_file"
 	. "github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_suite"
 	"github.com/stretchr/testify/suite"
 )
 
-type defaultMountLocalFile struct {
+type defaultMountCommonLocalFile struct {
 	defaultMountCommonTest
 	suite.Suite
 }
 
-func (t *defaultMountLocalFile) SetupTest() {
+type defaultMountRegionalBucketLocalFile struct {
+	CommonLocalFileTestSuite
+	defaultMountCommonLocalFile
+	test_suite.TestifySuite
+}
+
+func (t *defaultMountCommonLocalFile) SetupTest() {
 	t.createLocalFile()
 }
 
-func (t *defaultMountLocalFile) SetupSubTest() {
+func (t *defaultMountCommonLocalFile) SetupSubTest() {
 	t.createLocalFile()
 }
 
-func (t *defaultMountLocalFile) createLocalFile() {
+func (t *defaultMountCommonLocalFile) createLocalFile() {
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	t.filePath = path.Join(testDirPath, t.fileName)
 	// Create a local file with O_DIRECT.
@@ -46,7 +54,15 @@ func (t *defaultMountLocalFile) createLocalFile() {
 
 // Executes all tests that run with single streamingWrites configuration for localFiles.
 func TestDefaultMountLocalFileTest(t *testing.T) {
-	s := new(defaultMountLocalFile)
-	s.defaultMountCommonTest.TestifySuite = &s.Suite
-	suite.Run(t, s)
+	if setup.IsZonalBucketRun() {
+		s := new(defaultMountCommonLocalFile)
+		s.defaultMountCommonTest.TestifySuite = &s.Suite
+		suite.Run(t, s)
+	} else {
+		s := new(defaultMountRegionalBucketLocalFile)
+		s.defaultMountCommonTest.TestifySuite = &s.defaultMountCommonLocalFile.Suite
+		s.CommonLocalFileTestSuite.TestifySuite = &s.defaultMountCommonLocalFile.Suite
+		s.TestifySuite = &s.defaultMountCommonLocalFile.Suite
+		suite.Run(t, s)
+	}
 }

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -94,6 +94,8 @@ func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedFromSameMountR
 }
 
 func (t *unfinalizedObjectOperations) TestOverWritingUnfinalizedObjectsReturnsESTALE() {
+	// TODO(b/411333280): Enable the test once flush onn unfinalized Object fix.
+	t.T().Skip("Skipping the test due to b/411333280")
 	var size int64 = operations.MiB
 	_ = client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, t.fileName), size)
 	fh := operations.OpenFile(path.Join(t.testDirPath, t.fileName), t.T())

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -94,7 +94,7 @@ func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedFromSameMountR
 }
 
 func (t *unfinalizedObjectOperations) TestOverWritingUnfinalizedObjectsReturnsESTALE() {
-	// TODO(b/411333280): Enable the test once flush onn unfinalized Object fix.
+	// TODO(b/411333280): Enable the test once flush on unfinalized Object is fixed.
 	t.T().Skip("Skipping the test due to b/411333280")
 	var size int64 = operations.MiB
 	_ = client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, t.fileName), size)


### PR DESCRIPTION
### Description
Ensure implicit sync file inode at the time bwh is initialized. This ensures as soon as bwh is created we have the correct generation from the server. With this change Local File Tests from local_file package which were running started failing for ZB with streaming writes as those tests validate local file but in this case file is not local and it is promoted to generation backed inode as soon as created. Removed local_file package tests from running as part of streaming writes test as those require a large refactoring and error checking for multiple scenarios.

Note: Manually verified that ZB tests are passing.

### Link to the issue in case of a bug fix.
[b/414501988](http://b/414501988)

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Tested stale handle skipped tests in this [PR](https://github.com/GoogleCloudPlatform/gcsfuse/pull/3104)

### Any backward incompatible change? If so, please explain.
