### PR TITLE
Removing files created on disk after the test

### DIFF
--- a/tools/integration_tests/read_large_files/concurrent_read_files_test.go
+++ b/tools/integration_tests/read_large_files/concurrent_read_files_test.go
@@ -62,6 +62,9 @@ func TestReadFilesConcurrently(t *testing.T) {
 
 	// Wait on threads to end.
 	err := eG.Wait()
+	for i := 0; i < NumberOfFilesInLocalDiskForConcurrentRead; i++ {
+		operations.RemoveFile(filesPathInLocalDisk[i])
+	}
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}


### PR DESCRIPTION
### Description
Currently in TestReadFilesConcurrently, we don't delete the local files created on disk after the test is finished. Making changes to remove the local files after the test. 

### Link to the issue in case of a bug fix.
b/422632324

### Testing details
1. Manual - Manually ran the test package and tests are passing
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No