### PR TITLE
Use read-type constants from "common" package instead of "internal/util"

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -32,7 +32,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/semaphore"
 )
@@ -327,7 +326,7 @@ func (job *Job) downloadObjectToFile(cacheFile *os.File) (err error) {
 			if newReader != nil {
 				readHandle = newReader.ReadHandle()
 			}
-			common.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, util.Sequential, newReaderLimit-start)
+			common.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, common.ReadTypeSequential, newReaderLimit-start)
 		}
 
 		maxRead := min(ReadChunkSize, newReaderLimit-start)

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -26,7 +26,6 @@ import (
 	cacheutil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -61,7 +60,7 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 		}
 	}()
 
-	common.CaptureGCSReadMetrics(ctx, job.metricsHandle, util.Parallel, end-start)
+	common.CaptureGCSReadMetrics(ctx, job.metricsHandle, common.ReadTypeParallel, end-start)
 
 	// Use standard copy function if O_DIRECT is disabled and memory aligned
 	// buffer otherwise.

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -107,7 +107,7 @@ func (t *gcsReaderTest) Test_NewGCSReader() {
 
 	assert.Equal(t.T(), object, gcsReader.object)
 	assert.Equal(t.T(), t.mockBucket, gcsReader.bucket)
-	assert.Equal(t.T(), testUtil.Sequential, gcsReader.readType)
+	assert.Equal(t.T(), common.ReadTypeSequential, gcsReader.readType)
 }
 
 func (t *gcsReaderTest) Test_ReadAt_InvalidOffset() {
@@ -290,7 +290,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{testUtil.Sequential, testUtil.Sequential, testUtil.Sequential, testUtil.Sequential},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -298,7 +298,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{testUtil.Sequential, testUtil.Sequential, testUtil.Sequential, testUtil.Sequential},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -306,7 +306,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{testUtil.Sequential, testUtil.Sequential, testUtil.Random, testUtil.Random, testUtil.Random},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 		{
@@ -314,7 +314,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{testUtil.Sequential, testUtil.Sequential, testUtil.Random, testUtil.Random, testUtil.Random},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 	}
@@ -325,7 +325,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			require.Equal(t.T(), len(tc.readRanges), len(tc.expectedReadTypes), "Test Parameter Error: readRanges and expectedReadTypes should have same length")
 			t.gcsReader.mrr.isMRDInUse = false
 			t.gcsReader.seeks = 0
-			t.gcsReader.rangeReader.readType = testUtil.Sequential
+			t.gcsReader.rangeReader.readType = common.ReadTypeSequential
 			t.gcsReader.expectedOffset = 0
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testUtil.GenerateRandomBytes(int(t.object.Size))
@@ -608,7 +608,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 	t.gcsReader.rangeReader.reader = nil
 	t.gcsReader.mrr.isMRDInUse = false
 	t.gcsReader.seeks = 0
-	t.gcsReader.rangeReader.readType = testUtil.Sequential
+	t.gcsReader.rangeReader.readType = common.ReadTypeSequential
 	t.gcsReader.expectedOffset = 0
 	t.gcsReader.totalReadBytes = 0
 	t.object.Size = 20 * MiB
@@ -640,7 +640,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 
 		assert.NoError(t.T(), err)
 		assert.Equal(t.T(), uint64(seeks), t.gcsReader.seeks)
-		assert.Equal(t.T(), testUtil.Random, t.gcsReader.readType)
+		assert.Equal(t.T(), common.ReadTypeRandom, t.gcsReader.readType)
 		assert.Equal(t.T(), int64(readRange[1]), t.gcsReader.expectedOffset)
 	}
 }

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 )
 
 const (
@@ -280,7 +279,7 @@ func (rr *RangeReader) startRead(start int64, end int64) error {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, util.Sequential, requestedDataSize)
+	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, common.ReadTypeSequential, requestedDataSize)
 
 	return nil
 }

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -29,7 +29,6 @@ import (
 	cacheUtil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/jacobsa/fuse/fuseops"
 )
 
@@ -119,9 +118,9 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 
 		logger.Tracef("%.13v -> %s", requestID, requestOutput)
 
-		readType := util.Random
+		readType := common.ReadTypeRandom
 		if isSequential {
-			readType = util.Sequential
+			readType = common.ReadTypeSequential
 		}
 		captureFileCacheMetrics(ctx, fc.metricHandle, readType, bytesRead, cacheHit, executionTime)
 	}()

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -30,7 +30,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/jacobsa/fuse/fuseops"
 	"golang.org/x/net/context"
 )
@@ -112,7 +111,7 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 		limit:                 -1,
 		seeks:                 0,
 		totalReadBytes:        0,
