### PR TITLE
[testing_on_gke][FIO jobFile support part-2] Take rw_type also from fio jobfile if jobfile is provided

### DIFF
--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -36,25 +36,25 @@ def validate_fio_workload(workload: dict, name: str):
       print(f"{name} does not have '{requiredWorkloadAttribute}' key in it.")
       return False
     if not type(workload[requiredWorkloadAttribute]) is expectedType:
-      print(
+      raise Exception(
           f"In {name}, the type of '{requiredWorkloadAttribute}' is of type"
           f" '{type(workload[requiredWorkloadAttribute])}', not {expectedType}"
       )
-      return False
     if expectedType == str and ' ' in workload[requiredWorkloadAttribute]:
-      print(f"{name} has space in the value of '{requiredWorkloadAttribute}'")
-      return False
+      raise Exception(
+          f"{name} has space in the value of '{requiredWorkloadAttribute}'"
+      )
 
   if 'numEpochs' in workload:
     if not type(workload['numEpochs']) is int:
-      print(
+      raise Exception(
           f"In {name}, the type of workload['numEpochs'] is of type"
           f" {type(workload['numEpochs'])}, not {int}"
       )
-      return False
     if int(workload['numEpochs']) < 0:
-      print(f"In {name}, the value of workload['numEpochs'] < 0, expected: >=0")
-      return False
+      raise Exception(
+          f"In {name}, the value of workload['numEpochs'] < 0, expected: >=0"
+      )
 
   if 'dlioWorkload' in workload:
     print(f"{name} has 'dlioWorkload' key in it, which is unexpected.")
@@ -64,17 +64,15 @@ def validate_fio_workload(workload: dict, name: str):
   if 'jobFile' in fioWorkload:
     jobFile = fioWorkload['jobFile'].strip()
     if len(jobFile) == 0:
-      print(
+      raise Exception(
           '{name} has jobFile attribute in it, but it is empty, so ignoring'
           ' this workload.'
       )
-      return False
     elif ' ' in jobFile:
-      print(
+      raise Exception(
           '{name} has jobFile attribute in it, but it has space (" ") in it, so'
           ' ignoring this workload.'
       )
-      return False
   else:
     for requiredAttribute, expectedType in {
         'fileSize': str,
@@ -83,39 +81,36 @@ def validate_fio_workload(workload: dict, name: str):
         'numThreads': int,
     }.items():
       if requiredAttribute not in fioWorkload:
-        print(f'In {name}, fioWorkload does not have {requiredAttribute} in it')
-        return False
+        raise Exception(
+            f'In {name}, fioWorkload does not have {requiredAttribute} in it'
+        )
       if not type(fioWorkload[requiredAttribute]) is expectedType:
-        print(
+        raise Exception(
             f'In {name}, fioWorkload[{requiredAttribute}] is of type'
             f' {type(fioWorkload[requiredAttribute])}, expected:'
             f' {expectedType} '
         )
-        return False
 
     if 'readTypes' in fioWorkload:
       readTypes = fioWorkload['readTypes']
       if not type(readTypes) is list:
-        print(
+        raise Exception(
             f"In {name}, fioWorkload['readTypes'] is of type {type(readTypes)},"
             " not 'list'."
         )
-        return False
       for readType in readTypes:
         if not type(readType) is str:
-          print(
+          raise Exception(
               f'In {name}, one of the values in'
               f" fioWorkload['readTypes'] is '{readType}', which is of type"
               f' {type(readType)}, not str'
           )
-          return False
         if not readType == 'read' and not readType == 'randread':
-          print(
-              f"In {name}, one of the values in fioWorkload['readTypes'] is"
+          raise Exception(
+              f"In {name}, fioWorkload['readTypes'] is"
               f" '{readType}' which is not a supported value. Supported values"
               ' are read, randread'
           )
-          return False
 
   return True
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/fio_workload.py
@@ -22,6 +22,7 @@ import json
 
 
 DefaultNumEpochs = 4
+DefaultReadTypes = ['read', 'randread']
 
 
 def validate_fio_workload(workload: dict, name: str):
@@ -162,7 +163,7 @@ class FioWorkload:
       blockSize: str = None,
       filesPerThread: int = None,
       numThreads: int = None,
-      readTypes: list = None,
+      readTypes: list = DefaultReadTypes,
       jobFile: str = None,
   ):
     self.scenario = scenario
@@ -221,7 +222,7 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
           fioWorkloadAttributes['readTypes'] = (
               fioWorkload['readTypes']
               if 'readTypes' in fioWorkload
-              else ['read', 'randread']
+              else DefaultReadTypes
           )
         for attr in ['bucket', 'gcsfuseMountOptions']:
           fioWorkloadAttributes[attr] = workload[attr]

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -135,7 +135,7 @@ spec:
         wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/perfmetrics/scripts/job_files/read_cache_load_test.fio
         {{ end }}
 
-        {{ end }} 
+        {{ end }}
 
         echo "Setup default values..."
         epoch={{ .Values.numEpochs }}
@@ -169,9 +169,9 @@ spec:
         for i in $(seq $epoch); do
           echo "[Epoch ${i}] start time:" `date +%s`
           free -mh # Memory usage before workload start.
-          
+
           {{ if .Values.fio.jobFile }}
-          READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
+          DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
           {{ else }}
           NUMJOBS=$num_of_threads NRFILES=$no_of_files_per_thread FILE_SIZE=$file_size BLOCK_SIZE=$block_size READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
           {{ end }}

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -87,23 +87,7 @@ def createHelmInstallCommands(
           f'--set numEpochs={fioWorkload.numEpochs}',
           f'--set gcsfuse.customCSIDriver={customCSIDriver}',
       ]
-      if fioWorkload.jobFile:
-        chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
-            fioWorkload, experimentID
-        )
-        moreHelmValues = [
-            f'--set fio.jobFile={fioWorkload.jobFile}',
-        ]
-        helm_commands.append(
-            _create_helm_command(
-                chartName,
-                podName,
-                outputDirPrefix,
-                commonHelmValues,
-                moreHelmValues,
-            )
-        )
-      else:
+      if not fioWorkload.jobFile:
         for readType in fioWorkload.readTypes:
           chartName, podName, outputDirPrefix = (
               fio_workload.FioChartNamePodName(
@@ -126,6 +110,22 @@ def createHelmInstallCommands(
                   moreHelmValues,
               )
           )
+      else:
+        chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
+            fioWorkload, experimentID
+        )
+        moreHelmValues = [
+            f'--set fio.jobFile={fioWorkload.jobFile}',
+        ]
+        helm_commands.append(
+            _create_helm_command(
+                chartName,
+                podName,
+                outputDirPrefix,
+                commonHelmValues,
+                moreHelmValues,
+            )
+        )
   return helm_commands
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -51,46 +51,81 @@ def createHelmInstallCommands(
     resourceLimits = {'cpu': 0, 'memory': '0'}
     resourceRequests = resourceLimits
 
+  # Internal function to keep reusable logic
+  # scoped to this function.
+  def _create_helm_command(
+      chartName: str,
+      podName: str,
+      outputDirPrefix: str,
+      commonHelmValues: [],
+      moreHelmValues: [],
+  ) -> str:
+    commands = [
+        f'helm install {chartName} loading-test',
+        f'--set podName={podName}',
+        f'--set outputDirPrefix={outputDirPrefix}',
+    ]
+    commands.extend(commonHelmValues)
+    commands.extend(moreHelmValues)
+    return ' '.join(commands)
+
   for fioWorkload in fioWorkloads:
     if fioWorkload.numEpochs > 0:
-      for readType in fioWorkload.readTypes:
+      commonHelmValues = [
+          f'--set bucketName={fioWorkload.bucket}',
+          f'--set scenario={fioWorkload.scenario}',
+          f'--set experimentID={experimentID}',
+          (
+              '--set'
+              f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
+          ),
+          f'--set nodeType={machineType}',
+          f"--set resourceLimits.cpu={resourceLimits['cpu']}",
+          f"--set resourceLimits.memory={resourceLimits['memory']}",
+          f"--set resourceRequests.cpu={resourceRequests['cpu']}",
+          f"--set resourceRequests.memory={resourceRequests['memory']}",
+          f'--set numEpochs={fioWorkload.numEpochs}',
+          f'--set gcsfuse.customCSIDriver={customCSIDriver}',
+      ]
+      if fioWorkload.jobFile:
         chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
-            fioWorkload, experimentID, readType
+            fioWorkload, experimentID
         )
-        commands = [
-            f'helm install {chartName} loading-test',
-            f'--set bucketName={fioWorkload.bucket}',
-            f'--set scenario={fioWorkload.scenario}',
-            f'--set experimentID={experimentID}',
-            (
-                '--set'
-                f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
-            ),
-            f'--set nodeType={machineType}',
-            f'--set podName={podName}',
-            f'--set outputDirPrefix={outputDirPrefix}',
-            f"--set resourceLimits.cpu={resourceLimits['cpu']}",
-            f"--set resourceLimits.memory={resourceLimits['memory']}",
-            f"--set resourceRequests.cpu={resourceRequests['cpu']}",
-            f"--set resourceRequests.memory={resourceRequests['memory']}",
-            f'--set numEpochs={fioWorkload.numEpochs}',
-            f'--set gcsfuse.customCSIDriver={customCSIDriver}',
+        moreHelmValues = [
+            f'--set fio.jobFile={fioWorkload.jobFile}',
         ]
-        if fioWorkload.jobFile:
-          commands.append(
-              f'--set fio.jobFile={fioWorkload.jobFile}',
+        helm_commands.append(
+            _create_helm_command(
+                chartName,
+                podName,
+                outputDirPrefix,
+                commonHelmValues,
+                moreHelmValues,
+            )
+        )
+      else:
+        for readType in fioWorkload.readTypes:
+          chartName, podName, outputDirPrefix = (
+              fio_workload.FioChartNamePodName(
+                  fioWorkload, experimentID, readType
+              )
           )
-        else:
-          commands.extend([
+          moreHelmValues = [
               f'--set fio.fileSize={fioWorkload.fileSize}',
               f'--set fio.blockSize={fioWorkload.blockSize}',
               f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
               f'--set fio.numThreads={fioWorkload.numThreads}',
               f'--set fio.readType={readType}',
-          ])
-
-        helm_command = ' '.join(commands)
-        helm_commands.append(helm_command)
+          ]
+          helm_commands.append(
+              _create_helm_command(
+                  chartName,
+                  podName,
+                  outputDirPrefix,
+                  commonHelmValues,
+                  moreHelmValues,
+              )
+          )
   return helm_commands
 
 

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -61,7 +61,6 @@ def createHelmInstallCommands(
             f'helm install {chartName} loading-test',
             f'--set bucketName={fioWorkload.bucket}',
             f'--set scenario={fioWorkload.scenario}',
-            f'--set fio.readType={readType}',
             f'--set experimentID={experimentID}',
             (
                 '--set'
@@ -87,6 +86,7 @@ def createHelmInstallCommands(
               f'--set fio.blockSize={fioWorkload.blockSize}',
               f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
               f'--set fio.numThreads={fioWorkload.numThreads}',
+              f'--set fio.readType={readType}',
           ])
 
         helm_command = ' '.join(commands)

--- a/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
+++ b/perfmetrics/scripts/testing_on_gke/examples/fio/run_tests.py
@@ -60,14 +60,14 @@ def createHelmInstallCommands(
       commonHelmValues: [],
       moreHelmValues: [],
   ) -> str:
-    commands = [
+    command = [
         f'helm install {chartName} loading-test',
         f'--set podName={podName}',
         f'--set outputDirPrefix={outputDirPrefix}',
     ]
-    commands.extend(commonHelmValues)
-    commands.extend(moreHelmValues)
-    return ' '.join(commands)
+    command.extend(commonHelmValues)
+    command.extend(moreHelmValues)
+    return ' '.join(command)
 
   for fioWorkload in fioWorkloads:
     if fioWorkload.numEpochs > 0:


### PR DESCRIPTION
### Description
If a FIO workload has a jobFile attribute, ignore the readType (rw/operation) attribute passed in it, and derive its readType from the jobFile.

This is dependent on https://github.com/GoogleCloudPlatform/gcsfuse/pull/3350 . This is followed up in #3357 .

This has been migrated to https://github.com/GoogleCloudPlatform/gcsfuse-tools/pull/24 .

### Link to the issue in case of a bug fix.
[b/417969847](http://b/417969847)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
