### PR TITLE
 Limit blocks for streaming writes; fallback to staged writes

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -15,10 +15,13 @@
 package block
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/sync/semaphore"
 )
+
+var CantAllocateAnyBlockError error = errors.New("cant allocate any streaming write block as global max blocks limit is reached")
 
 // BlockPool handles the creation of blocks as per the user configuration.
 type BlockPool struct {
@@ -53,7 +56,12 @@ func NewBlockPool(blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphor
 		totalBlocks:        0,
 		globalMaxBlocksSem: globalMaxBlocksSem,
 	}
-	return
+	semAcquired := bp.globalMaxBlocksSem.TryAcquire(1)
+	if semAcquired == false {
+		return nil, CantAllocateAnyBlockError
+	}
+
+	return bp, nil
 }
 
 // Get returns a block. It returns an existing block if it's ready for reuse or
@@ -89,7 +97,8 @@ func (bp *BlockPool) canAllocateBlock() bool {
 		return false
 	}
 
-	// Always allow allocation if this is the first block for the file.
+	// Always allow allocation if this is the first block for the file since it has been reserved at
+	// the time of block pool creation.
 	if bp.totalBlocks == 0 {
 		return true
 	}
@@ -119,9 +128,7 @@ func (bp *BlockPool) ClearFreeBlockChannel() error {
 				return fmt.Errorf("munmap error: %v", err)
 			}
 			bp.totalBlocks--
-			if bp.totalBlocks != 0 {
-				bp.globalMaxBlocksSem.Release(1)
-			}
+			bp.globalMaxBlocksSem.Release(1)
 		default:
 			// Return if there are no more blocks on the channel.
 			return nil

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -57,7 +57,7 @@ func NewBlockPool(blockSize int64, maxBlocks int64, globalMaxBlocksSem *semaphor
 		globalMaxBlocksSem: globalMaxBlocksSem,
 	}
 	semAcquired := bp.globalMaxBlocksSem.TryAcquire(1)
-	if semAcquired == false {
+	if !semAcquired {
 		return nil, CantAllocateAnyBlockError
 	}
 

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -132,17 +132,17 @@ func (t *BlockPoolTest) TestBlockSize() {
 func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 	tests := []struct {
 		name                     string
-		clearLastBlock           bool
+		releaseLastBlock         bool
 		possibleSemaphoreAcquire int64
 	}{
 		{
-			name:                     "clear_last_block_true",
-			clearLastBlock:           true,
+			name:                     "release_last_block_true",
+			releaseLastBlock:         true,
 			possibleSemaphoreAcquire: 4,
 		},
 		{
-			name:                     "clear_last_block_false",
-			clearLastBlock:           false,
+			name:                     "release_last_block_false",
+			releaseLastBlock:         false,
 			possibleSemaphoreAcquire: 3,
 		},
 	}
@@ -161,7 +161,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 			}
 			require.Equal(t.T(), int64(4), bp.totalBlocks)
 
-			err = bp.ClearFreeBlockChannel(tt.clearLastBlock)
+			err = bp.ClearFreeBlockChannel(tt.releaseLastBlock)
 
 			require.Nil(t.T(), err)
 			require.EqualValues(t.T(), 0, bp.totalBlocks)

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -130,7 +130,7 @@ func (t *BlockPoolTest) TestBlockSize() {
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannel() {
-	bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(3))
+	bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(4))
 	require.Nil(t.T(), err)
 	blocks := make([]Block, 4)
 	for i := 0; i < 4; i++ {
@@ -154,25 +154,33 @@ func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 	require.False(t.T(), bp.globalMaxBlocksSem.TryAcquire(1))
 }
 
-func (t *BlockPoolTest) TestFirstBlockIsCreatedWithoutAcquiringGlobalSem() {
-	bp, err := NewBlockPool(1024, 3, semaphore.NewWeighted(0))
+func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
+	globalBlocksSem := semaphore.NewWeighted(1)
+
+	bp, err := NewBlockPool(1024, 3, globalBlocksSem)
+
 	require.Nil(t.T(), err)
+	// Validate that semaphore got acquired.
+	acquired := globalBlocksSem.TryAcquire(1)
+	assert.False(t.T(), acquired)
+	// Validate that 1st block can be created as it was reserved.
 	b1, err := bp.Get()
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), b1)
-	// Adding block to freeBlocksCh
+	// Validate that adding block to freeBlocksCh and clearing it up releases the semaphore
 	bp.freeBlocksCh <- b1
 	require.Equal(t.T(), int64(1), bp.totalBlocks)
-
 	err = bp.ClearFreeBlockChannel()
-
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(0), bp.totalBlocks)
 	require.Nil(t.T(), b1.(*memoryBlock).buffer)
+	// Validate that semaphore can be acquired now.
+	acquired = globalBlocksSem.TryAcquire(1)
+	assert.True(t.T(), acquired)
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
-	globalMaxBlocksSem := semaphore.NewWeighted(1)
+	globalMaxBlocksSem := semaphore.NewWeighted(3)
 	bp1, err := NewBlockPool(1024, 3, globalMaxBlocksSem)
 	require.Nil(t.T(), err)
 	bp2, err := NewBlockPool(1024, 3, globalMaxBlocksSem)
