### PR TITLE
Revert "Enable Read Stall Retry by default"

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -353,7 +353,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
+	flagSet.BoolP("enable-read-stall-retry", "", false, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
 	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -400,7 +400,7 @@
   usage: >-
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
-  default: true
+  default: false
   hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -712,7 +712,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              true,
+						Enable:              false,
 						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,
@@ -732,7 +732,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              false,
+						Enable:              true,
 						MinReqTimeout:       10 * time.Second,
 						MaxReqTimeout:       200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1253,7 +1253,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              true,
+						Enable:              false,
 						InitialReqTimeout:   20 * time.Second,
 						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -35,7 +35,7 @@ gcs-connection:
 gcs-retries:
   chunk-transfer-timeout-secs: 20
   read-stall:
-    enable: false
+    enable: true
     min-req-timeout: 10s
     max-req-timeout: 200s
     initial-req-timeout: 20s


### PR DESCRIPTION
Description :
Revert the PR to enable Read Stall Retries by default as we started seeing regression in tail latencies and job duration on running LG Air workload with 1MiB I/O.

Bug Link : [b/414516573](https://b.corp.google.com/issues/414516573)