### PR TITLE
[testing-on-gke] Add support to output throughput in MB/s

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/parse_logs.py
@@ -196,10 +196,10 @@ def write_records_to_csv_output_file(output: dict, output_file_path: str):
   with open(output_file_path, "a") as output_file:
     # Write a new header row.
     output_file.write(
-        "File Size,File #,Total Size (GB),Batch Size,Scenario,Epoch,Duration"
+        "File Size,File #,Total Size (GiB),Batch Size,Scenario,Epoch,Duration"
         " (s),GPU Utilization (%),Throughput (sample/s),Throughput"
         " (MB/s),Throughput over Local SSD (%),GCSFuse Lowest Memory"
-        " (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU (core),GCSFuse"
+        " (MiB),GCSFuse Highest Memory (MiB),GCSFuse Lowest CPU (core),GCSFuse"
         " Highest CPU (core),Pod,Start,End,GcsfuseMountOptions,InstanceID\n"
     )
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -38,7 +38,7 @@ record = {
     "scenario": "",
     "duration": 0,
     "IOPS": 0,
-    "throughput_mb_per_second": 0,
+    "throughput_mib_per_second": 0,
     "throughput_over_local_ssd": 0,
     "start_epoch": "",
     "end_epoch": "",
@@ -227,7 +227,7 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
           per_epoch_output_data["jobs"][0]["read"]["runtime"] / 1000
       )
       r["IOPS"] = int(per_epoch_output_data["jobs"][0]["read"]["iops"])
-      r["throughput_mb_per_second"] = int(
+      r["throughput_mib_per_second"] = int(
           per_epoch_output_data["jobs"][0]["read"]["bw_bytes"] / (1024**2)
       )
       r["start_epoch"] = per_epoch_output_data["jobs"][0]["job_start"] // 1000
@@ -272,9 +272,9 @@ def write_records_to_csv_output_file(output: dict, output_file_path: str):
     # Write a new header.
     output_file_fwr.write(
         "File Size,Read Type,Scenario,Epoch,Duration"
-        " (s),Throughput (MB/s),IOPS,Throughput over Local SSD (%),GCSFuse"
+        " (s),Throughput (MiB/s),IOPS,Throughput over Local SSD (%),GCSFuse"
         " Lowest"
-        " Memory (MB),GCSFuse Highest Memory (MB),GCSFuse Lowest CPU"
+        " Memory (MiB),GCSFuse Highest Memory (MiB),GCSFuse Lowest CPU"
         " (core),GCSFuse Highest CPU"
         " (core),Pod,Start,End,GcsfuseMoutOptions,BlockSize,FilesPerThread,NumThreads,InstanceID,"
         "e2e_latency_ns_max,e2e_latency_ns_p50,e2e_latency_ns_p90,e2e_latency_ns_p99,e2e_latency_ns_p99.9,"
@@ -299,9 +299,9 @@ def write_records_to_csv_output_file(output: dict, output_file_path: str):
                 == len(record_set["records"][scenario])
             ):
               r["throughput_over_local_ssd"] = round(
-                  r["throughput_mb_per_second"]
+                  r["throughput_mib_per_second"]
                   / record_set["records"]["local-ssd"][i][
-                      "throughput_mb_per_second"
+                      "throughput_mib_per_second"
                   ]
                   * 100,
                   2,
@@ -317,7 +317,7 @@ def write_records_to_csv_output_file(output: dict, output_file_path: str):
             continue
 
           output_file_fwr.write(
-              f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mb_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.instance_id},"
+              f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mib_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.instance_id},"
           )
           output_file_fwr.write(
               f"{r['e2e_latency_ns_max']},{r['e2e_latency_ns_p50']},{r['e2e_latency_ns_p90']},{r['e2e_latency_ns_p99']},{r['e2e_latency_ns_p99.9']},"
@@ -388,7 +388,7 @@ def write_records_to_bq_table(
         row.e2e_latency_ns_p99 = r["e2e_latency_ns_p99"]
         row.e2e_latency_ns_p99_9 = r["e2e_latency_ns_p99.9"]
         row.iops = r["IOPS"]
-        row.throughput_in_mbps = r["throughput_mb_per_second"]
+        row.throughput_in_mbps = r["throughput_mib_per_second"]
         row.fio_workload_id = fio_workload_id(row)
 
         rows.append(row)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -203,7 +203,9 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
       global_options = per_epoch_output_data["global options"]
       nrfiles = int(global_options["nrfiles"])
       numjobs = int(global_options["numjobs"])
-      bs = per_epoch_output_data["jobs"][0]["job options"]["bs"]
+      job0 = per_epoch_output_data["jobs"][0]
+
+      bs = job0["job options"]["bs"]
 
       # If the record for this key has not been added, create a new entry
       # for it.
@@ -217,24 +219,22 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
             },
         }
 
+      job0_read_metrics = job0["read"]
+      bs = job0["job options"]["bs"]
+
       # Create a record for this key.
       r = record.copy()
-      bs = per_epoch_output_data["jobs"][0]["job options"]["bs"]
       r["pod_name"] = pod_name
       r["epoch"] = epoch
       r["scenario"] = scenario
-      r["duration"] = int(
-          per_epoch_output_data["jobs"][0]["read"]["runtime"] / 1000
-      )
-      r["IOPS"] = int(per_epoch_output_data["jobs"][0]["read"]["iops"])
+      r["duration"] = int(job0_read_metrics["runtime"] / 1000)
+      r["IOPS"] = int(job0_read_metrics["iops"])
       r["throughput_mib_per_second"] = int(
-          per_epoch_output_data["jobs"][0]["read"]["bw_bytes"] / (1024**2)
+          job0_read_metrics["bw_bytes"] / (1024**2)
       )