-		readType:              util.Sequential,
+		readType:              common.ReadTypeSequential,
 		sequentialReadSizeMb:  sequentialReadSizeMb,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
@@ -248,9 +247,9 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		// Here rr.fileCacheHandle will not be nil since we return from the above in those cases.
 		logger.Tracef("%.13v -> %s", requestId, requestOutput)
 
-		readType := util.Random
+		readType := common.ReadTypeRandom
 		if isSeq {
-			readType = util.Sequential
+			readType = common.ReadTypeSequential
 		}
 		captureFileCacheMetrics(ctx, rr.metricHandle, readType, n, cacheHit, executionTime)
 	}()
@@ -512,7 +511,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, util.Sequential, requestedDataSize)
+	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, common.ReadTypeSequential, requestedDataSize)
 
 	return
 }
@@ -550,7 +549,7 @@ func (rr *randomReader) getReadInfo(
 	// (average read size in bytes rounded up to the next MiB).
 	end = int64(rr.object.Size)
 	if rr.seeks >= minSeeksForRandom {
-		rr.readType = util.Random
+		rr.readType = common.ReadTypeRandom
 		averageReadBytes := rr.totalReadBytes / rr.seeks
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MiB) + 1) * MiB)
@@ -580,7 +579,7 @@ func (rr *randomReader) getReadInfo(
 // readerType specifies the go-sdk interface to use for reads.
 func readerType(readType string, start int64, end int64, bucketType gcs.BucketType) ReaderType {
 	bytesToBeRead := end - start
-	if readType == util.Random && bytesToBeRead < maxReadSize && bucketType.Zonal {
+	if readType == common.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
 		return MultiRangeReader
 	}
 	return RangeReader

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -141,7 +141,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Sequential() {
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), testutil.Sequential, t.rr.wrapped.readType)
+			assert.Equal(t.T(), common.ReadTypeSequential, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -174,7 +174,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), testutil.Random, t.rr.wrapped.readType)
+			assert.Equal(t.T(), common.ReadTypeRandom, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -191,7 +191,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 	}{
 		{
 			name:       "ZonalBucketRandomRead",
-			readType:   testutil.Random,
+			readType:   common.ReadTypeRandom,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -199,7 +199,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "ZonalBucketRandomReadLargerThan8MB",
-			readType:   testutil.Random,
+			readType:   common.ReadTypeRandom,
 			start:      0,
 			end:        9 * MiB,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -207,7 +207,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "ZonalBucketSequentialRead",
-			readType:   testutil.Sequential,
+			readType:   common.ReadTypeSequential,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -215,7 +215,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "RegularBucketRandomRead",
-			readType:   testutil.Random,
+			readType:   common.ReadTypeRandom,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: false},
@@ -223,7 +223,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "RegularBucketSequentialRead",
-			readType:   testutil.Sequential,
+			readType:   common.ReadTypeSequential,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: false},
@@ -641,7 +641,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Sequential, testutil.Sequential},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -649,7 +649,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Sequential, testutil.Sequential},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -657,7 +657,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Random, testutil.Random, testutil.Random},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 		{
@@ -665,7 +665,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{testutil.Sequential, testutil.Sequential, testutil.Random, testutil.Random, testutil.Random},
+			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 	}
@@ -676,7 +676,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.rr.wrapped.seeks = 0
-			t.rr.wrapped.readType = testutil.Sequential
+			t.rr.wrapped.readType = common.ReadTypeSequential
 			t.rr.wrapped.expectedOffset = 0
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -706,7 +706,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 	t.rr.wrapped.reader = nil
 	t.rr.wrapped.isMRDInUse = false
 	t.rr.wrapped.seeks = 0
-	t.rr.wrapped.readType = testutil.Sequential
+	t.rr.wrapped.readType = common.ReadTypeSequential
 	t.rr.wrapped.expectedOffset = 0
 	t.rr.wrapped.totalReadBytes = 0
 	t.object.Size = 20 * MiB
@@ -737,7 +737,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 		_, err := t.rr.wrapped.ReadAt(t.rr.ctx, buf, int64(readRange[0]))
 
 		assert.NoError(t.T(), err)
-		assert.Equal(t.T(), testutil.Random, t.rr.wrapped.readType)
+		assert.Equal(t.T(), common.ReadTypeRandom, t.rr.wrapped.readType)
 		assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset)
 		assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks)
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -22,16 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
-)
-
-const (
-	// TODO: Remove these constants in favor of common.* constants.
-	// Constants for read types - Sequential/Random
-	Sequential = common.ReadTypeSequential
-	Random     = common.ReadTypeRandom
-	Parallel   = common.ReadTypeParallel
 )
 
 const (


### PR DESCRIPTION

### Description


### Link to the issue in case of a bug fix.
b/427746195

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No