### PR TITLE
feat: cloud profiler support for cpu/heap/goroutines/mutex profiling

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -537,7 +537,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("profiling-mutex", "", false, "To enable/disable the mutex profiling. Only work when profiling is enabled.")
 
-	flagSet.StringP("profiling-version-tag", "", "", "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled.")
+	flagSet.StringP("profiling-version-tag", "", "gcsfuse-0.0.0", "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled.")
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -359,7 +359,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-cloud-profiling", "", false, "To enable/disable the cloud profiling, by default disabled")
+	flagSet.BoolP("enable-cloud-profiling", "", false, "To enable/disable the cloud profiling, by default disabled. Only work when profiling is enabled.")
 
 	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
 
@@ -527,17 +527,17 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("profile-allocated-heap", "", false, "Enable allocated heap (HeapProfileAllocs) profiling.")
+	flagSet.BoolP("profiling-allocated-heap", "", false, "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-cpu", "", false, "Enable CPU profiling.")
+	flagSet.BoolP("profiling-cpu", "", false, "To enable/disable the CPU profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-goroutines", "", false, "Enable goroutine profiling.")
+	flagSet.BoolP("profiling-goroutines", "", false, "To enable/disable the goroutine profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-heap", "", false, "Enable heap profiling.")
+	flagSet.BoolP("profiling-heap", "", false, "To enable/disable the heap profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-mutex", "", false, "Enable mutex (contention) profiling.")
+	flagSet.BoolP("profiling-mutex", "", false, "To enable/disable the mutex profiling. Only work when profiling is enabled.")
 
