### PR TITLE
[Process Improvement] Standardize PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
-**Please ensure your PR title follows the format: `[Category] Your Title`**
-The `[Category]` can be anything that clearly describes the primary scope or type of the PR (e.g., Project Name, Bug Fix).
+**Please ensure your PR title follows the format:**
+```
+type(scope): subject
+```
+Example:
+feat(api): add user login endpoint
+
 ### Description
 
 ### Link to the issue in case of a bug fix.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+**Please ensure your PR title follows the format: `[Category] Your Title`**
+The `[Category]` can be anything that clearly describes the primary scope or type of the PR. e.g. Project name, Bug fix, etc.
+
 ### Description
 
 ### Link to the issue in case of a bug fix.
@@ -9,3 +12,4 @@
 3. Integration tests - NA
 
 ### Any backward incompatible change? If so, please explain.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 **Please ensure your PR title follows the format: `[Category] Your Title`**
-The `[Category]` can be anything that clearly describes the primary scope or type of the PR. e.g. Project name, Bug fix, etc.
-
+The `[Category]` can be anything that clearly describes the primary scope or type of the PR (e.g., Project Name, Bug Fix).
 ### Description
 
 ### Link to the issue in case of a bug fix.
@@ -12,4 +11,3 @@ The `[Category]` can be anything that clearly describes the primary scope or typ
 3. Integration tests - NA
 
 ### Any backward incompatible change? If so, please explain.
-

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,36 +1,42 @@
 name: PR Title Check
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
+  pull_request_target:
+    types:
+    - opened
+    - edited
+
+permissions:
+  pull-requests: write
 
 jobs:
-  check-title:
+  main:
+    name: Validate PR title
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      checks: write
 
     steps:
-    - name: Check PR title format
-      run: |
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        echo "PR Title: $PR_TITLE"
-        
-        # Updated regex pattern:
-        # Allows any non-empty string inside the first set of brackets.
-        # Example: [ANY_TEXT_HERE], [Bug Fix], [Feature]
-        if [[ "$PR_TITLE" =~ ^\[[^\]]+\](.+)$ ]]; then
-          echo "PR title '$PR_TITLE' adheres to the required format."
-          exit 0
-        else
-          echo "Error: PR title '$PR_TITLE' does not follow the required format."
-          echo "Please ensure the title starts with a category enclosed in square brackets. e.g., [Category] Your concise title."
-          echo "Examples:"
-          echo "  [Auth] Implement password reset feature"
-          echo "  [Bug Fix] Fix infinite loop in user login"
-          echo "  [Feature] Add dark mode toggle"
-          exit 1
-        fi
-      shell: bash
+    - uses: amannn/action-semantic-pull-request@v5
+      id: lint_pr_title
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: marocchino/sticky-pull-request-comment@v2
+      if: always() && (steps.lint_pr_title.outputs.error_message != null)
+      with:
+        header: pr-title-lint-error
+        message: |
+          Hey there and thank you for opening this pull request! 👋🏼
+          
+          We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+          
+          Details:
+          
+          ```
+          ${{ steps.lint_pr_title.outputs.error_message }}
+          ```
+
+    - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: pr-title-lint-error
+        delete: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,12 +16,12 @@ jobs:
         # Updated regex pattern:
         # Allows any non-empty string inside the first set of brackets.
         # Example: [ANY_TEXT_HERE], [Bug Fix], [Feature]
-        if [[ "$PR_TITLE" =~ ^\[[^\]]+\]\ .*. ]]; then
+        if [[ "$PR_TITLE" =~ ^\[[^\]]+\](.+)$ ]]; then
           echo "PR title '$PR_TITLE' adheres to the required format."
           exit 0
         else
           echo "Error: PR title '$PR_TITLE' does not follow the required format."
-          echo "Please ensure the title starts with a category enclosed in square brackets, followed by a space, e.g., [Category] Your concise title."
+          echo "Please ensure the title starts with a category enclosed in square brackets. e.g., [Category] Your concise title."
           echo "Examples:"
           echo "  [Auth] Implement password reset feature"
           echo "  [Bug Fix] Fix infinite loop in user login"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   check-title:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
     steps:
     - name: Check PR title format
       run: |

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,31 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR title format
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        echo "PR Title: $PR_TITLE"
+        
+        # Updated regex pattern:
+        # Allows any non-empty string inside the first set of brackets.
+        # Example: [ANY_TEXT_HERE], [Bug Fix], [Feature]
+        if [[ "$PR_TITLE" =~ ^\[[^\]]+\]\ .*. ]]; then
+          echo "PR title '$PR_TITLE' adheres to the required format."
+          exit 0
+        else
+          echo "Error: PR title '$PR_TITLE' does not follow the required format."
+          echo "Please ensure the title starts with a category enclosed in square brackets, followed by a space, e.g., [Category] Your concise title."
+          echo "Examples:"
+          echo "  [Auth] Implement password reset feature"
+          echo "  [Bug Fix] Fix infinite loop in user login"
+          echo "  [Feature] Add dark mode toggle"
+          exit 1
+        fi
+      shell: bash


### PR DESCRIPTION
### Description
A standardized format for PR titles to streamline the process of generating release notes.

To achieve this, the following changes have been implemented:

1. Updated PR Template: The pull request template has been updated to include instructions for the new title format, guiding contributors to use a title structure.
2. New CI Check: A new GitHub Actions workflow, pr-title-check.yml, has been added to automatically enforce this standard. This uses [standard templated](https://github.com/marketplace/actions/semantic-pull-request).

### Link to the issue in case of a bug fix.
[b/430442495](https://b.corp.google.com/issues/430442495)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No