### PR TITLE
Block Pool: Release Block Flow Improvement for Buffered Write

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -113,6 +113,15 @@ func (bp *BlockPool) FreeBlocksChannel() chan Block {
 	return bp.freeBlocksCh
 }
 
+// Release puts the block back into the free blocks channel for reuse.
+func (bp *BlockPool) Release(b Block) {
+	select {
+	case bp.freeBlocksCh <- b:
+	default:
+		panic("Block pool's free blocks channel is full, this should never happen")
+	}
+}
+
 // BlockSize returns the block size used by the blockPool.
 func (bp *BlockPool) BlockSize() int64 {
 	return bp.blockSize
@@ -137,4 +146,10 @@ func (bp *BlockPool) ClearFreeBlockChannel(releaseLastBlock bool) error {
 			return nil
 		}
 	}
+}
+
+// TotalFreeBlocks returns the total number of free blocks available in the pool.
+// This is useful for testing and debugging purposes.
+func (bp *BlockPool) TotalFreeBlocks() int {
+	return len(bp.freeBlocksCh)
 }

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -117,7 +117,7 @@ func NewBWHandler(req *CreateBWHandlerRequest) (bwh BufferedWriteHandler, err er
 			Object:                   req.Object,
 			ObjectName:               req.ObjectName,
 			Bucket:                   req.Bucket,
-			FreeBlocksCh:             bp.FreeBlocksChannel(),
+			BlockPool:                bp,
 			MaxBlocksPerFile:         req.MaxBlocksPerFile,
 			BlockSize:                req.BlockSize,
 			ChunkTransferTimeoutSecs: req.ChunkTransferTimeoutSecs,

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -182,13 +182,14 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), obj)
 	assert.Equal(t.T(), mockObj, obj)
-	// The blocks should be available on the free channel for reuse.
+	// All the 5 blocks should be available on the free channel for reuse.
+	assert.Equal(t.T(), 5, t.uh.blockPool.TotalFreeBlocks())
 	for _, expect := range blocks {
-
 		got, err := t.uh.blockPool.Get()
 		require.NoError(t.T(), err)
 		assert.Equal(t.T(), expect, got)
 	}
+	assert.Equal(t.T(), 0, t.uh.blockPool.TotalFreeBlocks())
 	assertAllBlocksProcessed(t.T(), t.uh)
 }
 

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -60,7 +60,7 @@ func (t *UploadHandlerTest) SetupTest() {
 		Object:                   nil,
 		ObjectName:               "testObject",
 		Bucket:                   t.mockBucket,
-		FreeBlocksCh:             t.blockPool.FreeBlocksChannel(),
+		BlockPool:                t.blockPool,
 		MaxBlocksPerFile:         maxBlocks,
 		BlockSize:                blockSize,
 		ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
@@ -80,7 +80,7 @@ func (t *UploadHandlerTest) createUploadHandlerWithObjectOfGivenSize(size uint64
 		},
 		ObjectName:               "testObject",
 		Bucket:                   t.mockBucket,
-		FreeBlocksCh:             t.blockPool.FreeBlocksChannel(),
+		BlockPool:                t.blockPool,
 		MaxBlocksPerFile:         maxBlocks,
 		BlockSize:                blockSize,
 		ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
@@ -184,7 +184,9 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	assert.Equal(t.T(), mockObj, obj)
 	// The blocks should be available on the free channel for reuse.
 	for _, expect := range blocks {
-		got := <-t.uh.freeBlocksCh
+
+		got, err := t.uh.blockPool.Get()
+		require.NoError(t.T(), err)
 		assert.Equal(t.T(), expect, got)
 	}
 	assertAllBlocksProcessed(t.T(), t.uh)
@@ -338,7 +340,7 @@ func (t *UploadHandlerTest) TestUploadSingleBlockThrowsErrorInCopy() {
 	// Expect an error on upload due to error while copying content to GCS writer.
 	assertUploadFailureError(t.T(), t.uh)
 	assertAllBlocksProcessed(t.T(), t.uh)
-	assert.Equal(t.T(), 1, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 1, t.uh.blockPool.TotalFreeBlocks())
 }
 
 func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
@@ -366,7 +368,7 @@ func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
 
 	assertUploadFailureError(t.T(), t.uh)
 	assertAllBlocksProcessed(t.T(), t.uh)
-	assert.Equal(t.T(), 4, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 4, t.uh.blockPool.TotalFreeBlocks())
 }
 
 func assertUploadFailureError(t *testing.T, handler *UploadHandler) {
@@ -431,7 +433,7 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 	// AwaitBlocksUpload.
 	t.uh.AwaitBlocksUpload()
 
-	assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
+	assert.Equal(t.T(), 5, t.uh.blockPool.TotalFreeBlocks())
 	assert.Equal(t.T(), 0, len(t.uh.uploadCh))
 	assertAllBlocksProcessed(t.T(), t.uh)
 }
@@ -539,7 +541,7 @@ func (t *UploadHandlerTest) TestDestroy() {
 			t.uh.Destroy()
 
 			assertAllBlocksProcessed(t.T(), t.uh)
-			assert.Equal(t.T(), 5, len(t.uh.freeBlocksCh))
+			assert.Equal(t.T(), 5, t.uh.blockPool.TotalFreeBlocks())
 			assert.Equal(t.T(), 0, len(t.uh.uploadCh))
 			// Check if uploadCh is closed.
 			select {


### PR DESCRIPTION
### Description
- Replacing blockPool.FreeBlockChannel() with blockPool.Release(block)

### Link to the issue in case of a bug fix.
b/429960425

### Testing details
1. Manual - Locally tested, working fine as expected.
2. Unit tests - Automation
3. Integration tests - Automation

### Any backward incompatible change? If so, please explain.
