### PR TITLE
[testing-on-gke][FIO jobFile support part-1] Support jobFile in fioWorkload

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -61,11 +61,17 @@ def validate_fio_workload(workload: dict, name: str):
 
   fioWorkload = workload['fioWorkload']
   if 'jobFile' in fioWorkload:
-    jobFile = fioWorkload['jobFile']
-    if len(jobFile.strip()) == 0:
+    jobFile = fioWorkload['jobFile'].strip()
+    if len(jobFile) == 0:
       print(
           '{name} has jobFile attribute in it, but it is empty, so ignoring'
           ' this workload.'
+      )
+      return False
+    elif ' ' in jobFile:
+      print(
+          '{name} has jobFile attribute in it, but it has space (" ") in it, so'
+          ' ignoring this workload.'
       )
       return False
   else:
@@ -205,24 +211,20 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
         if 'jobFile' in fioWorkload:
           fioWorkloadAttributes['jobFile'] = fioWorkload['jobFile']
         else:
-          for fioWorkloadAttribute in [
+          for attr in [
               'fileSize',
               'blockSize',
               'numThreads',
               'filesPerThread',
           ]:
-            fioWorkloadAttributes[fioWorkloadAttribute] = fioWorkload[
-                fioWorkloadAttribute
-            ]
-        fioWorkloadAttributes['bucket'] = workload['bucket']
+            fioWorkloadAttributes[attr] = fioWorkload[attr]
+        for attr in ['bucket', 'gcsfuseMountOptions']:
+          fioWorkloadAttributes[attr] = workload[attr]
         fioWorkloadAttributes['readTypes'] = (
             fioWorkload['readTypes']
             if 'readTypes' in fioWorkload
             else ['read', 'randread']
         )
-        fioWorkloadAttributes['gcsfuseMountOptions'] = workload[
-            'gcsfuseMountOptions'
-        ]
         fioWorkloadAttributes['numEpochs'] = (
             workload['numEpochs']
             if 'numEpochs' in workload

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -201,51 +201,36 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
         print(f'workloads#{i} is not a valid FIO workload, so ignoring it.')
       else:
         fioWorkload = workload['fioWorkload']
+        fioWorkloadAttributes = dict()
         if 'jobFile' in fioWorkload:
-          jobFile = fioWorkload['jobFile']
+          fioWorkloadAttributes['jobFile'] = fioWorkload['jobFile']
         else:
-          fileSize = fioWorkload['fileSize']
-          blockSize = fioWorkload['blockSize']
-          filesPerThread = fioWorkload['filesPerThread']
-          numThreads = fioWorkload['numThreads']
-        bucket = workload['bucket']
-        readTypes = (
+          for fioWorkloadAttribute in [
+              'fileSize',
+              'blockSize',
+              'numThreads',
+              'filesPerThread',
+          ]:
+            fioWorkloadAttributes[fioWorkloadAttribute] = fioWorkload[
+                fioWorkloadAttribute
+            ]
+        fioWorkloadAttributes['bucket'] = workload['bucket']
+        fioWorkloadAttributes['readTypes'] = (
             fioWorkload['readTypes']
             if 'readTypes' in fioWorkload
             else ['read', 'randread']
         )
-        gcsfuseMountOptions = workload['gcsfuseMountOptions']
-        numEpochs = (
+        fioWorkloadAttributes['gcsfuseMountOptions'] = workload[
+            'gcsfuseMountOptions'
+        ]
+        fioWorkloadAttributes['numEpochs'] = (
             workload['numEpochs']
             if 'numEpochs' in workload
             else DefaultNumEpochs
         )
         for scenario in scenarios:
-          if not jobFile:
-            fioWorkloads.append(
-                FioWorkload(
-                    scenario=scenario,
-                    fileSize=fileSize,
-                    blockSize=blockSize,
-                    filesPerThread=filesPerThread,
-                    numThreads=numThreads,
-                    bucket=bucket,
-                    readTypes=readTypes,
-                    gcsfuseMountOptions=gcsfuseMountOptions,
-                    numEpochs=numEpochs,
-                )
-            )
-          else:
-            fioWorkloads.append(
-                FioWorkload(
-                    scenario=scenario,
-                    bucket=bucket,
-                    readTypes=readTypes,
-                    gcsfuseMountOptions=gcsfuseMountOptions,
-                    numEpochs=numEpochs,
-                    jobFile=jobFile,
-                )
-            )
+          fioWorkloadAttributes['scenario'] = scenario
+          fioWorkloads.append(FioWorkload(**fioWorkloadAttributes))
   return fioWorkloads
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -59,22 +59,29 @@ spec:
         apt-get update
         apt-get install -y libaio-dev gcc make git time wget
 
+        {{ if .Values.fio.jobFile }}
+        job_file={{ .Values.fio.jobFile }}
+        {{ else }}
         no_of_files_per_thread={{ .Values.fio.filesPerThread }}
         block_size={{ .Values.fio.blockSize }}
         file_size={{ .Values.fio.fileSize }}
         num_of_threads={{ .Values.fio.numThreads }}
+        {{ end }}
 
-        {{ if eq .Values.scenario "local-ssd" }}
+        {{ if or .Values.fio.jobFile (eq .Values.scenario "local-ssd") }}
         echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         apt-get update && apt-get install -y google-cloud-cli
 
+        {{ if eq .Values.scenario "local-ssd" }}
         gcloud storage cp -r gs://{{ .Values.bucketName }}/* /data
 
         echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
         sleep 300
+        {{ end }}
+
         {{ end }}
 
         # We are building fio from source because of the issue: https://github.com/axboe/fio/issues/1668.
@@ -92,6 +99,13 @@ spec:
 
         echo "Preparing fio config file..."
         filename=/fio_loading_test_job.fio
+
+        {{ if .Values.fio.jobFile }}
+
+        gcloud storage cp -v {{.Values.fio.jobFile}} $filename
+
+        {{ else }}
+
         {{ if eq .Values.fio.fileSize "200G" }}
         cat > $filename << EOF
         [global]
@@ -120,6 +134,8 @@ spec:
         {{ else }}
         wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/perfmetrics/scripts/job_files/read_cache_load_test.fio
         {{ end }}
+
+        {{ end }} 
 
         echo "Setup default values..."
         epoch={{ .Values.numEpochs }}
@@ -153,7 +169,12 @@ spec:
         for i in $(seq $epoch); do
           echo "[Epoch ${i}] start time:" `date +%s`
           free -mh # Memory usage before workload start.
+          
+          {{ if .Values.fio.jobFile }}
+          READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
+          {{ else }}
           NUMJOBS=$num_of_threads NRFILES=$no_of_files_per_thread FILE_SIZE=$file_size BLOCK_SIZE=$block_size READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
+          {{ end }}
           free -mh # Memory usage after workload completion.
           echo "[Epoch ${i}] end time:" `date +%s`
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -40,6 +40,7 @@ fio:
   blockSize: 64K
   filesPerThread: "20000"
   numThreads: "50"
+  jobFile: ""
 
 gcsfuse:
   metadataCacheTTLSeconds: "6048000"

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -62,10 +62,6 @@ def createHelmInstallCommands(
             f'--set bucketName={fioWorkload.bucket}',
             f'--set scenario={fioWorkload.scenario}',
             f'--set fio.readType={readType}',
-            f'--set fio.fileSize={fioWorkload.fileSize}',
-            f'--set fio.blockSize={fioWorkload.blockSize}',
-            f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
-            f'--set fio.numThreads={fioWorkload.numThreads}',
             f'--set experimentID={experimentID}',
             (
                 '--set'
@@ -81,6 +77,17 @@ def createHelmInstallCommands(
             f'--set numEpochs={fioWorkload.numEpochs}',
             f'--set gcsfuse.customCSIDriver={customCSIDriver}',
         ]
+        if fioWorkload.jobFile:
+          commands.append(
+              f'--set fio.jobFile={fioWorkload.jobFile}',
+          )
+        else:
+          commands.extend([
+              f'--set fio.fileSize={fioWorkload.fileSize}',
+              f'--set fio.blockSize={fioWorkload.blockSize}',
+              f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
+              f'--set fio.numThreads={fioWorkload.numThreads}',
+          ])
 
         helm_command = ' '.join(commands)
         helm_commands.append(helm_command)
@@ -92,7 +99,10 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      fioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
+      fioWorkloads,
+      args.experiment_id,
+      args.machine_type,
+      args.custom_csi_driver,
   )
   buckets = {fioWorkload.bucket for fioWorkload in fioWorkloads}
   role = 'roles/storage.objectUser'


### PR DESCRIPTION
### Description
- Add `jobFile` in FioWorkload and in all related code. It takes precedence over other attributes `fileSize`, `blockSize` etc.
- Pass FioWorkload.jobFile as `fio.jobFile` to pod workload config through helm
- In the helm pod workload template, add support to download and use `fio.jobFile` instead of using `fio.fileSize` etc. when `fio.jobFile` has been passed.

~This change is dependent on #3349 .~ This change is followed up in #3351 .

This changeset has been migrated to https://github.com/GoogleCloudPlatform/gcsfuse-tools/pull/23 .

### Link to the issue in case of a bug fix.
[b/417969847](http://b/417969847)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
