### PR TITLE
[read-unfinalized-object] [part1] Relax file-cache checks for unfinalized objects

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -124,8 +124,9 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		// For unfinalized objects (supported only in zonal buckets),
 		// it is known that the object size can grow over time, and thus
 		// their object-size can be more than their cached-entry size.
-		// To allow reading from cache for such objects, fllback to GCS if
-		// the cached size is not less than the intended cache entry size.
+		// To allow reading from cache for such objects without invalidating
+		// their cache entry, fallback to GCS if
+		// the downloaded size at least equals their intended cache entry size.
 		if bucket.BucketType().Zonal && object.IsUnfinalized() && fileInfoData.Offset >= fileInfoData.FileSize {
 			return fmt.Errorf("Unexpected %q was fully downloaded in cache earlier, but is not sufficient to serve this read-request (required=%v, available=%v, to-be-downloaded=%v), so falling back to GCS. %w", object.Name, requiredOffset, fileInfoData.Offset, fileInfoData.FileSize, util.ErrFallbackToGCS)
 		}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -185,10 +185,6 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 
 		jobStatus, err = fch.fileDownloadJob.Download(ctx, requiredOffset, waitForDownload)
 		if err != nil {
-			if bucket.BucketType().Zonal && object.IsUnfinalized() {
-				err = util.ErrFallbackToGCS
-				return
-			}
 			n = 0
 			cacheHit = false
 			err = fmt.Errorf("read: while downloading through job: %w", err)

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -121,9 +121,6 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		return fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 	}
 	if fileInfoData.Offset < requiredOffset {
-		//if bucket.BucketType().Zonal && object.IsUnfinalized() {
-		//return util.ErrFallbackToGCS
-		//}
 		return fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
 	}
 

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -199,6 +199,12 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 		// completed or failed. The offset must be equal to size of object for job
 		// to be completed.
 
