### PR TITLE
Adding simulated clock implementation for time.After method

### DIFF
--- a/internal/clock/simulated_clock.go
+++ b/internal/clock/simulated_clock.go
@@ -37,7 +37,7 @@ type SimulatedClock struct {
 func NewSimulatedClock(startTime time.Time) *SimulatedClock {
 	return &SimulatedClock{
 		t:       startTime,
-		pending: make([]*afterRequest, 0),
+		pending: nil,
 	}
 }
 
@@ -111,7 +111,5 @@ func (sc *SimulatedClock) processPending() {
 		}
 	}
 
-	if len(stillPending) < len(sc.pending) { // Optimization: only re-slice if necessary
-		sc.pending = stillPending
-	}
+	sc.pending = stillPending
 }

--- a/internal/clock/simulated_clock.go
+++ b/internal/clock/simulated_clock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google Inc. All Rights Reserved.
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@ func (sc *SimulatedClock) AdvanceTime(d time.Duration) {
 	sc.processPending()
 }
 
-// After returns a time channel and returns the time over the returned channel after
-// the provided duration.
+// After returns a time channel and the expectedFired time is sent over the returned
+// channel after the provided duration.
 // If the duration is zero or negative, it sends the current simulated time immediately.
 func (sc *SimulatedClock) After(d time.Duration) <-chan time.Time {
 	sc.mu.Lock()

--- a/internal/clock/simulated_clock.go
+++ b/internal/clock/simulated_clock.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+// afterRequest holds the information for a pending After call in SimulatedClock.
+type afterRequest struct {
+	targetTime time.Time
+	ch         chan time.Time
+}
+
+// SimulatedClock is a clock that allows for manipulation of the time,
+// which does not change unless AdvanceTime or SetTime is called.
+// The zero value is a clock initialized to the zero time.
+type SimulatedClock struct {
+	mu      sync.RWMutex
+	t       time.Time       // GUARDED_BY(mu)
+	pending []*afterRequest // GUARDED_BY(mu)
+}
+
+func NewSimulatedClock(startTime time.Time) *SimulatedClock {
+	return &SimulatedClock{
+		t:       startTime,
+		pending: make([]*afterRequest, 0),
+	}
+}
+
+func (sc *SimulatedClock) Now() time.Time {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	return sc.t
+}
+
+// SetTime sets the current time according to the clock.
+// It also processes any pending After calls that should fire.
+func (sc *SimulatedClock) SetTime(t time.Time) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.t = t
+	sc.processPending()
+}
+
+// AdvanceTime advances the current time according to the clock by the supplied duration.
+// It also processes any pending After calls that should fire.
+func (sc *SimulatedClock) AdvanceTime(d time.Duration) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.t = sc.t.Add(d)
+	sc.processPending()
+}
+
+// After returns a time channel and returns the time over the returned channel after
+// the provided duration.
+// If the duration is zero or negative, it sends the current simulated time immediately.
+func (sc *SimulatedClock) After(d time.Duration) <-chan time.Time {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	ch := make(chan time.Time, 1)
+	effectiveTargetTime := sc.t.Add(d)
+
+	// If duration is non-positive, fire immediately with the current time.
+	// Or if the target time is not after the current time (e.g. d <= 0)
+	if !effectiveTargetTime.After(sc.t) {
+		ch <- sc.t // Send current time as per time.After behavior for d <= 0
+		return ch
+	}
+
+	// Otherwise, schedule it.
+	ar := &afterRequest{
+		targetTime: effectiveTargetTime,
+		ch:         ch,
+	}
+	sc.pending = append(sc.pending, ar)
+
+	return ch
+}
+
+// processPending checks all pending After requests and fires those
+// whose target time has been reached or passed by the current simulated time.
+// This method must be called with sc.mu held.
+func (sc *SimulatedClock) processPending() {
+	var stillPending []*afterRequest
+	fired := false // To help re-slice efficiently if many items fire
+
+	for _, ar := range sc.pending {
+		// If current time sc.t is not before the targetTime (i.e., sc.t >= ar.targetTime)
+		if !sc.t.Before(ar.targetTime) {
+			ar.ch <- ar.targetTime // Send the time it was scheduled to fire
+			// Do not close the channel, to mimic time.After behavior
+			fired = true
+		} else {
+			stillPending = append(stillPending, ar)
+		}
+	}
+
+	if fired || len(stillPending) < len(sc.pending) { // Optimization: only re-slice if necessary
+		sc.pending = stillPending
+	}
+}

