### PR TITLE
feat(Readdirplus): Integrate readdirplus with flag

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -172,6 +172,9 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		EnableParallelDirOps: !(newConfig.FileSystem.DisableParallelDirops),
 		// We disable write-back cache when streaming writes are enabled.
 		DisableWritebackCaching: newConfig.Write.EnableStreamingWrites,
+		// Enables ReadDirPlus, allowing the kernel to retrieve directory entries and their
+		// attributes in a single operation.
+		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
 	}
 
 	// GCSFuse to Jacobsa Fuse Log Level mapping:

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -114,3 +114,37 @@ func TestGetFuseMountConfig_LoggerInitializationInFuse(t *testing.T) {
 		assert.Equal(t, tc.shouldInitializeTrace, fuseMountCfg.DebugLogger != nil)
 	}
 }
+
+func TestGetFuseMountConfig_EnableReaddirplus(t *testing.T) {
+	testCases := []struct {
+		name              string
+		enableReaddirplus bool
+		expectedValue     bool
+	}{
+		{
+			name:              "ExperimentalEnableReaddirplusFlagFalse",
+			enableReaddirplus: false,
+			expectedValue:     false,
+		},
+		{
+			name:              "ExperimentalEnableReaddirplusFlagTrue",
+			enableReaddirplus: true,
+			expectedValue:     true,
+		},
+	}
+
+	fsName := "mybucket"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			newConfig := &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					ExperimentalEnableReaddirplus: tc.enableReaddirplus,
+				},
+			}
+
+			fuseMountCfg := getFuseMountConfig(fsName, newConfig)
+
+			assert.Equal(t, tc.expectedValue, fuseMountCfg.EnableReaddirplus)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This PR integrates the --experimental-enable-readdirplus flag to activate the ReaddirPlus functionality.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - Mounted a GCS bucket using the --experimental-enable-readdirplus flag to verify that ReadDirPlus is being called.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
