### PR TITLE
remove extra go routine in read flow

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1833,7 +1833,7 @@ func (fs *fileSystem) CreateFile(
 
 	// CreateFile() invoked to create new files, can be safely considered as filehandle
 	// opened in append mode.
-	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, util.Append, &fs.newConfig.Read)
+	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, util.Append, fs.newConfig)
 	op.Handle = handleID
 
 	fs.mu.Unlock()
@@ -2547,7 +2547,7 @@ func (fs *fileSystem) OpenFile(
 
 	// Figure out the mode in which the file is being opened.
 	openMode := util.FileOpenMode(op)
-	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, openMode, &fs.newConfig.Read)
+	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, openMode, fs.newConfig)
 	op.Handle = handleID
 
 	// When we observe object generations that we didn't create, we assign them

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -63,19 +63,19 @@ type FileHandle struct {
 	// openMode is used to store the mode in which the file is opened.
 	openMode util.OpenMode
 
-	// Read related mounting configuration.
-	readConfig *cfg.ReadConfig
+	// Mount configuration.
+	config *cfg.Config
 }
 
 // LOCKS_REQUIRED(fh.inode.mu)
-func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, openMode util.OpenMode, rc *cfg.ReadConfig) (fh *FileHandle) {
+func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, openMode util.OpenMode, c *cfg.Config) (fh *FileHandle) {
 	fh = &FileHandle{
 		inode:                 inode,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
 		metricHandle:          metricHandle,
 		openMode:              openMode,
-		readConfig:            rc,
+		config:                c,
 	}
 
 	fh.inode.RegisterFileHandle(fh.openMode == util.Read)
@@ -270,7 +270,7 @@ func (fh *FileHandle) tryEnsureReader(ctx context.Context, sequentialReadSizeMb 
 	}
 
 	// Attempt to create an appropriate reader.
-	rr := gcsx.NewRandomReader(fh.inode.Source(), fh.inode.Bucket(), sequentialReadSizeMb, fh.fileCacheHandler, fh.cacheFileForRangeRead, fh.metricHandle, &fh.inode.MRDWrapper, fh.readConfig)
+	rr := gcsx.NewRandomReader(fh.inode.Source(), fh.inode.Bucket(), sequentialReadSizeMb, fh.fileCacheHandler, fh.cacheFileForRangeRead, fh.metricHandle, &fh.inode.MRDWrapper, fh.config)
 
 	fh.reader = rr
 	return
@@ -314,7 +314,7 @@ func (fh *FileHandle) tryEnsureReadManager(ctx context.Context, sequentialReadSi
 		CacheFileForRangeRead: fh.cacheFileForRangeRead,
 		MetricHandle:          fh.metricHandle,
 		MrdWrapper:            &fh.inode.MRDWrapper,
-		ReadConfig:            fh.readConfig,
+		ReadConfig:            &fh.config.Read,
 	})
 
 	return nil

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -144,7 +144,7 @@ func (t *fileTest) TestFileHandleWrite() {
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	config := &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
 	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_obj", nil, false)
-	fh := NewFileHandle(in, nil, false, nil, util.Write, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, nil, util.Write, &cfg.Config{})
 	data := []byte("hello")
 
 	_, err := fh.Write(t.ctx, data, 0)
@@ -167,7 +167,7 @@ func (t *fileTest) Test_Read_Success() {
 	expectedData := []byte("hello from reader")
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_reader", expectedData, false)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -183,7 +183,7 @@ func (t *fileTest) Test_ReadWithReadManager_Success() {
 	expectedData := []byte("hello from readManager")
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_readManager", expectedData, false)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -215,7 +215,7 @@ func (t *fileTest) Test_ReadWithReadManager_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 			fh.inode.Lock()
 			mockRM := new(read_manager.MockReadManager)
 			mockRM.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ReaderResponse{}, tc.returnErr)
@@ -253,7 +253,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 			fh.inode.Lock()
 			mockReader := new(gcsx.MockRandomReader)
 			mockReader.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ObjectData{}, tc.returnErr)
@@ -278,7 +278,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	fh.inode.Lock()
 	mockRM := new(read_manager.MockReadManager)
 	mockRM.On("Destroy").Return()
@@ -300,7 +300,7 @@ func (t *fileTest) Test_Read_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	fh.inode.Lock()
 	mockR := new(gcsx.MockRandomReader)
 	mockR.On("Destroy").Return()
