### PR TITLE
Make --enable-read-stall-retry flag hidden

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -401,6 +401,10 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
+	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
+		return err
+	}
+
 	flagSet.BoolP("enable-streaming-writes", "", true, "Enables streaming uploads during write file operation.")
 
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -431,6 +431,7 @@
     To turn on/off retries for stalled read requests. This is based on a timeout
     that changes depending on how long similar requests took in the past.
   default: true
+  hide-flag: true
 
 - config-path: "gcs-retries.read-stall.initial-req-timeout"
   flag-name: "read-stall-initial-req-timeout"


### PR DESCRIPTION
### Description
This PR hides the `--enable-read-stall-retry` flag. 

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/430750460

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