@@ -205,27 +213,23 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 	require.Nil(t.T(), b4.(*memoryBlock).buffer)
 }
 
-func (t *BlockPoolTest) TestGetWhenGlobalMaxBlocksIsZero() {
+func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
 	bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(0))
-	require.Nil(t.T(), err)
 
-	// First block is allowed even with globalMaxBlocks being zero.
-	b1, err := bp.Get()
-	require.Nil(t.T(), err)
-	require.NotNil(t.T(), b1)
-	// We shouldn't be allowed to create another block.
-	t.validateGetBlockIsBlocked(bp)
+	require.Error(t.T(), err)
+	assert.Nil(t.T(), bp)
+	assert.ErrorContains(t.T(), err, CantAllocateAnyBlockError.Error())
 }
 
 func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
 	bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(2))
 	require.Nil(t.T(), err)
 
-	// 3 blocks can be created.
-	for i := 0; i < 3; i++ {
+	// 2 blocks can be created.
+	for i := 0; i < 2; i++ {
 		_ = t.validateGetBlockIsNotBlocked(bp)
 	}
-	require.Equal(t.T(), int64(3), bp.totalBlocks)
+	require.Equal(t.T(), int64(2), bp.totalBlocks)
 
 	t.validateGetBlockIsBlocked(bp)
 }

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -130,28 +130,49 @@ func (t *BlockPoolTest) TestBlockSize() {
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannel() {
-	bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(4))
-	require.Nil(t.T(), err)
-	blocks := make([]Block, 4)
-	for i := 0; i < 4; i++ {
-		blocks[i] = t.validateGetBlockIsNotBlocked(bp)
+	tests := []struct {
+		name                     string
+		clearLastBlock           bool
+		possibleSemaphoreAcquire int64
+	}{
+		{
+			name:                     "clear_last_block_true",
+			clearLastBlock:           true,
+			possibleSemaphoreAcquire: 4,
+		},
+		{
+			name:                     "clear_last_block_false",
+			clearLastBlock:           false,
+			possibleSemaphoreAcquire: 3,
+		},
 	}
-	// Adding 2 blocks to freeBlocksCh
-	bp.freeBlocksCh <- blocks[0]
-	bp.freeBlocksCh <- blocks[1]
-	require.Equal(t.T(), int64(4), bp.totalBlocks)
 
-	err = bp.ClearFreeBlockChannel()
+	for _, tt := range tests {
+		t.Run(tt.name, func() {
+			bp, err := NewBlockPool(1024, 10, semaphore.NewWeighted(4))
+			require.Nil(t.T(), err)
+			blocks := make([]Block, 4)
+			for i := 0; i < 4; i++ {
+				blocks[i] = t.validateGetBlockIsNotBlocked(bp)
+			}
+			// Adding all blocks to freeBlocksCh
+			for i := 0; i < 4; i++ {
+				bp.freeBlocksCh <- blocks[i]
+			}
+			require.Equal(t.T(), int64(4), bp.totalBlocks)
 
-	require.Nil(t.T(), err)
-	require.Equal(t.T(), int64(2), bp.totalBlocks)
-	require.Nil(t.T(), blocks[0].(*memoryBlock).buffer)
-	require.Nil(t.T(), blocks[1].(*memoryBlock).buffer)
-	require.NotNil(t.T(), blocks[2].(*memoryBlock).buffer)
-	require.NotNil(t.T(), blocks[3].(*memoryBlock).buffer)
-	// Check if semaphore is released correctly.
-	require.True(t.T(), bp.globalMaxBlocksSem.TryAcquire(2))
-	require.False(t.T(), bp.globalMaxBlocksSem.TryAcquire(1))
+			err = bp.ClearFreeBlockChannel(tt.clearLastBlock)
+
+			require.Nil(t.T(), err)
+			require.EqualValues(t.T(), 0, bp.totalBlocks)
+			for i := 0; i < 4; i++ {
+				require.Nil(t.T(), blocks[i].(*memoryBlock).buffer)
+			}
+			// Check if semaphore is released correctly.
+			require.True(t.T(), bp.globalMaxBlocksSem.TryAcquire(tt.possibleSemaphoreAcquire))
+			require.False(t.T(), bp.globalMaxBlocksSem.TryAcquire(1))
+		})
+	}
 }
 
 func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
@@ -170,7 +191,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
 	// Validate that adding block to freeBlocksCh and clearing it up releases the semaphore
 	bp.freeBlocksCh <- b1
 	require.Equal(t.T(), int64(1), bp.totalBlocks)
-	err = bp.ClearFreeBlockChannel()
+	err = bp.ClearFreeBlockChannel(true)
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(0), bp.totalBlocks)
 	require.Nil(t.T(), b1.(*memoryBlock).buffer)
@@ -195,7 +216,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 	// Freeing up bp1.
 	bp1.freeBlocksCh <- b1
 	bp1.freeBlocksCh <- b2
