### PR TITLE
Cancel the context of reader and then Drain it and Close it in Async. Also Disable the Page Cache.

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2568,7 +2568,8 @@ func (fs *fileSystem) OpenFile(
 	// new inode IDs. So for a given inode, all modifications go through the
 	// kernel. Therefore it's safe to tell the kernel to keep the page cache from
 	// open to open for a given inode.
-	op.KeepPageCache = true
+	op.KeepPageCache = false
+	op.UseDirectIO = true
 
 	return
 }

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -645,8 +645,21 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 // closeReader fetches the readHandle before closing the reader instance.
 func (rr *randomReader) closeReader() {
 	rr.readHandle = rr.reader.ReadHandle()
-	err := rr.reader.Close()
-	if err != nil {
-		logger.Warnf("error while closing reader: %v", err)
+
+	// Cancel the context.
+	if rr.cancel != nil {
+		rr.cancel()
 	}
+
+	// Drain in the background.
+	go func(r io.ReadCloser) {
+		_, err := io.Copy(io.Discard, r)
+		if err != nil {
+			logger.Warnf("async drain error: %v", err)
+		}
+		err = r.Close()
+		if err != nil {
+			logger.Warnf("async close error: %v", err)
+		}
+	}(rr.reader)
 }


### PR DESCRIPTION
### Description
This is a sample PR to cancel the context of reader and then drain it and close it in asynchronously.
It also Disables the Page Cache.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
