### PR TITLE
[Random Reader Refactoring] Adding inactive reader support

### DIFF
--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/storage/gcs"
@@ -71,12 +72,12 @@ type GCSReader struct {
 	totalReadBytes uint64
 }
 
-func NewGCSReader(obj *gcs.MinObject, bucket gcs.Bucket, metricHandle common.MetricHandle, mrdWrapper *gcsx.MultiRangeDownloaderWrapper, sequentialReadSizeMb int32) *GCSReader {
+func NewGCSReader(obj *gcs.MinObject, bucket gcs.Bucket, metricHandle common.MetricHandle, mrdWrapper *gcsx.MultiRangeDownloaderWrapper, sequentialReadSizeMb int32, config *cfg.ReadConfig) *GCSReader {
 	return &GCSReader{
 		object:               obj,
 		bucket:               bucket,
 		sequentialReadSizeMb: sequentialReadSizeMb,
-		rangeReader:          NewRangeReader(obj, bucket, metricHandle),
+		rangeReader:          NewRangeReader(obj, bucket, config, metricHandle),
 		mrr:                  NewMultiRangeReader(obj, metricHandle, mrdWrapper),
 		readType:             util.Sequential,
 	}

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -157,7 +157,7 @@ func (gr *GCSReader) getReadInfo(start int64, size int64) (int64, error) {
 	// Determine the end position based on the read pattern.
 	end := gr.determineEnd(start)
 
-	// Limit the end position to SequentialReadSizeMb.
+	// Limit the end position to sequentialReadSizeMb.
 	end = gr.limitEnd(start, end)
 
 	return end, nil

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/clock"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
@@ -73,7 +74,7 @@ func (t *gcsReaderTest) SetupTest() {
 		Generation: 1234,
 	}
 	t.mockBucket = new(storage.TestifyMockBucket)
-	t.gcsReader = NewGCSReader(t.object, t.mockBucket, common.NewNoopMetrics(), nil, sequentialReadSizeInMb)
+	t.gcsReader = NewGCSReader(t.object, t.mockBucket, common.NewNoopMetrics(), nil, sequentialReadSizeInMb, nil)
 	t.ctx = context.Background()
 }
 
@@ -92,7 +93,7 @@ func (t *gcsReaderTest) Test_NewGCSReader() {
 		Generation: 4321,
 	}
 
-	gcsReader := NewGCSReader(object, t.mockBucket, common.NewNoopMetrics(), nil, 200)
+	gcsReader := NewGCSReader(object, t.mockBucket, common.NewNoopMetrics(), nil, 200, nil)
 
 	assert.Equal(t.T(), object, gcsReader.object)
 	assert.Equal(t.T(), t.mockBucket, gcsReader.bucket)
@@ -484,6 +485,77 @@ func (t *gcsReaderTest) Test_ReadInfo_Random() {
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), random, t.gcsReader.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
+		})
+	}
+}
+
+// Validates:
+// 1. No change in ReadAt behavior based inactiveStreamTimeout config.
+// 2. Valid timeout config creates inactiveTimeoutReader instance of storage.Reader.
+func (t *gcsReaderTest) Test_ReadAt_WithAndWithoutReadConfig() {
+	testCases := []struct {
+		name                        string
+		config                      *cfg.ReadConfig
+		expectInactiveTimeoutReader bool
+	}{
+		{
+			name:                        "WithoutReadConfig",
+			config:                      nil,
+			expectInactiveTimeoutReader: false,
+		},
+		{
+			name:                        "WithReadConfigAndZeroTimeout",
+			config:                      &cfg.ReadConfig{InactiveStreamTimeout: 0},
+			expectInactiveTimeoutReader: false,
+		},
+		{
+			name:                        "WithReadConfigAndPositiveTimeout",
+			config:                      &cfg.ReadConfig{InactiveStreamTimeout: 10 * time.Millisecond},
+			expectInactiveTimeoutReader: true,
+		},
+	}
+
+	objectSize := uint64(20)
+	readOffset := int64(0)
+	readLength := 10 // Reading only 10 bytes from the complete object reader.
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.SetupTest() // Resets mockBucket, rr, etc. for each sub-test
+			defer t.TearDownTest()
+
+			t.gcsReader.rangeReader.config = tc.config
+			t.gcsReader.rangeReader.reader = nil // Ensure startRead path is taken in ReadAt
+			t.object.Size = objectSize
+			// Prepare fake content for the GCS object.
+			// startRead will attempt to read the entire object [0, objectSize)
+			// because objectSize is small compared to typical sequentialReadSizeMb.
+			fakeReaderContent := testUtil.GenerateRandomBytes(int(t.object.Size))
+			rc := &fake.FakeReader{ReadCloser: getReadCloser(fakeReaderContent)}
+			expectedReadObjectRequest := &gcs.ReadObjectRequest{
+				Name:       t.object.Name,
+				Generation: t.object.Generation,
+				Range: &gcs.ByteRange{
+					Start: uint64(readOffset), // Read from the beginning
+					Limit: t.object.Size,      // getReadInfo will determine this limit
+				},
+				ReadCompressed: t.object.HasContentEncodingGzip(),
+				ReadHandle:     nil, // No existing read handle
+			}
+			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, expectedReadObjectRequest).Return(rc, nil).Once()
+			// BucketType is called by ReadAt -> getReadInfo -> readerType to determine reader strategy.
+			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false}).Once()
+
+			objectData, err := t.readAt(readOffset, int64(readLength))
+
+			t.mockBucket.AssertExpectations(t.T())
+			assert.NoError(t.T(), err)
+			assert.Equal(t.T(), readLength, objectData.Size)
+			assert.Equal(t.T(), fakeReaderContent[:readLength], objectData.DataBuf[:objectData.Size]) // Ensure buffer is populated correctly
+			assert.NotNil(t.T(), t.gcsReader.rangeReader.reader, "Reader should be active as partial data read from the requested range.")
+			assert.NotNil(t.T(), t.gcsReader.rangeReader.cancel)
+			assert.Equal(t.T(), int64(readLength), t.gcsReader.rangeReader.start)
+			assert.Equal(t.T(), int64(t.object.Size), t.gcsReader.rangeReader.limit)
 		})
 	}
 }

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -566,6 +566,8 @@ func (t *gcsReaderTest) Test_ReadAt_WithAndWithoutReadConfig() {
 			assert.NotNil(t.T(), t.gcsReader.rangeReader.cancel)
 			assert.Equal(t.T(), int64(readLength), t.gcsReader.rangeReader.start)
 			assert.Equal(t.T(), int64(t.object.Size), t.gcsReader.rangeReader.limit)
+			_, isInactiveTimeoutReader := t.gcsReader.rangeReader.reader.(*gcsx.InactiveTimeoutReader)
+			assert.Equal(t.T(), tc.expectInactiveTimeoutReader, isInactiveTimeoutReader)
 		})
 	}
 }

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -64,7 +64,7 @@ func (t *rangeReaderTest) SetupTest() {
 		Generation: 1234,
 	}
 	t.mockBucket = new(storage.TestifyMockBucket)