-	err = bp1.ClearFreeBlockChannel()
+	err = bp1.ClearFreeBlockChannel(true)
 	require.Nil(t.T(), err)
 	require.Nil(t.T(), b1.(*memoryBlock).buffer)
 	require.Nil(t.T(), b2.(*memoryBlock).buffer)
@@ -207,7 +228,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 	// Freeing up bp2.
 	bp2.freeBlocksCh <- b3
 	bp2.freeBlocksCh <- b4
-	err = bp2.ClearFreeBlockChannel()
+	err = bp2.ClearFreeBlockChannel(true)
 	require.Nil(t.T(), err)
 	require.Nil(t.T(), b3.(*memoryBlock).buffer)
 	require.Nil(t.T(), b4.(*memoryBlock).buffer)

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -205,12 +205,6 @@ func (wh *bufferedWriteHandlerImpl) Sync() (o *gcs.MinObject, err error) {
 			return nil, fmt.Errorf("could not upload entire data, expected offset %d, Got %d", wh.totalSize, o.Size)
 		}
 	}
-	// Release memory used by buffers.
-	err = wh.blockPool.ClearFreeBlockChannel()
-	if err != nil {
-		// Only logging an error in case of resource leak as upload succeeded.
-		logger.Errorf("blockPool.ClearFreeBlockChannel() failed during sync: %v", err)
-	}
 	err = wh.uploadHandler.UploadError()
 	if err != nil {
 		return nil, err

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -17,7 +17,6 @@ package bufferedwrites
 import (
 	"context"
 	"errors"
-	"math"
 	"strings"
 	"testing"
 	"time"
@@ -294,8 +293,7 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	assert.NoError(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-	totalBlocks := len(bwhImpl.blockPool.FreeBlocksChannel())
-	assert.True(testSuite.T(), 1 <= totalBlocks && totalBlocks <= 5)
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 	assert.Nil(testSuite.T(), o)
 }
 
@@ -343,8 +341,7 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			// Current block should also be uploaded.
 			assert.Nil(testSuite.T(), bwhImpl.current)
 			assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-			totalBlocks := len(bwhImpl.blockPool.FreeBlocksChannel())
-			assert.True(testSuite.T(), 1 <= totalBlocks && totalBlocks <= int(math.Ceil(float64(tc.numBlocks))))
+			assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
 			// Read the object from back door.
 			content, err := storageutil.ReadObject(context.Background(), bwhImpl.uploadHandler.bucket, bwhImpl.uploadHandler.objectName)
 			if tc.bucketType.Zonal {

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -17,6 +17,7 @@ package bufferedwrites
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -293,7 +294,8 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	assert.NoError(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	totalBlocks := len(bwhImpl.blockPool.FreeBlocksChannel())
+	assert.True(testSuite.T(), 1 <= totalBlocks && totalBlocks <= 5)
 	assert.Nil(testSuite.T(), o)
 }
 
@@ -333,7 +335,7 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			err = testSuite.bwh.Write(buffer, 0)
 			require.Nil(testSuite.T(), err)
 
-			// Wait for 3 blocks to upload successfully.
+			// Wait for blocks to upload successfully.
 			o, err := testSuite.bwh.Sync()
 
 			require.NoError(testSuite.T(), err)
@@ -341,7 +343,8 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			// Current block should also be uploaded.
 			assert.Nil(testSuite.T(), bwhImpl.current)
 			assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-			assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+			totalBlocks := len(bwhImpl.blockPool.FreeBlocksChannel())
+			assert.True(testSuite.T(), 1 <= totalBlocks && totalBlocks <= int(math.Ceil(float64(tc.numBlocks))))
 			// Read the object from back door.
 			content, err := storageutil.ReadObject(context.Background(), bwhImpl.uploadHandler.bucket, bwhImpl.uploadHandler.objectName)
 			if tc.bucketType.Zonal {

--- a/internal/fs/stale_file_handle_streaming_writes_common_test.go
+++ b/internal/fs/stale_file_handle_streaming_writes_common_test.go
@@ -15,6 +15,8 @@
 package fs_test
 
 import (
+	"math"
+
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +42,7 @@ func (t *staleFileHandleStreamingWritesCommon) SetupSuite() {
 	serverCfg.Write.EnableStreamingWrites = true
 	serverCfg.Write.BlockSizeMb = operations.MiB
 	serverCfg.Write.MaxBlocksPerFile = 1
+	serverCfg.Write.GlobalMaxBlocks = math.MaxInt
 
 	t.serverCfg.NewConfig = serverCfg
 	t.mountCfg.DisableWritebackCaching = true


### PR DESCRIPTION
### Description
This PR ensures streaming writes respect the `--write-global-max-blocks` limit. Previously, streaming writes could create at least 1 block per file, ignoring this global cap. This one block was not counted towards the global limit. Now this block will be reserved at the time of block pool creation.

Now, if a file needs a new block but global-max-blocks is reached, GCSFuse will not create buffered write handler and use disk staged writes.

This change significantly improves resource management and stability by preventing uncontrolled block creation.

Limits and flag changes will be done in subsequent PR.

### Link to the issue in case of a bug fix.
b/417094016

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - existing tests WAI

### Any backward incompatible change? If so, please explain.
NA
