### PR TITLE
Log both source and destination folder in gcs debug log for RenameFolder

### DIFF
--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -300,7 +300,7 @@ func (b *debugBucket) CreateFolder(ctx context.Context, folderName string) (fold
 }
 
 func (b *debugBucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (o *gcs.Folder, err error) {
-	id, desc, start := b.startRequest("RenameFolder(%q)", folderName)
+	id, desc, start := b.startRequest("RenameFolder(%q, %q)", folderName, destinationFolderId)
 	defer b.finishRequest(id, desc, start, &err)
 
 	o, err = b.wrapped.RenameFolder(ctx, folderName, destinationFolderId)


### PR DESCRIPTION
### Description
Log both source and destination folder in RenameFolder debug log . This to make debugging easier using gcsfuse debug logs.

### Link to the issue in case of a bug fix.
[b/414503184](http://b/414503184)

### Testing details
1. Manual - Tested.
   - Before
   ```sh
   {"timestamp":{"seconds":1746202763,"nanos":779817438},"severity":"TRACE","message":"fuse_debug: Op 0x00000018        connection.go:426] <- Rename (PID 84541, old_parent 1, old_name \"a\", new_parent 1, new_name \"b\")"}
   {"timestamp":{"seconds":1746202763,"nanos":779917854},"severity":"TRACE","message":"gcs: Req              0x6: <- RenameFolder(\"a/\")"}
   {"timestamp":{"seconds":1746202763,"nanos":850611929},"severity":"TRACE","message":"gcs: Req              0x6: -> RenameFolder(\"a/\") (70.678157ms): OK"}
   {"timestamp":{"seconds":1746202763,"nanos":850663526},"severity":"TRACE","message":"fuse_debug: Op 0x00000018        connection.go:521] -> Rename ()"}
   ```
   - After
   ```
   {"timestamp":{"seconds":1746202763,"nanos":779817438},"severity":"TRACE","message":"fuse_debug: Op 0x00000018        connection.go:426] <- Rename (PID 84541, old_parent 1, old_name \"a\", new_parent 1, new_name \"b\")"}
   {"timestamp":{"seconds":1746202763,"nanos":779917854},"severity":"TRACE","message":"gcs: Req              0x6: <- RenameFolder(\"a/\", \"b/\")"}
   {"timestamp":{"seconds":1746202763,"nanos":850611929},"severity":"TRACE","message":"gcs: Req              0x6: -> RenameFolder(\"a/\", \"b/\") (70.678157ms): OK"}
   {"timestamp":{"seconds":1746202763,"nanos":850663526},"severity":"TRACE","message":"fuse_debug: Op 0x00000018        connection.go:521] -> Rename ()"}
   ```
3. Unit tests - NA
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
