### PR TITLE
Adding warning log for unexpected EOFs while reading

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/jacobsa/syncutil"
 	"golang.org/x/net/context"
 )
@@ -140,6 +141,9 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 		objectData, err = fh.reader.ReadAt(ctx, dst, offset)
 		switch {
 		case errors.Is(err, io.EOF):
+			if err != io.EOF {
+				logger.Warnf("Unexpected EOF error encountered while reading, err: %v type: %T ", err, err)
+			}
 			err = io.EOF
 			return
 


### PR DESCRIPTION
### Description
Related to the recent discussion about EOFs, It is observed that seldom, we get wrapped EOF errors due to closed stream or any other connectivity issues. These errors are supposed to be retried at the GoSDK level , and hence any final EOF received from the ReadAt function is supposed to be ignored, considering it to be a io.EOF as the expected ones comes directly as `io.EOF`.

While we do not have an exhaustive list of EOFs which can pop up in the read path, we are adding a warning log whenever we are ignoring an EOF (wrapped or otherwise ) for easy debugging of cases when we do not serve any data leading to corruption.

### Link to the issue in case of a bug fix.
[b/406196625](https://b.corp.google.com/issues/406196625)

### Testing details
1. Manual - Manually tested by passing a wrapped EOF. WAI
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
