### PR TITLE
Add boolean clobberedCheck parameter to Attributes method of Inode interface

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1348,7 +1348,7 @@ func (fs *fileSystem) getAttributes(
 	expiration time.Time,
 	err error) {
 	// Call through.
-	attr, err = in.Attributes(ctx)
+	attr, err = in.Attributes(ctx, true)
 	if err != nil {
 		return
 	}

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -147,17 +147,7 @@ func (d *baseDirInode) Destroy() (err error) {
 
 // LOCKS_REQUIRED(d)
 func (d *baseDirInode) Attributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	// Set up basic attributes.
-	attrs = d.attrs
-	attrs.Nlink = 1
-
-	return
-}
-
-// LOCKS_REQUIRED(d)
-func (d *baseDirInode) ExtractAttributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	ctx context.Context, clobberedCheck bool) (attrs fuseops.InodeAttributes, err error) {
 	// Set up basic attributes.
 	attrs = d.attrs
 	attrs.Nlink = 1

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -156,6 +156,16 @@ func (d *baseDirInode) Attributes(
 }
 
 // LOCKS_REQUIRED(d)
+func (d *baseDirInode) ExtractAttributes(
+	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	// Set up basic attributes.
+	attrs = d.attrs
+	attrs.Nlink = 1
+
+	return
+}
+
+// LOCKS_REQUIRED(d)
 func (d *baseDirInode) LookUpChild(ctx context.Context, name string) (*Core, error) {
 	var err error
 	bucket, ok := d.buckets[name]

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -152,16 +152,16 @@ func (t *BaseDirTest) LookupCount() {
 	ExpectTrue(t.in.DecrementLookupCount(1))
 }
 
-func (t *BaseDirTest) Attributes() {
-	attrs, err := t.in.Attributes(t.ctx)
+func (t *BaseDirTest) Attributes_ClobberedCheckTrue() {
+	attrs, err := t.in.Attributes(t.ctx, true)
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)
 	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
 }
 
-func (t *BaseDirTest) ExtractAttributes() {
-	attrs, err := t.in.ExtractAttributes(t.ctx)
+func (t *BaseDirTest) Attributes_ClobberedCheckFalse() {
+	attrs, err := t.in.Attributes(t.ctx, false)
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -160,6 +160,14 @@ func (t *BaseDirTest) Attributes() {
 	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
 }
 
+func (t *BaseDirTest) ExtractAttributes() {
+	attrs, err := t.in.ExtractAttributes(t.ctx)
+	AssertEq(nil, err)
+	ExpectEq(uid, attrs.Uid)
+	ExpectEq(gid, attrs.Gid)
+	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
+}
+
 func (t *BaseDirTest) LookUpChild_NonExistent() {
 	result, err := t.in.LookUpChild(t.ctx, "missing_bucket")
 

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -154,6 +154,7 @@ func (t *BaseDirTest) LookupCount() {
 
 func (t *BaseDirTest) Attributes_ClobberedCheckTrue() {
 	attrs, err := t.in.Attributes(t.ctx, true)
+
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)
@@ -162,6 +163,7 @@ func (t *BaseDirTest) Attributes_ClobberedCheckTrue() {
 
 func (t *BaseDirTest) Attributes_ClobberedCheckFalse() {
 	attrs, err := t.in.Attributes(t.ctx, false)
+
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -512,17 +512,7 @@ func (d *dirInode) Destroy() (err error) {
 
 // LOCKS_REQUIRED(d)
 func (d *dirInode) Attributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	// Set up basic attributes.
-	attrs = d.attrs
-	attrs.Nlink = 1
-
-	return
-}
-
-// LOCKS_REQUIRED(d)
-func (d *dirInode) ExtractAttributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	ctx context.Context, clobberedCheck bool) (attrs fuseops.InodeAttributes, err error) {
 	// Set up basic attributes.
 	attrs = d.attrs
 	attrs.Nlink = 1

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -520,6 +520,16 @@ func (d *dirInode) Attributes(
 	return
 }
 
+// LOCKS_REQUIRED(d)
+func (d *dirInode) ExtractAttributes(
+	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	// Set up basic attributes.
+	attrs = d.attrs
+	attrs.Nlink = 1
+
+	return
+}
+
 func (d *dirInode) Bucket() *gcsx.SyncerBucket {
 	return d.bucket
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -241,6 +241,7 @@ func (t *DirTest) LookupCount() {
 
 func (t *DirTest) Attributes_WithClobberedCheckTrue() {
 	attrs, err := t.in.Attributes(t.ctx, true)
+
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)
@@ -249,6 +250,7 @@ func (t *DirTest) Attributes_WithClobberedCheckTrue() {
 
 func (t *DirTest) Attributes_WithClobberedCheckFalse() {
 	attrs, err := t.in.Attributes(t.ctx, false)
+
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -247,6 +247,14 @@ func (t *DirTest) Attributes() {
 	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
 }
 
+func (t *DirTest) ExtractAttributes() {
+	attrs, err := t.in.ExtractAttributes(t.ctx)
+	AssertEq(nil, err)
+	ExpectEq(uid, attrs.Uid)
+	ExpectEq(gid, attrs.Gid)
+	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
+}
+
 func (t *DirTest) LookUpChild_NonExistent() {
 	const name = "qux"
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -239,16 +239,16 @@ func (t *DirTest) LookupCount() {
 	ExpectTrue(t.in.DecrementLookupCount(1))
 }
 
-func (t *DirTest) Attributes() {
-	attrs, err := t.in.Attributes(t.ctx)
+func (t *DirTest) Attributes_WithClobberedCheckTrue() {
+	attrs, err := t.in.Attributes(t.ctx, true)
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)
 	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
 }
 
-func (t *DirTest) ExtractAttributes() {
-	attrs, err := t.in.ExtractAttributes(t.ctx)
+func (t *DirTest) Attributes_WithClobberedCheckFalse() {
+	attrs, err := t.in.Attributes(t.ctx, false)
 	AssertEq(nil, err)
 	ExpectEq(uid, attrs.Uid)
 	ExpectEq(gid, attrs.Gid)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -328,6 +328,85 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 	return
 }
 
+// populateAttributes returns the attributes for the file inode.
+// The `checkClobbered` parameter controls whether this function performs a
+// remote check to see if the backing GCS object has been modified by another
+// process.
+// LOCKS_REQUIRED(f.mu)
+func (f *FileInode) populateAttributes(ctx context.Context, checkClobbered bool) (attrs fuseops.InodeAttributes, err error) {
+	attrs = f.attrs
+	// Obtain default information from the source object.
+	attrs.Mtime = f.src.Updated
+	attrs.Size = f.src.Size
+
+	// If the source object has an mtime metadata key, use that instead of its
+	// update time.
+	// If the file was copied via gsutil, we'll have goog-reserved-file-mtime
+	if strTimestamp, ok := f.src.Metadata["goog-reserved-file-mtime"]; ok {
+		if timestamp, err := strconv.ParseInt(strTimestamp, 0, 64); err == nil {
+			attrs.Mtime = time.Unix(timestamp, 0)
+		}
+	}
+
+	// Otherwise, if its been synced with gcsfuse before, we'll have gcsfuse_mtime
+	if formatted, ok := f.src.Metadata["gcsfuse_mtime"]; ok {
+		attrs.Mtime, err = time.Parse(time.RFC3339Nano, formatted)
+		if err != nil {
+			err = fmt.Errorf("time.Parse(%q): %w", formatted, err)
+			return
+		}
+	}
+
+	// If we've got local content, its size and (maybe) mtime take precedence.
+	if f.content != nil {
+		var sr gcsx.StatResult
+		sr, err = f.content.Stat()
+		if err != nil {
+			err = fmt.Errorf("stat: %w", err)
+			return
+		}
+
+		attrs.Size = uint64(sr.Size)
+		if sr.Mtime != nil {
+			attrs.Mtime = *sr.Mtime
+		}
+	}
+
+	if f.bwh != nil {
+		writeFileInfo := f.bwh.WriteFileInfo()
+		attrs.Mtime = writeFileInfo.Mtime
+		attrs.Size = uint64(writeFileInfo.TotalSize)
+	}
+
+	// We require only that atime and ctime be "reasonable".
+	attrs.Atime = attrs.Mtime
+	attrs.Ctime = attrs.Mtime
+
+	if checkClobbered {
+		// If the object has been clobbered, we reflect that as the inode being
+		// unlinked.
+		var clobbered bool
+		_, clobbered, err = f.clobbered(ctx, false, false)
+		if err != nil {
+			err = fmt.Errorf("clobbered: %w", err)
+			return
+		}
+		if clobbered {
+			attrs.Nlink = 0
+			return
+		}
+	}
+
+	attrs.Nlink = 1
+
+	// For local files, also checking if file is unlinked locally.
+	if f.IsLocal() && f.IsUnlinked() {
+		attrs.Nlink = 0
+	}
+
+	return
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Public interface
 ////////////////////////////////////////////////////////////////////////
@@ -470,71 +549,13 @@ func (f *FileInode) Destroy() (err error) {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) Attributes(
 	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	attrs = f.attrs
+	return f.populateAttributes(ctx, true)
+}
 
-	// Obtain default information from the source object.
-	attrs.Mtime = f.src.Updated
-	attrs.Size = f.src.Size
-
-	// If the source object has an mtime metadata key, use that instead of its
-	// update time.
-	// If the file was copied via gsutil, we'll have goog-reserved-file-mtime
-	if strTimestamp, ok := f.src.Metadata["goog-reserved-file-mtime"]; ok {
-		if timestamp, err := strconv.ParseInt(strTimestamp, 0, 64); err == nil {
-			attrs.Mtime = time.Unix(timestamp, 0)
-		}
-	}
-
-	// Otherwise, if its been synced with gcsfuse before, we'll have gcsfuse_mtime
-	if formatted, ok := f.src.Metadata["gcsfuse_mtime"]; ok {
-		attrs.Mtime, err = time.Parse(time.RFC3339Nano, formatted)
-		if err != nil {
-			err = fmt.Errorf("time.Parse(%q): %w", formatted, err)
-			return
-		}
-	}
-
-	// If we've got local content, its size and (maybe) mtime take precedence.
-	if f.content != nil {
-		var sr gcsx.StatResult
-		sr, err = f.content.Stat()
-		if err != nil {
-			err = fmt.Errorf("stat: %w", err)
-			return
-		}
-
-		attrs.Size = uint64(sr.Size)
-		if sr.Mtime != nil {
-			attrs.Mtime = *sr.Mtime
-		}
-	}
-
-	if f.bwh != nil {
-		writeFileInfo := f.bwh.WriteFileInfo()
-		attrs.Mtime = writeFileInfo.Mtime
-		attrs.Size = uint64(writeFileInfo.TotalSize)
-	}
-
-	// We require only that atime and ctime be "reasonable".
-	attrs.Atime = attrs.Mtime
-	attrs.Ctime = attrs.Mtime
-
-	// If the object has been clobbered, we reflect that as the inode being
-	// unlinked.
-	_, clobbered, err := f.clobbered(ctx, false, false)
-	if err != nil {
-		err = fmt.Errorf("clobbered: %w", err)
-		return
-	}
-
-	attrs.Nlink = 1
-
-	// For local files, also checking if file is unlinked locally.
-	if clobbered || (f.IsLocal() && f.IsUnlinked()) {
-		attrs.Nlink = 0
-	}
-
-	return
+// LOCKS_REQUIRED(f.mu)
+func (f *FileInode) ExtractAttributes(
+	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	return f.populateAttributes(ctx, false)
 }
 
 func (f *FileInode) Bucket() *gcsx.SyncerBucket {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -328,85 +328,6 @@ func (f *FileInode) ensureContent(ctx context.Context) (err error) {
 	return
 }
 
-// populateAttributes returns the attributes for the file inode.
-// The `checkClobbered` parameter controls whether this function performs a
-// remote check to see if the backing GCS object has been modified by another
-// process.
-// LOCKS_REQUIRED(f.mu)
-func (f *FileInode) populateAttributes(ctx context.Context, checkClobbered bool) (attrs fuseops.InodeAttributes, err error) {
-	attrs = f.attrs
-	// Obtain default information from the source object.
-	attrs.Mtime = f.src.Updated
-	attrs.Size = f.src.Size
-
-	// If the source object has an mtime metadata key, use that instead of its
-	// update time.
-	// If the file was copied via gsutil, we'll have goog-reserved-file-mtime
-	if strTimestamp, ok := f.src.Metadata["goog-reserved-file-mtime"]; ok {
-		if timestamp, err := strconv.ParseInt(strTimestamp, 0, 64); err == nil {
-			attrs.Mtime = time.Unix(timestamp, 0)
-		}
-	}
-
-	// Otherwise, if its been synced with gcsfuse before, we'll have gcsfuse_mtime
-	if formatted, ok := f.src.Metadata["gcsfuse_mtime"]; ok {
-		attrs.Mtime, err = time.Parse(time.RFC3339Nano, formatted)
-		if err != nil {
-			err = fmt.Errorf("time.Parse(%q): %w", formatted, err)
-			return
-		}
-	}
-
-	// If we've got local content, its size and (maybe) mtime take precedence.
-	if f.content != nil {
-		var sr gcsx.StatResult
-		sr, err = f.content.Stat()
-		if err != nil {
-			err = fmt.Errorf("stat: %w", err)
-			return
-		}
-
-		attrs.Size = uint64(sr.Size)
-		if sr.Mtime != nil {
-			attrs.Mtime = *sr.Mtime
-		}
-	}
-
-	if f.bwh != nil {
-		writeFileInfo := f.bwh.WriteFileInfo()
-		attrs.Mtime = writeFileInfo.Mtime
-		attrs.Size = uint64(writeFileInfo.TotalSize)
-	}
-
-	// We require only that atime and ctime be "reasonable".
-	attrs.Atime = attrs.Mtime
-	attrs.Ctime = attrs.Mtime
-
-	if checkClobbered {
-		// If the object has been clobbered, we reflect that as the inode being
-		// unlinked.
-		var clobbered bool
-		_, clobbered, err = f.clobbered(ctx, false, false)
-		if err != nil {
-			err = fmt.Errorf("clobbered: %w", err)
-			return
-		}
-		if clobbered {
-			attrs.Nlink = 0
-			return
-		}
-	}
-
-	attrs.Nlink = 1
-
-	// For local files, also checking if file is unlinked locally.
-	if f.IsLocal() && f.IsUnlinked() {
-		attrs.Nlink = 0
-	}
-
-	return
-}
-
 ////////////////////////////////////////////////////////////////////////
 // Public interface
 ////////////////////////////////////////////////////////////////////////
@@ -548,14 +469,78 @@ func (f *FileInode) Destroy() (err error) {
 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) Attributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	return f.populateAttributes(ctx, true)
-}
+	ctx context.Context, clobberedCheck bool) (attrs fuseops.InodeAttributes, err error) {
+	attrs = f.attrs
+	// Obtain default information from the source object.
+	attrs.Mtime = f.src.Updated
+	attrs.Size = f.src.Size
 
-// LOCKS_REQUIRED(f.mu)
-func (f *FileInode) ExtractAttributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	return f.populateAttributes(ctx, false)
+	// If the source object has an mtime metadata key, use that instead of its
+	// update time.
+	// If the file was copied via gsutil, we'll have goog-reserved-file-mtime
+	if strTimestamp, ok := f.src.Metadata["goog-reserved-file-mtime"]; ok {
+		if timestamp, err := strconv.ParseInt(strTimestamp, 0, 64); err == nil {
+			attrs.Mtime = time.Unix(timestamp, 0)
+		}
+	}
+
+	// Otherwise, if its been synced with gcsfuse before, we'll have gcsfuse_mtime
+	if formatted, ok := f.src.Metadata["gcsfuse_mtime"]; ok {
+		attrs.Mtime, err = time.Parse(time.RFC3339Nano, formatted)
+		if err != nil {
+			err = fmt.Errorf("time.Parse(%q): %w", formatted, err)
+			return
+		}
+	}
+
+	// If we've got local content, its size and (maybe) mtime take precedence.
+	if f.content != nil {
+		var sr gcsx.StatResult
+		sr, err = f.content.Stat()
+		if err != nil {
+			err = fmt.Errorf("stat: %w", err)
+			return
+		}
+
+		attrs.Size = uint64(sr.Size)
+		if sr.Mtime != nil {
+			attrs.Mtime = *sr.Mtime
+		}
+	}
+
+	if f.bwh != nil {
+		writeFileInfo := f.bwh.WriteFileInfo()
+		attrs.Mtime = writeFileInfo.Mtime
+		attrs.Size = uint64(writeFileInfo.TotalSize)
+	}
+
+	// We require only that atime and ctime be "reasonable".
+	attrs.Atime = attrs.Mtime
+	attrs.Ctime = attrs.Mtime
+
+	if clobberedCheck {
+		// If the object has been clobbered, we reflect that as the inode being
+		// unlinked.
+		var clobbered bool
+		_, clobbered, err = f.clobbered(ctx, false, false)
+		if err != nil {
+			err = fmt.Errorf("clobbered: %w", err)
+			return
+		}
+		if clobbered {
+			attrs.Nlink = 0
+			return
+		}
+	}
+
+	attrs.Nlink = 1
+
+	// For local files, also checking if file is unlinked locally.
+	if f.IsLocal() && f.IsUnlinked() {
+		attrs.Nlink = 0
+	}
+
+	return
 }
 
 func (f *FileInode) Bucket() *gcsx.SyncerBucket {

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -345,7 +345,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			assert.False(t.T(), gcsSynced)
 			require.NotNil(t.T(), t.in.bwh)
 			// validate attributes.
-			attrs, err := t.in.Attributes(t.ctx)
+			attrs, err := t.in.Attributes(t.ctx, true)
 			require.Nil(t.T(), err)
 			assert.WithinDuration(t.T(), attrs.Mtime, createTime, 0)
 			assert.Equal(t.T(), uint64(4), attrs.Size)
@@ -360,7 +360,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			assert.Nil(t.T(), t.in.bwh)
 			assert.NotNil(t.T(), t.in.content)
 			// The inode should agree about the new mtime and size.
-			attrs, err = t.in.Attributes(t.ctx)
+			attrs, err = t.in.Attributes(t.ctx, true)
 			require.Nil(t.T(), err)
 			assert.Equal(t.T(), uint64(len(tc.expectedContent)), attrs.Size)
 			assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
@@ -388,7 +388,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	assert.Nil(t.T(), t.in.bwh)
 	assert.NotNil(t.T(), t.in.content)
 	// validate attributes.
-	attrs, err := t.in.Attributes(t.ctx)
+	attrs, err := t.in.Attributes(t.ctx, true)
 	require.Nil(t.T(), err)
 	assert.WithinDuration(t.T(), attrs.Mtime, createTime, 0)
 	assert.Equal(t.T(), uint64(10), attrs.Size)
@@ -402,7 +402,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	// Ensure bwh not re-created.
 	assert.Nil(t.T(), t.in.bwh)
 	// The inode should agree about the new mtime and size.
-	attrs, err = t.in.Attributes(t.ctx)
+	attrs, err = t.in.Attributes(t.ctx, true)
 	require.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(len("hello\x00taco")), attrs.Size)
 	assert.WithinDuration(t.T(), attrs.Mtime, mtime, 0)
@@ -523,7 +523,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndFlush() {
 			// Verify that fileInode is no more local
 			assert.False(t.T(), t.in.IsLocal())
 			// Check attributes.
-			attrs, err := t.in.Attributes(t.ctx)
+			attrs, err := t.in.Attributes(t.ctx, true)
 			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(len("tacos")), attrs.Size)
 			assert.Equal(t.T(), t.clock.Now().UTC(), attrs.Mtime.UTC())
@@ -578,7 +578,7 @@ func (t *FileStreamingWritesTest) TestFlushEmptyFile() {
 			// Verify that fileInode is no more local
 			assert.False(t.T(), t.in.IsLocal())
 			// Check attributes.
-			attrs, err := t.in.Attributes(t.ctx)
+			attrs, err := t.in.Attributes(t.ctx, true)
 			require.NoError(t.T(), err)
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 			// For synced file, mtime is updated by SetInodeAttributes call.
@@ -744,7 +744,7 @@ func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreate
 	// Ensure bwh not re-created.
 	assert.Nil(t.T(), t.in.bwh)
 	// The inode should agree about the new size.
-	attrs, err := t.in.Attributes(t.ctx)
+	attrs, err := t.in.Attributes(t.ctx, true)
 	require.Nil(t.T(), err)
 	assert.Equal(t.T(), uint64(10), attrs.Size)
 	// sync file and validate content

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -302,6 +302,20 @@ func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreaming
 	assert.Equal(t.T(), t.initialContents, string(contents))
 }
 
+func (t *FileTest) TestExtractAttributes() {
+	attrs, err := t.in.ExtractAttributes(t.ctx)
+	require.NoError(t.T(), err)
+
+	assert.Equal(t.T(), uint64(len(t.initialContents)), attrs.Size)
+	assert.Equal(t.T(), uint32(1), attrs.Nlink)
+	assert.Equal(t.T(), uint32(uid), attrs.Uid)
+	assert.Equal(t.T(), uint32(gid), attrs.Gid)
+	assert.Equal(t.T(), fileMode, attrs.Mode)
+	assert.Equal(t.T(), attrs.Atime, t.backingObj.Updated)
+	assert.Equal(t.T(), attrs.Ctime, t.backingObj.Updated)
+	assert.Equal(t.T(), attrs.Mtime, t.backingObj.Updated)
+}
+
 func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx)
 	require.NoError(t.T(), err)

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -41,10 +41,10 @@ type Inode interface {
 	IncrementLookupCount()
 
 	// Return up to date attributes for this inode.
-	Attributes(ctx context.Context) (fuseops.InodeAttributes, error)
-
-	// Extract attributes for this inode.
-	ExtractAttributes(ctx context.Context) (fuseops.InodeAttributes, error)
+	// The `clobberedCheck` parameter controls whether this function performs a
+	// remote check to see if the backing GCS object has been modified by another
+	// process.
+	Attributes(ctx context.Context, clobberedCheck bool) (fuseops.InodeAttributes, error)
 
 	// Decrement the lookup count for the inode by the given amount.
 	//

--- a/internal/fs/inode/inode.go
+++ b/internal/fs/inode/inode.go
@@ -43,6 +43,9 @@ type Inode interface {
 	// Return up to date attributes for this inode.
 	Attributes(ctx context.Context) (fuseops.InodeAttributes, error)
 
+	// Extract attributes for this inode.
+	ExtractAttributes(ctx context.Context) (fuseops.InodeAttributes, error)
+
 	// Decrement the lookup count for the inode by the given amount.
 	//
 	// If this method returns true, the lookup count has hit zero and the

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -140,13 +140,7 @@ func (s *SymlinkInode) Destroy() (err error) {
 }
 
 func (s *SymlinkInode) Attributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
-	attrs = s.attrs
-	return
-}
-
-func (s *SymlinkInode) ExtractAttributes(
-	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	ctx context.Context, clobberedCheck bool) (attrs fuseops.InodeAttributes, err error) {
 	attrs = s.attrs
 	return
 }

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -145,6 +145,12 @@ func (s *SymlinkInode) Attributes(
 	return
 }
 
+func (s *SymlinkInode) ExtractAttributes(
+	ctx context.Context) (attrs fuseops.InodeAttributes, err error) {
+	attrs = s.attrs
+	return
+}
+
 // Target returns the target of the symlink.
 func (s *SymlinkInode) Target() (target string) {
 	target = s.target

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -81,10 +81,8 @@ func (t *SymlinkTest) TestAttributes() {
 		Gid:  1002,
 		Mode: 0777 | os.ModeSymlink,
 	}
-	inodeID := fuseops.InodeID(42)
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
-	s := inode.NewSymlinkInode(inodeID, name, m, attrs)
-
+	s := inode.NewSymlinkInode(fuseops.InodeID(42), name, m, attrs)
 	tests := []struct {
 		name           string
 		clobberedCheck bool

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -68,7 +68,7 @@ func (t *SymlinkTest) TestIsSymLinkForNilObject() {
 	AssertEq(false, inode.IsSymlink(nil))
 }
 
-func (t *SymlinkTest) TestExtractAttributes() {
+func (t *SymlinkTest) TestAttributes() {
 	metadata := map[string]string{
 		inode.SymlinkMetadataKey: "target",
 	}
@@ -81,18 +81,27 @@ func (t *SymlinkTest) TestExtractAttributes() {
 		Gid:  1002,
 		Mode: 0777 | os.ModeSymlink,
 	}
-
 	inodeID := fuseops.InodeID(42)
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
 	s := inode.NewSymlinkInode(inodeID, name, m, attrs)
 
-	// Call ExtractAttributes
-	extracted, err := s.ExtractAttributes(context.TODO())
+	tests := []struct {
+		name           string
+		clobberedCheck bool
+	}{
+		{"WithClobberedCheckFalse", false},
+		{"WithClobberedCheckTrue", true},
+	}
 
-	// Check expected values
-	AssertEq(nil, err)
-	ExpectEq(uint32(1), extracted.Nlink)
-	ExpectEq(attrs.Uid, extracted.Uid)
-	ExpectEq(attrs.Gid, extracted.Gid)
-	ExpectEq(attrs.Mode, extracted.Mode)
+	for _, tt := range tests {
+		// Call Attributes
+		extracted, err := s.Attributes(context.TODO(), tt.clobberedCheck)
+
+		// Check expected values
+		AssertEq(nil, err)
+		ExpectEq(uint32(1), extracted.Nlink)
+		ExpectEq(attrs.Uid, extracted.Uid)
+		ExpectEq(attrs.Gid, extracted.Gid)
+		ExpectEq(attrs.Mode, extracted.Mode)
+	}
 }


### PR DESCRIPTION
### Description
Modify the Attributes method in the Inode interface by adding a clobberedCheck boolean parameter. This change allows callers to control whether a remote check is performed to verify if the backing GCS object has been modified or "clobbered".

Disabling this check offers a more performant alternative for retrieving inode attributes in scenarios where this verification is not strictly necessary.

### Link to the issue in case of a bug fix.
 https://b.corp.google.com/issues/423824746

### Testing details
1. Manual - NA
2. Unit tests - Updated unit tests to verify the functionality of the Attributes method with the new clobberedCheck parameter for FileInode, Dir, BaseDir, and Symlink.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
