### PR TITLE
integrating takeover API in all bucket layers

### DIFF
--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -69,11 +69,6 @@ func (b contentTypeBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs
 }
 
 func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
-	// Guess a content type if necessary.
-	if req.ContentType == "" {
-		req.ContentType = mime.TypeByExtension(path.Ext(req.Name))
-	}
-
-	// Pass on the request.
-	return b.Bucket.CreateAppendableObjectWriter(ctx, req)
+	//TODO: Implementation
+	return nil, 0, nil
 }

--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -68,7 +68,7 @@ func (b contentTypeBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs
 	return b.Bucket.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
 }
 
-func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	//TODO: Implementation
-	return nil, 0, nil
+	return nil, nil
 }

--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -18,6 +18,7 @@ import (
 	"mime"
 	"path"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -66,4 +67,14 @@ func (b contentTypeBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs
 
 	// Pass on the request.
 	return b.Bucket.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
+}
+
+func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	// Guess a content type if necessary.
+	if req.ContentType == "" {
+		req.ContentType = mime.TypeByExtension(path.Ext(req.Name))
+	}
+
+	// Pass on the request.
+	return b.Bucket.CreateAppendableObjectWriter(ctx, req, opts)
 }

--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -18,7 +18,6 @@ import (
 	"mime"
 	"path"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -69,12 +68,12 @@ func (b contentTypeBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs
 	return b.Bucket.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
 }
 
-func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+func (b contentTypeBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
 	// Guess a content type if necessary.
 	if req.ContentType == "" {
 		req.ContentType = mime.TypeByExtension(path.Ext(req.Name))
 	}
 
 	// Pass on the request.
-	return b.Bucket.CreateAppendableObjectWriter(ctx, req, opts)
+	return b.Bucket.CreateAppendableObjectWriter(ctx, req)
 }

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -116,7 +116,7 @@ func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gc
 	*mReq = *req
 	mReq.Name = b.wrappedName(req.Name)
 
-	wc, off, err := b.wrapped.CreateAppendableObjectWriter(ctx, req)
+	wc, off, err := b.wrapped.CreateAppendableObjectWriter(ctx, mReq)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -103,6 +104,20 @@ func (b *prefixBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cre
 	mReq.Name = b.wrappedName(req.Name)
 
 	wc, err := b.wrapped.CreateObjectChunkWriter(ctx, mReq, chunkSize, callBack)
+	if err != nil {
+		return nil, err
+	}
+
+	return wc, err
+}
+
+func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	// Modify the request and call through.
+	mReq := new(gcs.CreateObjectRequest)
+	*mReq = *req
+	mReq.Name = b.wrappedName(req.Name)
+
+	wc, err := b.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -111,17 +111,8 @@ func (b *prefixBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cre
 }
 
 func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
-	// Modify the request and call through.
-	mReq := new(gcs.CreateObjectChunkWriterRequest)
-	*mReq = *req
-	mReq.Name = b.wrappedName(req.Name)
-
-	wc, off, err := b.wrapped.CreateAppendableObjectWriter(ctx, mReq)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return wc, off, err
+	//TODO: Implementation
+	return nil, 0, nil
 }
 
 func (b *prefixBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -110,9 +110,9 @@ func (b *prefixBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cre
 	return wc, err
 }
 
-func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	//TODO: Implementation
-	return nil, 0, nil
+	return nil, nil
 }
 
 func (b *prefixBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"golang.org/x/net/context"
 )
@@ -111,18 +110,18 @@ func (b *prefixBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cre
 	return wc, err
 }
 
