### PR TITLE
refactor(formatting): Disable goimports in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ generate:
 	go generate ./...
 
 imports: generate
-	goimports -w .
+	
 
 fmt: imports
 	go mod tidy && go fmt ./...


### PR DESCRIPTION
### Description
goimports currently is leading to a lot of churn in the GCSFuse codebase. Disabling it until we know the root-cause.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
