### PR TITLE
Add support for truncate to lower for streaming writes and fix promotion to generation backed Inode in Write and Truncate Flow.

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -261,10 +261,9 @@ func (wh *bufferedWriteHandlerImpl) SetMtime(mtime time.Time) {
 
 func (wh *bufferedWriteHandlerImpl) Truncate(size int64) error {
 	if size < wh.totalSize {
-		logger.Errorf("BufferedWriteHandler.TruncateToLowerSizeError for object: %s, file size: %d, truncate size: %d",
-			wh.uploadHandler.objectName, wh.totalSize, size)
 		return ErrTruncateSizeLessThanFileSize
 	}
+
 	wh.truncatedSize = size
 	return nil
 }

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -88,7 +88,6 @@ type WriteFileInfo struct {
 }
 
 var ErrOutOfOrderWrite = errors.New("outOfOrder write detected")
-var ErrTruncateSizeLessThanFileSize = errors.New("truncate size less than file size")
 
 type CreateBWHandlerRequest struct {
 	Object                   *gcs.Object
@@ -261,7 +260,7 @@ func (wh *bufferedWriteHandlerImpl) SetMtime(mtime time.Time) {
 
 func (wh *bufferedWriteHandlerImpl) Truncate(size int64) error {
 	if size < wh.totalSize {
-		return ErrTruncateSizeLessThanFileSize
+		return ErrOutOfOrderWrite
 	}
 
 	wh.truncatedSize = size

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -88,6 +88,7 @@ type WriteFileInfo struct {
 }
 
 var ErrOutOfOrderWrite = errors.New("outOfOrder write detected")
+var ErrTruncateSizeLessThanFileSize = errors.New("truncate size less than file size")
 
 type CreateBWHandlerRequest struct {
 	Object                   *gcs.Object
@@ -260,9 +261,10 @@ func (wh *bufferedWriteHandlerImpl) SetMtime(mtime time.Time) {
 
 func (wh *bufferedWriteHandlerImpl) Truncate(size int64) error {
 	if size < wh.totalSize {
-		return fmt.Errorf("cannot truncate to lesser size when upload is in progress")
+		logger.Errorf("BufferedWriteHandler.TruncateToLowerSizeError for object: %s, file size: %d, truncate size: %d",
+			wh.uploadHandler.objectName, wh.totalSize, size)
+		return ErrTruncateSizeLessThanFileSize
 	}
-
 	wh.truncatedSize = size
 	return nil
 }

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -410,6 +410,7 @@ func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {
 	err := testSuite.bwh.Truncate(2)
 
 	assert.Error(testSuite.T(), err)
+	assert.Equal(testSuite.T(), ErrOutOfOrderWrite, err)
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithSizeGreaterThanCurrentObjectSize() {

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -161,7 +161,7 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 // unfinalized objects in zonal buckets, streaming writes is used.
 // Note that the writes are still done at the inode level.
 // LOCKS_EXCLUDED(fh.inode)
-func (fh *FileHandle) Write(ctx context.Context, data []byte, offset int64) error {
+func (fh *FileHandle) Write(ctx context.Context, data []byte, offset int64) (bool, error) {
 	fh.inode.Lock()
 	defer fh.inode.Unlock()
 

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -116,7 +116,7 @@ func TestFileHandleWrite(t *testing.T) {
 	ctx := context.Background()
 	data := []byte("hello")
 
-	err := fh.Write(ctx, data, 0)
+	_, err := fh.Write(ctx, data, 0)
 
 	assert.Nil(t, err)
 	// Validate that write is successful at inode.

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -939,9 +939,6 @@ func (f *FileInode) Truncate(
 			return
 		}
 	}
-	if !errors.Is(err, bufferedwrites.ErrTruncateSizeLessThanFileSize) {
-		return fmt.Errorf("got unexpected error from bwh.Truncate(): %w", err)
-	}
 	// If truncate size is less than total size, finalize and fall back to temp file.
 	if errors.Is(err, bufferedwrites.ErrTruncateSizeLessThanFileSize) {
 		logger.Warnf("Falling back to staged writes on disk for file %s (inode %d) due to err: %v.", f.Name(), f.ID(), err.Error())
@@ -951,7 +948,9 @@ func (f *FileInode) Truncate(
 			return fmt.Errorf("could not finalize what has been written so far: %w", err)
 		}
 	}
-
+	if err != nil {
+		return fmt.Errorf("got unexpected error from bwh.Truncate(): %w", err)
+	}
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)
 	if err != nil {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -203,6 +203,14 @@ func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnNonZeroS
 	assert.Nil(t.T(), t.in.bwh)
 }
 
+func (t *FileStreamingWritesCommon) TestTruncateNegative() {
+	// Truncate neagtive.
+	gcsSynced, err := t.in.Truncate(t.ctx, -1)
+
+	require.Error(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Tests (Zonal Bucket)
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -189,8 +189,10 @@ func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnZeroSize
 
 func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnNonZeroSizeDoesNotRecreatesBwhOnInitAgain() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0, util.Write))
-	err := t.in.flushUsingBufferedWriteHandler()
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+	err = t.in.flushUsingBufferedWriteHandler()
 	require.NoError(t.T(), err)
 	assert.Nil(t.T(), t.in.bwh)
 
@@ -215,16 +217,20 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 
 func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForZonalBuckets() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsPromotesInodeToNonLocal() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("pizza"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("pizza"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	require.False(t.T(), gcsSynced)
 
-	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites()
 
 	require.NoError(t.T(), err)
 	assert.True(t.T(), gcsSynced)
@@ -236,10 +242,12 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsUpdatesSrcSize() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites()
 
 	require.NoError(t.T(), err)
 	assert.True(t.T(), gcsSynced)
@@ -260,16 +268,20 @@ func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsTrue
 
 func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForNonZonalBuckets() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotPromoteInodeToNonLocal() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("taco"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
-	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites()
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -279,10 +291,12 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 
 func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotUpdateSrcSize() {
 	t.createBufferedWriteHandler()
-	assert.NoError(t.T(), t.in.Write(t.ctx, []byte("foobar"), 0, util.Write))
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, util.Write)
+	assert.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	gcsSynced, err := t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites()
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -319,8 +333,9 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			createTime := t.clock.Now()
 			t.clock.AdvanceTime(15 * time.Minute)
 			// Sequential Write at offset 0
-			err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
 			require.Nil(t.T(), err)
+			assert.False(t.T(), gcsSynced)
 			require.NotNil(t.T(), t.in.bwh)
 			// validate attributes.
 			attrs, err := t.in.Attributes(t.ctx)
@@ -330,8 +345,9 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 
 			// Out of order write.
 			mtime := t.clock.Now()
-			err = t.in.Write(t.ctx, []byte("hello"), tc.offset, util.Write)
+			gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), tc.offset, util.Write)
 			require.Nil(t.T(), err)
+			assert.True(t.T(), gcsSynced)
 
 			// Ensure bwh cleared and temp file created.
 			assert.Nil(t.T(), t.in.bwh)
@@ -342,7 +358,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			assert.Equal(t.T(), uint64(len(tc.expectedContent)), attrs.Size)
 			assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
 			// sync file and validate content
-			gcsSynced, err := t.in.Sync(t.ctx)
+			gcsSynced, err = t.in.Sync(t.ctx)
 			require.Nil(t.T(), err)
 			assert.True(t.T(), gcsSynced)
 			// Read the object's contents.
@@ -358,8 +374,9 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	assert.True(t.T(), t.in.IsLocal())
 	createTime := t.in.mtimeClock.Now()
 	// Out of order write.
-	err := t.in.Write(t.ctx, []byte("taco"), 6, util.Write)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 6, util.Write)
 	require.Nil(t.T(), err)
+	assert.True(t.T(), gcsSynced)
 	// Ensure bwh cleared and temp file created.
 	assert.Nil(t.T(), t.in.bwh)
 	assert.NotNil(t.T(), t.in.content)
@@ -371,8 +388,9 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 
 	// Ordered write.
 	mtime := t.clock.Now()
-	err = t.in.Write(t.ctx, []byte("hello"), 0, util.Write)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 0, util.Write)
 	require.Nil(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	// Ensure bwh not re-created.
 	assert.Nil(t.T(), t.in.bwh)
@@ -382,7 +400,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	assert.Equal(t.T(), uint64(len("hello\x00taco")), attrs.Size)
 	assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
 	// sync file and validate content
-	gcsSynced, err := t.in.Sync(t.ctx)
+	gcsSynced, err = t.in.Sync(t.ctx)
 	require.Nil(t.T(), err)
 	assert.True(t.T(), gcsSynced)
 	// Read the object's contents.
@@ -393,17 +411,19 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesOnClobberedFileThrowsError() {
 	t.createBufferedWriteHandler()
-	err := t.in.Write(t.ctx, []byte("hi"), 0, util.Write)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, util.Write)
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), t.in.bwh)
+	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 	// Clobber the file.
 	objWritten, err := storageutil.CreateObject(t.ctx, t.bucket, fileName, []byte("taco"))
 	require.Nil(t.T(), err)
 
-	err = t.in.Write(t.ctx, []byte("hello"), 10, util.Write)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 10, util.Write)
 
 	require.Error(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	var fileClobberedError *gcsfuse_errors.FileClobberedError
 	assert.ErrorAs(t.T(), err, &fileClobberedError)
 	// Validate Object on GCS not updated.
@@ -428,9 +448,10 @@ func (t *FileStreamingWritesTest) TestUnlinkLocalFileAfterWrite() {
 	assert.True(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
 	// Write some content.
-	err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
+	assert.False(t.T(), gcsSynced)
 
 	// Unlink.
 	t.in.Unlink()
@@ -445,9 +466,10 @@ func (t *FileStreamingWritesTest) TestUnlinkEmptySyncedFile() {
 	assert.False(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
 	// Write some content to temp file.
-	err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
+	assert.False(t.T(), gcsSynced)
 
 	// Unlink.
 	t.in.Unlink()
@@ -480,9 +502,10 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndFlush() {
 			}
 			t.createBufferedWriteHandler()
 			// Write some content to temp file.
-			err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
 			assert.Nil(t.T(), err)
 			assert.NotNil(t.T(), t.in.bwh)
+			assert.False(t.T(), gcsSynced)
 			t.clock.AdvanceTime(10 * time.Second)
 
 			err = t.in.Flush(t.ctx)
@@ -640,12 +663,13 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndSync() {
 			}
 			t.createBufferedWriteHandler()
 			// Write some content to temp file.
-			err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, util.Write)
 			assert.Nil(t.T(), err)
 			assert.NotNil(t.T(), t.in.bwh)
+			assert.False(t.T(), gcsSynced)
 			t.clock.AdvanceTime(10 * time.Second)
 
-			gcsSynced, err := t.in.Sync(t.ctx)
+			gcsSynced, err = t.in.Sync(t.ctx)
 
 			require.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
@@ -670,8 +694,9 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndSync() {
 func (t *FileStreamingWritesTest) TestSourceGenerationSizeForLocalFileIsReflected() {
 	t.createBufferedWriteHandler()
 	assert.True(t.T(), t.in.IsLocal())
-	err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, util.Write)
+	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, util.Write)
 	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	sg := t.in.SourceGeneration()
 	assert.Nil(t.T(), t.backingObj)
@@ -684,8 +709,9 @@ func (t *FileStreamingWritesTest) TestSourceGenerationSizeForSyncedFileIsReflect
 	t.createInode(fileName, emptyGCSFile)
 	assert.False(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
-	err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, util.Write)
+	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, util.Write)
 	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	sg := t.in.SourceGeneration()
 	assert.EqualValues(t.T(), t.backingObj.Generation, sg.Object)
@@ -697,14 +723,16 @@ func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreate
 	t.createBufferedWriteHandler()
 	assert.True(t.T(), t.in.IsLocal())
 	// Out of order write.
-	err := t.in.Write(t.ctx, []byte("taco"), 2, util.Write)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 2, util.Write)
 	require.Nil(t.T(), err)
+	assert.True(t.T(), gcsSynced)
 	// Ensure bwh cleared and temp file created.
 	assert.Nil(t.T(), t.in.bwh)
 	assert.NotNil(t.T(), t.in.content)
 
-	err = t.in.Truncate(t.ctx, 10)
+	gcsSynced, err = t.in.Truncate(t.ctx, 10)
 	require.Nil(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 
 	// Ensure bwh not re-created.
 	assert.Nil(t.T(), t.in.bwh)
@@ -713,7 +741,7 @@ func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreate
 	require.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(10), attrs.Size)
 	// sync file and validate content
-	gcsSynced, err := t.in.Sync(t.ctx)
+	gcsSynced, err = t.in.Sync(t.ctx)
 	require.Nil(t.T(), err)
 	assert.True(t.T(), gcsSynced)
 	// Read the object's contents.
@@ -813,8 +841,9 @@ func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
 		},
 	}
 
-	err := t.in.Write(context.Background(), []byte("hello"), 0, util.Write)
+	gcsSynced, err := t.in.Write(context.Background(), []byte("hello"), 0, util.Write)
 
 	require.Error(t.T(), err)
+	assert.False(t.T(), gcsSynced)
 	assert.Regexp(t.T(), writeErr.Error(), err.Error())
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -422,6 +422,16 @@ func (t *FileTest) TestTruncate() {
 	assert.Equal(t.T(), attrs.Mtime, truncateTime)
 }
 
+func (t *FileTest) TestTruncateNegative() {
+	assert.Equal(t.T(), "taco", t.initialContents)
+
+	// Truncate neagtive.
+	gcsSynced, err := t.in.Truncate(t.ctx, -1)
+
+	require.Error(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+}
+
 func (t *FileTest) TestWriteThenSync() {
 	testcases := []struct {
 		name     string

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -1050,7 +1050,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 
 			t.createBufferedWriteHandler(true)
-			err = t.in.Write(t.ctx, []byte("hihello"), 0)
+			err = t.in.Write(t.ctx, []byte("hihello"), 0, util.Write)
 			assert.Nil(t.T(), err)
 			assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
 			// Fetch the attributes and check if the file size reflects the write.

--- a/internal/fs/streaming_writes_empty_gcs_object_test.go
+++ b/internal/fs/streaming_writes_empty_gcs_object_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -50,20 +51,21 @@ func (t *StreamingWritesEmptyGCSObjectTest) TearDownSuite() {
 	t.fsTest.TearDownTestSuite()
 }
 func (t *StreamingWritesEmptyGCSObjectTest) SetupTest() {
-	// Create an object on bucket.
+	// Create an empty object on bucket.
 	_, err := storageutil.CreateObject(
 		ctx,
 		bucket,
 		fileName,
-		[]byte("bar"))
+		[]byte(""))
 	assert.Equal(t.T(), nil, err)
 	// Open file handle to read or write.
 	t.f1, err = os.OpenFile(path.Join(mntDir, fileName), os.O_RDWR|syscall.O_DIRECT, filePerms)
 	assert.Equal(t.T(), nil, err)
 
-	// Validate that file exists on GCS.
-	_, err = storageutil.ReadObject(ctx, bucket, fileName)
-	assert.NoError(t.T(), err)
+	// Validate that empty file exists on GCS.
+	content, err := storageutil.ReadObject(ctx, bucket, fileName)
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), "", string(content))
 }
 
 func (t *StreamingWritesEmptyGCSObjectTest) TearDownTest() {

--- a/tools/integration_tests/local_file/stat_file.go
+++ b/tools/integration_tests/local_file/stat_file.go
@@ -59,7 +59,8 @@ func (t *CommonLocalFileTestSuite) TestStatOnLocalFileWithConflictingFileNameSuf
 func (t *CommonLocalFileTestSuite) TestTruncateLocalFileToSmallerSize() {
 	testDirPath = setup.SetupTestDirectory(testDirName)
 	// Create a local file.
-	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t.T())
+	fileName := FileName1 + setup.GenerateRandomString(5)
+	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, fileName, t.T())
 	// Writing contents to local file .
 	operations.WriteWithoutClose(fh, FileContents, t.T())
 
@@ -77,5 +78,5 @@ func (t *CommonLocalFileTestSuite) TestTruncateLocalFileToSmallerSize() {
 
 	// Close the file and validate that the file is created on GCS.
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, fh, testDirName,
-		FileName1, FileContents[:SmallerSizeTruncate], t.T())
+		fileName, FileContents[:SmallerSizeTruncate], t.T())
 }

--- a/tools/integration_tests/local_file/stat_file.go
+++ b/tools/integration_tests/local_file/stat_file.go
@@ -61,7 +61,7 @@ func (t *CommonLocalFileTestSuite) TestTruncateLocalFileToSmallerSize() {
 	// Create a local file.
 	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t.T())
 	// Writing contents to local file .
-	WritingToLocalFileShouldNotWriteToGCS(ctx, storageClient, fh, testDirName, FileName1, t.T())
+	operations.WriteWithoutClose(fh, FileContents, t.T())
 
 	// Stat the file to validate if new contents are written.
 	operations.VerifyStatFile(filePath, SizeOfFileContents, FilePerms, t.T())
@@ -71,8 +71,6 @@ func (t *CommonLocalFileTestSuite) TestTruncateLocalFileToSmallerSize() {
 	if err != nil {
 		t.T().Fatalf("os.Truncate err: %v", err)
 	}
-
-	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, FileName1, t.T())
 
 	// Stat the file to validate if file is truncated correctly.
 	operations.VerifyStatFile(filePath, SmallerSizeTruncate, FilePerms, t.T())

--- a/tools/integration_tests/local_file/stat_file.go
+++ b/tools/integration_tests/local_file/stat_file.go
@@ -56,7 +56,7 @@ func (t *CommonLocalFileTestSuite) TestStatOnLocalFileWithConflictingFileNameSuf
 		FileName1, "", t.T())
 }
 
-func (t *localFileTestSuite) TestTruncateLocalFileToSmallerSize() {
+func (t *CommonLocalFileTestSuite) TestTruncateLocalFileToSmallerSize() {
 	testDirPath = setup.SetupTestDirectory(testDirName)
 	// Create a local file.
 	filePath, fh := CreateLocalFileInTestDir(ctx, storageClient, testDirPath, FileName1, t.T())

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -36,6 +36,12 @@ func (t *StreamingWritesSuite) TestTruncate() {
 	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, string(data[:]), t.T())
 }
 
+func (t *StreamingWritesSuite) TestTruncateNegative() {
+	err := t.f1.Truncate(-1)
+
+	assert.Error(t.T(), err)
+}
+
 func (t *StreamingWritesSuite) TestWriteAfterTruncate() {
 	truncateSize := 10
 
@@ -166,23 +172,7 @@ func (t *StreamingWritesSuite) TestWriteTruncateWrite() {
 	}
 }
 
-func (t *StreamingWritesSuite) TestTruncateToLowerSyncsFileToGcsForStreamingWrites() {
-	// Write
-	operations.WriteWithoutClose(t.f1, "foobar", t.T())
-	operations.VerifyStatFile(t.filePath, int64(len("foobar")), FilePerms, t.T())
-
-	// Perform truncate
-	err := t.f1.Truncate(3)
-
-	require.NoError(t.T(), err)
-	operations.VerifyStatFile(t.filePath, 3, FilePerms, t.T())
-	if !t.fallbackToDiskCase {
-		ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "foobar", t.T())
-	}
-	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, "foo", t.T())
-}
-
-func (t *StreamingWritesSuite) TestTruncateToLowerSyncsFileToGcsAndDeletingFileDeletsFileFromGcs() {
+func (t *StreamingWritesSuite) TestTruncateDownAndDeleteFile() {
 	// Write
 	operations.WriteWithoutClose(t.f1, "foobar", t.T())
 	operations.VerifyStatFile(t.filePath, int64(len("foobar")), FilePerms, t.T())

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -124,11 +124,5 @@ func (t *StreamingWritesSuite) TestTruncateToLowerSizeAfterWrite() {
 	// Perform truncate
 	err := t.f1.Truncate(int64(5))
 
-	if t.fallbackToDiskCase {
-		require.NoError(t.T(), err)
-	} else {
-		// Truncating to lower size after writes are not allowed if buffered writes are used.
-		require.Error(t.T(), err)
-		operations.VerifyStatFile(t.filePath, int64(2*len(FileContents)), FilePerms, t.T())
-	}
+	require.NoError(t.T(), err)
 }

--- a/tools/integration_tests/streaming_writes/write_file_test.go
+++ b/tools/integration_tests/streaming_writes/write_file_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streaming_writes
+
+import (
+	"os"
+
+	. "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/require"
+)
+
+func (t *StreamingWritesSuite) TestOutOfOrderWriteSyncsFileToGcs() {
+	// Write
+	operations.WriteWithoutClose(t.f1, "foobar", t.T())
+	operations.VerifyStatFile(t.filePath, int64(len("foobar")), FilePerms, t.T())
+
+	// Perform out of order write.
+	operations.WriteAt("foo", 3, t.f1, t.T())
+
+	if !t.fallbackToDiskCase {
+		ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "foobar", t.T())
+	}
+	CloseFileAndValidateContentFromGCS(ctx, storageClient, t.f1, testDirName, t.fileName, "foofoo", t.T())
+}
+
+func (t *StreamingWritesSuite) TestOutOfOrderWriteSyncsFileToGcsAndDeletingFileDeletsFileFromGcs() {
+	// Write
+	operations.WriteWithoutClose(t.f1, "foobar", t.T())
+	operations.VerifyStatFile(t.filePath, int64(len("foobar")), FilePerms, t.T())
+	// Perform out of order write.
+	operations.WriteAt("foo", 3, t.f1, t.T())
+	if !t.fallbackToDiskCase {
+		ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, t.fileName, "foobar", t.T())
+	}
+
+	err := os.Remove(t.filePath)
+
+	require.NoError(t.T(), err)
+	ValidateObjectNotFoundErrOnGCS(ctx, storageClient, testDirName, t.fileName, t.T())
+}


### PR DESCRIPTION
### Description
Add support for truncate to lower size than current file size during streaming writes. We are going to finalise the file and fallback to stage disk. This PR also fixes the promotion to generation backed Inodes for both out of order write flow and truncate to lower size scenario.

### Link to the issue in case of a bug fix.
b/421367385

### Testing details
1. Manual - Done
2. Unit tests - Updated.
3. Integration tests - Ran as part of presubmit.

### Any backward incompatible change? If so, please explain.
