### PR TITLE
Script to find micro benchmarks for writing file with single thread 

### DIFF
--- a/perfmetrics/scripts/micro_benchmarks/read_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/read_single_thread.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 import subprocess
 import time
 import argparse
@@ -129,6 +130,8 @@ def main():
     print(f"Total bytes read from {args.total_files} files: {total_bytes}")
   except RuntimeError as e:
     print(f"Failed during file read: {e}")
+    helper.unmount_gcs_directory(MOUNT_DIR)
+    sys.exit(1)  # Exit with error status
   duration = time.time() - start
 
   # Unmount after test

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
@@ -21,13 +21,30 @@ MOUNT_DIR = "gcs"
 FILE_PREFIX = "testfile"
 
 def delete_existing_file(file_path):
-  """Deletes the file if it exists."""
+  """
+  Deletes the file at the specified path if it exists.
+
+  Args:
+      file_path (str): The full path to the file to delete.
+
+  Returns:
+      None
+  """
   if os.path.exists(file_path):
     os.remove(file_path)
     print(f"{file_path} existed and was cleared.")
 
 def write_random_file(file_path, file_size_in_bytes):
-  """Creates a binary file of given size filled with random data."""
+  """
+  Creates a binary file filled with random data of the specified size.
+
+  Args:
+      file_path (str): The full path where the file should be created.
+      file_size_in_bytes (int): The size of the file in bytes.
+
+  Returns:
+      None
+  """
   with open(file_path, 'wb') as f:
     f.write(os.urandom(file_size_in_bytes))
   print(f"Created {file_path} of size {file_size_in_bytes / (1000 ** 3):.4f} GB")

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
@@ -1,0 +1,89 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import argparse
+import helper
+
+MOUNT_DIR = "gcs"
+FILE_PREFIX = "testfile_write"
+
+def create_files(num_files, file_size_in_gb, file_prefix="file"):
+  """
+  Creates a specified number of binary files with random data of a given size in GB.
+
+  Args:
+      num_files (int): Number of files to create.
+      file_size_in_gb (float): Size of each file in GB (base 10).
+      file_prefix (str): Prefix for the filenames.
+
+  Returns:
+      int | None: Total bytes written on success, None on failure.
+  """
+  total_bytes_written = 0
+  file_size_in_bytes = int(file_size_in_gb * (1000 ** 3))
+
+  for i in range(num_files):
+    file_path = os.path.join(MOUNT_DIR, f"{file_prefix}_{file_size_in_gb}_{i}.bin")
+
+    try:
+      if os.path.exists(file_path):
+        os.remove(file_path)
+        print(f"{file_path} existed and was cleared.")
+
+      with open(file_path, 'wb') as f:
+        f.write(os.urandom(file_size_in_bytes))
+        total_bytes_written += file_size_in_bytes
+
+      print(f"Created {file_path} of size {file_size_in_gb:.4f} GB")
+
+    except Exception as e:
+      print(f"Error creating file {file_path}: {e}")
+      return None
+
+  print(f"Total bytes written: {total_bytes_written / (1000**3):.4f} GB")
+  return total_bytes_written
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Measure GCS write bandwidth via gcsfuse.")
+  parser.add_argument("--bucket", required=True)
+  parser.add_argument("--gcsfuse-config", default="--implicit-dirs")
+  parser.add_argument("--total-files", type=int, default=1)
+  parser.add_argument("--file-size-gb", type=float)
+  args = parser.parse_args()
+
+  workflow_type = "WRITE_{args.total_files}_{args.file_size_gb}GB_SINGLE_THREAD"
+  helper.mount_bucket(MOUNT_DIR, args.bucket, args.gcsfuse_config)
+
+  print(f"Starting write of {args.total_files} files...")
+  start = time.time()
+  try:
+    total_bytes = create_files(args.total_files, args.file_size_gb, FILE_PREFIX)
+  except RuntimeError as e:
+    print(f"Failed during file write: {e}")
+  duration = time.time() - start
+
+  helper.unmount_gcs_directory(MOUNT_DIR)
+
+  helper.log_to_bigquery(
+      duration_sec=duration,
+      total_bytes=total_bytes,
+      gcsfuse_config=args.gcsfuse_config,
+      workload_type=workflow_type,
+  )
+
+if __name__ == "__main__":
+  main()

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
@@ -20,14 +20,13 @@ import helper
 MOUNT_DIR = "gcs"
 FILE_PREFIX = "testfile_write"
 
