### PR TITLE
Add ReadEntryCores method to DirInode interface

### DIFF
--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -191,6 +191,18 @@ func (d *baseDirInode) ReadEntries(
 	return nil, "", syscall.ENOTSUP
 }
 
+// LOCKS_REQUIRED(d)
+func (d *baseDirInode) ReadEntryCores(
+	ctx context.Context,
+	tok string) (cores map[Name]*Core, newTok string, err error) {
+
+	// The subdirectories of the base directory should be all the accessible
+	// buckets. Although the user is allowed to visit each individual
+	// subdirectory, listing all the subdirectories (i.e. the buckets) can be
+	// very expensive and currently not supported.
+	return nil, "", syscall.ENOTSUP
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Forbidden Public interface
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -192,9 +192,7 @@ func (d *baseDirInode) ReadEntries(
 }
 
 // LOCKS_REQUIRED(d)
-func (d *baseDirInode) ReadEntryCores(
-	ctx context.Context,
-	tok string) (cores map[Name]*Core, newTok string, err error) {
+func (d *baseDirInode) ReadEntryCores(ctx context.Context, tok string) (cores map[Name]*Core, newTok string, err error) {
 
 	// The subdirectories of the base directory should be all the accessible
 	// buckets. Although the user is allowed to visit each individual

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -17,6 +17,7 @@ package inode
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -227,4 +228,13 @@ func (t *BaseDirTest) Test_ShouldInvalidateKernelListCache_TtlExpired() {
 	t.clock.AdvanceTime(10 * time.Second)
 
 	AssertEq(true, t.in.ShouldInvalidateKernelListCache(ttl))
+}
+
+func (t *BaseDirTest) TestReadEntryCores() {
+	cores, newTok, err := t.in.ReadEntryCores(t.ctx, "")
+
+	// Should return ENOTSUP because listing is unsupported.
+	ExpectEq(nil, cores)
+	ExpectEq("", newTok)
+	ExpectEq(syscall.ENOTSUP, err)
 }

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -100,9 +100,7 @@ type DirInode interface {
 	// empty. Otherwise it will be non-empty. There is no guarantee about the
 	// number of entries returned; it may be zero even with a non-empty
 	// continuation token.
-	ReadEntryCores(
-		ctx context.Context,
-		tok string) (cores map[Name]*Core, newTok string, err error)
+	ReadEntryCores(ctx context.Context, tok string) (cores map[Name]*Core, newTok string, err error)
 
 	// Create an empty child file with the supplied (relative) name, failing with
 	// *gcs.PreconditionError if a backing object already exists in GCS.
@@ -788,9 +786,8 @@ func (d *dirInode) ReadEntries(
 	ctx context.Context,
 	tok string) (entries []fuseutil.Dirent, newTok string, err error) {
 	var cores map[Name]*Core
-	cores, newTok, err = d.readObjects(ctx, tok)
+	cores, newTok, err = d.ReadEntryCores(ctx, tok)
 	if err != nil {
-		err = fmt.Errorf("read objects: %w", err)
 		return
 	}
 
@@ -810,14 +807,10 @@ func (d *dirInode) ReadEntries(
 		entries = append(entries, entry)
 	}
 
-	d.prevDirListingTimeStamp = d.cacheClock.Now()
 	return
 }
 
-func (d *dirInode) ReadEntryCores(
-	ctx context.Context,
-	tok string) (cores map[Name]*Core, newTok string, err error) {
-
+func (d *dirInode) ReadEntryCores(ctx context.Context, tok string) (cores map[Name]*Core, newTok string, err error) {
 	cores, newTok, err = d.readObjects(ctx, tok)
 	if err != nil {
 		err = fmt.Errorf("read objects: %w", err)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -91,6 +91,19 @@ type DirInode interface {
 		ctx context.Context,
 		tok string) (entries []fuseutil.Dirent, newTok string, err error)
 
+	// ReadEntryCores reads a batch of directory entries and returns them as a
+	// map of `inode.Core` objects along with a continuation token that can be
+	// used to pick up the read operation where it left off.
+	// Supply the empty token on the first call.
+	//
+	// At the end of the directory, the returned continuation token will be
+	// empty. Otherwise it will be non-empty. There is no guarantee about the
+	// number of entries returned; it may be zero even with a non-empty
+	// continuation token.
+	ReadEntryCores(
+		ctx context.Context,
+		tok string) (cores map[Name]*Core, newTok string, err error)
+
 	// Create an empty child file with the supplied (relative) name, failing with
 	// *gcs.PreconditionError if a backing object already exists in GCS.
 	// Return the full name of the child and the GCS object it backs up.
@@ -795,6 +808,20 @@ func (d *dirInode) ReadEntries(
 			entry.Type = fuseutil.DT_Directory
 		}
 		entries = append(entries, entry)
+	}
+
+	d.prevDirListingTimeStamp = d.cacheClock.Now()
+	return
+}
+
+func (d *dirInode) ReadEntryCores(
+	ctx context.Context,
+	tok string) (cores map[Name]*Core, newTok string, err error) {
+
+	cores, newTok, err = d.readObjects(ctx, tok)
+	if err != nil {
+		err = fmt.Errorf("read objects: %w", err)
+		return
 	}
 
 	d.prevDirListingTimeStamp = d.cacheClock.Now()


### PR DESCRIPTION
### Description
Add the ReadEntryCores method to the DirInode interface and its implementations. This method allows for reading a batch of directory entries and returning them as a map of inode.Core objects.

This change is a foundational step for the future implementation of the ReadDirPlus FUSE operation.

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests in base_dir_test.go and dir_test.go
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
