### PR TITLE
 Use the same code-flow regardless of metrics being enabled

### DIFF
--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -175,9 +175,7 @@ func (bm *bucketManager) SetUpBucket(
 	}
 
 	// Enable monitoring.
-	if bm.config.EnableMonitoring {
-		b = monitor.NewMonitoringBucket(b, metricHandle)
-	}
+	b = monitor.NewMonitoringBucket(b, metricHandle)
 
 	// Enable gcs logs.
 	b = storage.NewDebugBucket(b)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -95,8 +95,7 @@ func (bh *bucketHandle) NewReaderWithReadHandle(
 	}
 
 	// NewRangeReader creates a "storage.Reader" object which is also io.ReadCloser since it contains both Read() and Close() methods present in io.ReadCloser interface.
-	var storageReader *storage.Reader
-	storageReader, err = obj.NewRangeReader(ctx, start, length)
+	storageReader, err := obj.NewRangeReader(ctx, start, length)
 	if err == nil {
 		reader = newGCSFullReadCloser(storageReader)
 	}


### PR DESCRIPTION
### Description
Currently, enabling metrics will conditionally enable a decorator that activates the code flows to record metrics. However, this leads to test-gaps since we currently don't enable metrics in our tests and that decorator doesn't come into picture while running tests. So, we unify the flow with/without metrics enabled so that the monitoring decorator will always be set even in cases when no metrics are to be computed.

Perf:
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 542.32MiB/s  | 1.14MiB/s  |  77.38MiB/s  |  1.21MiB/s   |
|   PR   |  0.25MiB   | 535.05MiB/s  | 1.23MiB/s  |  78.74MiB/s  |   1.3MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3855.53MiB/s | 86.18MiB/s | 1499.94MiB/s |  83.39MiB/s  |
|   PR   | 48.828MiB  | 3948.37MiB/s | 82.54MiB/s | 1511.09MiB/s |  85.45MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 4024.28MiB/s | 80.03MiB/s | 676.21MiB/s  |  31.58MiB/s  |
|   PR   | 976.562MiB | 4025.74MiB/s | 79.85MiB/s | 1092.69MiB/s |  28.57MiB/s  |

### Link to the issue in case of a bug fix.
b/414289412

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Metrics are already covered by prom_test.go. This change unconditionally applies the metrics decorator and therefore many other tests that earlier skipped the metrics decorator now also activate the metrics flow.

### Any backward incompatible change? If so, please explain.
NA