### PR TITLE
feat(read unfinalized object): part3 - Add e2e test package read_unfinalized_object

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -216,6 +216,7 @@ TEST_PACKAGES_COMMON=(
   "negative_stat_cache"
   "stale_handle"
   "release_version"
+  "read_unfinalized_object"
 )
 
 # Test packages for regional buckets.

--- a/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
+++ b/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
@@ -158,12 +158,12 @@ func TestUnfinalizedObjectReadTest(t *testing.T) {
 	// Run tests.
 	for _, flags := range flagsSet {
 		ts.flags = flags
-		require.NoError(os.Mkdir(ts.cacheDir, setup.DirPermission_0755))
+		require.NoError(t, os.Mkdir(ts.cacheDir, setup.DirPermission_0755))
 		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
 		log.Printf("Running tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
 		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
 		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
-		require.NoError(os.RemoveAll(ts.cacheDir))
+		require.NoError(t, os.RemoveAll(ts.cacheDir))
 	}
 }

--- a/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
+++ b/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -89,19 +90,33 @@ func (t *unfinalizedObjectReads) Test_ReadUnfinalizedWithNoActiveAppends_RandomR
 	maxReadChunkSize := int64(200 * util.MiB)
 	fullFilePath := path.Join(t.testDirPath, t.fileName)
 	t.createUnfinalizedObject(fileSize)
+	maxParallelReads := 10
+	var wg sync.WaitGroup
+	// Use a buffered channel as a semaphore to limit concurrent reads.
+	sem := make(chan struct{}, maxParallelReads)
 
 	// Read unfinalized object in random chunks.
 	for range numReads {
-		readChunkSize := 1 + rand.Int63n(maxReadChunkSize-1)
-		readOffset := rand.Int63n(fileSize - readChunkSize)
+		wg.Add(1)
+		// Acquire a token. This will block if the semaphore is full.
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			// Release the token back to the semaphore.
+			defer func() { <-sem }()
+			readChunkSize := 1 + rand.Int63n(maxReadChunkSize-1)
+			readOffset := rand.Int63n(fileSize - readChunkSize)
 
-		readContent, err := operations.ReadChunkFromFile(path.Join(t.testDirPath, t.fileName), readChunkSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
+			readContent, err := operations.ReadChunkFromFile(path.Join(t.testDirPath, t.fileName), readChunkSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 
-		endOffset := readOffset + readChunkSize
-		require.NoErrorf(t.T(), err, "Failed to read %q from [%09d, %09d]: %v", fullFilePath, readOffset, readOffset+readChunkSize, err)
-		expectedContent := t.content[readOffset:endOffset]
-		assert.Equalf(t.T(), string(readContent), expectedContent, "Read of %q from [%09d, %09d] failed with content mismatch.", fullFilePath, readOffset, readOffset+readChunkSize)
+			endOffset := readOffset + readChunkSize
+			require.NoErrorf(t.T(), err, "Failed to read %q from [%09d, %09d]: %v", fullFilePath, readOffset, readOffset+readChunkSize, err)
+			expectedContent := t.content[readOffset:endOffset]
+			assert.Equalf(t.T(), string(readContent), expectedContent, "Read of %q from [%09d, %09d] failed with content mismatch.", fullFilePath, readOffset, readOffset+readChunkSize)
+		}()
 	}
+	// Wait for all concurrent reads to complete.
+	wg.Wait()
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
+++ b/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unfinalized_object
+
+import (
+	"context"
+	"log"
+	"path"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+////////////////////////////////////////////////////////////////////////
+// Boilerplate
+////////////////////////////////////////////////////////////////////////
+
+type unfinalizedObjectReads struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	fileName      string
+	content       string
+	suite.Suite
+}
+
+func (t *unfinalizedObjectReads) SetupTest() {
+	t.testDirPath = client.SetupTestDirectory(t.ctx, t.storageClient, testDirName)
+	t.fileName = path.Base(t.T().Name()) + setup.GenerateRandomString(5)
+	var size int = operations.MiB
+	t.content = setup.GenerateRandomString(size)
+}
+
+func (t *unfinalizedObjectReads) TeardownTest() {}
+
+// //////////////////////////////////////////////////////////////////////
+// Helpers
+// //////////////////////////////////////////////////////////////////////
+func (t *unfinalizedObjectReads) createUnfinalizedObject() {
+	t.T().Helper()
+	// Create un-finalized object via same mount.
+	fh := operations.CreateFile(path.Join(t.testDirPath, t.fileName), setup.FilePermission_0600, t.T())
+	operations.WriteWithoutClose(fh, t.content, t.T())
+	defer operations.CloseFileShouldNotThrowError(t.T(), fh)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
+func (t *unfinalizedObjectReads) TestUnfinalizedObjectsCanBeRead() {
+	t.createUnfinalizedObject()
+
+	// Read un-finalized object.
+	readContent, err := operations.ReadFileSequentially(path.Join(t.testDirPath, t.fileName), util.MiB)
+
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), t.content, string(readContent))
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Function (Runs once before all tests)
+////////////////////////////////////////////////////////////////////////
+
+func TestUnfinalizedObjectReadTest(t *testing.T) {
+	ts := &unfinalizedObjectReads{ctx: context.Background()}
+	// Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&ts.ctx, &ts.storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			t.Errorf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		suite.Run(t, ts)
+		return
+	}
+
+	// Define flag set to run the tests.
+	flagsSet := [][]string{
+		{"--metadata-cache-ttl-secs=0"},
+		{"--metadata-cache-ttl-secs=300"},
+	}
+
+	// Run tests.
+	for _, flags := range flagsSet {
+		ts.flags = flags
+		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
+	}
+}

--- a/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
+++ b/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
@@ -87,18 +87,17 @@ func (t *unfinalizedObjectReads) Test_ReadUnfinalizedWithNoActiveAppends_RandomR
 	numReads := 50
 	fileSize := int64(500 * util.MiB)
 	maxReadChunkSize := int64(200 * util.MiB)
-	fullFilePath = path.Join(t.testDirPath, t.fileName)
-	t.createoUnfinalizedObject(fileSize)
+	fullFilePath := path.Join(t.testDirPath, t.fileName)
+	t.createUnfinalizedObject(fileSize)
 
-	// Read un-finalized object.
-	for numRandomReadsRemaining := numReads; numRandomReadsRemaining > 0; numRandomReadsRemaining-- {
-		readChunkSize := rand.Int63n(maxReadChunkSize)
+	// Read unfinalized object in random chunks.
+	for range numReads {
+		readChunkSize := 1 + rand.Int63n(maxReadChunkSize-1)
 		readOffset := rand.Int63n(fileSize - readChunkSize)
-		endOffset := readOffset + readChunkSize
 
-		//t.T().Logf("Testing reading chunk from [%09d,%09d) ...", readOffset, readOffset+readChunkSize)
 		readContent, err := operations.ReadChunkFromFile(path.Join(t.testDirPath, t.fileName), readChunkSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 
+		endOffset := readOffset + readChunkSize
 		require.NoErrorf(t.T(), err, "Failed to read %q from [%09d, %09d]: %v", fullFilePath, readOffset, readOffset+readChunkSize, err)
 		expectedContent := t.content[readOffset:endOffset]
 		assert.Equalf(t.T(), string(readContent), expectedContent, "Read of %q from [%09d, %09d] failed with content mismatch.", fullFilePath, readOffset, readOffset+readChunkSize)

--- a/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
+++ b/tools/integration_tests/read_unfinalized_object/reads_with_no_active_appends_test.go
@@ -158,12 +158,12 @@ func TestUnfinalizedObjectReadTest(t *testing.T) {
 	// Run tests.
 	for _, flags := range flagsSet {
 		ts.flags = flags
-		os.Mkdir(ts.cacheDir, setup.DirPermission_0755)
+		require.NoError(os.Mkdir(ts.cacheDir, setup.DirPermission_0755))
 		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
 		log.Printf("Running tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
 		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
 		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
-		os.RemoveAll(ts.cacheDir)
+		require.NoError(os.RemoveAll(ts.cacheDir))
 	}
 }

--- a/tools/integration_tests/read_unfinalized_object/setup_test.go
+++ b/tools/integration_tests/read_unfinalized_object/setup_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unfinalized_object
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName = "ReadUnfinalizedObjectTest"
+)
+
+var (
+	mountFunc func([]string) error
+)
+
+////////////////////////////////////////////////////////////////////////
+// TestMain
+////////////////////////////////////////////////////////////////////////
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	if !setup.IsZonalBucketRun() {
+		log.Printf("Test not support for non-zonal bucket. Pass --zonal=true to enable.") // improve logging
+		os.Exit(0)
+	}
+
+	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as operations tests validates content from the bucket.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		setup.RunTestsForMountedDirectoryFlag(m)
+	}
+
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -152,7 +152,8 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "streaming_writes"
   "write_large_files"
   "unfinalized_object"
-   "release_version"
+  "release_version"
+  "read_unfinalized_object"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,


### PR DESCRIPTION
### Description
- This is dependent on ~#3401~ and ~#3405~ .

### Link to the issue in case of a bug fix.
[b/427355037](http://b/427355037)
[b/427354120](http://b/427354120)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - ran as [presubmit](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/0879406f-10c0-4360-bc4e-f46f300bc5c7)

### Any backward incompatible change? If so, please explain.
