### PR TITLE
[testing-on-gke] [BQ-integration-improvement] Add retry for failed insert_rows 

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -20,6 +20,7 @@ to the tables.
 """
 
 import argparse
+from collections.abc import Iterable
 import os
 import socket
 import sys
@@ -212,45 +213,64 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     Exceptions:
     When the retry transaction fails too, then it re-throws that exception.
     """
+    # Call insert_rows on BQ client. If all goes well, result will be None.
     result = self.client.insert_rows(table, rows_to_insert)
+
+    # if result is not None, it is expected to be of type
+    # Sequence[dict[str,typing.Any]] .
+    # Each entry in the sequence is for each row sent for insertion.
+    # Each entry will be a dict containing an int-value for key 'index' and a list-value
+    # for key 'errors'. The value for 'errors' would be a list of dicts each
+    # representing a metadata of the errors for that row.
+    # In the 'errors' items, the reason for failure is captured in the value for
+    # the key 'reason'. The 'reason' is 'stopped' for rows that
+    # didn't fail themselves and were rolled back
+    # because of other failed rows.
     if result:
-      if isinstance(result, list):
-        failed_row_indices = dict()
+      if isinstance(result, Iterable):
+        failed_rows_metadata = dict()
         for result_entry in result:
           if (
               isinstance(result_entry, dict)
               and 'index' in result_entry
               and 'errors' in result_entry
-              and isinstance(result_entry['errors'], list)
+              and isinstance(result_entry['errors'], Iterable)
           ):
             for result_entry_error in result_entry['errors']:
               if (
                   isinstance(result_entry_error, dict)
                   and 'reason' in result_entry_error
-                  and result_entry_error['reason'] != 'stopped'
               ):
-                failed_row_indices[result_entry['index']] = result_entry_error[
-                    'message'
-                ]
-                break
-        print(
-            'The following rows failed to insert to BQ table: \n{}'.format([
-                f'Row # {_failed_row_index}:'
-                f' {rows_to_insert[_failed_row_index]}, error message:'
-                f' {failed_row_indices[_failed_row_index]}\n'
-                for _failed_row_index in failed_row_indices
-            ])
-        )
-        print('Going to retry inserting the rest ...')
+                if result_entry_error['reason'] != 'stopped':
+                  failed_rows_metadata[result_entry['index']] = (
+                      result_entry_error['message']
+                  )
+                  break
+              else:
+                raise Exception(
+                    'insert_rows returned improper error result for'
+                    f' index={result_entry["index"]}: {result}'
+                )
+          else:
+            raise Exception(
+                f'insert_rows returned improper error result: {result}'
+            )
+        print('The following rows failed to insert to BQ table: ')
+        for failed_row_index in failed_rows_metadata:
+          print(
+              f'{rows_to_insert[failed_row_index]}, error message: '
+              f'{failed_rows_metadata[failed_row_index]}'
+          )
+        print('Going to retry inserting the rest of the rows ...')
         row_indices_to_retry = set(range(len(rows_to_insert))) - (
-            failed_row_indices.keys()
+            failed_rows_metadata.keys()
         )
         rows_to_retry = [rows_to_insert[i] for i in row_indices_to_retry]
         result = self.client.insert_rows(table, rows_to_retry)
         if result:
-          raise Exception(f'{result}')
+          raise Exception(f'insert_rows failed on retry: {result}')
       else:
-        raise Exception(f'{result}')
+        raise Exception(f'insert_rows returned improper error result: {result}')
 
   def insert_rows(self, fioTableRows: []):
     """Pass a list of FioTableRow objects to insert into the fio-table.

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -208,20 +208,20 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     table: A BQ table handle.
     rows_to_insert: A list of tuples to insert rows into the above BQ table.
     """
-    # Call insert_rows on BQ client. If all goes well, result will be None.
-    result = self.client.insert_rows(table, rows_to_insert)
-    if result:
+    # Call insert_rows on BQ client. If all goes well, error will be None.
+    error = self.client.insert_rows(table, rows_to_insert)
+    if error:
       # As a fallback, try inserting all rows one-by-one.
       print(
-          'Some rows failed to insert using insert_rows.\nResult:'
-          f' {result}\nWill now try to insert each row one by one.'
+          'Some rows failed to insert using insert_rows.\n  Error:'
+          f' {error}.\n  Will now try to insert each row one by one.'
       )
       for row_to_insert in rows_to_insert:
-        result = self.client.insert_rows(table, [row_to_insert])
-        if result:
+        error = self.client.insert_rows(table, [row_to_insert])
+        if error:
           print(
               'Warning: Failed to insert the following row even on retry.'
-              f'\n   row: {repr(row_to_insert)}\n   result: {result}'
+              f'\n   row: {repr(row_to_insert)}\n   Error: {error}'
           )
 
   def insert_rows(self, fioTableRows: []):

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -195,6 +195,15 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
       print(f'Failed to create fio table {self.table_id}: {e}')
       raise
 
+  def _num_rows(self) -> int:
+    """Returns total number of rows in the current BQ table."""
+    query = (
+        f'select {FIO_TABLE_ROW_SCHEMA[0]} from'
+        f' {self.project_id}.{self.dataset_id}.{self.table_id}'
+    )
+    results = self.client.query_and_wait(query)
+    return results.total_rows if results else 0
+
   def _insert_rows_with_retry(self, table, rows_to_insert: []):
     """Inserts given rows to the given table in a single transaction.
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -84,6 +84,7 @@ class BqUtilsTest(unittest.TestCase):
 
   def test_insert_multiple_rows(self):
     rows = []
+    orig_num_rows = self.fioBqExporter._num_rows()
 
     rowCommon = self.create_sample_fio_table_row()
 
@@ -102,9 +103,11 @@ class BqUtilsTest(unittest.TestCase):
     rows.append(row)
 
     self.fioBqExporter.insert_rows(rows)
+    self.assertEqual(self.fioBqExporter._num_rows(), orig_num_rows + 2)
 
   def test_insert_rows_with_one_bad_row(self):
     rows = []
+    orig_num_rows = self.fioBqExporter._num_rows()
 
     rowCommon = self.create_sample_fio_table_row()
 
@@ -126,6 +129,17 @@ class BqUtilsTest(unittest.TestCase):
     # Despite bad row(s), the insert_rows itself will not fail
     # because of the fallback in insert_rows.
     self.fioBqExporter.insert_rows(rows)
+    self.assertEqual(
+        self.fioBqExporter._num_rows(), orig_num_rows + num_rows - 1
+    )
+
+  def test_num_rows(self):
+    row = self.create_sample_fio_table_row()
+    orig_num_rows = self.fioBqExporter._num_rows()
+
+    self.fioBqExporter.insert_rows([row])
+
+    self.assertEqual(self.fioBqExporter._num_rows(), orig_num_rows + 1)
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -83,7 +83,6 @@ class BqUtilsTest(unittest.TestCase):
     return row
 
   def test_insert_multiple_rows(self):
-    # sample append call.
     rows = []
 
     rowCommon = self.create_sample_fio_table_row()
@@ -105,7 +104,6 @@ class BqUtilsTest(unittest.TestCase):
     self.fioBqExporter.insert_rows(rows)
 
   def test_insert_some_bad_rows(self):
-    # sample append call.
     rows = []
 
     rowCommon = self.create_sample_fio_table_row()
@@ -138,7 +136,7 @@ class BqUtilsTest(unittest.TestCase):
     row.end_time = row.start_time
     rows.append(row)
 
-    # Despite bad rows, the insert_rows itself will fail
+    # Despite bad rows, the insert_rows itself will not fail
     # because of the fallback in insert_rows.
     self.fioBqExporter.insert_rows(rows)
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -67,10 +67,10 @@ class BqUtilsTest(unittest.TestCase):
     row.end_epoch = row.start_epoch + row.duration_in_seconds
     row.files_per_thread = 20000
     row.gcsfuse_mount_options = 'implicit-dirs'
-    row.highest_cpu_usage = uniform(row.lowest_cpu_usage, 100.0)
     row.lowest_cpu_usage = uniform(1.0, 100.0)
-    row.highest_memory_usage = uniform(row.lowest_memory_usage, 10000.0)
+    row.highest_cpu_usage = uniform(row.lowest_cpu_usage, 100.0)
     row.lowest_memory_usage = uniform(10.0, 10000.0)
+    row.highest_memory_usage = uniform(row.lowest_memory_usage, 10000.0)
     row.iops = uniform(10.0, 10000.0)
     row.machine_type = 'n2-standard-32'
     row.num_threads = 50
@@ -117,9 +117,9 @@ class BqUtilsTest(unittest.TestCase):
     row.end_time = row.start_time
     rows.append(row)
 
+    # bad row with bad start_time and end_time.
     row = copy.deepcopy(row)
     row.epoch = 2
-    # Bad start_time here should cause this row to fail to insert.
     row.start_time = Timestamp('')
     row.end_time = row.start_time
     rows.append(row)
@@ -131,13 +131,15 @@ class BqUtilsTest(unittest.TestCase):
     row.end_time = row.start_time
     rows.append(row)
 
+    # bad row with bad start_time and end_time.
     row = copy.deepcopy(row)
     row.epoch = 2
-    # Bad start_time here should cause this row to fail to insert.
     row.start_time = Timestamp('')
     row.end_time = row.start_time
     rows.append(row)
 
+    # Despite bad rows, the insert_rows itself will fail
+    # because of the fallback in insert_rows.
     self.fioBqExporter.insert_rows(rows)
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -14,9 +14,16 @@
 
 """This file defines tests for functionalities in bq_utils.py"""
 
+import calendar
+import copy
+from random import randrange, uniform
+import sys
+import time
 import unittest
+
+sys.path.append('../')
+from utils.utils import unix_to_timestamp
 from bq_utils import FioBigqueryExporter, FioTableRow, Timestamp
-import utils
 
 
 class BqUtilsTest(unittest.TestCase):
@@ -26,51 +33,112 @@ class BqUtilsTest(unittest.TestCase):
     self.bq_project_id = 'gcs-fuse-test-ml'
     self.bq_dataset_id = 'gargnitin_test_gke_test_tool_outputs'
     self.bq_table_id = 'fio_outputs_test'
-
-  def test_create_bq_table(self):
     # Create a sample table for manual testing.
-    fioBqExporter = FioBigqueryExporter(
+    self.fioBqExporter = FioBigqueryExporter(
         self.bq_project_id, self.bq_dataset_id, self.bq_table_id
     )
 
-    # sample append call.
-    rows = []
+  @classmethod
+  def cur_epoch(self) -> int:
+    return int(calendar.timegm(time.gmtime()))
 
+  @classmethod
+  def cur_timestamp(self) -> Timestamp:
+    return unix_to_timestamp(self.cur_epoch())
+
+  @classmethod
+  def create_sample_fio_table_row(self):
     row = FioTableRow()
-    row.fio_workload_id = 'fio-workload-id-1'
-    row.experiment_id = 'expt-id-1'
+    row.fio_workload_id = 'fio-workload-{randrange(10000000000)}'
+    row.experiment_id = f'expt-{self.cur_epoch()}'
     row.epoch = 1
     row.file_size = '1M'
     row.file_size_in_bytes = 2**20
     row.block_size = '256K'
     row.block_size_in_bytes = 2**18
     row.bucket_name = 'sample-zb-bucket'
-    row.duration_in_seconds = 10
-    row.e2e_latency_ns_max = 100
-    row.e2e_latency_ns_p50 = 50
-    row.e2e_latency_ns_p90 = 90
-    row.e2e_latency_ns_p99 = 99
-    row.e2e_latency_ns_p99_9 = 99.9
-    row.end_epoch = 1746678693
-    row.start_epoch = 1746678683
+    row.e2e_latency_ns_p50 = randrange(1, 1000)
+    row.e2e_latency_ns_p90 = randrange(row.e2e_latency_ns_p50, 10000)
+    row.e2e_latency_ns_p99 = randrange(row.e2e_latency_ns_p90, 100000)
+    row.e2e_latency_ns_p99_9 = randrange(row.e2e_latency_ns_p99, 1000000)
+    row.e2e_latency_ns_max = randrange(row.e2e_latency_ns_p99_9, 10000000)
+    row.start_epoch = self.cur_epoch()
+    row.duration_in_seconds = randrange(1, 60)
+    row.end_epoch = row.start_epoch + row.duration_in_seconds
     row.files_per_thread = 20000
     row.gcsfuse_mount_options = 'implicit-dirs'
-    row.highest_cpu_usage = 10.0
-    row.lowest_cpu_usage = 1.0
-    row.highest_memory_usage = 10000
-    row.lowest_memory_usage = 100
-    row.iops = 1000
+    row.highest_cpu_usage = uniform(row.lowest_cpu_usage, 100.0)
+    row.lowest_cpu_usage = uniform(1.0, 100.0)
+    row.highest_memory_usage = uniform(row.lowest_memory_usage, 10000.0)
+    row.lowest_memory_usage = uniform(10.0, 10000.0)
+    row.iops = uniform(10.0, 10000.0)
     row.machine_type = 'n2-standard-32'
     row.num_threads = 50
     row.operation = 'read'
-    row.pod_name = 'sample-pod-name'
+    row.pod_name = f'sample-pod-name-{randrange(100000000000)}'
     row.scenario = 'gcsfuse-generic'
-    row.start_time = Timestamp('2025-05-08 04:31:23 UTC')
-    row.end_time = Timestamp('2025-05-08 04:31:33 UTC')
-    row.throughput_in_mbps = 8000
+    row.start_time = self.cur_timestamp()
+    row.end_time = row.start_time
+    row.throughput_in_mbps = uniform(1.0, 10000.0)
+    return row
 
+  def test_insert_multiple_rows(self):
+    # sample append call.
+    rows = []
+
+    rowCommon = self.create_sample_fio_table_row()
+
+    row = copy.deepcopy(rowCommon)
+    row.fio_workload_id = f'fio_workload1_{row.experiment_id}'
+    row.epoch = 1
+    row.start_time = Timestamp('2025-05-09 08:31 UTC')
+    row.end_time = row.start_time
     rows.append(row)
-    fioBqExporter.insert_rows(rows)
+
+    row = copy.deepcopy(row)
+    row.fio_workload_id = f'fio_workload2_{row.experiment_id}'
+    row.epoch = 1
+    row.start_time = Timestamp('2025-05-09 08:32 UTC')
+    row.end_time = row.start_time
+    rows.append(row)
+
+    self.fioBqExporter.insert_rows(rows)
+
+  def test_insert_some_bad_rows(self):
+    # sample append call.
+    rows = []
+
+    rowCommon = self.create_sample_fio_table_row()
+
+    row = copy.deepcopy(rowCommon)
+    row.fio_workload_id = f'fio_workload1_{row.experiment_id}'
+    row.epoch = 1
+    row.start_time = self.cur_timestamp()
+    row.end_time = row.start_time
+    rows.append(row)
+
+    row = copy.deepcopy(row)
+    row.epoch = 2
+    # Bad start_time here should cause this row to fail to insert.
+    row.start_time = Timestamp('')
+    row.end_time = row.start_time
+    rows.append(row)
+
+    row = copy.deepcopy(row)
+    row.fio_workload_id = f'fio_workload2_{row.experiment_id}'
+    row.epoch = 1
+    row.start_time = self.cur_timestamp()
+    row.end_time = row.start_time
+    rows.append(row)
+
+    row = copy.deepcopy(row)
+    row.epoch = 2
+    # Bad start_time here should cause this row to fail to insert.
+    row.start_time = Timestamp('')
+    row.end_time = row.start_time
+    rows.append(row)
+
+    self.fioBqExporter.insert_rows(rows)
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -103,40 +103,27 @@ class BqUtilsTest(unittest.TestCase):
 
     self.fioBqExporter.insert_rows(rows)
 
-  def test_insert_some_bad_rows(self):
+  def test_insert_rows_with_one_bad_row(self):
     rows = []
 
     rowCommon = self.create_sample_fio_table_row()
 
     row = copy.deepcopy(rowCommon)
-    row.fio_workload_id = f'fio_workload1_{row.experiment_id}'
-    row.epoch = 1
-    row.start_time = self.cur_timestamp()
-    row.end_time = row.start_time
-    rows.append(row)
+    num_rows = 20
+    for i in range(num_rows):
+      row = copy.deepcopy(row)
+      row.fio_workload_id = f'fio_workload{i}_{row.experiment_id}'
+      row.epoch = 1
+      if i == 0:
+        # First row is bad row because of empty start_time and end_time.
+        row.start_time = Timestamp('')
+        row.end_time = Timestamp('')
+      else:
+        row.start_time = self.cur_timestamp()
+        row.end_time = row.start_time
+      rows.append(row)
 
-    # bad row with bad start_time and end_time.
-    row = copy.deepcopy(row)
-    row.epoch = 2
-    row.start_time = Timestamp('')
-    row.end_time = row.start_time
-    rows.append(row)
-
-    row = copy.deepcopy(row)
-    row.fio_workload_id = f'fio_workload2_{row.experiment_id}'
-    row.epoch = 1
-    row.start_time = self.cur_timestamp()
-    row.end_time = row.start_time
-    rows.append(row)
-
-    # bad row with bad start_time and end_time.
-    row = copy.deepcopy(row)
-    row.epoch = 2
-    row.start_time = Timestamp('')
-    row.end_time = row.start_time
-    rows.append(row)
-
-    # Despite bad rows, the insert_rows itself will not fail
+    # Despite bad row(s), the insert_rows itself will not fail
     # because of the fallback in insert_rows.
     self.fioBqExporter.insert_rows(rows)
 


### PR DESCRIPTION
### Description
- Robustness improvement for BQ integration for GKE AI/ML tool. 
- Adds utility to return the number of rows in the BQ table.
- If some bad rows out are sent for insert_rows in BQ table, then BQ client stops even the good rows from being inserted. This change retries inserting all rows one by one on failure. This also adds the unit tests for the same.

This has a follow-up in https://github.com/GoogleCloudPlatform/gcsfuse/pull/3304 .

### Link to the issue in case of a bug fix.
[b/412923482](http://b/412923482)

### Testing details
1. Manual - Manually tested using the tests added in bq_utils_test.py . In the test, there are two good rows and two bad rows added. The test passed as insert_rows retried without the failed rows as fallback. The test also printed out the following error message:
```sh
Some rows failed to insert using insert_rows.
Result: [{'index': 0, 'errors': [{'reason': 'invalid', 'location': 'end_time', 'debugInfo': '', 'message': "Could not parse '' as a timestamp. Required format is YYYY-MM-DD HH:MM[:SS[.SSSSSS]]"}]}, {'index': 1, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 2, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 3, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 4, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 5, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 6, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 7, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 8, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 9, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 10, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 11, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 12, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 13, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 14, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 15, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 16, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 17, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 18, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}, {'index': 19, 'errors': [{'reason': 'stopped', 'location': '', 'debugInfo': '', 'message': ''}]}]
Will now try to insert each row one by one.
Warning: Failed to insert the following row even on retry.
   row: ('fio_workload0_expt-1747233011', 'expt-1747233011', '1', 'read', '1M', '1048576', '256K', '262144', '50', '20000', 'sample-zb-bucket', 'n2-standard-32', 'implicit-dirs', '', '', '1747233011', '1747233028', '17', '54.328412561647696', '62.8445112818461', '234.4037324404621', '5107.129294444692', 'sample-pod-name-92435752489', 'gcsfuse-generic', '4997982', '838', '8630', '47701', '278717', '900.8615728153275', '1653.8761996217986')
   result: [{'index': 0, 'errors': [{'reason': 'invalid', 'location': 'start_time', 'debugInfo': '', 'message': "Could not parse '' as a timestamp. Required format is YYYY-MM-DD HH:MM[:SS[.SSSSSS]]"}]}]
```
3. Unit tests - New tests added
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