+		// For unfinalized objects (supported only in zonal buckets),
+		// it is known that the object size can grow over time, and thus
+		// their object-size can be more than their cached-entry size.
+		// To allow reading from cache for such objects, don't compare
+		// cached-entry size to the object size, but only to what is needed
+		// to be read.
 		if bucket.BucketType().Zonal && object.IsUnfinalized() {
 			err = fch.validateEntryInFileInfoCache(bucket, object, uint64(requiredOffset), false)
 		} else {

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -207,14 +207,10 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 		// If fileDownloadJob is nil then it means either the job is successfully
 		// completed or failed. The offset must be equal to size of object for job
 		// to be completed.
-
 		if bucket.BucketType().Zonal && object.IsUnfinalized() {
-			// For unfinalized objects (supported only in zonal buckets),
-			// it is known that the object size can grow over time, and thus
-			// their object-size can be more than their cached-entry size.
-			// To allow reading from cache for such objects, don't compare
-			// cached-entry size to the object size, but only to what is needed
-			// to be read.
+			// For unfinalized (zonal) objects, object size can grow.
+			// Validate against `requiredOffset` to allow reading from partially
+			// downloaded cache.
 			err = fch.validateEntryInFileInfoCache(bucket, object, uint64(requiredOffset), false)
 		} else {
 			err = fch.validateEntryInFileInfoCache(bucket, object, object.Size, false)

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -167,6 +167,9 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	// If the end-offset is within the cached size, then the read will be served from the cache.
 	// If offset is within the cached size and end-offset is beyond the cached-size, then
 	// we will fallback to GCS in the later logic, but we should still create the cache download job even in that case.
+	//
+	// Note: Change the below check to `(offset + len(dst)) > int64(fileInfoData.FileSize))` if the below
+	// check causes a problem in any edge-case.
 	if bucket.BucketType().Zonal && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
 		err = util.ErrFallbackToGCS
 		return

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -173,7 +173,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	// If the end-offset is within the cached size, then the read will be served from the cache.
 	// If offset is within the cached size and end-offset is beyond the cached-size, then
 	// we will fallback to GCS in the later logic, but we should still create the cache download job even in that case.
-	if bucket.BucketType().Zonal && object.IsUnfinalized() && offset > int64(fileInfoData.FileSize) {
+	if bucket.BucketType().Zonal && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
 		err = util.ErrFallbackToGCS
 		return
 	}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -93,14 +93,14 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 // It returns nil if entry is present, otherwise returns an appropriate error.
 // Whether to change the order in cache while lookup is controlled via
 // changeCacheOrder.
-func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *gcs.MinObject, requiredOffset uint64, changeCacheOrder bool) error {
+func (fch *CacheHandle) getFileInfoData(bucket gcs.Bucket, object *gcs.MinObject, changeCacheOrder bool) (*data.FileInfo, error) {
 	fileInfoKey := data.FileInfoKey{
 		BucketName: bucket.Name(),
 		ObjectName: object.Name,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	if err != nil {
-		return fmt.Errorf("error while creating key for bucket %s and object %s: %w", bucket.Name(), object.Name, err)
+		return nil, fmt.Errorf("error while creating key for bucket %s and object %s: %w", bucket.Name(), object.Name, err)
 	}
 
 	var fileInfo lru.ValueType
@@ -110,13 +110,30 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		fileInfo = fch.fileInfoCache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	}
 	if fileInfo == nil {
-		return fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
+		return nil, fmt.Errorf("%w: no entry found in file info cache for key %v", util.ErrInvalidFileInfoCache, fileInfoKeyName)
 	}
 
 	// The generation check below is required because it may happen that file
 	// being read is evicted from cache during or after reading the required offset
 	// from local cached file to `dst` buffer.
-	fileInfoData := fileInfo.(data.FileInfo)
+	fileInfoData, ok := fileInfo.(data.FileInfo)
+	if !ok {
+		return nil, fmt.Errorf("getFileInfoData: failed to get fileInfoData from file-cache for %q: %w", object.Name, util.ErrInvalidFileHandle)
+	}
+
+	return &fileInfoData, nil
+}
+
+// validateEntryInFileInfoCache checks if entry is present for a given object in
+// file info cache with same generation and at least requiredOffset.
+// It returns nil if entry is present, otherwise returns an appropriate error.
+// Whether to change the order in cache while lookup is controlled via
+// changeCacheOrder.
+func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *gcs.MinObject, requiredOffset uint64, changeCacheOrder bool) error {
+	fileInfoData, err := fch.getFileInfoData(bucket, object, changeCacheOrder)
+	if err != nil {
+		return fmt.Errorf("validateEntryInFileInfoCache: failed to get fileInfoData for %q: %w", object.Name, err)
+	}
 	if fileInfoData.ObjectGeneration != object.Generation {
 		return fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 	}
@@ -146,6 +163,17 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 
 	if offset < 0 || offset >= int64(object.Size) {
 		return 0, false, fmt.Errorf("wrong offset requested: %d, object size: %d", offset, object.Size)
+	}
+
+	fileInfoData, errFileInfo := fch.getFileInfoData(bucket, object, false)
+	if errFileInfo != nil {
+		return 0, false, fmt.Errorf("%w Error in getCachedFileInfo: %v", util.ErrInvalidFileInfoCache, errFileInfo)
+	}
+
+	// New check to ensure we bail out early in case the requested data is beyond cached size for an unfinalized object
+	if bucket.BucketType().Zonal && object.IsUnfinalized() && offset+int64(len(dst)) > int64(fileInfoData.FileSize) {
+		err = util.ErrFallbackToGCS
+		return
 	}
 
 	// Checking before updating the previous offset.

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -121,7 +121,7 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		return fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 	}
 	if fileInfoData.Offset < requiredOffset {
-		if object.IsUnfinalized() {
+		if bucket.BucketType().Zonal && object.IsUnfinalized() {
 			return util.ErrFallbackToGCS
 		}
 		return fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
@@ -188,7 +188,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 
 		jobStatus, err = fch.fileDownloadJob.Download(ctx, requiredOffset, waitForDownload)
 		if err != nil {
-			if object.IsUnfinalized() {
+			if bucket.BucketType().Zonal && object.IsUnfinalized() {
 				err = util.ErrFallbackToGCS
 				return
 			}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -88,9 +88,8 @@ func (fch *CacheHandle) shouldReadFromCache(jobStatus *downloader.JobStatus, req
 	return err
 }
 
-// validateEntryInFileInfoCache checks if entry is present for a given object in
-// file info cache with same generation and at least requiredOffset.
-// It returns nil if entry is present, otherwise returns an appropriate error.
+// getFileInfoData returns the file-info cache entry for the given object
+// in the associated bucket.
 // Whether to change the order in cache while lookup is controlled via
 // changeCacheOrder.
 func (fch *CacheHandle) getFileInfoData(bucket gcs.Bucket, object *gcs.MinObject, changeCacheOrder bool) (*data.FileInfo, error) {

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -121,9 +121,9 @@ func (fch *CacheHandle) validateEntryInFileInfoCache(bucket gcs.Bucket, object *
 		return fmt.Errorf("%w: generation of cached object: %v is different from required generation: %v", util.ErrInvalidFileInfoCache, fileInfoData.ObjectGeneration, object.Generation)
 	}
 	if fileInfoData.Offset < requiredOffset {
-		if bucket.BucketType().Zonal && object.IsUnfinalized() {
-			return util.ErrFallbackToGCS
-		}
+		//if bucket.BucketType().Zonal && object.IsUnfinalized() {
+		//return util.ErrFallbackToGCS
+		//}
 		return fmt.Errorf("%w offset of cached object: %v is less than required offset %v", util.ErrInvalidFileInfoCache, fileInfoData.Offset, requiredOffset)
 	}
 
@@ -205,7 +205,12 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 		// If fileDownloadJob is nil then it means either the job is successfully
 		// completed or failed. The offset must be equal to size of object for job
 		// to be completed.
-		err = fch.validateEntryInFileInfoCache(bucket, object, object.Size, false)
+
+		if bucket.BucketType().Zonal && object.IsUnfinalized() {
+			err = fch.validateEntryInFileInfoCache(bucket, object, uint64(requiredOffset), false)
+		} else {
+			err = fch.validateEntryInFileInfoCache(bucket, object, object.Size, false)
+		}
 		if err != nil {
 			return 0, false, err
 		}

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -156,7 +156,8 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		// If offset in file info cache is less than object size and there is no
 		// reference to download job then it means the job has failed.
 		existingJob := chr.jobManager.GetJob(object.Name, bucket.Name())
-		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size) && (!(object.Finalized.IsZero() && bucket.BucketType().Zonal))
+		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
+		shouldInvalidate = shouldInvalidate && (!(object.IsUnfinalized() && bucket.BucketType().Zonal))
 		if (!shouldInvalidate) && (existingJob != nil) {
 			existingJobStatus := existingJob.GetStatus().Name
 			shouldInvalidate = (existingJobStatus == downloader.Failed) || (existingJobStatus == downloader.Invalid)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -156,15 +156,7 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		// If offset in file info cache is less than object size and there is no
 		// reference to download job then it means the job has failed.
 		existingJob := chr.jobManager.GetJob(object.Name, bucket.Name())
-		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
-		if shouldInvalidate {
-			// For unfinalized (zonal) objects, size can grow. Don't invalidate if the
-			// cached data matches the object's original size (`fileInfoData.FileSize`),
-			// as this is expected growth, not a download failure.
-			if bucket.BucketType().Zonal && object.IsUnfinalized() && fileInfoData.Offset == fileInfoData.FileSize {
-				shouldInvalidate = false
-			}
-		}
+		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < fileInfoData.FileSize)
 		if (!shouldInvalidate) && (existingJob != nil) {
 			existingJobStatus := existingJob.GetStatus().Name
 			shouldInvalidate = (existingJobStatus == downloader.Failed) || (existingJobStatus == downloader.Invalid)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -178,17 +178,6 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 				}
 			}
 			addEntryToCache = true
-		} else if bucket.BucketType().Zonal && object.IsUnfinalized() {
-			// If the entry is considered valid but there's no download job, we may need
-			// to create one. This is critical for unfinalized objects that have grown
-			// or for resuming a previously failed/partial download.
-			if existingJob == nil && fileInfoData.Offset < object.Size {
-				// A job is required to download the remaining content.
-				// The CreateJobIfNotExists method will internally use the existing
-				// FileInfo entry to configure the job to resume from fileInfoData.Offset.
-				_ = chr.jobManager.CreateJobIfNotExists(object, bucket)
-			}
-			addEntryToCache = false
 		}
 	}
 

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -158,14 +158,9 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		existingJob := chr.jobManager.GetJob(object.Name, bucket.Name())
 		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
 		if shouldInvalidate {
-			// For unfinalized objects (supported only in zonal buckets),
-			// it is known that the object size can grow over time, and thus
-			// their object-size can be more than their cached-entry size,
-			// so we should not invalidate cache-entry for them just because
-			// the size of the completed download is less than the latest object size for them.
-			// We should however invalidate their cache entry if their downloaded size
-			// is less than their total intended size of the cache file entry,
-			// to safeguard against previous download failures.
+			// For unfinalized (zonal) objects, size can grow. Don't invalidate if the
+			// cached data matches the object's original size (`fileInfoData.FileSize`),
+			// as this is expected growth, not a download failure.
 			if bucket.BucketType().Zonal && object.IsUnfinalized() && fileInfoData.Offset == fileInfoData.FileSize {
 				shouldInvalidate = false
 			}

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -161,9 +161,10 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 			// For unfinalized objects (supported only in zonal buckets),
 			// it is known that the object size can grow over time, and thus
 			// their object-size can be more than their cached-entry size,
-			// so we should not invalidate cache-entry for them because of size-check.
-			// As we are not comparing the downloaded size against object size,
-			// we should compare it against the total intended size of the cache file entry,
+			// so we should not invalidate cache-entry for them just because
+			// the size of the completed download is less than the latest object size for them.
+			// We should however invalidate their cache entry if their downloaded size
+			// is less than their total intended size of the cache file entry,
 			// to safeguard against previous download failures.
 			if bucket.BucketType().Zonal && object.IsUnfinalized() && fileInfoData.Offset == fileInfoData.FileSize {
 				shouldInvalidate = false

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -178,6 +178,17 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 				}
 			}
 			addEntryToCache = true
+		} else if bucket.BucketType().Zonal && object.IsUnfinalized() {
+			// If the entry is considered valid but there's no download job, we may need
+			// to create one. This is critical for unfinalized objects that have grown
+			// or for resuming a previously failed/partial download.
+			if existingJob == nil && fileInfoData.Offset < object.Size {
+				// A job is required to download the remaining content.
+				// The CreateJobIfNotExists method will internally use the existing
+				// FileInfo entry to configure the job to resume from fileInfoData.Offset.
+				_ = chr.jobManager.CreateJobIfNotExists(object, bucket)
+			}
+			addEntryToCache = false
 		}
 	}
 

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -157,6 +157,9 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		// reference to download job then it means the job has failed.
 		existingJob := chr.jobManager.GetJob(object.Name, bucket.Name())
 		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
