### PR TITLE
Add markers for benchmark tables

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,7 +84,7 @@ numbers will be different for edits/appends to existing files.
 all writes are first staged to a local temporary directory before being written
 to GCS on close/fsync.
 
-# Benchmarks start
+<!-- Benchmarks start -->
 
 ## GCSFuse Benchmarking on c4 machine-type
 * VM Type: c4-standard-96
@@ -171,7 +171,7 @@ to GCS on close/fsync.
 | 100M |1M | 10 | 3519 | 3518 | 11.83 |
 | 1G | 1M | 2 | 1892 | 1891 | 45.40  |
 
-# Benchmarks end
+<!-- Benchmarks end -->
 
 ## Steps to benchmark GCSFuse performance
 


### PR DESCRIPTION
### Description
Adding benchmark markers [END, START] to identify section where benchmark results should be updated with script.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