-	t.rangeReader = NewRangeReader(t.object, t.mockBucket, common.NewNoopMetrics())
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, common.NewNoopMetrics())
 	t.ctx = context.Background()
 }
 
@@ -146,7 +146,7 @@ func (t *rangeReaderTest) Test_NewRangeReader() {
 		Generation: 4321,
 	}
 
-	reader := NewRangeReader(object, t.mockBucket, common.NewNoopMetrics())
+	reader := NewRangeReader(object, t.mockBucket, nil, common.NewNoopMetrics())
 
 	assert.Equal(t.T(), object, reader.object)
 	assert.Equal(t.T(), t.mockBucket, reader.bucket)

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// inactiveTimeoutReader is a wrapper over gcs.StorageReader that automatically
+// InactiveTimeoutReader is a wrapper over gcs.StorageReader that automatically
 // closes the wrapped GCS reader connection after a specified period of
 // inactivity (timeout). When a read operation is attempted on an inactive
 // (closed) reader, it automatically attempts to reconnect using the last known
@@ -46,7 +46,7 @@ import (
 //     relative to the background routine wake-up cycle.
 //   - Thread Safety: The reader is safe for concurrent use by multiple goroutines,
 //     protected by an internal mutex.
-type inactiveTimeoutReader struct {
+type InactiveTimeoutReader struct {
 	object *gcs.MinObject
 	bucket gcs.Bucket
 
@@ -93,12 +93,12 @@ func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, o
 		return nil, ErrZeroInactivityTimeout
 	}
 
-	itr := &inactiveTimeoutReader{
+	itr := &InactiveTimeoutReader{
 		object:     object,
 		bucket:     bucket,
 		reqRange:   byteRange,
 		readHandle: readHandle,
-		mu:         locker.New("inactiveTimeoutReader: "+object.Name, func() {}),
+		mu:         locker.New("InactiveTimeoutReader: "+object.Name, func() {}),
 		isActive:   false,
 	}
 	itr.ctx, itr.cancel = context.WithCancel(ctx)
@@ -115,7 +115,7 @@ func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, o
 }
 
 // createGCSReader is a helper method to create the underlined reader from itr.start + itr.seen offset.
-func (itr *inactiveTimeoutReader) createGCSReader() (gcs.StorageReader, error) {
+func (itr *InactiveTimeoutReader) createGCSReader() (gcs.StorageReader, error) {
 	reader, err := itr.bucket.NewReaderWithReadHandle(
 		itr.ctx,
 		&gcs.ReadObjectRequest{
@@ -145,7 +145,7 @@ func (itr *inactiveTimeoutReader) createGCSReader() (gcs.StorageReader, error) {
 //
 // Calling Read() after explicitly calling Close() is not supported and will
 // lead to undefined behavior.
-func (itr *inactiveTimeoutReader) Read(p []byte) (n int, err error) {
+func (itr *InactiveTimeoutReader) Read(p []byte) (n int, err error) {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
@@ -165,7 +165,7 @@ func (itr *inactiveTimeoutReader) Read(p []byte) (n int, err error) {
 // Close explicitly closes the underlying gcs.StorageReader if it's currently open.
 // It also signals the background monitor goroutine to stop.
 // Returns an error if closing the underlying reader fails.
-func (itr *inactiveTimeoutReader) Close() (err error) {
+func (itr *InactiveTimeoutReader) Close() (err error) {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
@@ -187,7 +187,7 @@ func (itr *inactiveTimeoutReader) Close() (err error) {
 // ReadHandle returns the read handle associated with the underlying GCS reader.
 // If the reader has been closed due to inactivity, it returns the handle
 // stored from the last active reader.
-func (itr *inactiveTimeoutReader) ReadHandle() (rh storagev2.ReadHandle) {
+func (itr *InactiveTimeoutReader) ReadHandle() (rh storagev2.ReadHandle) {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
@@ -199,7 +199,7 @@ func (itr *inactiveTimeoutReader) ReadHandle() (rh storagev2.ReadHandle) {
 }
 
 // monitor runs in a background goroutine, and checks for inactivity.
-func (itr *inactiveTimeoutReader) monitor(clock clock.Clock, timeout time.Duration) {
+func (itr *InactiveTimeoutReader) monitor(clock clock.Clock, timeout time.Duration) {
 	timer := clock.After(timeout)
 	for {
 		select {
@@ -217,7 +217,7 @@ func (itr *inactiveTimeoutReader) monitor(clock clock.Clock, timeout time.Durati
 // If the reader was marked as active since the last check, it resets the
 // activity flag. If the reader was inactive, it closes the underlying GCS reader.
 // It always returns a new timer channel for the next fire.
-func (itr *inactiveTimeoutReader) handleTimeout() {
+func (itr *InactiveTimeoutReader) handleTimeout() {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
@@ -230,7 +230,7 @@ func (itr *inactiveTimeoutReader) handleTimeout() {
 
 // closeGCSReader closes the wrapped gcsReader, itr.mu.Lock() should be taken
 // before calling this.
-func (itr *inactiveTimeoutReader) closeGCSReader() {
+func (itr *InactiveTimeoutReader) closeGCSReader() {
 	if itr.gcsReader == nil {
 		return
 	}

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -158,7 +158,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_NoReadCloserWithinTimeout() {
 
 	n2, err2 := s.reader.Read(buf)
 
-	inactiveReader := s.reader.(*inactiveTimeoutReader)
+	inactiveReader := s.reader.(*InactiveTimeoutReader)
 	s.True(inactiveReader.isActive)
 	s.NoError(err2)
 	s.Equal(6, n2)
@@ -189,7 +189,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to make the read inactive.
 	require.Eventually(s.T(), func() bool {
-		rr := s.reader.(*inactiveTimeoutReader)
+		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
@@ -198,7 +198,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
-		rr := s.reader.(*inactiveTimeoutReader)
+		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return (rr.gcsReader == nil)
@@ -231,7 +231,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to make the read inactive.
 	require.Eventually(s.T(), func() bool {
-		rr := s.reader.(*inactiveTimeoutReader)
+		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
@@ -240,7 +240,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
-		rr := s.reader.(*inactiveTimeoutReader)
+		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return (rr.gcsReader == nil)
@@ -276,7 +276,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Close_ExplicitClose() {
 	err := s.reader.Close()
 
 	s.NoError(err)
-	s.Nil(s.reader.(*inactiveTimeoutReader).gcsReader)
+	s.Nil(s.reader.(*InactiveTimeoutReader).gcsReader)
 	s.reader = nil // Prevent TearDownTest from closing again
 }
 
@@ -287,7 +287,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveClose() {
 	s.setupReader(0) // Sets up s.reader and s.initialFakeReader
 	expectedHandleAfterClose := []byte("handle-after-close")
 	s.initialFakeReader.Handle = expectedHandleAfterClose
-	itr := s.reader.(*inactiveTimeoutReader)
+	itr := s.reader.(*InactiveTimeoutReader)
 	itr.isActive = false // Simulate inactivity
 
 	itr.handleTimeout()
@@ -304,7 +304,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_ActiveBecomeInactive
 	s.setupReader(0) // Sets up s.reader and s.initialFakeReader
 	expectedHandleAfterClose := []byte("handle-after-close")
 	s.initialFakeReader.Handle = expectedHandleAfterClose
-	itr := s.reader.(*inactiveTimeoutReader)
+	itr := s.reader.(*InactiveTimeoutReader)
 	itr.isActive = true
 
 	itr.handleTimeout()
@@ -318,7 +318,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_closeGCSReader_NilReader() {
 	s.timeout = 50 * time.Millisecond
 	s.readHandle = []byte("handle-before-close")
 	s.setupReader(0) // Sets up s.reader and s.initialFakeReader
-	itr := s.reader.(*inactiveTimeoutReader)
+	itr := s.reader.(*InactiveTimeoutReader)
 	itr.gcsReader = nil
 
 	itr.closeGCSReader()
@@ -334,7 +334,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_closeGCSReader_NonNilReader() {
 	s.setupReader(0) // Sets up s.reader and s.initialFakeReader
 	expectedHandleAfterClose := []byte("handle-after-close")
 	s.initialFakeReader.Handle = expectedHandleAfterClose
-	itr := s.reader.(*inactiveTimeoutReader)
+	itr := s.reader.(*InactiveTimeoutReader)
 
 	itr.closeGCSReader()
 
@@ -370,7 +370,7 @@ func (s *InactiveTimeoutReaderTestSuite) TestRaceCondition() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			s.reader.(*inactiveTimeoutReader).handleTimeout()
+			s.reader.(*InactiveTimeoutReader).handleTimeout()
 		}
 	}()
 

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -866,7 +866,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ValidateTimeout
 
 // Validates:
 // 1. No change in ReadAt behavior based inactiveStreamTimeout config.
-// 2. Valid timeout config creates inactiveTimeoutReader instance of storage.Reader.
+// 2. Valid timeout config creates InactiveTimeoutReader instance of storage.Reader.
 func (t *RandomReaderStretchrTest) Test_ReadAt_WithAndWithoutReadConfig() {
 	testCases := []struct {
 		name                        string
@@ -932,7 +932,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_WithAndWithoutReadConfig() {
 			assert.NotNil(t.T(), t.rr.wrapped.cancel)
 			assert.Equal(t.T(), int64(readLength), t.rr.wrapped.start)
 			assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.limit)
-			_, isInactiveTimeoutReader := t.rr.wrapped.reader.(*inactiveTimeoutReader)
+			_, isInactiveTimeoutReader := t.rr.wrapped.reader.(*InactiveTimeoutReader)
 			assert.Equal(t.T(), tc.expectInactiveTimeoutReader, isInactiveTimeoutReader)
 		})
 	}

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -43,7 +43,7 @@ type ReadManagerConfig struct {
 	CacheFileForRangeRead bool
 	MetricHandle          common.MetricHandle
 	MrdWrapper            *gcsx.MultiRangeDownloaderWrapper
-	readConfig            *cfg.ReadConfig
+	ReadConfig            *cfg.ReadConfig
 }
 
 // NewReadManager creates a new ReadManager for the given GCS object,
@@ -69,10 +69,12 @@ func NewReadManager(object *gcs.MinObject, bucket gcs.Bucket, config *ReadManage
 	gcsReader := clientReaders.NewGCSReader(
 		object,
 		bucket,
-		config.MetricHandle,
-		config.MrdWrapper,
-		config.SequentialReadSizeMB,
-		config.readConfig,
+		&clientReaders.GCSReaderConfig{
+			MetricHandle:         config.MetricHandle,
+			MrdWrapper:           config.MrdWrapper,
+			SequentialReadSizeMb: config.SequentialReadSizeMB,
+			ReadConfig:           config.ReadConfig,
+		},
 	)
 	// Add the GCS reader as a fallback.
 	readers = append(readers, gcsReader)

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/googlecloudplatform/gcsfuse/v2/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v2/common"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v2/internal/gcsx"
@@ -42,6 +43,7 @@ type ReadManagerConfig struct {
 	CacheFileForRangeRead bool
 	MetricHandle          common.MetricHandle
 	MrdWrapper            *gcsx.MultiRangeDownloaderWrapper
+	readConfig            *cfg.ReadConfig
 }
 
 // NewReadManager creates a new ReadManager for the given GCS object,
@@ -70,6 +72,7 @@ func NewReadManager(object *gcs.MinObject, bucket gcs.Bucket, config *ReadManage
 		config.MetricHandle,
 		config.MrdWrapper,
 		config.SequentialReadSizeMB,
+		config.readConfig,
 	)
 	// Add the GCS reader as a fallback.
 	readers = append(readers, gcsReader)


### PR DESCRIPTION
### Description
- Adding inactive reader support - https://github.com/GoogleCloudPlatform/gcsfuse/pull/3284
- Made InactiveTimeoutReader public
- Created GCSReaderConfig to store all the fields related to GCSReaders.

### Link to the issue in case of a bug fix.
[b/420579744](https://b.corp.google.com/issues/420579744)


### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
