### PR TITLE
Block: adding Cap() method

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -30,6 +30,9 @@ type Block interface {
 	// can be >= data_size.
 	Size() int64
 
+	// Cap returns the capacity of the block, kind of block-size.
+	Cap() int64
+
 	// Write writes the given data to block.
 	Write(bytes []byte) (n int, err error)
 
@@ -80,6 +83,11 @@ func (m *memoryBlock) Reuse() {
 func (m *memoryBlock) Size() int64 {
 	return m.offset.end - m.offset.start
 }
+
+func (m *memoryBlock) Cap() int64 {
+	return int64(cap(m.buffer))
+}
+
 func (m *memoryBlock) Write(bytes []byte) (int, error) {
 	if m.Size()+int64(len(bytes)) > int64(cap(m.buffer)) {
 		return 0, fmt.Errorf("received data more than capacity of the block")

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -260,3 +260,21 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockSetAbsStartOffsetTwiceInvalid()
 
 	assert.Error(testSuite.T(), err)
 }
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockCap() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+
+	assert.Equal(testSuite.T(), int64(12), mb.Cap())
+}
+
+func (testSuite *MemoryBlockTest) TestMemoryBlockCapAfterWrite() {
+	mb, err := createBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hi")
+	n, err := mb.Write(content)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), 2, n)
+
+	assert.Equal(testSuite.T(), int64(12), mb.Cap())
+}


### PR DESCRIPTION
### Description
- Adding cap() method to get block-capacity.
- This will be handy to know the block-size from the block.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
