### PR TITLE
Fixed flaky parallel download test [Test_ParallelDownloadObjectToFile_NewReaderWithReadHandle]

### DIFF
--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
@@ -56,6 +57,7 @@ func (t *ParallelDownloaderJobTestifyTest) SetupTest() {
 func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_NewReaderWithReadHandle() {
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
+	chunkSize := 3 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	t.initReadCacheTestifyTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	t.job.cancelCtx, t.job.cancelFunc = context.WithCancel(context.Background())
@@ -72,26 +74,79 @@ func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_New
 	// DownloadChunkSizeMb = 3mb there will be one call to NewReaderWithReadHandle
 	// with read handle.
 	handle := []byte("opaque-handle")
-	rc1 := io.NopCloser(strings.NewReader(string(objectContent[0 : 3*util.MiB])))
-	rd1 := &fake.FakeReader{ReadCloser: rc1, Handle: handle}
-	rc2 := io.NopCloser(strings.NewReader(string(objectContent[3*util.MiB : 6*util.MiB])))
-	rd2 := &fake.FakeReader{ReadCloser: rc2, Handle: handle}
-	rc3 := io.NopCloser(strings.NewReader(string(objectContent[6*util.MiB : 9*util.MiB])))
-	rd3 := &fake.FakeReader{ReadCloser: rc3, Handle: handle}
-	rc4 := io.NopCloser(strings.NewReader(string(objectContent[9*util.MiB : 10*util.MiB])))
-	rd4 := &fake.FakeReader{ReadCloser: rc4, Handle: handle}
+	var (
+		actualCallCount    int64
+		nilHandleCallCount int64
+		mu                 sync.Mutex // To protect counter updates from concurrent mock calls
+	)
+	// Reset counters
+	actualCallCount = 0
+	nilHandleCallCount = 0
+
+	// Helper function to increment counters based on the actual request seen by the mock
+	incrementCounters := func(args mock.Arguments) {
+		req := args.Get(1).(*gcs.ReadObjectRequest) // Second arg to NewReaderWithReadHandle
+		mu.Lock()
+		actualCallCount++
+		if req.ReadHandle == nil {
+			nilHandleCallCount++
+		}
+		mu.Unlock()
+	}
+
+	// Define ranges for clarity
+	rangeR1 := &gcs.ByteRange{Start: uint64(0 * chunkSize), Limit: uint64(1 * chunkSize)}
+	rangeR2 := &gcs.ByteRange{Start: uint64(1 * chunkSize), Limit: uint64(2 * chunkSize)}
+	rangeR3 := &gcs.ByteRange{Start: uint64(2 * chunkSize), Limit: uint64(3 * chunkSize)}
+	rangeR4 := &gcs.ByteRange{Start: uint64(3 * chunkSize), Limit: uint64(objectSize)} // Last chunk
+
+	// Create FakeReaders for each chunk, all will return the same propagatedHandle
+	readerR1 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[0*chunkSize : 1*chunkSize]))), Handle: handle}
+	readerR2 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[1*chunkSize : 2*chunkSize]))), Handle: handle}
+	readerR3 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[2*chunkSize : 3*chunkSize]))), Handle: handle}
+	readerR4 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[3*chunkSize : objectSize]))), Handle: handle}
+
 	t.mockBucket.On("Name").Return(storage.TestBucketName)
-	readObjectReq := gcs.ReadObjectRequest{Name: objectName, Range: &gcs.ByteRange{Start: 0, Limit: 3 * util.MiB}, ReadHandle: nil}
-	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, &readObjectReq).Return(rd1, nil).Times(1)
-	readObjectReq2 := gcs.ReadObjectRequest{Name: objectName, Range: &gcs.ByteRange{Start: 3 * util.MiB, Limit: 6 * util.MiB}, ReadHandle: nil}
-	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, &readObjectReq2).Return(rd2, nil).Times(1)
-	readObjectReq3 := gcs.ReadObjectRequest{Name: objectName, Range: &gcs.ByteRange{Start: 6 * util.MiB, Limit: 9 * util.MiB}, ReadHandle: nil}
-	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, &readObjectReq3).Return(rd3, nil).Times(1)
-	readObjectReq4 := gcs.ReadObjectRequest{Name: objectName, Range: &gcs.ByteRange{Start: 9 * util.MiB, Limit: 10 * util.MiB}, ReadHandle: handle}
-	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, &readObjectReq4).Return(rd4, nil).Times(1)
+
+	// Chunk 1 (R1): Must be ReadHandle: nil
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR1.Start && req.Range.Limit == rangeR1.Limit &&
+			req.ReadHandle == nil
+	})).Run(incrementCounters).Return(readerR1, nil).Once()
+
+	// Chunk 2 (R2): ReadHandle can be nil or propagated. Match primarily on range.
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR2.Start && req.Range.Limit == rangeR2.Limit
+	})).Run(incrementCounters).Return(readerR2, nil).Once()
+
+	// Chunk 3 (R3): ReadHandle can be nil or propagated. Match primarily on range.
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR3.Start && req.Range.Limit == rangeR3.Limit
+	})).Run(incrementCounters).Return(readerR3, nil).Once()
+
+	// Chunk 4 (R4): ReadHandle should not be nil
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR4.Start && req.Range.Limit == rangeR4.Limit && req.ReadHandle != nil
+	})).Run(incrementCounters).Return(readerR4, nil).Once()
 
 	// Start download
 	err = t.job.parallelDownloadObjectToFile(file)
+
+	assert.Equal(t.T(), nil, err, "parallelDownloadObjectToFile should not return an error")
+	assert.Equal(t.T(), int64(4), actualCallCount, "Total calls to NewReaderWithReadHandle should be 4")
+	// Assert the number of calls with ReadHandle: nil falls within the expected range.
+	// For ParallelDownloadsPerFile = 3 and 4 chunks:
+	// - nilHandleCallCount must be at least 1 (for the very first chunk processed by any worker).
+	// - nilHandleCallCount can be at most ParallelDownloadsPerFile (3), as each of the 3 launched workers
+	//   uses a nil handle only for its first operation.
+	// 1 <= nilHandleCallCount <= 3.
+	minExpectedNilCalls := int64(1)
+	maxExpectedNilCalls := int64(3)
+	numberOfChunks := int64(4) // Based on objectSize and chunkSize
+
+	assert.True(t.T(), nilHandleCallCount >= minExpectedNilCalls && nilHandleCallCount <= maxExpectedNilCalls,
+		"Expected nilHandleCallCount to be between %d and %d (inclusive), but got %d. ParallelDownloadsPerFile=%d, Chunks=%d",
+		minExpectedNilCalls, maxExpectedNilCalls, nilHandleCallCount, t.job.fileCacheConfig.ParallelDownloadsPerFile, numberOfChunks)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Equal(t.T(), nil, err)


### PR DESCRIPTION
### Description
Refactors Test_ParallelDownloadObjectToFile_NewReaderWithReadHandle
with aggregate counting for ReadHandle usage, making it robust
to goroutine scheduling races and ensuring consistent results.

### Link to the issue in case of a bug fix.
b/418921265

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
