### PR TITLE
Make metric updates asynchronous and non-blocking

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -389,7 +389,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	metricHandle := common.NewNoopMetrics()
 	if cfg.IsMetricsEnabled(&newConfig.Metrics) {
 		metricExporterShutdownFn = monitor.SetupOTelMetricExporters(ctx, newConfig)
-		if metricHandle, err = common.NewOTelMetrics(ctx, 3, 32); err != nil {
+		if metricHandle, err = common.NewOTelMetrics(ctx, 3, 256); err != nil {
 			metricHandle = common.NewNoopMetrics()
 		}
 	}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -389,7 +389,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	metricHandle := common.NewNoopMetrics()
 	if cfg.IsMetricsEnabled(&newConfig.Metrics) {
 		metricExporterShutdownFn = monitor.SetupOTelMetricExporters(ctx, newConfig)
-		if metricHandle, err = common.NewOTelMetrics(10, 1024); err != nil {
+		if metricHandle, err = common.NewOTelMetrics(ctx, 10, 1024); err != nil {
 			metricHandle = common.NewNoopMetrics()
 		}
 	}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -389,7 +389,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	metricHandle := common.NewNoopMetrics()
 	if cfg.IsMetricsEnabled(&newConfig.Metrics) {
 		metricExporterShutdownFn = monitor.SetupOTelMetricExporters(ctx, newConfig)
-		if metricHandle, err = common.NewOTelMetrics(); err != nil {
+		if metricHandle, err = common.NewOTelMetrics(10, 1024); err != nil {
 			metricHandle = common.NewNoopMetrics()
 		}
 	}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -389,7 +389,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 	metricHandle := common.NewNoopMetrics()
 	if cfg.IsMetricsEnabled(&newConfig.Metrics) {
 		metricExporterShutdownFn = monitor.SetupOTelMetricExporters(ctx, newConfig)
-		if metricHandle, err = common.NewOTelMetrics(ctx, 10, 1024); err != nil {
+		if metricHandle, err = common.NewOTelMetrics(ctx, 3, 32); err != nil {
 			metricHandle = common.NewNoopMetrics()
 		}
 	}

--- a/common/otel_metrics.go
+++ b/common/otel_metrics.go
@@ -203,8 +203,15 @@ func (o *otelMetrics) FileCacheReadLatency(ctx context.Context, latency time.Dur
 	})
 }
 
-func NewOTelMetrics(workers int, taskBufferSize int) (MetricHandle, error) {
+func NewOTelMetrics(ctx context.Context, workers int, taskBufferSize int) (MetricHandle, error) {
 	taskCh := make(chan func(), taskBufferSize)
+	// close channel when context is done.
+	go func() {
+		<-ctx.Done()
+		close(taskCh)
+	}()
+
+	// Start the workers to execute the tasks.
 	for range workers {
 		go func() {
 			for {

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -89,7 +89,7 @@ func isHNSTestRun(t *testing.T) bool {
 }
 
 func (testSuite *PromTest) SetupSuite() {
-	setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
+	//setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
 	err := setup.SetUpTestDir()
 	require.NoErrorf(testSuite.T(), err, "error while building GCSFuse: %p", err)
 }

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -89,7 +89,7 @@ func isHNSTestRun(t *testing.T) bool {
 }
 
 func (testSuite *PromTest) SetupSuite() {
-	//setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
+	setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
 	err := setup.SetUpTestDir()
 	require.NoErrorf(testSuite.T(), err, "error while building GCSFuse: %p", err)
 }


### PR DESCRIPTION
### Description
Ensure that metric updates don't impede the throughput by making them async. Any slowness in metrics updates will be non-blocking

I chose the number of workers as 3 and a buffer size of 256 since that seemed enough to sustain a load of 1K reads across 128 threads on c4-standard-96.

Impact:
Single-threaded read throughput increased from 54MiB/s to ~89MiB/s on c4-standard-96.

CPU profile shows that the core logic of ReadFile is taking higher CPU which is a good thing.
![image](https://github.com/user-attachments/assets/27795489-cd08-4b21-b786-2127ee7af5d7)


### Link to the issue in case of a bug fix.
b/429458220

### Testing details
1. Manual - Yes - verified that the metrics were getting updated.
2. Unit tests - NA
3. Integration tests - Covered by existing tests in prom_test.go

### Any backward incompatible change? If so, please explain.
