### PR TITLE
refactor(block-pool): deleting the FreeBlocksChannel() method of block-pool

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -108,11 +108,6 @@ func (bp *BlockPool) canAllocateBlock() bool {
 	return semAcquired
 }
 
-// FreeBlocksChannel returns the freeBlocksCh being used by the block pool.
-func (bp *BlockPool) FreeBlocksChannel() chan Block {
-	return bp.freeBlocksCh
-}
-
 // Release puts the block back into the free blocks channel for reuse.
 func (bp *BlockPool) Release(b Block) {
 	select {

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -300,18 +300,6 @@ func (t *BlockPoolTest) validateGetBlockIsNotBlocked(bp *BlockPool) Block {
 	}
 }
 
-func (t *BlockPoolTest) TestFreeBlocksChannel() {
-	freeBlocksCh := make(chan Block)
-	bp := &BlockPool{
-		freeBlocksCh: freeBlocksCh,
-	}
-
-	ch := bp.FreeBlocksChannel()
-
-	assert.NotNil(t.T(), ch)
-	assert.Equal(t.T(), freeBlocksCh, ch)
-}
-
 func (t *BlockPoolTest) TestCanAllocateBlock() {
 	tests := []struct {
 		name        string

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -227,7 +227,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 	assert.NotNil(testSuite.T(), obj)
 	assert.Equal(testSuite.T(), uint64(2), obj.Size)
 	// Validate that all blocks have been freed up.
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
@@ -293,7 +293,7 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	assert.NoError(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 	assert.Nil(testSuite.T(), o)
 }
 
@@ -341,7 +341,7 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			// Current block should also be uploaded.
 			assert.Nil(testSuite.T(), bwhImpl.current)
 			assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-			assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+			assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 			// Read the object from back door.
 			content, err := storageutil.ReadObject(context.Background(), bwhImpl.uploadHandler.bucket, bwhImpl.uploadHandler.objectName)
 			if tc.bucketType.Zonal {
@@ -452,7 +452,7 @@ func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 
 	require.Nil(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
 }
 
@@ -462,7 +462,7 @@ func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	assert.Nil(testSuite.T(), bwhImpl.uploadHandler.cancelFunc)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 }
 
 func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
@@ -481,7 +481,7 @@ func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
 
 	assert.True(testSuite.T(), cancelCalled)
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
-	assert.Equal(testSuite.T(), 0, len(bwhImpl.blockPool.FreeBlocksChannel()))
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 }
 
 func (testSuite *BufferedWriteTest) TestReFlushAfterUploadFails() {


### PR DESCRIPTION
### Description
- Follow up on this PR: https://github.com/GoogleCloudPlatform/gcsfuse/pull/3475
- Deleting the unused method FreeBlocksChannel() of block-pool. Replaced that with Release() to free the used block.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - Automation
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
