### PR TITLE
Add getopt in e2e script for enhanced command line arg handling.

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -20,15 +20,9 @@ readonly EXECUTE_INTEGRATION_TEST_LABEL="execute-integration-tests"
 readonly EXECUTE_INTEGRATION_TEST_LABEL_ON_ZB="execute-integration-tests-on-zb"
 readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly EXECUTE_CHECKPOINT_TEST_LABEL="execute-checkpoint-test"
-readonly RUN_E2E_TESTS_ON_INSTALLED_PACKAGE=false
-readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 readonly BUCKET_LOCATION=us-west4
-readonly RUN_TEST_ON_TPC_ENDPOINT=false
 readonly GO_VERSION="1.24.0"
 readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
-
-# This flag, if set true, will indicate to underlying script to customize for a presubmit run.
-readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=true
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
@@ -125,7 +119,7 @@ then
 
   echo "Running e2e tests on zonal bucket(s) ..."
   # $1 argument is refering to value of testInstalledPackage.
-  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG true
+  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --zonal --track-resource-usage
 fi
 
 # Execute integration tests on non-zonal bucket(s).
@@ -136,7 +130,7 @@ then
 
   echo "Running e2e tests on non-zonal bucket(s) ..."
   # $1 argument is refering to value of testInstalledPackage.
-  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG false
+  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --track-resource-usage
 fi
 
 # Execute package build tests.

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -15,12 +15,10 @@
 
 # Script Usage Documentation
 usage() {
-  echo "Usage: $0 [options]"
-  echo "Options:"
-  echo "  Required:"
-  echo "    --bucket-location             <location>     The Google Cloud Storage bucket location (e.g., 'us-central1')."
+  echo "Usage: $0 --bucket-location <bucket-location> [options]"
+  echo "    --bucket-location            <location>     The Google Cloud Storage bucket location (e.g., 'us-central1')."
   echo ""
-  echo "  Optional:"
+  echo "Options:"
   echo "    --test-installed-package                     Test installed gcsfuse package. (Default: false)"
   echo "    --skip-non-essential-tests                   Skip non-essential tests inside packages. (Default: false)"
   echo "    --tpc-endpoint                               Run tests on TPC endpoint. (Default: false)"
@@ -31,7 +29,7 @@ usage() {
   echo "    --package-level-parallelism   <parallelism>  To adjust the number of packages to execute in parallel. (Default: 10)"
   echo "    --track-resource-usage                       To track resource(cpu/mem/disk) usage during e2e run. (Default: false)"
   echo "    --help                                       Display this help and exit."
-  exit 1
+  exit "$1"
 }
 
 # Logging Helpers
@@ -101,7 +99,7 @@ LONG=bucket-location:,test-installed-package,skip-non-essential-tests,no-build-b
 PARSED=$(getopt --options "" --longoptions "$LONG" --name "$0" -- "$@")
 if [[ $? -ne 0 ]]; then
     # getopt will have already printed an error message
-    usage
+    usage 1
 fi
 
 # Read the parsed options back into the positional parameters.
@@ -147,7 +145,7 @@ while (( $# >= 1 )); do
             shift
             ;;
         --help)
-            usage
+            usage 0
             ;;
         --)
             shift
@@ -155,7 +153,7 @@ while (( $# >= 1 )); do
             ;;
         *)
             log_error "Unrecognized arguments [$*]."
-            usage
+            usage 1
             ;;
     esac
 done
@@ -166,7 +164,7 @@ validate_option_value() {
   local value=$2
   if [[ -z "$value" || "$value" == -* ]]; then
     log_error "Invalid or empty value [$value] for option $option."
-    usage
+    usage 1
   fi
 }
 


### PR DESCRIPTION
### Description
Adding `getopt` option in e2e test run script which offers enhanced arg handling and clean way of executing script.
Ref: https://www.man7.org/linux/man-pages/man3/getopt.3.html
Fixed optional resource usage collection in e2e script as per the comment in : https://github.com/GoogleCloudPlatform/gcsfuse/pull/3414#discussion_r2154229482
#### Example ways to run the script~
```
$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location us-central1

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location us-central1 --presubmit

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location us-central1 --presubmit --zonal
```
#### Example ways to not run the script~
```
$ ./tools/integration_tests/improved_run_e2e_tests.sh 
[INFO] 2025-06-25 11:12:10: Bash version: 5.2
[ERROR] 2025-06-25 11:12:10: Invalid or empty value [] for option --bucket-location.
Usage: ./tools/integration_tests/improved_run_e2e_tests.sh [options]
Options:
  Required:
    --bucket-location             <location>     The Google Cloud Storage bucket location (e.g., 'us-central1').

  Optional:
    --test-installed-package                     Test installed gcsfuse package. (Default: false)
    --skip-non-essential-tests                   Skip non-essential tests inside packages. (Default: false)
    --tpc-endpoint                               Run tests on TPC endpoint. (Default: false)
    --presubmit                                  Run tests with presubmit flag. (Default: false)
    --zonal                                      Run tests with zonal bucket. (Default: false)
    --no-build-binary-in-script                  To disable building gcsfuse binary in script. (Default: false)
    --package-level-parallelism   <parallelism>  To adjust the number of packages to execute in parallel. (Default: 10)
    --track-resource-usage                       To track resource(cpu/mem/disk) usage during e2e run. (Default: false)
    --help                                       Display this help and exit.


$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location
[INFO] 2025-06-25 11:12:38: Bash version: 5.2
./tools/integration_tests/improved_run_e2e_tests.sh: option '--bucket-location' requires an argument

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location ""
[INFO] 2025-06-25 11:13:19: Bash version: 5.2
[ERROR] 2025-06-25 11:13:19: Invalid or empty value [] for option --bucket-location.

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location --another-param
[INFO] 2025-06-25 11:13:50: Bash version: 5.2
[ERROR] 2025-06-25 11:13:50: Invalid or empty value [--another-param] for option --bucket-location.

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location us-central1 --non-existent-flag
[INFO] 2025-06-25 11:14:27: Bash version: 5.2
./tools/integration_tests/improved_run_e2e_tests.sh: unrecognized option '--non-existent-flag'

$ ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location us-central1 --presubmit=some-value
[INFO] 2025-06-25 11:15:00: Bash version: 5.2
./tools/integration_tests/improved_run_e2e_tests.sh: option '--presubmit' doesn't allow an argument
```
### Link to the issue in case of a bug fix.
b/426462003

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
No
