### PR TITLE
Refactor metrics to move unit conversion logic to otel_metrics

### DIFF
--- a/common/noop_metrics.go
+++ b/common/noop_metrics.go
@@ -14,7 +14,10 @@
 
 package common
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 func NewNoopMetrics() MetricHandle {
 	var n noopMetrics
@@ -23,17 +26,17 @@ func NewNoopMetrics() MetricHandle {
 
 type noopMetrics struct{}
 
-func (*noopMetrics) GCSReadBytesCount(_ context.Context, _ int64)                       {}
-func (*noopMetrics) GCSReaderCount(_ context.Context, _ int64, _ []MetricAttr)          {}
-func (*noopMetrics) GCSRequestCount(_ context.Context, _ int64, _ []MetricAttr)         {}
-func (*noopMetrics) GCSRequestLatency(_ context.Context, value float64, _ []MetricAttr) {}
-func (*noopMetrics) GCSReadCount(_ context.Context, _ int64, _ []MetricAttr)            {}
-func (*noopMetrics) GCSDownloadBytesCount(_ context.Context, _ int64, _ []MetricAttr)   {}
+func (*noopMetrics) GCSReadBytesCount(_ context.Context, _ int64)                         {}
+func (*noopMetrics) GCSReaderCount(_ context.Context, _ int64, _ []MetricAttr)            {}
+func (*noopMetrics) GCSRequestCount(_ context.Context, _ int64, _ []MetricAttr)           {}
+func (*noopMetrics) GCSRequestLatency(_ context.Context, _ time.Duration, _ []MetricAttr) {}
+func (*noopMetrics) GCSReadCount(_ context.Context, _ int64, _ []MetricAttr)              {}
+func (*noopMetrics) GCSDownloadBytesCount(_ context.Context, _ int64, _ []MetricAttr)     {}
 
-func (*noopMetrics) OpsCount(_ context.Context, _ int64, _ []MetricAttr)         {}
-func (*noopMetrics) OpsLatency(_ context.Context, value float64, _ []MetricAttr) {}
-func (*noopMetrics) OpsErrorCount(_ context.Context, _ int64, _ []MetricAttr)    {}
+func (*noopMetrics) OpsCount(_ context.Context, _ int64, _ []MetricAttr)           {}
+func (*noopMetrics) OpsLatency(_ context.Context, _ time.Duration, _ []MetricAttr) {}
+func (*noopMetrics) OpsErrorCount(_ context.Context, _ int64, _ []MetricAttr)      {}
 
-func (*noopMetrics) FileCacheReadCount(_ context.Context, _ int64, _ []MetricAttr)         {}
-func (*noopMetrics) FileCacheReadBytesCount(_ context.Context, _ int64, _ []MetricAttr)    {}
-func (*noopMetrics) FileCacheReadLatency(_ context.Context, value float64, _ []MetricAttr) {}
+func (*noopMetrics) FileCacheReadCount(_ context.Context, _ int64, _ []MetricAttr)           {}
+func (*noopMetrics) FileCacheReadBytesCount(_ context.Context, _ int64, _ []MetricAttr)      {}
+func (*noopMetrics) FileCacheReadLatency(_ context.Context, _ time.Duration, _ []MetricAttr) {}

--- a/common/otel_metrics.go
+++ b/common/otel_metrics.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -96,8 +97,8 @@ func (o *otelMetrics) GCSRequestCount(ctx context.Context, inc int64, attrs []Me
 	o.gcsRequestCount.Add(ctx, inc, attrsToAddOption(attrs)...)
 }
 
-func (o *otelMetrics) GCSRequestLatency(ctx context.Context, value float64, attrs []MetricAttr) {
-	o.gcsRequestLatency.Record(ctx, value, attrsToRecordOption(attrs)...)
+func (o *otelMetrics) GCSRequestLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr) {
+	o.gcsRequestLatency.Record(ctx, float64(latency.Milliseconds()), attrsToRecordOption(attrs)...)
 }
 
 func (o *otelMetrics) GCSReadCount(ctx context.Context, inc int64, attrs []MetricAttr) {
@@ -112,8 +113,8 @@ func (o *otelMetrics) OpsCount(ctx context.Context, inc int64, attrs []MetricAtt
 	o.fsOpsCount.Add(ctx, inc, attrsToAddOption(attrs)...)
 }
 
-func (o *otelMetrics) OpsLatency(ctx context.Context, value float64, attrs []MetricAttr) {
-	o.fsOpsLatency.Record(ctx, value, attrsToRecordOption(attrs)...)
+func (o *otelMetrics) OpsLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr) {
+	o.fsOpsLatency.Record(ctx, float64(latency.Microseconds()), attrsToRecordOption(attrs)...)
 }
 
 func (o *otelMetrics) OpsErrorCount(ctx context.Context, inc int64, attrs []MetricAttr) {
@@ -128,8 +129,8 @@ func (o *otelMetrics) FileCacheReadBytesCount(ctx context.Context, inc int64, at
 	o.fileCacheReadBytesCount.Add(ctx, inc, attrsToAddOption(attrs)...)
 }
 
-func (o *otelMetrics) FileCacheReadLatency(ctx context.Context, value float64, attrs []MetricAttr) {
-	o.fileCacheReadLatency.Record(ctx, value, attrsToRecordOption(attrs)...)
+func (o *otelMetrics) FileCacheReadLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr) {
+	o.fileCacheReadLatency.Record(ctx, float64(latency.Microseconds()), attrsToRecordOption(attrs)...)
 }
 
 func NewOTelMetrics() (MetricHandle, error) {

--- a/common/telemetry.go
+++ b/common/telemetry.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel/metric"
 )
@@ -55,21 +56,21 @@ type GCSMetricHandle interface {
 	GCSReadBytesCount(ctx context.Context, inc int64)
 	GCSReaderCount(ctx context.Context, inc int64, attrs []MetricAttr)
 	GCSRequestCount(ctx context.Context, inc int64, attrs []MetricAttr)
-	GCSRequestLatency(ctx context.Context, value float64, attrs []MetricAttr)
+	GCSRequestLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr)
 	GCSReadCount(ctx context.Context, inc int64, attrs []MetricAttr)
 	GCSDownloadBytesCount(ctx context.Context, inc int64, attrs []MetricAttr)
 }
 
 type OpsMetricHandle interface {
 	OpsCount(ctx context.Context, inc int64, attrs []MetricAttr)
-	OpsLatency(ctx context.Context, value float64, attrs []MetricAttr)
+	OpsLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr)
 	OpsErrorCount(ctx context.Context, inc int64, attrs []MetricAttr)
 }
 
 type FileCacheMetricHandle interface {
 	FileCacheReadCount(ctx context.Context, inc int64, attrs []MetricAttr)
 	FileCacheReadBytesCount(ctx context.Context, inc int64, attrs []MetricAttr)
-	FileCacheReadLatency(ctx context.Context, value float64, attrs []MetricAttr)
+	FileCacheReadLatency(ctx context.Context, latency time.Duration, attrs []MetricAttr)
 }
 type MetricHandle interface {
 	GCSMetricHandle

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -236,7 +236,7 @@ func recordOp(ctx context.Context, metricHandle common.MetricHandle, method stri
 			{Key: common.FSErrCategory, Value: errCategory}},
 		)
 	}
-	metricHandle.OpsLatency(ctx, float64(time.Since(start).Microseconds()), []common.MetricAttr{{Key: common.FSOp, Value: method}})
+	metricHandle.OpsLatency(ctx, time.Since(start), []common.MetricAttr{{Key: common.FSOp, Value: method}})
 }
 
 // WithMonitoring takes a FileSystem, returns a FileSystem with monitoring

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -207,7 +207,7 @@ func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHand
 	})
 
 	metricHandle.FileCacheReadBytesCount(ctx, int64(readDataSize), []common.MetricAttr{{Key: common.ReadType, Value: readType}})
