### PR TITLE
remove streaming writes stall retries & fix e2e emulator tests

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -228,7 +228,8 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc := &ObjectWriter{obj.NewWriter(ctx)}
 	wc.ChunkSize = chunkSize
 	wc.Writer = storageutil.SetAttrsInWriter(wc.Writer, req)
-	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
+	// TODO(b/424091803): Uncomment once chunk transfer timeout issue in resumable uploads is fixed in dependencies.
+	// wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	if callBack == nil {
 		callBack = func(bytesUploadedSoFar int64) {
 			logger.Tracef("gcs: Req %#16x: -- UploadBlock(%q): %20v bytes uploaded so far", ctx.Value(gcs.ReqIdField), req.Name, bytesUploadedSoFar)

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -101,9 +101,10 @@ func TestChunkTransferTimeoutInfinity(t *testing.T) {
 }
 
 func TestChunkTransferTimeout(t *testing.T) {
+	// TODO(b/424091803): Enable streaming writes once chunk transfer timeout issue in resumable uploads is fixed in dependencies.
 	flagSets := [][]string{
-		{},
-		{"--chunk-transfer-timeout-secs=5"},
+		{"--enable-streaming-writes=false"},
+		{"--enable-streaming-writes=false", "--chunk-transfer-timeout-secs=5"},
 	}
 
 	stallScenarios := []struct {


### PR DESCRIPTION
### Description
Remove stall retries for streaming writes and fix e2e emulator tests.

### Link to the issue in case of a bug fix.
b/424098921

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmits.

### Any backward incompatible change? If so, please explain.
