### PR TITLE
feat(Readdirplus): Implement ReadDirPlus operation

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2022,17 +2022,17 @@ func (fs *fileSystem) CreateSymlink(
 
 // LOCKS_EXCLUDED(fs.mu)
 func (fs *fileSystem) RmDir(
-// When rm -r or os.RemoveAll call is made, the following calls are made in order
-//	 1. RmDir (only in the case of os.RemoveAll)
-//	 2. Unlink all nested files,
-//	 3. lookupInode call on implicit directory
-//	 4. Rmdir on the directory.
-//
-// When type cache ttl is set, we construct an implicitDir even though one doesn't
-// exist on GCS (https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/fs/inode/dir.go#L452),
-// and thus, we get rmDir call to GCSFuse.
-// Whereas when ttl is zero, lookupInode call itself fails and RmDir is not called
-// because object is not present in GCS.
+	// When rm -r or os.RemoveAll call is made, the following calls are made in order
+	//	 1. RmDir (only in the case of os.RemoveAll)
+	//	 2. Unlink all nested files,
+	//	 3. lookupInode call on implicit directory
+	//	 4. Rmdir on the directory.
+	//
+	// When type cache ttl is set, we construct an implicitDir even though one doesn't
+	// exist on GCS (https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/internal/fs/inode/dir.go#L452),
+	// and thus, we get rmDir call to GCSFuse.
+	// Whereas when ttl is zero, lookupInode call itself fails and RmDir is not called
+	// because object is not present in GCS.
 
 	ctx context.Context,
 	op *fuseops.RmDirOp) (err error) {
@@ -2546,7 +2546,7 @@ func (fs *fileSystem) Unlink(
 	err = parent.DeleteChildFile(
 		ctx,
 		op.Name,
-		0, // Latest generation
+		0,   // Latest generation
 		nil) // No meta-generation precondition
 
 	if err != nil {

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests to check Readdirplus operation.
+package fs_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/jacobsa/fuse/fusetesting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+////////////////////////////////////////////////////////////////////////
+// ReadDirPlusTest
+////////////////////////////////////////////////////////////////////////
+
+type ReadDirPlusTest struct {
+	suite.Suite
+	fsTest
+}
+
+func TestReadDirPlusTestSuite(t *testing.T) {
+	suite.Run(t, new(ReadDirPlusTest))
+}
+
+func (t *ReadDirPlusTest) SetupSuite() {
+	t.mountCfg.EnableReaddirplus = true
+	t.serverCfg.ImplicitDirectories = true
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *ReadDirPlusTest) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func (t *ReadDirPlusTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func (t *ReadDirPlusTest) TestEmptyDirectory() {
+	entries, err := fusetesting.ReadDirPlusPicky(mntDir)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 0, len(entries))
+}
+
+func (t *ReadDirPlusTest) TestDirectoryWithVariousEntryTypes() {
+	// Set up contents.
+	assert.Nil(t.T(), t.createObjects(
+		map[string]string{
+			"file.txt":          "taco",
+			"dir/":              "",
+			"dir/baz":           "burrito",
+			"implicit/file.txt": "content",
+		}))
+	// Set up a symlink.
+	err := os.Symlink("file.txt", path.Join(mntDir, "symlink_to_file"))
+	assert.Nil(t.T(), err)
+	expectedEntries := []string{
+		"dir",
+		"file.txt",
+		"implicit",
+		"symlink_to_file",
+	}
+
+	// Read the directory.
+	entries, err := fusetesting.ReadDirPlusPicky(mntDir)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), len(expectedEntries), len(entries))
+	// Check entries.
+	for i, entry := range entries {
+		assert.Equal(t.T(), expectedEntries[i], entry.Name())
+
+		switch entry.Name() {
+		case "file.txt":
+			assert.False(t.T(), entry.IsDir())
+			assert.Equal(t.T(), int64(len("taco")), entry.Size())
+			assert.Equal(t.T(), filePerms, entry.Mode())
+		case "dir":
+			assert.True(t.T(), entry.IsDir())
+			assert.Equal(t.T(), dirPerms|os.ModeDir, entry.Mode())
+		case "implicit":
+			assert.True(t.T(), entry.IsDir())
+			assert.Equal(t.T(), dirPerms|os.ModeDir, entry.Mode())
+		case "symlink_to_file":
+			assert.False(t.T(), entry.IsDir())
+			assert.Equal(t.T(), os.ModeSymlink, entry.Mode()&os.ModeType)
+		default:
+			assert.FailNow(t.T(), "unexpected entry: %s", entry.Name())
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////
+// LocalFileEntriesReadDirPlusTest
+////////////////////////////////////////////////////////////////////////
+
+type LocalFileEntriesReadDirPlusTest struct {
+	suite.Suite
+	fsTest
+}
+
+func TestLocalFileEntriesReadDirPlusTestSuite(t *testing.T) {
+	suite.Run(t, new(LocalFileEntriesReadDirPlusTest))
+}
+
+func (t *LocalFileEntriesReadDirPlusTest) SetupSuite() {
+	t.mountCfg.EnableReaddirplus = true
+	t.serverCfg.InodeAttributeCacheTTL = 60 * time.Second
+	t.serverCfg.NewConfig = &cfg.Config{
+		Write: cfg.WriteConfig{
+			CreateEmptyFile: false,
+		}}
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *LocalFileEntriesReadDirPlusTest) TearDownTest() {
+	fmt.Println("done")
+	t.fsTest.TearDown()
+}
+
+func (t *LocalFileEntriesReadDirPlusTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func (t *LocalFileEntriesReadDirPlusTest) TestDirectoryWithLocalFile() {
+	// Create a local file that is not yet synced to GCS.
+	f, err := os.Create(path.Join(mntDir, "local_file"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	// Read the directory.
+	entries, err := fusetesting.ReadDirPlusPicky(mntDir)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 1, len(entries))
+	// Check the entry for the local file.
+	entry := entries[0]
+	assert.Equal(t.T(), "local_file", entry.Name())
+	assert.False(t.T(), entry.IsDir())
+	assert.Equal(t.T(), filePerms, entry.Mode())
+}
+
+func (t *LocalFileEntriesReadDirPlusTest) TestDirWithOneLocalAndOneGCSEntry() {
+	// Create a remote object on GCS
+	assert.Nil(t.T(), t.createObjects(map[string]string{"gcs_file": "content"}))
+	// Create a local-only file
+	f, err := os.Create(path.Join(mntDir, "local_file"))
+	assert.Nil(t.T(), err)
+	defer f.Close()
+
+	// Read the directory
+	entries, err := fusetesting.ReadDirPlusPicky(mntDir)
+
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), 2, len(entries))
+	assert.Equal(t.T(), "gcs_file", entries[0].Name())
+	assert.False(t.T(), entries[0].IsDir())
+	assert.Equal(t.T(), int64(len("content")), entries[0].Size())
+	assert.Equal(t.T(), "local_file", entries[1].Name())
+	assert.False(t.T(), entries[1].IsDir())
+}

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/jacobsa/fuse/fusetesting"
@@ -125,7 +124,6 @@ func TestLocalFileEntriesReadDirPlusTestSuite(t *testing.T) {
 
 func (t *LocalFileEntriesReadDirPlusTest) SetupSuite() {
 	t.mountCfg.EnableReaddirplus = true
-	t.serverCfg.InodeAttributeCacheTTL = 60 * time.Second
 	t.serverCfg.NewConfig = &cfg.Config{
 		Write: cfg.WriteConfig{
 			CreateEmptyFile: false,

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -87,7 +87,6 @@ func (t *ReadDirPlusTest) TestDirectoryWithVariousEntryTypes() {
 	// Check entries.
 	for i, entry := range entries {
 		assert.Equal(t.T(), expectedEntries[i], entry.Name())
-
 		switch entry.Name() {
 		case "file.txt":
 			assert.False(t.T(), entry.IsDir())

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -16,7 +16,6 @@
 package fs_test
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -132,7 +131,6 @@ func (t *LocalFileEntriesReadDirPlusTest) SetupSuite() {
 }
 
 func (t *LocalFileEntriesReadDirPlusTest) TearDownTest() {
-	fmt.Println("done")
 	t.fsTest.TearDown()
 }
 


### PR DESCRIPTION
### Description
This PR implements the `ReadDirPlus` operation. 

The implementation includes:
The implementation includes:
- The `ReadDirPlus` method in `internal/fs/fs.go`.
- Three new helper functions:
    - `coreToDirentPlus`: Creates a `fuseutil.DirentPlus` entry from an inode core.
    - `localFileEntriesPlus`: Lists local files that are not yet present on GCS.
    - `lookupAndFetchAttributesForLocalFileEntriesPlus`: Performs a lookup and fetches attributes for each local file entry.


This feature is controlled by a new `EnableReaddirplus` mount option and is disabled by default.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/423824641

### Testing details
1. Manual - NA
2. Unit tests -  Added fs test `internal/fs/read_dir_plus_test.go` to cover various scenarios:
     - Reading an empty directory (`TestEmptyDirectory`).
    - Reading a directory with various GCS entry types, including files, explicit and implicit directories, and symlinks (`TestDirectoryWithVariousEntryTypes`).
    - Reading a directory containing a single local-only (unsynced) file (`TestDirectoryWithLocalFile`).
    - Reading a directory with both a GCS-backed file and a local-only file (`TestDirWithOneLocalAndOneGCSEntry`).
3. Integration tests - Will be added in a seperate PR.

### Any backward incompatible change? If so, please explain.