--- a/internal/clock/simulated_clock.go
+++ b/internal/clock/simulated_clock.go
@@ -100,20 +100,18 @@ func (sc *SimulatedClock) After(d time.Duration) <-chan time.Time {
 // This method must be called with sc.mu held.
 func (sc *SimulatedClock) processPending() {
 	var stillPending []*afterRequest
-	fired := false // To help re-slice efficiently if many items fire
 
 	for _, ar := range sc.pending {
 		// If current time sc.t is not before the targetTime (i.e., sc.t >= ar.targetTime)
 		if !sc.t.Before(ar.targetTime) {
 			ar.ch <- ar.targetTime // Send the time it was scheduled to fire
 			// Do not close the channel, to mimic time.After behavior
-			fired = true
 		} else {
 			stillPending = append(stillPending, ar)
 		}
 	}
 
-	if fired || len(stillPending) < len(sc.pending) { // Optimization: only re-slice if necessary
+	if len(stillPending) < len(sc.pending) { // Optimization: only re-slice if necessary
 		sc.pending = stillPending
 	}
 }

--- a/internal/clock/simulated_clock_test.go
+++ b/internal/clock/simulated_clock_test.go
@@ -1,0 +1,265 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	// A non-zero reference time for tests
+	referenceTime    = time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)
+	shortTestTimeout = 10 * time.Millisecond // For non-blocking channel checks
+	fireTestTimeout  = 50 * time.Millisecond // When expecting a channel to fire
+)
+
+// Helper to assert that a channel receives a specific time within a timeout.
+func assertReceivesTime(t *testing.T, ch <-chan time.Time, expectedTime time.Time, timeout time.Duration, msgAndArgs ...interface{}) {
+	t.Helper()
+	select {
+	case actualTime := <-ch:
+		assert.True(t, expectedTime.Equal(actualTime), "Received time %v, expected %v. %s", actualTime, expectedTime, msgAndArgs)
+	case <-time.After(timeout): // Using real time.After for test timeout
+		t.Fatalf("Timeout waiting for time on channel. Expected %v. %s", expectedTime, msgAndArgs)
+	}
+}
+
+// Helper to assert that a channel does NOT receive a time within a short duration.
+func assertNotReceivesTime(t *testing.T, ch <-chan time.Time, timeout time.Duration, msgAndArgs ...interface{}) {
+	t.Helper()
+	select {
+	case receivedTime := <-ch:
+		t.Fatalf("Expected no time on channel, but received %v. %s", receivedTime, msgAndArgs)
+	case <-time.After(timeout): // Using real time.After for test timeout
+		// Success, nothing received
+	}
+}
+
+func TestSimulatedClock_Now(t *testing.T) {
+	testCases := []struct {
+		name             string
+		initialTimeSetup func(sc *SimulatedClock)
+		expectedTime     time.Time
+	}{
+		{
+			name:             "InitialState_IsZeroTime",
+			initialTimeSetup: func(sc *SimulatedClock) {},
+			expectedTime:     referenceTime,
+		},
+		{
+			name: "AfterSetTime_ReturnsSetTime",
+			initialTimeSetup: func(sc *SimulatedClock) {
+				sc.SetTime(referenceTime)
+			},
+			expectedTime: referenceTime,
+		},
+		{
+			name: "AfterAdvanceTime_ReturnsAdvancedTime",
+			initialTimeSetup: func(sc *SimulatedClock) {
+				sc.SetTime(referenceTime)
+				sc.AdvanceTime(time.Hour)
+			},
+			expectedTime: referenceTime.Add(time.Hour),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := NewSimulatedClock(referenceTime)
+			tc.initialTimeSetup(clock)
+
+			now := clock.Now()
+
+			assert.True(t, now.Equal(tc.expectedTime), "clock.Now() returned %v, expected %v", now, tc.expectedTime)
+		})
+	}
+}
+
+func TestSimulatedClock_SetTime(t *testing.T) {
+	testCases := []struct {
+		name             string
+		initialTimeSetup func(sc *SimulatedClock) // To set a pre-existing time if needed
+		timeToSet        time.Time
+		expectedAfter    time.Time
+	}{
+		{
+			name:             "SetFromZeroTime",
+			initialTimeSetup: func(sc *SimulatedClock) {},
+			timeToSet:        referenceTime,
+			expectedAfter:    referenceTime,
+		},
+		{
+			name: "OverwriteExistingTime",
+			initialTimeSetup: func(sc *SimulatedClock) {
+				sc.SetTime(referenceTime.Add(-time.Hour)) // Start with a different time
+			},
+			timeToSet:     referenceTime,
+			expectedAfter: referenceTime,
+		},
+		{
+			name:             "SetToZeroTime",
+			initialTimeSetup: func(sc *SimulatedClock) { sc.SetTime(referenceTime) },
+			timeToSet:        time.Time{}, // Zero time
+			expectedAfter:    time.Time{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := NewSimulatedClock(referenceTime)
+			tc.initialTimeSetup(clock)
+
+			clock.SetTime(tc.timeToSet)
+
+			assert.True(t, clock.Now().Equal(tc.expectedAfter), "After SetTime, clock.Now() was %v, expected %v", clock.Now(), tc.expectedAfter)
+		})
+	}
+}
+
+func TestSimulatedClock_AdvanceTime(t *testing.T) {
+	testCases := []struct {
+		name         string
+		initialTime  time.Time
+		advanceBy    time.Duration
+		expectedTime time.Time
+	}{
+		{
+			name:         "AdvancePositiveDuration",
+			initialTime:  referenceTime,
+			advanceBy:    5 * time.Minute,
+			expectedTime: referenceTime.Add(5 * time.Minute),
+		},
+		{
+			name:         "AdvanceNegativeDuration",
+			initialTime:  referenceTime,
+			advanceBy:    -2 * time.Hour,
+			expectedTime: referenceTime.Add(-2 * time.Hour),
+		},
+		{
+			name:         "AdvanceByZeroDuration",
+			initialTime:  referenceTime,
+			advanceBy:    0,
+			expectedTime: referenceTime,
+		},
+		{
+			name:         "AdvanceFromZeroTime",
+			initialTime:  time.Time{},
+			advanceBy:    time.Hour,
+			expectedTime: (time.Time{}).Add(time.Hour),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := NewSimulatedClock(referenceTime)
+			clock.SetTime(tc.initialTime) // Set initial time for the clock
+
+			clock.AdvanceTime(tc.advanceBy)
+
+			assert.True(t, clock.Now().Equal(tc.expectedTime), "After AdvanceTime, clock.Now() was %v, expected %v", clock.Now(), tc.expectedTime)
+		})
+	}
+}
+
+func TestSimulatedClock_After(t *testing.T) {
+	testCases := []struct {
+		name          string
+		afterDuration time.Duration
+		action        func(sc *SimulatedClock) // Action to manipulate the clock after After() is called
+		expectFire    bool
+	}{
+		{
+			name:          "ZeroDuration_FiresImmediately",
+			afterDuration: 0,
+			action:        func(sc *SimulatedClock) { /* No action needed for immediate fire */ },
+			expectFire:    true,
+		},
+		{
+			name:          "NegativeDuration_FiresImmediately",
+			afterDuration: -5 * time.Second,
+			action:        func(sc *SimulatedClock) { /* No action needed for immediate fire */ },
+			expectFire:    true,
+		},
+		{
+			name:          "PositiveDuration_Fires_WhenTimeAdvancedPastDuration",
+			afterDuration: 10 * time.Second,
+			action: func(sc *SimulatedClock) {
+				sc.AdvanceTime(15 * time.Second) // Advance well past the duration
+			},
+			expectFire: true,
+		},
+		{
+			name:          "PositiveDuration_Fires_WhenTimeSetPastDuration",
+			afterDuration: 10 * time.Second,
+			action: func(sc *SimulatedClock) {
+				sc.SetTime(referenceTime.Add(15 * time.Second)) // Set time well past the duration
+			},
+			expectFire: true,
+		},
+		{
+			name:          "PositiveDuration_DoesNotFire_WhenTimeAdvancedBeforeDuration",
+			afterDuration: 10 * time.Second,
+			action: func(sc *SimulatedClock) {
+				sc.AdvanceTime(5 * time.Second) // Advance, but not enough
+			},
+			expectFire: false,
+		},
+		{
+			name:          "PositiveDuration_DoesNotFire_WhenTimeSetBeforeDuration",
+			afterDuration: 10 * time.Second,
+			action: func(sc *SimulatedClock) {
+				sc.SetTime(referenceTime.Add(5 * time.Second)) // Set time, but not enough
+			},
+			expectFire: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := NewSimulatedClock(referenceTime)
+			clockTimeAtAfterCall := clock.Now()
+
+			ch := clock.After(tc.afterDuration)
+			require.NotNil(t, ch, "Channel should not be nil")
+
+			// Perform the action (if any) that might trigger the timer
+			if tc.action != nil {
+				tc.action(clock)
+			}
+
+			// Determine the expected time on the channel if it fires
+			// For zero/negative duration, it's the time After() was called.
+			// For positive, it's that time + duration.
+			var expectedFireTimeOnChannel time.Time
+			if tc.afterDuration <= 0 {
+				expectedFireTimeOnChannel = clockTimeAtAfterCall
+			} else {
+				expectedFireTimeOnChannel = clockTimeAtAfterCall.Add(tc.afterDuration)
+			}
+
+			if tc.expectFire {
+				assertReceivesTime(t, ch, expectedFireTimeOnChannel, fireTestTimeout,
+					"Expected timer to fire with time %v", expectedFireTimeOnChannel)
+			} else {
+				assertNotReceivesTime(t, ch, shortTestTimeout,
+					"Expected timer not to fire")
+			}
+		})
+	}
+}

