### PR TITLE
[DRAFT] Cancel the context and drain the reader before closing it

### DIFF
--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -644,9 +644,16 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 
 // closeReader fetches the readHandle before closing the reader instance.
 func (rr *randomReader) closeReader() {
-	rr.readHandle = rr.reader.ReadHandle()
-	err := rr.reader.Close()
-	if err != nil {
-		logger.Warnf("error while closing reader: %v", err)
+	       if rr.cancel != nil {
+	             rr.cancel()
+	       }
+			rr.readHandle = rr.reader.ReadHandle()
+			_, err := io.Copy(io.Discard,rr.reader)
+			if err !=nil {
+				logger.Warnf("error while drainging reader: %v", err)
+			}
+			err = rr.reader.Close()
+			if err != nil {
+					logger.Warnf("error while closing reader: %v", err)
+			}
 	}
-}


### PR DESCRIPTION
### Description
This is a sample PR to cancel the context and drain the reader before closing it.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
