### PR TITLE
Forward env variables `GCE_METADATA_*` to gcsfuse daemon process in case of background run

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -338,6 +338,17 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 				p)
 		}
 
+		// Forward GCE_METADATA_HOST and other related environment variables.
+		for _, envvar := range []string{"GCE_METADATA_HOST"} {
+			if p, ok := os.LookupEnv(envvar); ok {
+				env = append(env, fmt.Sprintf("%s=%s", envvar, p))
+				fmt.Fprintf(
+					os.Stdout,
+					"Added environment %s: %s\n",
+					envvar, p)
+			}
+		}
+
 		// Pass the parent process working directory to child process via
 		// environment variable. This variable will be used to resolve relative paths.
 		if parentProcessExecutionDir, err := os.Getwd(); err == nil {

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -322,13 +322,14 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 				p)
 		}
 
-		// Forward GCE_METADATA_HOST and other related environment variables.
-		// Pass along GOOGLE_APPLICATION_CREDENTIALS, since we document in
+		// Forward environment variables.
+		// Forward GOOGLE_APPLICATION_CREDENTIALS, since we document in
 		// mounting.md that it can be used for specifying a key file.
-		// Pass through the no_proxy environment variable. Whenever
+		// Forward the no_proxy environment variable. Whenever
 		// using the http(s)_proxy environment variables. This should
 		// also be included to know for which hosts the use of proxies
 		// should be ignored.
