### PR TITLE
ci: Upgrade to python311 in micro benchmark script

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
@@ -27,16 +27,11 @@ commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 
 cd "./perfmetrics/scripts/micro_benchmarks"
 
-echo "Install latest python3.11"
-sudo apt update
-sudo apt install software-properties-commo
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt update
-sudo apt install python3.11
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+echo "Upgrade python3 version"
+./perfmetrics/scripts/upgrade_python3.sh
 
 echo "Installing dependencies..."
-python3.11 -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 
@@ -48,13 +43,13 @@ echo "Running Python scripts for hns bucket..."
 FILE_SIZE_READ_GB=15
 READ_LOG_FILE="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-single-threaded-read-${FILE_SIZE_READ_GB}gb-test.txt"
 GCSFUSE_READ_FLAGS="--log-file $READ_LOG_FILE"
-python3.11 read_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_READ_FLAGS" --total-files 10 --file-size-gb "$FILE_SIZE_READ_GB"
+python3 read_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_READ_FLAGS" --total-files 10 --file-size-gb "$FILE_SIZE_READ_GB"
 exit_read_code=$?
 
 FILE_SIZE_WRITE_GB=15
 WRITE_LOG_FILE="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-single-threaded-write-${FILE_SIZE_WRITE_GB}gb-test.txt"
 GCSFUSE_WRITE_FLAGS="--log-file $WRITE_LOG_FILE"
-python3.11 write_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_WRITE_FLAGS" --total-files 1 --file-size-gb "$FILE_SIZE_WRITE_GB"
+python3 write_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_WRITE_FLAGS" --total-files 1 --file-size-gb "$FILE_SIZE_WRITE_GB"
 exit_write_code=$?
 
 deactivate

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
@@ -27,8 +27,16 @@ commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 
 cd "./perfmetrics/scripts/micro_benchmarks"
 
+echo "Install latest python3.11"
+sudo apt update
+sudo apt install software-properties-commo
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.11
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
 echo "Installing dependencies..."
-python3 -m venv venv
+python3.11 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 
@@ -40,13 +48,13 @@ echo "Running Python scripts for hns bucket..."
 FILE_SIZE_READ_GB=15
 READ_LOG_FILE="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-single-threaded-read-${FILE_SIZE_READ_GB}gb-test.txt"
 GCSFUSE_READ_FLAGS="--log-file $READ_LOG_FILE"
-python3 read_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_READ_FLAGS" --total-files 10 --file-size-gb "$FILE_SIZE_READ_GB"
+python3.11 read_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_READ_FLAGS" --total-files 10 --file-size-gb "$FILE_SIZE_READ_GB"
 exit_read_code=$?
 
 FILE_SIZE_WRITE_GB=15
 WRITE_LOG_FILE="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-single-threaded-write-${FILE_SIZE_WRITE_GB}gb-test.txt"
 GCSFUSE_WRITE_FLAGS="--log-file $WRITE_LOG_FILE"
-python3 write_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_WRITE_FLAGS" --total-files 1 --file-size-gb "$FILE_SIZE_WRITE_GB"
+python3.11 write_single_thread.py --bucket single-threaded-tests --gcsfuse-config "$GCSFUSE_WRITE_FLAGS" --total-files 1 --file-size-gb "$FILE_SIZE_WRITE_GB"
 exit_write_code=$?
 
 deactivate

--- a/perfmetrics/scripts/upgrade_python3.sh
+++ b/perfmetrics/scripts/upgrade_python3.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+set -e
+
+PYTHON_VERSION=3.11.9
+INSTALL_PREFIX="/usr/local"
+
+# Install dependencies silently
+sudo apt update > /dev/null
+sudo apt install -y \
+  build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
+  libssl-dev libreadline-dev libffi-dev curl libsqlite3-dev \
+  libbz2-dev liblzma-dev tk-dev uuid-dev wget > /dev/null
+
+# Download Python source silently
+cd /usr/src
+sudo wget -q https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+sudo tar -xf Python-${PYTHON_VERSION}.tgz > /dev/null
+cd Python-${PYTHON_VERSION}
+
+# Configure silently
+sudo ./configure --enable-optimizations --prefix=$INSTALL_PREFIX > /dev/null
+
+# Build silently
+sudo make -j"$(nproc)" > /dev/null
+
+# Install silently
+sudo make altinstall > /dev/null
+
+# Install pip silently
+sudo $INSTALL_PREFIX/bin/python3.11 -m ensurepip > /dev/null
+sudo $INSTALL_PREFIX/bin/python3.11 -m pip install --upgrade pip > /dev/null
+
+# Remove old alternatives silently
+sudo update-alternatives --remove-all python3 > /dev/null 2>&1 || true
+sudo update-alternatives --remove-all pip3 > /dev/null 2>&1 || true
+
+# Register Python 3.11 as alternative silently
+sudo update-alternatives --install /usr/bin/python3 python3 $INSTALL_PREFIX/bin/python3.11 1 > /dev/null
+sudo update-alternatives --install /usr/bin/pip3 pip3 $INSTALL_PREFIX/bin/pip3.11 1 > /dev/null
+
+# Set Python 3.11 as default silently
+sudo update-alternatives --set python3 $INSTALL_PREFIX/bin/python3.11 > /dev/null
+sudo update-alternatives --set pip3 $INSTALL_PREFIX/bin/pip3.11 > /dev/null
+
+# Final version check (visible)
+python3 --version
+pip3 --version


### PR DESCRIPTION
### Description
Micro benchmark build is failing because kokoro has some older python version but it requires latest one.

### Link to the issue in case of a bug fix.
[b/431566452](https://b.corp.google.com/issues/431566452)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
