### PR TITLE
Enable Inactive Timeout Reader by Default with 10s Timeout

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -569,7 +569,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
-	flagSet.DurationP("read-inactive-stream-timeout", "", 0*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout.")
+	flagSet.DurationP("read-inactive-stream-timeout", "", 10000000000*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout.")
 
 	if err := flagSet.MarkHidden("read-inactive-stream-timeout"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -712,7 +712,7 @@
     Duration of inactivity after which an open GCS read stream is automatically closed.
     This helps conserve resources when a file handle remains open without active Read calls.
     A value of '0s' disables this timeout.
-  default: "0s"
+  default: "10s"
   hide-flag: true
 
 - config-path: "write.block-size-mb"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1425,7 +1425,7 @@ func TestArgsParsing_ReadInactiveTimeoutConfig(t *testing.T) {
 		{
 			name:            "default",
 			cfgFile:         "empty.yaml",
-			expectedTimeout: 0,
+			expectedTimeout: 10 * time.Second,
 		},
 		{
 			name:            "override_default",


### PR DESCRIPTION
### Description
This PR enables the inactive reader feature with 10s timeout.

### Link to the issue in case of a bug fix.
b/424668838

### Testing details
1. Manual - Done.
2. Unit tests - Automated.
3. Integration tests - Automated.

### Any backward incompatible change? If so, please explain.
