### PR TITLE
[testing-on-gke] [BQ-integration-part-3] Implement export to bigquery table in python script

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
@@ -142,7 +142,7 @@ class DlioWorkload:
     self.numEpochs = numEpochs
 
 
-def ParseTestConfigForDlioWorkloads(testConfigFileName: str):
+def parse_test_config_for_dlio_workloads(testConfigFileName: str):
   """Parses the given workload test configuration file for DLIO workloads."""
   print(f'Parsing {testConfigFileName} for DLIO workloads ...')
   with open(testConfigFileName) as f:

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -52,7 +52,7 @@ record = {
 }
 
 
-def downloadDlioOutputs(dlioWorkloads: set, instanceId: str) -> int:
+def download_dlio_outputs(dlioWorkloads: set, instanceId: str) -> int:
   """Downloads instanceId-specific dlio outputs for each dlioWorkload locally.
 
   Outputs in the bucket are in the following object naming format
@@ -260,10 +260,10 @@ if __name__ == "__main__":
   args = parse_arguments()
   ensure_directory_exists(_LOCAL_LOGS_LOCATION)
 
-  dlioWorkloads = dlio_workload.ParseTestConfigForDlioWorkloads(
+  dlioWorkloads = dlio_workload.parse_test_config_for_dlio_workloads(
       args.workload_config
   )
-  downloadDlioOutputs(dlioWorkloads, args.instance_id)
+  download_dlio_outputs(dlioWorkloads, args.instance_id)
 
   output = create_output_scenarios_from_downloaded_files(args)
 

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -79,7 +79,7 @@ def downloadDlioOutputs(dlioWorkloads: set, instanceId: str) -> int:
   return 0
 
 
-def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
+def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
   """Creates output records from the downloaded local files.
 
   The following creates a dict called 'output'
@@ -192,7 +192,7 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
   return output
 
 
-def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
+def write_records_to_csv_output_file(output: dict, output_file_path: str):
   with open(output_file_path, "a") as output_file:
     # Write a new header row.
     output_file.write(
@@ -265,13 +265,13 @@ if __name__ == "__main__":
   )
   downloadDlioOutputs(dlioWorkloads, args.instance_id)
 
-  output = createOutputScenariosFromDownloadedFiles(args)
+  output = create_output_scenarios_from_downloaded_files(args)
 
   output_file_path = args.output_file
   # Create the parent directory of output_file_path if doesn't
   # exist already.
   ensure_directory_exists(os.path.dirname(output_file_path))
