### PR TITLE
Fix flaky Download_WhenAsyncFails test

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -367,10 +367,10 @@ func (job *Job) downloadObjectToFile(cacheFile *os.File) (err error) {
 //
 // Acquires and releases LOCK(job.mu)
 func (job *Job) cleanUpDownloadAsyncJob() {
-	// Close the job.doneCh, clear the cancelFunc & cancelCtx and call the
+	// Clear the cancelFunc & cancelCtx and call the
 	// remove job callback function.
+	// Finally, close the job.doneCh.
 	job.cancelFunc()
-	close(job.doneCh)
 
 	job.mu.Lock()
 	if job.removeJobCallback != nil {
@@ -379,6 +379,7 @@ func (job *Job) cleanUpDownloadAsyncJob() {
 	}
 	job.cancelCtx, job.cancelFunc = nil, nil
 	job.mu.Unlock()
+	close(job.doneCh)
 }
 
 // createCacheFile is a helper function which creates file in cache using

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -582,6 +582,8 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	AssertEq(Failed, jobStatus.Name)
 	AssertGe(jobStatus.Offset, 0)
 	AssertTrue(errors.Is(jobStatus.Err, lru.ErrInvalidUpdateEntrySize))
+	// Wait for the async goroutine to complete its cleanup.
+	<-dt.job.doneCh
 	// Verify callback is executed
 	AssertTrue(callbackExecuted.Load())
 }


### PR DESCRIPTION
### Description
There are two issues being fixed in this PR
* Make sure that tests wait for cleanup to finish before checking status of remove callback
* doneCh is closed at the end of the cleanup function. This will make sure that all callbacks are executed and contexts are made null before channel is closed.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/420327719

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