+		// For unfinalized objects (supported only in zonal buckets),
+		// it is known that the object size can grow over time, and thus
+		// their object-size can be more than their cached-entry size.
 		shouldInvalidate = shouldInvalidate && (!(object.IsUnfinalized() && bucket.BucketType().Zonal))
 		if (!shouldInvalidate) && (existingJob != nil) {
 			existingJobStatus := existingJob.GetStatus().Name

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -159,8 +159,11 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
 		// For unfinalized objects (supported only in zonal buckets),
 		// it is known that the object size can grow over time, and thus
-		// their object-size can be more than their cached-entry size.
-		shouldInvalidate = shouldInvalidate && (!(object.IsUnfinalized() && bucket.BucketType().Zonal))
+		// their object-size can be more than their cached-entry size,
+		// so we should not invalidate cache-entry for them because of size-check.
+		if shouldInvalidate && bucket.BucketType().Zonal && object.IsUnfinalized() {
+			shouldInvalidate = false
+		}
 		if (!shouldInvalidate) && (existingJob != nil) {
 			existingJobStatus := existingJob.GetStatus().Name
 			shouldInvalidate = (existingJobStatus == downloader.Failed) || (existingJobStatus == downloader.Invalid)

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -156,7 +156,7 @@ func (chr *CacheHandler) addFileInfoEntryAndCreateDownloadJob(object *gcs.MinObj
 		// If offset in file info cache is less than object size and there is no
 		// reference to download job then it means the job has failed.
 		existingJob := chr.jobManager.GetJob(object.Name, bucket.Name())
-		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size)
+		shouldInvalidate := (existingJob == nil) && (fileInfoData.Offset < object.Size) && (!(object.Finalized.IsZero() && bucket.BucketType().Zonal))
 		if (!shouldInvalidate) && (existingJob != nil) {
 			existingJobStatus := existingJob.GetStatus().Name
 			shouldInvalidate = (existingJobStatus == downloader.Failed) || (existingJobStatus == downloader.Invalid)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -497,7 +497,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	t.mockBucket.AssertExpectations(t.T())
 }
 
-func (t *fileCacheReaderTest) Test_ReadAt_Read_ZonalBucket_UnfinalizedObject_FailedJobNextReadCreatesNewJobAndCacheHit() {
+func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCacheHit_UnfinalizedObject() {
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	// First NewReaderWithReadHandle call fails, simulating a failed attempt to read from GCS.
 	// This triggers a fallback to GCS reader.

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -409,32 +409,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	t.mockBucket.AssertExpectations(t.T())
 }
 
-func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFileHandleAfterThenCacheHitWithNewFileCacheHandle_UnfinalizedObject() {
-	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
-	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
-	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
-	assert.NotNil(t.T(), t.reader.fileCacheHandle)
-	err = t.reader.fileCacheHandle.Close()
-	assert.NoError(t.T(), err)
-	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
-	assert.Zero(t.T(), readerResponse.Size)
-	assert.Nil(t.T(), t.reader.fileCacheHandle)
-
-	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-
-	// Reading from file cache with new file cache handle.
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
-	assert.NotNil(t.T(), t.reader.fileCacheHandle)
-	t.mockBucket.AssertExpectations(t.T())
-}
-
 func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -504,39 +478,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// Second ReadAt call: The file cache should be populated as a result of this successful read.
 	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
-	assert.NotNil(t.T(), t.reader.fileCacheHandle)
-
-	// Third ReadAt call: Should be served directly from the file cache.
-	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
-	assert.NotNil(t.T(), t.reader.fileCacheHandle)
-	t.mockBucket.AssertExpectations(t.T())
-}
-
-func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCacheHit_UnfinalizedObject() {
-	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
-	// First NewReaderWithReadHandle call fails, simulating a failed attempt to read from GCS.
-	// This triggers a fallback to GCS reader.
-	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
-	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{Zonal: true, Hierarchical: true})
-	// First ReadAt call:
-	// - Should result in a FallbackToAnotherReader error.
-	// - No data should be returned.
-	// - The job should be marked as failed (if jobManager is functioning correctly).
-	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-	require.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
-	assert.Zero(t.T(), readerResponse.Size)
-	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
-	require.True(t.T(), job == nil || job.GetStatus().Name == downloader.Failed)
-	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc)
-	// Second ReadAt call: The file cache should be populated as a result of this successful read.
-	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
-	require.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
 

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -526,7 +526,7 @@ func (t *fileCacheReaderTest) skipForNonZonalBucket() {
 	}
 }
 