-def create_files(num_files, file_size_in_gb, file_prefix="file"):
+def create_files(num_files, file_size_in_gb):
   """
   Creates a specified number of binary files with random data of a given size in GB.
 
   Args:
       num_files (int): Number of files to create.
       file_size_in_gb (float): Size of each file in GB (base 10).
-      file_prefix (str): Prefix for the filenames.
 
   Returns:
       int | None: Total bytes written on success, None on failure.
@@ -36,7 +35,7 @@ def create_files(num_files, file_size_in_gb, file_prefix="file"):
   file_size_in_bytes = int(file_size_in_gb * (1000 ** 3))
 
   for i in range(num_files):
-    file_path = os.path.join(MOUNT_DIR, f"{file_prefix}_{file_size_in_gb}_{i}.bin")
+    file_path = os.path.join(MOUNT_DIR, f"{FILE_PREFIX}_{file_size_in_gb}_{i}.bin")
 
     try:
       if os.path.exists(file_path):
@@ -71,7 +70,7 @@ def main():
   print(f"Starting write of {args.total_files} files...")
   start = time.time()
   try:
-    total_bytes = create_files(args.total_files, args.file_size_gb, FILE_PREFIX)
+    total_bytes = create_files(args.total_files, args.file_size_gb)
   except RuntimeError as e:
     print(f"Failed during file write: {e}")
   duration = time.time() - start

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
@@ -21,7 +21,7 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("write_single_thread.os.remove")
   @mock.patch("write_single_thread.os.path.exists", return_value=False)
   def test_create_files_success(self, mock_exists, mock_remove, mock_open, mock_urandom):
-    result = create_files(2, 1e-7, file_prefix="test")  # Small size to avoid memory issues
+    result = create_files(2, 1e-7)  # Small size to avoid memory issues
 
     self.assertIsInstance(result, int)
     self.assertGreater(result, 0)
@@ -33,7 +33,7 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("write_single_thread.os.remove", side_effect=PermissionError("Cannot remove"))
   @mock.patch("write_single_thread.os.path.exists", return_value=True)
   def test_create_files_remove_failure(self, mock_exists, mock_remove, mock_open, mock_urandom):
-    result = create_files(1, 1e-7, file_prefix="test")
+    result = create_files(1, 1e-7)
 
     self.assertIsNone(result)
     mock_remove.assert_called_once()
@@ -43,7 +43,7 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("write_single_thread.os.remove")
   @mock.patch("write_single_thread.os.path.exists", return_value=False)
   def test_create_files_write_failure(self, mock_exists, mock_remove, mock_open, mock_urandom):
-    result = create_files(1, 1e-7, file_prefix="test")
+    result = create_files(1, 1e-7)
 
     self.assertIsNone(result)
     mock_open.assert_called_once()

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
@@ -21,6 +21,7 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("os.remove")
   def test_delete_existing_file(self, mock_remove, mock_exists):
     delete_existing_file("/tmp/testfile.bin")
+
     mock_remove.assert_called_once_with("/tmp/testfile.bin")
 
   @mock.patch("os.urandom", return_value=b"x" * 1024)
@@ -28,6 +29,7 @@ class TestWriteFiles(unittest.TestCase):
   def test_write_random_file(self, mock_open_file, mock_urandom):
     file_path = "/tmp/testfile.bin"
     size = 1024
+
     write_random_file(file_path, size)
 
     mock_open_file.assert_called_once_with(file_path, 'wb')
@@ -37,8 +39,9 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("builtins.open", new_callable=mock.mock_open)
   def test_create_files_success(self, mock_open_file, mock_urandom):
     paths = ["/tmp/file1.bin", "/tmp/file2.bin"]
-    total = create_files(paths, file_size_in_gb=1e-8)  # ~10 bytes each
     expected_total = 20  # 2 files * 10 bytes
+
+    total = create_files(paths, file_size_in_gb=1e-8)  # ~10 bytes each
 
     self.assertEqual(total, expected_total)
     self.assertEqual(mock_open_file.call_count, 2)
@@ -46,7 +49,9 @@ class TestWriteFiles(unittest.TestCase):
   @mock.patch("builtins.open", side_effect=Exception("write error"))
   def test_create_files_failure(self, mock_open_file):
     paths = ["/tmp/file1.bin"]
+
     total = create_files(paths, file_size_in_gb=1e-8)
+
     self.assertIsNone(total)
 
 if __name__ == '__main__':

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread_test.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from unittest import mock
+from write_single_thread import  create_files
+
+class TestWriteFiles(unittest.TestCase):
+  @mock.patch("write_single_thread.os.urandom", return_value=b"x" * 100)
+  @mock.patch("write_single_thread.open", new_callable=mock.mock_open)
+  @mock.patch("write_single_thread.os.remove")
+  @mock.patch("write_single_thread.os.path.exists", return_value=False)
+  def test_create_files_success(self, mock_exists, mock_remove, mock_open, mock_urandom):
+    result = create_files(2, 1e-7, file_prefix="test")  # Small size to avoid memory issues
+
+    self.assertIsInstance(result, int)
+    self.assertGreater(result, 0)
+    self.assertEqual(mock_open.call_count, 2)
+    mock_remove.assert_not_called()  # Because os.path.exists returned False
+
+  @mock.patch("write_single_thread.os.urandom", return_value=b"x" * 100)
+  @mock.patch("write_single_thread.open", new_callable=mock.mock_open)
+  @mock.patch("write_single_thread.os.remove", side_effect=PermissionError("Cannot remove"))
+  @mock.patch("write_single_thread.os.path.exists", return_value=True)
+  def test_create_files_remove_failure(self, mock_exists, mock_remove, mock_open, mock_urandom):
+    result = create_files(1, 1e-7, file_prefix="test")
+
+    self.assertIsNone(result)
+    mock_remove.assert_called_once()
+
+  @mock.patch("write_single_thread.os.urandom", return_value=b"x" * 100)
+  @mock.patch("write_single_thread.open", side_effect=OSError("Disk full"))
+  @mock.patch("write_single_thread.os.remove")
+  @mock.patch("write_single_thread.os.path.exists", return_value=False)
+  def test_create_files_write_failure(self, mock_exists, mock_remove, mock_open, mock_urandom):
+    result = create_files(1, 1e-7, file_prefix="test")
+
+    self.assertIsNone(result)
+    mock_open.assert_called_once()
+
+if __name__ == '__main__':
+  unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
### Description

1. Create function to create file of given size with single thread.
2. Calculate latency, bandwidth and log in big query table.
3. File size, Num of files can be passed through flags.

### Link to the issue in case of a bug fix.
[b/415708057](https://b.corp.google.com/issues/415708057)

### Testing details
1. Manual - Manually tested script
4. Unit tests - Added
5. Integration tests - NA

### Any backward incompatible change? If so, please explain.
