### PR TITLE
feat(inode): Add LocalFileEntriesPlus to DirInode interface

### DIFF
--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -257,7 +257,7 @@ func (d *baseDirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEn
 	return nil
 }
 
-func (d *baseDirInode) LocalFileEntriesPlus(localFileInodes map[Name]Inode) (localEntries map[string]fuseutil.DirentPlus) {
+func (d *baseDirInode) LocalFileEntriesPlus(localFileInodes map[Name]Inode) (localEntriesPlus map[string]fuseutil.DirentPlus) {
 	// Base directory can not contain local files.
 	return nil
 }

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -257,6 +257,11 @@ func (d *baseDirInode) LocalFileEntries(localFileInodes map[Name]Inode) (localEn
 	return nil
 }
 
+func (d *baseDirInode) LocalFileEntriesPlus(localFileInodes map[Name]Inode) (localEntries map[string]fuseutil.DirentPlus) {
+	// Base directory can not contain local files.
+	return nil
+}
+
 func (d *baseDirInode) ShouldInvalidateKernelListCache(ttl time.Duration) bool {
 	// Keeping the default behavior although list operation is not supported
 	// for baseDirInode.

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -263,12 +263,17 @@ func (t *BaseDirTest) TestLocalFileEntriesPlus() {
 	}
 
 	// Call LocalFileEntriesPlus with a non-empty map.
-	result := t.in.LocalFileEntriesPlus(localFileInodes)
+	entries := t.in.LocalFileEntriesPlus(localFileInodes)
 
-	ExpectEq(nil, result)
+	ExpectEq(nil, entries)
+}
 
-	// Also test with a nil map.
-	result = t.in.LocalFileEntriesPlus(nil)
+func (t *BaseDirTest) TestLocalFileEntriesPlusWithNilLocalFileInodes() {
+	// create emptyLocalFileInodes map
+	emptyLocalFileInodes := make(map[Name]Inode)
 
-	ExpectEq(nil, result)
+	// Call LocalFileEntriesPlus with a non-empty map.
+	entries := t.in.LocalFileEntriesPlus(emptyLocalFileInodes)
+
+	ExpectEq(nil, entries)
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -237,17 +237,6 @@ func (t *DirTest) getLocalDirentKey(in Inode) string {
 	return path.Base(in.Name().LocalName())
 }
 
-func (t *DirTest) assertInodeAttributes(expected Inode, actual fuseops.ChildInodeEntry) {
-	AssertEq(expected.ID(), actual.Child)
-
-	attrs, err := expected.Attributes(context.Background(), false)
-
-	AssertEq(nil, err)
-	AssertEq(attrs.Uid, actual.Attributes.Uid)
-	AssertEq(attrs.Gid, actual.Attributes.Gid)
-	AssertEq(attrs.Mode, actual.Attributes.Mode)
-}
-
 func (t *DirTest) validateCore(cores map[Name]*Core, entryName string, isDir bool, expectedType metadata.Type, expectedFullName string) {
 	var name Name
 	if isDir {
@@ -1717,15 +1706,14 @@ func (t *DirTest) LocalFileEntriesPlusWith2LocalChildFiles() {
 	entries := t.in.LocalFileEntriesPlus(localFileInodes)
 
 	AssertEq(2, len(entries))
+	// validate entry for 1_localChild
 	e1 := entries[t.getLocalDirentKey(in1)]
 	AssertEq("1_localChild", e1.Dirent.Name)
 	AssertEq(fuseutil.DT_File, e1.Dirent.Type)
-	t.assertInodeAttributes(in1, e1.Entry)
-
+	// validate entry for 2_localChild
 	e2 := entries[t.getLocalDirentKey(in2)]
 	AssertEq("2_localChild", e2.Dirent.Name)
 	AssertEq(fuseutil.DT_File, e2.Dirent.Type)
-	t.assertInodeAttributes(in2, e2.Entry)
 }
 
 func (t *DirTest) LocalFileEntriesPlusWithNoLocalChildFiles() {
@@ -1759,7 +1747,6 @@ func (t *DirTest) LocalFileEntriesPlusWithUnlinkedLocalChildFiles() {
 	AssertEq(1, len(entries))
 	entry := entries[t.getLocalDirentKey(in1)]
 	AssertEq("linked_child", entry.Dirent.Name)
-	t.assertInodeAttributes(in1, entry.Entry)
 }
 
 func (t *DirTest) Test_ShouldInvalidateKernelListCache_ListingNotHappenedYet() {


### PR DESCRIPTION
**Please ensure your PR title follows the format:**
```
type(scope): subject
```
Example:
feat(api): add user login endpoint

### Description
This change introduces a new method, LocalFileEntriesPlus to the DirInode interface and its implementations (dirInode and baseDirInode).

The LocalFileEntriesPlus method returns local file entries as map[string]fuseutil.DirentPlus 

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - Added unit tests for dirInode and baseDirInode to verify the correct behavior of LocalFileEntriesPlus.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
