### PR TITLE
ci: Add missing dependency for micro benchmarks failing on kokoro machine

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/micro_benchmarks/build.sh
@@ -58,14 +58,20 @@ deactivate
 set -e
 
 # Final result
+exit_code=0
 if [[ $exit_read_code -ne 0 ]]; then
   echo "Read benchmark failed with exit code $exit_read_code"
-  exit $exit_read_code
+  exit_code=$exit_read_code
 fi
 
 if [[ $exit_write_code -ne 0 ]]; then
   echo "Write benchmark failed with exit code $exit_write_code"
-  exit $exit_write_code
+  exit_code=$exit_write_code
+fi
+
+if [[ $exit_code != 0 ]]; then
+  echo "Benchmarks failed."
+  exit $exit_code
 fi
 
 echo "Benchmarks completed successfully."

--- a/perfmetrics/scripts/micro_benchmarks/requirements.txt
+++ b/perfmetrics/scripts/micro_benchmarks/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-storage
 pyarrow
 pandas_gbq
 google-crc32c
+psutil


### PR DESCRIPTION
### Description
Some of the dependency are missing on kokoro machine, causing failure in execution.  Also fix exit code logic in case both (Read and write) tests will fail.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - Tested on kokoro machine
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