-func (t *fileCacheReaderTest) fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize uint64, cachedObjectSize int64) {
+func (t *fileCacheReaderTest) fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize uint64) {
 	t.T().Helper()
 	t.mockBucket.On("Name").Return("test-bucket")
 	testContent := testutil.GenerateRandomBytes(int(t.unfinalized_object.Size))
@@ -551,16 +551,15 @@ func (t *fileCacheReaderTest) waitForDownloadJobToFinish(obj *gcs.MinObject) {
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondCachedSizeAfterSizeIncreasedShouldThrowFallbackError() {
 	t.skipForNonZonalBucket()
-
 	origObjectSize := t.unfinalized_object.Size
-	cachedObjectSize := int64(origObjectSize)
 	// First read, which may start a background download job.
-	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize, cachedObjectSize)
+	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 	// Wait for the background download job to complete to avoid a data race.
 	// This is needed to avoid the race condition on the size of t.unfinalized_object later on.
 	t.waitForDownloadJobToFinish(t.unfinalized_object)
 
 	// Resize the object, and read beyond previously cached size and within new object size.
+	cachedObjectSize := int64(origObjectSize)
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
@@ -574,11 +573,9 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondC
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondObjectSizeAfterSizeIncreasedShouldThrowEOFError() {
 	t.skipForNonZonalBucket()
-
 	origObjectSize := t.unfinalized_object.Size
-	cachedObjectSize := int64(origObjectSize)
 	// First read, which may start a background download job.
-	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize, cachedObjectSize)
+	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 	// Wait for the background download job to complete to avoid a data race.
 	// This is needed to avoid the race condition on the size of t.unfinalized_object later on.
 	t.waitForDownloadJobToFinish(t.unfinalized_object)
@@ -597,16 +594,15 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondO
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondCachedSizeWithIncreasedObjectSizeShouldThrowFallbackError() {
 	t.skipForNonZonalBucket()
-
 	origObjectSize := t.unfinalized_object.Size
-	cachedObjectSize := int64(origObjectSize)
 	// First read, which may start a background download job.
-	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize, cachedObjectSize)
+	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 	// Wait for the background download job to complete to avoid a data race.
 	// This is needed to avoid the race condition on the size of t.unfinalized_object later on.
 	t.waitForDownloadJobToFinish(t.unfinalized_object)
 
 	// Resize the object, and read from below previously cached size and within new object size.
+	cachedObjectSize := int64(origObjectSize)
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
@@ -620,16 +616,15 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondObjectSizeWithIncreasedObjectSizeShouldThrowFallbackError() {
 	t.skipForNonZonalBucket()
-
 	origObjectSize := t.unfinalized_object.Size
-	cachedObjectSize := int64(origObjectSize)
 	// First read, which may start a background download job.
-	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize, cachedObjectSize)
+	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 	// Wait for the background download job to complete to avoid a data race.
 	// This is needed to avoid the race condition on the size of t.unfinalized_object later on.
 	t.waitForDownloadJobToFinish(t.unfinalized_object)
 
 	// Resize the object, and read from below cached size and beyond this new object size.
+	cachedObjectSize := int64(origObjectSize)
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
@@ -643,11 +638,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondCachedSizeShouldNotThrowError() {
 	t.skipForNonZonalBucket()
-
 	origObjectSize := t.unfinalized_object.Size
-	cachedObjectSize := int64(origObjectSize)
-	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize, cachedObjectSize)
+	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 
+	cachedObjectSize := int64(origObjectSize)
 	readerResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, cachedObjectSize+1), cachedObjectSize/2)
 
 	assert.NoError(t.T(), err)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -84,6 +84,7 @@ func (t *fileCacheReaderTest) SetupTest() {
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
 	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
 	t.ctx = context.Background()
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 }
 
 func (t *fileCacheReaderTest) TearDownTest() {
@@ -151,7 +152,6 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
 	// First read will be a cache miss.
 	n, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
@@ -174,7 +174,6 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_SequentialSubsequentR
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -202,7 +201,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start := 0
 	end := 10
 	require.Less(t.T(), end, int(t.object.Size))
@@ -244,7 +242,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, end-start)
 
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
@@ -263,7 +260,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -294,7 +290,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -328,7 +323,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc1)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
 	assert.NoError(t.T(), err)
