### PR TITLE
add chunk transfer timeout for streaming writes uploads.

### DIFF
--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -102,8 +102,7 @@ func (uh *UploadHandler) Upload(block block.Block) error {
 
 // createObjectWriter creates a GCS object writer.
 func (uh *UploadHandler) createObjectWriter() (err error) {
-	// TODO: b/381479965: Dynamically set chunkTransferTimeoutSecs based on chunk size. 0 here means no timeout.
-	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, 0)
+	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, uh.chunkTransferTimeout)
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
 	var ctx context.Context

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -360,7 +360,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 				*req.MetaGenerationPrecondition == t.uh.obj.MetaGeneration &&
 				req.ContentEncoding == t.uh.obj.ContentEncoding &&
 				req.ContentType == t.uh.obj.ContentType &&
-				req.ChunkTransferTimeoutSecs == 0
+				req.ChunkTransferTimeoutSecs == chunkTransferTimeoutSecs
 		}),
 		mock.Anything,
 		mock.Anything).Return(writer, nil)
@@ -386,7 +386,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 			return req.Name == t.uh.objectName &&
 				*req.GenerationPrecondition == 0 &&
 				req.MetaGenerationPrecondition == nil &&
-				req.ChunkTransferTimeoutSecs == 0
+				req.ChunkTransferTimeoutSecs == chunkTransferTimeoutSecs
 		}),
 		mock.Anything,
 		mock.Anything).Return(writer, nil)


### PR DESCRIPTION
### Description
This PR adds chunk transfer timeout of streaming writes chunk uploads. The value for chunk transfer timeout for 32MiB is proposed to be same as previous 16MiB chunk transfer.
### Link to the issue in case of a bug fix.
b/381479965

### Experiments
go/gcsfuse-chunk-timeout-streaming-writes-http
go/gcsfuse-chunk-transfer-timeout

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
