### PR TITLE
[testing-on-gke] Don't re-insert entries for already inserted experiment_id to the BQ table

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -243,19 +243,16 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
               f'\n   row: {repr(row_to_insert)}\n   Error: {error}'
           )
 
-  def insert_rows(self, fioTableRows: [], experiment_id: str = None):
+  def insert_rows(self, fioTableRows: []):
     """Pass a list of FioTableRow objects to insert into the fio-table.
 
     This inserts all the given rows of data in a single transaction.
     It is expected and verified that all the rows being inserted have the same
-    experiment_id.
+    experiment_id (determined from the first row).
 
     Arguments:
 
     fioTableRows: a list of FioTableRow objects.
-    experiment_id: experiment_id associated with all the rows.
-    If experiment_id not passed, it is determined from the
-    first row.
 
     Raises:
       Exception: If some row insertion failed.
@@ -270,10 +267,9 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     # values, then divide the rows into K batches each with homogeneous
     # experiment_id and then insert only those batches whose experiment_id's
     # are not there in the table already.
+    experiment_id = fioTableRows[0].experiment_id
     if not experiment_id:
-      experiment_id = fioTableRows[0].experiment_id
-      if not experiment_id:
-        raise Exception('experiment_id is null for first row')
+      raise Exception('experiment_id is null for first row')
     # Confirm that all the rows for insertion have the correct experiment_id.
     for row in fioTableRows:
       if row.experiment_id != experiment_id:

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -204,6 +204,16 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     results = self.client.query_and_wait(query)
     return results.total_rows if results else 0
 
+  def _has_experiment_id(self, experiment_id: str) -> bool:
+    """Returns true if the current BQ table has any rows for the given experiment_id."""
+    query = (
+        'select count(*) as num_rows from'
+        f' {self.project_id}.{self.dataset_id}.{self.table_id} where'
+        f" experiment_id='{experiment_id}' group by experiment_id"
+    )
+    results = self.client.query_and_wait(query)
+    return results and results.total_rows > 0
+
   def _insert_rows_with_retry(self, table, rows_to_insert: []):
     """Inserts given rows to the given table in a single transaction.
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -266,7 +266,16 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
       return
     if not experiment_id:
       experiment_id = fioTableRows[0].experiment_id
