### PR TITLE
Make codecov upload optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: codecov/codecov-action@v4.3.1
       timeout-minutes: 5
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
 


### PR DESCRIPTION
### Description
Codecov uploads fail for external contributors because they lack access to the secret stored on GitHub required to upload the Codecov report. We are making this step optional to prevent it from failing the CI pipeline and blocking external contributors' PRs.

### Link to the issue in case of a bug fix.
b/427367094

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
