### PR TITLE
Encapsulate test environment variables

### DIFF
--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -36,7 +36,7 @@ func (s *disabledNegativeStatCacheTest) Setup(t *testing.T) {
 }
 
 func (s *disabledNegativeStatCacheTest) Teardown(t *testing.T) {
-	setup.UnmountGCSFuse(rootDir)
+	setup.UnmountGCSFuse(testEnv.rootDir)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -44,7 +44,7 @@ func (s *disabledNegativeStatCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled(t *testing.T) {
-	targetDir := path.Join(testDirPath, "explicit_dir")
+	targetDir := path.Join(testEnv.testDirPath, "explicit_dir")
 	// Create test directory
 	operations.CreateDirectory(targetDir, t)
 	targetFile := path.Join(targetDir, "file1.txt")
@@ -57,7 +57,7 @@ func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled(t *testing
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, "explicit_dir/file1.txt", "some-content", t)
+	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDirName, "explicit_dir/file1.txt", "some-content", t)
 
 	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
 	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -37,7 +37,7 @@ func (s *finiteNegativeStatCacheTest) Setup(t *testing.T) {
 }
 
 func (s *finiteNegativeStatCacheTest) Teardown(t *testing.T) {
-	setup.UnmountGCSFuse(rootDir)
+	setup.UnmountGCSFuse(testEnv.rootDir)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -45,7 +45,7 @@ func (s *finiteNegativeStatCacheTest) Teardown(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *finiteNegativeStatCacheTest) TestFiniteNegativeStatCache(t *testing.T) {
-	targetDir := path.Join(testDirPath, "explicit_dir")
+	targetDir := path.Join(testEnv.testDirPath, "explicit_dir")
 	// Create test directory
 	operations.CreateDirectory(targetDir, t)
 	targetFile := path.Join(targetDir, "file1.txt")
@@ -58,7 +58,7 @@ func (s *finiteNegativeStatCacheTest) TestFiniteNegativeStatCache(t *testing.T) 
 	assert.ErrorContains(t, err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	client.CreateObjectInGCSTestDir(ctx, storageClient, testDirName, path.Join("explicit_dir", "file1.txt"), "some-content", t)
+	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDirName, path.Join("explicit_dir", "file1.txt"), "some-content", t)
 
 	// Error should be returned again, as call will not be served from GCS due to finite gcsfuse stat cache
 	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -35,6 +35,13 @@ const (
 	onlyDirMounted = "OnlyDirMountNegativeStatCache"
 )
 
+// env holds the comprehensive operational environment, configuration, and
+// shared resources for this package.
+//
+// IMPORTANT: To prevent global variable pollution, enhance code clarity,
+// and facilitate easier testing. We strongly suggest that, all new package-level
+// variables (which would otherwise be declared with `var` at the package root) should
+// be added as fields to this 'env' struct instead.
 type env struct {
 	testDirPath string
 	mountFunc   func([]string) error

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -35,9 +35,6 @@ const (
 	onlyDirMounted = "OnlyDirMountNegativeStatCache"
 )
 
-// env holds the comprehensive operational environment, configuration, and
-// shared resources for this package.
-//
 // IMPORTANT: To prevent global variable pollution, enhance code clarity,
 // and facilitate easier testing. We strongly suggest that, all new package-level
 // variables (which would otherwise be declared with `var` at the package root) should

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 // IMPORTANT: To prevent global variable pollution, enhance code clarity,
-// and facilitate easier testing. We strongly suggest that, all new package-level
+// and avoid inadvertent errors. We strongly suggest that, all new package-level
 // variables (which would otherwise be declared with `var` at the package root) should
 // be added as fields to this 'env' struct instead.
 type env struct {


### PR DESCRIPTION
### Description
E2E tests make extensive use of global variables which hampers readability and can give rise to inadvertent logical errors due to name clashes.

This change demonstrates how to encapsulate them into a structure and its usage.

### Link to the issue in case of a bug fix.
b/417329502

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
NA