### PR TITLE
Add GCSFuse release version in flag parse crash

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,10 +155,10 @@ func convertToPosixArgs(args []string, c *cobra.Command) []string {
 var ExecuteMountCmd = func() {
 	rootCmd, err := newRootCmd(Mount)
 	if err != nil {
-		log.Fatalf("Error occurred while creating the root command: %v", err)
+		log.Fatalf("Error occurred while creating the root command on gcsfuse/%s: %v", common.GetVersion(), err)
 	}
 	rootCmd.SetArgs(convertToPosixArgs(os.Args, rootCmd))
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatalf("Error occurred during command execution: %v", err)
+		log.Fatalf("Error occurred during command execution on gcsfuse/%s: %v", common.GetVersion(), err)
 	}
 }


### PR DESCRIPTION
### Description
Add GCSFuse release version in flag parse crash

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