@@ -355,7 +349,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd1)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, readerResponse.DataBuf)
@@ -388,7 +381,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -414,7 +406,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -438,7 +429,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -463,7 +453,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// This triggers a fallback to GCS reader.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	// First ReadAt call:
 	// - Should result in a FallbackToAnotherReader error.
 	// - No data should be returned.
@@ -536,7 +525,6 @@ func (t *fileCacheReaderTest) Test_Destroy_NonNilCacheHandle() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -371,6 +371,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -471,6 +471,39 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	t.mockBucket.AssertExpectations(t.T())
 }
 
+func (t *fileCacheReaderTest) Test_ReadAt_Read_ZonalBucket_UnfinalizedObject_FailedJobNextReadCreatesNewJobAndCacheHit() {
+	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
+	// First NewReaderWithReadHandle call fails, simulating a failed attempt to read from GCS.
+	// This triggers a fallback to GCS reader.
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
+	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{Zonal: true, Hierarchical: true})
+	// First ReadAt call:
+	// - Should result in a FallbackToAnotherReader error.
+	// - No data should be returned.
+	// - The job should be marked as failed (if jobManager is functioning correctly).
+	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	require.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
+	assert.Zero(t.T(), readerResponse.Size)
+	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
+	require.True(t.T(), job == nil || job.GetStatus().Name == downloader.Failed)
+	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc)
+	// Second ReadAt call: The file cache should be populated as a result of this successful read.
+	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
+	assert.NotNil(t.T(), t.reader.fileCacheHandle)
+
+	// Third ReadAt call: Should be served directly from the file cache.
+	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
+	assert.NotNil(t.T(), t.reader.fileCacheHandle)
+	t.mockBucket.AssertExpectations(t.T())
+}
+
 func (t *fileCacheReaderTest) Test_ReadAt_NegativeOffsetShouldThrowError() {
 	t.mockBucket.On("Name").Return("test-bucket")
 

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -142,6 +142,7 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	buf := make([]byte, t.object.Size)
 	// First read will be a cache miss.
 	n, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
@@ -164,6 +165,7 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_SequentialSubsequentR
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -191,6 +193,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start := 0
 	end := 10
 	require.Less(t.T(), end, int(t.object.Size))
@@ -232,6 +235,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	buf := make([]byte, end-start)
 
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
@@ -250,6 +254,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -280,6 +285,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -313,6 +319,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc1)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	buf := make([]byte, t.object.Size)
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
 	assert.NoError(t.T(), err)
@@ -339,6 +346,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd1)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, readerResponse.DataBuf)
@@ -423,6 +431,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -446,6 +455,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -539,11 +549,13 @@ func (t *fileCacheReaderTest) Test_ReadAt_NegativeOffsetShouldThrowError() {
 	assert.Zero(t.T(), readerResponse.Size)
 }
 
+
 func (t *fileCacheReaderTest) Test_Destroy_NonNilCacheHandle() {
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -371,6 +371,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -443,6 +444,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// This triggers a fallback to GCS reader.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	// First ReadAt call:
 	// - Should result in a FallbackToAnotherReader error.
 	// - No data should be returned.

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -371,7 +371,6 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -84,7 +84,6 @@ func (t *fileCacheReaderTest) SetupTest() {
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
 	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
 	t.ctx = context.Background()
-	t.mockBucket.On("BucketType").Return(t.bucketType)
 }
 
 func (t *fileCacheReaderTest) TearDownTest() {
@@ -152,6 +151,7 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
 	// First read will be a cache miss.
 	n, cacheHit, err := t.reader.tryReadingFromFileCache(t.ctx, buf, 0)
@@ -174,6 +174,7 @@ func (t *fileCacheReaderTest) Test_tryReadingFromFileCache_SequentialSubsequentR
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -201,6 +202,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start := 0
 	end := 10
 	require.Less(t.T(), end, int(t.object.Size))
@@ -242,6 +244,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, end-start)
 
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
@@ -260,6 +263,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -290,6 +294,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	start1 := 0
 	end1 := util.MiB
 	require.Less(t.T(), end1, int(t.object.Size))
@@ -323,6 +328,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rc1)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
 	readerResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
 	assert.NoError(t.T(), err)
@@ -349,6 +355,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd1)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, readerResponse.DataBuf)
@@ -381,6 +388,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -406,6 +414,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -429,6 +438,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -453,6 +463,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// This triggers a fallback to GCS reader.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	// First ReadAt call:
 	// - Should result in a FallbackToAnotherReader error.
 	// - No data should be returned.
@@ -525,6 +536,7 @@ func (t *fileCacheReaderTest) Test_Destroy_NonNilCacheHandle() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -414,7 +414,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -438,7 +438,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)
@@ -463,7 +463,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// This triggers a fallback to GCS reader.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	// First ReadAt call:
 	// - Should result in a FallbackToAnotherReader error.
 	// - No data should be returned.
@@ -516,7 +516,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondC
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{Zonal: true, Hierarchical: true})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, 17), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), 17, readerResponse.Size)
@@ -536,7 +536,7 @@ func (t *fileCacheReaderTest) Test_Destroy_NonNilCacheHandle() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, rd)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 	readerResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), readerResponse.DataBuf, testContent)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -558,7 +558,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_OffsetBeyondObjectSizeShouldThrowError
 	assert.Zero(t.T(), readerResponse.Size)
 }
 
