### PR TITLE
Fix typo in e2e test script and a condition check.

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -16,12 +16,12 @@
 # Script Usage Documentation
 usage() {
   echo "Usage: $0 --bucket-location <bucket-location> [options]"
-  echo "    --bucket-location            <location>     The Google Cloud Storage bucket location (e.g., 'us-central1')."
+  echo "    --bucket-location            <location>      The Google Cloud Storage bucket location (e.g., 'us-central1')."
   echo ""
   echo "Options:"
   echo "    --test-installed-package                     Test installed gcsfuse package. (Default: false)"
   echo "    --skip-non-essential-tests                   Skip non-essential tests inside packages. (Default: false)"
-  echo "    --tpc-endpoint                               Run tests on TPC endpoint. (Default: false)"
+  echo "    --test-on-tpc-endpoint                       Run tests on TPC endpoint. (Default: false)"
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
   echo "    --zonal                                      Run tests with zonal bucket in --bucket-location region."
   echo "                                                 The placement for Zonal buckets by deafault is Zone A of --bucket-location. (Default: false)"
@@ -215,7 +215,7 @@ TEST_PACKAGES_COMMON=(
   # "grpc_validation"
   "negative_stat_cache"
   "stale_handle"
-   "release_version"
+  "release_version"
 )
 
 # Test packages for regional buckets.
@@ -622,7 +622,7 @@ main() {
   log_info ""
 
   # Decide whether to build GCSFuse based on RUN_E2E_TESTS_ON_PACKAGE
-  if [ ! ${TEST_INSTALLED_PACKAGE} ] && [ ${BUILD_BINARY_IN_SCRIPT} ]; then
+  if (! ${TEST_INSTALLED_PACKAGE} ) && ${BUILD_BINARY_IN_SCRIPT}; then
     log_info "TEST_INSTALLED_PACKAGE is not 'true' (value: '${TEST_INSTALLED_PACKAGE}') and BUILD_BINARY_IN_SCRIPT is 'true'."
     log_info "Building GCSFuse inside script..."
     if ! build_gcsfuse_once; then


### PR DESCRIPTION
### Description
Typo fixes for e2e script and an if condition which was not evaluating as intended after this PR: #3433
Now it's working as intended:
![image](https://github.com/user-attachments/assets/26a6cd2f-1fce-4ccb-a878-0d61e9f1ac4e)

### Link to the issue in case of a bug fix.
b/426462003

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Run as part of presubmit.

### Any backward incompatible change? If so, please explain.
