### PR TITLE
Enable Read Stall Retry by default

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -385,7 +385,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil.")
 
-	flagSet.BoolP("enable-read-stall-retry", "", false, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
+	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
 	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -399,7 +399,7 @@
   usage: >-
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -711,7 +711,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              false,
+						Enable:              true,
 						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,
@@ -731,7 +731,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              true,
+						Enable:              false,
 						MinReqTimeout:       10 * time.Second,
 						MaxReqTimeout:       200 * time.Second,
 						InitialReqTimeout:   20 * time.Second,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1294,7 +1294,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
-						Enable:              false,
+						Enable:              true,
 						InitialReqTimeout:   20 * time.Second,
 						MinReqTimeout:       1500 * time.Millisecond,
 						MaxReqTimeout:       1200 * time.Second,

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -37,7 +37,7 @@ gcs-connection:
 gcs-retries:
   chunk-transfer-timeout-secs: 20
   read-stall:
-    enable: true
+    enable: false
     min-req-timeout: 10s
     max-req-timeout: 200s
     initial-req-timeout: 20s


### PR DESCRIPTION
### Description
This PR enables Read Stall Retries by default.

### Bug Link
https://b.corp.google.com/issues/406926331

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
