### PR TITLE
insert gcs.minObj directly into stat cache in StatObjectFromGCS()

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -442,8 +442,7 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 	}
 
 	// Put the object in cache.
-	o := storageutil.ConvertMinObjectToObject(m)
-	b.insert(o)
+	b.insertMinObject(m)
 
 	return
 }


### PR DESCRIPTION
### Description
Previously, when a StatObject() call resulted in a cache miss or forceFetchFromGCS was true, the StatObjectFromGCS() method would fetch a minObj and extended attributes. This minObj was first converted to a gcs.Object while invoking the method to insert object into cache and the method itself would convert this gcs.Object back into minObj since that is what is being stored in the cache anyways. 

This PR eliminates that unnecessary inter-conversion by directly inserting the initially received minObj into the cache.


![image](https://github.com/user-attachments/assets/e2239a88-4383-4067-abcf-2cd34372363a)
Note: Observed improvement in random read BW
### Link to the issue in case of a bug fix.
[b/422080005](https://b.corp.google.com/issues/422080005)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