--- a/internal/clock/simulated_clock_test.go
+++ b/internal/clock/simulated_clock_test.go
@@ -63,7 +63,7 @@ func TestSimulatedClock_Now(t *testing.T) {
 
 			now := clock.Now()
 
-			assert.True(t, now.Equal(tc.expectedTime), "clock.Now() returned %v, expected %v", now, tc.expectedTime)
+			assert.Equal(t, tc.expectedTime, now)
 		})
 	}
 }
@@ -84,7 +84,7 @@ func TestSimulatedClock_SetTime(t *testing.T) {
 		{
 			name: "OverwriteExistingTime",
 			initialTimeSetup: func(sc *SimulatedClock) {
-				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(-time.Hour)) // Start with a different time
+				sc.SetTime(time.Date(2020, time.January, 1, 11, 0, 0, 0, time.UTC)) // Start with a different time
 			},
 			timeToSet:     time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 			expectedAfter: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
@@ -214,7 +214,7 @@ func TestSimulatedClock_After_ShouldFirePositiveDuration(t *testing.T) {
 			name:          "PositiveDuration_Fires_WhenTimeSetPastDuration",
 			afterDuration: 10 * time.Second,
 			action: func(sc *SimulatedClock) {
-				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(15 * time.Second)) // Set time well past the duration
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 15, 0, time.UTC)) // Set time well past the duration
 			},
 		},
 	}
