### PR TITLE
Upgrade gcloud version in scripts for CD pipeline

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -67,6 +67,7 @@ set -e
 # Print commands and their arguments as they are executed.
 set -x
 
+# Since we are now operating as the starterscriptuser, we need to set the environment variable for this user again.
 export PATH=/usr/local/google-cloud-sdk/bin:$PATH
 
 # Export the RUN_ON_ZB_ONLY variable so that it is available in the environment of the 'starterscriptuser' user.

--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -25,7 +25,7 @@ export PATH=/usr/local/google-cloud-sdk/bin:$PATH
 gcloud version && rm gcloud.tar.gz
 
 #details.txt file contains the release version and commit hash of the current release.
-gsutil cp  gs://gcsfuse-release-packages/version-detail/details.txt .
+gcloud storage cp  gs://gcsfuse-release-packages/version-detail/details.txt .
 # Writing VM instance name to details.txt (Format: release-test-<os-name>)
 vm_instance_name=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H "Metadata-Flavor: Google")
 # first line of details.txt contains the release version in the format MAJOR.MINOR.PATCH
@@ -141,7 +141,7 @@ if grep -q Failure ~/logs.txt; then
     echo "Test failed" &>> ~/logs.txt ;
 else
     touch success.txt
-    gsutil cp success.txt gs://gcsfuse-release-packages/v$(sed -n 1p details.txt)/installation-test/$(sed -n 3p details.txt)/   ;
+    gcloud storage cp success.txt gs://gcsfuse-release-packages/v$(sed -n 1p details.txt)/installation-test/$(sed -n 3p details.txt)/   ;
 fi
 
-gsutil cp ~/logs.txt gs://gcsfuse-release-packages/v$(sed -n 1p details.txt)/installation-test/$(sed -n 3p details.txt)/
+gcloud storage cp ~/logs.txt gs://gcsfuse-release-packages/v$(sed -n 1p details.txt)/installation-test/$(sed -n 3p details.txt)/


### PR DESCRIPTION
### Description
During the [initial setup](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/cd_scripts/e2e_test.sh#L40) stage for running tests on arm64 VMs, the gcloud storage cp command fails with a Python module loading error. This issue blocks the execution of our test suites on these architectures.

The failure has been observed on both Debian 11 arm64 and Rocky Linux arm64 environments.

The full error message is as follows:
```
ERROR: gcloud failed to load (gcloud.storage.cp): Problem loading gcloud.storage.cp: No module named 'grpc'.

This usually indicates corruption in your gcloud installation or problems with your Python interpreter.

Please verify that the following is the path to a working Python 3.8+ executable:
    /bin/python3
If it is not, please set the CLOUDSDK_PYTHON environment variable to point to a working Python 3.8+ executable.

If you are still experiencing problems, please run the following command to reinstall:
    $ gcloud components reinstall

If that command fails, please reinstall the Google Cloud CLI using the instructions here:
    https://cloud.google.com/sdk/
```

Python was having latest version only so upgrading gcloud version fixed the issue.

### Link to the issue in case of a bug fix.
[b/430036204](https://b.corp.google.com/issues/430036204)

### Testing details
1. Manual - Tested manually  by creating VM
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