-func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+func (b *prefixBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
 	// Modify the request and call through.
-	mReq := new(gcs.CreateObjectRequest)
+	mReq := new(gcs.CreateObjectChunkWriterRequest)
 	*mReq = *req
 	mReq.Name = b.wrappedName(req.Name)
 
-	wc, err := b.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
+	wc, off, err := b.wrapped.CreateAppendableObjectWriter(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return wc, err
+	return wc, off, err
 }
 
 func (b *prefixBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -93,11 +93,11 @@ func (mb *monitoringBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return wc, err
 }
 
-func (mb *monitoringBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+func (mb *monitoringBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	startTime := time.Now()
-	wc, off, err := mb.wrapped.CreateAppendableObjectWriter(ctx, req)
+	wc, err := mb.wrapped.CreateAppendableObjectWriter(ctx, req)
 	recordRequest(ctx, mb.metricHandle, "CreateAppendableObjectWriter", startTime)
-	return wc, off, err
+	return wc, err
 }
 
 func (mb *monitoringBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -93,6 +93,13 @@ func (mb *monitoringBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return wc, err
 }
 
+func (mb *monitoringBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storagev2.AppendableWriterOpts) (gcs.Writer, error) {
+	startTime := time.Now()
+	wc, err := mb.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
+	recordRequest(ctx, mb.metricHandle, "CreateAppendableObjectWriter", startTime)
+	return wc, err
+}
+
 func (mb *monitoringBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {
 	startTime := time.Now()
 	o, err := mb.wrapped.FinalizeUpload(ctx, w)

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -93,11 +93,11 @@ func (mb *monitoringBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return wc, err
 }
 
-func (mb *monitoringBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storagev2.AppendableWriterOpts) (gcs.Writer, error) {
+func (mb *monitoringBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
 	startTime := time.Now()
-	wc, err := mb.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
+	wc, off, err := mb.wrapped.CreateAppendableObjectWriter(ctx, req)
 	recordRequest(ctx, mb.metricHandle, "CreateAppendableObjectWriter", startTime)
-	return wc, err
+	return wc, off, err
 }
 
 func (mb *monitoringBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -107,7 +107,7 @@ func (b *throttledBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.
 	return
 }
 
-func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
+func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, err error) {
 	// Wait for permission to call through.
 	err = b.opThrottle.Wait(ctx, 1)
 	if err != nil {
@@ -115,7 +115,7 @@ func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req 
 	}
 
 	// Call through.
-	wc, off, err = b.wrapped.CreateAppendableObjectWriter(ctx, req)
+	wc, err = b.wrapped.CreateAppendableObjectWriter(ctx, req)
 
 	return
 }

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -107,7 +107,7 @@ func (b *throttledBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.
 	return
 }
 
-func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storagev2.AppendableWriterOpts) (wc gcs.Writer, err error) {
+func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
 	// Wait for permission to call through.
 	err = b.opThrottle.Wait(ctx, 1)
 	if err != nil {
@@ -115,7 +115,7 @@ func (b *throttledBucket) CreateAppendableObjectWriter(ctx context.Context, req 
 	}
 
 	// Call through.
-	wc, err = b.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
+	wc, off, err = b.wrapped.CreateAppendableObjectWriter(ctx, req)
 
 	return
 }

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -242,6 +242,13 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	return wc, nil
 }
 
+func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	//TODO implement it
+	return nil, nil
+}
+
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {
 	defer func() {
 		err = gcs.GetGCSError(err)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -243,10 +243,9 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 }
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
-	req *gcs.CreateObjectRequest,
-	opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
 	//TODO implement it
-	return nil, nil
+	return nil, 0, nil
 }
 
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -243,9 +243,9 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 }
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
-	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	//TODO implement it
-	return nil, 0, nil
+	return nil, nil
 }
 
 func (bh *bucketHandle) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -240,9 +240,9 @@ func (b *fastStatBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.C
 	return b.wrapped.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
 }
 
-func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	//TODO: implementation
-	return nil, 0, nil
+	return nil, nil
 }
 
 func (b *fastStatBucket) FinalizeUpload(ctx context.Context, writer gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -241,7 +241,8 @@ func (b *fastStatBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.C
 }
 
 func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
-	return b.wrapped.CreateAppendableObjectWriter(ctx, req)
+	//TODO: implementation
+	return nil, 0, nil
 }
 
 func (b *fastStatBucket) FinalizeUpload(ctx context.Context, writer gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -241,8 +240,8 @@ func (b *fastStatBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.C
 	return b.wrapped.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
 }
 
-func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
-	return b.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
+func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+	return b.wrapped.CreateAppendableObjectWriter(ctx, req)
 }
 
 func (b *fastStatBucket) FinalizeUpload(ctx context.Context, writer gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -238,6 +239,10 @@ func (b *fastStatBucket) CreateObject(
 
 func (b *fastStatBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
 	return b.wrapped.CreateObjectChunkWriter(ctx, req, chunkSize, callBack)
+}
+
+func (b *fastStatBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	return b.wrapped.CreateAppendableObjectWriter(ctx, req, opts)
 }
 
 func (b *fastStatBucket) FinalizeUpload(ctx context.Context, writer gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -181,6 +181,16 @@ func (b *debugBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Crea
 	return
 }
 
+func (b *debugBucket) CreateAppendableObjectWriter(ctx context.Context,
+	req *gcs.CreateObjectRequest,
+	opts *storagev2.AppendableWriterOpts) (wc gcs.Writer, err error) {
+	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q)", req.Name)
+	defer b.finishRequest(id, desc, start, &err)
+
+	wc, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req, opts)
+	return
+}
+
 func (b *debugBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (o *gcs.MinObject, err error) {
 	id, desc, start := b.startRequest("FinalizeUpload(%q)", w.ObjectName())
 	defer b.finishRequest(id, desc, start, &err)

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -183,7 +183,7 @@ func (b *debugBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Crea
 
 func (b *debugBucket) CreateAppendableObjectWriter(ctx context.Context,
 	req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
-	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q)", req.Name)
+	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q, %d)", req.Name, off)
 	defer b.finishRequest(id, desc, start, &err)
 
 	wc, off, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req)

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -182,12 +182,11 @@ func (b *debugBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Crea
 }
 
 func (b *debugBucket) CreateAppendableObjectWriter(ctx context.Context,
-	req *gcs.CreateObjectRequest,
-	opts *storagev2.AppendableWriterOpts) (wc gcs.Writer, err error) {
+	req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
 	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q)", req.Name)
 	defer b.finishRequest(id, desc, start, &err)
 
-	wc, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req, opts)
+	wc, off, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req)
 	return
 }
 

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -182,11 +182,11 @@ func (b *debugBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.Crea
 }
 
 func (b *debugBucket) CreateAppendableObjectWriter(ctx context.Context,
-	req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
-	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q, %d)", req.Name, off)
+	req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, err error) {
+	id, desc, start := b.startRequest("CreateAppendableObjectWriter(%q, %d)", req.Name, req.Offset)
 	defer b.finishRequest(id, desc, start, &err)
 
-	wc, off, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req)
+	wc, err = b.wrapped.CreateAppendableObjectWriter(context.WithValue(ctx, gcs.ReqIdField, id), req)
 	return
 }
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -691,9 +691,9 @@ func (b *bucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObj
 	return NewFakeObjectWriter(b, req)
 }
 