@@ -260,7 +260,7 @@ func TestSimulatedClock_After_ShouldNotFire(t *testing.T) {
 			name:          "PositiveDuration_DoesNotFire_WhenTimeSetBeforeDuration",
 			afterDuration: 10 * time.Second,
 			action: func(sc *SimulatedClock) {
-				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(5 * time.Second)) // Set time, but not enough
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 5, 0, time.UTC)) // Set time, but not enough
 			},
 		},
 	}

--- a/internal/clock/simulated_clock_test.go
+++ b/internal/clock/simulated_clock_test.go
@@ -104,7 +104,7 @@ func TestSimulatedClock_SetTime(t *testing.T) {
 
 			clock.SetTime(tc.timeToSet)
 
-			assert.True(t, clock.Now().Equal(tc.expectedAfter), "After SetTime, clock.Now() was %v, expected %v", clock.Now(), tc.expectedAfter)
+			assert.Equal(t, tc.expectedAfter, clock.Now())
 		})
 	}
 }
@@ -149,7 +149,7 @@ func TestSimulatedClock_AdvanceTime(t *testing.T) {
 
 			clock.AdvanceTime(tc.advanceBy)
 
-			assert.True(t, clock.Now().Equal(tc.expectedTime), "After AdvanceTime, clock.Now() was %v, expected %v", clock.Now(), tc.expectedTime)
+			assert.Equal(t, tc.expectedTime, clock.Now())
 		})
 	}
 }
