### PR TITLE
Block: Making block interface a reader

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -97,6 +97,7 @@ func (m *memoryBlock) Read(bytes []byte) (int, error) {
 //   - io.SeekStart: offset is relative to the start of the block.
 //   - io.SeekCurrent: offset is relative to the current readSeek position.
 //   - io.SeekEnd: offset is relative to the end of the block.
+//
 // It returns an error if the whence value is invalid or if the new
 // readSeek position is out of bounds.
 func (m *memoryBlock) Seek(offset int64, whence int) (int64, error) {

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -86,9 +86,7 @@ func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 	require.Equal(t.T(), 2, n)
 	require.Nil(t.T(), err)
 	// Validating the content of the block
-	off, err := b.Seek(0, io.SeekStart)
-	require.Nil(t.T(), err)
-	require.Equal(t.T(), int64(0), off)
+	require.Equal(t.T(), int64(0), b.(*memoryBlock).readSeek)
 	output, err := io.ReadAll(b)
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), content, output)

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -86,7 +86,10 @@ func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 	require.Equal(t.T(), 2, n)
 	require.Nil(t.T(), err)
 	// Validating the content of the block
-	output, err := io.ReadAll(b.Reader())
+	off, err := b.Seek(0, io.SeekStart)
+	require.Nil(t.T(), err)
+	require.Equal(t.T(), int64(0), off)
+	output, err := io.ReadAll(b)
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), content, output)
 	bp.freeBlocksCh <- b

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -43,9 +43,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockWrite() {
 
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), len(content), n)
-	off, err := mb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
-	require.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), int64(0), off)
+	assert.Equal(testSuite.T(), int64(0), mb.(*memoryBlock).readSeek)
 	assert.Equal(testSuite.T(), int64(2), mb.Size())
 	output, err := io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
@@ -108,9 +106,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReuse() {
 
 	mb.Reuse()
 
-	off, err := mb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
-	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), int64(0), off)
+	assert.Equal(testSuite.T(), int64(0), mb.(*memoryBlock).readSeek)
 	output, err = io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
 	assert.Empty(testSuite.T(), output)

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -15,6 +15,8 @@
 package block
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -41,7 +43,11 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockWrite() {
 
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), len(content), n)
-	output, err := io.ReadAll(mb.Reader())
+	off, err := mb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
+	require.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), int64(0), off)
+	assert.Equal(testSuite.T(), int64(2), mb.Size())
+	output, err := io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), content, output)
 	assert.Equal(testSuite.T(), int64(2), mb.Size())
@@ -68,7 +74,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockWriteWithMultipleWrites() {
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), 5, n)
 
-	output, err := io.ReadAll(mb.Reader())
+	output, err := io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), []byte("hihello"), output)
 	assert.Equal(testSuite.T(), int64(7), mb.Size())
@@ -95,14 +101,17 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReuse() {
 	n, err := mb.Write(content)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), 2, n)
-	output, err := io.ReadAll(mb.Reader())
+	output, err := io.ReadAll(mb)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), content, output)
 	require.Equal(testSuite.T(), int64(2), mb.Size())
 
 	mb.Reuse()
 
-	output, err = io.ReadAll(mb.Reader())
+	off, err := mb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), int64(0), off)
+	output, err = io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
 	assert.Empty(testSuite.T(), output)
 	assert.Equal(testSuite.T(), int64(0), mb.Size())
@@ -121,7 +130,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReaderForEmptyBlock() {
 	mb, err := createBlock(12)
 	require.Nil(testSuite.T(), err)
 
-	output, err := io.ReadAll(mb.Reader())
+	output, err := io.ReadAll(mb)
 	assert.Nil(testSuite.T(), err)
 	assert.Empty(testSuite.T(), output)
 	assert.Equal(testSuite.T(), int64(0), mb.Size())
@@ -134,7 +143,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockDeAllocate() {
 	n, err := mb.Write(content)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), 2, n)
