### PR TITLE
add tests for fall back to disk case when streaming writes are limited by global blocks

### DIFF
--- a/tools/integration_tests/streaming_writes/empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/empty_gcs_file_test.go
@@ -24,20 +24,20 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type defaultMountEmptyGCSFile struct {
-	defaultMountCommonTest
+type streamingWritesEmptyGCSFileTestSuite struct {
+	StreamingWritesSuite
 	suite.Suite
 }
 
-func (t *defaultMountEmptyGCSFile) SetupTest() {
+func (t *streamingWritesEmptyGCSFileTestSuite) SetupTest() {
 	t.createEmptyGCSFile()
 }
 
-func (t *defaultMountEmptyGCSFile) SetupSubTest() {
+func (t *streamingWritesEmptyGCSFileTestSuite) SetupSubTest() {
 	t.createEmptyGCSFile()
 }
 
-func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
+func (t *streamingWritesEmptyGCSFileTestSuite) createEmptyGCSFile() {
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	// Create an empty file on GCS.
 	CreateObjectInGCSTestDir(ctx, storageClient, testDirName, t.fileName, "", t.T())
@@ -47,8 +47,8 @@ func (t *defaultMountEmptyGCSFile) createEmptyGCSFile() {
 }
 
 // Executes all tests that run with single streamingWrites configuration for empty GCS Files.
-func TestDefaultMountEmptyGCSFileTest(t *testing.T) {
-	s := new(defaultMountEmptyGCSFile)
-	s.defaultMountCommonTest.TestifySuite = &s.Suite
+func TestEmptyGCSFileTestSuiteTest(t *testing.T) {
+	s := new(streamingWritesEmptyGCSFileTestSuite)
+	s.StreamingWritesSuite.TestifySuite = &s.Suite
 	suite.Run(t, s)
 }

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountCommonTest) TestReadFileAfterSync() {
+func (t *StreamingWritesSuite) TestReadFileAfterSync() {
 	// Write some content to the file.
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	assert.NoError(t.T(), err)
@@ -36,22 +36,18 @@ func (t *defaultMountCommonTest) TestReadFileAfterSync() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
-func (t *defaultMountCommonTest) TestReadBeforeFileIsFlushed() {
+func (t *StreamingWritesSuite) TestReadBeforeFileIsFlushed() {
 	// Write data to file.
 	operations.WriteAt(t.data, 0, t.f1, t.T())
 
 	// Try to read the file.
-	_, err := t.f1.Seek(0, 0)
-	require.NoError(t.T(), err)
-	buf := make([]byte, len(t.data))
-	_, err = t.f1.Read(buf)
+	t.validateReadCall(t.filePath)
 
-	require.Error(t.T(), err, "input/output error")
 	// Validate if correct content is uploaded to GCS after read error.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
-func (t *defaultMountCommonTest) TestReadAfterFlush() {
+func (t *StreamingWritesSuite) TestReadAfterFlush() {
 	// Write data to file and flush.
 	operations.WriteAt(t.data, 0, t.f1, t.T())
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())

--- a/tools/integration_tests/streaming_writes/rename_file_test.go
+++ b/tools/integration_tests/streaming_writes/rename_file_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountCommonTest) TestRenameBeforeFileIsFlushed() {
+func (t *StreamingWritesSuite) TestRenameBeforeFileIsFlushed() {
 	operations.WriteWithoutClose(t.f1, t.data, t.T())
 	operations.WriteWithoutClose(t.f1, t.data, t.T())
 	operations.VerifyStatFile(t.filePath, int64(2*len(t.data)), FilePerms, t.T())
@@ -42,7 +42,7 @@ func (t *defaultMountCommonTest) TestRenameBeforeFileIsFlushed() {
 	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
 }
 
-func (t *defaultMountCommonTest) TestSyncAfterRenameSucceeds() {
+func (t *StreamingWritesSuite) TestSyncAfterRenameSucceeds() {
 	_, err := t.f1.WriteAt([]byte(t.data), 0)
 	require.NoError(t.T(), err)
 	operations.VerifyStatFile(t.filePath, int64(len(t.data)), FilePerms, t.T())

--- a/tools/integration_tests/streaming_writes/setup_test.go
+++ b/tools/integration_tests/streaming_writes/setup_test.go
@@ -66,10 +66,10 @@ func TestMain(m *testing.M) {
 
 	// Define flag set to run the tests.
 	flagsSet := [][]string{
+		{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2", "--write-global-max-blocks=0"},
+		{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2", "--client-protocol=grpc"},
 		{"--rename-dir-limit=3", "--enable-streaming-writes=true", "--write-block-size-mb=1", "--write-max-blocks-per-file=2"},
 	}
-	// Run all tests for GRPC.
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--client-protocol=grpc", "")
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMounting

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileAndReadFromSymlink() {
+func (t *StreamingWritesSuite) TestCreateSymlinkForLocalFileAndReadFromSymlink() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())
@@ -40,7 +40,7 @@ func (t *defaultMountCommonTest) TestCreateSymlinkForLocalFileAndReadFromSymlink
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
 }
 
-func (t *defaultMountCommonTest) TestReadingFromSymlinkForDeletedLocalFile() {
+func (t *StreamingWritesSuite) TestReadingFromSymlinkForDeletedLocalFile() {
 	// Create Symlink.
 	symlink := path.Join(testDirPath, setup.GenerateRandomString(5))
 	operations.CreateSymLink(t.filePath, symlink, t.T())

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -127,7 +127,7 @@ func (t *StreamingWritesSuite) TestTruncateToLowerSizeAfterWrite() {
 	if t.fallbackToDiskCase {
 		require.NoError(t.T(), err)
 	} else {
-		// Truncating to lower size after writes are not allowed is buffered writes are used.
+		// Truncating to lower size after writes are not allowed if buffered writes are used.
 		require.Error(t.T(), err)
 		operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
 	}

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (t *defaultMountCommonTest) TestTruncate() {
+func (t *StreamingWritesSuite) TestTruncate() {
 	truncateSize := 2 * 1024 * 1024
 
 	err := t.f1.Truncate(int64(truncateSize))
@@ -34,7 +34,7 @@ func (t *defaultMountCommonTest) TestTruncate() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, string(data[:]), t.T())
 }
 
-func (t *defaultMountCommonTest) TestWriteAfterTruncate() {
+func (t *StreamingWritesSuite) TestWriteAfterTruncate() {
 	truncateSize := 10
 
 	testCases := []struct {
@@ -83,7 +83,7 @@ func (t *defaultMountCommonTest) TestWriteAfterTruncate() {
 
 }
 
-func (t *defaultMountCommonTest) TestWriteAndTruncate() {
+func (t *StreamingWritesSuite) TestWriteAndTruncate() {
 	var truncateSize int64 = 20
 	operations.WriteWithoutClose(t.f1, FileContents, t.T())
 	operations.VerifyStatFile(t.filePath, int64(len(FileContents)), FilePerms, t.T())
@@ -98,7 +98,7 @@ func (t *defaultMountCommonTest) TestWriteAndTruncate() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, FileContents+string(data[:]), t.T())
 }
 
-func (t *defaultMountCommonTest) TestWriteTruncateWrite() {
+func (t *StreamingWritesSuite) TestWriteTruncateWrite() {
 	truncateSize := 30
 
 	// Write
@@ -117,14 +117,18 @@ func (t *defaultMountCommonTest) TestWriteTruncateWrite() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, FileContents+FileContents+string(data[:]), t.T())
 }
 
-func (t *defaultMountCommonTest) TestTruncateToLowerSizeAfterWrite() {
+func (t *StreamingWritesSuite) TestTruncateToLowerSizeAfterWrite() {
 	// Write
 	operations.WriteWithoutClose(t.f1, FileContents+FileContents, t.T())
 	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
 	// Perform truncate
 	err := t.f1.Truncate(int64(5))
 
-	// Truncating to lower size after writes are not allowed.
-	require.Error(t.T(), err)
-	operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
+	if t.fallbackToDiskCase {
+		require.NoError(t.T(), err)
+	} else {
+		// Truncating to lower size after writes are not allowed is buffered writes are used.
+		require.Error(t.T(), err)
+		operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
+	}
 }

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -93,6 +93,9 @@ func getTokenSrc(path string) (tokenSrc oauth2.TokenSource, err error) {
 func ReadObjectFromGCS(ctx context.Context, client *storage.Client, object string) (string, error) {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
+	if client == nil {
+		return "", fmt.Errorf("client is nil")
+	}
 	// Create storage reader to read from GCS.
 	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {


### PR DESCRIPTION
### Description
This PR refactors existing streaming write tests and introduces a new flagset to execute these tests with zero global blocks. 0 global blocks are used here to ensure predictable behavior.

### Link to the issue in case of a bug fix.
b/417094016

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - added

### Any backward incompatible change? If so, please explain.
NA