@@ -188,7 +188,7 @@ func TestSimulatedClock_After_ShouldFireZeroOrNegativeDuration(t *testing.T) {
 
 			select {
 			case actualTime := <-ch:
-				assert.True(t, expectedFireTimeOnChannel.Equal(actualTime), "Received time %v, expected %v", actualTime, expectedFireTimeOnChannel)
+				assert.Equal(t, expectedFireTimeOnChannel, actualTime)
 
 			case <-time.After(fireTestTimeout):
 				t.Fatalf("Timeout waiting for time on channel. Expected after %v.", expectedFireTimeOnChannel)
@@ -234,7 +234,7 @@ func TestSimulatedClock_After_ShouldFirePositiveDuration(t *testing.T) {
 
 			select {
 			case actualTime := <-ch:
-				assert.True(t, expectedFireTimeOnChannel.Equal(actualTime), "Received time %v, expected %v", actualTime, expectedFireTimeOnChannel)
+				assert.Equal(t, expectedFireTimeOnChannel, actualTime)
 
 			case <-time.After(fireTestTimeout):
 				t.Fatalf("Timeout waiting for time on channel. Expected after %v.", expectedFireTimeOnChannel)

--- a/internal/clock/simulated_clock_test.go
+++ b/internal/clock/simulated_clock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google Inc. All Rights Reserved.
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/clock/simulated_clock_test.go
+++ b/internal/clock/simulated_clock_test.go
@@ -24,7 +24,6 @@ import (
 
 var (
 	// A non-zero reference time for tests
-	referenceTime    = time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)
 	shortTestTimeout = 10 * time.Millisecond // For non-blocking channel checks
 	fireTestTimeout  = 50 * time.Millisecond // When expecting a channel to fire
 )
@@ -38,28 +37,28 @@ func TestSimulatedClock_Now(t *testing.T) {
 		{
 			name:             "InitialState_IsZeroTime",
 			initialTimeSetup: func(sc *SimulatedClock) {},
-			expectedTime:     time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC), // referenceTime
+			expectedTime:     time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "AfterSetTime_ReturnsSetTime",
 			initialTimeSetup: func(sc *SimulatedClock) {
-				sc.SetTime(referenceTime)
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			},
-			expectedTime: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC), // referenceTime
+			expectedTime: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "AfterAdvanceTime_ReturnsAdvancedTime",
 			initialTimeSetup: func(sc *SimulatedClock) {
-				sc.SetTime(referenceTime)
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 				sc.AdvanceTime(time.Hour)
 			},
-			expectedTime: time.Date(2020, time.January, 1, 13, 0, 0, 0, time.UTC), // referenceTime + time.Hour
+			expectedTime: time.Date(2020, time.January, 1, 13, 0, 0, 0, time.UTC),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			tc.initialTimeSetup(clock)
 
 			now := clock.Now()
@@ -79,20 +78,20 @@ func TestSimulatedClock_SetTime(t *testing.T) {
 		{
 			name:             "SetFromZeroTime",
 			initialTimeSetup: func(sc *SimulatedClock) {},
-			timeToSet:        referenceTime,
-			expectedAfter:    time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC), // referenceTime
+			timeToSet:        time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
+			expectedAfter:    time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			name: "OverwriteExistingTime",
 			initialTimeSetup: func(sc *SimulatedClock) {
-				sc.SetTime(referenceTime.Add(-time.Hour)) // Start with a different time
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(-time.Hour)) // Start with a different time
 			},
-			timeToSet:     referenceTime,
-			expectedAfter: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC), // referenceTime - time.Hour
+			timeToSet:     time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
+			expectedAfter: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			name:             "SetToZeroTime",
-			initialTimeSetup: func(sc *SimulatedClock) { sc.SetTime(referenceTime) },
+			initialTimeSetup: func(sc *SimulatedClock) { sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC)) },
 			timeToSet:        time.Time{}, // Zero time
 			expectedAfter:    time.Time{},
 		},