-func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectRereadAfterSizeIncreaseFromOffsetBeyondCachedObjectSizeShouldThrowFallbackToGcsError() {
+func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondCachedSizeAfterSizeIncreaseShouldThrowFallbackError() {
 	t.mockBucket.On("Name").Return("test-bucket")
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -568,8 +568,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectRereadAfterSizeIncrea
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), 17, readerResponse.Size)
 
+	// Resize the object and read beyond previously cached size and within new size.
 	t.object.Size = 27
 	readerResponse, err = t.reader.ReadAt(t.ctx, make([]byte, 10), 17)
+
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readerResponse.Size)
 	assert.ErrorIs(t.T(), err, FallbackToAnotherReader)

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -152,9 +152,13 @@ type RandomReaderTest struct {
 	cacheDir     string
 	jobManager   *downloader.JobManager
 	cacheHandler *file.CacheHandler
+	bucketType   gcs.BucketType
 }
 
-func init() { RegisterTestSuite(&RandomReaderTest{}) }
+func init() {
+	RegisterTestSuite(&RandomReaderTest{bucketType: gcs.BucketType{}})
+	RegisterTestSuite(&RandomReaderTest{bucketType: gcs.BucketType{Zonal: true, Hierarchical: true}})
+}
 
 var _ SetUpInterface = &RandomReaderTest{}
 var _ TearDownInterface = &RandomReaderTest{}
@@ -232,7 +236,7 @@ func (t *RandomReaderTest) NoExistingReader() {
 	// The bucket should be called to set up a new reader.
 	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
 		WillOnce(Return(nil, errors.New("")))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	buf := make([]byte, 1)
 
 	_, err := t.rr.ReadAt(buf, 0)
@@ -266,7 +270,7 @@ func (t *RandomReaderTest) ExistingReader_ReadAtOffsetAfterTheReaderPosition() {
 func (t *RandomReaderTest) NewReaderReturnsError() {
 	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
 		WillOnce(Return(nil, errors.New("taco")))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	buf := make([]byte, 1)
 
 	_, err := t.rr.ReadAt(buf, 0)
@@ -282,7 +286,7 @@ func (t *RandomReaderTest) ReaderFails() {
 
 	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
 		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 
 	// Call
 	buf := make([]byte, 3)
@@ -438,7 +442,7 @@ func (t *RandomReaderTest) UpgradesReadsToObjectSize() {
 		Any(),
 		AllOf(rangeStartIs(1), rangeLimitIs(objectSize))).
 		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 
 	// Call through.
 	buf := make([]byte, readSize)
@@ -480,7 +484,7 @@ func (t *RandomReaderTest) UpgradeReadsToAverageSize() {
 			rangeStartIs(start),
 			rangeLimitIs(start+expectedBytesToRead),
 		)).WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 
 	// Call through.
 	buf := make([]byte, readSize)
@@ -514,7 +518,7 @@ func (t *RandomReaderTest) UpgradesSequentialReads_ExistingReader() {
 		Any(),
 		AllOf(rangeStartIs(1), rangeLimitIs(1+sequentialReadSizeInBytes))).
 		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 
 	// Call through.
 	buf := make([]byte, readSize)
@@ -549,7 +553,7 @@ func (t *RandomReaderTest) UpgradesSequentialReads_NoExistingReader() {
 		Any(),
 		AllOf(rangeStartIs(1), rangeLimitIs(1+readSize))).
 		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 
 	// Call through.
 	buf := make([]byte, readSize)
@@ -572,7 +576,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialFullObject() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	ExpectFalse(objectData.CacheHit)
@@ -593,7 +597,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialRangeRead() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	start := 0
 	end := 10 // not included
 	AssertLt(end, objectSize)
@@ -614,7 +618,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanRea
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -646,7 +650,7 @@ func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCache
 	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
 	t.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rc)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, end-start)
 	objectData, err := t.rr.ReadAt(buf, int64(start))
 	ExpectFalse(objectData.CacheHit)
@@ -677,7 +681,7 @@ func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCache
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, end-start)
 
 	objectData, err := t.rr.ReadAt(buf, int64(start))
@@ -698,7 +702,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetMor
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -731,7 +735,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetLes
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -769,7 +773,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -803,7 +807,7 @@ func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvali
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -843,43 +847,7 @@ func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvali
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	AssertFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
-	err = t.rr.wrapped.fileCacheHandle.Close()
-	AssertEq(nil, err)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
-	objectData, err = t.rr.ReadAt(buf, 0)
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
-	rc3 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc3)
-
-	objectData, err = t.rr.ReadAt(buf, 0)
-
-	ExpectEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
-}
-
-func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFileHandle_UnfinalizedObject() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{Zonal: true, Hierarchical: true}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -915,7 +883,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -947,7 +915,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -981,46 +949,7 @@ func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit() {
 	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
 		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	job := t.jobManager.GetJob(t.object.Name, t.bucket.Name())
-	AssertTrue(job == nil || job.GetStatus().Name == downloader.Failed)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd2)
-	// This call will populate the cache again.
-	objectData, err = t.rr.ReadAt(buf, 0)
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
-
-	objectData, err = t.rr.ReadAt(buf, 0)
-
-	ExpectEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
-}
-
-func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit_UnfinalizedObject() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	// First call goes to file cache succeeded by next call to random reader.
-	// First NewReaderWithReadHandle-call throws error, hence async job fails.
-	// Later NewReader-call returns a valid readCloser object hence fallback to
-	// GCS read will succeed.
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc, nil))
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{Zonal: true, Hierarchical: true}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -1056,7 +985,7 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{Zonal: true, Hierarchical: true}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	// First read will be a cache miss.
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
@@ -1093,7 +1022,7 @@ func (t *RandomReaderTest) Test_ReadAt_OffsetEqualToObjectSize() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	start1 := 0
 	end1 := util.MiB // equal to objectSize
 	// First call from offset 0 - objectSize
