### PR TITLE
chore: Pass grpc log env variables to gcsfuse daemon

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -284,7 +284,8 @@ func forwardedEnvVars() []string {
 	// also be included to know for which hosts the use of proxies
 	// should be ignored.
 	// Forward GCE_METADATA_HOST, GCE_METADATA_ROOT, GCE_METADATA_IP as these are used for mocked metadata services.
-	for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP"} {
+	// Forward GRPC_GO_LOG_VERBOSITY_LEVEL and GRPC_GO_LOG_SEVERITY_LEVEL as these are used to enable grpc debug logs.
+	for _, envvar := range []string{"GOOGLE_APPLICATION_CREDENTIALS", "no_proxy", "GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP", "GRPC_GO_LOG_VERBOSITY_LEVEL", "GRPC_GO_LOG_SEVERITY_LEVEL"} {
 		if envval, ok := os.LookupEnv(envvar); ok {
 			env = append(env, fmt.Sprintf("%s=%s", envvar, envval))
 			fmt.Fprintf(

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -282,6 +282,9 @@ func (t *MainTest) TestForwardedEnvVars() {
 		expectedForwardedEnvVars: []string{"GOOGLE_APPLICATION_CREDENTIALS=goog-app-cred"},
 	}, {
 		expectedForwardedEnvVars: []string{"GCSFUSE_IN_BACKGROUND_MODE=true"},
+	}, {
+		inputEnvVars:             map[string]string{"GRPC_GO_LOG_VERBOSITY_LEVEL": "99", "GRPC_GO_LOG_SEVERITY_LEVEL": "INFO"},
+		expectedForwardedEnvVars: []string{"GRPC_GO_LOG_VERBOSITY_LEVEL=99", "GRPC_GO_LOG_SEVERITY_LEVEL=INFO"},
 	},
 	} {
 		for envvar, envval := range input.inputEnvVars {

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -266,22 +266,26 @@ func (t *MainTest) TestIsDynamicMount() {
 
 func (t *MainTest) TestForwardedEnvVars() {
 	for _, input := range []struct {
-		inputEnvVars             map[string]string
-		expectedForwardedEnvVars []string
+		inputEnvVars                   map[string]string
+		expectedForwardedEnvVars       []string
+		unexpectedForwardedEnvVarNames []string
 	}{{
 		inputEnvVars:             map[string]string{"GCE_METADATA_HOST": "www.metadata-host.com", "GCE_METADATA_ROOT": "metadata-root", "GCE_METADATA_IP": "99.100.101.102"},
 		expectedForwardedEnvVars: []string{"GCE_METADATA_HOST=www.metadata-host.com", "GCE_METADATA_ROOT=metadata-root", "GCE_METADATA_IP=99.100.101.102"},
 	}, {
-		inputEnvVars:             map[string]string{"https_proxy": "https-proxy-123", "http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
-		expectedForwardedEnvVars: []string{"https_proxy=https-proxy-123", "no_proxy=no-proxy-123"},
+		inputEnvVars:                   map[string]string{"https_proxy": "https-proxy-123", "http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
+		expectedForwardedEnvVars:       []string{"https_proxy=https-proxy-123", "no_proxy=no-proxy-123"},
+		unexpectedForwardedEnvVarNames: []string{"http_proxy"},
 	}, {
-		inputEnvVars:             map[string]string{"http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
-		expectedForwardedEnvVars: []string{"http_proxy=http-proxy-123", "no_proxy=no-proxy-123"},
+		inputEnvVars:                   map[string]string{"http_proxy": "http-proxy-123", "no_proxy": "no-proxy-123"},
+		expectedForwardedEnvVars:       []string{"http_proxy=http-proxy-123", "no_proxy=no-proxy-123"},
+		unexpectedForwardedEnvVarNames: []string{"https_proxy"},
 	}, {
 		inputEnvVars:             map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": "goog-app-cred"},
 		expectedForwardedEnvVars: []string{"GOOGLE_APPLICATION_CREDENTIALS=goog-app-cred"},
 	}, {
-		expectedForwardedEnvVars: []string{"GCSFUSE_IN_BACKGROUND_MODE=true"},
+		expectedForwardedEnvVars:       []string{"GCSFUSE_IN_BACKGROUND_MODE=true"},
+		unexpectedForwardedEnvVarNames: []string{"GRPC_GO_LOG_VERBOSITY_LEVEL", "GRPC_GO_LOG_SEVERITY_LEVEL", "GCE_METADATA_HOST", "GCE_METADATA_IP", "GCE_METADATA_ROOT", "http_proxy", "https_proxy", "no_proxy", "GOOGLE_APPLICATION_CREDENTIALS"},
 	}, {
 		inputEnvVars:             map[string]string{"GRPC_GO_LOG_VERBOSITY_LEVEL": "99", "GRPC_GO_LOG_SEVERITY_LEVEL": "INFO"},
 		expectedForwardedEnvVars: []string{"GRPC_GO_LOG_VERBOSITY_LEVEL=99", "GRPC_GO_LOG_SEVERITY_LEVEL=INFO"},
@@ -290,8 +294,15 @@ func (t *MainTest) TestForwardedEnvVars() {
 		for envvar, envval := range input.inputEnvVars {
 			os.Setenv(envvar, envval)
 		}
+
 		forwardedEnvVars := forwardedEnvVars()
+
 		assert.Subset(t.T(), forwardedEnvVars, input.expectedForwardedEnvVars)
+		for _, forwardedEnvVar := range forwardedEnvVars {
+			forwardedEnvVarName, _, ok := strings.Cut(forwardedEnvVar, "=")
+			assert.True(t.T(), ok)
+			assert.NotContains(t.T(), input.unexpectedForwardedEnvVarNames, forwardedEnvVarName)
+		}
 		assert.Contains(t.T(), forwardedEnvVars, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 		for envvar := range input.inputEnvVars {
 			os.Unsetenv(envvar)


### PR DESCRIPTION
### Description
 - Forward environment variables GRPC_GO_LOG_VERBOSITY_LEVEL and GRPC_GO_LOG_SEVERITY_LEVEL to gcsfuse daemon for background run. This is needed for debugging errors coming from grpc.
 - This doesn't set these variables by default, only forwards them to the daemon, if they have been passed by the user to the gcsfuse command.

### Link to the issue in case of a bug fix.
[b/412688930](http://b/412688930#comment51)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as [presubmit](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/9ffe5e01-e9f6-44e1-9c1c-bdafccf5379b/summary) .

### Any backward incompatible change? If so, please explain.
