### PR TITLE
Run inactive_stream_timeout test as part of CI/CD

### DIFF
--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -121,6 +121,11 @@ func TestTimeoutEnabledSuite(t *testing.T) {
 	}
 
 	flagsSet := []gcsfuseTestFlags{
+		{ // Test with timeout enabled and http1 client protocol
+			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
+			fileName:            "timeout_with_http.yaml",
+			clientProtocol:      kHTTP1ClientProtocol,
+		},
 		{ // Test with timeout enabled and grpc client protocol
 			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
 			fileName:            "timeout_with_grpc.yaml",

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -87,11 +87,6 @@ func TestTimeoutDisabledSuite(t *testing.T) {
 	}
 
 	flagsSet := []gcsfuseTestFlags{
-		{ // Test with timeout enabled and http1 client protocol
-			inactiveReadTimeout: kDefaultInactiveReadTimeoutInSeconds * time.Second,
-			fileName:            "timeout_with_http.yaml",
-			clientProtocol:      kHTTP1ClientProtocol,
-		},
 		{ // Test with timeout disabled
 			inactiveReadTimeout: 0 * time.Second, // Disable timeout
 			clientProtocol:      kHTTP1ClientProtocol,

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -106,6 +106,7 @@ TEST_DIR_PARALLEL=(
   "stale_handle"
   "negative_stat_cache"
   "streaming_writes"
+  "inactive_stream_timeout"
 )
 
 # These tests never become parallel as it is changing bucket permissions.


### PR DESCRIPTION
### Description
- Adapt e2e test for PR to extend the timeout feature for http client-protocol
- Integrate the test package as part of  GCSFuse CI/CD.

### Link to the issue in case of a bug fix.
b/418891989

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
