### PR TITLE
feat: inactive timeout support for range reader

### DIFF
--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -1,0 +1,238 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsx
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	storagev2 "cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/clock"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/locker"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	"golang.org/x/net/context"
+)
+
+// inactiveTimeoutReader is a wrapper over gcs.StorageReader that automatically
+// closes the wrapped GCS reader connection after a specified period of
+// inactivity (timeout). When a read operation is attempted on an inactive
+// (closed) reader, it automatically attempts to reconnect using the last known
+// read handle and the appropriate offset based on bytes previously read.
+//
+// This is useful for managing resources, especially when dealing with many
+// potentially inactive or idle readers.
+//
+// Important notes:
+//   - Inactivity Timer: A background goroutine monitors read activity. If no
+//     Read calls occur within the timeout duration, the underlying gcsReader is
+//     closed.
+//   - Due to the activity check happens periodically (every timeout duration), the
+//     actual reader connection closure can happen anywhere b/w timeout and 2 * timeout
+//     after the very last read operation, depending on when the last read occurred
+//     relative to the background routine wake-up cycle.
+//   - Thread Safety: The reader is safe for concurrent use by multiple goroutines,
+//     protected by an internal mutex.
+type inactiveTimeoutReader struct {
+	object *gcs.MinObject
+	bucket gcs.Bucket
+
+	// The underlying GCS storage reader; nil if closed due to inactivity.
+	gcsReader gcs.StorageReader
+
+	// Total number of bytes successfully read so far.
+	seen int64
+
+	// Requested range [start, end) from this reader.
+	start, end int64
+
+	// The read handle used for efficient reconnection for zonal bucket.
+	readHandle []byte
+
+	// The parent context, used for creating new readers and monitoring cancellation.
+	parentContext context.Context
+
+	// Mutex protecting internal state (mainily gcsReader & isActive).
+	mu locker.Locker
+
+	// Flag set by Read and reset by the monitor goroutine to track activity within the timeout window.
+	isActive bool
+
+	// Channel used to signal the monitor goroutine to stop, typically during Close().
+	stopChan chan struct{}
+
+	// Used for waiting for timeout (helps us in mocking the functionality).
+	clock clock.Clock
+}
+
+var (
+	ErrZeroInactivityTimeout = errors.New("ErrZeroInactivityTimeout")
+)
+
+// NewInactiveTimeoutReader creates a new gcs.StorageReader that wraps an
+// underlying GCS reader. It attempts to create the initial reader using the
+// provided parameters. If successful, it starts a background goroutine to monitor
+// for inactivity based on the specified timeout.
+//
+// If the timeout duration is zero, it returns (nil, ErrZeroInactivityTimeout) as a zero timeout
+// defeats the purpose of this wrapper.
+func NewInactiveTimeoutReader(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, start int64, end int64, timeout time.Duration) (gcs.StorageReader, error) {
+	if timeout == time.Duration(0) {
+		return nil, ErrZeroInactivityTimeout
+	}
+
+	return NewInactiveTimeoutReaderWithClock(ctx, bucket, object, readHandle, start, end, timeout, clock.RealClock{})
+}
+
+func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, start int64, end int64, timeout time.Duration, clock clock.Clock) (gcs.StorageReader, error) {
+	if timeout == time.Duration(0) {
+		return nil, ErrZeroInactivityTimeout
+	}
+
+	tsr := &inactiveTimeoutReader{
+		object:        object,
+		bucket:        bucket,
+		start:         start,
+		end:           end,
+		parentContext: ctx,
+		readHandle:    readHandle,
+		mu:            locker.New("inactiveTimeoutReader: "+object.Name, func() {}),
+		isActive:      false,
+		stopChan:      make(chan struct{}),
+		clock:         clock,
+	}
+
+	var err error
+	tsr.gcsReader, err = tsr.createGCSReader()
+	if err == nil {
+		go tsr.monitor(timeout)
+	}
+	return tsr, err
+}
+
+// createGCSReader is a helper method to create the underlined reader from tsr.start + tsr.seen offset.
+func (tsr *inactiveTimeoutReader) createGCSReader() (gcs.StorageReader, error) {
+	reader, err := tsr.bucket.NewReaderWithReadHandle(
+		tsr.parentContext,
+		&gcs.ReadObjectRequest{
+			Name:       tsr.object.Name,
+			Generation: tsr.object.Generation,
+			Range: &gcs.ByteRange{
+				Start: uint64(tsr.start + tsr.seen),
+				Limit: uint64(tsr.end),
+			},
+			ReadCompressed: tsr.object.HasContentEncodingGzip(),
+			ReadHandle:     tsr.readHandle,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("NewReaderWithReadHandle: %w", err)
+	}
+	return reader, nil
+}
+
+// Read implements io.Reader interface.
+//
+// If the underlying reader has been closed due to inactivity, Read automatically
+// attempts to reconnect using the stored read handle and the correct offset
+// (start + bytes previously seen). If reconnection fails, the error is returned.
+//
+// Each successful Read call marks the reader as active, resetting the inactivity timer
+// in the background monitor. This method is thread-safe.
+//
+// Calling Read() after explicitly calling Close() is not supported and will
+// lead to undefined behavior.
+func (tsr *inactiveTimeoutReader) Read(p []byte) (n int, err error) {
+	tsr.mu.Lock()
+	defer tsr.mu.Unlock()
+
+	tsr.isActive = true
+
+	if tsr.gcsReader == nil {
+		tsr.gcsReader, err = tsr.createGCSReader()
+
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	n, err = tsr.gcsReader.Read(p)
+	tsr.seen += int64(n)
+	return
+}
+
+// Close explicitly closes the underlying gcs.StorageReader if it's currently open.
+// It also signals the background monitor goroutine to stop.
+// Returns an error if closing the underlying reader fails.
+func (tsr *inactiveTimeoutReader) Close() (err error) {
+	tsr.mu.Lock()
+	defer tsr.mu.Unlock()
+
+	close(tsr.stopChan) // Close background monitoring routine.
+
+	if tsr.gcsReader != nil {
+		err = tsr.gcsReader.Close()
+		tsr.gcsReader = nil
+		if err != nil {
+			return fmt.Errorf("close reader: %w", err)
+		}
+	}
+	return
+}
+
+// ReadHandle returns the read handle associated with the underlying GCS reader.
+// If the reader has been closed due to inactivity, it returns the handle
+// stored from the last active reader.
+func (tsr *inactiveTimeoutReader) ReadHandle() (rh storagev2.ReadHandle) {
+	tsr.mu.Lock()
+	defer tsr.mu.Unlock()
+
+	if tsr.gcsReader == nil {
+		return tsr.readHandle
+	}
+
+	return tsr.gcsReader.ReadHandle()
+}
+
+// monitor runs in a background goroutine, and checks for inactivity.
+func (tsr *inactiveTimeoutReader) monitor(timeout time.Duration) {
+	timer := tsr.clock.After(timeout)
+	for {
+		select {
+		case <-timer:
+			tsr.mu.Lock()
+			if tsr.isActive {
+				tsr.isActive = false
+				timer = tsr.clock.After(timeout)
+			} else {
+				if tsr.gcsReader != nil {
+					logger.Infof("Closing reader for object %q due to inactivity timeout (%v).\n", tsr.object.Name, timeout)
+					tsr.readHandle = tsr.gcsReader.ReadHandle()
+					err := tsr.gcsReader.Close()
+					if err != nil {
+						logger.Warnf("Error closing inactive reader for object %q: %v", tsr.object.Name, err)
+					}
+					tsr.gcsReader = nil
+				}
+			}
+			tsr.mu.Unlock()
+		case <-tsr.parentContext.Done():
+			return
+
+		case <-tsr.stopChan:
+			return
+		}
+	}
+}

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -1,0 +1,310 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/clock"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type InactiveTimeoutReaderTestSuite struct {
+	suite.Suite
+	ctx        context.Context
+	mockBucket *storage.TestifyMockBucket
+	object     *gcs.MinObject
+	reader     gcs.StorageReader // The reader under test
+
+	// Fields to hold results from setup for individual tests
+	initialData       []byte
+	readHandle        []byte
+	initialFakeReader *fake.FakeReader
+	timeout           time.Duration
+	simulatedClock    *clock.SimulatedClock
+}
+
+func TestInactiveTimeoutReaderTestSuite(t *testing.T) {
+	suite.Run(t, new(InactiveTimeoutReaderTestSuite))
+}
+
+func (s *InactiveTimeoutReaderTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.mockBucket = new(storage.TestifyMockBucket)
+
+	// Default values, can be overridden by tests before calling setupReader
+	s.initialData = []byte("default data")
+	s.timeout = 100 * time.Millisecond
+	s.object = &gcs.MinObject{Name: "test-object", Generation: 123, Size: uint64(len(s.initialData))}
+	s.reader = nil // Reset reader before each test
+	s.initialFakeReader = nil
+	s.simulatedClock = clock.NewSimulatedClock(time.Date(2020, time.January, 1, 12, 0, 0, 0, time.UTC))
+}
+
+func (s *InactiveTimeoutReaderTestSuite) TearDownTest() {
+	if s.reader != nil {
+		// Close the wrapper reader, not the potentially nil internal one
+		s.reader.Close()
+		s.reader = nil
+	}
+	s.mockBucket.AssertExpectations(s.T())
+}
+
+// setupReader is a helper within the suite to create the reader under test.
+// Tests should call this after setting specific suite properties like initialData or timeout.
+func (s *InactiveTimeoutReaderTestSuite) setupReader(startOffset int64) {
+	s.object.Size = uint64(len(s.initialData)) // Ensure object size matches data
+	readCloser := getReadCloser(s.initialData)
+	s.initialFakeReader = &fake.FakeReader{ReadCloser: readCloser, Handle: s.readHandle}
+
+	readObjectRequest := &gcs.ReadObjectRequest{
+		Name:       s.object.Name,
+		Generation: s.object.Generation,
+		Range: &gcs.ByteRange{
+			Start: uint64(startOffset),
+			Limit: s.object.Size,
+		},
+		ReadCompressed: s.object.HasContentEncodingGzip(),
+		ReadHandle:     s.readHandle,
+	}
+	s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, readObjectRequest).Return(s.initialFakeReader, nil).Times(1)
+
+	var err error
+	// Use NewInactiveTimeoutReader directly as NewStorageReaderWithInactiveTimeout is deprecated.
+	s.reader, err = NewInactiveTimeoutReaderWithClock(s.ctx, s.mockBucket, s.object, s.readHandle, startOffset, int64(s.object.Size), s.timeout, s.simulatedClock)
+	time.Sleep(5 * time.Millisecond) // Allow time to schedule and create a timer.
+	s.Require().NoError(err)
+	s.Require().NotNil(s.reader)
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_NewInactiveTimeoutReader_InitialReadError() {
+	s.initialData = make([]byte, 100) // Size doesn't matter here
+	s.object = &gcs.MinObject{Name: "fail-object", Generation: 456, Size: 100}
+	s.timeout = 100 * time.Millisecond
+	initialErr := errors.New("initial connection failed")
+	// Expect the initial NewReader call to fail
+	s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Name == s.object.Name &&
+			req.Generation == s.object.Generation &&
+			req.Range.Start == 0 &&
+			req.Range.Limit == 100
+	})).Return(nil, initialErr).Once()
+
+	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, 0, 100, s.timeout)
+
+	s.Error(err)
+	s.ErrorIs(err, initialErr) // Should be the exact error from the bucket
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_NewInactiveTimeoutReader_ZeroTimeoutError() {
+	s.initialData = []byte("zero timeout")
+	s.timeout = 0 * time.Millisecond // Zero timeout
+
+	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, 0, 100, s.timeout)
+
+	s.Error(err)
+	s.Equal(ErrZeroInactivityTimeout, err)
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_Read_SuccessfulWithinTimeout() {
+	// Test initial read.
+	{
+		s.initialData = []byte("hello world")
+		s.timeout = 100 * time.Millisecond
+		s.setupReader(0) // Initial read from offset 0
+		buf1 := make([]byte, 5)
+
+		n1, err1 := s.reader.Read(buf1)
+
+		s.NoError(err1)
+		s.Equal(5, n1)
+		s.Equal("hello", string(buf1[:n1]))
+	}
+
+	// Test no reader closure within timeout.
+	{
+		buf2 := make([]byte, 6)
+		s.simulatedClock.AdvanceTime(s.timeout / 2)
+		// Allow some time to routine incase timer fired in half timeout.
+		time.Sleep(5 * time.Millisecond)
+
+		n2, err2 := s.reader.Read(buf2)
+
+		inactiveReader := s.reader.(*inactiveTimeoutReader)
+		s.True(inactiveReader.isActive)
+		s.NoError(err2)
+		s.Equal(6, n2)
+		s.Equal(" world", string(buf2[:n2]))
+	}
+
+	// EOF
+	{
+		buf3 := make([]byte, 6)
+
+		n3, err3 := s.reader.Read(buf3)
+
+		s.Same(io.EOF, err3)
+		s.Equal(0, n3)
+	}
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
+	buf := make([]byte, 5)
+
+	// Initial read.
+	{
+		s.initialData = []byte("reconnect failure")
+		s.timeout = 50 * time.Millisecond
+		s.setupReader(0)
+
+		n, err := s.reader.Read(buf)
+
+		s.Require().NoError(err)
+		s.Require().Equal(5, n)
+	}
+
+	// Test fails while re-connect.
+	{
+		// First timeout fire will make the reader inactive.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
+		// Wait for the monitor routine to make the read inactive.
+		require.Eventually(s.T(), func() bool {
+			rr := s.reader.(*inactiveTimeoutReader)
+			return !rr.isActive
+		}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
+		// 2nd fire will close the inactive reader.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
+		// Wait for the monitor routine to close the wrapped reader.
+		require.Eventually(s.T(), func() bool {
+			rr := s.reader.(*inactiveTimeoutReader)
+			return (rr.gcsReader == nil)
+		}, time.Second, 10*time.Millisecond, "Monitor did not close the reader in time")
+		reconnectErr := errors.New("failed to create new reader")
+		expectedReadHandle := s.initialFakeReader.Handle
+		s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+			return req.Name == s.object.Name &&
+				req.Range.Start == 5 && // Expect reconnect from offset 5
+				bytes.Equal(req.ReadHandle, expectedReadHandle)
+		})).Return(nil, reconnectErr).Times(1) // Expect only one call for the first failed attempt
+
+		nFail1, errFail1 := s.reader.Read(buf)
+
+		// First failed reconnect attempt
+		s.Error(errFail1)
+		s.ErrorIs(errFail1, reconnectErr)
+		s.Contains(errFail1.Error(), "NewReaderWithReadHandle:")
+		s.Equal(0, nFail1)
+	}
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect() {
+	// Test the first read.
+	{
+		s.initialData = []byte("abcdefghijklmnopqrstuvwxyz")
+		s.timeout = 50 * time.Second
+		s.setupReader(0)
+		buf := make([]byte, 10)
+
+		n, err := s.reader.Read(buf)
+
+		s.Require().NoError(err)
+		s.Require().Equal(10, n)
+		s.Equal("abcdefghij", string(buf[:n]))
+	}
+
+	// Test reconnect after timeout
+	{
+		// First timeout fire will make the reader inactive.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
+		// Wait for the monitor routine to make the read inactive.
+		require.Eventually(s.T(), func() bool {
+			rr := s.reader.(*inactiveTimeoutReader)
+			return !rr.isActive
+		}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
+		// 2nd fire will close the inactive reader.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
+		// Wait for the monitor routine to close the wrapped reader.
+		require.Eventually(s.T(), func() bool {
+			rr := s.reader.(*inactiveTimeoutReader)
+			return (rr.gcsReader == nil)
+		}, time.Second, 10*time.Millisecond, "Monitor did not close the reader in time")
+		expectedReadHandleAfterClose := s.initialFakeReader.Handle // The handle that should be stored after close
+		reconnectReadObjectRequest := &gcs.ReadObjectRequest{
+			Name:       s.object.Name,
+			Generation: s.object.Generation,
+			Range: &gcs.ByteRange{
+				Start: uint64(10), // Expect reconnect from offset 10
+				Limit: s.object.Size,
+			},
+			ReadCompressed: s.object.HasContentEncodingGzip(),
+			ReadHandle:     expectedReadHandleAfterClose, // Expect the stored handle to be used for reconnect
+		}
+		// Use the same initialFakeReader for simplicity, as it tracks the read offset internally.
+		s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, reconnectReadObjectRequest).Return(s.initialFakeReader, nil).Times(1)
+		bufReconnect := make([]byte, 5)
+
+		// Act - read after timeout (should trigger reconnect)
+		nReconnect, errReconnect := s.reader.Read(bufReconnect)
+
+		// Assert
+		s.Require().NoError(errReconnect, "Read after timeout failed")
+		s.Require().Equal(5, nReconnect)
+		s.Equal("klmno", string(bufReconnect[:nReconnect])) // Should read from the *reconnect* reader's data
+	}
+
+	// Test reading the remaining data
+	{
+		bufRemaining := make([]byte, 20)
+
+		nRemaining, errRemaining := s.reader.Read(bufRemaining)
+
+		s.Require().NoError(errRemaining)
+		s.Equal(11, nRemaining, "Incorrect number of remaining bytes read") // 26 total - 10 initial - 5 reconnect = 11
+		s.Equal("pqrstuvwxyz", string(bufRemaining[:nRemaining]))
+	}
+
+	// Test EOF
+	{
+		buf := make([]byte, 20)
+
+		n, err := s.reader.Read(buf)
+
+		s.Same(io.EOF, err)
+		s.Equal(0, n)
+	}
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_Close_ExplicitClose() {
+	s.initialData = []byte("close me")
+	s.timeout = 100 * time.Millisecond
+	s.setupReader(0)
+
+	err := s.reader.Close()
+	s.reader = nil // Prevent TearDownTest from closing again
+
+	s.NoError(err)
+}
+
+// TODO: Add concurrent test to make sure thread safety.

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -264,9 +264,11 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Close_ExplicitClose() {
 	s.setupReader(0)
 
 	err := s.reader.Close()
-	s.reader = nil // Prevent TearDownTest from closing again
 
 	s.NoError(err)
+	s.Nil(s.reader.(*inactiveTimeoutReader).cancel)
+	s.Nil(s.reader.(*inactiveTimeoutReader).ctx)
+	s.reader = nil // Prevent TearDownTest from closing again
 }
 
 func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveClose() {


### PR DESCRIPTION
### Description

This PR introduces a new reader wrapper, inactiveTimeoutReader, to automatically close open GCS read streams after a timeout. Useful for gRPC client-protocol where total number of max-streams is limited and surpassing the limit leads to stuck/hang.

More concurrent tests will be implemented in the follow up PR.

### Link to the issue in case of a bug fix.
b/412465587

### Testing details
1. Manual - Functional testing using a python script which starts reads, idle for more than timeout and then read again.
2. Unit tests - added.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
