### PR TITLE
setting generation for object handle before creating takeover writer

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -245,7 +245,9 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
-	obj := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest).Generation(req.Generation)
+	obj := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest)
+	// To create the takeover writer, the objectHandle.Generation must be set.
+	obj = obj.Generation(*req.CreateObjectRequest.GenerationPrecondition)
 	callBack := func(bytesUploadedSoFar int64) {
 		logger.Tracef("gcs: Req %#16x: -- UploadBlock(%q): %20v bytes uploaded so far", ctx.Value(gcs.ReqIdField), req.Name, bytesUploadedSoFar)
 	}

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -152,16 +152,6 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 	return
 }
 
-func (bh *bucketHandle) getObjectHandleWithGenerationAndPreconditionSet(ctx context.Context, req *gcs.CreateObjectChunkWriterRequest) (*storage.ObjectHandle, error) {
-	objHandle := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest)
-	attrs, err := bh.bucket.Object(req.Name).Attrs(ctx)
-	if err != nil {
-		err = fmt.Errorf("error in fetching object attributes: %w", err)
-		return nil, err
-	}
-	return objHandle.Generation(attrs.Generation), nil
-}
-
 func (bh *bucketHandle) getObjectHandleWithPreconditionsSet(req *gcs.CreateObjectRequest) *storage.ObjectHandle {
 	obj := bh.bucket.Object(req.Name)
 
@@ -255,10 +245,7 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
-	obj, err := bh.getObjectHandleWithGenerationAndPreconditionSet(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("error while fetching object handle for %s : %v", req.Name, err)
-	}
+	obj := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest).Generation(req.Generation)
 	callBack := func(bytesUploadedSoFar int64) {
 		logger.Tracef("gcs: Req %#16x: -- UploadBlock(%q): %20v bytes uploaded so far", ctx.Value(gcs.ReqIdField), req.Name, bytesUploadedSoFar)
 	}

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -435,7 +435,4 @@ type CreateObjectChunkWriterRequest struct {
 	// Offset from where write has to start. Used only in case of appends flows.
 	// Default value is zero which means it's a new object write.
 	Offset int64
-
-	// Generation of the appendable object.
-	Generation int64
 }

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -435,4 +435,7 @@ type CreateObjectChunkWriterRequest struct {
 	// Offset from where write has to start. Used only in case of appends flows.
 	// Default value is zero which means it's a new object write.
 	Offset int64
+
+	// Generation of the appendable object.
+	Generation int64
 }


### PR DESCRIPTION
### Description
The object handle for creating the takeover writer must be set before method invocation.

### Link to the issue in case of a bug fix.
[b/422892135](b/422892135)
### Testing details
1. Manual - Tested as part of POC, that the writer is successfully getting created. 
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
