### PR TITLE
Early termination in Test_ListWithMoveDir on failure in renameFolder

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -94,10 +94,10 @@ func (s *concurrentListingTest) Test_OpenDirAndLookUp(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForLightOperations; i++ {
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -106,7 +106,7 @@ func (s *concurrentListingTest) Test_OpenDirAndLookUp(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForLightOperations; i++ {
 			_, err := os.Stat(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -140,13 +140,13 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndLookUp(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ {
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -155,7 +155,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndLookUp(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForLightOperations; i++ {
 			_, err := os.Stat(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -193,13 +193,13 @@ func (s *concurrentListingTest) Test_MultipleConcurrentReadDir(t *testing.T) {
 
 			for j := 0; j < iterationsForMediumOperations; j++ {
 				f, err := os.Open(targetDir)
-				assert.Nil(t, err)
+				require.Nil(t, err)
 
 				_, err = f.Readdirnames(-1) // Read all directory entries
-				assert.Nil(t, err)
+				require.Nil(t, err)
 
 				err = f.Close()
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			}
 		}()
 	}
@@ -235,13 +235,13 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileOperations(t *testin
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ { // Adjust iteration count if needed
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -254,18 +254,18 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileOperations(t *testin
 
 			// Create
 			f, err := os.Create(filePath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Rename
 			err = os.Rename(filePath, renamedFilePath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Delete
 			err = os.Remove(renamedFilePath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -300,13 +300,13 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndDirOperations(t *testing
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ {
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -319,15 +319,15 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndDirOperations(t *testing
 
 			// Create
 			err := os.Mkdir(dirPath, 0755)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Rename
 			err = os.Rename(dirPath, renamedDirPath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Delete
 			err = os.Remove(renamedDirPath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -362,13 +362,13 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileEdit(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ {
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -380,15 +380,15 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileEdit(t *testing.T) {
 
 			// Create file
 			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Edit file (append some data)
 			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, setup.FilePermission_0600)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			_, err = f.Write([]byte("This is an edit."))
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -423,13 +423,13 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ { // Adjust iteration count if needed
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -441,15 +441,15 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 
 			// Create file
 			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Edit file (append some data)
 			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, setup.FilePermission_0600)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			_, err = f.Write([]byte("This is an edit."))
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -462,15 +462,15 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 
 			// Create
 			err := os.Mkdir(dirPath, 0755)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Rename
 			err = os.Rename(dirPath, renamedDirPath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// Delete
 			err = os.Remove(renamedDirPath)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -479,7 +479,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 		defer wg.Done()
 		for i := 0; i < iterationsForLightOperations; i++ {
 			_, err := os.Stat(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -488,10 +488,10 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations(t *testing.T) 
 		defer wg.Done()
 		for i := 0; i < iterationsForLightOperations; i++ {
 			f, err := os.Open(targetDir)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			err = f.Close()
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		}
 	}()
 
@@ -526,12 +526,12 @@ func (s *concurrentListingTest) Test_ListWithMoveFile(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < iterationsForMediumOperations; i++ { // Adjust iteration count if needed
 			f, err := os.Open(targetDir)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
-			assert.NoError(t, f.Close())
+			require.NoError(t, f.Close())
 		}
 	}()
 
@@ -545,10 +545,10 @@ func (s *concurrentListingTest) Test_ListWithMoveFile(t *testing.T) {
 		for i := 0; i < iterationsForHeavyOperations; i++ { // Adjust iteration count if needed
 			// Move File in the target directory
 			err = operations.Move(path.Join(testDirPath, "move_file.txt"), path.Join(targetDir, "move_file.txt"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Move File out of the target directory
 			err = operations.Move(path.Join(targetDir, "move_file.txt"), path.Join(testDirPath, "move_file.txt"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}()
 
@@ -586,9 +586,9 @@ func (s *concurrentListingTest) Test_ListWithMoveDir(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = f.Readdirnames(-1)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
-			assert.NoError(t, f.Close())
+			require.NoError(t, f.Close())
 		}
 	}()
 	// Create Dir
@@ -640,7 +640,7 @@ func (s *concurrentListingTest) Test_StatWithNewFileWrite(t *testing.T) {
 		for i := 0; i < iterationsForMediumOperations; i++ {
 			_, err := os.Stat(targetDir)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}()
 
@@ -652,7 +652,7 @@ func (s *concurrentListingTest) Test_StatWithNewFileWrite(t *testing.T) {
 			filePath := path.Join(targetDir, fmt.Sprintf("tmp_file_%d.txt", i))
 			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}()
 

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -601,10 +601,10 @@ func (s *concurrentListingTest) Test_ListWithMoveDir(t *testing.T) {
 		for i := 0; i < iterationsForHeavyOperations; i++ { // Adjust iteration count if needed
 			// Move Dir in the target dir
 			err = operations.Move(path.Join(testDirPath, "move_dir"), path.Join(targetDir, "move_dir"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// Move Dir out of the target dir
 			err = operations.Move(path.Join(targetDir, "move_dir"), path.Join(testDirPath, "move_dir"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}()
 


### PR DESCRIPTION
### Description
- Switching failure in folder renames from soft-failures to fatal-asserts as they should be.
- Extended it to all failures in concurrent_operations where proceeding after failure is pointless.

This is to reduce unnecessary repeated failures after a fatal failure.

### Link to the issue in case of a bug fix.
[b/414503184](http://b/414503184)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Tested with [presubmit](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/1f5807ab-c2bc-4598-b778-2fc9b8198b1c/summary) .

### Any backward incompatible change? If so, please explain.
