### PR TITLE
Encapsulate global vars in a struct for a few e2e tests

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -29,16 +29,22 @@ import (
 
 const DirForExplicitDirTests = "dirForExplicitDirTests"
 
-var (
+// IMPORTANT: To prevent global variable pollution, enhance code clarity,
+// and avoid inadvertent errors. We strongly suggest that, all new package-level
+// variables (which would otherwise be declared with `var` at the package root) should
+// be added as fields to this 'env' struct instead.
+type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
-)
+}
+
+var testEnv env
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 	// Create storage client before running tests.
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	testEnv.ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
@@ -48,7 +54,7 @@ func TestMain(m *testing.M) {
 
 	// These tests will not run on HNS buckets because the "--implicit-dirs=false" flag does not function similarly to how it does on FLAT buckets.
 	// Note that HNS buckets do not have the concept of implicit directories.
-	if setup.IsHierarchicalBucket(ctx, storageClient) {
+	if setup.IsHierarchicalBucket(testEnv.ctx, testEnv.storageClient) {
 		log.Println("These tests will not run on HNS buckets.")
 		return
 	}

--- a/tools/integration_tests/explicit_dir/list_test.go
+++ b/tools/integration_tests/explicit_dir/list_test.go
@@ -40,7 +40,7 @@ func TestListOnlyExplicitObjectsFromBucket(t *testing.T) {
 
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, DirForExplicitDirTests)
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, DirForExplicitDirTests)
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(DirForExplicitDirTests)
 	}

--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -34,7 +34,7 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
 	}
@@ -54,7 +54,7 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
 	}
@@ -76,7 +76,7 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
 	}
@@ -102,7 +102,7 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
 	}
@@ -129,7 +129,7 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
 	}
@@ -153,7 +153,7 @@ func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
 	testDirPath := setupTestDir(testDirName)
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
 	}

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -36,10 +36,17 @@ const NumberOfFilesInExplicitDirInImplicitSubDir = 1
 const NumberOfFilesInExplicitDirInImplicitDir = 1
 const DirForImplicitDirTests = "dirForImplicitDirTests"
 
-var (
+// IMPORTANT: To prevent global variable pollution, enhance code clarity,
+// and avoid inadvertent errors. We strongly suggest that, all new package-level
+// variables (which would otherwise be declared with `var` at the package root) should
+// be added as fields to this 'env' struct instead.
+type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
-)
+	testDirPath   string
+}
+
+var testEnv env
 
 func setupTestDir(dirName string) string {
 	dir := setup.SetupTestDirectory(DirForImplicitDirTests)
@@ -55,8 +62,8 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// Create storage client before running tests.
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	testEnv.ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
@@ -66,7 +73,7 @@ func TestMain(m *testing.M) {
 
 	flagsSet := [][]string{{"--implicit-dirs"}}
 
-	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
+	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(testEnv.ctx, testEnv.storageClient); err == nil {
 		flagsSet = append(flagsSet, hnsFlagSet)
 	}
 
@@ -77,6 +84,6 @@ func TestMain(m *testing.M) {
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flagsSet, m)
 
 	// Clean up test directory created.
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -42,7 +42,7 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 
 	// TODO: Remove the condition and keep the storage-client flow for non-ZB too.
 	if setup.IsZonalBucketRun() {
-		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(ctx, t, storageClient, path.Join(DirForImplicitDirTests, testDirName))
+		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	} else {
 		implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName))
 	}


### PR DESCRIPTION
### Description
Encapsulate global vars in a struct for following tests
* implicit_dir
* explicit_dir

### Link to the issue in case of a bug fix.
b/419266928

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
NA