-	metricHandle.FileCacheReadLatency(ctx, float64(readLatency.Microseconds()), []common.MetricAttr{{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)}})
+	metricHandle.FileCacheReadLatency(ctx, readLatency, []common.MetricAttr{{Key: common.CacheHit, Value: strconv.FormatBool(cacheHit)}})
 }
 
 func (fc *FileCacheReader) Destroy() {

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -28,9 +28,7 @@ import (
 func recordRequest(ctx context.Context, metricHandle common.MetricHandle, method string, start time.Time) {
 	metricHandle.GCSRequestCount(ctx, 1, []common.MetricAttr{{Key: common.GCSMethod, Value: method}})
 
-	latencyUs := time.Since(start).Microseconds()
-	latencyMs := float64(latencyUs) / 1000.0
-	metricHandle.GCSRequestLatency(ctx, latencyMs, []common.MetricAttr{{Key: common.GCSMethod, Value: method}})
+	metricHandle.GCSRequestLatency(ctx, time.Since(start), []common.MetricAttr{{Key: common.GCSMethod, Value: method}})
 }
 
 func CaptureMultiRangeDownloaderMetrics(ctx context.Context, metricHandle common.MetricHandle, method string, start time.Time) {


### PR DESCRIPTION
Metrics units should be a concern of metrics related files as opposed to the code that generates those metrics.

### Description

Perf:

| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|----------|--------------|-----------|----------------|----------------|
| Master |  0.25MiB   | 553.65MiB/s  | 1.09MiB/s  |  81.91MiB/s  |  1.14MiB/s   |
|   PR   |  0.25MiB   | 573.52MiB/s  | 1.18MiB/s  |  81.43MiB/s  |  1.22MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3923.0MiB/s  | 84.98MiB/s | 1518.44MiB/s |  85.93MiB/s  |
|   PR   | 48.828MiB  | 3930.72MiB/s | 82.77MiB/s | 1557.12MiB/s |  84.43MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 3875.87MiB/s | 79.38MiB/s | 687.03MiB/s  |  30.76MiB/s  |
|   PR   | 976.562MiB | 3874.53MiB/s | 79.33MiB/s | 942.37MiB/s  |  29.43MiB/s  |

### Link to the issue in case of a bug fix.
b/417142000

### Testing details
1. Manual - Manually verified that the latency metrics are of the same order before and after the change.
2. Unit tests - NA
3. Integration tests - Tested by existing integration tests in prom_test.go

### Any backward incompatible change? If so, please explain.
No