-	output, err := io.ReadAll(mb.Reader())
+	output, err := io.ReadAll(mb)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), content, output)
 	require.Equal(testSuite.T(), int64(2), mb.Size())
@@ -161,4 +170,101 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockCapAfterWrite() {
 	require.Equal(testSuite.T(), 2, n)
 
 	assert.Equal(testSuite.T(), int64(12), mb.Cap())
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockReadSuccess() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	n, err := mb.Write(content)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), len(content), n)
+	readBuffer := make([]byte, 5)
+
+	n, err = mb.Read(readBuffer)
+
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), 5, n)
+	assert.Equal(testSuite.T(), "hello", string(readBuffer))
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockReadWithReadBufferMoreThanBlockSize() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	n, err := mb.Write(content)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), len(content), n)
+	readBuffer := make([]byte, 20)
+
+	n, err = mb.Read(readBuffer)
+
+	require.NoError(testSuite.T(), err)
+	require.Equal(testSuite.T(), 11, n) // Read should return all bytes written.
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockReadSeekBeyondEnd() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	n, err := mb.Write(content)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), len(content), n)
+	readBuffer := make([]byte, 12)
+	off, err := mb.Seek(13, io.SeekStart) // Reset the read position out of the block.
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), int64(13), off)
+
+	n, err = mb.Read(readBuffer)
+
+	require.Equal(testSuite.T(), io.EOF, err)
+	require.Equal(testSuite.T(), 0, n)
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockReadFailure() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	readBuffer := make([]byte, 5)
+	off, err := mb.Seek(-1, 0) // Set readSeek to an invalid position.
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), int64(-1), off)
+
+	n, err := mb.Read(readBuffer)
+
+	require.Equal(testSuite.T(), errors.New("readSeek -1 is less than start offset 0"), err)
+	require.Equal(testSuite.T(), 0, n) // Read should return 0 bytes read.
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockSeek() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	n, err := mb.Write(content)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), len(content), n)
+
+	tests := []struct {
+		whence         int
+		offset         int64
+		expectedOutput string
+		expectedOffset int64
+	}{
+		{io.SeekStart, 0, "hello", 0},   // After this, readSeek = 5
+		{io.SeekCurrent, 1, "world", 6}, // After this readSeek = 11
+		{io.SeekEnd, -6, " worl", 5},
+	}
+
+	for _, tt := range tests {
+		testSuite.T().Run(fmt.Sprintf("whence=%d, offset=%d, expectedOutput:%s", tt.whence, tt.offset, tt.expectedOutput), func(t *testing.T) {
+			offset, err := mb.Seek(tt.offset, tt.whence)
+
+			require.Nil(t, err)
+			require.Equal(t, tt.expectedOffset, offset)
+			readBuffer := make([]byte, 5)
+			n, err = mb.Read(readBuffer)
+			require.Nil(t, err)
+			require.Equal(t, 5, n)
+			assert.Equal(t, tt.expectedOutput, string(readBuffer))
+		})
+	}
 }

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -43,7 +43,7 @@ func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReuse() {
 	n, err := pmb.Write(content)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), 2, n)
-	output, err := io.ReadAll(pmb.Reader())
+	output, err := io.ReadAll(pmb)
 	require.Nil(testSuite.T(), err)
 	require.Equal(testSuite.T(), content, output)
 	require.Equal(testSuite.T(), int64(2), pmb.Size())
