### PR TITLE
Enable optimized config for high perf node

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -341,7 +341,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("dir-mode", "", "0755", "Permissions bits for directories, in octal.")
 
-	flagSet.BoolP("disable-autoconfig", "", true, "Disable optimizing configuration automatically for a machine")
+	flagSet.BoolP("disable-autoconfig", "", false, "Disable optimizing configuration automatically for a machine")
 
 	if err := flagSet.MarkHidden("disable-autoconfig"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -75,7 +75,7 @@
   flag-name: "disable-autoconfig"
   type: "bool"
   usage: "Disable optimizing configuration automatically for a machine"
-  default: true
+  default: false
   hide-flag: true
 
 - config-path: "enable-atomic-rename-object"


### PR DESCRIPTION
### Description
Enable optimized config for high perf node

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
