### PR TITLE
[Buffered Reader] Implement PrefetchBlock by extending Existing Block

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -97,6 +97,11 @@ func (m *memoryBlock) Deallocate() error {
 
 // createBlock creates a new block.
 func createBlock(blockSize int64) (Block, error) {
+	return createMemoryBlock(blockSize)
+}
+
+// createMemoryBlock creates a new memory block with the given size.
+func createMemoryBlock(blockSize int64) (*memoryBlock, error) {
 	prot, flags := syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE
 	addr, err := syscall.Mmap(-1, 0, int(blockSize), prot, flags)
 	if err != nil {

--- a/internal/block/prefetch_block.go
+++ b/internal/block/prefetch_block.go
@@ -53,7 +53,7 @@ type prefetchBlock struct {
 }
 
 func (p *prefetchBlock) Reuse() {
-	p.Reuse()
+	p.memoryBlock.Reuse()
 	p.notification = make(chan int, 1)
 	p.cancelFunc = nil
 	p.id = 0

--- a/internal/block/prefetch_block.go
+++ b/internal/block/prefetch_block.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package block
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+)
+
+type PrefetchBlock interface {
+	Block
+
+	// Returns complete buffer slice to read any specific data.
+	Data() []byte
+
+	// NotificationChannel returns a channel that notifies when the block is
+	// ready to consume.
+	NotificationChannel() <-chan int
+
+	// GetId returns the id of the block. The id is used to identify the portion of
+	// the block that is being prefetched. The id is used to calculate the offset
+	// of the block in the buffer, where the data is stored.
+	GetId() int64
+
+	// SetId sets the id of the block. The id is used to identify the portion of
+	SetId(id int64)
+}
+
+type prefetchBlock struct {
+	memoryBlock
+
+	// notification is a channel that notifies when the block is ready to consume.
+	notification chan int
+
+	// cancelFunc is used to cancel the prefetch operation if needed.
+	cancelFunc context.CancelCauseFunc
+
+	// Represents the portion with offset [id * blockSize, (id+1) * blockSize).
+	id int64
+}
+
+func (p *prefetchBlock) Reuse() {
+	p.Reuse()
+	p.notification = make(chan int, 1)
+	p.cancelFunc = nil
+	p.id = 0
+}
+
+func (p *prefetchBlock) Data() []byte {
+	return p.buffer
+}
+
+func (p *prefetchBlock) NotificationChannel() <-chan int {
+	return p.notification
+}
+
+// createPrefetchBlock creates a new block.
+func createPrefetchBlock(blockSize int64) (PrefetchBlock, error) {
+	prot, flags := syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE
+	addr, err := syscall.Mmap(-1, 0, int(blockSize), prot, flags)
+	if err != nil {
+		return nil, fmt.Errorf("mmap error: %v", err)
+	}
+
+	pb := prefetchBlock{
+		memoryBlock: memoryBlock{
+			buffer: addr,
+			offset: offset{0, 0},
+		},
+		notification: make(chan int, 1),
+		cancelFunc:   nil,
+		id:           0,
+	}
+
+	return &pb, nil
+}
+
+func (p *prefetchBlock) GetId() int64 {
+	return p.id
+}
+
+func (p *prefetchBlock) SetId(id int64) {
+	p.id = id
+}

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -15,11 +15,12 @@
 package block
 
 import (
+	"io"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"io"
-	"testing"
 )
 
 type prefetchBlockTest struct {
@@ -30,10 +31,24 @@ func TestPrefetchBlockTestSuite(t *testing.T) {
 	suite.Run(t, new(prefetchBlockTest))
 }
 
+func (testSuite *prefetchBlockTest) TestCreatePrefetchBlock() {
+	pb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+
+	// No write operation, so size should be 0
+	assert.Equal(testSuite.T(), int64(0), pb.Size())
+	output, err := io.ReadAll(pb.Reader())
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), []byte{}, output)
+	assert.Equal(testSuite.T(), int64(0), pb.GetId())
+	assert.NotNil(testSuite.T(), pb.NotificationChannel())
+}
+
 func (testSuite *prefetchBlockTest) TestPrefetchBlockWrite() {
 	pb, err := createPrefetchBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hi")
+
 	n, err := pb.Write(content)
 
 	assert.Nil(testSuite.T(), err)
@@ -44,13 +59,25 @@ func (testSuite *prefetchBlockTest) TestPrefetchBlockWrite() {
 	assert.Equal(testSuite.T(), int64(2), pb.Size())
 }
 
+func (testSuite *prefetchBlockTest) TestPrefetchBlockWriteWithDataGreaterThanCapacity() {
+	pb, err := createPrefetchBlock(1)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hi")
+
+	n, err := pb.Write(content)
+
+	assert.NotNil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), 0, n)
+	assert.EqualError(testSuite.T(), err, outOfCapacityError)
+}
+
 func (testSuite *prefetchBlockTest) TestPrefetchBlockReuse() {
 	pb, err := createPrefetchBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hi")
 	n, err := pb.Write(content)
-	assert.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), len(content), n)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), len(content), n)
 
 	pb.Reuse()
 
