### PR TITLE
zero byte read to fetch size for unfinalized obj

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -98,6 +98,7 @@ be interacting with the file system.`)
 		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.
 		ChunkTransferTimeoutSecs:           newConfig.GcsRetries.ChunkTransferTimeoutSecs,
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
+		ExperimentalEnableRapidAppends:     newConfig.Write.ExperimentalEnableRapidAppends,
 	}
 	bm := gcsx.NewBucketManager(bucketCfg, storageHandle)
 

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -117,7 +117,7 @@ func (cht *cacheHandleTest) SetupTest() {
 	storageHandle := cht.fakeStorage.CreateStorageHandle()
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
-	cht.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
+	cht.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
 	assert.Nil(cht.T(), err)
 
 	// Create test object in the bucket.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -71,7 +71,7 @@ func initializeCacheHandlerTestArgs(t *testing.T, fileCacheConfig *cfg.FileCache
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
 	ctx := context.Background()
-	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
+	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
 	require.NoError(t, err)
 
 	// Create test object in the bucket.

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -66,7 +66,7 @@ func (dt *downloaderTest) setupHelper() {
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
 	ctx := context.Background()
-	dt.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
+	dt.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
 	ExpectEq(nil, err)
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -145,7 +145,7 @@ func TestParallelDownloads(t *testing.T) {
 			cache, cacheDir := configureCache(t, 2*tc.objectSize)
 			storageHandle := configureFakeStorage(t)
 			ctx := context.Background()
-			bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
+			bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
 			assert.Nil(t, err)
 			minObj, content := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", tc.objectSize)
 			fileCacheConfig := &cfg.FileCacheConfig{
@@ -187,7 +187,7 @@ func TestMultipleConcurrentDownloads(t *testing.T) {
 	storageHandle := configureFakeStorage(t)
 	cache, cacheDir := configureCache(t, 30*util.MiB)
 	ctx := context.Background()
-	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
+	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
 	assert.Nil(t, err)
 	minObj1, content1 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", 10*util.MiB)
 	minObj2, content2 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/bar.txt", 5*util.MiB)

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -62,9 +62,10 @@ type BucketConfig struct {
 	// Note that if the process fails or is interrupted the temporary object will
 	// not be cleaned up, so the user must ensure that TmpObjectPrefix is
 	// periodically garbage collected.
-	AppendThreshold          int64
-	ChunkTransferTimeoutSecs int64
-	TmpObjectPrefix          string
+	AppendThreshold                int64
+	ChunkTransferTimeoutSecs       int64
+	TmpObjectPrefix                string
+	ExperimentalEnableRapidAppends bool
 }
 
 // BucketManager manages the lifecycle of buckets.
@@ -167,7 +168,7 @@ func (bm *bucketManager) SetUpBucket(
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
 	} else {
-		b, err = bm.storageHandle.BucketHandle(ctx, name, bm.config.BillingProject)
+		b, err = bm.storageHandle.BucketHandle(ctx, name, bm.config.BillingProject, bm.config.ExperimentalEnableRapidAppends)
 		if err != nil {
 			err = fmt.Errorf("BucketHandle: %w", err)
 			return

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -61,7 +61,7 @@ func (t *BucketManagerTest) SetUp(_ *TestInfo) {
 			LocationType:          "zone",
 		}, nil)
 	ctx := context.Background()
-	t.bucket, err = t.storageHandle.BucketHandle(ctx, TestBucketName, "")
+	t.bucket, err = t.storageHandle.BucketHandle(ctx, TestBucketName, "", false)
 
 	AssertNe(nil, t.bucket)
 	AssertEq(nil, err)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -161,7 +161,7 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 
 // Note: This is not production ready code and will be removed once StatObject
 // requests return correct attr values for appendable objects.
-func (bh *bucketHandle) updateObjectSizeFromZeroByteReader(ctx context.Context, attrs *storage.ObjectAttrs) error {
+func (bh *bucketHandle) fetchLatestSizeOfUnfinalizedObject(ctx context.Context, attrs *storage.ObjectAttrs) error {
 	if bh.BucketType().Zonal && bh.enableRapidAppends {
 		// Get object handle
 		obj := bh.bucket.Object(attrs.Name)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -143,9 +143,9 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 		return
 	}
 	if attrs.Finalized.IsZero() {
-		if err = bh.updateObjectSizeFromZeroByteReader(ctx, attrs); err != nil {
-		  err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
-		  return
+		if err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs); err != nil {
+			err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
+			return
 		}
 	}
 
@@ -168,8 +168,7 @@ func (bh *bucketHandle) fetchLatestSizeOfUnfinalizedObject(ctx context.Context, 
 		// Create a new reader
 		reader, err := obj.NewRangeReader(ctx, 0, 0)
 		if err != nil {
-			return fmt.Errorf("failed to create zero-byte reader for object %q: %w", attrs.Name, err)
-			return err
+			return fmt.Errorf("failed to create zero-byte reader for object %q: %v", attrs.Name, err)
 		}
 		err = reader.Close()
 		if err != nil {
@@ -433,7 +432,7 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 			return
 		}
 		if attrs.Finalized.IsZero() {
-			err = bh.updateObjectSizeFromZeroByteReader(ctx, attrs)
+			err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs)
 		}
 
 		// Prefix attribute will be set for the objects returned as part of Prefix[] array in list response.

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -39,10 +39,11 @@ const FullBucketPathHNS = "projects/_/buckets/%s"
 
 type bucketHandle struct {
 	gcs.Bucket
-	bucket        *storage.BucketHandle
-	bucketName    string
-	bucketType    *gcs.BucketType
-	controlClient StorageControlClient
+	bucket             *storage.BucketHandle
+	bucketName         string
+	bucketType         *gcs.BucketType
+	controlClient      StorageControlClient
+	enableRapidAppends bool
 }
 
 func (bh *bucketHandle) Name() string {

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -433,7 +433,8 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 		}
 		if attrs.Finalized.IsZero() {
 			if err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs); err != nil {
-			  err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
+				err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
+				return
 			}
 		}
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -165,7 +165,7 @@ func (bh *bucketHandle) updateObjectSizeFromZeroByteReader(ctx context.Context, 
 		// Create a new reader
 		reader, err := obj.NewRangeReader(ctx, 0, 0)
 		if err != nil {
-			logger.Debugf("failed to create zero-byte reader for object %q: %v", attrs.Name, err)
+			return fmt.Errorf("failed to create zero-byte reader for object %q: %w", attrs.Name, err)
 			return err
 		}
 		err = reader.Close()

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -432,7 +432,9 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 			return
 		}
 		if attrs.Finalized.IsZero() {
-			err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs)
+			if err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs); err != nil {
+			  err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
+			}
 		}
 
 		// Prefix attribute will be set for the objects returned as part of Prefix[] array in list response.

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -143,7 +143,10 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 		return
 	}
 	if attrs.Finalized.IsZero() {
-		err = bh.updateObjectSizeFromZeroByteReader(ctx, attrs)
+		if err = bh.updateObjectSizeFromZeroByteReader(ctx, attrs); err != nil {
+		  err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
+		  return
+		}
 	}
 
 	// Converting attrs to type *Object

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -66,7 +66,7 @@ func createBucketHandle(testSuite *BucketHandleTest, resp *controlpb.StorageLayo
 	var err error
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(resp, err1)
-	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "")
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", false)
 	testSuite.bucketHandle.controlClient = testSuite.mockClient
 
 	assert.NotNil(testSuite.T(), testSuite.bucketHandle)
@@ -1496,7 +1496,7 @@ func (testSuite *BucketHandleTest) TestBucketHandleWithError() {
 	var err error
 	// Test when the client returns an error.
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).Return(x, errors.New("mocked error"))
-	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "")
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", false)
 
 	assert.Nil(testSuite.T(), testSuite.bucketHandle)
 	assert.Contains(testSuite.T(), err.Error(), "mocked error")

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1502,6 +1502,18 @@ func (testSuite *BucketHandleTest) TestBucketHandleWithError() {
 	assert.Contains(testSuite.T(), err.Error(), "mocked error")
 }
 
+func (testSuite *BucketHandleTest) TestBucketHandleWithRapidAppendsEnabled() {
+	var err error
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).Return(&controlpb.StorageLayout{}, nil)
+	testSuite.mockClient.On("getClient", mock.Anything, mock.Anything).Return(&storage.Client{}, nil)
+
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", true)
+
+	assert.NotNil(testSuite.T(), testSuite.bucketHandle)
+	assert.True(testSuite.T(), testSuite.bucketHandle.enableRapidAppends)
+	assert.Nil(testSuite.T(), err)
+}
+
 func (testSuite *BucketHandleTest) TestBucketTypeWithHierarchicalNamespaceIsNil() {
 	createBucketHandle(testSuite, &controlpb.StorageLayout{}, nil)
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -55,7 +55,7 @@ type StorageHandle interface {
 	// to that project rather than to the bucket's owning project.
 	//
 	// A user-project is required for all operations on Requester Pays buckets.
-	BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error)
+	BucketHandle(ctx context.Context, bucketName string, billingProject string, enableRapidAppends bool) (bh *bucketHandle, err error)
 }
 
 type storageClient struct {
@@ -318,7 +318,7 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool) (*st
 	return nil, fmt.Errorf("invalid client-protocol requested: %s", sh.clientConfig.ClientProtocol)
 }
 
-func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error) {
+func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string, enableRapidAppends bool) (bh *bucketHandle, err error) {
 	var client *storage.Client
 	bucketType, err := sh.lookupBucketType(bucketName)
 	if err != nil {
@@ -347,10 +347,11 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 	}
 
 	bh = &bucketHandle{
-		bucket:        storageBucketHandle,
-		bucketName:    bucketName,
-		controlClient: sh.storageControlClient,
-		bucketType:    bucketType,
+		bucket:             storageBucketHandle,
+		bucketName:         bucketName,
+		controlClient:      sh.storageControlClient,
+		bucketType:         bucketType,
+		enableRapidAppends: enableRapidAppends,
 	}
 
 	return

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -77,7 +77,7 @@ func (testSuite *StorageHandleTest) mockStorageLayout(bucketType gcs.BucketType)
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockStorageLayout(gcs.BucketType{})
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, "")
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, "", false)
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Nil(testSuite.T(), err)
@@ -90,7 +90,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithEm
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("bucket does not exist"))
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, "")
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, "", false)
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), bucketHandle)
@@ -100,7 +100,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmpty
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockStorageLayout(gcs.BucketType{Hierarchical: true})
 
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, projectID)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, projectID, false)
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Nil(testSuite.T(), err)
@@ -116,7 +116,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNo
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("bucket does not exist"))
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, projectID)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, projectID, false)
 
 	assert.Nil(testSuite.T(), bucketHandle)
 	assert.NotNil(testSuite.T(), err)
@@ -253,7 +253,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 	testSuite.mockStorageLayout(gcs.BucketType{})
 	sh := fakeStorage.CreateStorageHandle()
 	assert.NotNil(testSuite.T(), sh)
-	bh, err := sh.BucketHandle(testSuite.ctx, TestBucketName, projectID)
+	bh, err := sh.BucketHandle(testSuite.ctx, TestBucketName, projectID, false)
 
 	assert.Nil(testSuite.T(), bh)
 	assert.NotNil(testSuite.T(), err)


### PR DESCRIPTION
### Description
Currently, stat calls incorrectly report the size of unfinalized objects as zero. This poses a significant blocker for unfinalized object support, as our read/write operations depend on accurate size information. As a temporary workaround, we're implementing a zero-byte reader. This is because the reader's attributes correctly reflect the unfinalized object's size.


Caveat: Listing is slightly slow.
### Link to the issue in case of a bug fix.
[b/422944268](b/422944268)

### Testing details
1. Manual - Manual ls, stat show correct object size.
2. Unit tests - Skipping as this is a temporary fix.
3. Integration tests - [Automated](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/e4580def-3dfa-405a-9d62-7bb8d5caaea2/summary)

### Any backward incompatible change? If so, please explain.
