### PR TITLE
CI: Adding minimum threshold for micro benchmark

### DIFF
--- a/perfmetrics/scripts/micro_benchmarks/read_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/read_single_thread.py
@@ -146,5 +146,12 @@ def main():
       workload_type=workflow_type,
   )
 
+  # TODO: Remove this once alerts are configured.
+  bandwidth_mbps = total_bytes / duration / 1000 / 1000
+  # 160 Mbps is the minimum threshold based on the 3-runs average bandwidth
+  if bandwidth_mbps < 160:
+    print(f"Failure: Read bandwidth too low ({bandwidth_mbps} Mbps < 160 Mbps)")
+    sys.exit(1)
+
 if __name__ == "__main__":
   main()

--- a/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
+++ b/perfmetrics/scripts/micro_benchmarks/write_single_thread.py
@@ -132,5 +132,12 @@ def main():
       workload_type=workflow_type,
   )
 
+  # TODO: Remove this once alerts are configured.
+  bandwidth_mbps = total_bytes / duration / 1000 / 1000
+  # 80 Mbps is the minimum threshold based on the 3-runs average bandwidth
+  if bandwidth_mbps < 80:
+    print(f"Failure: Write bandwidth too low ({bandwidth_mbps} Mbps < 80 Mbps)")
+    sys.exit(1)
+
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
### Description
Setting up proper alerts will take time. For now, we'll make temporary changes in the scripts: if the bandwidth drops below a particular threshold, the Kokoro build will fail, which should get the on-duty team's attention.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - Tested
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