@@ -1130,7 +1059,7 @@ func (t *RandomReaderTest) Test_Destroy_NonNilCacheHandle() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
 	buf := make([]byte, objectSize)
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
 	AssertFalse(cacheHit)

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -572,6 +572,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialFullObject() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	ExpectFalse(objectData.CacheHit)
@@ -592,6 +593,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialRangeRead() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	start := 0
 	end := 10 // not included
 	AssertLt(end, objectSize)
@@ -612,6 +614,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanRea
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -674,7 +677,7 @@ func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCache
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, end-start)
 
 	objectData, err := t.rr.ReadAt(buf, int64(start))
@@ -695,7 +698,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetMor
 	// Mock for download job's NewReader call
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -728,7 +731,7 @@ func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetLes
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	start1 := 0
 	end1 := util.MiB // not included
 	AssertLt(end1, objectSize)
@@ -766,7 +769,7 @@ func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -800,7 +803,7 @@ func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvali
 	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -912,6 +915,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -943,6 +947,7 @@ func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -1051,6 +1056,7 @@ func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{Zonal: true, Hierarchical: true}))
 	buf := make([]byte, objectSize)
 	// First read will be a cache miss.
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
@@ -1087,6 +1093,7 @@ func (t *RandomReaderTest) Test_ReadAt_OffsetEqualToObjectSize() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	start1 := 0
 	end1 := util.MiB // equal to objectSize
 	// First call from offset 0 - objectSize
@@ -1123,6 +1130,7 @@ func (t *RandomReaderTest) Test_Destroy_NonNilCacheHandle() {
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
+	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
 	AssertFalse(cacheHit)

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -840,7 +840,7 @@ func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvali
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)
@@ -940,7 +940,7 @@ func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit() {
 	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
 		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc, nil))
 	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(gcs.BucketType{}))
 	buf := make([]byte, objectSize)
 	objectData, err := t.rr.ReadAt(buf, 0)
 	AssertEq(nil, err)

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -99,10 +99,15 @@ type readManagerTest struct {
 	mockBucket  *storage.TestifyMockBucket
 	readManager *ReadManager
 	ctx         context.Context
+	bucketType  gcs.BucketType
 }
 