@@ -52,7 +52,10 @@ func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReuse() {
 
 	pmb.Reuse()
 
-	output, err = io.ReadAll(pmb.Reader())
+	off, err := pmb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), int64(0), off)
+	output, err = io.ReadAll(pmb)
 	assert.Nil(testSuite.T(), err)
 	assert.Empty(testSuite.T(), output)
 	assert.Equal(testSuite.T(), int64(0), pmb.Size())

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -52,9 +52,7 @@ func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReuse() {
 
 	pmb.Reuse()
 
-	off, err := pmb.Seek(0, io.SeekStart) // Reset the read position to the start of the block.
-	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), int64(0), off)
+	assert.Equal(testSuite.T(), int64(0), pmb.(*prefetchMemoryBlock).readSeek)
 	output, err = io.ReadAll(pmb)
 	assert.Nil(testSuite.T(), err)
 	assert.Empty(testSuite.T(), output)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -130,33 +130,49 @@ func (uh *UploadHandler) UploadError() (err error) {
 // uploader is the single-threaded goroutine that uploads blocks.
 func (uh *UploadHandler) uploader() {
 	for currBlock := range uh.uploadCh {
-		if uh.UploadError() != nil {
-			uh.blockPool.Release(currBlock)
-			uh.wg.Done()
-			continue
-		}
-		// Reset the readSeek to 0 before uploading.
-		if off, err := currBlock.Seek(0, io.SeekStart); err == nil && off == 0 {
-			_, err = io.Copy(uh.writer, currBlock)
-			if errors.Is(err, context.Canceled) {
-				// Context canceled error indicates that the file was deleted from the
-				// same mount. In this case, we suppress the error to match local
-				// filesystem behavior.
-				err = nil
-			}
-			if err != nil {
-				logger.Errorf("buffered write upload failed for object %s: error in io.Copy: %v", uh.objectName, err)
-				err = gcs.GetGCSError(err)
-				uh.uploadError.Store(&err)
-			}
-		} else {
-			logger.Errorf("buffered write upload failed for object %s: error in block.Seek: %v", uh.objectName, err)
-			uh.uploadError.Store(&err)
-		}
+		uh.uploadBlock(currBlock)
 
-		// Put back the uploaded block on the block pool for re-use.
+		// Put back the uploaded block to the pool for re-use,
+		// irrespective of whether the upload was successful or not.
 		uh.blockPool.Release(currBlock)
 		uh.wg.Done()
+	}
+}
+
+// uploadBlock uploads the block to GCS.
+// It is called by the uploader goroutine.
+// If the block is nil, it logs a warning and returns.
+// If there is already an error in uploadError, it returns without doing anything.
+// If there is an error during upload, it returns after storing the error in uploadError.
+func (uh *UploadHandler) uploadBlock(b block.Block) {
+	if b == nil {
+		logger.Warnf("uploadBlock: received nil block for object %s", uh.objectName)
+		return
+	}
+
+	if uh.UploadError() != nil {
+		return
+	}
+
+	// Reset the readSeek to 0 before uploading.
+	if off, err := b.Seek(0, io.SeekStart); err != nil || off != 0 {
+		err := fmt.Errorf("buffered write upload failed for object %s: error in block.Seek: %v with offset: %d", uh.objectName, err, off)
+		uh.uploadError.Store(&err)
+		logger.Errorf("uploadBlock: %v", err)
+		return
+	}
+
+	_, err := io.Copy(uh.writer, b)
+	if errors.Is(err, context.Canceled) {
+		// Context canceled error indicates that the file was deleted from the
+		// same mount. In this case, we suppress the error to match local
+		// filesystem behavior.
+		err = nil
+	}
+	if err != nil {
+		err = gcs.GetGCSError(err)
+		uh.uploadError.Store(&err)
+		logger.Errorf("uploadBlock: failed for object %s: error in io.Copy: %v", uh.objectName, err)
 	}
 }
 

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -139,7 +139,7 @@ func (uh *UploadHandler) uploader() {
 	}
 }
 
-// uploadBlock uploads the block to GCS.
+// uploadBlock uploads the block content to GCS writer.
 // It is called by the uploader goroutine.
 // If the block is nil, it logs a warning and returns.
 // If there is already an error in uploadError, it returns without doing anything.


### PR DESCRIPTION
### Description
- Making the block interface also a reader.
- Passing directly block instead while uploading the content to gcs instead of reader.

### Link to the issue in case of a bug fix.
b/429969295

### Testing details
1. Manual - Tested locally, working as expected.
2. Unit tests - Automated
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
