### PR TITLE
chores: Increase CI linux timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         go: [ 1.24.x ]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description
- Adding ci linux timeout to 25 minutes.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - Automated.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