-    if experiment_id and self._has_experiment_id(experiment_id):
+      if not experiment_id:
+        raise Exception('experiment_id is null for first row')
+    # confirm that all the rows for insertion have the correct experiment_id.
+    for row in fioTableRows:
+      if row.experiment_id != experiment_id:
+        raise Exception(
+            'There is a mismatch in the experiment_id for a row. Expected:'
+            f' {experiment_id}, Got: {row.experiment_id}'
+        )
+    if self._has_experiment_id(experiment_id):
       print(
           'Bigquery table'
           f' {self.project_id}.{self.dataset_id}.{self.table_id} already has'

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils.py
@@ -287,7 +287,7 @@ class FioBigqueryExporter(ExperimentsGCSFuseBQ):
     # table.
     if self._has_experiment_id(experiment_id):
       print(
-          'Bigquery table'
+          'Warning: Bigquery table'
           f' {self.project_id}.{self.dataset_id}.{self.table_id} already has'
           f' the experiment_id {experiment_id}, so skipping inserting rows for'
           ' it..'

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -157,20 +157,14 @@ class BqUtilsTest(unittest.TestCase):
         self.fioBqExporter._has_experiment_id('invalid-experiment-id')
     )
 
-  def test_insert_rows_with_mismatched_experiment_id_1(self):
+  def test_insert_rows_with_unset_experiment_id(self):
     row = self.create_sample_fio_table_row()
     row.experiment_id = None
 
     with self.assertRaises(Exception):
       self.fioBqExporter.insert_rows([row])
 
-  def test_insert_rows_with_mismatched_experiment_id_2(self):
-    row = self.create_sample_fio_table_row()
-
-    with self.assertRaises(Exception):
-      self.fioBqExporter.insert_rows([row], experiment_id='mismatching-expt-id')
-
-  def test_insert_rows_with_mismatched_experiment_id_3(self):
+  def test_insert_rows_with_mismatched_experiment_ids(self):
     row1 = self.create_sample_fio_table_row()
     row1.experiment_id = 'expt-id-1'
     row2 = copy.deepcopy(row1)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -143,11 +143,36 @@ class BqUtilsTest(unittest.TestCase):
 
   def test_has_experiment_id(self):
     row = self.create_sample_fio_table_row()
+
     self.fioBqExporter.insert_rows([row])
+
     self.assertTrue(self.fioBqExporter._has_experiment_id(row.experiment_id))
+
     self.assertFalse(
         self.fioBqExporter._has_experiment_id('invalid-experiment-id')
     )
+
+  def test_insert_rows_with_mismatched_experiment_id_1(self):
+    row = self.create_sample_fio_table_row()
+    row.experiment_id = None
+
+    with self.assertRaises(Exception):
+      self.fioBqExporter.insert_rows([row])
+
+  def test_insert_rows_with_mismatched_experiment_id_2(self):
+    row = self.create_sample_fio_table_row()
+
+    with self.assertRaises(Exception):
+      self.fioBqExporter.insert_rows([row], experiment_id='mismatching-expt-id')
+
+  def test_insert_rows_with_mismatched_experiment_id_3(self):
+    row1 = self.create_sample_fio_table_row()
+    row1.experiment_id = 'expt-id-1'
+    row2 = copy.deepcopy(row1)
+    row2.experiment_id = 'expt-id-2'
+
+    with self.assertRaises(Exception):
+      self.fioBqExporter.insert_rows([row1, row2])
 
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -141,6 +141,14 @@ class BqUtilsTest(unittest.TestCase):
 
     self.assertEqual(self.fioBqExporter._num_rows(), orig_num_rows + 1)
 
+  def test_has_experiment_id(self):
+    row = self.create_sample_fio_table_row()
+    self.fioBqExporter.insert_rows([row])
+    self.assertTrue(self.fioBqExporter._has_experiment_id(row.experiment_id))
+    self.assertFalse(
+        self.fioBqExporter._has_experiment_id('invalid-experiment-id')
+    )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/bq_utils_test.py
@@ -146,8 +146,13 @@ class BqUtilsTest(unittest.TestCase):
 
     self.fioBqExporter.insert_rows([row])
 
+    # _has_experiment_id should return true for an experiment_id
+    # which has already been added to the table.
     self.assertTrue(self.fioBqExporter._has_experiment_id(row.experiment_id))
 
+  def test_has_experiment_id_negative(self):
+    # _has_experiment_id should return false for an experiment_id
+    # which has not been added to the table.
     self.assertFalse(
         self.fioBqExporter._has_experiment_id('invalid-experiment-id')
     )

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -411,7 +411,7 @@ def write_records_to_bq_table(
     return
 
   fioBqExporter = FioBigqueryExporter(bq_project_id, bq_dataset_id, bq_table_id)
-  fioBqExporter.insert_rows(fioTableRows=rows, experiment_id=experiment_id)
+  fioBqExporter.insert_rows(fioTableRows=rows)
   print(
       "\nSuccessfully exported outputs of FIO test runs to"
       f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_id} !!!\n"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/parse_logs.py
@@ -411,7 +411,7 @@ def write_records_to_bq_table(
     return
 
   fioBqExporter = FioBigqueryExporter(bq_project_id, bq_dataset_id, bq_table_id)
-  fioBqExporter.insert_rows(fioTableRows=rows)
+  fioBqExporter.insert_rows(fioTableRows=rows, experiment_id=experiment_id)
   print(
       "\nSuccessfully exported outputs of FIO test runs to"
       f" BigQuery table {bq_project_id}:{bq_dataset_id}.{bq_table_id} !!!\n"


### PR DESCRIPTION
### Description
This detects if the data for the given experiment_id is already present in the BQ table, and skips inserting rows for it if so.

This is dependent on https://github.com/GoogleCloudPlatform/gcsfuse/pull/3282 for unit test code.

### Link to the issue in case of a bug fix.
[b/412923482](http://b/412923482)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
