### PR TITLE
chore(ci): Don't run go specific test if PR doesn't contain any related file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,30 @@ on:
   pull_request:
     branches:
       - '*'
-    paths-ignore:
-      - '.github/**'
-      - 'docs/**'
-      - '*.md'
-      - 'tools/**'
-      - 'perfmetrics/**'
-      - 'samples/**'
+permissions:
+  contents: read
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_tests: ${{ steps.filter.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            run_tests:
+              - '!**/*.md'
+              - '!tools/**'
+              - '!perfmetrics/**'
+              - '!samples/**'
   format-test:
+    needs: filter
+    if: ${{ needs.filter.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -31,6 +45,8 @@ jobs:
       run: go fmt ./... && go mod tidy && git diff --exit-code --name-only
 
   linux-tests:
+    needs: filter
+    if: ${{ needs.filter.outputs.run_tests == 'true' }}
     strategy:
       matrix:
         go: [ 1.24.x ]
@@ -63,6 +79,8 @@ jobs:
         flags: unittests
 
   lint:
+    needs: filter
+    if: ${{ needs.filter.outputs.run_tests == 'true' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '*.md'
+      - 'tools/**'
+      - 'perfmetrics/**'
+      - 'samples/**'
 
 jobs:
   format-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
               - '!perfmetrics/**'
               - '!samples/**'
   format-test:
-    needs: filter
-    if: ${{ needs.filter.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -79,8 +77,6 @@ jobs:
         flags: unittests
 
   lint:
-    needs: filter
-    if: ${{ needs.filter.outputs.run_tests == 'true' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
- Only run go tests when pr contains related changes.
- Used https://github.com/dorny/paths-filter to implement this. Can't use standard [paths or paths ignore](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) in workflow actions as it leads to stuck. This is because linux-test is required, and using path or paths-ignore at workflow level skip the execution of linux-test and PR will get stuck waiting for the status of required `linux-test`.

### Link to the issue in case of a bug fix.
b/431911068

### Testing details
1. Manual - Tested.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
