### PR TITLE
[testing-on-gke] Make user-passed instance_id unique

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -151,7 +151,7 @@ fi
 test -n "${zone}" || export zone=${DEFAULT_ZONE}
 # GKE cluster related
 if test -z "${cluster_name}"; then
-  exitWithError "${cluster_name} was not set."
+  exitWithError "cluster_name was not set."
 fi
 test -n "${node_pool}" || export node_pool=${DEFAULT_NODE_POOL}
 test -n "${machine_type}" || export machine_type=${DEFAULT_MACHINE_TYPE}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -109,7 +109,7 @@ function printHelp() {
   # Test runtime configuration
   echo "pod_wait_time_in_seconds=<number e.g. 60 for checking pod status every 1 min, default=\"${DEFAULT_POD_WAIT_TIME_IN_SECONDS}\">"
   echo "pod_timeout_in_seconds=<number e.g. 3600 for timing out pod runs, should be more than the value of pod_wait_time_in_seconds, default=\"${DEFAULT_POD_TIMEOUT_IN_SECONDS}\">"
-  echo "instance_id=<description of this particular test-run, it does not need to be unique e.g. \"cache test #43\""
+  echo "instance_id=<Optional description of this particular test-run, it does not need to be unique e.g. \"cache test #43\""
   echo "workload_config=<path/to/workload/configuration/file e.g. /a/b/c.json >"
   echo "output_dir=</absolute/path/to/output/dir, output files will be written at output_dir/fio/output.csv and output_dir/dlio/output.csv>"
   echo "force_update_gcsfuse_code=<true|false, to force-update the gcsfuse-code to given branch if gcsfuse_src_dir has been set. Default=\"${DEFAULT_FORCE_UPDATE_GCSFUSE_CODE}\">"

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -36,7 +36,7 @@ def run_command(command: str) -> int:
 
 
 def escape_commas_in_string(unescapedStr: str) -> str:
-  """Returns equivalent string with ',' replaced with '\,' ."""
+  """Returns equivalent string with , replaced with \, ."""
   return unescapedStr.replace(',', '\,')
 
 


### PR DESCRIPTION
### Description
If user passes an instance_id, then suffix it with user-name/date-time/uuid to make it unique. If user also passed 'only_parse', then use the passed `instance_id` as it is.

### Link to the issue in case of a bug fix
[b/412923482](http://b/412923482)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
