### PR TITLE
Taking Inode RLock while reading via file-handle

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2577,19 +2577,21 @@ func (fs *fileSystem) ReadFile(
 	fs.mu.Unlock()
 
 	fh.Lock()
-	fh.Inode().Lock()
 	defer fh.Unlock()
 	// TODO(b/417136852): Remove bucket type check when we start leaving zonal bucket objects unfinalized.
 	// Flush Pending streaming writes file for regional bucket and issue read within same inode lock.
 	if fh.Inode().IsUsingBWH() && !fh.Inode().Bucket().BucketType().Zonal {
+		fh.Inode().Lock()
 		err = fs.flushFile(ctx, fh.Inode())
 		if err != nil {
 			fh.Inode().Unlock()
 			return err
 		}
+		fh.Inode().Unlock()
 	}
-	// Serve the read.
 
+	// Serve the read.
+	fh.Inode().RLock()
 	if fs.newConfig.EnableNewReader {
 		op.Dst, op.BytesRead, err = fh.ReadWithReadManager(ctx, op.Dst, op.Offset, fs.sequentialReadSizeMb)
 	} else {

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -169,7 +169,7 @@ func (t *fileTest) Test_Read_Success() {
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_reader", expectedData, false)
 	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	buf := make([]byte, len(expectedData))
-	fh.inode.Lock()
+	fh.inode.RLock()
 
 	output, n, err := fh.Read(t.ctx, buf, 0, 200)
 
@@ -185,7 +185,7 @@ func (t *fileTest) Test_ReadWithReadManager_Success() {
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_readManager", expectedData, false)
 	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
 	buf := make([]byte, len(expectedData))
-	fh.inode.Lock()
+	fh.inode.RLock()
 
 	output, n, err := fh.ReadWithReadManager(t.ctx, buf, 0, 200)
 
@@ -216,7 +216,7 @@ func (t *fileTest) Test_ReadWithReadManager_ErrorScenarios() {
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
 			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
-			fh.inode.Lock()
+			fh.inode.RLock()
 			mockRM := new(read_manager.MockReadManager)
 			mockRM.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ReaderResponse{}, tc.returnErr)
 			mockRM.On("Object").Return(&object)
@@ -254,7 +254,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
 			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
-			fh.inode.Lock()
+			fh.inode.RLock()
 			mockReader := new(gcsx.MockRandomReader)
 			mockReader.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ObjectData{}, tc.returnErr)
 			mockReader.On("Object").Return(&object)
@@ -279,7 +279,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
 	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
-	fh.inode.Lock()
+	fh.inode.RLock()
 	mockRM := new(read_manager.MockReadManager)
 	mockRM.On("Destroy").Return()
 	fh.readManager = mockRM
@@ -301,7 +301,7 @@ func (t *fileTest) Test_Read_FallbackToInode() {
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
 	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.Config{})
-	fh.inode.Lock()
+	fh.inode.RLock()
 	mockR := new(gcsx.MockRandomReader)
 	mockR.On("Destroy").Return()
 	fh.reader = mockR

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -341,6 +341,14 @@ func (f *FileInode) Unlock() {
 	f.mu.Unlock()
 }
 
+func (f *FileInode) RLock() {
+	f.mu.RLock()
+}
+
+func (f *FileInode) RUnlock() {
+	f.mu.RUnlock()
+}
+
 func (f *FileInode) ID() fuseops.InodeID {
 	return f.id
 }


### PR DESCRIPTION
### Description
- Taking inode.RLock() while reading via file-handle
- Permanently disabling the content cache path, which is unused and seems not required in the future. Keeping this will make lock/unlock implementation dirty.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
