### PR TITLE
E2E test for inactiveStreamTimeout Support

### DIFF
--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -42,7 +42,7 @@ const (
 	kChunkSizeToRead                     = 128 * 1024       // 64 KiB
 	kTestFileName                        = "foo"
 	kDefaultInactiveReadTimeoutInSeconds = 1 // A short timeout for testing
-	kLogFileNameForMountedDirectoryTests = "/tmp/gcsfuse_inactive_read_timeout_test_logs/log.json"
+	kLogFileNameForMountedDirectoryTests = "/tmp/inactive_stream_timeout_logs/log.json"
 	kHTTP1ClientProtocol                 = "http1"
 	kGRPCClientProtocol                  = "grpc"
 )
@@ -146,8 +146,7 @@ func createConfigFile(flags *gcsfuseTestFlags) string {
 			"format":    "json", // Ensure JSON logs for easier parsing
 		},
 	}
-	filePath := setup.YAMLConfigFile(mountConfig, flags.fileName)
-	return filePath
+	return setup.YAMLConfigFile(mountConfig, flags.fileName)
 }
 
 func TestMain(m *testing.M) {

--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inactive_stream_timeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	kTestDirName                         = "inactiveReadTimeoutTest"
+	kOnlyDirMounted                      = "onlyDirInactiveReadTimeout"
+	kFileSize                            = 10 * 1024 * 1024 // 10 MiB
+	kChunkSizeToRead                     = 128 * 1024       // 64 KiB
+	kTestFileName                        = "foo"
+	kDefaultInactiveReadTimeoutInSeconds = 1 // A short timeout for testing
+	kLogFileNameForMountedDirectoryTests = "/tmp/gcsfuse_inactive_read_timeout_test_logs/log.json"
+	kHTTP1ClientProtocol                 = "http1"
+	kGRPCClientProtocol                  = "grpc"
+)
+
+var (
+	// Stores test directory path in the mounted path.
+	gTestDirPath string
+
+	// Used to run the test for different types of mount by modify this function.
+	gMountFunc func([]string) error
+
+	// Actual mounted directory, for dynamic mount it becomes gRootDir/<bucket_name>
+	gMountDir string
+
+	// Root directory which is mounted by gcsfuse.
+	gRootDir string
+
+	// Clients to create the object in GCS.
+	gStorageClient *storage.Client
+	gCtx           context.Context
+)
+
+type gcsfuseTestFlags struct {
+	cliFlags            []string
+	inactiveReadTimeout time.Duration
+	fileName            string
+	clientProtocol      string
+}
+
+func setupFile(ctx context.Context, storageClient *storage.Client, fileName string, fileSize int, t *testing.T) string {
+	t.Helper()
+	client.SetupFileInTestDirectory(ctx, storageClient, kTestDirName, fileName, int64(fileSize), t)
+	return path.Join(gTestDirPath, fileName)
+}
+
+func loadLogLines(reader io.Reader) ([]string, error) {
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(content), "\n"), nil
+}
+
+// validateInactiveReaderClosedLog checks if the "Closing reader for object ... due to inactivity"
+// log message is present (or absent) for the given objectName, b/w the [startTime, endTime] interval.
+// Also expects based on the shouldBePresent value.
+func validateInactiveReaderClosedLog(t *testing.T, logFile, objectName string, shouldBePresent bool, startTime, endTime time.Time) {
+	t.Helper()
+	// Be specific about the object name in the expected message.
+	expectedMsgSubstring := fmt.Sprintf("Closing reader for object %q due to inactivity.", objectName)
+
+	file, err := os.Open(logFile)
+	require.NoError(t, err, "Failed to open log file")
+	defer file.Close()
+
+	logLines, err := loadLogLines(file)
+	require.NoError(t, err, "Failed to read log file")
+
+	found := false
+	for _, line := range logLines {
+		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line) // Assuming read_logs can parse general log lines too or a more generic parser is available.
+		// If parsing fails, it might be a non-JSON line or a different structured log.
+		// For this specific message, we expect it to be in the "Message" field of a structured log.
+
+		if err == nil && logEntry != nil {
+			// Check if the log entry's timestamp is within the expected window.
+			if (logEntry.Timestamp.After(startTime) || logEntry.Timestamp.Equal(startTime)) &&
+				(logEntry.Timestamp.Before(endTime) || logEntry.Timestamp.Equal(endTime)) {
+				if strings.Contains(logEntry.Message, expectedMsgSubstring) {
+					found = true
+					break
+				}
+			}
+		}
+	}
+
+	if shouldBePresent {
+		require.True(t, found, "Expected log message substring '%s' not found between %v and %v", expectedMsgSubstring, startTime, endTime)
+	} else {
+		require.False(t, found, "Unexpected log message substring '%s' found between %v and %v", expectedMsgSubstring, startTime, endTime)
+	}
+}
+
+func mountGCSFuseAndSetupTestDir(ctx context.Context, flags []string, storageClient *storage.Client, testDirName string) {
+	setup.MountGCSFuseWithGivenMountFunc(flags, gMountFunc)
+	setup.SetMntDir(gMountDir)
+	gTestDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+}
+
+// createConfigFile generate mount config.yaml.
+func createConfigFile(flags *gcsfuseTestFlags) string {
+	mountConfig := map[string]interface{}{
+		"read": map[string]interface{}{
+			"inactive-stream-timeout": flags.inactiveReadTimeout.String(),
+		},
+		"gcs-connection": map[string]interface{}{
+			"client-protocol": flags.clientProtocol,
+		},
+		"logging": map[string]interface{}{
+			"file-path": setup.LogFile(),
+			"format":    "json", // Ensure JSON logs for easier parsing
+		},
+	}
+	filePath := setup.YAMLConfigFile(mountConfig, flags.fileName)
+	return filePath
+}
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	// Create common storage client to be used in test.
+	gCtx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&gCtx, &gStorageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	if setup.MountedDirectory() != "" {
+		gMountDir = setup.MountedDirectory()
+		setup.SetLogFile(kLogFileNameForMountedDirectoryTests)
+		// Run tests for mounted directory if the flag is set.
+		os.Exit(m.Run())
+	}
+
+	// Else run tests for testBucket.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	log.Println("Running static mounting tests...")
+	// MountDir and RootDir will be same for static mount.
+	gMountDir, gRootDir = setup.MntDir(), setup.MntDir()
+	gMountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+
+	if successCode == 0 {
+		log.Println("Running dynamic mounting tests...")
+		// For dyanamic mount - gMountDir = gRootDir + <bucket_name>
+		gMountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		gMountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		successCode = m.Run()
+	}
+
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(kOnlyDirMounted + "/")
+		gMountDir = gRootDir
+		gMountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		successCode = m.Run()
+		setup.CleanupDirectoryOnGCS(gCtx, gStorageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), kTestDirName))
+	}
+
+	setup.CleanupDirectoryOnGCS(gCtx, gStorageClient, path.Join(setup.TestBucket(), kTestDirName))
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inactive_stream_timeout
+
+import (
+	"context"
+	"log"
+	"path"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/require"
+)
+
+const DefaultSequentialReadSizeMb = 5
+
+type timeoutEnabledSuite struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+}
+
+func (s *timeoutEnabledSuite) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.ctx, s.flags, s.storageClient, kTestDirName)
+}
+
+func (s *timeoutEnabledSuite) Teardown(t *testing.T) {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
+		setup.UnmountGCSFuseAndDeleteLogFile(gRootDir)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *timeoutEnabledSuite) TestReaderCloses(t *testing.T) {
+	timeoutDuration := kDefaultInactiveReadTimeoutInSeconds * time.Second
+	gcsFileName := path.Join(kTestDirName, kTestFileName)
+	mountFilePath := setupFile(s.ctx, s.storageClient, kTestFileName, kFileSize, t)
+
+	// 1. Open file.
+	fileHandle, err := operations.OpenFileAsReadonly(mountFilePath)
+	require.NoError(t, err)
+	defer fileHandle.Close()
+
+	// 2. Read small chunk from 0 offset.
+	buff := make([]byte, kChunkSizeToRead)
+	_, err = fileHandle.ReadAt(buff, 0)
+	require.NoError(t, err)
+	endTimeRead := time.Now()
+
+	// 3. Wait for timeout
+	time.Sleep(2*timeoutDuration + 1*time.Second) // Add buffer
+	endTimeWait := time.Now()
+
+	// 4. "Closing reader" log should be present.
+	validateInactiveReaderClosedLog(t, setup.LogFile(), gcsFileName, true, endTimeRead, endTimeWait)
+
+	// 5. Further reads should work as it is.
+	_, err = fileHandle.ReadAt(buff, 8)
+	require.NoError(t, err)
+}
+
+func (s *timeoutEnabledSuite) TestReaderStaysOpenWithinTimeout(t *testing.T) {
+	timeoutDuration := kDefaultInactiveReadTimeoutInSeconds * time.Second
+	gcsFileName := path.Join(kTestDirName, kTestFileName)
+	localFilePath := setupFile(s.ctx, s.storageClient, kTestFileName, kFileSize, t)
+
+	fileHandle, err := operations.OpenFileAsReadonly(localFilePath)
+	require.NoError(t, err)
+	defer fileHandle.Close()
+
+	// 1. First read.
+	buff := make([]byte, kChunkSizeToRead)
+	_, err = fileHandle.ReadAt(buff, 0)
+	require.NoError(t, err)
+	endTimeRead1 := time.Now()
+
+	// 2. Wait for a period SHORTER than the timeout.
+	time.Sleep(timeoutDuration / 2)
+	startTimeRead2 := time.Now()
+
+	// 3. Second read.
+	_, err = fileHandle.ReadAt(buff, int64(kChunkSizeToRead)) // Read the next chunk
+	require.NoError(t, err, "Second read within timeout failed")
+
+	// 4. Check log: "Closing reader for object..." should NOT be present for this object
+	// between the first read's end and the second read's start.
+	validateInactiveReaderClosedLog(t, setup.LogFile(), gcsFileName, false, endTimeRead1, startTimeRead2)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestTimeoutEnabledSuite(t *testing.T) {
+	ts := &timeoutEnabledSuite{ctx: context.Background(), storageClient: gStorageClient}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	flagsSet := []gcsfuseTestFlags{
+		{ // Test with timeout enabled and grpc client protocol
+			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
+			fileName:            "no_timeout.yaml",
+			clientProtocol:      kGRPCClientProtocol,
+		},
+	}
+
+	for _, flags := range flagsSet {
+		configFilePath := createConfigFile(&flags)
+		ts.flags = []string{"--config-file=" + configFilePath}
+		if flags.cliFlags != nil {
+			ts.flags = append(ts.flags, flags.cliFlags...)
+		}
+		log.Printf("Running inactive_read_timeout tests with flags: %s", ts.flags)
+
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -74,7 +74,7 @@ func (s *timeoutEnabledSuite) TestReaderCloses(t *testing.T) {
 	// 4. "Closing reader" log should be present.
 	validateInactiveReaderClosedLog(t, setup.LogFile(), gcsFileName, true, endTimeRead, endTimeWait)
 
-	// 5. Further reads should work as it is.
+	// 5. Further reads should work as it is, yeah it will create a new reader.
 	_, err = fileHandle.ReadAt(buff, 8)
 	require.NoError(t, err)
 }
@@ -123,7 +123,7 @@ func TestTimeoutEnabledSuite(t *testing.T) {
 	flagsSet := []gcsfuseTestFlags{
 		{ // Test with timeout enabled and grpc client protocol
 			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
-			fileName:            "no_timeout.yaml",
+			fileName:            "timeout_with_grpc.yaml",
 			clientProtocol:      kGRPCClientProtocol,
 		},
 	}

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inactive_stream_timeout
+
+import (
+	"context"
+	"log"
+	"path"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/require"
+)
+
+type timeoutDisabledSuite struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+}
+
+func (s *timeoutDisabledSuite) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.ctx, s.flags, s.storageClient, kTestDirName)
+}
+
+func (s *timeoutDisabledSuite) Teardown(t *testing.T) {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
+		setup.UnmountGCSFuseAndDeleteLogFile(gRootDir)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (s *timeoutDisabledSuite) TestNoReaderCloser(t *testing.T) {
+	timeoutDuration := kDefaultInactiveReadTimeoutInSeconds * time.Second
+	gcsFileName := path.Join(kTestDirName, kTestFileName)
+	mountFilePath := setupFile(s.ctx, s.storageClient, kTestFileName, kFileSize, t)
+
+	// 1. Open file.
+	fileHandle, err := operations.OpenFileAsReadonly(mountFilePath)
+	require.NoError(t, err)
+	defer fileHandle.Close()
+
+	// 2. Read small chunk from 0 offset.
+	buff := make([]byte, kChunkSizeToRead)
+	_, err = fileHandle.ReadAt(buff, 0)
+	require.NoError(t, err)
+	endTimeRead := time.Now()
+
+	// 3. Wait for timeout
+	time.Sleep(2*timeoutDuration + 1*time.Second) // Add buffer
+	endTimeWait := time.Now()
+
+	// 4. Shouldn't be any `Close reader logs...`.
+	validateInactiveReaderClosedLog(t, setup.LogFile(), gcsFileName, false, endTimeRead, endTimeWait)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestTimeoutDisabledSuite(t *testing.T) {
+	ts := &timeoutDisabledSuite{ctx: context.Background(), storageClient: gStorageClient}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	flagsSet := []gcsfuseTestFlags{
+		{ // Test with timeout enabled and http1 client protocol
+			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
+			fileName:            "timeout_with_http.yaml",
+			clientProtocol:      kHTTP1ClientProtocol,
+		},
+		{ // Test with timeout disabled
+			inactiveReadTimeout: 0 * time.Second, // Disable timeout
+			clientProtocol:      kHTTP1ClientProtocol,
+			fileName:            "zero_timeout.yaml",
+		},
+	}
+
+	for _, flags := range flagsSet {
+		configFilePath := createConfigFile(&flags)
+		ts.flags = []string{"--config-file=" + configFilePath}
+		if flags.cliFlags != nil {
+			ts.flags = append(ts.flags, flags.cliFlags...)
+		}
+		log.Printf("Running inactive_read_timeout tests with flags: %s", ts.flags)
+
+		test_setup.RunTests(t, ts)
+	}
+}

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -626,3 +626,29 @@ sudo umount $MOUNT_DIR
 gcsfuse --enable-streaming-writes=true  $TEST_BUCKET_NAME $MOUNT_DIR
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/write_large_files/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME ${ZONAL_BUCKET_ARG}
 sudo umount $MOUNT_DIR
+
+# Test package: inactive_stream_timeout
+# Run tests when timeout is disabled.
+log_dir="/tmp/inactive_stream_timeout_logs"
+mkdir -p $log_dir
+log_file="$log_dir/log.json"
+gcsfuse --read-inactive-stream-timeout=0s --log-file $log_file --log-severity=trace --log-format=json $TEST_BUCKET_NAME $MOUNT_DIR
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/inactive_stream_timeout/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME -run "TestTimeoutDisabledSuite"
+sudo umount $MOUNT_DIR
+rm -rf $log_dir
+
+# Run tests when timeout is enabled.
+test_cases=(
+  "TestTimeoutEnabledSuite/TestReaderCloses"
+  "TestTimeoutEnabledSuite/TestReaderStaysOpenWithinTimeout"
+)
+for test_case in "${test_cases[@]}"; do
+  log_dir="/tmp/inactive_stream_timeout_logs"
+  mkdir -p $log_dir
+  log_file="$log_dir/log.json"
+  gcsfuse --read-inactive-stream-timeout=1s  --client-protocol grpc --log-file $log_file --log-severity=trace --log-format=json $TEST_BUCKET_NAME $MOUNT_DIR
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/inactive_stream_timeout/...  -p 1 --integrationTest -v --mountedDirectory=$MOUNT_DIR --testbucket=$TEST_BUCKET_NAME -run $test_case
+  sudo umount $MOUNT_DIR
+  rm -rf $log_dir
+done
+

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/structure.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/structure.go
@@ -14,6 +14,10 @@
 
 package read_logs
 
+import (
+	"time"
+)
+
 // StructuredReadLogEntry stores the structured format to be created from logs.
 type StructuredReadLogEntry struct {
 	Handle           int64
@@ -63,4 +67,10 @@ type JobData struct {
 type handleAndChunkIndex struct {
 	handle     int64
 	chunkIndex int
+}
+
+// LogEntry struct to match the JSON structure
+type LogEntry struct {
+	Timestamp time.Time `json:"time"`
+	Message   string    `json:"message"`
 }


### PR DESCRIPTION
### Description
1. WithTimeout test to validate - reader is closed and further reader works as expected.
2. WithoutTimeout test to validate - no such read closer after the timeout.

### Link to the issue in case of a bug fix.
b/416943998

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