-	flagSet.StringP("profiling-version-tag", "", "", "Set the version tag for profiling data.")
+	flagSet.StringP("profiling-version-tag", "", "", "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled.")
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
@@ -912,7 +912,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("profiling.allocated-heap", flagSet.Lookup("profile-allocated-heap")); err != nil {
+	if err := v.BindPFlag("profiling.allocated-heap", flagSet.Lookup("profiling-allocated-heap")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -244,9 +244,9 @@ type ProfilingConfig struct {
 
 	Heap bool `yaml:"heap"`
 
-	Mutex bool `yaml:"mutex"`
+	Label string `yaml:"label"`
 
-	VersionTag string `yaml:"version-tag"`
+	Mutex bool `yaml:"mutex"`
 }
 
 type ReadConfig struct {
@@ -359,7 +359,11 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-cloud-profiling", "", false, "To enable/disable the cloud profiling, by default disabled. Only work when profiling is enabled.")
+	flagSet.BoolP("enable-cloud-profiling", "", false, "Enables cloud profiling, by default disabled.")
+
+	if err := flagSet.MarkHidden("enable-cloud-profiling"); err != nil {
+		return err
+	}
 
 	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
 
@@ -527,17 +531,41 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("profiling-allocated-heap", "", false, "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled.")
+	flagSet.BoolP("profiling-allocated-heap", "", true, "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-cpu", "", false, "To enable/disable the CPU profiling. Only work when profiling is enabled.")
+	if err := flagSet.MarkHidden("profiling-allocated-heap"); err != nil {
+		return err
+	}
 
-	flagSet.BoolP("profiling-goroutines", "", false, "To enable/disable the goroutine profiling. Only work when profiling is enabled.")
+	flagSet.BoolP("profiling-cpu", "", true, "To enable/disable the CPU profiling. Only work when profiling is enabled.")
 
-	flagSet.BoolP("profiling-heap", "", false, "To enable/disable the heap profiling. Only work when profiling is enabled.")
+	if err := flagSet.MarkHidden("profiling-cpu"); err != nil {
+		return err
+	}
 
-	flagSet.BoolP("profiling-mutex", "", false, "To enable/disable the mutex profiling. Only work when profiling is enabled.")
+	flagSet.BoolP("profiling-goroutines", "", false, "Enables goroutines profiling. This only works when --enable-cloud-profiling is set to true.")
 
-	flagSet.StringP("profiling-version-tag", "", "gcsfuse-0.0.0", "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled.")
+	if err := flagSet.MarkHidden("profiling-goroutines"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("profiling-heap", "", true, "Enables heap profiling. This only works when --enable-cloud-profiling is set to true.")
+
+	if err := flagSet.MarkHidden("profiling-heap"); err != nil {
+		return err
+	}
+
+	flagSet.StringP("profiling-label", "", "gcsfuse-0.0.0", "Allow setting a profile label to uniquely identify and compare profiling data with other profiles. This only works when --enable-cloud-profiling is set to true.  ")
+
+	if err := flagSet.MarkHidden("profiling-label"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("profiling-mutex", "", false, "Enables mutex profiling. This only works when --enable-cloud-profiling is set to true.")
+
+	if err := flagSet.MarkHidden("profiling-mutex"); err != nil {
+		return err
+	}
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
@@ -928,11 +956,11 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("profiling.mutex", flagSet.Lookup("profiling-mutex")); err != nil {
+	if err := v.BindPFlag("profiling.label", flagSet.Lookup("profiling-label")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiling.version-tag", flagSet.Lookup("profiling-version-tag")); err != nil {
+	if err := v.BindPFlag("profiling.mutex", flagSet.Lookup("profiling-mutex")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -66,7 +66,7 @@ type Config struct {
 
 	OnlyDir string `yaml:"only-dir"`
 
-	Profiler ProfilerConfig `yaml:"profiler"`
+	Profiling ProfilingConfig `yaml:"profiling"`
 
 	Read ReadConfig `yaml:"read"`
 
@@ -233,7 +233,7 @@ type MonitoringConfig struct {
 	ExperimentalTracingSamplingRatio float64 `yaml:"experimental-tracing-sampling-ratio"`
 }
 
-type ProfilerConfig struct {
+type ProfilingConfig struct {
 	AllocatedHeap bool `yaml:"allocated-heap"`
 
 	Cpu bool `yaml:"cpu"`
@@ -529,15 +529,15 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("profile-allocated-heap", "", false, "Enable allocated heap (HeapProfileAllocs) profiling.")
 
-	flagSet.BoolP("profile-cpu", "", false, "Enable CPU profiling.")
+	flagSet.BoolP("profiling-cpu", "", false, "Enable CPU profiling.")
 
-	flagSet.BoolP("profile-goroutines", "", false, "Enable goroutine profiling.")
+	flagSet.BoolP("profiling-goroutines", "", false, "Enable goroutine profiling.")
 
-	flagSet.BoolP("profile-heap", "", false, "Enable heap profiling.")
+	flagSet.BoolP("profiling-heap", "", false, "Enable heap profiling.")
 
-	flagSet.BoolP("profile-mutex", "", false, "Enable mutex (contention) profiling.")
+	flagSet.BoolP("profiling-mutex", "", false, "Enable mutex (contention) profiling.")
 
-	flagSet.StringP("profile-version-tag", "", "", "Set the version tag for profiling data.")
+	flagSet.StringP("profiling-version-tag", "", "", "Set the version tag for profiling data.")
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
@@ -716,7 +716,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.enabled", flagSet.Lookup("enable-cloud-profiling")); err != nil {
+	if err := v.BindPFlag("profiling.enabled", flagSet.Lookup("enable-cloud-profiling")); err != nil {
 		return err
 	}
 
@@ -912,27 +912,27 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.allocated-heap", flagSet.Lookup("profile-allocated-heap")); err != nil {
+	if err := v.BindPFlag("profiling.allocated-heap", flagSet.Lookup("profile-allocated-heap")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.cpu", flagSet.Lookup("profile-cpu")); err != nil {
+	if err := v.BindPFlag("profiling.cpu", flagSet.Lookup("profiling-cpu")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.goroutines", flagSet.Lookup("profile-goroutines")); err != nil {
+	if err := v.BindPFlag("profiling.goroutines", flagSet.Lookup("profiling-goroutines")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.heap", flagSet.Lookup("profile-heap")); err != nil {
+	if err := v.BindPFlag("profiling.heap", flagSet.Lookup("profiling-heap")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.mutex", flagSet.Lookup("profile-mutex")); err != nil {
+	if err := v.BindPFlag("profiling.mutex", flagSet.Lookup("profiling-mutex")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("profiler.version-tag", flagSet.Lookup("profile-version-tag")); err != nil {
+	if err := v.BindPFlag("profiling.version-tag", flagSet.Lookup("profiling-version-tag")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -531,13 +531,13 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("profiling-allocated-heap", "", true, "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled.")
+	flagSet.BoolP("profiling-allocated-heap", "", true, "Enables allocated heap (HeapProfileAllocs) profiling. This only works when --enable-cloud-profiling is set to true.")
 
 	if err := flagSet.MarkHidden("profiling-allocated-heap"); err != nil {
 		return err
 	}
 
-	flagSet.BoolP("profiling-cpu", "", true, "To enable/disable the CPU profiling. Only work when profiling is enabled.")
+	flagSet.BoolP("profiling-cpu", "", true, "Enables cpu profiling. This only works when --enable-cloud-profiling is set to true.")
 
 	if err := flagSet.MarkHidden("profiling-cpu"); err != nil {
 		return err

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -66,6 +66,8 @@ type Config struct {
 
 	OnlyDir string `yaml:"only-dir"`
 
+	Profiler ProfilerConfig `yaml:"profiler"`
+
 	Read ReadConfig `yaml:"read"`
 
 	Write WriteConfig `yaml:"write"`
@@ -231,6 +233,22 @@ type MonitoringConfig struct {
 	ExperimentalTracingSamplingRatio float64 `yaml:"experimental-tracing-sampling-ratio"`
 }
 
+type ProfilerConfig struct {
+	AllocatedHeap bool `yaml:"allocated-heap"`
+
+	Cpu bool `yaml:"cpu"`
+
+	Enabled bool `yaml:"enabled"`
+
+	Goroutines bool `yaml:"goroutines"`
+
+	Heap bool `yaml:"heap"`
+
+	Mutex bool `yaml:"mutex"`
+
+	VersionTag string `yaml:"version-tag"`
+}
+
 type ReadConfig struct {
 	InactiveStreamTimeout time.Duration `yaml:"inactive-stream-timeout"`
 }
@@ -340,6 +358,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("enable-atomic-rename-object"); err != nil {
 		return err
 	}
+
+	flagSet.BoolP("enable-cloud-profiling", "", false, "To enable/disable the cloud profiling, by default disabled")
 
 	flagSet.BoolP("enable-empty-managed-folders", "", false, "This handles the corner case in listing managed folders. There are two corner cases (a) empty managed folder (b) nested managed folder which doesn't contain any descendent as object. This flag always works in conjunction with --implicit-dirs flag. (a) If only ImplicitDirectories is true, all managed folders are listed other than above two mentioned cases. (b) If both ImplicitDirectories and EnableEmptyManagedFolders are true, then all the managed folders are listed including the above-mentioned corner case. (c) If ImplicitDirectories is false then no managed folders are listed irrespective of enable-empty-managed-folders flag.")
 
@@ -506,6 +526,18 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("precondition-errors"); err != nil {
 		return err
 	}
+
+	flagSet.BoolP("profile-allocated-heap", "", false, "Enable allocated heap (HeapProfileAllocs) profiling.")
+
+	flagSet.BoolP("profile-cpu", "", false, "Enable CPU profiling.")
+
+	flagSet.BoolP("profile-goroutines", "", false, "Enable goroutine profiling.")
+
+	flagSet.BoolP("profile-heap", "", false, "Enable heap profiling.")
+
+	flagSet.BoolP("profile-mutex", "", false, "Enable mutex (contention) profiling.")
+
+	flagSet.StringP("profile-version-tag", "", "", "Set the version tag for profiling data.")
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
@@ -681,6 +713,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-atomic-rename-object", flagSet.Lookup("enable-atomic-rename-object")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.enabled", flagSet.Lookup("enable-cloud-profiling")); err != nil {
 		return err
 	}
 
@@ -873,6 +909,30 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.precondition-errors", flagSet.Lookup("precondition-errors")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.allocated-heap", flagSet.Lookup("profile-allocated-heap")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.cpu", flagSet.Lookup("profile-cpu")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.goroutines", flagSet.Lookup("profile-goroutines")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.heap", flagSet.Lookup("profile-heap")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.mutex", flagSet.Lookup("profile-mutex")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("profiler.version-tag", flagSet.Lookup("profile-version-tag")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -655,45 +655,45 @@
   default: ""
 
 - config-path: "profiling.allocated-heap"
-  flag-name: "profile-allocated-heap"
+  flag-name: "profiling-allocated-heap"
   type: "bool"
-  usage: "Enable allocated heap (HeapProfileAllocs) profiling."
+  usage: "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.cpu"
   flag-name: "profiling-cpu"
   type: "bool"
-  usage: "Enable CPU profiling."
+  usage: "To enable/disable the CPU profiling. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.enabled"
   flag-name: "enable-cloud-profiling"
   type: "bool"
-  usage: "To enable/disable the cloud profiling, by default disabled"
+  usage: "To enable/disable the cloud profiling, by default disabled. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.goroutines"
   flag-name: "profiling-goroutines"
   type: "bool"
-  usage: "Enable goroutine profiling."
+  usage: "To enable/disable the goroutine profiling. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.heap"
   flag-name: "profiling-heap"
   type: "bool"
-  usage: "Enable heap profiling."
+  usage: "To enable/disable the heap profiling. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.mutex"
   flag-name: "profiling-mutex"
   type: "bool"
-  usage: "Enable mutex (contention) profiling."
+  usage: "To enable/disable the mutex profiling. Only work when profiling is enabled."
   default: false
 
 - config-path: "profiling.version-tag"
   flag-name: "profiling-version-tag"
   type: "string"
-  usage: "Set the version tag for profiling data."
+  usage: "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled."
   default: ""
 
 - config-path: "read.inactive-stream-timeout"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -654,44 +654,44 @@
   usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
   default: ""
 
-- config-path: "profiler.allocated-heap"
+- config-path: "profiling.allocated-heap"
   flag-name: "profile-allocated-heap"
   type: "bool"
   usage: "Enable allocated heap (HeapProfileAllocs) profiling."
   default: false
 
-- config-path: "profiler.cpu"
-  flag-name: "profile-cpu"
+- config-path: "profiling.cpu"
+  flag-name: "profiling-cpu"
   type: "bool"
   usage: "Enable CPU profiling."
   default: false
 
-- config-path: "profiler.enabled"
+- config-path: "profiling.enabled"
   flag-name: "enable-cloud-profiling"
   type: "bool"
   usage: "To enable/disable the cloud profiling, by default disabled"
   default: false
 
-- config-path: "profiler.goroutines"
-  flag-name: "profile-goroutines"
+- config-path: "profiling.goroutines"
+  flag-name: "profiling-goroutines"
   type: "bool"
   usage: "Enable goroutine profiling."
   default: false
 
-- config-path: "profiler.heap"
-  flag-name: "profile-heap"
+- config-path: "profiling.heap"
+  flag-name: "profiling-heap"
   type: "bool"
   usage: "Enable heap profiling."
   default: false
 
-- config-path: "profiler.mutex"
-  flag-name: "profile-mutex"
+- config-path: "profiling.mutex"
+  flag-name: "profiling-mutex"
   type: "bool"
   usage: "Enable mutex (contention) profiling."
   default: false
 
-- config-path: "profiler.version-tag"
-  flag-name: "profile-version-tag"
+- config-path: "profiling.version-tag"
+  flag-name: "profiling-version-tag"
   type: "string"
   usage: "Set the version tag for profiling data."
   default: ""

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -658,43 +658,52 @@
   flag-name: "profiling-allocated-heap"
   type: "bool"
   usage: "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled."
-  default: false
+  default: true
+  hide-flag: true
 
 - config-path: "profiling.cpu"
   flag-name: "profiling-cpu"
   type: "bool"
   usage: "To enable/disable the CPU profiling. Only work when profiling is enabled."
-  default: false
+  default: true
+  hide-flag: true
 
 - config-path: "profiling.enabled"
   flag-name: "enable-cloud-profiling"
   type: "bool"
-  usage: "To enable/disable the cloud profiling, by default disabled. Only work when profiling is enabled."
+  usage: "Enables cloud profiling, by default disabled."
   default: false
+  hide-flag: true
 
 - config-path: "profiling.goroutines"
   flag-name: "profiling-goroutines"
   type: "bool"
-  usage: "To enable/disable the goroutine profiling. Only work when profiling is enabled."
+  usage: "Enables goroutines profiling. This only works when --enable-cloud-profiling is set to true."
   default: false
+  hide-flag: true
 
 - config-path: "profiling.heap"
   flag-name: "profiling-heap"
   type: "bool"
-  usage: "To enable/disable the heap profiling. Only work when profiling is enabled."
-  default: false
+  usage: "Enables heap profiling. This only works when --enable-cloud-profiling is set to true."
+  default: true
+  hide-flag: true
+
+- config-path: "profiling.label"
+  flag-name: "profiling-label"
+  type: "string"
+  usage: >-
+    Allow setting a profile label to uniquely identify and compare profiling data with other profiles.
+    This only works when --enable-cloud-profiling is set to true.  
+  default: "gcsfuse-0.0.0"
+  hide-flag: true
 
 - config-path: "profiling.mutex"
   flag-name: "profiling-mutex"
   type: "bool"
-  usage: "To enable/disable the mutex profiling. Only work when profiling is enabled."
+  usage: "Enables mutex profiling. This only works when --enable-cloud-profiling is set to true."
   default: false
-
-- config-path: "profiling.version-tag"
-  flag-name: "profiling-version-tag"
-  type: "string"
-  usage: "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled."
-  default: "gcsfuse-0.0.0"
+  hide-flag: true
 
 - config-path: "read.inactive-stream-timeout"
   flag-name: "read-inactive-stream-timeout"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -694,7 +694,7 @@
   flag-name: "profiling-version-tag"
   type: "string"
   usage: "Set the version tag for profiling data, used to compare b/w two versions. Only work when profiling is enabled."
-  default: ""
+  default: "gcsfuse-0.0.0"
 
 - config-path: "read.inactive-stream-timeout"
   flag-name: "read-inactive-stream-timeout"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -654,6 +654,48 @@
   usage: "Mount only a specific directory within the bucket. See docs/mounting for more information"
   default: ""
 
+- config-path: "profiler.allocated-heap"
+  flag-name: "profile-allocated-heap"
+  type: "bool"
+  usage: "Enable allocated heap (HeapProfileAllocs) profiling."
+  default: false
+
+- config-path: "profiler.cpu"
+  flag-name: "profile-cpu"
+  type: "bool"
+  usage: "Enable CPU profiling."
+  default: false
+
+- config-path: "profiler.enabled"
+  flag-name: "enable-cloud-profiling"
+  type: "bool"
+  usage: "To enable/disable the cloud profiling, by default disabled"
+  default: false
+
+- config-path: "profiler.goroutines"
+  flag-name: "profile-goroutines"
+  type: "bool"
+  usage: "Enable goroutine profiling."
+  default: false
+
+- config-path: "profiler.heap"
+  flag-name: "profile-heap"
+  type: "bool"
+  usage: "Enable heap profiling."
+  default: false
+
+- config-path: "profiler.mutex"
+  flag-name: "profile-mutex"
+  type: "bool"
+  usage: "Enable mutex (contention) profiling."
+  default: false
+
+- config-path: "profiler.version-tag"
+  flag-name: "profile-version-tag"
+  type: "string"
+  usage: "Set the version tag for profiling data."
+  default: ""
+
 - config-path: "read.inactive-stream-timeout"
   flag-name: "read-inactive-stream-timeout"
   type: "duration"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -657,14 +657,14 @@
 - config-path: "profiling.allocated-heap"
   flag-name: "profiling-allocated-heap"
   type: "bool"
-  usage: "To enable/disable the allocated heap (HeapProfileAllocs) profiling. Only work when profiling is enabled."
+  usage: "Enables allocated heap (HeapProfileAllocs) profiling. This only works when --enable-cloud-profiling is set to true."
   default: true
   hide-flag: true
 
 - config-path: "profiling.cpu"
   flag-name: "profiling-cpu"
   type: "bool"
-  usage: "To enable/disable the CPU profiling. Only work when profiling is enabled."
+  usage: "Enables cpu profiling. This only works when --enable-cloud-profiling is set to true."
   default: true
   hide-flag: true
 

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -396,7 +396,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	shutdownFn := common.JoinShutdownFunc(metricExporterShutdownFn, shutdownTracingFn)
 
 	// No-op if profiler config is disabled.
-	profiler.SetupCloudProfiler(&newConfig.Profiler)
+	profiler.SetupCloudProfiler(&newConfig.Profiling)
 
 	// Mount, writing information about our progress to the writer that package
 	// daemonize gives us and telling it about the outcome.

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/monitor"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/mount"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/profiler"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/util"
@@ -393,6 +394,9 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	}
 	shutdownTracingFn := monitor.SetupTracing(ctx, newConfig)
 	shutdownFn := common.JoinShutdownFunc(metricExporterShutdownFn, shutdownTracingFn)
+
+	// No-op if profiler config is disabled.
+	profiler.SetupCloudProfiler(&newConfig.Profiler)
 
 	// Mount, writing information about our progress to the writer that package
 	// daemonize gives us and telling it about the outcome.

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -395,8 +395,10 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	shutdownTracingFn := monitor.SetupTracing(ctx, newConfig)
 	shutdownFn := common.JoinShutdownFunc(metricExporterShutdownFn, shutdownTracingFn)
 
-	// No-op if profiler config is disabled.
-	profiler.SetupCloudProfiler(&newConfig.Profiling)
+	// No-op if profiler is disabled.
+	if err := profiler.SetupCloudProfiler(&newConfig.Profiling); err != nil {
+		logger.Warnf("Failed to setup cloud profiler: %v", err)
+	}
 
 	// Mount, writing information about our progress to the writer that package
 	// daemonize gives us and telling it about the outcome.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1313,11 +1313,11 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 			args: []string{"gcsfuse", "bucket", "mountpoint"},
 			expectedConfig: cfg.ProfilingConfig{
 				Enabled:       false, // Profiler is disabled by default
-				VersionTag:    "",
+				Label:         "gcsfuse-0.0.0",
 				Mutex:         false, // Default for --profiling-mutex
-				Cpu:           false, // Default for --profiling-cpu
-				AllocatedHeap: false, // Default for --profiling-allocated-heap
-				Heap:          false, // Default for --profiling-heap
+				Cpu:           true,  // Default for --profiling-cpu
+				AllocatedHeap: true,  // Default for --profiling-allocated-heap
+				Heap:          true,  // Default for --profiling-heap
 				Goroutines:    false, // Default for --profiling-goroutines
 			},
 		},
@@ -1326,20 +1326,20 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 			args: []string{"gcsfuse", "--enable-cloud-profiling", "bucket", "mountpoint"},
 			expectedConfig: cfg.ProfilingConfig{
 				Enabled:       true,
-				VersionTag:    "",
+				Label:         "gcsfuse-0.0.0",
 				Mutex:         false,
-				Cpu:           false,
-				AllocatedHeap: false,
-				Heap:          false,
+				Cpu:           true,
+				AllocatedHeap: true,
+				Heap:          true,
 				Goroutines:    false,
 			},
 		},
 		{
-			name: "Profiler enabled, all sub-profilers explicitly true and version tag set",
-			args: []string{"gcsfuse", "--enable-cloud-profiling", "--profiling-version-tag=v1.0.0", "--profiling-mutex=true", "--profiling-cpu=true", "--profiling-allocated-heap=true", "--profiling-heap=true", "--profiling-goroutines=true", "bucket", "mountpoint"},
+			name: "Profiler enabled, all sub-profilers explicitly true and label set",
+			args: []string{"gcsfuse", "--enable-cloud-profiling", "--profiling-label=v1.0.0", "--profiling-mutex=true", "--profiling-cpu=true", "--profiling-allocated-heap=true", "--profiling-heap=true", "--profiling-goroutines=true", "bucket", "mountpoint"},
 			expectedConfig: cfg.ProfilingConfig{
 				Enabled:       true,
-				VersionTag:    "v1.0.0",
+				Label:         "v1.0.0",
 				Mutex:         true,
 				Cpu:           true,
 				AllocatedHeap: true,
@@ -1352,7 +1352,7 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 			args: []string{"gcsfuse", "--enable-cloud-profiling", "--profiling-mutex=false", "--profiling-cpu=false", "--profiling-allocated-heap=false", "--profiling-heap=false", "--profiling-goroutines=false", "bucket", "mountpoint"},
 			expectedConfig: cfg.ProfilingConfig{
 				Enabled:       true,
-				VersionTag:    "",
+				Label:         "gcsfuse-0.0.0",
 				Mutex:         false,
 				Cpu:           false,
 				AllocatedHeap: false,
@@ -1365,11 +1365,11 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 			args: []string{"gcsfuse", "--enable-cloud-profiling=false", "--profiling-mutex=true", "--profiling-cpu=false", "bucket", "mountpoint"},
 			expectedConfig: cfg.ProfilingConfig{
 				Enabled:       false, // Master switch is off
-				VersionTag:    "",
+				Label:         "gcsfuse-0.0.0",
 				Mutex:         true,  // Flag was parsed
 				Cpu:           false, // Flag was parsed
-				AllocatedHeap: false, // Default for its flag
-				Heap:          false, // Default for its flag
+				AllocatedHeap: true,  // Default for its flag
+				Heap:          true,  // Default for its flag
 				Goroutines:    false, // Default for its flag
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/longrunning v0.6.6 // indirect
 	cloud.google.com/go/monitoring v1.24.0 // indirect
+	cloud.google.com/go/profiler v0.4.2 // indirect
 	cloud.google.com/go/pubsub v1.47.0 // indirect
 	cloud.google.com/go/trace v1.11.4 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
@@ -73,6 +74,7 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
 	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ cloud.google.com/go/longrunning v0.6.6 h1:XJNDo5MUfMM05xK3ewpbSdmt7R2Zw+aQEMbdQR
 cloud.google.com/go/longrunning v0.6.6/go.mod h1:hyeGJUrPHcx0u2Uu1UFSoYZLn4lkMrccJig0t4FI7yw=
 cloud.google.com/go/monitoring v1.24.0 h1:csSKiCJ+WVRgNkRzzz3BPoGjFhjPY23ZTcaenToJxMM=
 cloud.google.com/go/monitoring v1.24.0/go.mod h1:Bd1PRK5bmQBQNnuGwHBfUamAV1ys9049oEPHnn4pcsc=
+cloud.google.com/go/profiler v0.4.2 h1:KojCmZ+bEPIQrd7bo2UFvZ2xUPLHl55KzHl7iaR4V2I=
+cloud.google.com/go/profiler v0.4.2/go.mod h1:7GcWzs9deJHHdJ5J9V1DzKQ9JoIoTGhezwlLbwkOoCs=
 cloud.google.com/go/pubsub v1.47.0 h1:Ou2Qu4INnf7ykrFjGv2ntFOjVo8Nloh/+OffF4mUu9w=
 cloud.google.com/go/pubsub v1.47.0/go.mod h1:LaENesmga+2u0nDtLkIOILskxsfvn/BXX9Ak1NFxOs8=
 cloud.google.com/go/secretmanager v1.14.6 h1:/ooktIMSORaWk9gm3vf8+Mg+zSrUplJFKBztP993oL0=
@@ -111,6 +113,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
+github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQuYXQ+6EN5stWmeY/AZqtM8xk9k=
+github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=

--- a/internal/profiler/cloud_profiler.go
+++ b/internal/profiler/cloud_profiler.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	cloudprofiler "cloud.google.com/go/profiler"
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+)
+
+// profilerStart is a variable to enable mocking of profiler.Start in tests.
+//
+//nolint:gochecknoglobals
+var profilerStart = cloudprofiler.Start
+
+// SetupCloudProfiler initializes and starts the Cloud Profiler based on the application configuration.
+func SetupCloudProfiler(mpc *cfg.ProfilerConfig) error {
+	if !mpc.Enabled {
+		return nil
+	}
+
+	pConfig := cloudprofiler.Config{
+		Service:              "GCSFuse",
+		ServiceVersion:       mpc.VersionTag,
+		MutexProfiling:       mpc.Mutex,
+		NoCPUProfiling:       !mpc.Cpu,
+		NoAllocProfiling:     !mpc.AllocatedHeap,
+		NoHeapProfiling:      !mpc.Heap,
+		NoGoroutineProfiling: !mpc.Goroutines,
+		AllocForceGC:         true,
+	}
+
+	if err := profilerStart(pConfig); err != nil {
+		logger.Warnf("Unable to start the profiler: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/profiler/cloud_profiler.go
+++ b/internal/profiler/cloud_profiler.go
@@ -17,7 +17,6 @@ package profiler
 import (
 	cloudprofiler "cloud.google.com/go/profiler"
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 )
 
 // profilerStart is a variable to enable mocking of profiler.Start in tests.
@@ -42,10 +41,5 @@ func SetupCloudProfiler(mpc *cfg.ProfilingConfig) error {
 		AllocForceGC:         true,
 	}
 
-	if err := profilerStart(pConfig); err != nil {
-		logger.Warnf("Unable to start the profiler: %v", err)
-		return err
-	}
-
-	return nil
+	return profilerStart(pConfig)
 }

--- a/internal/profiler/cloud_profiler.go
+++ b/internal/profiler/cloud_profiler.go
@@ -26,7 +26,7 @@ import (
 var profilerStart = cloudprofiler.Start
 
 // SetupCloudProfiler initializes and starts the Cloud Profiler based on the application configuration.
-func SetupCloudProfiler(mpc *cfg.ProfilerConfig) error {
+func SetupCloudProfiler(mpc *cfg.ProfilingConfig) error {
 	if !mpc.Enabled {
 		return nil
 	}

--- a/internal/profiler/cloud_profiler.go
+++ b/internal/profiler/cloud_profiler.go
@@ -17,6 +17,7 @@ package profiler
 import (
 	cloudprofiler "cloud.google.com/go/profiler"
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
 )
 
 // profilerStart is a variable to enable mocking of profiler.Start in tests.
@@ -31,7 +32,7 @@ func SetupCloudProfiler(mpc *cfg.ProfilingConfig) error {
 	}
 
 	pConfig := cloudprofiler.Config{
-		Service:              "GCSFuse",
+		Service:              "gcsfuse",
 		ServiceVersion:       mpc.VersionTag,
 		MutexProfiling:       mpc.Mutex,
 		NoCPUProfiling:       !mpc.Cpu,
@@ -41,5 +42,10 @@ func SetupCloudProfiler(mpc *cfg.ProfilingConfig) error {
 		AllocForceGC:         true,
 	}
 
-	return profilerStart(pConfig)
+	if err := profilerStart(pConfig); err != nil {
+		return err
+	}
+
+	logger.Info("Cloud Profiler started successfully.")
+	return nil
 }

--- a/internal/profiler/cloud_profiler_test.go
+++ b/internal/profiler/cloud_profiler_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"errors"
+	"testing"
+
+	cloudprofiler "cloud.google.com/go/profiler"
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// defaultProfilerSettings provides a base configuration for profiler tests.
+var defaultProfilerSettings = cfg.ProfilerConfig{
+	Enabled:       false, // Explicitly set per test
+	VersionTag:    "test-version",
+	Mutex:         true,
+	Cpu:           true,
+	AllocatedHeap: true,
+	Heap:          true,
+	Goroutines:    true,
+}
+
+func TestSetupCloudProfiler_Disabled(t *testing.T) {
+	// Save and restore the original profilerStart function.
+	originalProfilerStart := profilerStart
+	t.Cleanup(func() {
+		profilerStart = originalProfilerStart
+	})
+	mockProfilerStartCalled := false
+	profilerStart = func(cfg cloudprofiler.Config, options ...option.ClientOption) error {
+		mockProfilerStartCalled = true
+		return nil
+	}
+	profilerConfig := &defaultProfilerSettings // Uses the package-level var
+	profilerConfig.Enabled = false
+
+	err := SetupCloudProfiler(profilerConfig)
+
+	require.NoError(t, err, "SetupCloudProfiler should not return an error")
+	assert.False(t, mockProfilerStartCalled, "profilerStart should not be called when profiler is disabled")
+}
+
+func TestSetupCloudProfiler_EnabledSuccess(t *testing.T) {
+	// Save and restore the original profilerStart function.
+	originalProfilerStart := profilerStart
+	t.Cleanup(func() {
+		profilerStart = originalProfilerStart
+	})
+
+	var capturedProfilerConfig cloudprofiler.Config
+	mockProfilerStartCalled := false
+	profilerStart = func(pcfg cloudprofiler.Config, options ...option.ClientOption) error {
+		mockProfilerStartCalled = true
+		capturedProfilerConfig = pcfg
+		return nil
+	}
+
+	profilerConfig := &defaultProfilerSettings // Uses the package-level var
+	profilerConfig.Enabled = true
+	profilerConfig.VersionTag = "v1.2.3"
+	profilerConfig.Mutex = true
+	profilerConfig.Cpu = true            // NoCPUProfiling = false
+	profilerConfig.AllocatedHeap = false // NoAllocProfiling = true
+	profilerConfig.Heap = true           // NoHeapProfiling = false
+	profilerConfig.Goroutines = false    // NoGoroutineProfiling = true
+
+	err := SetupCloudProfiler(profilerConfig)
+
+	require.NoError(t, err, "SetupCloudProfiler should not return an error")
+	require.True(t, mockProfilerStartCalled, "profilerStart should be called")
+	assert.Equal(t, "GCSFuse", capturedProfilerConfig.Service)
+	assert.Equal(t, "v1.2.3", capturedProfilerConfig.ServiceVersion)
+	assert.Equal(t, true, capturedProfilerConfig.MutexProfiling)
+	assert.Equal(t, false, capturedProfilerConfig.NoCPUProfiling)
+	assert.Equal(t, true, capturedProfilerConfig.NoAllocProfiling)
+	assert.Equal(t, false, capturedProfilerConfig.NoHeapProfiling)
+	assert.Equal(t, true, capturedProfilerConfig.NoGoroutineProfiling)
+	assert.True(t, capturedProfilerConfig.AllocForceGC)
+}
+
+func TestSetupCloudProfiler_EnabledStartFails(t *testing.T) {
+	// Save and restore the original profilerStart function.
+	originalProfilerStart := profilerStart
+	t.Cleanup(func() {
+		profilerStart = originalProfilerStart
+	})
+	expectedErr := errors.New("profiler failed to start")
+	profilerStart = func(pcfg cloudprofiler.Config, options ...option.ClientOption) error { return expectedErr }
+	profilerConfig := &defaultProfilerSettings // Uses the package-level var
+	profilerConfig.Enabled = true
+
+	err := SetupCloudProfiler(profilerConfig)
+
+	assert.EqualError(t, err, expectedErr.Error())
+}

--- a/internal/profiler/cloud_profiler_test.go
+++ b/internal/profiler/cloud_profiler_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // defaultProfilerSettings provides a base configuration for profiler tests.
-var defaultProfilerSettings = cfg.ProfilerConfig{
+var defaultProfilerSettings = cfg.ProfilingConfig{
 	Enabled:       false, // Explicitly set per test
 	VersionTag:    "test-version",
 	Mutex:         true,

--- a/internal/profiler/cloud_profiler_test.go
+++ b/internal/profiler/cloud_profiler_test.go
@@ -25,17 +25,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-// defaultProfilerSettings provides a base configuration for profiler tests.
-var defaultProfilerSettings = cfg.ProfilingConfig{
-	Enabled:       false,
-	VersionTag:    "test-version",
-	Mutex:         false,
-	Cpu:           false,
-	AllocatedHeap: false,
-	Heap:          false,
-	Goroutines:    false,
-}
-
 func TestSetupCloudProfiler_Disabled(t *testing.T) {
 	// Save and restore the original profilerStart function.
 	originalProfilerStart := profilerStart


### PR DESCRIPTION
### Description
- Adding support to profile cpu, heap, mutex, go-routines and upload to cloud for analysis.
- Controlled by a hidden flag `--enable-cloud-profiling`, by default disabled.
- Only for dev purpose.

### Link to the issue in case of a bug fix.
b/418896993

### Testing details
1. Manual - Working as expected.
![image](https://github.com/user-attachments/assets/b09bc1b8-d6e5-4335-a7b6-b14e127124ae)

3. Unit tests - Added.
4. Integration tests - in the next PR.

### Any backward incompatible change? If so, please explain.