+		// Forward GCE_METADATA_HOST as it is used for mocked metadata services.
 		for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST"} {
 			if envval, ok := os.LookupEnv(envvar); ok {
 				env = append(env, fmt.Sprintf("%s=%s", envvar, envval))

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -301,7 +301,7 @@ func forwardedEnvVars() []string {
 
 	// Here, parent process doesn't pass the $HOME to child process implicitly,
 	// hence we need to pass it explicitly.
-	if homeDir, _ := os.UserHomeDir(); true {
+	if homeDir, err := os.UserHomeDir(); err == nil {
 		env = append(env, fmt.Sprintf("HOME=%s", homeDir))
 	}
 

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -249,6 +249,9 @@ func isDynamicMount(bucketName string) bool {
 	return bucketName == "" || bucketName == "_"
 }
 
+// forwardedEnvVars collects and returns all the environment
+// variables which should be sent to the gcsfuse daemon
+// process in case of background run.
 func forwardedEnvVars() []string {
 	// Pass along PATH so that the daemon can find fusermount on Linux.
 	env := []string{
@@ -272,14 +275,13 @@ func forwardedEnvVars() []string {
 			p)
 	}
 
-	// Forward environment variables.
 	// Forward GOOGLE_APPLICATION_CREDENTIALS, since we document in
 	// mounting.md that it can be used for specifying a key file.
 	// Forward the no_proxy environment variable. Whenever
 	// using the http(s)_proxy environment variables. This should
 	// also be included to know for which hosts the use of proxies
 	// should be ignored.
-	// Forward GCE_METADATA_HOST as it is used for mocked metadata services.
+	// Forward GCE_METADATA_HOST, GCE_METADATA_ROOT, GCE_METADATA_IP as these are used for mocked metadata services.
 	for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP"} {
 		if envval, ok := os.LookupEnv(envvar); ok {
 			env = append(env, fmt.Sprintf("%s=%s", envvar, envval))

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -305,11 +305,6 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 			fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 		}
 
-		// Pass along GOOGLE_APPLICATION_CREDENTIALS, since we document in
-		// mounting.md that it can be used for specifying a key file.
-		if p, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); ok {
-			env = append(env, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", p))
-		}
 		// Pass through the https_proxy/http_proxy environment variable,
 		// in case the host requires a proxy server to reach the GCS endpoint.
 		// https_proxy has precedence over http_proxy, in case both are set
@@ -326,20 +321,15 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 				"Added environment http_proxy: %s\n",
 				p)
 		}
+
+		// Forward GCE_METADATA_HOST and other related environment variables.
+		// Pass along GOOGLE_APPLICATION_CREDENTIALS, since we document in
+		// mounting.md that it can be used for specifying a key file.
 		// Pass through the no_proxy environment variable. Whenever
 		// using the http(s)_proxy environment variables. This should
 		// also be included to know for which hosts the use of proxies
 		// should be ignored.
-		if p, ok := os.LookupEnv("no_proxy"); ok {
-			env = append(env, fmt.Sprintf("no_proxy=%s", p))
-			fmt.Fprintf(
-				os.Stdout,
-				"Added environment no_proxy: %s\n",
-				p)
-		}
-
-		// Forward GCE_METADATA_HOST and other related environment variables.
-		for _, envvar := range []string{"GCE_METADATA_HOST"} {
+		for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST"} {
 			if envval, ok := os.LookupEnv(envvar); ok {
 				env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
 				fmt.Fprintf(

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -340,12 +340,12 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 
 		// Forward GCE_METADATA_HOST and other related environment variables.
 		for _, envvar := range []string{"GCE_METADATA_HOST"} {
-			if p, ok := os.LookupEnv(envvar); ok {
-				env = append(env, fmt.Sprintf("%s=%s", envvar, p))
+			if envval, ok := os.LookupEnv(envvar); ok {
+				env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
 				fmt.Fprintf(
 					os.Stdout,
 					"Added environment %s: %s\n",
-					envvar, p)
+					envvar, envval)
 			}
 		}
 

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -330,7 +330,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 		// also be included to know for which hosts the use of proxies
 		// should be ignored.
 		// Forward GCE_METADATA_HOST as it is used for mocked metadata services.
-		for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST"} {
+		for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP"} {
 			if envval, ok := os.LookupEnv(envvar); ok {
 				env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
 				fmt.Fprintf(

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -249,6 +249,67 @@ func isDynamicMount(bucketName string) bool {
 	return bucketName == "" || bucketName == "_"
 }
 
+func forwardedEnvVars() []string {
+	// Pass along PATH so that the daemon can find fusermount on Linux.
+	env := []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+	}
+
+	// Pass through the https_proxy/http_proxy environment variable,
+	// in case the host requires a proxy server to reach the GCS endpoint.
+	// https_proxy has precedence over http_proxy, in case both are set
+	if p, ok := os.LookupEnv("https_proxy"); ok {
+		env = append(env, fmt.Sprintf("https_proxy=%s", p))
+		fmt.Fprintf(
+			os.Stdout,
+			"Added environment https_proxy: %s\n",
+			p)
+	} else if p, ok := os.LookupEnv("http_proxy"); ok {
+		env = append(env, fmt.Sprintf("http_proxy=%s", p))
+		fmt.Fprintf(
+			os.Stdout,
+			"Added environment http_proxy: %s\n",
+			p)
+	}
+
+	// Forward environment variables.
+	// Forward GOOGLE_APPLICATION_CREDENTIALS, since we document in
+	// mounting.md that it can be used for specifying a key file.
+	// Forward the no_proxy environment variable. Whenever
+	// using the http(s)_proxy environment variables. This should
+	// also be included to know for which hosts the use of proxies
+	// should be ignored.
+	// Forward GCE_METADATA_HOST as it is used for mocked metadata services.
+	for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP"} {
+		if envval, ok := os.LookupEnv(envvar); ok {
+			env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
+			fmt.Fprintf(
+				os.Stdout,
+				"Added environment %s: %s\n",
+				envvar, envval)
+		}
+	}
+
+	// Pass the parent process working directory to child process via
+	// environment variable. This variable will be used to resolve relative paths.
+	if parentProcessExecutionDir, err := os.Getwd(); err == nil {
+		env = append(env, fmt.Sprintf("%s=%s", util.GCSFUSE_PARENT_PROCESS_DIR,
+			parentProcessExecutionDir))
+	}
+
+	// Here, parent process doesn't pass the $HOME to child process implicitly,
+	// hence we need to pass it explicitly.
+	if homeDir, _ := os.UserHomeDir(); true {
+		env = append(env, fmt.Sprintf("HOME=%s", homeDir))
+	}
+
+	// This environment variable will be helpful to distinguish b/w the main
+	// process and daemon process. If this environment variable set that means
+	// programme is running as daemon process.
+	env = append(env, fmt.Sprintf("%s=true", logger.GCSFuseInBackgroundMode))
+	return env
+}
+
 func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	// Ideally this call to SetLogFormat (which internally creates a new defaultLogger)
 	// should be set as an else to the 'if flags.Foreground' check below, but currently
@@ -300,63 +361,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 		args := append([]string{"--foreground"}, os.Args[1:]...)
 		args[len(args)-1] = mountPoint
 
-		// Pass along PATH so that the daemon can find fusermount on Linux.
-		env := []string{
-			fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
-		}
-
-		// Pass through the https_proxy/http_proxy environment variable,
-		// in case the host requires a proxy server to reach the GCS endpoint.
-		// https_proxy has precedence over http_proxy, in case both are set
-		if p, ok := os.LookupEnv("https_proxy"); ok {
-			env = append(env, fmt.Sprintf("https_proxy=%s", p))
-			fmt.Fprintf(
-				os.Stdout,
-				"Added environment https_proxy: %s\n",
-				p)
-		} else if p, ok := os.LookupEnv("http_proxy"); ok {
-			env = append(env, fmt.Sprintf("http_proxy=%s", p))
-			fmt.Fprintf(
-				os.Stdout,
-				"Added environment http_proxy: %s\n",
-				p)
-		}
-
-		// Forward environment variables.
-		// Forward GOOGLE_APPLICATION_CREDENTIALS, since we document in
-		// mounting.md that it can be used for specifying a key file.
-		// Forward the no_proxy environment variable. Whenever
-		// using the http(s)_proxy environment variables. This should
-		// also be included to know for which hosts the use of proxies
-		// should be ignored.
-		// Forward GCE_METADATA_HOST as it is used for mocked metadata services.
-		for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP"} {
-			if envval, ok := os.LookupEnv(envvar); ok {
-				env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
-				fmt.Fprintf(
-					os.Stdout,
-					"Added environment %s: %s\n",
-					envvar, envval)
-			}
-		}
-
-		// Pass the parent process working directory to child process via
-		// environment variable. This variable will be used to resolve relative paths.
-		if parentProcessExecutionDir, err := os.Getwd(); err == nil {
-			env = append(env, fmt.Sprintf("%s=%s", util.GCSFUSE_PARENT_PROCESS_DIR,
-				parentProcessExecutionDir))
-		}
-
-		// Here, parent process doesn't pass the $HOME to child process implicitly,
-		// hence we need to pass it explicitly.
-		if homeDir, _ := os.UserHomeDir(); err == nil {
-			env = append(env, fmt.Sprintf("HOME=%s", homeDir))
-		}
-
-		// This environment variable will be helpful to distinguish b/w the main
-		// process and daemon process. If this environment variable set that means
-		// programme is running as daemon process.
-		env = append(env, fmt.Sprintf("%s=true", logger.GCSFuseInBackgroundMode))
+		env := forwardedEnvVars()
 
 		// logfile.stderr will capture the standard error (stderr) output of the gcsfuse background process.
 		var stderrFile *os.File

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -288,7 +288,7 @@ func (t *MainTest) TestForwardedEnvVars() {
 		forwardedEnvVars := forwardedEnvVars()
 		assert.Subset(t.T(), forwardedEnvVars, input.expectedForwardedEnvVars)
 		assert.Contains(t.T(), forwardedEnvVars, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
-		for envvar, _ := range input.inputEnvVars {
+		for envvar := range input.inputEnvVars {
 			os.Unsetenv(envvar)
 		}
 	}

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -261,3 +261,35 @@ func (t *MainTest) TestIsDynamicMount() {
 		assert.Equal(t.T(), input.isDynamic, isDynamicMount(input.bucketName))
 	}
 }
+
+func (t *MainTest) TestForwardedEnvVars() {
+	for _, input := range []struct {
+		inputEnvVars             map[string]string
+		expectedForwardedEnvVars []string
+	}{{
+		inputEnvVars:             map[string]string{"GCE_METADATA_HOST": "www.metadata-host.com", "GCE_METADATA_ROOT": "metadata-root", "GCE_METADATA_IP": "99.100.101.102"},
+		expectedForwardedEnvVars: []string{"GCE_METADATA_HOST=www.metadata-host.com", "GCE_METADATA_ROOT=metadata-root", "GCE_METADATA_IP=99.100.101.102"},
+	}, {
+		inputEnvVars:             map[string]string{"https_proxy": "https-proxy-123", "http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
+		expectedForwardedEnvVars: []string{"https_proxy=https-proxy-123", "no_proxy=no-proxy-123"},
+	}, {
+		inputEnvVars:             map[string]string{"http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
+		expectedForwardedEnvVars: []string{"http_proxy=http-proxy-123", "no_proxy=no-proxy-123"},
+	}, {
+		inputEnvVars:             map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": "goog-app-cred"},
+		expectedForwardedEnvVars: []string{"GOOGLE_APPLICATION_CREDENTIALS=goog-app-cred"},
+	}, {
+		expectedForwardedEnvVars: []string{"GCSFUSE_IN_BACKGROUND_MODE=true"},
+	},
+	} {
+		for envvar, envval := range input.inputEnvVars {
+			os.Setenv(envvar, envval)
+		}
+		forwardedEnvVars := forwardedEnvVars()
+		assert.Subset(t.T(), forwardedEnvVars, input.expectedForwardedEnvVars)
+		assert.Contains(t.T(), forwardedEnvVars, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+		for envvar, _ := range input.inputEnvVars {
+			os.Unsetenv(envvar)
+		}
+	}
+}


### PR DESCRIPTION
### Description
Forward env variables `GCE_METADATA_HOST`, `GCE_METADATA_ROOT`, `GCE_METADATA_IP` to gcsfuse daemon process in case of background run. `GCE_METADATA_HOST` is used [here](https://github.com/googleapis/google-cloud-go/blob/a6c85f6387ee6aa291e786c882637fb03f3302f4/compute/metadata/metadata.go#L461) to determine where to send the metadata requests.

### Link to the issue in case of a bug fix.
[b/414377352](http://b/414377352)

### Testing details
1. Manual - Tested manually that after this change, the env vars GCE_METADATA_HOST, GCE_METADATA_ROOT and GCE_METADATA_IP are being passed down the gcsfuse daemon process.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
