### PR TITLE
Revert "Adding gcsx path in the flake race-detector test"

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -3,7 +3,7 @@ on:
   # Enable triggering the workflow manually
   workflow_dispatch:
   push:
-    branches: ["master"]
+    branches: [ "master" ]
 
 jobs:
   flake-detector:
@@ -34,5 +34,5 @@ jobs:
       - name: Test all
         run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 5 -skip `cat flaky_tests.lst | go run tools/scripts/skip_tests/main.go` `go list ./...`
 
-      - name: RaceDetector Test
-        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 5 ./internal/cache/... ./internal/gcsx/...
+      - name: Cache RaceDetector Test
+        run: CGO_ENABLED=0 go test -p 1 -timeout 75m -count 5 ./internal/cache/...


### PR DESCRIPTION
This reverts commit 0369877ae7ebd003d2c7c3b428d3c59052288d36.

### Description
Reverting the by mistake pushed commit in the master branch.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
