### PR TITLE
feat(entry-timeout): Set EntryExpiration for dentry caching

### DIFF
--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -43,7 +43,7 @@ func TestReadDirPlusTestSuite(t *testing.T) {
 func (t *ReadDirPlusTest) SetupSuite() {
 	t.mountCfg.EnableReaddirplus = true
 	t.serverCfg.ImplicitDirectories = true
-	t.serverCfg.InodeAttributeCacheTTL = 60 * time.Second
+	t.serverCfg.InodeAttributeCacheTTL = 5 * time.Second
 	t.serverCfg.NewConfig = &cfg.Config{
 		FileSystem: cfg.FileSystemConfig{
 			ExperimentalEnableDentryCache: true,
@@ -112,6 +112,39 @@ func (t *ReadDirPlusTest) TestDirectoryWithVariousEntryTypes() {
 			assert.FailNow(t.T(), "unexpected entry: %s", entry.Name())
 		}
 	}
+}
+
+// Test that stat after Readdirplus return the same attributes as Readdirplus even if data on GCS has changed
+func (t *ReadDirPlusTest) TestStatAfterReaddirplus() {
+	// Set up contents.
+	testFileName := "file.txt"
+	filePath := path.Join(mntDir, testFileName)
+	initialContent := generateRandomString(10)
+	updatedContent := generateRandomString(5)
+	assert.Nil(t.T(), t.createObjects(map[string]string{testFileName: initialContent}))
+
+	// Read the directory with Readdirplus.
+	_, _ = fusetesting.ReadDirPlusPicky(mntDir)
+	// Modify the file content in GCS.
+	assert.Nil(t.T(), t.createObjects(map[string]string{testFileName: updatedContent}))
+	// Stat the file before entry expires in cache.
+	// This should return the same attributes as Readdirplus.
+	fileInfo, err := os.Stat(filePath)
+
+	// Check that the stat returns the old attributes.
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), testFileName, fileInfo.Name())
+	assert.Equal(t.T(), int64(len(initialContent)), fileInfo.Size())
+	// Check stat after cache expiry.
+	// Wait for a duration longer than the metadata cache TTL.
+	time.Sleep(6 * time.Second)
+	// Stat the file again.
+	// This should return the updated attributes.
+	fileInfo, err = os.Stat(filePath)
+	// Check that the stat returns the updated attributes.
+	assert.Nil(t.T(), err)
+	assert.Equal(t.T(), testFileName, fileInfo.Name())
+	assert.Equal(t.T(), int64(len(updatedContent)), fileInfo.Size())
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/jacobsa/fuse/fusetesting"
@@ -42,6 +43,12 @@ func TestReadDirPlusTestSuite(t *testing.T) {
 func (t *ReadDirPlusTest) SetupSuite() {
 	t.mountCfg.EnableReaddirplus = true
 	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.InodeAttributeCacheTTL = 60 * time.Second
+	t.serverCfg.NewConfig = &cfg.Config{
+		FileSystem: cfg.FileSystemConfig{
+			ExperimentalEnableDentryCache: true,
+		},
+	}
 	t.fsTest.SetUpTestSuite()
 }
 
@@ -122,7 +129,11 @@ func TestLocalFileEntriesReadDirPlusTestSuite(t *testing.T) {
 
 func (t *LocalFileEntriesReadDirPlusTest) SetupSuite() {
 	t.mountCfg.EnableReaddirplus = true
+	t.serverCfg.InodeAttributeCacheTTL = 60 * time.Second
 	t.serverCfg.NewConfig = &cfg.Config{
+		FileSystem: cfg.FileSystemConfig{
+			ExperimentalEnableDentryCache: true,
+		},
 		Write: cfg.WriteConfig{
 			CreateEmptyFile: false,
 		}}

--- a/internal/fs/read_dir_plus_test.go
+++ b/internal/fs/read_dir_plus_test.go
@@ -43,7 +43,7 @@ func TestReadDirPlusTestSuite(t *testing.T) {
 func (t *ReadDirPlusTest) SetupSuite() {
 	t.mountCfg.EnableReaddirplus = true
 	t.serverCfg.ImplicitDirectories = true
-	t.serverCfg.InodeAttributeCacheTTL = 5 * time.Second
+	t.serverCfg.InodeAttributeCacheTTL = 500 * time.Millisecond
 	t.serverCfg.NewConfig = &cfg.Config{
 		FileSystem: cfg.FileSystemConfig{
 			ExperimentalEnableDentryCache: true,
@@ -137,7 +137,7 @@ func (t *ReadDirPlusTest) TestStatAfterReaddirplus() {
 	assert.Equal(t.T(), int64(len(initialContent)), fileInfo.Size())
 	// Check stat after cache expiry.
 	// Wait for a duration longer than the metadata cache TTL.
-	time.Sleep(6 * time.Second)
+	time.Sleep(time.Second)
 	// Stat the file again.
 	// This should return the updated attributes.
 	fileInfo, err = os.Stat(filePath)


### PR DESCRIPTION
### Description
This change enables dentry (directory entry) caching by setting the entry expiration timeout when the experimental-enable-dentry-cache flag is set.
This change allows the kernel to cache the mapping of file paths to inodes.
The expiration time is set on entries returned by LookUpInode and ReadDirPlus operations.

### Link to the issue in case of a bug fix.
b/423824806

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