-func TestReadManagerTestSuite(t *testing.T) {
-	suite.Run(t, new(readManagerTest))
+func TestNonZonalBucketReadManagerTestSuite(t *testing.T) {
+	suite.Run(t, &readManagerTest{bucketType: gcs.BucketType{}})
+}
+
+func TestZonalBucketReadManagerTestSuite(t *testing.T) {
+	suite.Run(t, &readManagerTest{bucketType: gcs.BucketType{Zonal: true, Hierarchical: true}})
 }
 
 func (t *readManagerTest) SetupTest() {
@@ -183,9 +188,8 @@ func (t *readManagerTest) Test_ReadAt_InvalidOffset() {
 func (t *readManagerTest) Test_ReadAt_NoExistingReader() {
 	// The bucket should be called to set up a new reader.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("network error"))
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(1)
+	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(2)
 	t.mockBucket.On("Name").Return("test-bucket")
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 
 	_, err := t.readAt(0, 1)
 
@@ -198,7 +202,7 @@ func (t *readManagerTest) Test_ReadAt_ReaderFailsWithTimeout() {
 	r := iotest.OneByteReader(iotest.TimeoutReader(strings.NewReader("xxx")))
 	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(rc, nil).Once()
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(1)
+	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(1)
 
 	_, err := t.readAt(0, 3)
 
@@ -209,7 +213,7 @@ func (t *readManagerTest) Test_ReadAt_ReaderFailsWithTimeout() {
 
 func (t *readManagerTest) Test_ReadAt_FileClobbered() {
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, &gcs.NotFoundError{})
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(1)
+	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(1)
 	t.mockBucket.On("Name").Return("test-bucket")
 
 	_, err := t.readAt(1, 3)
@@ -229,7 +233,7 @@ func (t *readManagerTest) Test_ReadAt_FullObjectFromCache() {
 	// Mock the reader that returns full object data
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, fakeReader)
 	t.mockBucket.On("Name").Return("test-bucket").Maybe()
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("BucketType").Return(t.bucketType)
 
 	// Act: First read (expected to be served via GCS, populating the cache)
 	firstResp, err := t.readAt(0, int64(objectSize))

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -185,6 +185,7 @@ func (t *readManagerTest) Test_ReadAt_NoExistingReader() {
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("network error"))
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(1)
 	t.mockBucket.On("Name").Return("test-bucket")
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 
 	_, err := t.readAt(0, 1)
 
@@ -228,6 +229,7 @@ func (t *readManagerTest) Test_ReadAt_FullObjectFromCache() {
 	// Mock the reader that returns full object data
 	t.mockNewReaderWithHandleCallForTestBucket(0, t.object.Size, fakeReader)
 	t.mockBucket.On("Name").Return("test-bucket").Maybe()
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 
 	// Act: First read (expected to be served via GCS, populating the cache)
 	firstResp, err := t.readAt(0, int64(objectSize))

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -340,25 +340,7 @@ func (b *fastStatBucket) StatObject(
 		}
 
 		// Otherwise, return MinObject and nil ExtendedObjectAttributes.
-		if entry.Finalized.IsZero() {
-			req.ReturnExtendedObjectAttributes = false
-			// Following does two things.
-			// 1. A GCS stat-call (GetObjectMetadata) which takes up about 20ms.
-			// 2. A zero-byte reader creation to get the latest size of the object, which takes about 780 ms.
-			// This is a temporary measure as GCS stat-call doesn't always return the latest size for
-			// unfinalized objects.
-			// 1st is not strictly needed at this point given the 2nd call, so we could skip the 1st call,
-			// and directly call the function for 2nd. Though it will need a lot of interface changes, so keeping that
-			// as an improvement TODO.
-			m, _, err = b.StatObjectFromGcs(ctx, req)
-			if err != nil {
-				err = fmt.Errorf("failed in GCS stat-call for unfinalized object %q to get latest size: %w", req.Name, err)
-				return
-			}
-
-			return
-		}
-
+		m = entry
 		return
 	}
 

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -340,7 +340,25 @@ func (b *fastStatBucket) StatObject(
 		}
 
 		// Otherwise, return MinObject and nil ExtendedObjectAttributes.
-		m = entry
+		if entry.Finalized.IsZero() {
+			req.ReturnExtendedObjectAttributes = false
+			// Following does two things.
+			// 1. A GCS stat-call (GetObjectMetadata) which takes up about 20ms.
+			// 2. A zero-byte reader creation to get the latest size of the object, which takes about 780 ms.
+			// This is a temporary measure as GCS stat-call doesn't always return the latest size for
+			// unfinalized objects.
+			// 1st is not strictly needed at this point given the 2nd call, so we could skip the 1st call,
+			// and directly call the function for 2nd. Though it will need a lot of interface changes, so keeping that
+			// as an improvement TODO.
+			m, _, err = b.StatObjectFromGcs(ctx, req)
+			if err != nil {
+				err = fmt.Errorf("failed in GCS stat-call for unfinalized object %q to get latest size: %w", req.Name, err)
+				return
+			}
+
+			return
+		}
+
 		return
 	}
 

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -113,3 +113,7 @@ type ExtendedObjectAttributes struct {
 func (mo MinObject) HasContentEncodingGzip() bool {
 	return mo.ContentEncoding == ContentEncodingGzip
 }
+
+func (mo MinObject) IsUnfinalized() bool {
+	return mo.Finalized.IsZero()
+}

--- a/internal/storage/gcs/object_test.go
+++ b/internal/storage/gcs/object_test.go
@@ -55,7 +55,7 @@ func (t *ObjectTest) HasContentEncodingGzipNegative() {
 }
 
 func (t *ObjectTest) IsFinalized() {
-	mo := MinObject{Finalized: time.Now()}
+	mo := MinObject{Finalized: time.Date(2025, time.June, 19, 18, 23, 30, 0, time.UTC)}
 
 	AssertFalse(mo.IsUnfinalized())
 }

--- a/internal/storage/gcs/object_test.go
+++ b/internal/storage/gcs/object_test.go
@@ -16,6 +16,7 @@ package gcs
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/jacobsa/ogletest"
 )
@@ -51,4 +52,16 @@ func (t *ObjectTest) HasContentEncodingGzipNegative() {
 
 		AssertFalse(mo.HasContentEncodingGzip())
 	}
+}
+
+func (t *ObjectTest) IsFinalized() {
+	mo := MinObject{Finalized: time.Now()}
+
+	AssertFalse(mo.IsUnfinalized())
+}
+
+func (t *ObjectTest) IsNotFinalized() {
+	mo := MinObject{}
+
+	AssertTrue(mo.IsUnfinalized())
 }


### PR DESCRIPTION
### Description
The change is based on [design doc](https://docs.google.com/document/d/1eKAsVbvmiBYtPs8h3jbapN8jP_Pmegb4_AW8WlTdNts/edit?usp=sharing&resourcekey=0-z2SvePxO8kTVnL64-qHq5w)

Changes in behavior for unfinalized objects:
- Don't invalidate file-cache entry if size of completed download entry >= intended downloaded size
- Don't fall back to GCS from file-cache read if size of completed download entry >= intended upper limit of offset to be read.
- Fallback to GCS while reading from cache_handle if requested read isn't available from the cached file-info data size. If partial read is possible from the cache, then go ahead and start the download job.

Additional changes
- Added a simple utility for easily checking if an object is unfinalized.
- Enable zonal bucket unit tests for TestFileCacheReader, TestRandomReader and TestReadManager.
- Add new unit tests corresponding to the above code changes.
- Update existing unit tests corresponding to the above code changes.

~Dependencies~
- ~This builds on top of #3387 and is thus blocked for merge until that PR is merged~

Out of scope:
- This does not add support for reading unfinalized objects itself. That's covered in the in https://github.com/GoogleCloudPlatform/gcsfuse/pull/3405 .
- The changes in this don't touch any non-zonal non-unfinalized objects in any way.

### Link to the issue in case of a bug fix.
[b/421294827](http://b/421294827)

### Testing details
1. Manual - Tested manually.
2. Unit tests - Tested automatically by this PR. Add more UTs for the changes in the code.
3. Integration tests - ran with presubmit ([only zonal](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/b21fc64b-349f-4287-bff6-2bc06371fc02/details), [e2e zonal, non-zonal and perf test run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/fa4f953d-79d2-445e-93a7-3306010e4d72))
4. Perf tests results
```md
+--------+------------+--------------+------------+--------------+--------------+
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
+--------+------------+--------------+------------+--------------+--------------+
| Master |  0.25MiB   | 555.31MiB/s  |  1.2MiB/s  |  77.32MiB/s  |  1.17MiB/s   |
|   PR   |  0.25MiB   | 581.98MiB/s  | 1.21MiB/s  |  77.26MiB/s  |   1.2MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 3900.45MiB/s | 85.61MiB/s | 1554.19MiB/s |  84.39MiB/s  |
|   PR   | 48.828MiB  | 3849.86MiB/s | 85.42MiB/s | 1499.03MiB/s |  84.85MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 3742.3MiB/s  | 79.22MiB/s | 763.35MiB/s  |  39.24MiB/s  |
|   PR   | 976.562MiB | 3711.34MiB/s | 77.93MiB/s | 1296.53MiB/s |  38.71MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
+--------+------------+--------------+------------+--------------+--------------+
```

### Any backward incompatible change? If so, please explain.
