### PR TITLE
Dir Handle changes to support Readdirplus operation

### DIFF
--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -450,7 +450,6 @@ func (dh *DirHandle) FetchEntryCores(ctx context.Context, op *fuseops.ReadDirPlu
 // ReadDirPlus populates the FUSE response buffer using a pre-processed list
 // of directory entries.
 // LOCKS_REQUIRED(dh.Mu)
-// LOCKS_EXCLUDED(dh.in)
 func (dh *DirHandle) ReadDirPlus(op *fuseops.ReadDirPlusOp, entries []fuseutil.DirentPlus, localEntries map[string]fuseutil.DirentPlus) (err error) {
 	// Sort, resolve conflicts, and set offsets.
 	entries, err = sortAndResolveEntries(entries, localEntries, func(e fuseutil.DirentPlus) *direntPlus { dp := direntPlus(e); return &dp }, func(w *direntPlus) fuseutil.DirentPlus { return fuseutil.DirentPlus(*w) })

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -451,14 +451,13 @@ func (dh *DirHandle) FetchEntryCores(ctx context.Context, op *fuseops.ReadDirPlu
 // of directory entries.
 // LOCKS_REQUIRED(dh.Mu)
 func (dh *DirHandle) ReadDirPlus(op *fuseops.ReadDirPlusOp, entries []fuseutil.DirentPlus, localEntries map[string]fuseutil.DirentPlus) (err error) {
-	// Sort, resolve conflicts, and set offsets.
-	entries, err = sortAndResolveEntries(entries, localEntries, func(e fuseutil.DirentPlus) *direntPlus { dp := direntPlus(e); return &dp }, func(w *direntPlus) fuseutil.DirentPlus { return fuseutil.DirentPlus(*w) })
-	if err != nil {
-		return
-	}
-
 	// If entriesPlus has not been populated yet, populate it.
 	if !dh.entriesPlusValid {
+		// Sort, resolve conflicts, and set offsets.
+		entries, err = sortAndResolveEntries(entries, localEntries, func(e fuseutil.DirentPlus) *direntPlus { dp := direntPlus(e); return &dp }, func(w *direntPlus) fuseutil.DirentPlus { return fuseutil.DirentPlus(*w) })
+		if err != nil {
+			return
+		}
 		// Update state.
 		dh.entriesPlus = entries
 		dh.entriesPlusValid = true

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -16,6 +16,7 @@ package handle
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
@@ -25,6 +26,39 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 	"golang.org/x/net/context"
 )
+
+// DirEntry is a generic interface for directory entries that expose
+// name, type, and offset. It is implemented by fuseutil.Dirent and fuseutil.DirentPlus.
+type DirEntry interface {
+	GetName() string
+	SetName(name string)
+	GetType() fuseutil.DirentType
+	SetOffset(offset fuseops.DirOffset)
+}
+
+// Dirent wraps fuseutil.Dirent to provide method implementations required by the DirEntry interface.
+// Used to allow generic operations over directory entries.
+type Dirent struct {
+	fuseutil.Dirent
+}
+
+// DirentPlus wraps fuseutil.DirentPlus to provide method implementations required by the DirEntry interface.
+// Used to allow generic operations over directory entries.
+type DirentPlus struct {
+	fuseutil.DirentPlus
+}
+
+// For Dirent
+func (d *Dirent) GetName() string                    { return d.Name }
+func (d *Dirent) SetName(name string)                { d.Name = name }
+func (d *Dirent) GetType() fuseutil.DirentType       { return d.Type }
+func (d *Dirent) SetOffset(offset fuseops.DirOffset) { d.Offset = offset }
+
+// For DirentPlus
+func (dp *DirentPlus) GetName() string                    { return dp.Dirent.Name }
+func (dp *DirentPlus) SetName(name string)                { dp.Dirent.Name = name }
+func (dp *DirentPlus) GetType() fuseutil.DirentType       { return dp.Dirent.Type }
+func (dp *DirentPlus) SetOffset(offset fuseops.DirOffset) { dp.Dirent.Offset = offset }
 
 // DirHandle is the state required for reading from directories.
 type DirHandle struct {
@@ -48,12 +82,26 @@ type DirHandle struct {
 	// GUARDED_BY(Mu)
 	entries []fuseutil.Dirent
 
+	// All entries in the directory along with their attributes. Populated the first time we need one.
+	//
+	// INVARIANT: For each i, entriesPlus[i+1].Offset == entriesPlus[i].Offset + 1
+	//
+	// GUARDED_BY(Mu)
+	entriesPlus []fuseutil.DirentPlus
+
 	// Has entries yet been populated?
 	//
 	// INVARIANT: If !entriesValid, then len(entries) == 0
 	//
 	// GUARDED_BY(Mu)
 	entriesValid bool
+
+	// Has entriesPlus yet been populated?
+	//
+	// INVARIANT: If !entriesPlusValid, then len(entriesPlus) == 0
+	//
+	// GUARDED_BY(Mu)
+	entriesPlusValid bool
 }
 
 // NewDirHandle creates a directory handle that obtains listings from the supplied inode.
@@ -77,11 +125,11 @@ func NewDirHandle(
 ////////////////////////////////////////////////////////////////////////
 
 // Directory entries, sorted by name.
-type sortedDirents []fuseutil.Dirent
+type SortedDirEntries[T DirEntry] []T
 
-func (p sortedDirents) Len() int           { return len(p) }
-func (p sortedDirents) Less(i, j int) bool { return p[i].Name < p[j].Name }
-func (p sortedDirents) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p SortedDirEntries[T]) Len() int           { return len(p) }
+func (p SortedDirEntries[T]) Less(i, j int) bool { return p[i].GetName() < p[j].GetName() }
+func (p SortedDirEntries[T]) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 func (dh *DirHandle) checkInvariants() {
 	// INVARIANT: For each i, entries[i+1].Offset == entries[i].Offset + 1
@@ -99,6 +147,22 @@ func (dh *DirHandle) checkInvariants() {
 	if !dh.entriesValid && len(dh.entries) != 0 {
 		panic("Unexpected non-empty entries slice")
 	}
+
+	// INVARIANT: For each i, entriesPlus[i+1].Dirent.Offset == entriesPlus[i].Dirent.Offset + 1
+	for i := 0; i < len(dh.entriesPlus)-1; i++ {
+		if !(dh.entriesPlus[i+1].Dirent.Offset == dh.entriesPlus[i].Dirent.Offset+1) {
+			panic(
+				fmt.Sprintf(
+					"Unexpected offset sequence: %v, %v",
+					dh.entriesPlus[i].Dirent.Offset,
+					dh.entriesPlus[i+1].Dirent.Offset))
+		}
+	}
+
+	// INVARIANT: If !entriesPlusValid, then len(entriesPlus) == 0
+	if !dh.entriesPlusValid && len(dh.entriesPlus) != 0 {
+		panic("Unexpected non-empty entries slice")
+	}
 }
 
 // Resolve name conflicts between file objects and directory objects (e.g. the
@@ -106,37 +170,37 @@ func (dh *DirHandle) checkInvariants() {
 // GCS object names, to conflicting file names.
 //
 // Input must be sorted by name.
-func fixConflictingNames(entries []fuseutil.Dirent, localEntries map[string]fuseutil.Dirent) (output []fuseutil.Dirent, err error) {
+func fixConflictingNames[T DirEntry](entries []T, localEntries map[string]T) (output []T, err error) {
 	// Sanity check.
-	if !sort.IsSorted(sortedDirents(entries)) {
+	if !sort.IsSorted(SortedDirEntries[T](entries)) {
 		err = fmt.Errorf("expected sorted input")
 		return
 	}
 
 	// Examine each adjacent pair of names.
 	for i := range entries {
-		e := &entries[i]
+		e := entries[i]
 
 		// Find the previous entry.
 		if i == 0 {
-			output = append(output, *e)
+			output = append(output, e)
 			continue
 		}
 
-		prev := &output[len(output)-1]
+		prev := output[len(output)-1]
 
 		// Does the pair have matching names?
-		if e.Name != prev.Name {
-			output = append(output, *e)
+		if e.GetName() != prev.GetName() {
+			output = append(output, e)
 			continue
 		}
 
 		// We expect exactly one to be a directory.
-		eIsDir := e.Type == fuseutil.DT_Directory
-		prevIsDir := prev.Type == fuseutil.DT_Directory
+		eIsDir := e.GetType() == fuseutil.DT_Directory
+		prevIsDir := prev.GetType() == fuseutil.DT_Directory
 
 		if eIsDir == prevIsDir {
-			if _, ok := localEntries[e.Name]; ok && !eIsDir {
+			if _, ok := localEntries[e.GetName()]; ok && !eIsDir {
 				// We have found same entry in GCS and local file entries, i.e, the
 				// entry is uploaded to GCS but not yet deleted from local entries.
 				// Do not return the duplicate entry as part of list response.
@@ -144,24 +208,76 @@ func fixConflictingNames(entries []fuseutil.Dirent, localEntries map[string]fuse
 			} else {
 				err = fmt.Errorf(
 					"weird dirent type pair for name %q: %v, %v",
-					e.Name,
-					e.Type,
-					prev.Type)
+					e.GetName(),
+					e.GetType(),
+					prev.GetType())
 				return
 			}
 		}
 
 		// Repair whichever is not the directory.
 		if eIsDir {
-			prev.Name += inode.ConflictingFileNameSuffix
+			prev.SetName(prev.GetName() + inode.ConflictingFileNameSuffix)
 		} else {
-			e.Name += inode.ConflictingFileNameSuffix
+			e.SetName(e.GetName() + inode.ConflictingFileNameSuffix)
 		}
 
-		output = append(output, *e)
+		output[len(output)-1] = prev
+		output = append(output, e)
 	}
 
 	return
+}
+
+// sortAndResolveEntries is a generic helper function that takes a list of
+// directory entries, sorts them, resolves name conflicts, and sets their
+// offsets.
+//
+// This generic function supports both fuseutil.Dirent and fuseutil.DirentPlus
+// by wrapping/ unwrapping them into DirEntry interface-compatible types.
+func sortAndResolveEntries[Entry any, WrappedEntry DirEntry](entries []Entry, localEntries map[string]Entry, wrap func(Entry) WrappedEntry, unwrap func(WrappedEntry) Entry) ([]Entry, error) {
+	// Append local file entries (not synced to GCS).
+	for _, localEntry := range localEntries {
+		entries = append(entries, localEntry)
+	}
+
+	// Wrap
+	wrappedEntries := make([]WrappedEntry, 0, len(entries))
+	for _, entry := range entries {
+		wrappedEntries = append(wrappedEntries, wrap(entry))
+	}
+	wrappedLocalEntries := make(map[string]WrappedEntry)
+	for name, entry := range localEntries {
+		wrappedLocalEntries[name] = wrap(entry)
+	}
+
+	// Ensure that the entries are sorted, for use in fixConflictingNames
+	// below.
+	sort.Sort(SortedDirEntries[WrappedEntry](wrappedEntries))
+
+	// Fix name conflicts.
+	// When a local file is synced to GCS but not removed from the local file map,
+	// the entries list will have two duplicate entries.
+	// To handle this scenario, we are removing the duplicate entry before
+	// returning the response to kernel.
+	fixedEntries, err := fixConflictingNames(wrappedEntries, wrappedLocalEntries)
+	if err != nil {
+		err = fmt.Errorf("fixConflictingNames: %w", err)
+		return nil, err
+	}
+
+	// Fix up offset fields.
+	for i, fe := range fixedEntries {
+		fe.SetOffset(fuseops.DirOffset(i) + 1)
+	}
+
+	// Unwrap
+	finalEntries := make([]Entry, 0, len(fixedEntries))
+	for _, fe := range fixedEntries {
+		finalEntries = append(finalEntries, unwrap(fe))
+	}
+
+	return finalEntries, nil
 }
 
 // Read all entries for the directory, fix up conflicting names, and fill in
@@ -194,29 +310,10 @@ func readAllEntries(
 		}
 	}
 
-	// Append local file entries (not synced to GCS).
-	for _, localEntry := range localEntries {
-		entries = append(entries, localEntry)
-	}
-
-	// Ensure that the entries are sorted, for use in fixConflictingNames
-	// below.
-	sort.Sort(sortedDirents(entries))
-
-	// Fix name conflicts.
-	// When a local file is synced to GCS but not removed from the local file map,
-	// the entries list will have two duplicate entries.
-	// To handle this scenario, we are removing the duplicate entry before
-	// returning the response to kernel.
-	entries, err = fixConflictingNames(entries, localEntries)
+	// Sort, resolve conflicts, and set offsets.
+	entries, err = sortAndResolveEntries(entries, localEntries, func(e fuseutil.Dirent) *Dirent { return &Dirent{Dirent: e} }, func(w *Dirent) fuseutil.Dirent { return w.Dirent })
 	if err != nil {
-		err = fmt.Errorf("fixConflictingNames: %w", err)
-		return
-	}
-
-	// Fix up offset fields.
-	for i := 0; i < len(entries); i++ {
-		entries[i].Offset = fuseops.DirOffset(i) + 1
+		return nil, err
 	}
 
 	// Return a bogus inode ID for each entry, but not the root inode ID.
@@ -234,6 +331,33 @@ func readAllEntries(
 	// to a local action?
 	for i := range entries {
 		entries[i].Inode = fuseops.RootInodeID + 1
+	}
+
+	return
+}
+
+// readAllEntryCores retrieves all directory entry cores for the given inode,
+// handling pagination and accumulating the results.
+// LOCKS_REQUIRED(in)
+func readAllEntryCores(ctx context.Context, in inode.DirInode) (cores map[inode.Name]*inode.Core, err error) {
+	// Read entries from GCS.
+	// Read one batch at a time.
+	var tok string
+	cores = make(map[inode.Name]*inode.Core)
+	for {
+		// Read a batch from GCS
+		var batch map[inode.Name]*inode.Core
+		batch, tok, err = in.ReadEntryCores(ctx, tok)
+		if err != nil {
+			return
+		}
+		// Accumulate.
+		maps.Copy(cores, batch)
+
+		// Are we done?
+		if tok == "" {
+			break
+		}
 	}
 
 	return
@@ -302,6 +426,74 @@ func (dh *DirHandle) ReadDir(
 	// We copy out entries until we run out of entries or space.
 	for i := index; i < len(dh.entries); i++ {
 		n := fuseutil.WriteDirent(op.Dst[op.BytesRead:], dh.entries[i])
+		if n == 0 {
+			break
+		}
+
+		op.BytesRead += n
+	}
+
+	return
+}
+
+// FetchEntryCores retrieves the core inode data for all entries within the directory from GCS.
+//
+// Special case: If the request offset is zero, it assumes the directory is being read from the
+// beginning and resets the cached list of entries.
+//
+// LOCKS_REQUIRED(dh.Mu)
+// LOCKS_EXCLUDED(dh.in)
+func (dh *DirHandle) FetchEntryCores(ctx context.Context, op *fuseops.ReadDirPlusOp) (cores map[inode.Name]*inode.Core, err error) {
+	// If the request is for offset zero, we assume that either this is the first
+	// call or rewinddir has been called. Reset state.
+	if op.Offset == 0 {
+		dh.entriesPlus = nil
+		dh.entriesPlusValid = false
+	}
+
+	// Do we need to read entries from GCS?
+	if !dh.entriesPlusValid {
+		dh.in.Lock()
+		cores, err = readAllEntryCores(ctx, dh.in)
+		if err != nil {
+			dh.in.Unlock()
+			return
+		}
+		dh.in.Unlock()
+	}
+
+	return
+}
+
+// ReadDirPlus populates the FUSE response buffer using a pre-processed list
+// of directory entries.
+// LOCKS_REQUIRED(dh.Mu)
+// LOCKS_EXCLUDED(dh.in)
+func (dh *DirHandle) ReadDirPlus(op *fuseops.ReadDirPlusOp, entries []fuseutil.DirentPlus, localEntries map[string]fuseutil.DirentPlus) (err error) {
+	// Sort, resolve conflicts, and set offsets.
+	entries, err = sortAndResolveEntries(entries, localEntries, func(e fuseutil.DirentPlus) *DirentPlus { return &DirentPlus{DirentPlus: e} }, func(w *DirentPlus) fuseutil.DirentPlus { return w.DirentPlus })
+	if err != nil {
+		return
+	}
+
+	// If entriesPlus has not been populated yet, populate it.
+	if !dh.entriesPlusValid {
+		// Update state.
+		dh.entriesPlus = entries
+		dh.entriesPlusValid = true
+	}
+
+	// Is the offset past the end of what we have buffered? If so, this must be
+	// an invalid seekdir according to posix.
+	index := int(op.Offset)
+	if index > len(dh.entriesPlus) {
+		err = fuse.EINVAL
+		return
+	}
+
+	//We copy out entries until we run out of entries or space.
+	for i := index; i < len(dh.entriesPlus); i++ {
+		n := fuseutil.WriteDirentPlus(op.Dst[op.BytesRead:], dh.entriesPlus[i])
 		if n == 0 {
 			break
 		}

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -143,18 +143,18 @@ func (t *DirHandleTest) createTestDirentPlus(name string, dtype fuseutil.DirentT
 	}
 }
 
-func (t *DirHandleTest) validateEntryPlus(entry fuseutil.DirentPlus, name string, fileType fuseutil.DirentType, childInodeID fuseops.InodeID) {
-	AssertEq(name, entry.Dirent.Name)
-	AssertEq(fileType, entry.Dirent.Type)
-	AssertEq(childInodeID, entry.Entry.Child)
+func (t *DirHandleTest) validateEntryPlus(entry fuseutil.DirentPlus, expectedName string, expectedType fuseutil.DirentType, expectedChildInodeID fuseops.InodeID) {
+	AssertEq(expectedName, entry.Dirent.Name)
+	AssertEq(expectedType, entry.Dirent.Type)
+	AssertEq(expectedChildInodeID, entry.Entry.Child)
 }
 
-func (t *DirHandleTest) validateCore(core *inode.Core, name string, filetype metadata.Type, minObjectName string) {
+func (t *DirHandleTest) validateCore(core *inode.Core, expectedName string, expectedType metadata.Type, expectedMinObjectName string) {
 	AssertNe(nil, core)
 	AssertNe(nil, core.MinObject)
-	AssertEq(name, path.Base(core.FullName.LocalName()))
-	AssertEq(minObjectName, core.MinObject.Name)
-	AssertEq(filetype, core.Type())
+	AssertEq(expectedName, path.Base(core.FullName.LocalName()))
+	AssertEq(expectedMinObjectName, core.MinObject.Name)
+	AssertEq(expectedType, core.Type())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -340,11 +340,9 @@ func (t *DirHandleTest) ReadAllEntryCoresReturnsAllEntryCores() {
 	// validations
 	AssertEq(nil, err)
 	AssertEq(2, len(cores))
-
 	entry1, ok := cores[inode.NewFileName(t.dh.in.Name(), "gcsObject1")]
 	AssertTrue(ok, "Core for gcsObject1 not found")
 	t.validateCore(entry1, "gcsObject1", metadata.RegularFileType, "testDir/gcsObject1")
-
 	entry2, ok := cores[inode.NewFileName(t.dh.in.Name(), "gcsObject2")]
 	AssertTrue(ok, "Core for gcsObject2 not found")
 	t.validateCore(entry2, "gcsObject2", metadata.RegularFileType, "testDir/gcsObject2")
@@ -362,7 +360,6 @@ func (t *DirHandleTest) FetchEntryCoresFetchesCores() {
 
 	AssertEq(nil, err)
 	AssertEq(1, len(cores))
-
 	entry, ok := cores[inode.NewFileName(t.dh.in.Name(), "testFile")]
 	AssertTrue(ok, "Core for gcsFile1 not found")
 	t.validateCore(entry, "testFile", metadata.RegularFileType, "testDir/testFile")
@@ -394,6 +391,9 @@ func (t *DirHandleTest) FetchEntryCoresNonZeroOffsetFetchesIfCacheInvalid() {
 
 	AssertEq(nil, err)
 	AssertEq(1, len(cores))
+	entry, ok := cores[inode.NewFileName(t.dh.in.Name(), "fetchThis")]
+	AssertTrue(ok, "Core for fetchThis not found")
+	t.validateCore(entry, "fetchThis", metadata.RegularFileType, "testDir/fetchThis")
 }
 
 func (t *DirHandleTest) ReadDirPlusResponseForNoFile() {
@@ -417,7 +417,6 @@ func (t *DirHandleTest) ReadDirPlusSameNameLocalAndGCSFile() {
 	}
 	gcsFile := t.createTestDirentPlus("sameName", fuseutil.DT_File, 1001, 10)
 	localFile := t.createTestDirentPlus("sameName", fuseutil.DT_File, 1002, 0)
-
 	gcsEntriesPlus := []fuseutil.DirentPlus{gcsFile}
 	localFileEntriesPlus := map[string]fuseutil.DirentPlus{"sameName": localFile}
 
@@ -434,7 +433,6 @@ func (t *DirHandleTest) ReadDirPlusSameNameLocalFileAndGCSDirectory() {
 	}
 	gcsDir := t.createTestDirentPlus("sameName", fuseutil.DT_Directory, 1001, 0)
 	gcsEntriesPlus := []fuseutil.DirentPlus{gcsDir}
-
 	localFile := t.createTestDirentPlus("sameName", fuseutil.DT_File, 2001, 20)
 	localFileEntriesPlus := map[string]fuseutil.DirentPlus{"sameName": localFile}
 
@@ -442,7 +440,6 @@ func (t *DirHandleTest) ReadDirPlusSameNameLocalFileAndGCSDirectory() {
 
 	AssertEq(nil, err)
 	AssertEq(2, len(t.dh.entriesPlus))
-
 	t.validateEntryPlus(t.dh.entriesPlus[0], "sameName", fuseutil.DT_Directory, 1001)
 	t.validateEntryPlus(t.dh.entriesPlus[1], "sameName"+inode.ConflictingFileNameSuffix, fuseutil.DT_File, 2001)
 	AssertEq(t.dh.entriesPlus[1].Dirent.Offset, t.dh.entriesPlus[0].Dirent.Offset+1)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -782,6 +782,7 @@ func (d *dirInode) readObjects(
 	return
 }
 
+// LOCKS_REQUIRED(d)
 func (d *dirInode) ReadEntries(
 	ctx context.Context,
 	tok string) (entries []fuseutil.Dirent, newTok string, err error) {
@@ -810,6 +811,7 @@ func (d *dirInode) ReadEntries(
 	return
 }
 
+// LOCKS_REQUIRED(d)
 func (d *dirInode) ReadEntryCores(ctx context.Context, tok string) (cores map[Name]*Core, newTok string, err error) {
 	cores, newTok, err = d.readObjects(ctx, tok)
 	if err != nil {


### PR DESCRIPTION
### Description
This PR supports ReadDirPlus implementation by adding the logic to fetch directory entry cores and populate the FUSE response buffer. To support this new functionality efficiently and avoid code duplication, the underlying directory entry processing logic has been refactored.

Key Changes:
A new FetchEntryCores function has been added to retrieve the core inode data for all entries within a directory from GCS.
The ReadDirPlus method uses this data to populate the response buffer with both the entry names and their attributes.

Refactoring to Avoid Duplication:
A generic DirEntry interface has been introduced to abstract common operations over the different directory entry types (fuseutil.Dirent and fuseutil.DirentPlus).
A generic helper function, resolveAndSortEntries, now centralizes the logic for sorting entries, resolving name conflicts, and setting offsets for both the ReadDir and ReadDirPlus code paths.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - Added comprehensive unit tests in dir_handle_test.go to validate the new ReadDirPlus flow, conflict resolution, and core data fetching logic.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
