### PR TITLE
Help doc update for inactive stream timeout

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -569,7 +569,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
-	flagSet.DurationP("read-inactive-stream-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout. Note: Currently only applies when using the 'grpc' client-protocol.")
+	flagSet.DurationP("read-inactive-stream-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout.")
 
 	if err := flagSet.MarkHidden("read-inactive-stream-timeout"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -712,7 +712,6 @@
     Duration of inactivity after which an open GCS read stream is automatically closed.
     This helps conserve resources when a file handle remains open without active Read calls.
     A value of '0s' disables this timeout.
-    Note: Currently only applies when using the 'grpc' client-protocol.
   default: "0s"
   hide-flag: true
 


### PR DESCRIPTION
### Description
Follow up this [PR](https://github.com/GoogleCloudPlatform/gcsfuse/pull/3325). Missed updating the help doc. Now, the timeout applies for all `client-protocol` value.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
