### PR TITLE
[read-unfinalized-object] [part2] Enable read of unfinalized objects while being written via streaming

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2593,9 +2593,8 @@ func (fs *fileSystem) ReadFile(
 		// when we start leaving zonal bucket objects unfinalized.
 		if !fh.Inode().Bucket().BucketType().Zonal {
 			err = fs.flushFile(ctx, fh.Inode())
-		} else if fh.Inode().Source().IsUnfinalized() {
-			// Flush, but don't finalized for unfinalized objects
-			// in zonal buckets.
+		} else {
+			// Flush but don't finalize, in zonal bucket.
 			err = fs.syncFile(ctx, fh.Inode())
 		}
 		if err != nil {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2587,10 +2587,17 @@ func (fs *fileSystem) ReadFile(
 	fh.Lock()
 	fh.Inode().Lock()
 	defer fh.Unlock()
-	// TODO(b/417136852): Remove bucket type check when we start leaving zonal bucket objects unfinalized.
-	// Flush Pending streaming writes file for regional bucket and issue read within same inode lock.
-	if fh.Inode().IsUsingBWH() && !fh.Inode().Bucket().BucketType().Zonal {
-		err = fs.flushFile(ctx, fh.Inode())
+	if fh.Inode().IsUsingBWH() {
+		// Flush Pending streaming writes and issue read within same inode lock.
+		// TODO(b/417136852): Remove bucket type check and call only flushFile
+		// when we start leaving zonal bucket objects unfinalized.
+		if !fh.Inode().Bucket().BucketType().Zonal {
+			err = fs.flushFile(ctx, fh.Inode())
+		} else if fh.Inode().Source().IsUnfinalized() {
+			// Flush, but don't finalized for unfinalized objects
+			// in zonal buckets.
+			err = fs.syncFile(ctx, fh.Inode())
+		}
 		if err != nil {
 			fh.Inode().Unlock()
 			return err

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -170,18 +170,6 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// fh.inode.mu is already locked to ensure that we have a reader for its current
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
-
-	// TODO: Remove this if-block once we stop finalizing
-	// objects in zonal bucket on writes by default (b/426512250).
-	if fh.inode.Bucket().Bucket.BucketType().Zonal && fh.inode.Source().IsUnfinalized() {
-		_, err = fh.inode.SyncPendingBufferedWrites()
-		if err != nil {
-			fh.inode.Unlock()
-			err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)
-			return
-		}
-	}
-
 	err = fh.tryEnsureReader(ctx, sequentialReadSizeMb)
 	if err != nil {
 		fh.inode.Unlock()

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -171,11 +171,13 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
 
-	_, err = fh.inode.SyncPendingBufferedWrites()
-	if err != nil {
-		fh.inode.Unlock()
-		err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)
-		return
+	if fh.inode.Bucket().Bucket.BucketType().Zonal && fh.inode.Source().IsUnfinalized() {
+		_, err = fh.inode.SyncPendingBufferedWrites()
+		if err != nil {
+			fh.inode.Unlock()
+			err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)
+			return
+		}
 	}
 
 	err = fh.tryEnsureReader(ctx, sequentialReadSizeMb)

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -171,6 +171,8 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
 
+	// TODO: Remove this if-block once we stop finalizing
+	// objects in zonal bucket on writes by default (b/426512250).
 	if fh.inode.Bucket().Bucket.BucketType().Zonal && fh.inode.Source().IsUnfinalized() {
 		_, err = fh.inode.SyncPendingBufferedWrites()
 		if err != nil {

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -170,6 +170,14 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	// fh.inode.mu is already locked to ensure that we have a reader for its current
 	// state, or clear fh.reader if it's not possible to create one (probably
 	// because the inode is dirty).
+
+	_, err = fh.inode.SyncPendingBufferedWrites()
+	if err != nil {
+		fh.inode.Unlock()
+		err = fmt.Errorf("fh.inode.SyncPendingBufferedWrites: %w", err)
+		return
+	}
+
 	err = fh.tryEnsureReader(ctx, sequentialReadSizeMb)
 	if err != nil {
 		fh.inode.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -553,9 +553,9 @@ func (f *FileInode) Read(
 	offset int64) (n int, err error) {
 	// It is not nil when streaming writes are enabled and bucket type is Zonal.
 	if f.bwh != nil {
-		// Allow reading from unfinalized objects (which are supported only in zonal buckets as of now).
-		if f.bucket == nil || !f.bucket.BucketType().Zonal || !f.src.IsUnfinalized() {
-			err = fmt.Errorf("cannot read a finalized object when upload is in progress: %w", syscall.ENOTSUP)
+		// Allow reading from unfinalized objects.
+		if !f.src.IsUnfinalized() {
+			err = fmt.Errorf("cannot read a file when upload in progress: %w", syscall.ENOTSUP)
 			return
 		}
 	}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -551,11 +550,6 @@ func (f *FileInode) Read(
 	ctx context.Context,
 	dst []byte,
 	offset int64) (n int, err error) {
-	// It is not nil when streaming writes are enabled and bucket type is Zonal.
-	if f.bwh != nil {
-		err = fmt.Errorf("cannot read a file when upload in progress: %w", syscall.ENOTSUP)
-		return
-	}
 
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -552,9 +551,8 @@ func (f *FileInode) Read(
 	ctx context.Context,
 	dst []byte,
 	offset int64) (n int, err error) {
-	// It is not nil when streaming writes are enabled and bucket type is Zonal.
 	if f.bwh != nil {
-		err = fmt.Errorf("Unexpected read call for %q when steaming write is in progress for it: %w", f.Name().LocalName(), syscall.ENOTSUP)
+		err = fmt.Errorf("unexpected read call for %q when streaming write is in progress for it", f.Name().LocalName())
 		return
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -551,6 +552,11 @@ func (f *FileInode) Read(
 	ctx context.Context,
 	dst []byte,
 	offset int64) (n int, err error) {
+	// It is not nil when streaming writes are enabled and bucket type is Zonal.
+	if f.bwh != nil {
+		err = fmt.Errorf("Unexpected read call for %q when steaming write is in progress for it: %w", f.Name().LocalName(), syscall.ENOTSUP)
+		return
+	}
 
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -550,6 +551,14 @@ func (f *FileInode) Read(
 	ctx context.Context,
 	dst []byte,
 	offset int64) (n int, err error) {
+	// It is not nil when streaming writes are enabled and bucket type is Zonal.
+	if f.bwh != nil {
+		// Allow reading from unfinalized objects (which are supported only in zonal buckets as of now).
+		if f.bucket == nil || !f.bucket.BucketType().Zonal || !f.src.IsUnfinalized() {
+			err = fmt.Errorf("cannot read a finalized object when upload is in progress: %w", syscall.ENOTSUP)
+			return
+		}
+	}
 
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -223,13 +223,12 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
-func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForZonalBuckets() {
+func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsTrueAfterWriteForZonalBuckets() {
 	t.createBufferedWriteHandler()
 	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, util.Write)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
-
-	assert.False(t.T(), t.in.SourceGenerationIsAuthoritative())
+	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
 }
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsPromotesInodeToNonLocal() {

--- a/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
+++ b/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"slices"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/stretchr/testify/assert"
@@ -53,12 +52,7 @@ func (t *StreamingWritesSuite) TearDownSuite() {
 func (t *StreamingWritesSuite) validateReadCall(fh *os.File, content string) {
 	readContent := make([]byte, len(content))
 	n, err := fh.ReadAt(readContent, 0)
-	// TODO(b/417136852): Fix validation once zb reads start working.
-	if false /*setup.IsZonalBucketRun() && !t.fallbackToDiskCase*/ {
-		operations.ValidateEOPNOTSUPPError(t.T(), err)
-	} else {
-		require.NoError(t.T(), err)
-		assert.Equal(t.T(), len(content), n)
-		assert.Equal(t.T(), content, string(readContent))
-	}
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), len(content), n)
+	assert.Equal(t.T(), content, string(readContent))
 }

--- a/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
+++ b/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
@@ -54,7 +54,7 @@ func (t *StreamingWritesSuite) validateReadCall(fh *os.File, content string) {
 	readContent := make([]byte, len(content))
 	n, err := fh.ReadAt(readContent, 0)
 	// TODO(b/417136852): Fix validation once zb reads start working.
-	if setup.IsZonalBucketRun() && !t.fallbackToDiskCase {
+	if false /*setup.IsZonalBucketRun() && !t.fallbackToDiskCase*/ {
 		operations.ValidateEOPNOTSUPPError(t.T(), err)
 	} else {
 		require.NoError(t.T(), err)

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 	"path"
-	"syscall"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -55,19 +54,19 @@ func (t *unfinalizedObjectReads) TeardownTest() {}
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (t *unfinalizedObjectReads) TestUnfinalizedObjectsCantBeRead() {
+func (t *unfinalizedObjectReads) TestUnfinalizedObjectsCanBeRead() {
 	var size int = operations.MiB
+	writtenContent := setup.GenerateRandomString(size)
 	// Create un-finalized object via same mount.
 	fh := operations.CreateFile(path.Join(t.testDirPath, t.fileName), setup.FilePermission_0600, t.T())
-	operations.WriteWithoutClose(fh, setup.GenerateRandomString(size), t.T())
+	operations.WriteWithoutClose(fh, writtenContent, t.T())
 	defer operations.CloseFileShouldNotThrowError(t.T(), fh)
 
 	// Read un-finalized object.
-	content, err := operations.ReadFileSequentially(path.Join(t.testDirPath, t.fileName), util.MiB)
+	readContent, err := operations.ReadFileSequentially(path.Join(t.testDirPath, t.fileName), util.MiB)
 
-	require.Error(t.T(), err)
-	assert.ErrorContains(t.T(), err, syscall.ENOTSUP.Error())
-	assert.Empty(t.T(), content, "expected empty content, but got size: %v", len(content))
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), writtenContent, string(readContent))
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
**What this change does**:
- ~This builds on top of #3401 . So, it shouldn't be merged before that one.~
- This pull request enables reading from GCS objects while they are being written to via streaming.
- This change is particularly relevant for zonal buckets. 
- The changes primarily involves modifying the conditions under which a read is permitted and ensuring data is flushed to GCS before a read occurs.
- The associated unit and integration tests have been updated to validate this new behavior.
- Undoes changes from #3250 


**What it does not do**:
- It doesn't add new e2e tests for testing reads of unfinalized objects. That task is separately tracked in [b/421361399](http://421361399) .

### Link to the issue in case of a bug fix.
[b/425828097](http://b/425828097)
[b/410698332](http://b/410698332)
[b/422355580](http://b/422355580)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran ([run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/4b6912a9-8436-49bb-b598-0f093450db4f), [run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/0c1664e4-b451-4949-b3e0-d80e69279077), [run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/3a579676-35b9-44c8-8e7f-5d3342cd5239), [run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/007fbb49-62b5-4cb8-9b26-e6f20824bf99)) as part of presubmit .

### Any backward incompatible change? If so, please explain.
