### PR TITLE
[testing-on-gke] Fix bug in zb output download

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -755,8 +755,8 @@ function downloadFioOutputsFromBucket() {
   dst_dir="${gcsfuse_src_dir}/perfmetrics/scripts/testing_on_gke/bin/fio-logs/${instance_id}/${fileSize}"
   if test -d "${src_dir}" ; then
     mkdir -pv "${dst_dir}"
-    echo "Copying files from \"${src_dir}\" to \"${dst_dir}/\" ... "
-    cp -rfvu "${src_dir}"/* "${dst_dir}"/
+    echo "Copying files of type ${fileSize}* from \"${src_dir}\" to \"${dst_dir}/\" ... "
+    cp -rfvu "${src_dir}"/${fileSize}* "${dst_dir}"/
   fi
 
   echo "  Unmounting \"${bucket}\" from \"${mountpath}\" ... "


### PR DESCRIPTION
### Description
This fixes the bug in downloading the fio outputs generated by gke ai/ml test tool for runs on ZB buckets (i.e. with `zonal=true`). This failure is specifically in a case where a single input bucket is used for runs of different file-size values in different fio workloads. This fix downloads only the fio outputs relevant to specific file-sizes while parsing outputs for that file-size.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
