### PR TITLE
docs(troubleshooting): Update troubleshooting doc for unsupported objects

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,10 +111,10 @@ Unable to list unsupported objects in a mounted bucket, i.e. objects which have 
 
 This error can be mitigated in one of the following two ways.
 
-* move/rename such objects e.g. for object of name like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or 
-* delete such objects it e.g. for objects of name like `A//B`, use `gcloud storage rm -r A//`
+* Move/Rename such objects e.g. for object of names like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), Or
+* Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm -r A//`.
 
-. Refer [semantics](semantics.md#unsupported-object-names) for more details.
+Refer [semantics](semantics.md#unsupported-object-names) for more details.
 
 ### Experiencing hang while executing "ls" on a directory containing large number of files/directories.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,8 +106,7 @@ Unable to mount with the following error `daemonize.Run: readFromProcess: sub-pr
 Fuse package is not installed. It may throw this error. Run the following command to install fuse <br/> <code> sudo apt-get install fuse </code> for Debian/Ubuntu <br/> <code> sudo yum install fuse </code> for RHEL/CentOs/Rocky <br/>
 
 ### Encountered unsupported prefixes during listing, or ls: reading directory \<mountpath>/\<path>:  Input/output error
-
-Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -r gs://<bucket>/**//**`.
+Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud storage ls gs://<bucket>/**//**`.
 
 This error can be mitigated in one of the following two ways.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,9 +105,10 @@ Unable to mount with the following error `daemonize.Run: readFromProcess: sub-pr
 
 Fuse package is not installed. It may throw this error. Run the following command to install fuse <br/> <code> sudo apt-get install fuse </code> for Debian/Ubuntu <br/> <code> sudo yum install fuse </code> for RHEL/CentOs/Rocky <br/>
 
-### ls: reading directory \<mountpath>/\<path>:  Input/output error
+### Encountered unsupported prefixes during listing, or ls: reading directory \<mountpath>/\<path>:  Input/output error
 
-Find out if you have any object(s) with name/prefix having `//` in it or starting with `/`, in the mounted GCS bucket (use `gsutil ls gs://<bucket>/<path>` to find out). If yes, move/rename such objects to name/prefix not having `//` or starting with `/` (e.g. for object/prefix `A//B`, use `gsutil -m mv -r gs://<bucket>/A//* gs://<bucket>/A/`), or delete it (use `gsutil -m rm -r A//`). Refer [semantics](semantics.md#unsupported-object-names) for more details.
+Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -l -r gs://<bucket>/**//**`.
+To ignore this error, move/rename such objects e.g. for object/prefix `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or delete it (use `gcloud storagerm -r A//`. Refer [semantics](semantics.md#unsupported-object-names) for more details.
 
 ### Experiencing hang while executing "ls" on a directory containing large number of files/directories.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,7 +111,7 @@ Unable to list unsupported objects in a mounted bucket, i.e. objects which have 
 
 This error can be mitigated in one of the following two ways.
 
-* Move/Rename such objects e.g. for object of names like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), Or
+* Move/Rename such objects e.g. for objects of names like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), Or
 * Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm -r A//`.
 
 Refer [semantics](semantics.md#unsupported-object-names) for more details.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,7 +111,7 @@ Unable to list unsupported objects in a mounted bucket, i.e. objects which have 
 This error can be mitigated in one of the following two ways.
 
 * Move/Rename such objects e.g. for objects of names like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), Or
-* Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm -r A//`.
+* Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm gs://A//**`.
 
 Refer [semantics](semantics.md#unsupported-object-names) for more details.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,7 +111,7 @@ Unable to list unsupported objects in a mounted bucket, i.e. objects which have 
 This error can be mitigated in one of the following two ways.
 
 * Move/Rename such objects e.g. for objects of names like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), Or
-* Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm gs://A//**`.
+* Delete such objects e.g. for objects of names like `A//B`, use `gcloud storage rm gs://<bucket>/A//**`.
 
 Refer [semantics](semantics.md#unsupported-object-names) for more details.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,7 +107,7 @@ Fuse package is not installed. It may throw this error. Run the following comman
 
 ### Encountered unsupported prefixes during listing, or ls: reading directory \<mountpath>/\<path>:  Input/output error
 
-Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -l -r gs://<bucket>/**//**`.
+Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -r gs://<bucket>/**//**`.
 
 This error can be mitigated in one of the following two ways.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,7 +108,7 @@ Fuse package is not installed. It may throw this error. Run the following comman
 ### Encountered unsupported prefixes during listing, or ls: reading directory \<mountpath>/\<path>:  Input/output error
 
 Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -l -r gs://<bucket>/**//**`.
-To ignore this error, move/rename such objects e.g. for object/prefix `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or delete it (use `gcloud storagerm -r A//`. Refer [semantics](semantics.md#unsupported-object-names) for more details.
+To suppress this error, move/rename such objects e.g. for object/prefix `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or delete it (use `gcloud storage rm -r A//`. Refer [semantics](semantics.md#unsupported-object-names) for more details.
 
 ### Experiencing hang while executing "ls" on a directory containing large number of files/directories.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,7 +108,13 @@ Fuse package is not installed. It may throw this error. Run the following comman
 ### Encountered unsupported prefixes during listing, or ls: reading directory \<mountpath>/\<path>:  Input/output error
 
 Unable to list unsupported objects in a mounted bucket, i.e. objects which have names with `//` in them or have names starting with `/` e.g. `gs://<bucket>//A` or `gs://<bucket>/A//B` etc. Such objects can be listed by the following command: `gcloud ls -l -r gs://<bucket>/**//**`.
-To suppress this error, move/rename such objects e.g. for object/prefix `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or delete it (use `gcloud storage rm -r A//`. Refer [semantics](semantics.md#unsupported-object-names) for more details.
+
+This error can be mitigated in one of the following two ways.
+
+* move/rename such objects e.g. for object of name like `A//B`, use `gcloud storage mv gs://<bucket>/A//* gs://<bucket>/A/`), or 
+* delete such objects it e.g. for objects of name like `A//B`, use `gcloud storage rm -r A//`
+
+. Refer [semantics](semantics.md#unsupported-object-names) for more details.
 
 ### Experiencing hang while executing "ls" on a directory containing large number of files/directories.
 


### PR DESCRIPTION
### Description
This adds a more clear identifier error log, diagnosis and mitigation for unsupported GCS objects in a
gcsfuse mounted bucket.

### Link to the issue in case of a bug fix.
[b/431536850](http://b/431536850)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