@@ -100,7 +99,7 @@ func TestSimulatedClock_SetTime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			tc.initialTimeSetup(clock)
 
 			clock.SetTime(tc.timeToSet)
@@ -119,21 +118,21 @@ func TestSimulatedClock_AdvanceTime(t *testing.T) {
 	}{
 		{
 			name:         "AdvancePositiveDuration",
-			initialTime:  referenceTime,
+			initialTime:  time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 			advanceBy:    5 * time.Minute,
-			expectedTime: time.Date(2020, time.January, 1, 12, 5, 0, 0, time.UTC), // refereceTime + 5 minutes
+			expectedTime: time.Date(2020, time.January, 1, 12, 5, 0, 0, time.UTC),
 		},
 		{
 			name:         "AdvanceNegativeDuration",
-			initialTime:  referenceTime,
+			initialTime:  time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 			advanceBy:    -2 * time.Hour,
-			expectedTime: time.Date(2020, time.January, 1, 10, 0, 0, 0, time.UTC), // referenceTime - 2 hours
+			expectedTime: time.Date(2020, time.January, 1, 10, 0, 0, 0, time.UTC),
 		},
 		{
 			name:         "AdvanceByZeroDuration",
-			initialTime:  referenceTime,
+			initialTime:  time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 			advanceBy:    0,
-			expectedTime: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC), // referenceTime
+			expectedTime: time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC),
 		},
 		{
 			name:         "AdvanceFromZeroTime",
@@ -145,7 +144,7 @@ func TestSimulatedClock_AdvanceTime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			clock.SetTime(tc.initialTime) // Set initial time for the clock
 
 			clock.AdvanceTime(tc.advanceBy)
@@ -175,7 +174,7 @@ func TestSimulatedClock_After_ShouldFireZeroOrNegativeDuration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			clockTimeAtAfterCall := clock.Now()
 
 			ch := clock.After(tc.afterDuration)
@@ -215,14 +214,14 @@ func TestSimulatedClock_After_ShouldFirePositiveDuration(t *testing.T) {
 			name:          "PositiveDuration_Fires_WhenTimeSetPastDuration",
 			afterDuration: 10 * time.Second,
 			action: func(sc *SimulatedClock) {
-				sc.SetTime(referenceTime.Add(15 * time.Second)) // Set time well past the duration
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(15 * time.Second)) // Set time well past the duration
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 			clockTimeAtAfterCall := clock.Now()
 
 			ch := clock.After(tc.afterDuration)
@@ -261,14 +260,14 @@ func TestSimulatedClock_After_ShouldNotFire(t *testing.T) {
 			name:          "PositiveDuration_DoesNotFire_WhenTimeSetBeforeDuration",
 			afterDuration: 10 * time.Second,
 			action: func(sc *SimulatedClock) {
-				sc.SetTime(referenceTime.Add(5 * time.Second)) // Set time, but not enough
+				sc.SetTime(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC).Add(5 * time.Second)) // Set time, but not enough
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock := NewSimulatedClock(referenceTime)
+			clock := NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
 
 			ch := clock.After(tc.afterDuration)
 			require.NotNil(t, ch, "Channel should not be nil")


### PR DESCRIPTION
### Description
- Adding a simulated clock for time.After() method.
- Current fake_clock implementation doesn't provide the SetTime() and AdvanceTime() support with time.After implementation.

### Link to the issue in case of a bug fix.
b/414538309

### Testing details
1. Manual - NA
2. Unit tests - Automated
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