-  writeRecordsToCsvOutputFile(output, output_file_path)
+  write_records_to_csv_output_file(output, output_file_path)
   print(
       "\n\nSuccessfully published outputs of DLIO test runs to"
       f" {output_file_path} !!!\n\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -89,7 +89,7 @@ def createHelmInstallCommands(
 
 
 def main(args) -> None:
-  dlioWorkloads = dlio_workload.ParseTestConfigForDlioWorkloads(
+  dlioWorkloads = dlio_workload.parse_test_config_for_dlio_workloads(
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -168,6 +168,8 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     dataset = bigquery.Dataset(f'{self.project_id}.{self.dataset_id}')
     try:
       self.client.create_dataset(dataset, exists_ok=True)
+      # Wait for the dataset to be created and ready to be referenced
+      time.sleep(120)
     except Exception as e:
       print(f'Failed to create dataset {dataset}: {e}')
       raise

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -168,12 +168,6 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     dataset = bigquery.Dataset(f'{self.project_id}.{self.dataset_id}')
     try:
       self.client.create_dataset(dataset, exists_ok=True)
-      print(
-          f'Created dataset {dataset}, now sleeping for sometime to let it'
-          ' reflect ...'
-      )
-      # Wait for the dataset to be created and ready to be referenced
-      time.sleep(120)
     except Exception as e:
       print(f'Failed to create dataset {dataset}: {e}')
       raise

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -166,7 +166,7 @@ class FioWorkload:
     )
 
 
-def ParseTestConfigForFioWorkloads(fioTestConfigFile: str):
+def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
   """Parses the given workload test configuration file for FIO workloads."""
   print(f'Parsing {fioTestConfigFile} for FIO workloads ...')
   with open(fioTestConfigFile) as f:

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -28,7 +28,7 @@ sys.path.append("../")
 import fio_workload
 from utils.parse_logs_common import ensure_directory_exists, download_gcs_objects, parse_arguments, SUPPORTED_SCENARIOS, fetch_cpu_memory_data
 from fio.bq_utils import FioBigqueryExporter, FioTableRow, Timestamp
-from utils.utils import unix_to_timestamp
+from utils.utils import unix_to_timestamp, convert_size_to_size_in_bytes
 
 _LOCAL_LOGS_LOCATION = "../../bin/fio-logs"
 
@@ -356,6 +356,7 @@ def writeRecordsToBqTable(
         r = record_set["records"][scenario][epoch]
         row = FioTableRow()
         row.file_size = record_set["mean_file_size"]
+        row.file_size_in_bytes = convert_size_to_size_in_bytes(row.file_size)
         row.operation = record_set["read_type"]
         row.scenario = scenario
         row.epoch = r["epoch"]
@@ -371,6 +372,7 @@ def writeRecordsToBqTable(
         row.end_time = Timestamp(r["end"])
         row.gcsfuse_mount_options = r["gcsfuse_mount_options"]
         row.block_size = r["blockSize"]
+        row.block_size_in_bytes = convert_size_to_size_in_bytes(row.block_size)
         row.files_per_thread = r["filesPerThread"]
         row.num_threads = r["numThreads"]
         row.experiment_id = experiment_id

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -332,7 +332,11 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
 
 
 def writeRecordsToBqTable(
-    output: dict, bq_project_id: str, bq_dataset_id: str, bq_table_id: str
+    output: dict,
+    experiment_id: str,
+    bq_project_id: str,
+    bq_dataset_id: str,
+    bq_table_id: str,
 ):
   fioBqExporter = FioBigqueryExporter(bq_project_id, bq_dataset_id, bq_table_id)
 
@@ -369,7 +373,7 @@ def writeRecordsToBqTable(
         row.block_size = r["blockSize"]
         row.files_per_thread = r["filesPerThread"]
         row.num_threads = r["numThreads"]
-        row.experiment_id = args.instance_id
+        row.experiment_id = experiment_id
         row.e2e_latency_ns_max = r["e2e_latency_ns_max"]
         row.e2e_latency_ns_p50 = r["e2e_latency_ns_p50"]
         row.e2e_latency_ns_p90 = r["e2e_latency_ns_p90"]
@@ -380,7 +384,7 @@ def writeRecordsToBqTable(
 
         rows.append(row)
 
-  fioBqExporter.append_rows(rows)
+  fioBqExporter.append_rows(rows=rows, experiment_id=experiment_id)
   print(
       "\nSuccessfully exported outputs of FIO test runs to"
       f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_id} !!!\n"
@@ -415,5 +419,9 @@ if __name__ == "__main__":
       and args.bq_table_id.strip()
   ):
     writeRecordsToBqTable(
-        output, args.bq_project_id, args.bq_dataset_id, args.bq_table_id
+        output=output,
+        bq_project_id=args.bq_project_id,
+        bq_dataset_id=args.bq_dataset_id,
+        bq_table_id=args.bq_table_id,
+        experiment_id=args.instance_id,
     )

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -393,7 +393,7 @@ def writeRecordsToBqTable(
 
         rows.append(row)
 
-  fioBqExporter.insert_rows(fioTableRows=rows, experiment_id=experiment_id)
+  fioBqExporter.insert_rows(fioTableRows=rows)
   print(
       "\nSuccessfully exported outputs of FIO test runs to"
       f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_id} !!!\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -325,6 +325,10 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
           output_file_fwr.write(f"{r['bucket_name']},{r['machine_type']}\n")
 
     output_file_fwr.close()
+    print(
+        "\n\nSuccessfully published outputs of FIO test runs to"
+        f" {output_file_path} !!!\n\n"
+    )
 
 
 def writeRecordsToBqTable(
@@ -402,6 +406,10 @@ def writeRecordsToBqTable(
 
   # output_file_fwr.close()
   fioBqExporter.append_rows(rows)
+  print(
+      "\n\nSuccessfully exported outputs of FIO test runs to"
+      f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_name} !!!\n\n"
+  )
 
 
 if __name__ == "__main__":
@@ -421,15 +429,14 @@ if __name__ == "__main__":
   # Create the parent directory of output_file_path if doesn't exist already.
   ensure_directory_exists(os.path.dirname(output_file_path))
   writeRecordsToCsvOutputFile(output, output_file_path)
-  print(
-      "\n\nSuccessfully published outputs of FIO test runs to"
-      f" {output_file_path} !!!\n\n"
-  )
 
   # Export output dict to bigquery table.
   if (
-      args.bq_project_id.strip()
+      args.bq_project_id
+      and args.bq_project_id.strip()
+      and args.bq_dataset_id
       and args.bq_dataset_id.strip()
+      and args.bq_table_id
       and args.bq_table_id.strip()
   ):
     writeRecordsToBqTable(

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -331,6 +331,10 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
     )
 
 
+def fio_workload_id(row: FioTableRow) -> str:
+  return f"fio_{row.start_epoch}_{row.operation}_{row.file_size}_{row.block_size}_{row.num_threads}_{row.files_per_thread}_{row.bucket_name}_{row.machine_type}_{row.experiment_id}_{row.pod_name}"
+
+
 def writeRecordsToBqTable(
     output: dict,
     experiment_id: str,
@@ -385,6 +389,7 @@ def writeRecordsToBqTable(
         row.e2e_latency_ns_p99_9 = r["e2e_latency_ns_p99.9"]
         row.iops = r["IOPS"]
         row.throughput_in_mbps = r["throughput_mb_per_second"]
+        row.fio_workload_id = fio_workload_id(row)
 
         rows.append(row)
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -413,7 +413,7 @@ def writeRecordsToBqTable(
 
 
 if __name__ == "__main__":
-  args = parse_arguments(add_bq_support=True)
+  args = parse_arguments(fio_or_dlio="FIO", add_bq_support=True)
   ensure_directory_exists(_LOCAL_LOGS_LOCATION)
 
   if not args.predownloaded_output_files:

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -62,7 +62,7 @@ record = {
 }
 
 
-def downloadFioOutputs(fioWorkloads: set, instanceId: str) -> int:
+def download_fio_outputs(fioWorkloads: set, instanceId: str) -> int:
   """Downloads instanceId-specific fio outputs for each fioWorkload locally.
 
   Outputs in the bucket are in the following object naming format
@@ -92,7 +92,7 @@ def downloadFioOutputs(fioWorkloads: set, instanceId: str) -> int:
   return 0
 
 
-def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
+def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
   """Creates output records from the downloaded local files.
 
   The following creates a dict called 'output'
@@ -267,7 +267,7 @@ def createOutputScenariosFromDownloadedFiles(args: dict) -> dict:
   return output
 
 
-def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
+def write_records_to_csv_output_file(output: dict, output_file_path: str):
   with open(output_file_path, "a") as output_file_fwr:
     # Write a new header.
     output_file_fwr.write(
@@ -335,7 +335,7 @@ def fio_workload_id(row: FioTableRow) -> str:
   return f"{row.experiment_id}_{row.operation}_{row.file_size}_{row.block_size}_{row.num_threads}_{row.files_per_thread}_{row.start_epoch}"
 
 
-def writeRecordsToBqTable(
+def write_records_to_bq_table(
     output: dict,
     experiment_id: str,
     bq_project_id: str,
@@ -408,15 +408,15 @@ if __name__ == "__main__":
     fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
         args.workload_config
     )
-    downloadFioOutputs(fioWorkloads, args.instance_id)
+    download_fio_outputs(fioWorkloads, args.instance_id)
 
-  output = createOutputScenariosFromDownloadedFiles(args)
+  output = create_output_scenarios_from_downloaded_files(args)
 
   # Export output dict to CSV.
   output_file_path = args.output_file
   # Create the parent directory of output_file_path if doesn't exist already.
   ensure_directory_exists(os.path.dirname(output_file_path))
-  writeRecordsToCsvOutputFile(output, output_file_path)
+  write_records_to_csv_output_file(output, output_file_path)
 
   # Export output dict to bigquery table.
   if (
@@ -427,7 +427,7 @@ if __name__ == "__main__":
       and args.bq_table_id
       and args.bq_table_id.strip()
   ):
-    writeRecordsToBqTable(
+    write_records_to_bq_table(
         output=output,
         bq_project_id=args.bq_project_id,
         bq_dataset_id=args.bq_dataset_id,

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -384,7 +384,7 @@ def writeRecordsToBqTable(
 
         rows.append(row)
 
-  fioBqExporter.append_rows(rows=rows, experiment_id=experiment_id)
+  fioBqExporter.insert_rows(fioTableRows=rows, experiment_id=experiment_id)
   print(
       "\nSuccessfully exported outputs of FIO test runs to"
       f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_id} !!!\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -28,7 +28,7 @@ sys.path.append("../")
 import fio_workload
 from utils.parse_logs_common import ensure_directory_exists, download_gcs_objects, parse_arguments, SUPPORTED_SCENARIOS, fetch_cpu_memory_data
 from fio.bq_utils import FioBigqueryExporter, FioTableRow, Timestamp
-from utils.utils import unix_to_timestamp, convert_size_to_size_in_bytes
+from utils.utils import unix_to_timestamp, convert_size_to_bytes
 
 _LOCAL_LOGS_LOCATION = "../../bin/fio-logs"
 
@@ -332,7 +332,7 @@ def writeRecordsToCsvOutputFile(output: dict, output_file_path: str):
 
 
 def fio_workload_id(row: FioTableRow) -> str:
-  return f"fio_{row.start_epoch}_{row.operation}_{row.file_size}_{row.block_size}_{row.num_threads}_{row.files_per_thread}_{row.bucket_name}_{row.machine_type}_{row.experiment_id}_{row.pod_name}"
+  return f"{row.experiment_id}_{row.operation}_{row.file_size}_{row.block_size}_{row.num_threads}_{row.files_per_thread}_{row.start_epoch}"
 
 
 def writeRecordsToBqTable(
@@ -363,9 +363,9 @@ def writeRecordsToBqTable(
         row.epoch = r["epoch"]
         row.operation = record_set["read_type"]
         row.file_size = record_set["mean_file_size"]
-        row.file_size_in_bytes = convert_size_to_size_in_bytes(row.file_size)
+        row.file_size_in_bytes = convert_size_to_bytes(row.file_size)
         row.block_size = r["blockSize"]
-        row.block_size_in_bytes = convert_size_to_size_in_bytes(row.block_size)
+        row.block_size_in_bytes = convert_size_to_bytes(row.block_size)
         row.num_threads = r["numThreads"]
         row.files_per_thread = r["filesPerThread"]
         row.bucket_name = r["bucket_name"]

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -355,34 +355,36 @@ def writeRecordsToBqTable(
       for epoch in range(len(record_set["records"][scenario])):
         r = record_set["records"][scenario][epoch]
         row = FioTableRow()
+        row.experiment_id = experiment_id
+        row.epoch = r["epoch"]
+        row.operation = record_set["read_type"]
         row.file_size = record_set["mean_file_size"]
         row.file_size_in_bytes = convert_size_to_size_in_bytes(row.file_size)
-        row.operation = record_set["read_type"]
-        row.scenario = scenario
-        row.epoch = r["epoch"]
-        row.duration_in_seconds = r["duration"]
-        row.throughput_in_mbps = r["throughput_mb_per_second"]
-        row.iops = r["IOPS"]
-        row.lowest_memory_usage = r["lowest_memory"]
-        row.highest_memory_usage = r["highest_memory"]
-        row.lowest_cpu_usage = r["lowest_cpu"]
-        row.highest_cpu_usage = r["highest_cpu"]
-        row.pod_name = r["pod_name"]
-        row.start_time = Timestamp(r["start"])
-        row.end_time = Timestamp(r["end"])
-        row.gcsfuse_mount_options = r["gcsfuse_mount_options"]
         row.block_size = r["blockSize"]
         row.block_size_in_bytes = convert_size_to_size_in_bytes(row.block_size)
-        row.files_per_thread = r["filesPerThread"]
         row.num_threads = r["numThreads"]
-        row.experiment_id = experiment_id
+        row.files_per_thread = r["filesPerThread"]
+        row.bucket_name = r["bucket_name"]
+        row.machine_type = r["machine_type"]
+        row.gcsfuse_mount_options = r["gcsfuse_mount_options"]
+        row.start_time = Timestamp(r["start"])
+        row.end_time = Timestamp(r["end"])
+        row.start_epoch = r["start_epoch"]
+        row.end_epoch = r["end_epoch"]
+        row.duration_in_seconds = r["duration"]
+        row.lowest_cpu_usage = r["lowest_cpu"]
+        row.highest_cpu_usage = r["highest_cpu"]
+        row.lowest_memory_usage = r["lowest_memory"]
+        row.highest_memory_usage = r["highest_memory"]
+        row.pod_name = r["pod_name"]
+        row.scenario = scenario
         row.e2e_latency_ns_max = r["e2e_latency_ns_max"]
         row.e2e_latency_ns_p50 = r["e2e_latency_ns_p50"]
         row.e2e_latency_ns_p90 = r["e2e_latency_ns_p90"]
         row.e2e_latency_ns_p99 = r["e2e_latency_ns_p99"]
         row.e2e_latency_ns_p99_9 = r["e2e_latency_ns_p99.9"]
-        row.bucket_name = r["bucket_name"]
-        row.machine_type = r["machine_type"]
+        row.iops = r["IOPS"]
+        row.throughput_in_mbps = r["throughput_mb_per_second"]
 
         rows.append(row)
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -416,15 +416,22 @@ if __name__ == "__main__":
 
   output = createOutputScenariosFromDownloadedFiles(args)
 
-  # output_file_path = args.output_file
-  # Create the parent directory of output_file_path if doesn't
-  # exist already.
-  # ensure_directory_exists(os.path.dirname(output_file_path))
-  # writeRecordsToCsvOutputFile(output, output_file_path)
-  writeRecordsToBqTable(
-      output, args.bq_project_id, args.bq_dataset_id, args.bq_table_id
-  )
+  # Export output dict to CSV.
+  output_file_path = args.output_file
+  # Create the parent directory of output_file_path if doesn't exist already.
+  ensure_directory_exists(os.path.dirname(output_file_path))
+  writeRecordsToCsvOutputFile(output, output_file_path)
   print(
       "\n\nSuccessfully published outputs of FIO test runs to"
       f" {output_file_path} !!!\n\n"
   )
+
+  # Export output dict to bigquery table.
+  if (
+      args.bq_project_id.strip()
+      and args.bq_dataset_id.strip()
+      and args.bq_table_id.strip()
+  ):
+    writeRecordsToBqTable(
+        output, args.bq_project_id, args.bq_dataset_id, args.bq_table_id
+    )

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -405,7 +405,7 @@ if __name__ == "__main__":
   ensure_directory_exists(_LOCAL_LOGS_LOCATION)
 
   if not args.predownloaded_output_files:
-    fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
+    fioWorkloads = fio_workload.parse_test_config_for_fio_workloads(
         args.workload_config
     )
     download_fio_outputs(fioWorkloads, args.instance_id)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -88,7 +88,7 @@ def createHelmInstallCommands(
 
 
 def main(args) -> None:
-  fioWorkloads = fio_workload.ParseTestConfigForFioWorkloads(
+  fioWorkloads = fio_workload.parse_test_config_for_fio_workloads(
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -67,6 +67,12 @@ readonly DEFAULT_POD_TIMEOUT_IN_SECONDS=604800
 readonly DEFAULT_FORCE_UPDATE_GCSFUSE_CODE=false
 readonly DEFAULT_ZONAL=false
 
+# Config for exporting fio outputs to a Bigquery table.
+readonly DEFAULT_BQ_PROJECT_ID='gcs-fuse-test-ml'
+readonly DEFAULT_BQ_DATASET_ID='gke_test_tool_outputs'
+readonly DEFAULT_BQ_TABLE_ID='fio_outputs'
+
+
 function printHelp() {
   echo "Usage guide: "
   echo "[ENV_OPTIONS] "${0}" [ARGS]"
@@ -352,7 +358,6 @@ function installDependencies() {
   fi
   # Install python client for bigquery.
   # TODO: Make this conditional on bigquery export !
-  pip install --require-hashes -r $(dirname ${0})/fio/requirements.txt >/dev/null
   pip3 install --upgrade google-cloud-bigquery >/dev/null
   pip3 install --upgrade google-cloud-storage >/dev/null
   pip install google-api-python-client >/dev/null
@@ -793,7 +798,7 @@ function areThereAnyDLIOWorkloads() {
 function fetchAndParseFioOutputs() {
   printf "\nFetching and parsing fio outputs ...\n\n"
   cd "${gke_testing_dir}"/examples/fio
-  parse_logs_args="--project-number=${project_number} --workload-config ${workload_config} --instance-id ${instance_id} --output-file ${output_dir}/fio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace}"
+  parse_logs_args="--project-number=${project_number} --workload-config ${workload_config} --instance-id ${instance_id} --output-file ${output_dir}/fio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace} --bq-project-id=${DEFAULT_BQ_PROJECT_ID} --bq-dataset-id=${DEFAULT_BQ_DATASET_ID} --bq-table-id=${DEFAULT_BQ_TABLE_ID}"
   if ${zonal}; then
     python3 parse_logs.py ${parse_logs_args} --predownloaded-output-files
   else

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -125,17 +125,17 @@ def parse_arguments(add_bq_support: bool = False) -> object:
         "--bq-project-id",
         metavar="GCP Project ID/name",
         help="Bigquery project ID",
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "--bq-dataset-id",
         help="Bigquery dataset id",
-        required=True,
+        required=False,
     )
     parser.add_argument(
         "--bq-table-id",
         help="Bigquery table name",
-        required=True,
+        required=False,
     )
 
   return parser.parse_args()

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -54,9 +54,13 @@ def download_gcs_objects(src: str, dst: str) -> Tuple[int, str]:
   return result.returncode, ""
 
 
-def parse_arguments(add_bq_support: bool = False) -> object:
+# Common argument parser for both fio and dlio
+# output parsers.
+def parse_arguments(
+    fio_or_dlio: str = "DLIO", add_bq_support: bool = False
+) -> object:
   parser = argparse.ArgumentParser(
-      prog="DLIO Unet3d test output parser",
+      prog=f"{fio_or_dlio} output parser",
       description=(
           "This program takes in a json workload configuration file and parses"
           " it for valid FIO workloads and the locations of their test outputs"

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -54,7 +54,7 @@ def download_gcs_objects(src: str, dst: str) -> Tuple[int, str]:
   return result.returncode, ""
 
 
-def parse_arguments() -> object:
+def parse_arguments(add_bq_support: bool = False) -> object:
   parser = argparse.ArgumentParser(
       prog="DLIO Unet3d test output parser",
       description=(
@@ -120,6 +120,24 @@ def parse_arguments() -> object:
       default=False,
       action="store_true",
   )
+  if add_bq_support:
+    parser.add_argument(
+        "--bq-project-id",
+        metavar="GCP Project ID/name",
+        help="Bigquery project ID",
+        required=True,
+    )
+    parser.add_argument(
+        "--bq-dataset-id",
+        help="Bigquery dataset id",
+        required=True,
+    )
+    parser.add_argument(
+        "--bq-table-id",
+        help="Bigquery table name",
+        required=True,
+    )
+
   return parser.parse_args()
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
@@ -275,17 +275,21 @@ def get_cpu_from_monitoring_api(
     return -1, -1
 
 
-def convert_size_to_size_in_bytes(size_in_string: str) -> int:
+def convert_size_to_bytes(size_in_string: str) -> int:
   """Converts string-form numbers like 1k, 1m, 1g, 1K, 1M, 1G etc.
 
   to normal numbers i.e. 10^3, 10^6, 10^9, 2^10, 2^20, 2^30 respectively.
+
+  The conversion is based on how FIO represents sizes e.g. small codes i.e.
+  k,m,g for powers of 10, and capital codes i.e. K,M,G for powers of 1024.
 
   Arguments:
 
   size_in_string: strings like '1k', '1m', '1g', '1K', '1M', '1G' etc.
 
   Returns:
-  1000 for input '1k' etc.
+  1000, 1000000, 1000000000 for input '1k','1m','1g' etc. respectively.
+  1024, 1048576 for input '1K', '1M' etc. respectively.
   """
   if size_in_string is None:
     return 0

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils.py
@@ -273,3 +273,39 @@ def get_cpu_from_monitoring_api(
         " it !"
     )
     return -1, -1
+
+
+def convert_size_to_size_in_bytes(size_in_string: str) -> int:
+  """Converts string-form numbers like 1k, 1m, 1g, 1K, 1M, 1G etc.
+
+  to normal numbers i.e. 10^3, 10^6, 10^9, 2^10, 2^20, 2^30 respectively.
+
+  Arguments:
+
+  size_in_string: strings like '1k', '1m', '1g', '1K', '1M', '1G' etc.
+
+  Returns:
+  1000 for input '1k' etc.
+  """
+  if size_in_string is None:
+    return 0
+
+  # Remove all leading and trailing spaces.
+  size_in_string = size_in_string.strip()
+  if len(size_in_string) == 0:
+    return 0
+  multiplier_char = size_in_string[-1]
+  multiplier_map = {
+      "k": 10**3,
+      "m": 10**6,
+      "g": 10**9,
+      "K": 2**10,
+      "M": 2**20,
+      "G": 2**30,
+  }
+  if multiplier_char in multiplier_map:
+    multiplier = multiplier_map[multiplier_char]
+    base_value = 1 if len(size_in_string) == 1 else int(size_in_string[:-1])
+    return base_value * multiplier
+  else:
+    return int(size_in_string)

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
@@ -17,7 +17,7 @@
 
 import unittest
 import utils
-from utils import get_cpu_from_monitoring_api, get_memory_from_monitoring_api, timestamp_to_epoch
+from utils import convert_size_to_size_in_bytes, get_cpu_from_monitoring_api, get_memory_from_monitoring_api, timestamp_to_epoch
 
 
 class UtilsTest(unittest.TestCase):
@@ -112,6 +112,39 @@ class UtilsTest(unittest.TestCase):
             input['expected_limits_cpu'],
             resource_limits[0]['cpu'],
         )
+
+  def test_convert_size_to_size_in_bytes(self):
+    inputs = {
+        '': 0,
+        '1': 1,
+        '-1': -1,
+        '0': 0,
+        'k': 1000,
+        'm': 1000000,
+        'g': 1000000000,
+        'K': 1024,
+        'M': 1048576,
+        'G': 1073741824,
+        '1k': 1000,
+        '1m': 1000000,
+        '1g': 1000000000,
+        '1K': 1024,
+        '1M': 1048576,
+        '1G': 1073741824,
+        '2k': 2000,
+        '2m': 2000000,
+        '2g': 2000000000,
+        '2K': 2048,
+        '2M': 2097152,
+        '2G': 2147483648,
+    }
+    for input, output in inputs.items():
+      self.assertEqual(
+          convert_size_to_size_in_bytes(input),
+          output,
+          f'Failed to convert for input = "{input}", expected-output ='
+          f' {output}',
+      )
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/utils_test.py
@@ -17,7 +17,7 @@
 
 import unittest
 import utils
-from utils import convert_size_to_size_in_bytes, get_cpu_from_monitoring_api, get_memory_from_monitoring_api, timestamp_to_epoch
+from utils import convert_size_to_bytes, get_cpu_from_monitoring_api, get_memory_from_monitoring_api, timestamp_to_epoch
 
 
 class UtilsTest(unittest.TestCase):
@@ -113,7 +113,7 @@ class UtilsTest(unittest.TestCase):
             resource_limits[0]['cpu'],
         )
 
-  def test_convert_size_to_size_in_bytes(self):
+  def test_convert_size_to_bytes(self):
     inputs = {
         '': 0,
         '1': 1,
@@ -140,7 +140,7 @@ class UtilsTest(unittest.TestCase):
     }
     for input, output in inputs.items():
       self.assertEqual(
-          convert_size_to_size_in_bytes(input),
+          convert_size_to_bytes(input),
           output,
           f'Failed to convert for input = "{input}", expected-output ='
           f' {output}',


### PR DESCRIPTION
### Description
This builds on top of #3281 and adds the remaining proposed elements from the LLD at [go/fio-perf-dashboard-design](http://goto.google.com/fio-perf-dashboard-design) .
- implements export to bigquery table in python script (by creating a new FioBqExporter and invoking append_rows on it from the fio output metrics)
- adds arguments for bigquery project-id, dataset-id and table-id in fio output parser
- Passes the BQ arguments from the top-level CLI .
- add utility for converting file/block size like `64K` etc. to `65536` etc for calculating metrics like file_size_in_bytes etc.
- add utility for creating a fio_workload_id from the output metrics.

This is on top of #3281 .

### Link to the issue in case of a bug fix.
[b/412924212](http://b/412924212)

### Testing details
1. Manual - Tested manually.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