@@ -62,21 +89,23 @@ func (testSuite *prefetchBlockTest) TestPrefetchBlockReuse() {
 	assert.NotNil(testSuite.T(), pb.NotificationChannel())
 }
 
-func (testSuite *prefetchBlockTest) TestCreatePrefetchBlock() {
+func (testSuite *prefetchBlockTest) TestPrefetchBlockGetIdForEmptyBlock() {
 	pb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
 
-	assert.Nil(testSuite.T(), err)
-	assert.NotNil(testSuite.T(), pb)
-	assert.NotNil(testSuite.T(), pb.NotificationChannel())
+	// Initially, the ID should be 0
+	assert.Equal(testSuite.T(), int64(0), pb.GetId())
 }
 
-func (testSuite *prefetchBlockTest) TestPrefetchBlockWriteWithDataGreaterThanCapacity() {
-	pb, err := createPrefetchBlock(1)
+// TestPrefetchBlockSetId sets the ID of the prefetch block and verifies it.
+func (testSuite *prefetchBlockTest) TestPrefetchBlockSetId() {
+	pb, err := createPrefetchBlock(12)
 	require.Nil(testSuite.T(), err)
-	content := []byte("hi")
-	n, err := pb.Write(content)
 
-	assert.NotNil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), 0, n)
-	assert.EqualError(testSuite.T(), err, outOfCapacityError)
+	// Set a new ID
+	newId := int64(5)
+	pb.SetId(newId)
+
+	// Verify that the ID is set correctly
+	assert.Equal(testSuite.T(), newId, pb.GetId())
 }

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package block
+
+import (
+	// "context"
+	// "fmt"
+	// "syscall"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"io"
+	"testing"
+)
+
+type prefetchBlockTest struct {
+	MemoryBlockTest
+}
+
+func TestPrefetchBlockTestSuite(t *testing.T) {
+	suite.Run(t, new(prefetchBlockTest))
+}
+
+func (testSuite *prefetchBlockTest) TestPrefetchBlockWrite() {
+	pb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hi")
+	n, err := pb.Write(content)
+
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), len(content), n)
+	output, err := io.ReadAll(pb.Reader())
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), content, output)
+	assert.Equal(testSuite.T(), int64(2), pb.Size())
+}
+
+// Write test for Reuse method
+func (testSuite *prefetchBlockTest) TestPrefetchBlockReuse() {
+	pb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hi")
+	n, err := pb.Write(content)
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), len(content), n)
+
+	// Reuse the block
+	pb.Reuse()
+
+	// After reuse, the size should be reset to 0
+	// assert.Equal(testSuite.T(), int64(0), pb.Size())
+	// output, err := io.ReadAll(pb.Reader())
+	// assert.Nil(testSuite.T(), err)
+	// assert.Equal(testSuite.T(), []byte{}, output)
+}
+
+func (testSuite *prefetchBlockTest) TestCreatePrefetchBlock() {
+	pb, err := createPrefetchBlock(12)
+
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), pb)
+	assert.NotNil(testSuite.T(), pb.NotificationChannel())
+}

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -15,9 +15,6 @@
 package block
 
 import (
-	// "context"
-	// "fmt"
-	// "syscall"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -47,7 +44,6 @@ func (testSuite *prefetchBlockTest) TestPrefetchBlockWrite() {
 	assert.Equal(testSuite.T(), int64(2), pb.Size())
 }
 
-// Write test for Reuse method
 func (testSuite *prefetchBlockTest) TestPrefetchBlockReuse() {
 	pb, err := createPrefetchBlock(12)
 	require.Nil(testSuite.T(), err)
@@ -56,14 +52,14 @@ func (testSuite *prefetchBlockTest) TestPrefetchBlockReuse() {
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), len(content), n)
 
-	// Reuse the block
 	pb.Reuse()
 
-	// After reuse, the size should be reset to 0
-	// assert.Equal(testSuite.T(), int64(0), pb.Size())
-	// output, err := io.ReadAll(pb.Reader())
-	// assert.Nil(testSuite.T(), err)
-	// assert.Equal(testSuite.T(), []byte{}, output)
+	assert.Equal(testSuite.T(), int64(0), pb.Size())
+	output, err := io.ReadAll(pb.Reader())
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), []byte{}, output)
+	assert.Equal(testSuite.T(), int64(0), pb.GetId())
+	assert.NotNil(testSuite.T(), pb.NotificationChannel())
 }
 
 func (testSuite *prefetchBlockTest) TestCreatePrefetchBlock() {
@@ -72,4 +68,15 @@ func (testSuite *prefetchBlockTest) TestCreatePrefetchBlock() {
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), pb)
 	assert.NotNil(testSuite.T(), pb.NotificationChannel())
+}
+
+func (testSuite *prefetchBlockTest) TestPrefetchBlockWriteWithDataGreaterThanCapacity() {
+	pb, err := createPrefetchBlock(1)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hi")
+	n, err := pb.Write(content)
+
+	assert.NotNil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), 0, n)
+	assert.EqualError(testSuite.T(), err, outOfCapacityError)
 }


### PR DESCRIPTION
### Description
- Create PrefetchBlock by Extending the Existing Block

### Link to the issue in case of a bug fix.
b/426061112

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
