### PR TITLE
[Random Reader Refactoring] Increase totalBytes for existing reader

### DIFF
--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -116,6 +116,7 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 	}
 	defer func() {
 		gr.updateExpectedOffset(offset + int64(readerResponse.Size))
+		gr.totalReadBytes += uint64(readerResponse.Size)
 	}()
 
 	var err error
@@ -138,12 +139,10 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 	readerType := gr.readerType(offset, end, gr.bucket.BucketType())
 	if readerType == RangeReaderType {
 		readerResponse, err = gr.rangeReader.ReadAt(ctx, readReq)
-		gr.totalReadBytes += uint64(readerResponse.Size)
 		return readerResponse, err
 	}
 
 	readerResponse, err = gr.mrr.ReadAt(ctx, readReq)
-	gr.totalReadBytes += uint64(readerResponse.Size)
 
 	return readerResponse, err
 }


### PR DESCRIPTION
### Description
- Inc totalBytes in case reading from existing reader as well.

### Link to the issue in case of a bug fix.
[b/426166667](https://b.corp.google.com/issues/426166667)

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Done
4. Perf tests

Performance tests were conducted by averaging results from multiple runs.
  i. Scenario 1: 200 MiB file, 1 thread, 1 MiB block size
   - Without this fix: 180 MiB/s
   - With this fix: 250 MiB/s (same as master)

  ii. Scenario 2: 200 MiB file, 1 thread, 4 KiB block size
   - Without this fix: 20 MiB/s
   - With this fix: 50 MiB/s (same as master)

### Any backward incompatible change? If so, please explain.