-func (b *bucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
+func (b *bucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
 	//TODO implement it
-	return nil, 0, nil
+	return nil, nil
 }
 
 func (b *bucket) FlushPendingWrites(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -29,7 +29,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -692,9 +691,9 @@ func (b *bucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObj
 	return NewFakeObjectWriter(b, req)
 }
 
-func (b *bucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+func (b *bucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, int64, error) {
 	//TODO implement it
-	return nil, nil
+	return nil, 0, nil
 }
 
 func (b *bucket) FlushPendingWrites(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -689,6 +690,11 @@ func (b *bucket) CreateObject(
 
 func (b *bucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, _ int, _ func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
 	return NewFakeObjectWriter(b, req)
+}
+
+func (b *bucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (gcs.Writer, error) {
+	//TODO implement it
+	return nil, nil
 }
 
 func (b *bucket) FlushPendingWrites(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -106,9 +106,7 @@ type Bucket interface {
 	// partially flushed to GCS, but not finalized. All bytes written will be appended
 	// continuing from the offset.
 	CreateAppendableObjectWriter(ctx context.Context,
-		req *CreateObjectRequest,
-		opts *storage.AppendableWriterOpts,
-	) (Writer, error)
+		req *CreateObjectChunkWriterRequest) (Writer, int64, error)
 
 	// FinalizeUpload closes the storage.Writer which completes the write
 	// operation and creates an object on GCS.

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -102,6 +102,14 @@ type Bucket interface {
 	// writer is closed (object is finalised).
 	CreateObjectChunkWriter(ctx context.Context, req *CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (Writer, error)
 
+	// CreateAppendableObjectWriter creates a *storage.Writer to an object which has been
+	// partially flushed to GCS, but not finalized. All bytes written will be appended
+	// continuing from the offset.
+	CreateAppendableObjectWriter(ctx context.Context,
+		req *CreateObjectRequest,
+		opts *storage.AppendableWriterOpts,
+	) (Writer, error)
+
 	// FinalizeUpload closes the storage.Writer which completes the write
 	// operation and creates an object on GCS.
 	FinalizeUpload(ctx context.Context, writer Writer) (*MinObject, error)

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -104,9 +104,9 @@ type Bucket interface {
 
 	// CreateAppendableObjectWriter creates a *storage.Writer to an object which has been
 	// partially flushed to GCS, but not finalized. All bytes written will be appended
-	// continuing from the offset.
+	// continuing from the offset passed via the CreateObjectChunkWriterRequest.
 	CreateAppendableObjectWriter(ctx context.Context,
-		req *CreateObjectChunkWriterRequest) (Writer, int64, error)
+		req *CreateObjectChunkWriterRequest) (Writer, error)
 
 	// FinalizeUpload closes the storage.Writer which completes the write
 	// operation and creates an object on GCS.

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -18,6 +18,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
+	"time"
 
 	storagev2 "cloud.google.com/go/storage"
 	storagev1 "google.golang.org/api/storage/v1"
@@ -421,4 +422,25 @@ type MoveObjectRequest struct {
 	// If non-nil, the destination object will be created/overwritten only if the
 	// current meta-generation for the source object is equal to the given value.
 	SrcMetaGenerationPrecondition *int64
+}
+
+// CreateObjectChunkWriterRequest represents a request to create a storage.Writer
+// which can either be used for regular writes or appendable object writes via the
+// the CreateObjectChunkWriter or CreateAppendableObjectWriter method respectively.
+type CreateObjectChunkWriterRequest struct {
+	*CreateObjectRequest
+
+	// Maximum number of bytes that writer will attempt to send to server in a
+	// single request. See Writer.ChunkSize
+	ChunkSize int
+
+	// ChunkRetryDeadline sets a per-chunk retry deadline for multi-chunk
+	// resumable uploads. See Writer.ChunkRetryDeadline.
+	ChunkRetryDeadline time.Duration
+
+	// ProgressFunc is used to monitor the progress of large writes.
+	// See Writer.ProgressFunc
+	ProgressFunc func(int64)
+
+	FinalizeOnClose bool // default is false. See Writer.FinalizeOnClose
 }

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -424,8 +424,8 @@ type MoveObjectRequest struct {
 }
 
 // CreateObjectChunkWriterRequest represents a request to create a storage.Writer
-// which can either be used for regular writes or appendable object writes via the
-// the CreateObjectChunkWriter or CreateAppendableObjectWriter method respectively.
+// which can be used for appendable object writes via the CreateAppendableObjectWriter
+// method.
 type CreateObjectChunkWriterRequest struct {
 	CreateObjectRequest
 
@@ -433,6 +433,6 @@ type CreateObjectChunkWriterRequest struct {
 	ChunkSize int
 
 	// Offset from where write has to start. Used only in case of appends flows.
-	// Default value is zero which means its a new object write.
+	// Default value is zero which means it's a new object write.
 	Offset int64
 }

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -18,7 +18,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"time"
 
 	storagev2 "cloud.google.com/go/storage"
 	storagev1 "google.golang.org/api/storage/v1"
@@ -428,19 +427,12 @@ type MoveObjectRequest struct {
 // which can either be used for regular writes or appendable object writes via the
 // the CreateObjectChunkWriter or CreateAppendableObjectWriter method respectively.
 type CreateObjectChunkWriterRequest struct {
-	*CreateObjectRequest
+	CreateObjectRequest
 
-	// Maximum number of bytes that writer will attempt to send to server in a
-	// single request. See Writer.ChunkSize
+	// Size of each chunk to be uploaded to GCS
 	ChunkSize int
 
-	// ChunkRetryDeadline sets a per-chunk retry deadline for multi-chunk
-	// resumable uploads. See Writer.ChunkRetryDeadline.
-	ChunkRetryDeadline time.Duration
-
-	// ProgressFunc is used to monitor the progress of large writes.
-	// See Writer.ProgressFunc
-	ProgressFunc func(int64)
-
-	FinalizeOnClose bool // default is false. See Writer.FinalizeOnClose
+	// Offset from where write has to start. Used only in case of appends flows.
+	// Default value is zero which means its a new object write.
+	Offset int64
 }

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -17,6 +17,7 @@ package mock
 import (
 	"context"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/mock"
 )
@@ -53,6 +54,14 @@ func (m *TestifyMockBucket) CreateObject(ctx context.Context, req *gcs.CreateObj
 }
 
 func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (wc gcs.Writer, err error) {
+	args := m.Called(ctx, req)
+	if args.Get(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(gcs.Writer), nil
+}
+
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (wc gcs.Writer, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
 		return nil, args.Error(1)

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -17,7 +17,6 @@ package mock
 import (
 	"context"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/mock"
 )
@@ -61,12 +60,12 @@ func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return args.Get(0).(gcs.Writer), nil
 }
 
-func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (wc gcs.Writer, err error) {
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
-		return nil, args.Error(1)
+		return nil, 0, args.Error(2)
 	}
-	return args.Get(0).(gcs.Writer), nil
+	return args.Get(0).(gcs.Writer), args.Get(1).(int64), nil
 }
 
 func (m *TestifyMockBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -60,12 +60,12 @@ func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return args.Get(0).(gcs.Writer), nil
 }
 
-func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
-		return nil, 0, args.Error(2)
+		return nil, args.Error(1)
 	}
-	return args.Get(0).(gcs.Writer), args.Get(1).(int64), nil
+	return args.Get(0).(gcs.Writer), nil
 }
 
 func (m *TestifyMockBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -160,7 +160,7 @@ func (m *mockBucket) CreateObjectChunkWriter(p0 context.Context, p1 *gcs.CreateO
 	return
 }
 
-func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectChunkWriterRequest) (o0 gcs.Writer, o1 int64, o3 error) {
+func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectChunkWriterRequest) (o0 gcs.Writer, o1 int64, o2 error) {
 	//TODO
 	return
 }

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -160,7 +160,7 @@ func (m *mockBucket) CreateObjectChunkWriter(p0 context.Context, p1 *gcs.CreateO
 	return
 }
 
-func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectChunkWriterRequest) (o0 gcs.Writer, o1 int64, o2 error) {
+func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectChunkWriterRequest) (o0 gcs.Writer, o1 error) {
 	//TODO
 	return
 }

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -11,6 +11,7 @@ import (
 	runtime "runtime"
 	unsafe "unsafe"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	oglemock "github.com/jacobsa/oglemock"
 	context "golang.org/x/net/context"
@@ -157,6 +158,10 @@ func (m *mockBucket) CreateObjectChunkWriter(p0 context.Context, p1 *gcs.CreateO
 		o1 = retVals[1].(error)
 	}
 
+	return
+}
+
+func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectRequest, p2 *storage.AppendableWriterOpts) (o0 gcs.Writer, o1 error) {
 	return
 }
 

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -11,7 +11,6 @@ import (
 	runtime "runtime"
 	unsafe "unsafe"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	oglemock "github.com/jacobsa/oglemock"
 	context "golang.org/x/net/context"
@@ -161,7 +160,8 @@ func (m *mockBucket) CreateObjectChunkWriter(p0 context.Context, p1 *gcs.CreateO
 	return
 }
 
-func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectRequest, p2 *storage.AppendableWriterOpts) (o0 gcs.Writer, o1 error) {
+func (m *mockBucket) CreateAppendableObjectWriter(p0 context.Context, p1 *gcs.CreateObjectChunkWriterRequest) (o0 gcs.Writer, o1 int64, o3 error) {
+	//TODO
 	return
 }
 

--- a/internal/storage/testify_mock_bucket.go
+++ b/internal/storage/testify_mock_bucket.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"context"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/mock"
 )
@@ -61,12 +60,12 @@ func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return args.Get(0).(gcs.Writer), nil
 }
 
-func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (wc gcs.Writer, err error) {
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
-		return nil, args.Error(1)
+		return nil, 0, args.Error(2)
 	}
-	return args.Get(0).(gcs.Writer), nil
+	return args.Get(0).(gcs.Writer), args.Get(1).(int64), nil
 }
 
 func (m *TestifyMockBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {

--- a/internal/storage/testify_mock_bucket.go
+++ b/internal/storage/testify_mock_bucket.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
 	"github.com/stretchr/testify/mock"
 )
@@ -53,6 +54,14 @@ func (m *TestifyMockBucket) CreateObject(ctx context.Context, req *gcs.CreateObj
 }
 
 func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (wc gcs.Writer, err error) {
+	args := m.Called(ctx, req)
+	if args.Get(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(gcs.Writer), nil
+}
+
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectRequest, opts *storage.AppendableWriterOpts) (wc gcs.Writer, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
 		return nil, args.Error(1)

--- a/internal/storage/testify_mock_bucket.go
+++ b/internal/storage/testify_mock_bucket.go
@@ -60,12 +60,12 @@ func (m *TestifyMockBucket) CreateObjectChunkWriter(ctx context.Context, req *gc
 	return args.Get(0).(gcs.Writer), nil
 }
 
-func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, off int64, err error) {
+func (m *TestifyMockBucket) CreateAppendableObjectWriter(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (wc gcs.Writer, err error) {
 	args := m.Called(ctx, req)
 	if args.Get(1) != nil {
-		return nil, 0, args.Error(2)
+		return nil, args.Error(1)
 	}
-	return args.Get(0).(gcs.Writer), args.Get(1).(int64), nil
+	return args.Get(0).(gcs.Writer), nil
 }
 
 func (m *TestifyMockBucket) FinalizeUpload(ctx context.Context, w gcs.Writer) (*gcs.MinObject, error) {


### PR DESCRIPTION
### Description

Adding CreateAppendableObjectWriter method to all bucket interfaces , to implement the takeover support for appendable unfinalized objects in ZB. Ref: [link](https://github.com/tritone/google-cloud-go/blob/24b051557ee14dbe3fdaf66e0d422bd88c1331c6/storage/storage.go#L1267)
Implementation and tests will be included in a follow-up PR.

### Link to the issue in case of a bug fix.
[b/415727697](b/415727697)

### Testing details
1. Manual - Manually testing of different flows - No breakage.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
