### PR TITLE
E2E test for cloud profiler support

### DIFF
--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -67,20 +67,8 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucketFlag()
 	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 
-	// Set up flags to run tests on.
-	yamlContent := map[string]interface{}{
-		"profiling": map[string]interface{}{
-			"enabled":        true,
-			"cpu":            true,
-			"heap":           true,
-			"goroutines":     true,
-			"mutex":          true,
-			"allocated-heap": true,
-			"label":          testServiceVersion,
-		},
-	}
 	flags := [][]string{
-		{"--config-file=" + setup.YAMLConfigFile(yamlContent, "cloud_profiler_enabled.yaml")},
+		{"--enable-cloud-profiling", "--profiling-cpu", "--profiling-heap", "--profiling-goroutines", "--profiling-mutex", "--profiling-allocated-heap", fmt.Sprintf("--profiling-label=%s", testServiceVersion)},
 	}
 	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
 	successCode := static_mounting.RunTests(flags, m)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud_profiler_test
+
+// Command to run the test from gcsfuse root directory:
+// go test ./tools/integration_tests/cloud_profiler/... --integrationTest --testbucket <bucket_name> -testInstalledPackage -v -timeout 20m
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/uuid"
+	"github.com/googlecloudplatform/gcsfuse/v2/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName     = "CloudProfilerTest"
+	testServiceName = "gcsfuse"
+)
+
+var (
+	testServiceVersion string
+)
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	var storageClient *storage.Client
+	ctx := context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	setup.RunTestsForMountedDirectoryFlag(m)
+
+	// Else run tests for testBucket.
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
+
+	// Set up flags to run tests on.
+	yamlContent := map[string]interface{}{
+		"profiling": map[string]interface{}{
+			"enabled":        true,
+			"cpu":            true,
+			"heap":           true,
+			"goroutines":     true,
+			"mutex":          true,
+			"allocated-heap": true,
+			"label":          testServiceVersion,
+		},
+	}
+	flags := [][]string{
+		{"--config-file=" + setup.YAMLConfigFile(yamlContent, "cloud_profiler_enabled.yaml")},
+	}
+	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
+	successCode := static_mounting.RunTests(flags, m)
+
+	// Clean up test directory created.
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -139,7 +139,8 @@ func TestValidateProfilerWithActualService(t *testing.T) {
 	// 2. Create a profiler service api client.
 	// 3. Make list call to the profiler service api client and fetch the profiles.
 	// 4. Filter and match if the right profile data exists.
-	fetchProjectCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	fetchProjectCtx, fetchProjectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer fetchProjectCancel()
 	projectID, err := metadata.ProjectIDWithContext(fetchProjectCtx) // Reduced timeout, 5s is usually sufficient.
 	if err != nil {
 		t.Logf("metadata.ProjectIDWithContext failed: %v, try fetching from environment variable.", err)

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -43,7 +43,7 @@ func getGCPProjectID(t *testing.T) string {
 }
 
 // checkIfProfileExistForServiceAndVersion queries the Cloud Profiler API for profiles
-// returns true in case of the first match, false if no matching profile found.
+// returns true just after the first matching profile, false if no matching profile found.
 // Ref: https://cloud.google.com/profiler/docs/reference/v2/rest
 func checkIfProfileExistForServiceAndVersion(
 	ctx context.Context,
@@ -94,7 +94,7 @@ func checkIfProfileExistForServiceAndVersion(
 func TestValidateProfilerWithActualService(t *testing.T) {
 	// GCSFuse process will be started as part of mount.
 	// Allow some time to export the profile data to GCP profiler service.
-	time.Sleep(time.Minute)
+	time.Sleep(2*time.Minute + 30*time.Second)
 
 	// 1. Fetch GCP projectID.
 	// 2. Create a profiler service api client.

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -132,8 +132,8 @@ func TestValidateProfilerWithActualService(t *testing.T) {
 	setup.SetupTestDirectory(testDirName)
 	operations.CreateFileWithContent(filePath, 0644, string(randomData), t)
 	// Start Workload and Allow Time for Profiling
-	// performRepeatedRead(t.Context(), t, filePath, 3*time.Minute)
-	// time.Sleep(time.Minute)
+	performRepeatedRead(t.Context(), t, filePath, 3*time.Minute)
+	time.Sleep(time.Minute)
 
 	// 1. Fetch GCP projectID.
 	// 2. Create a profiler service api client.

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud_profiler_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+	gcpProfiler "google.golang.org/api/cloudprofiler/v2"
+	"google.golang.org/api/option"
+
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/util/setup"
+)
+
+func performRepeatedRead(ctx context.Context, t *testing.T, filePath string, duration time.Duration) {
+	timeout := time.After(duration)
+	readFileCnt := 0
+	for {
+		select {
+		case <-timeout:
+			t.Logf("performRepeatedRead: Duration %v reached.", duration)
+			return
+		case <-ctx.Done():
+			t.Log("performRepeatedRead: Context cancelled.")
+			return
+		default:
+			_, err := operations.ReadFile(filePath)
+			if err != nil { // Log transient errors but continue reading
+				t.Logf("ReadFile failed during performRepeatedRead (filePath: %s): %v", filePath, err)
+			} else {
+				readFileCnt++
+				// Just to show some progress.
+				if readFileCnt%2500 == 0 {
+					t.Logf("Read file operation completed %d times.", readFileCnt)
+				}
+			}
+		}
+	}
+}
+
+// listProfilesForServiceAndVersion queries the Cloud Profiler API for profiles
+// matching the given service name and version within the specified time window.
+// It handles pagination and basic retries for transient errors.
+// Ref: https://cloud.google.com/profiler/docs/reference/v2/rest
+func listProfilesForServiceAndVersion(
+	ctx context.Context,
+	t *testing.T, // Pass testing.T for logging within the helper
+	profilerAPIClient *gcpProfiler.Service,
+	projectID string,
+) ([]*gcpProfiler.Profile, error) {
+
+	t.Logf("Querying profiles for service [%s] version [%s]", testServiceName, testServiceVersion)
+	var profiles []*gcpProfiler.Profile
+	maxPagesToFetch := 5 // Limiting total list calls, 1000 per calls.
+	pagesFetched := 0
+	var pageToken string
+	for {
+		pagesFetched++
+		if pagesFetched > maxPagesToFetch {
+			t.Logf("Reached max pages (%d) to fetch. Stopping profile query.", maxPagesToFetch)
+			break
+		}
+
+		listCall := profilerAPIClient.Projects.Profiles.List(fmt.Sprintf("projects/%s", projectID))
+		if pageToken != "" {
+			listCall.PageToken(pageToken)
+		}
+		resp, errCall := listCall.Do()
+		if errCall != nil {
+			// Basic retry for transient errors
+			if strings.Contains(errCall.Error(), "try again") || strings.Contains(errCall.Error(), "unavailable") {
+				t.Logf("List profiles call failed, retrying once: %v", errCall)
+				time.Sleep(10 * time.Second)
+				resp, errCall = listCall.Do() // Retry the call
+			}
+			if errCall != nil {
+				return nil, fmt.Errorf("failed to list profiles from API: %w", errCall)
+			}
+		}
+
+		t.Logf("Size of the response: %d", len(resp.Profiles))
+		// Filter by service name and version on the client side.
+		for _, p := range resp.Profiles {
+			if p.Deployment != nil && p.Deployment.Target == testServiceName {
+				profileAPIVersion := ""
+				if p.Deployment.Labels != nil {
+					profileAPIVersion = p.Deployment.Labels["version"] // "version" is the label key used by the agent
+				}
+				if profileAPIVersion == testServiceVersion {
+					profiles = append(profiles, p)
+				}
+			}
+		}
+
+		if resp.NextPageToken == "" {
+			break // No more pages
+		}
+		pageToken = resp.NextPageToken
+		t.Logf("Fetching next page of profiles (token: %s)...", pageToken)
+	}
+
+	return profiles, nil
+}
+
+func TestValidateProfilerWithActualService(t *testing.T) {
+	// Setup directory and file to perform read workload.
+	randomData, err := operations.GenerateRandomData(5 * 1024 * 1024)
+	if err != nil {
+		t.Fatalf("operations.GenerateRandomData: %v", err)
+	}
+	testDirPath := path.Join(setup.MntDir(), testDirName)
+	filePath := path.Join(testDirPath, "a.txt")
+	setup.SetupTestDirectory(testDirName)
+	operations.CreateFileWithContent(filePath, 0644, string(randomData), t)
+	// Start Workload and Allow Time for Profiling
+	// performRepeatedRead(t.Context(), t, filePath, 3*time.Minute)
+	// time.Sleep(time.Minute)
+
+	// 1. Fetch GCP projectID.
+	// 2. Create a profiler service api client.
+	// 3. Make list call to the profiler service api client and fetch the profiles.
+	// 4. Filter and match if the right profile data exists.
+	fetchProjectCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	projectID, err := metadata.ProjectIDWithContext(fetchProjectCtx) // Reduced timeout, 5s is usually sufficient.
+	if err != nil {
+		t.Logf("metadata.ProjectIDWithContext failed: %v, try fetching from environment variable.", err)
+		projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if projectID == "" {
+			t.Skip("Not able to fetch project ID from metadata server or GOOGLE_CLOUD_PROJECT environment variable. Skipping integration test.")
+		}
+	}
+	apiCtx := context.Background()
+	profilerAPIClient, err := gcpProfiler.NewService(apiCtx, option.WithScopes(gcpProfiler.CloudPlatformScope))
+	if err != nil {
+		t.Fatalf("Failed to create Cloud Profiler API client: %v", err)
+	}
+	profilesFoundForTestServiceAndVersion, err := listProfilesForServiceAndVersion(apiCtx, t, profilerAPIClient, projectID)
+	if err != nil {
+		t.Fatalf("listProfilesForServiceAndVersion: %v", err)
+	}
+
+	// Validate the result.
+	expectedProfileTypesInAPI := map[string]bool{
+		"CPU":        false,
+		"HEAP":       false,
+		"THREADS":    false,
+		"CONTENTION": false,
+		"HEAP_ALLOC": false,
+	}
+	for _, p := range profilesFoundForTestServiceAndVersion {
+		if p.ProfileType != "" {
+			if _, ok := expectedProfileTypesInAPI[p.ProfileType]; ok {
+				expectedProfileTypesInAPI[p.ProfileType] = true
+				t.Logf("Marked API profile type '%s' as found.", p.ProfileType)
+			}
+		}
+	}
+	atleastOneFound := false
+	allExpectedFound := true
+	for typeStr, found := range expectedProfileTypesInAPI {
+		if !found {
+			allExpectedFound = false
+			t.Logf("Expected profile type '%s' was NOT found.", typeStr)
+		} else {
+			atleastOneFound = true
+			t.Logf("Found profile type '%s'.", typeStr)
+		}
+	}
+	if !allExpectedFound {
+		t.Logf("Total profiles found for this service/version during test: %d", len(profilesFoundForTestServiceAndVersion))
+		if len(profilesFoundForTestServiceAndVersion) > 0 {
+			t.Log("Details of profiles found:")
+			for _, p := range profilesFoundForTestServiceAndVersion {
+				t.Logf("  - Name: %s, Type: %s, Labels: %v", p.Name, p.ProfileType, p.Deployment.Labels)
+			}
+		}
+	} else {
+		t.Log("All expected profile types (CPU, HEAP) were successfully found for the test service and version.")
+	}
+	if !atleastOneFound {
+		t.Errorf("Failed: none of the profile found.")
+	}
+}


### PR DESCRIPTION
### Description
- Adding e2e test to validate gcsfuse uploads the profiles to the gcp profiler service.
- Performs read for 3 minutes, and check the profile for the given profiling-label.
- Test returns success if any of the profile (for unique label) present on the  profiling server. [ListingProfile](https://cloud.google.com/profiler/docs/reference/v2/rest/v2/projects.profiles/list) api doesn't provide any filtering based on the label or timing, because of which test fetches only first 5000 entries and check if required profile present or not. 
- Successful integration test run logs:
```
{"timestamp":{"seconds":1748286118,"nanos":380113950},"severity":"INFO","message":"Using GCSFuse installed on the target machine"}
{"timestamp":{"seconds":1748286118,"nanos":380199430},"severity":"INFO","message":"Enabling cloud profiler with version tag: ve2e0.0.0-ec06da3c"}
{"timestamp":{"seconds":1748286118,"nanos":380205053},"severity":"INFO","message":"Running static mounting tests..."}
{"timestamp":{"seconds":1748286118,"nanos":516212870},"severity":"INFO","message":"Running static mounting tests with flags: [--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap --profiling-label=ve2e0.0.0-ec06da3c]"}
=== RUN   TestValidateProfilerWithActualService
    with_gcp_profiler_service_test.go:55: Querying profiles for service [gcsfuse] version [ve2e0.0.0-ec06da3c]
    with_gcp_profiler_service_test.go:65: Processing page 1 of profiles, number of profiles in page: 1000
    with_gcp_profiler_service_test.go:74: Found matching profile: Type=CONTENTION, ID=ve2e0.0.0-ec06da3c
--- PASS: TestValidateProfilerWithActualService (186.62s)
PASS
{"timestamp":{"seconds":1748286305,"nanos":149750713},"severity":"INFO","message":"Test log: /tmp/gcsfuse_readwrite_test_3365842802/gcsfuse.log"}
ok      github.com/googlecloudplatform/gcsfuse/v2/tools/integration_tests/cloud_profiler        186.835s
```

### Link to the issue in case of a bug fix.
b/419032549

### Testing details
1. Manual - yes, working as expected.
2. Unit tests - NA
3. Integration tests - CPU profile generated with e2e tests.

Sample profile-types:
**Heap:**
![image](https://github.com/user-attachments/assets/3be85ebf-3686-4629-a75d-64fd6dd125dc)

**CPU:**
![image](https://github.com/user-attachments/assets/fdc87ced-00a1-4e81-8688-e8bead4dcf3e)

**Heap alloc:**
![image](https://github.com/user-attachments/assets/e3c00f49-26b5-45a4-93ba-a0fb0bbcec9e)

**Threads/go-routines:**
![image](https://github.com/user-attachments/assets/0da64b94-9497-4cdb-bc05-72df2c5866de)

**mutex/contention:**
![image](https://github.com/user-attachments/assets/8d81dbad-529b-4cf0-af0c-0516bce59efd)


### Any backward incompatible change? If so, please explain.