-      r["start_epoch"] = per_epoch_output_data["jobs"][0]["job_start"] // 1000
+      r["start_epoch"] = job0["job_start"] // 1000
       r["end_epoch"] = per_epoch_output_data["timestamp_ms"] // 1000
-      r["start"] = unix_to_timestamp(
-          per_epoch_output_data["jobs"][0]["job_start"]
-      )
+      r["start"] = unix_to_timestamp(job0["job_start"])
       r["end"] = unix_to_timestamp(per_epoch_output_data["timestamp_ms"])
 
       fetch_cpu_memory_data(args=args, record=r)
@@ -245,7 +245,7 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
       r["blockSize"] = bs
       r["filesPerThread"] = nrfiles
       r["numThreads"] = numjobs
-      clat_ns = per_epoch_output_data["jobs"][0]["read"]["clat_ns"]
+      clat_ns = job0_read_metrics["clat_ns"]
       r["e2e_latency_ns_max"] = clat_ns["max"]
       clat_ns_percentile = clat_ns["percentile"]
       r["e2e_latency_ns_p50"] = clat_ns_percentile["50.000000"]

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -226,41 +226,44 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
 
       # Create a record for this key.
       r = record.copy()
-      r["pod_name"] = pod_name
-      r["epoch"] = epoch
-      r["scenario"] = scenario
-      r["duration"] = int(job0_read_metrics["runtime"] / 1000)
-      r["IOPS"] = int(job0_read_metrics["iops"])
-      r["throughput_bytes_per_second"] = job0_read_metrics["bw_bytes"]
-      r["throughput_mib_per_second"] = round(
-          (r["throughput_bytes_per_second"] / (1024**2)), 2
-      )
-      r["throughput_mb_per_second"] = round(
-          (r["throughput_bytes_per_second"] / 1e6), 2
-      )
-      r["start_epoch"] = job0["job_start"] // 1000
-      r["end_epoch"] = per_epoch_output_data["timestamp_ms"] // 1000
-      r["start"] = unix_to_timestamp(job0["job_start"])
-      r["end"] = unix_to_timestamp(per_epoch_output_data["timestamp_ms"])
+      try:
+        r["pod_name"] = pod_name
+        r["epoch"] = epoch
+        r["scenario"] = scenario
+        r["duration"] = int(job0_read_metrics["runtime"] / 1000)
+        r["IOPS"] = int(job0_read_metrics["iops"])
+        r["throughput_bytes_per_second"] = job0_read_metrics["bw_bytes"]
+        r["throughput_mib_per_second"] = round(
+            (r["throughput_bytes_per_second"] / (1024**2)), 2
+        )
+        r["throughput_mb_per_second"] = round(
+            (r["throughput_bytes_per_second"] / 1e6), 2
+        )
+        r["start_epoch"] = job0["job_start"] // 1000
+        r["end_epoch"] = per_epoch_output_data["timestamp_ms"] // 1000
+        r["start"] = unix_to_timestamp(job0["job_start"])
+        r["end"] = unix_to_timestamp(per_epoch_output_data["timestamp_ms"])
 
-      fetch_cpu_memory_data(args=args, record=r)
+        fetch_cpu_memory_data(args=args, record=r)
 
-      r["gcsfuse_mount_options"] = gcsfuse_mount_options
-      r["bucket_name"] = bucket_name
-      r["machine_type"] = machine_type
-      r["blockSize"] = bs
-      r["filesPerThread"] = nrfiles
-      r["numThreads"] = numjobs
-      clat_ns = job0_read_metrics["clat_ns"]
-      r["e2e_latency_ns_max"] = clat_ns["max"]
-      clat_ns_percentile = clat_ns["percentile"]
-      r["e2e_latency_ns_p50"] = clat_ns_percentile["50.000000"]
-      r["e2e_latency_ns_p90"] = clat_ns_percentile["90.000000"]
-      r["e2e_latency_ns_p99"] = clat_ns_percentile["99.000000"]
-      r["e2e_latency_ns_p99.9"] = clat_ns_percentile["99.900000"]
-
-      # This print is for debugging in case something goes wrong.
-      pprint.pprint(r)
+        r["gcsfuse_mount_options"] = gcsfuse_mount_options
+        r["bucket_name"] = bucket_name
+        r["machine_type"] = machine_type
+        r["blockSize"] = bs
+        r["filesPerThread"] = nrfiles
+        r["numThreads"] = numjobs
+        clat_ns = job0_read_metrics["clat_ns"]
+        r["e2e_latency_ns_max"] = clat_ns["max"]
+        clat_ns_percentile = clat_ns["percentile"]
+        r["e2e_latency_ns_p50"] = clat_ns_percentile["50.000000"]
+        r["e2e_latency_ns_p90"] = clat_ns_percentile["90.000000"]
+        r["e2e_latency_ns_p99"] = clat_ns_percentile["99.000000"]
+        r["e2e_latency_ns_p99.9"] = clat_ns_percentile["99.900000"]
+      except Exception as e:
+        print(f"Failed to create following record with error: {e}")
+        # This print is for debugging in case something goes wrong.
+        pprint.pprint(r)
+        continue
 
       # If a slot for record for this particular epoch has not been created yet,
       # append enough empty records to make a slot.


### PR DESCRIPTION
### Description
- The tool should calculate throughput in both MiB/s (for backward compatibility) and MB/s (for future)
- Clean-up code a bit
- Print out correct units (MiBs) for low/high memory usage
- Print out records during parsing only when they fail, reduces log size

### Link to the issue in case of a bug fix.
[b/412923482](http://b/412923482)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
