### PR TITLE
Adding e2e tests for release version 

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -193,6 +193,7 @@ TEST_DIR_PARALLEL=(
   "stale_handle"
   "negative_stat_cache"
   "streaming_writes"
+  "release_version"
 )
 
 # These tests never become parallel as they are changing bucket permissions.

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -134,6 +134,7 @@ TEST_PACKAGES_COMMON=(
   # "grpc_validation"
   "negative_stat_cache"
   "stale_handle"
+   "release_version"
 )
 
 # Test packages for regional buckets.
@@ -433,7 +434,7 @@ build_gcsfuse_once() {
   log_info "Using GCSFuse source directory: ${gcsfuse_src_dir}"
 
   log_info "Building GCSFuse using 'go run ./tools/build_gcsfuse/main.go'..."
-  (cd "${gcsfuse_src_dir}" && go run ./tools/build_gcsfuse/main.go . "${build_output_dir}" "e2e-$(date +%s)")
+  (cd "${gcsfuse_src_dir}" && go run ./tools/build_gcsfuse/main.go . "${build_output_dir}" "0.0.0")
   if [ $? -ne 0 ]; then
     log_error "Building GCSFuse binaries using 'go run ./tools/build_gcsfuse/main.go' failed."
     rm -rf "${build_output_dir}" # Clean up created temp dir

--- a/tools/integration_tests/release_version/release_version_test.go
+++ b/tools/integration_tests/release_version/release_version_test.go
@@ -31,7 +31,7 @@ func TestReleaseVersion(t *testing.T) {
 	}
 	output := strings.TrimSpace(string(outputBytes))
 	t.Logf("gcsfuse --version output:\n%s", output) // Log the output for debugging
-	expectedPattern := `^gcsfuse version (.+) \(Go version (go.+)\)$`
+	expectedPattern := `^gcsfuse version (\d+\.\d+\.\d+) \(Go version (go.+)\)$`
 	r := regexp.MustCompile(expectedPattern)
 	// Match the output against the pattern
 	matches := r.FindStringSubmatch(output)

--- a/tools/integration_tests/release_version/release_version_test.go
+++ b/tools/integration_tests/release_version/release_version_test.go
@@ -33,7 +33,7 @@ func TestReleaseVersion(t *testing.T) {
 	t.Logf("gcsfuse --version output:\n%s", output) // Log the output for debugging
 	expectedPattern := `^gcsfuse version (.+) \(Go version (go.+)\)$`
 	r := regexp.MustCompile(expectedPattern)
-	// 4. Match the output against the pattern
+	// Match the output against the pattern
 	matches := r.FindStringSubmatch(output)
 	if len(matches) != 3 { // Expect 3 elements: full match, version, go version
 		t.Errorf("Output did not match expected pattern.\nExpected pattern: %q\nActual output: %q\nMatches: %v", expectedPattern, output, matches)

--- a/tools/integration_tests/release_version/release_version_test.go
+++ b/tools/integration_tests/release_version/release_version_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release_version
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestReleaseVersion(t *testing.T) {
+	cmd := exec.Command("gcsfuse", "--version")
+
+	outputBytes, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Fatalf("Failed to execute 'gcsfuse --version': %v\nOutput: %s", err, string(outputBytes))
+	}
+	output := strings.TrimSpace(string(outputBytes))
+	t.Logf("gcsfuse --version output:\n%s", output) // Log the output for debugging
+	expectedPattern := `^gcsfuse version (.+) \(Go version (go.+)\)$`
+	r := regexp.MustCompile(expectedPattern)
+	// 4. Match the output against the pattern
+	matches := r.FindStringSubmatch(output)
+	if len(matches) != 3 { // Expect 3 elements: full match, version, go version
+		t.Errorf("Output did not match expected pattern.\nExpected pattern: %q\nActual output: %q\nMatches: %v", expectedPattern, output, matches)
+	} else {
+		version := matches[1]
+		goVersion := matches[2]
+		if version == "" {
+			t.Errorf("Extracted gcsfuse version is empty")
+		}
+		if goVersion == "" {
+			t.Errorf("Extracted Go version is empty")
+		}
+	}
+}

--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -26,9 +26,6 @@ import (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	// write-global-max-blocks=2 is for checking multiple file writes in parallel.
-	// concurrent_write_files_test.go- we are writing 3 files in parallel.
-	// with this config, we are giving 2 blocks to 2 files and 1 block to other file.
 	flags := [][]string{{}}
 
 	if setup.MountedDirectory() != "" {

--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release_version
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+)
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	// write-global-max-blocks=2 is for checking multiple file writes in parallel.
+	// concurrent_write_files_test.go- we are writing 3 files in parallel.
+	// with this config, we are giving 2 blocks to 2 files and 1 block to other file.
+	flags := [][]string{{}}
+
+	if setup.MountedDirectory() != "" {
+		log.Print("These tests will not run for mountedDirectory flag.")
+		os.Exit(1)
+	}
+
+	// Run tests for testBucket
+	setup.SetUpTestDirForTestBucketFlag()
+
+	successCode := static_mounting.RunTests(flags, m)
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -19,23 +19,20 @@ import (
 	"os"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	flags := [][]string{{}}
-
 	if setup.MountedDirectory() != "" {
 		log.Print("These tests will not run for mountedDirectory flag.")
 		os.Exit(1)
 	}
 
-	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucketFlag()
 
-	successCode := static_mounting.RunTests(flags, m)
+	successCode := m.Run()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -152,6 +152,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "streaming_writes"
   "write_large_files"
   "unfinalized_object"
+   "release_version"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -118,6 +118,7 @@ TEST_DIR_PARALLEL=(
   "streaming_writes"
   "inactive_stream_timeout"
   "cloud_profiler"
+  "release_version"
 )
 
 # These tests never become parallel as it is changing bucket permissions.

--- a/tools/util/build_gcsfuse.go
+++ b/tools/util/build_gcsfuse.go
@@ -73,7 +73,7 @@ func BuildGcsfuse(dstDir string) (err error) {
 			toolPath,
 			srcDir,
 			dstDir,
-			"fake_version",
+			"0.0.0",
 		)
 
 		var output []byte


### PR DESCRIPTION
### Description
- Add e2e tests for `gcsfuse --version`

### Link to the issue in case of a bug fix.
[b/425285473](https://b.corp.google.com/issues/425285473)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
