### PR TITLE
[Optimization] Avoid creating unnecessary contexts in fs.go

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1479,9 +1479,7 @@ func (fs *fileSystem) LookUpInode(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the parent directory in question.
 	fs.mu.Lock()
@@ -1515,9 +1513,7 @@ func (fs *fileSystem) GetInodeAttributes(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the inode.
 	fs.mu.Lock()
@@ -1543,9 +1539,7 @@ func (fs *fileSystem) SetInodeAttributes(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the inode.
 	fs.mu.Lock()
@@ -1619,9 +1613,7 @@ func (fs *fileSystem) MkDir(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the parent.
 	fs.mu.Lock()
@@ -1678,9 +1670,7 @@ func (fs *fileSystem) MkNode(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	if (op.Mode & (iofs.ModeNamedPipe | iofs.ModeSocket)) != 0 {
 		return syscall.ENOTSUP
@@ -1819,9 +1809,7 @@ func (fs *fileSystem) CreateFile(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Create the child.
 	var child inode.Inode
@@ -1870,9 +1858,7 @@ func (fs *fileSystem) CreateSymlink(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the parent.
 	fs.mu.Lock()
@@ -1940,9 +1926,7 @@ func (fs *fileSystem) RmDir(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the parent.
 	fs.mu.Lock()
@@ -2048,9 +2032,7 @@ func (fs *fileSystem) Rename(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the old and new parents.
 	fs.mu.Lock()
@@ -2409,9 +2391,7 @@ func (fs *fileSystem) Unlink(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 
 	fs.mu.Lock()
@@ -2506,9 +2486,7 @@ func (fs *fileSystem) ReadDir(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the handle.
 	fs.mu.Lock()
@@ -2588,9 +2566,7 @@ func (fs *fileSystem) ReadFile(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Save readOp in context for access in logs.
 	ctx = context.WithValue(ctx, gcsx.ReadOp, op)
@@ -2653,9 +2629,7 @@ func (fs *fileSystem) WriteFile(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 
 	if fs.newConfig.Write.ExperimentalEnableRapidAppends {
@@ -2699,9 +2673,7 @@ func (fs *fileSystem) SyncFile(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the inode.
 	fs.mu.Lock()
@@ -2732,9 +2704,7 @@ func (fs *fileSystem) FlushFile(
 	if fs.newConfig.FileSystem.IgnoreInterrupts {
 		// When ignore interrupts config is set, we are creating a new context not
 		// cancellable by parent context.
-		var cancel context.CancelFunc
-		ctx, cancel = util.IsolateContextFromParentContext(ctx)
-		defer cancel()
+		ctx = context.Background()
 	}
 	// Find the inode.
 	fs.mu.Lock()

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"os"
@@ -104,11 +103,4 @@ func BytesToHigherMiBs(bytes uint64) uint64 {
 	}
 	const bytesInOneMiB uint64 = 1 << 20
 	return uint64(math.Ceil(float64(bytes) / float64(bytesInOneMiB)))
-}
-
-// IsolateContextFromParentContext creates a copy of the parent context which is
-// not cancelled when parent context is cancelled.
-func IsolateContextFromParentContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	ctx = context.WithoutCancel(ctx)
-	return context.WithCancel(ctx)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"context"
 	"math"
 	"os"
 	"path/filepath"
@@ -213,18 +212,4 @@ func (ts *UtilTest) TestBytesToHigherMiBs() {
 	for _, tc := range cases {
 		assert.Equal(ts.T(), tc.mib, BytesToHigherMiBs(tc.bytes))
 	}
-}
-
-func (ts *UtilTest) TestIsolateContextFromParentContext() {
-	parentCtx, parentCtxCancel := context.WithCancel(context.Background())
-
-	// Call the method and cancel the parent context.
-	newCtx, newCtxCancel := IsolateContextFromParentContext(parentCtx)
-	parentCtxCancel()
-
-	// Validate new context is not cancelled after parent's cancellation.
-	assert.NoError(ts.T(), newCtx.Err())
-	// Cancel the new context and validate.
-	newCtxCancel()
-	assert.ErrorIs(ts.T(), newCtx.Err(), context.Canceled)
 }


### PR DESCRIPTION
### Description
As part of ignoring interrupts we made a change in GCSFuse as follows:
- remove cancel function on the the context passed by jacobsa/fuse
- Create our own cancel function using context from above step
- We call the cancel function before returning the response to jacobsa/fuse to clean up any associated resources.

All the GCSFuse operations are sync flows i.e, we get a response from GCS and return. Where ever there is async flow involved we create a new context so it will continue running even when the operation is done. So the steps to remove and create new context is all unnecessary. We can simply use context.Background() for the network calls in the sync flows. Async flows will anyways pass their own cancellable context.

### Link to the issue in case of a bug fix.
b/424375583

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
