### PR TITLE
Adding race detector test for inactive timeout reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         build_gcsfuse . /tmp ${GITHUB_SHA}
     - name: Test all
       run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
-    - name: Cache RaceDetector Test
+    - name: RaceDetector Test
       run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/... ./internal/gcsx/...
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Test all
       run: CGO_ENABLED=0 go test -p 1 -count 1 -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
     - name: Cache RaceDetector Test
-      run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/...
+      run: go test -p 1 -count 1 -v -race -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` ./internal/cache/... ./internal/gcsx/...
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.3.1
       timeout-minutes: 5

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -169,8 +169,8 @@ func (itr *inactiveTimeoutReader) Close() (err error) {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
+	itr.cancel()
 	itr.cancel = nil
-	itr.ctx = nil
 
 	if itr.gcsReader == nil {
 		return nil
@@ -179,9 +179,9 @@ func (itr *inactiveTimeoutReader) Close() (err error) {
 	err = itr.gcsReader.Close()
 	itr.gcsReader = nil
 	if err != nil {
-		return fmt.Errorf("close reader: %w", err)
+		return fmt.Errorf("Close reader: %w", err)
 	}
-	return err
+	return nil
 }
 
 // ReadHandle returns the read handle associated with the underlying GCS reader.

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -169,8 +169,8 @@ func (itr *inactiveTimeoutReader) Close() (err error) {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
+	// Signal background periodic routine to stop.
 	itr.cancel()
-	itr.cancel = nil
 
 	if itr.gcsReader == nil {
 		return nil

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -276,7 +276,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Close_ExplicitClose() {
 	err := s.reader.Close()
 
 	s.NoError(err)
-	s.Nil(s.reader.(*inactiveTimeoutReader).cancel)
+	s.Nil(s.reader.(*inactiveTimeoutReader).gcsReader)
 	s.reader = nil // Prevent TearDownTest from closing again
 }
 

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -188,6 +190,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	// Wait for the monitor routine to make the read inactive.
 	require.Eventually(s.T(), func() bool {
 		rr := s.reader.(*inactiveTimeoutReader)
+		rr.mu.Lock()
+		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
 	// 2nd fire will close the inactive reader.
@@ -195,6 +199,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
 		rr := s.reader.(*inactiveTimeoutReader)
+		rr.mu.Lock()
+		defer rr.mu.Unlock()
 		return (rr.gcsReader == nil)
 	}, time.Second, 10*time.Millisecond, "Monitor did not close the reader in time")
 	reconnectErr := errors.New("failed to create new reader")
@@ -226,6 +232,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	// Wait for the monitor routine to make the read inactive.
 	require.Eventually(s.T(), func() bool {
 		rr := s.reader.(*inactiveTimeoutReader)
+		rr.mu.Lock()
+		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
 	// 2nd fire will close the inactive reader.
@@ -233,6 +241,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
 		rr := s.reader.(*inactiveTimeoutReader)
+		rr.mu.Lock()
+		defer rr.mu.Unlock()
 		return (rr.gcsReader == nil)
 	}, time.Second, 10*time.Millisecond, "Monitor did not close the reader in time")
 	expectedReadHandleAfterClose := s.initialFakeReader.Handle // The handle that should be stored after close
@@ -267,7 +277,6 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Close_ExplicitClose() {
 
 	s.NoError(err)
 	s.Nil(s.reader.(*inactiveTimeoutReader).cancel)
-	s.Nil(s.reader.(*inactiveTimeoutReader).ctx)
 	s.reader = nil // Prevent TearDownTest from closing again
 }
 
@@ -333,4 +342,37 @@ func (s *InactiveTimeoutReaderTestSuite) Test_closeGCSReader_NonNilReader() {
 	s.Equal(expectedHandleAfterClose, itr.readHandle, "readHandle should be updated from closed reader")
 }
 
-// TODO: Add concurrent test to make sure thread safety.
+func (s *InactiveTimeoutReaderTestSuite) TestRaceCondition() {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	s.initialData = []byte(strings.Repeat("abc", 1000))
+	s.timeout = time.Second
+	s.readHandle = []byte("handle-before-close")
+	s.setupReader(0) // Sets up s.reader and s.initialFakeReader
+
+	// Read()
+	go func() {
+		defer wg.Done()
+		// Read the complete object with buffer size 100.
+		for offset := 0; offset < int(s.object.Size); offset += 100 {
+			rc := &fake.FakeReader{ReadCloser: getReadCloser(s.initialData[offset:])}
+			s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(rc, nil).Maybe()
+			buf := make([]byte, 100)
+
+			n, err := s.reader.Read(buf)
+
+			s.NoError(err)
+			s.Equal(100, n)
+		}
+	}()
+
+	// Concurrent handleTimeout.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			s.reader.(*inactiveTimeoutReader).handleTimeout()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Description
1. Adding race detector test for inactive timeout reader.
2. Enabling race detector test for the gcsx.
3. Fixing ctx crash when Close() resets the context to nil and simultaneous monitor routine access in the for-select loop.

### Link to the issue in case of a bug fix.
b/415783752

### Testing details
1. Manual - Test fails, when I remove lock from the handle-timeout implementation.
4. Unit tests - NA
5. Integration tests - NA

### Any backward incompatible change? If so, please explain.
