### PR TITLE
Flag to support inactive timeout reader

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -232,7 +232,7 @@ type MonitoringConfig struct {
 }
 
 type ReadConfig struct {
-	InactivityTimeout time.Duration `yaml:"inactivity-timeout"`
+	InactiveStreamTimeout time.Duration `yaml:"inactive-stream-timeout"`
 }
 
 type ReadStallGcsRetriesConfig struct {
@@ -507,9 +507,9 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
-	flagSet.DurationP("read-inactivity-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout. Note: Currently only applies when using the 'grpc' client-protocol.")
+	flagSet.DurationP("read-inactive-stream-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout. Note: Currently only applies when using the 'grpc' client-protocol.")
 
-	if err := flagSet.MarkHidden("read-inactivity-timeout"); err != nil {
+	if err := flagSet.MarkHidden("read-inactive-stream-timeout"); err != nil {
 		return err
 	}
 
@@ -872,7 +872,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("read.inactivity-timeout", flagSet.Lookup("read-inactivity-timeout")); err != nil {
+	if err := v.BindPFlag("read.inactive-stream-timeout", flagSet.Lookup("read-inactive-stream-timeout")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -66,6 +66,8 @@ type Config struct {
 
 	OnlyDir string `yaml:"only-dir"`
 
+	Read ReadConfig `yaml:"read"`
+
 	Write WriteConfig `yaml:"write"`
 }
 
@@ -227,6 +229,10 @@ type MonitoringConfig struct {
 	ExperimentalTracingMode string `yaml:"experimental-tracing-mode"`
 
 	ExperimentalTracingSamplingRatio float64 `yaml:"experimental-tracing-sampling-ratio"`
+}
+
+type ReadConfig struct {
+	InactivityTimeout time.Duration `yaml:"inactivity-timeout"`
 }
 
 type ReadStallGcsRetriesConfig struct {
@@ -500,6 +506,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
+
+	flagSet.DurationP("read-inactivity-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout. Note: Currently only applies when using the 'grpc' client-protocol.")
+
+	if err := flagSet.MarkHidden("read-inactivity-timeout"); err != nil {
+		return err
+	}
 
 	flagSet.DurationP("read-stall-initial-req-timeout", "", 20000000000*time.Nanosecond, "Initial value of the read-request dynamic timeout.")
 
@@ -857,6 +869,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metrics.prometheus-port", flagSet.Lookup("prometheus-port")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("read.inactivity-timeout", flagSet.Lookup("read-inactivity-timeout")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -654,8 +654,8 @@
   usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
   default: ""
 
-- config-path: "read.inactivity-timeout"
-  flag-name: "read-inactivity-timeout"
+- config-path: "read.inactive-stream-timeout"
+  flag-name: "read-inactive-stream-timeout"
   type: "duration"
   usage: >-
     Duration of inactivity after which an open GCS read stream is automatically closed.

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -300,7 +300,6 @@
     https://storage.googleapis.com/storage/v1.
   default: ""
 
-
 - config-path: "gcs-connection.experimental-enable-json-read"
   flag-name: "experimental-enable-json-read"
   type: "bool"
@@ -655,6 +654,17 @@
   usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
   default: ""
 
+- config-path: "read.inactivity-timeout"
+  flag-name: "read-inactivity-timeout"
+  type: "duration"
+  usage: >-
+    Duration of inactivity after which an open GCS read stream is automatically closed.
+    This helps conserve resources when a file handle remains open without active Read calls.
+    A value of '0s' disables this timeout.
+    Note: Currently only applies when using the 'grpc' client-protocol.
+  default: "0s"
+  hide-flag: true
+
 - config-path: "write.block-size-mb"
   flag-name: "write-block-size-mb"
   type: "int"
@@ -667,8 +677,7 @@
 - config-path: "write.create-empty-file"
   flag-name: "create-empty-file"
   type: "bool"
-  usage: "For a new file, it creates an empty file in Cloud Storage bucket as a
-  hold."
+  usage: "For a new file, it creates an empty file in Cloud Storage bucket as a hold."
   default: false
 
 - config-path: "write.enable-streaming-writes"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -124,7 +124,7 @@ func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig, c *Config) {
 func resolveReadconfig(c *Config, r *ReadConfig) {
 	// Only enable for GRPC client protocol.
 	if c.GcsConnection.ClientProtocol != GRPC {
-		r.InactivityTimeout = 0
+		r.InactiveStreamTimeout = 0
 	}
 }
 

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -121,7 +121,7 @@ func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig, c *Config) {
 	}
 }
 
-func resolveReadconfig(c *Config, r *ReadConfig) {
+func resolveReadConfig(c *Config, r *ReadConfig) {
 	// Only enable for GRPC client protocol.
 	if c.GcsConnection.ClientProtocol != GRPC {
 		r.InactiveStreamTimeout = 0
@@ -148,7 +148,7 @@ func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache, optimizedFlags)
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
-	resolveReadconfig(c, &c.Read)
+	resolveReadConfig(c, &c.Read)
 
 	return nil
 }

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -121,6 +121,13 @@ func resolveParallelDownloadsValue(v isSet, fc *FileCacheConfig, c *Config) {
 	}
 }
 
+func resolveReadconfig(c *Config, r *ReadConfig) {
+	// Only enable for GRPC client protocol.
+	if c.GcsConnection.ClientProtocol != GRPC {
+		r.InactivityTimeout = 0
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	var err error
@@ -141,6 +148,7 @@ func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache, optimizedFlags)
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
+	resolveReadconfig(c, &c.Read)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockIsSet struct{}
@@ -600,7 +601,7 @@ func TestRationalizeReadInactiveTimeoutConfig(t *testing.T) {
 			expectedTimeout: 0,
 		},
 		{
-			name: "gRPC_client_protocol",
+			name: "grpc_client_protocol",
 			config: &Config{
 				Read: ReadConfig{
 					InactiveStreamTimeout: 60 * time.Second,
@@ -618,9 +619,8 @@ func TestRationalizeReadInactiveTimeoutConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if assert.NoError(t, Rationalize(&mockIsSet{}, tc.config, []string{})) {
-				assert.EqualValues(t, tc.expectedTimeout, tc.config.Read.InactiveStreamTimeout)
-			}
+			require.NoError(t, Rationalize(&mockIsSet{}, tc.config, []string{}))
+			assert.EqualValues(t, tc.expectedTimeout, tc.config.Read.InactiveStreamTimeout)
 		})
 	}
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -591,7 +591,7 @@ func TestRationalizeReadInactiveTimeoutConfig(t *testing.T) {
 			name: "http_client_protocol",
 			config: &Config{
 				Read: ReadConfig{
-					InactivityTimeout: 60 * time.Second,
+					InactiveStreamTimeout: 60 * time.Second,
 				},
 				GcsConnection: GcsConnectionConfig{
 					ClientProtocol: HTTP1,
@@ -603,7 +603,7 @@ func TestRationalizeReadInactiveTimeoutConfig(t *testing.T) {
 			name: "gRPC_client_protocol",
 			config: &Config{
 				Read: ReadConfig{
-					InactivityTimeout: 60 * time.Second,
+					InactiveStreamTimeout: 60 * time.Second,
 				},
 				GcsConnection: GcsConnectionConfig{
 					ClientProtocol: GRPC,
@@ -619,7 +619,7 @@ func TestRationalizeReadInactiveTimeoutConfig(t *testing.T) {
 			t.Parallel()
 
 			if assert.NoError(t, Rationalize(&mockIsSet{}, tc.config, []string{})) {
-				assert.EqualValues(t, tc.expectedTimeout, tc.config.Read.InactivityTimeout)
+				assert.EqualValues(t, tc.expectedTimeout, tc.config.Read.InactiveStreamTimeout)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1299,6 +1299,11 @@ func TestArgsParsing_ReadInactiveTimeoutConfig(t *testing.T) {
 			cfgFile:         "override.yaml",
 			expectedTimeout: 0,
 		},
+		{
+			name:            "override_with_grpc",
+			cfgFile:         "override_with_grpc.yaml",
+			expectedTimeout: 30 * time.Second,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1312,9 +1317,8 @@ func TestArgsParsing_ReadInactiveTimeoutConfig(t *testing.T) {
 
 			err = cmd.Execute()
 
-			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedTimeout, gotConfig.Read.InactiveStreamTimeout)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedTimeout, gotConfig.Read.InactiveStreamTimeout)
 		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1313,7 +1313,7 @@ func TestArgsParsing_ReadInactiveTimeoutConfig(t *testing.T) {
 			err = cmd.Execute()
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedTimeout, gotConfig.Read.InactivityTimeout)
+				assert.Equal(t, tc.expectedTimeout, gotConfig.Read.InactiveStreamTimeout)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1282,3 +1282,39 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 		})
 	}
 }
+
+func TestArgsParsing_ReadInactiveTimeoutConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		cfgFile         string
+		expectedTimeout time.Duration
+	}{
+		{
+			name:            "default",
+			cfgFile:         "empty.yaml",
+			expectedTimeout: 0,
+		},
+		{
+			name:            "override_default",
+			cfgFile:         "override.yaml",
+			expectedTimeout: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := newRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotConfig = cfg
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs([]string{"gcsfuse", fmt.Sprintf("--config-file=testdata/read_config/%s", tc.cfgFile), "abc", "pqr"}, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedTimeout, gotConfig.Read.InactivityTimeout)
+			}
+		})
+	}
+}

--- a/cmd/testdata/read_config/override.yaml
+++ b/cmd/testdata/read_config/override.yaml
@@ -1,0 +1,2 @@
+read:
+  inactivity-timeout: 30s

--- a/cmd/testdata/read_config/override.yaml
+++ b/cmd/testdata/read_config/override.yaml
@@ -1,2 +1,2 @@
 read:
-  inactivity-timeout: 30s
+  inactive-stream-timeout: 30s

--- a/cmd/testdata/read_config/override_with_grpc.yaml
+++ b/cmd/testdata/read_config/override_with_grpc.yaml
@@ -1,0 +1,4 @@
+read:
+  inactive-stream-timeout: 30s
+gcs-connection:
+  client-protocol: grpc

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -1,4 +1,6 @@
 app-name: hello
+read:
+  inactive-stream-timeout: 10s
 write:
   create-empty-file: true
   enable-streaming-writes: true


### PR DESCRIPTION
### Description
- Adding a new hidden flag `--read-inactive-stream-timeout`
- Default value - 0s (that means disabled)
- Currently only applicable for `--client-protocol=grpc`

### Link to the issue in case of a bug fix.
412465859

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
