### PR TITLE
Make the --enable-read-stall-retry flag public

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -387,10 +387,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
-	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("enable-streaming-writes", "", true, "Enables streaming uploads during write file operation.")
 
 	flagSet.BoolP("experimental-enable-json-read", "", false, "By default, GCSFuse uses the GCS XML API to get and read objects. When this flag is specified, GCSFuse uses the GCS JSON API instead.\"")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -400,7 +400,6 @@
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
   default: true
-  hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"
   flag-name: "read-stall-initial-req-timeout"


### PR DESCRIPTION
### Description
This PR makes the --enable-read-stall-retry flag public for v3.1.0

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/425506968

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
