### PR TITLE
Block: Adding ReadAt method in block interface and memoryBlock

### DIFF
--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -15,10 +15,8 @@
 package block
 
 import (
-	"context"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,29 +206,4 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAthEOF() {
 	require.Equal(testSuite.T(), io.EOF, err)
 	require.Equal(testSuite.T(), 5, n)
 	assert.Equal(testSuite.T(), []byte("world"), readBuffer[0:n])
-}
-
-func (testSuite *MemoryBlockTest) TestAwaitReadyWaitIfNotNotify() {
-	mb, err := createBlock(12)
-	require.Nil(testSuite.T(), err)
-
-	ctx, cancel := context.WithTimeout(testSuite.T().Context(), 100*time.Millisecond)
-	defer cancel()
-
-	_, err = mb.AwaitReady(ctx)
-	assert.NotNil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), context.DeadlineExceeded, err)
-}
-
-func (testSuite *MemoryBlockTest) TestAwaitReadyReturnsStatusAfterNotify() {
-	mb, err := createBlock(12)
-	require.Nil(testSuite.T(), err)
-	go func() {
-		// time.Sleep(time.Millisecond) // Simulate some processing time
-		mb.NotifyReady(1)            // Notify the block is ready
-	}()
-
-	status, err := mb.AwaitReady(context.Background())
-	require.Nil(testSuite.T(), err)
-	assert.Equal(testSuite.T(), 1, status)
 }

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -141,8 +141,8 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockDeAllocate() {
 
 	err = mb.Deallocate()
 
-	require.Nil(testSuite.T(), err)
-	require.Nil(testSuite.T(), mb.(*memoryBlock).buffer)
+	assert.Nil(testSuite.T(), err)
+	assert.Nil(testSuite.T(), mb.(*memoryBlock).buffer)
 }
 
 func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtSuccess() {
@@ -156,8 +156,8 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtSuccess() {
 
 	n, err = mb.ReadAt(readBuffer, 6) // Read "world"
 
-	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), 5, n)
+	assert.Nil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), 5, n)
 	assert.Equal(testSuite.T(), []byte("world"), readBuffer)
 }
 
@@ -202,8 +202,8 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAthEOF() {
 
 	n, err = mb.ReadAt(readBuffer, 6) // Read "world"
 
-	require.NotNil(testSuite.T(), err)
-	require.Equal(testSuite.T(), io.EOF, err)
-	require.Equal(testSuite.T(), 5, n)
+	assert.NotNil(testSuite.T(), err)
+	assert.Equal(testSuite.T(), io.EOF, err)
+	assert.Equal(testSuite.T(), 5, n)
 	assert.Equal(testSuite.T(), []byte("world"), readBuffer[0:n])
 }

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -149,12 +149,11 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtSuccess() {
 	mb, err := createBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hello world")
-	n, err := mb.Write(content)
+	_, err = mb.Write(content)
 	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), 11, n)
 	readBuffer := make([]byte, 5)
 
-	n, err = mb.ReadAt(readBuffer, 6) // Read "world"
+	n, err := mb.ReadAt(readBuffer, 6) // Read "world"
 
 	assert.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), 5, n)
@@ -165,14 +164,14 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtBeyondBlockSize() {
 	mb, err := createBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hello world")
-	n, err := mb.Write(content)
+	_, err = mb.Write(content)
 	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), 11, n)
 	readBuffer := make([]byte, 5)
 
-	n, err = mb.ReadAt(readBuffer, 15) // Read beyond the block size
+	n, err := mb.ReadAt(readBuffer, 15) // Read beyond the block size
 
 	assert.NotNil(testSuite.T(), err)
+	assert.NotErrorIs(testSuite.T(), err, io.EOF)
 	assert.Equal(testSuite.T(), 0, n)
 }
 
@@ -180,29 +179,27 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtWithNegativeOffset() {
 	mb, err := createBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hello world")
-	n, err := mb.Write(content)
+	_, err = mb.Write(content)
 	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), 11, n)
 	readBuffer := make([]byte, 5)
 
-	n, err = mb.ReadAt(readBuffer, -1) // Negative offset
+	n, err := mb.ReadAt(readBuffer, -1) // Negative offset
 
 	assert.NotNil(testSuite.T(), err)
+	assert.NotErrorIs(testSuite.T(), err, io.EOF)
 	assert.Equal(testSuite.T(), 0, n)
 }
 
-func (testSuite *MemoryBlockTest) TestMemoryBlockReadAthEOF() {
+func (testSuite *MemoryBlockTest) TestMemoryBlockReadAtEOF() {
 	mb, err := createBlock(12)
 	require.Nil(testSuite.T(), err)
 	content := []byte("hello world")
-	n, err := mb.Write(content)
+	_, err = mb.Write(content)
 	require.Nil(testSuite.T(), err)
-	require.Equal(testSuite.T(), 11, n)
 	readBuffer := make([]byte, 15)
 
-	n, err = mb.ReadAt(readBuffer, 6) // Read "world"
+	n, err := mb.ReadAt(readBuffer, 6) // Read "world"
 
-	assert.NotNil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), io.EOF, err)
 	assert.Equal(testSuite.T(), 5, n)
 	assert.Equal(testSuite.T(), []byte("world"), readBuffer[0:n])


### PR DESCRIPTION
### Description
- Adding ReadAt method in block interface.
- Implementing ReadAt method for memory block.

### Link to the issue in case of a bug fix.
PR: b/430153116

### Testing details
1. Manual - NA
2. Unit tests - Automation
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
