### PR TITLE
[testing-on-gke] Switch from instance_id to experiment_id everywhere for consistency.

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/dlio_workload.py
@@ -182,7 +182,7 @@ def parse_test_config_for_dlio_workloads(testConfigFileName: str):
 
 
 def DlioChartNamePodName(
-    dlioWorkload: DlioWorkload, instanceID: str, batchSize: int
+    dlioWorkload: DlioWorkload, experimentID: str, batchSize: int
 ) -> (str, str, str):
   shortenScenario = {
       'local-ssd': 'ssd',
@@ -194,11 +194,11 @@ def DlioChartNamePodName(
       else 'other'
   )
 
-  hashOfWorkload = str(hash((instanceID, batchSize, dlioWorkload))).replace(
+  hashOfWorkload = str(hash((experimentID, batchSize, dlioWorkload))).replace(
       '-', ''
   )
   return (
       f'dlio-unet3d-{shortForScenario}-{dlioWorkload.recordLength}-{hashOfWorkload}',
       f'dlio-tester-{shortForScenario}-{dlioWorkload.recordLength}-{hashOfWorkload}',
-      f'{instanceID}/{dlioWorkload.numFilesTrain}-{dlioWorkload.recordLength}-{batchSize}-{hashOfWorkload}/{dlioWorkload.scenario}',
+      f'{experimentID}/{dlioWorkload.numFilesTrain}-{dlioWorkload.recordLength}-{batchSize}-{hashOfWorkload}/{dlioWorkload.scenario}',
   )

--- a/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/dlio/run_tests.py
@@ -38,7 +38,7 @@ import dlio_workload
 
 
 def createHelmInstallCommands(
-    dlioWorkloads: set, instanceId: str, machineType: str, customCSIDriver: str
+    dlioWorkloads: set, experimentID: str, machineType: str, customCSIDriver: str
 ) -> list:
   """Creates helm install commands for the given dlioWorkload objects."""
   helm_commands = []
@@ -57,7 +57,7 @@ def createHelmInstallCommands(
       for batchSize in dlioWorkload.batchSizes:
         chartName, podName, outputDirPrefix = (
             dlio_workload.DlioChartNamePodName(
-                dlioWorkload, instanceId, batchSize
+                dlioWorkload, experimentID, batchSize
             )
         )
         commands = [
@@ -67,7 +67,7 @@ def createHelmInstallCommands(
             f'--set dlio.numFilesTrain={dlioWorkload.numFilesTrain}',
             f'--set dlio.recordLength={dlioWorkload.recordLength}',
             f'--set dlio.batchSize={batchSize}',
-            f'--set instanceId={instanceId}',
+            f'--set experimentID={experimentID}',
             (
                 '--set'
                 f' gcsfuse.mountOptions={escape_commas_in_string(dlioWorkload.gcsfuseMountOptions)}'
@@ -93,7 +93,7 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      dlioWorkloads, args.instance_id, args.machine_type, args.custom_csi_driver
+      dlioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
   )
   buckets = [dlioWorkload.bucket for dlioWorkload in dlioWorkloads]
   role = 'roles/storage.objectUser'

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -212,7 +212,7 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
 
 
 def FioChartNamePodName(
-    fioWorkload: FioWorkload, instanceID: str, readType: str
+    fioWorkload: FioWorkload, experimentID: str, readType: str
 ) -> (str, str, str):
   shortenScenario = {
       'local-ssd': 'ssd',
@@ -230,11 +230,11 @@ def FioChartNamePodName(
       else 'ur'
   )
 
-  hashOfWorkload = str(hash((fioWorkload, instanceID, readType))).replace(
+  hashOfWorkload = str(hash((fioWorkload, experimentID, readType))).replace(
       '-', ''
   )
   return (
       f'fio-load-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
       f'fio-tester-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
-      f'{instanceID}/{fioWorkload.fileSize}-{fioWorkload.blockSize}-{fioWorkload.numThreads}-{fioWorkload.filesPerThread}-{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
+      f'{experimentID}/{fioWorkload.fileSize}-{fioWorkload.blockSize}-{fioWorkload.numThreads}-{fioWorkload.filesPerThread}-{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
   )

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -37,7 +37,7 @@ import fio_workload
 
 
 def createHelmInstallCommands(
-    fioWorkloads: set, instanceId: str, machineType: str, customCSIDriver: str
+    fioWorkloads: set, experimentID: str, machineType: str, customCSIDriver: str
 ) -> list:
   """Creates helm install commands for the given fioWorkload objects."""
   helm_commands = []
@@ -55,7 +55,7 @@ def createHelmInstallCommands(
     if fioWorkload.numEpochs > 0:
       for readType in fioWorkload.readTypes:
         chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
-            fioWorkload, instanceId, readType
+            fioWorkload, experimentID, readType
         )
         commands = [
             f'helm install {chartName} loading-test',
@@ -66,7 +66,7 @@ def createHelmInstallCommands(
             f'--set fio.blockSize={fioWorkload.blockSize}',
             f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
             f'--set fio.numThreads={fioWorkload.numThreads}',
-            f'--set instanceId={instanceId}',
+            f'--set experimentID={experimentID}',
             (
                 '--set'
                 f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
@@ -92,7 +92,7 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      fioWorkloads, args.instance_id, args.machine_type, args.custom_csi_driver
+      fioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
   )
   buckets = (fioWorkload.bucket for fioWorkload in fioWorkloads)
   role = 'roles/storage.objectUser'

--- a/perfmetrics/scripts/testing_on_gke/examples/run-automated.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-automated.sh
@@ -63,10 +63,10 @@ if test -z "${gcsfuse_branch}"; then
 fi
 export pod_wait_time_in_seconds=300
 export pod_timeout_in_seconds=64800
-# Pass instance_id from outside to continue previous run, if it got terminated
+# Pass experiment_id from outside to continue previous run, if it got terminated
 # somehow (timeout of ssh etc.)
-if test -z ${instance_id}; then
-  export instance_id=$(echo ${USER} | sed 's/_google//' | sed 's/_com//')-$(date +%Y%m%d-%H%M%S)
+if test -z ${experiment_id}; then
+  export experiment_id=$(echo ${USER} | sed 's/_google//' | sed 's/_com//')-$(date +%Y%m%d-%H%M%S)
 fi
 if test -z "${output_gsheet_id}"; then
   echo "output_gsheet_id has not been set."
@@ -94,7 +94,7 @@ echo "Run started at ${start_time}"
 touch log
 (./run-gke-tests.sh --debug |& tee -a log) || true
 # Use the following if you want to run it in a tmux session instead.
-# tmux new-session -d -s ${instance_id} 'bash -c "(./run-gke-tests.sh --debug |& tee -a log); sleep 604800 "'
+# tmux new-session -d -s ${experiment_id} 'bash -c "(./run-gke-tests.sh --debug |& tee -a log); sleep 604800 "'
 end_time=$(date +%Y-%m-%dT%H:%M:%SZ)
 echo "Run ended at ${end_time}"
 
@@ -114,7 +114,7 @@ if test -z "${output_bucket}"; then
   echo "output_bucket has not been set."
   exit 1
 fi
-output_path_uri=gs://${output_bucket}/outputs/${instance_id}
+output_path_uri=gs://${output_bucket}/outputs/${experiment_id}
 for file in fio/output.csv dlio/output.csv log run-gke-tests.sh workloads.json gcsfuse_commithash gcs_fuse_csi_driver_commithash; do
   if test -f ${file} ; then
     gcloud storage cp --content-type=text/text ${file} ${output_path_uri}/${file}

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -71,18 +71,18 @@ readonly DEFAULT_BQ_PROJECT_ID='gcs-fuse-test-ml'
 readonly DEFAULT_BQ_DATASET_ID='gke_test_tool_outputs'
 readonly DEFAULT_BQ_TABLE_ID='fio_outputs'
 
-# Create and return a unique instance_id taking
-# into account user's passed instance_id.
-function create_unique_instance_id() {
+# Create and return a unique experiment_id taking
+# into account user's passed experiment_id.
+function create_unique_experiment_id() {
   new_uuid=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
-  local generated_unique_instance_id=${USER}-$(date +%Y%m%d-%H%M%S)-${new_uuid}
+  local generated_unique_experiment_id=${USER}-$(date +%Y%m%d-%H%M%S)-${new_uuid}
   if [ $# -gt 0 ] && [ -n "${1}" ]; then
-    local user_provided_instance_id="${1}"
-    instance_id=${user_provided_instance_id// /-}"-"${generated_unique_instance_id}
+    local user_provided_experiment_id="${1}"
+    experiment_id=${user_provided_experiment_id// /-}"-"${generated_unique_experiment_id}
   else
-    instance_id=${generated_unique_instance_id}
+    experiment_id=${generated_unique_experiment_id}
   fi
-  echo "${instance_id}"
+  echo "${experiment_id}"
 }
 
 function printHelp() {
@@ -111,7 +111,7 @@ function printHelp() {
   # Test runtime configuration
   echo "pod_wait_time_in_seconds=<number e.g. 60 for checking pod status every 1 min, default=\"${DEFAULT_POD_WAIT_TIME_IN_SECONDS}\">"
   echo "pod_timeout_in_seconds=<number e.g. 3600 for timing out pod runs, should be more than the value of pod_wait_time_in_seconds, default=\"${DEFAULT_POD_TIMEOUT_IN_SECONDS}\">"
-  echo "instance_id=<Optional description of this particular test-run, it does not need to be unique e.g. \"cache test #43\""
+  echo "experiment_id=<Optional description of this particular test-run, it does not need to be unique e.g. \"cache test #43\""
   echo "workload_config=<path/to/workload/configuration/file e.g. /a/b/c.json >"
   echo "output_dir=</absolute/path/to/output/dir, output files will be written at output_dir/fio/output.csv and output_dir/dlio/output.csv>"
   echo "force_update_gcsfuse_code=<true|false, to force-update the gcsfuse-code to given branch if gcsfuse_src_dir has been set. Default=\"${DEFAULT_FORCE_UPDATE_GCSFUSE_CODE}\">"
@@ -238,16 +238,16 @@ elif [ "$only_parse" != "true" ] && [ "$only_parse" != "false" ]; then
   exitWithError "Unexpected value of only_parse: ${only_parse}. Expected: true or false ."
 fi
 
-# If user passes only_parse=true, then expect an instance_id
+# If user passes only_parse=true, then expect an experiment_id
 # also with it, and use it as it is.
 if ${only_parse}; then
-  if [ -z "${instance_id}" ]; then
-    exitWithError "instance_id not passed with only_parse=true"
+  if [ -z "${experiment_id}" ]; then
+    exitWithError "experiment_id not passed with only_parse=true"
   fi
 else
-  # create a new instance_id
-  export user_passed_instance_id="${instance_id}"
-  export instance_id=$(create_unique_instance_id "${user_passed_instance_id}")
+  # create a new experiment_id
+  export user_passed_experiment_id="${experiment_id}"
+  export experiment_id=$(create_unique_experiment_id "${user_passed_experiment_id}")
 fi
 
 if [[ ${pod_timeout_in_seconds} -le ${pod_wait_time_in_seconds} ]]; then
@@ -304,7 +304,7 @@ function printRunParameters() {
   # Test runtime configuration
   echo "pod_wait_time_in_seconds=\"${pod_wait_time_in_seconds}\""
   echo "pod_timeout_in_seconds=\"${pod_timeout_in_seconds}\""
-  echo "instance_id=User passed: \"${user_passed_instance_id}\", internally created: \"${instance_id}\""
+  echo "experiment_id=User passed: \"${user_passed_experiment_id}\", internally created: \"${experiment_id}\""
   echo "workload_config=\"${workload_config}\""
   echo "output_dir=\"${output_dir}\""
   echo "force_update_gcsfuse_code=\"${force_update_gcsfuse_code}\""
@@ -682,14 +682,14 @@ function deleteAllPods() {
 function deployAllFioHelmCharts() {
   printf "\nDeploying all fio helm charts ...\n\n"
   cd "${gke_testing_dir}"/examples/fio
-  python3 ./run_tests.py --workload-config "${workload_config}" --instance-id ${instance_id} --machine-type="${machine_type}" --project-id=${project_id} --project-number=${project_number} --namespace=${appnamespace} --ksa=${ksa} --custom-csi-driver=${applied_custom_csi_driver}
+  python3 ./run_tests.py --workload-config "${workload_config}" --experiment-id ${experiment_id} --machine-type="${machine_type}" --project-id=${project_id} --project-number=${project_number} --namespace=${appnamespace} --ksa=${ksa} --custom-csi-driver=${applied_custom_csi_driver}
   cd -
 }
 
 function deployAllDlioHelmCharts() {
   printf "\nDeploying all dlio helm charts ...\n\n"
   cd "${gke_testing_dir}"/examples/dlio
-  python3 ./run_tests.py --workload-config "${workload_config}" --instance-id ${instance_id} --machine-type="${machine_type}" --project-id=${project_id} --project-number=${project_number} --namespace=${appnamespace} --ksa=${ksa} --custom-csi-driver=${applied_custom_csi_driver}
+  python3 ./run_tests.py --workload-config "${workload_config}" --experiment-id ${experiment_id} --machine-type="${machine_type}" --project-id=${project_id} --project-number=${project_number} --namespace=${appnamespace} --ksa=${ksa} --custom-csi-driver=${applied_custom_csi_driver}
 
   cd -
 }
@@ -729,7 +729,7 @@ function waitTillAllPodsComplete() {
     else
       message="\n${num_noncompleted_pods} pod(s) is/are still pending/running (time till timeout=${time_till_timeout} seconds). Will check again in "${pod_wait_time_in_seconds}" seconds. Sleeping for now.\n\n"
       message+="\nYou can take a break too if you want. Just kill this run and connect back to it later, for fetching and parsing outputs, using the following command: \n\n"
-      message+="   only_parse=true instance_id=${instance_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type}"
+      message+="   only_parse=true experiment_id=${experiment_id} project_id=${project_id} project_number=${project_number} zone=${zone} machine_type=${machine_type}"
       message+=" use_custom_csi_driver=${use_custom_csi_driver}"
       if test -n "${custom_csi_driver}"; then
         message+=" custom_csi_driver=${custom_csi_driver}"
@@ -758,7 +758,7 @@ function waitTillAllPodsComplete() {
   done
 }
 
-# Download all the fio workload outputs for the current instance-id from the
+# Download all the fio workload outputs for the current experiment-id from the
 # given bucket and file-size.
 function downloadFioOutputsFromBucket() {
   local bucket=$1
@@ -781,10 +781,10 @@ function downloadFioOutputsFromBucket() {
   # Return to original directory.
   cd - >/dev/null
 
-  # If the given bucket has the fio outputs for the given instance-id, then
+  # If the given bucket has the fio outputs for the given experiment-id, then
   # copy/download them locally to the appropriate folder.
-  src_dir="${mountpath}/fio-output/${instance_id}"
-  dst_dir="${gcsfuse_src_dir}/perfmetrics/scripts/testing_on_gke/bin/fio-logs/${instance_id}/${fileSize}"
+  src_dir="${mountpath}/fio-output/${experiment_id}"
+  dst_dir="${gcsfuse_src_dir}/perfmetrics/scripts/testing_on_gke/bin/fio-logs/${experiment_id}/${fileSize}"
   if test -d "${src_dir}" ; then
     mkdir -pv "${dst_dir}"
     echo "Copying files of type ${fileSize}* from \"${src_dir}\" to \"${dst_dir}/\" ... "
@@ -830,7 +830,7 @@ function areThereAnyDLIOWorkloads() {
 function fetchAndParseFioOutputs() {
   printf "\nFetching and parsing fio outputs ...\n\n"
   cd "${gke_testing_dir}"/examples/fio
-  parse_logs_args="--project-number=${project_number} --workload-config ${workload_config} --instance-id ${instance_id} --output-file ${output_dir}/fio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace} --bq-project-id=${DEFAULT_BQ_PROJECT_ID} --bq-dataset-id=${DEFAULT_BQ_DATASET_ID} --bq-table-id=${DEFAULT_BQ_TABLE_ID}"
+  parse_logs_args="--project-number=${project_number} --workload-config ${workload_config} --experiment-id ${experiment_id} --output-file ${output_dir}/fio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace} --bq-project-id=${DEFAULT_BQ_PROJECT_ID} --bq-dataset-id=${DEFAULT_BQ_DATASET_ID} --bq-table-id=${DEFAULT_BQ_TABLE_ID}"
   if ${zonal}; then
     python3 parse_logs.py ${parse_logs_args} --predownloaded-output-files
   else
@@ -842,7 +842,7 @@ function fetchAndParseFioOutputs() {
 function fetchAndParseDlioOutputs() {
   printf "\nFetching and parsing dlio outputs ...\n\n"
   cd "${gke_testing_dir}"/examples/dlio
-  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --instance-id ${instance_id} --output-file "${output_dir}"/dlio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace}
+  python3 parse_logs.py --project-number=${project_number} --workload-config "${workload_config}" --experiment-id ${experiment_id} --output-file "${output_dir}"/dlio/output.csv --project-id=${project_id} --cluster-name=${cluster_name} --namespace-name=${appnamespace}
   cd -
 }
 

--- a/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
+++ b/perfmetrics/scripts/testing_on_gke/examples/run-gke-tests.sh
@@ -71,6 +71,27 @@ readonly DEFAULT_BQ_PROJECT_ID='gcs-fuse-test-ml'
 readonly DEFAULT_BQ_DATASET_ID='gke_test_tool_outputs'
 readonly DEFAULT_BQ_TABLE_ID='fio_outputs'
 
+# Handle deprecated flags.
+# Maps from deprecated flags to the message to be shown for them.
+declare -A deprecated_flags=(
+  ["instance_id"]="Use experiment_id instead."
+)
+for deprecated_flag in "${!deprecated_flags[@]}" ; do
+  deprecated_flag_value=${!deprecated_flag}
+  if test -n "${deprecated_flag_value}" ; then
+    # Special case handling. If instance_id is set, but experiment_id is not
+    # set, then let this be only an error message and copy the value of
+    # instance_id to experiment_id.
+    if [ "${deprecated_flag}"="instance_id" ] && test -z "${experiment_id}" ; then
+      echoerror "${deprecated_flag} is now deprecated, but passed with value \"${deprecated_flag_value}\". In future, please use experiment_id instead. For now, setting experiment_id=\"${instance_id}\" ."
+      export experiment_id="${instance_id}"
+      unset instance_id
+    else
+      exitWithError "${deprecated_flag} is now deprecated, but passed with value \"${deprecated_flag_value}\". ${deprecated_flags[${deprecated_flag}]}"
+    fi
+  fi
+done
+
 # Create and return a unique experiment_id taking
 # into account user's passed experiment_id.
 function create_unique_experiment_id() {

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/parse_logs_common.py
@@ -96,7 +96,7 @@ def parse_arguments(
       required=True,
   )
   parser.add_argument(
-      "--instance-id",
+      "--experiment-id",
       help="unique string ID for current test-run",
       required=True,
   )

--- a/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/utils/run_tests_common.py
@@ -56,7 +56,7 @@ def parse_args():
       required=True,
   )
   parser.add_argument(
-      '--instance-id',
+      '--experiment-id',
       metavar='A unique string ID to represent the test-run',
       help=(
           'Set to a unique string ID for current test-run. Do not put spaces'
@@ -119,7 +119,7 @@ def parse_args():
 
   args = parser.parse_args()
   for argument in [
-      'instance_id',
+      'experiment_id',
       'machine_type',
       'project_id',
       'namespace',


### PR DESCRIPTION
### Description
1. Rename instance-id to experiment-id for consistency everywhere. During design review for BQ integration, one of the strong suggestions was to use the name experiment-id instead of instance-id, so I had used experiment-id in the BQ table. This is a follow-up to it to make it consistent throughout.
2. If user passes instance-id, put an error log and use its value as experiment-id
3. If user passes both instance-id and experiment-id, throw an error.

### Link to the issue in case of a bug fix.
[b/412923482](http://b/412923482)

### Testing details
1. Manual - NA
4. Unit tests - NA
5. Integration tests - NA

### Any backward incompatible change? If so, please explain.
