### PR TITLE
Update Jacobsa FUSE version and add initial support for ReadDirPlus 

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -172,6 +172,8 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		EnableParallelDirOps: !(newConfig.FileSystem.DisableParallelDirops),
 		// We disable write-back cache when streaming writes are enabled.
 		DisableWritebackCaching: newConfig.Write.EnableStreamingWrites,
+		// Enable Readdirplus capability.
+		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
 	}
 
 	// GCSFuse to Jacobsa Fuse Log Level mapping:

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -172,8 +172,6 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		EnableParallelDirOps: !(newConfig.FileSystem.DisableParallelDirops),
 		// We disable write-back cache when streaming writes are enabled.
 		DisableWritebackCaching: newConfig.Write.EnableStreamingWrites,
-		// Enable Readdirplus capability.
-		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
 	}
 
 	// GCSFuse to Jacobsa Fuse Log Level mapping:

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/googlecloudplatform/gcsfuse/v3
 
 go 1.24.0
 
-// TODO: Remove this and update the github.com/jacobsa/fuse version, once the changes get merged
-replace github.com/jacobsa/fuse => github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04
-
 require (
 	cloud.google.com/go/auth v0.16.1
 	cloud.google.com/go/compute/metadata v0.7.0
@@ -19,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.2
 	github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec
-	github.com/jacobsa/fuse v0.0.0-20250506064942-d10bfe4fb08e
+	github.com/jacobsa/fuse v0.0.0-20250702080931-3e9d24d5e3ff
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/googlecloudplatform/gcsfuse/v3
 
 go 1.24.0
 
+// TODO: Remove this and update the github.com/jacobsa/fuse version, once the changes get merged
+replace github.com/jacobsa/fuse => github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04
+
 require (
 	cloud.google.com/go/auth v0.16.1
 	cloud.google.com/go/compute/metadata v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.52.0/go.mod h1:f/ad5NuHnYz8AOZGuR0cY+l36oSCstdxD73YlIchr6I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 h1:wbMd4eG/fOhsCa6+IP8uEDvWF5vl7rNoUWmP5f72Tbs=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0/go.mod h1:gdIm9TxRk5soClCwuB0FtdXsbqtw0aqPwBEurK9tPkw=
+github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04 h1:EDHh6cCaxFH+PdSKqBoYu8dteU5d6y565lzUb0+5Jqk=
+github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -138,8 +140,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtEMD2ouh8gOGIeDF9LrgXjo+9Q69RVzI=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20250506064942-d10bfe4fb08e h1:l3GV2yC45OcDO/ErTSS/LnLQdytjUSmmBFcQCjWSUDY=
-github.com/jacobsa/fuse v0.0.0-20250506064942-d10bfe4fb08e/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.52.0/go.mod h1:f/ad5NuHnYz8AOZGuR0cY+l36oSCstdxD73YlIchr6I=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0 h1:wbMd4eG/fOhsCa6+IP8uEDvWF5vl7rNoUWmP5f72Tbs=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.52.0/go.mod h1:gdIm9TxRk5soClCwuB0FtdXsbqtw0aqPwBEurK9tPkw=
-github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04 h1:EDHh6cCaxFH+PdSKqBoYu8dteU5d6y565lzUb0+5Jqk=
-github.com/aditimittal2003/fuse v0.0.0-20250701050603-375bc2cf8b04/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -140,6 +138,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtEMD2ouh8gOGIeDF9LrgXjo+9Q69RVzI=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
+github.com/jacobsa/fuse v0.0.0-20250702080931-3e9d24d5e3ff h1:QamXUXyWL9hTh55v6lFJdJOJN9bjX9i2Ml4zHZQq//M=
+github.com/jacobsa/fuse v0.0.0-20250702080931-3e9d24d5e3ff/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2508,6 +2508,14 @@ func (fs *fileSystem) ReadDir(
 }
 
 // LOCKS_EXCLUDED(fs.mu)
+func (fs *fileSystem) ReadDirPlus(
+	ctx context.Context,
+	op *fuseops.ReadDirPlusOp) (err error) {
+	// TODO: Implement ReadDirPlus to fetch directory entries with attributes.
+	return syscall.ENOSYS
+}
+
+// LOCKS_EXCLUDED(fs.mu)
 func (fs *fileSystem) ReleaseDirHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseDirHandleOp) (err error) {

--- a/internal/fs/wrappers/error_mapping.go
+++ b/internal/fs/wrappers/error_mapping.go
@@ -280,6 +280,15 @@ func (em *errorMapping) ReadDir(
 	return em.mapError("ReadDir", err)
 }
 
+func (em *errorMapping) ReadDirPlus(
+	ctx context.Context,
+	op *fuseops.ReadDirPlusOp) error {
+	defer em.handlePanic()
+
+	err := em.wrapped.ReadDirPlus(ctx, op)
+	return em.mapError("ReadDirPlus", err)
+}
+
 func (em *errorMapping) ReleaseDirHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseDirHandleOp) error {

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -330,6 +330,10 @@ func (fs *monitoring) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error 
 	return fs.invokeWrapped(ctx, "ReadDir", func(ctx context.Context) error { return fs.wrapped.ReadDir(ctx, op) })
 }
 
+func (fs *monitoring) ReadDirPlus(ctx context.Context, op *fuseops.ReadDirPlusOp) error {
+	return fs.invokeWrapped(ctx, "ReadDirPlus", func(ctx context.Context) error { return fs.wrapped.ReadDirPlus(ctx, op) })
+}
+
 func (fs *monitoring) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDirHandleOp) error {
 	return fs.invokeWrapped(ctx, "ReleaseDirHandle", func(ctx context.Context) error { return fs.wrapped.ReleaseDirHandle(ctx, op) })
 }

--- a/internal/fs/wrappers/tracing.go
+++ b/internal/fs/wrappers/tracing.go
@@ -119,6 +119,10 @@ func (fs *tracing) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
 	return fs.invokeWrapped(ctx, "ReadDir", func(ctx context.Context) error { return fs.wrapped.ReadDir(ctx, op) })
 }
 
+func (fs *tracing) ReadDirPlus(ctx context.Context, op *fuseops.ReadDirPlusOp) error {
+	return fs.invokeWrapped(ctx, "ReadDirPlus", func(ctx context.Context) error { return fs.wrapped.ReadDirPlus(ctx, op) })
+}
+
 func (fs *tracing) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDirHandleOp) error {
 	return fs.invokeWrapped(ctx, "ReleaseDirHandle", func(ctx context.Context) error { return fs.wrapped.ReleaseDirHandle(ctx, op) })
 }

--- a/internal/fs/wrappers/tracing_test.go
+++ b/internal/fs/wrappers/tracing_test.go
@@ -103,6 +103,10 @@ func (d dummyFS) ReadDir(_ context.Context, _ *fuseops.ReadDirOp) error {
 	return nil
 }
 
+func (d dummyFS) ReadDirPlus(_ context.Context, _ *fuseops.ReadDirPlusOp) error {
+	return nil
+}
+
 func (d dummyFS) ReleaseDirHandle(_ context.Context, _ *fuseops.ReleaseDirHandleOp) error {
 	return nil
 }


### PR DESCRIPTION
### Description
Update the github.com/jacobsa/fuse version in go.mod
Add ReadDirPlus method in tracing.go, monitoring.go, error_mapping.go
Add ReadDirPlus method in fs.go to return not implemented error.
### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
