### PR TITLE
Random object names in stale_handle/stale_file_handle_synced_file_test.go

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -611,3 +611,13 @@ func CreateProxyServerLogFile(t *testing.T) string {
 func AppendProxyEndpointToFlagSet(flagSet *[]string, port int) {
 	*flagSet = append(*flagSet, "--custom-endpoint="+fmt.Sprintf("http://localhost:%d/storage/v1/", port))
 }
+
+// GenerateRandomDirName returns a random directory name with the given prefix.
+func GenerateRandomDirName(prefix string) string {
+	return prefix + "-" + GenerateRandomString(5)
+}
+
+// GenerateRandomFileName returns a random directory name with the given prefix and .txt extension added.
+func GenerateRandomFileName(prefix string) string {
+	return prefix + "-" + GenerateRandomString(5) + ".txt"
+}


### PR DESCRIPTION
### Description
Randomize filenames in tests in stale_handle/stale_file_handle_synced_file_test.go
    
This is to make these completely independent of each other.

### Link to the issue in case of a bug fix.
[b/416834026](http://b/416834026)


### Testing details
1. Manual - Tested manually and passed.
2. Unit tests - NA
3. Integration tests - Ran through presubmit

### Any backward incompatible change? If so, please explain.
