### PR TITLE
[Migrate auth] Add new hidden flag for kill switch

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -36,6 +36,8 @@ type Config struct {
 
 	EnableHns bool `yaml:"enable-hns"`
 
+	EnableNewAuth bool `yaml:"enable-new-auth"`
+
 	EnableNewReader bool `yaml:"enable-new-reader"`
 
 	FileCache FileCacheConfig `yaml:"file-cache"`
@@ -374,6 +376,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
 
 	if err := flagSet.MarkHidden("enable-hns"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-new-auth", "", false, "Enable new authentication method to fetch the credentials")
+
+	if err := flagSet.MarkHidden("enable-new-auth"); err != nil {
 		return err
 	}
 
@@ -745,6 +753,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("enable-new-auth", flagSet.Lookup("enable-new-auth")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -34,9 +34,9 @@ type Config struct {
 
 	EnableAtomicRenameObject bool `yaml:"enable-atomic-rename-object"`
 
-	EnableHns bool `yaml:"enable-hns"`
+	EnableGoogleLibAuth bool `yaml:"enable-google-lib-auth"`
 
-	EnableNewAuth bool `yaml:"enable-new-auth"`
+	EnableHns bool `yaml:"enable-hns"`
 
 	EnableNewReader bool `yaml:"enable-new-reader"`
 
@@ -373,15 +373,15 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
+	flagSet.BoolP("enable-google-lib-auth", "", false, "Enable google library authentication method to fetch the credentials")
 
-	if err := flagSet.MarkHidden("enable-hns"); err != nil {
+	if err := flagSet.MarkHidden("enable-google-lib-auth"); err != nil {
 		return err
 	}
 
-	flagSet.BoolP("enable-new-auth", "", false, "Enable new authentication method to fetch the credentials")
+	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
 
-	if err := flagSet.MarkHidden("enable-new-auth"); err != nil {
+	if err := flagSet.MarkHidden("enable-hns"); err != nil {
 		return err
 	}
 
@@ -752,11 +752,11 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
+	if err := v.BindPFlag("enable-google-lib-auth", flagSet.Lookup("enable-google-lib-auth")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("enable-new-auth", flagSet.Lookup("enable-new-auth")); err != nil {
+	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -92,6 +92,13 @@
   default: true
   hide-flag: true
 
+- flag-name: "enable-new-auth"
+  config-path: "enable-new-auth"
+  type: "bool"
+  usage: "Enable new authentication method to fetch the credentials"
+  default: false
+  hide-flag: true
+
 - config-path: "enable-new-reader"
   flag-name: "enable-new-reader"
   type: "bool"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -85,18 +85,18 @@
   default: true
   hide-flag: true
 
+- flag-name: "enable-google-lib-auth"
+  config-path: "enable-google-lib-auth"
+  type: "bool"
+  usage: "Enable google library authentication method to fetch the credentials"
+  default: false
+  hide-flag: true
+
 - config-path: "enable-hns"
   flag-name: "enable-hns"
   type: "bool"
   usage: "Enables support for HNS buckets"
   default: true
-  hide-flag: true
-
-- flag-name: "enable-new-auth"
-  config-path: "enable-new-auth"
-  type: "bool"
-  usage: "Enable new authentication method to fetch the credentials"
-  default: false
   hide-flag: true
 
 - config-path: "enable-new-reader"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -989,6 +989,43 @@ func TestArgsParsing_EnableHNSFlags(t *testing.T) {
 	}
 }
 
+func TestArgsParsing_EnableNewAuthFlag(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  []string
+		expectedEnableNewAuth bool
+	}{
+		{
+			name:                  "default",
+			args:                  []string{"gcsfuse", "abc", "pqr"},
+			expectedEnableNewAuth: false,
+		},
+		{
+			name:                  "normal",
+			args:                  []string{"gcsfuse", "--enable-new-auth=true", "abc", "pqr"},
+			expectedEnableNewAuth: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotEnableNewAuth bool
+			cmd, err := newRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotEnableNewAuth = cfg.EnableNewAuth
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedEnableNewAuth, gotEnableNewAuth)
+			}
+		})
+	}
+}
+
 func TestArgsParsing_EnableAtomicRenameObjectFlag(t *testing.T) {
 	tests := []struct {
 		name                             string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -989,29 +989,29 @@ func TestArgsParsing_EnableHNSFlags(t *testing.T) {
 	}
 }
 
-func TestArgsParsing_EnableNewAuthFlag(t *testing.T) {
+func TestArgsParsing_EnableGoogleLibAuthFlag(t *testing.T) {
 	tests := []struct {
-		name                  string
-		args                  []string
-		expectedEnableNewAuth bool
+		name                        string
+		args                        []string
+		expectedEnableGoogleLibAuth bool
 	}{
 		{
-			name:                  "default",
-			args:                  []string{"gcsfuse", "abc", "pqr"},
-			expectedEnableNewAuth: false,
+			name:                        "default",
+			args:                        []string{"gcsfuse", "abc", "pqr"},
+			expectedEnableGoogleLibAuth: false,
 		},
 		{
-			name:                  "normal",
-			args:                  []string{"gcsfuse", "--enable-new-auth=true", "abc", "pqr"},
-			expectedEnableNewAuth: true,
+			name:                        "normal",
+			args:                        []string{"gcsfuse", "--enable-google-lib-auth=true", "abc", "pqr"},
+			expectedEnableGoogleLibAuth: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotEnableNewAuth bool
+			var gotEnableGoogleLibAuth bool
 			cmd, err := newRootCmd(func(cfg *cfg.Config, _, _ string) error {
-				gotEnableNewAuth = cfg.EnableNewAuth
+				gotEnableGoogleLibAuth = cfg.EnableGoogleLibAuth
 				return nil
 			})
 			require.Nil(t, err)
@@ -1020,7 +1020,7 @@ func TestArgsParsing_EnableNewAuthFlag(t *testing.T) {
 			err = cmd.Execute()
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedEnableNewAuth, gotEnableNewAuth)
+				assert.Equal(t, tc.expectedEnableGoogleLibAuth, gotEnableGoogleLibAuth)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
Created a hidden flag for the kill-switch. This is for backward compatibility if any issue occurs with the new authentication method.

### Link to the issue in case of a bug fix.
[b/426095550](https://b.corp.google.com/issues/426095550)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
