### PR TITLE
docs: update troubleshooting doc for exit 1 error

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,11 @@ Try mounting the gcsfuse with `--implicit-dirs` flag. Read the [semantics](https
 
 ### Mount failed with fusermount3 exit status 1
 
-It comes when the bucket is already mounted in a folder, and we try to mount it again. You need to unmount first and then remount.
+- It can come when the bucket is already mounted in a folder, and we try to mount it again. You need to unmount first and then remount.
+- It can also happen if you're trying to mount the bucket on a directory that has read-only permissions. Please provide write permissions to the directory and try mounting it again. You can use the below command to grant write permissions.
+  ```
+    chmod 755 mount_point
+  ```
 
 ### version GLIBC_x.yz not found
 


### PR DESCRIPTION
### Description
```
Error occurred during command execution on gcsfuse/3.1.0 (Go version go1.24.0): daemonize.Run: readFromProcess: sub-process: Error while mounting gcsfuse: mountWithArgs: mountWithStorageHandle: mount: mount: running /usr/bin/fusermount3: exit status 1"}
```

This can happen if you're trying to mount the bucket on a directory that has read-only permissions.

### Link to the issue in case of a bug fix.
[b/430801686](https://b.corp.google.com/issues/430801686)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