@@ -336,7 +336,7 @@ func (t *fileTest) TestOpenMode() {
 		parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 		config := &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
 		in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_obj", nil, false)
-		fh := NewFileHandle(in, nil, false, nil, tc.openMode, &cfg.ReadConfig{})
+		fh := NewFileHandle(in, nil, false, nil, tc.openMode, &cfg.Config{})
 
 		openMode := fh.OpenMode()
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -104,7 +104,7 @@ const (
 
 // NewRandomReader create a random reader for the supplied object record that
 // reads using the given bucket.
-func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, mrdWrapper *MultiRangeDownloaderWrapper, config *cfg.ReadConfig) RandomReader {
+func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, mrdWrapper *MultiRangeDownloaderWrapper, config *cfg.Config) RandomReader {
 	return &randomReader{
 		object:                o,
 		bucket:                bucket,
@@ -175,7 +175,7 @@ type randomReader struct {
 
 	metricHandle common.MetricHandle
 
-	config *cfg.ReadConfig
+	config *cfg.Config
 
 	// Specifies the next expected offset for the reads. Used to distinguish between
 	// sequential and random reads.
@@ -428,28 +428,30 @@ func (rr *randomReader) Destroy() {
 func (rr *randomReader) readFull(
 	ctx context.Context,
 	p []byte) (n int, err error) {
-	// Start a goroutine that will cancel the read operation we block on below if
-	// the calling context is cancelled, but only if this method has not already
-	// returned (to avoid souring the reader for the next read if this one is
-	// successful, since the calling context will eventually be cancelled).
-	readDone := make(chan struct{})
-	defer close(readDone)
+	if rr.config != nil && !rr.config.FileSystem.IgnoreInterrupts {
+		// Start a goroutine that will cancel the read operation we block on below if
+		// the calling context is cancelled, but only if this method has not already
+		// returned (to avoid souring the reader for the next read if this one is
+		// successful, since the calling context will eventually be cancelled).
+		readDone := make(chan struct{})
+		defer close(readDone)
 
-	go func() {
-		select {
-		case <-readDone:
-			return
-
-		case <-ctx.Done():
+		go func() {
 			select {
 			case <-readDone:
 				return
 
-			default:
-				rr.cancel()
+			case <-ctx.Done():
+				select {
+				case <-readDone:
+					return
+
+				default:
+					rr.cancel()
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	// Call through.
 	n, err = io.ReadFull(rr.reader, p)
@@ -464,7 +466,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	// Begin the read.
 	ctx, cancel := context.WithCancel(context.Background())
 
-	if rr.config != nil && rr.config.InactiveStreamTimeout > 0 {
+	if rr.config != nil && rr.config.Read.InactiveStreamTimeout > 0 {
 		rr.reader, err = NewInactiveTimeoutReader(
 			ctx,
 			rr.bucket,
@@ -474,7 +476,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 				Start: uint64(start),
 				Limit: uint64(end),
 			},
-			rr.config.InactiveStreamTimeout)
+			rr.config.Read.InactiveStreamTimeout)
 	} else {
 		rr.reader, err = rr.bucket.NewReaderWithReadHandle(
 			ctx,

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -934,7 +934,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ValidateTimeout
 func (t *RandomReaderStretchrTest) Test_ReadAt_WithAndWithoutReadConfig() {
 	testCases := []struct {
 		name                        string
-		config                      *cfg.ReadConfig
+		config                      *cfg.Config
 		expectInactiveTimeoutReader bool
 	}{
 		{
@@ -944,12 +944,12 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_WithAndWithoutReadConfig() {
 		},
 		{
 			name:                        "WithReadConfigAndZeroTimeout",
-			config:                      &cfg.ReadConfig{InactiveStreamTimeout: 0},
+			config:                      &cfg.Config{Read: cfg.ReadConfig{InactiveStreamTimeout: 0}},
 			expectInactiveTimeoutReader: false,
 		},
 		{
 			name:                        "WithReadConfigAndPositiveTimeout",
-			config:                      &cfg.ReadConfig{InactiveStreamTimeout: 10 * time.Millisecond},
+			config:                      &cfg.Config{Read: cfg.ReadConfig{InactiveStreamTimeout: 10 * time.Millisecond}},
 			expectInactiveTimeoutReader: true,
 		},
 	}


### PR DESCRIPTION
### Description
In the read flow when we read data from range reader into the buffer, GCSFuse creates a goroutine which takes care of checking for context cancelled while waiting for data from network. Since interrupts are disabled by default, there is no need of creating this goroutine always for every read request. Create this go routine only if user wants interrupts to be handled.

### Link to the issue in case of a bug fix.
b/425859120

### Testing details
1. Manual - 
Manual profiline results:
Before optimization:
![7FGsbXhaQGDZNPC](https://github.com/user-attachments/assets/d9de381e-bcd1-421e-a2e4-b3a11becea0f)

After optimization:
![5wowPCA4LAvNGNz](https://github.com/user-attachments/assets/a547f0c7-fd89-45e8-900c-8005ea739db2)

2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA