### PR TITLE
feat(MoveObject): Enable move object for flat bucket

### DIFF
--- a/internal/fs/flat_bucket_test.go
+++ b/internal/fs/flat_bucket_test.go
@@ -15,29 +15,26 @@
 package fs_test
 
 import (
-	"os"
-	"path"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type FlatBucketTests struct {
+	suite.Suite
 	fsTest
+	RenameDirTests
 	RenameFileTests
 }
 
-var expectedFooDirEntriesFlatBucket = []dirEntry{
-	{name: "test", isDir: true},
-	{name: "file1.txt", isDir: false},
-	{name: "file2.txt", isDir: false},
-	{name: "implicit_dir", isDir: true},
-}
-
 func TestFlatBucketTests(t *testing.T) { suite.Run(t, new(FlatBucketTests)) }
+
+func (t *FlatBucketTests) SetT(testingT *testing.T) {
+	t.Suite.SetT(testingT)
+	t.RenameDirTests.SetT(testingT)
+	t.RenameFileTests.SetT(testingT)
+}
 
 func (t *FlatBucketTests) SetupSuite() {
 	t.serverCfg.RenameDirLimit = 20
@@ -52,6 +49,8 @@ func (t *FlatBucketTests) TearDownSuite() {
 func (t *FlatBucketTests) SetupTest() {
 	err := t.createObjects(
 		map[string]string{
+			"foo/test2/":                 "",
+			"foo/test/":                  "",
 			"foo/file1.txt":              file1Content,
 			"foo/file2.txt":              file2Content,
 			"foo/test/file3.txt":         "xyz",
@@ -63,155 +62,4 @@ func (t *FlatBucketTests) SetupTest() {
 
 func (t *FlatBucketTests) TearDownTest() {
 	t.fsTest.TearDown()
-}
-
-func (t *FlatBucketTests) TestRenameDirWithSourceDirectoryHaveLocalFiles() {
-	oldDirPath := path.Join(mntDir, "foo", "test")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	file, err := os.OpenFile(path.Join(oldDirPath, "file4.txt"), os.O_RDWR|os.O_CREATE, filePerms)
-	assert.NoError(t.T(), err)
-	defer file.Close()
-	newDirPath := path.Join(mntDir, "bar", "foo_rename")
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.Error(t.T(), err)
-	// In the logs, we encountered the following error:
-	// "Rename: operation not supported, can't rename directory 'test' with open files: operation not supported."
-	// This was translated to an "operation not supported" error at the kernel level.
-	assert.True(t.T(), strings.Contains(err.Error(), "operation not supported"))
-}
-
-func (t *FlatBucketTests) TestRenameDirWithSameParent() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	require.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo_rename")
-	_, err = os.Stat(newDirPath)
-	require.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 4, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
-}
-
-func (t *FlatBucketTests) TestRenameDirWithDifferentParents() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "bar", "foo_rename")
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 4, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
-}
-
-func (t *FlatBucketTests) TestRenameDirWithOpenGCSFile() {
-	oldDirPath := path.Join(mntDir, "bar")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "bar_rename")
-	filePath := path.Join(oldDirPath, "file1.txt")
-	f, err := os.Open(filePath)
-	require.NoError(t.T(), err)
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	require.NoError(t.T(), err)
-	_, err = f.WriteString("test")
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "bad file descriptor"))
-	assert.NoError(t.T(), f.Close())
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 1, len(dirEntries))
-	assert.Equal(t.T(), "file1.txt", dirEntries[0].Name())
-	assert.False(t.T(), dirEntries[0].IsDir())
-}
-
-// Create directory foo.
-// Stat the directory foo.
-// Rename directory foo --> foo_rename
-// Stat the old directory.
-// Stat the new directory.
-// Read new directory and validate.
-// Create old directory again with same name - foo
-// Stat the directory - foo
-// Read directory again and validate it is empty.
-func (t *FlatBucketTests) TestCreateDirectoryWithSameNameAfterRename() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	require.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo_rename")
-	// Rename directory foo --> foo_rename
-	err = os.Rename(oldDirPath, newDirPath)
-	require.NoError(t.T(), err)
-	// Stat old directory.
-	_, err = os.Stat(oldDirPath)
-	require.Error(t.T(), err)
-	require.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	// Stat new directory.
-	_, err = os.Stat(newDirPath)
-	require.NoError(t.T(), err)
-	// Read new directory and validate.
-	dirEntries, err := os.ReadDir(newDirPath)
-	require.NoError(t.T(), err)
-	//require.Equal(t.T(), 5, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	require.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
-
-	// Create old directory again.
-	err = os.Mkdir(oldDirPath, dirPerms)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err = os.ReadDir(oldDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 0, len(dirEntries))
 }

--- a/internal/fs/flat_bucket_test.go
+++ b/internal/fs/flat_bucket_test.go
@@ -65,7 +65,7 @@ func (t *FlatBucketTests) TearDownTest() {
 	t.fsTest.TearDown()
 }
 
-func (t *FlatBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
+func (t *FlatBucketTests) TestRenameDirWithSourceDirectoryHaveLocalFiles() {
 	oldDirPath := path.Join(mntDir, "foo", "test")
 	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
@@ -83,7 +83,7 @@ func (t *FlatBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
 	assert.True(t.T(), strings.Contains(err.Error(), "operation not supported"))
 }
 
-func (t *FlatBucketTests) TestRenameFolderWithSameParent() {
+func (t *FlatBucketTests) TestRenameDirWithSameParent() {
 	oldDirPath := path.Join(mntDir, "foo")
 	_, err := os.Stat(oldDirPath)
 	require.NoError(t.T(), err)
@@ -113,7 +113,7 @@ func (t *FlatBucketTests) TestRenameFolderWithSameParent() {
 	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
 }
 
-func (t *FlatBucketTests) TestRenameFolderWithDifferentParents() {
+func (t *FlatBucketTests) TestRenameDirWithDifferentParents() {
 	oldDirPath := path.Join(mntDir, "foo")
 	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)
@@ -140,7 +140,7 @@ func (t *FlatBucketTests) TestRenameFolderWithDifferentParents() {
 	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
 }
 
-func (t *FlatBucketTests) TestRenameFolderWithOpenGCSFile() {
+func (t *FlatBucketTests) TestRenameDirWithOpenGCSFile() {
 	oldDirPath := path.Join(mntDir, "bar")
 	_, err := os.Stat(oldDirPath)
 	assert.NoError(t.T(), err)

--- a/internal/fs/flat_bucket_test.go
+++ b/internal/fs/flat_bucket_test.go
@@ -15,22 +15,35 @@
 package fs_test
 
 import (
+	"os"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type FlatBucketTests struct {
-	RenameFileTests
 	fsTest
+	RenameFileTests
+}
+
+var expectedFooDirEntriesFlatBucket = []dirEntry{
+	{name: "test", isDir: true},
+	{name: "file1.txt", isDir: false},
+	{name: "file2.txt", isDir: false},
+	{name: "implicit_dir", isDir: true},
 }
 
 func TestFlatBucketTests(t *testing.T) { suite.Run(t, new(FlatBucketTests)) }
 
 func (t *FlatBucketTests) SetupSuite() {
 	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.RenameDirLimit = 20
+	t.serverCfg.ImplicitDirectories = true
 	t.fsTest.SetUpTestSuite()
 }
 
@@ -39,10 +52,7 @@ func (t *FlatBucketTests) TearDownSuite() {
 }
 
 func (t *FlatBucketTests) SetupTest() {
-	err := t.createFolders([]string{"foo/", "bar/", "foo/test2/", "foo/test/"})
-	require.NoError(t.T(), err)
-
-	err = t.createObjects(
+	err := t.createObjects(
 		map[string]string{
 			"foo/file1.txt":              file1Content,
 			"foo/file2.txt":              file2Content,
@@ -55,4 +65,155 @@ func (t *FlatBucketTests) SetupTest() {
 
 func (t *FlatBucketTests) TearDownTest() {
 	t.fsTest.TearDown()
+}
+
+func (t *FlatBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
+	oldDirPath := path.Join(mntDir, "foo", "test")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	file, err := os.OpenFile(path.Join(oldDirPath, "file4.txt"), os.O_RDWR|os.O_CREATE, filePerms)
+	assert.NoError(t.T(), err)
+	defer file.Close()
+	newDirPath := path.Join(mntDir, "bar", "foo_rename")
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.Error(t.T(), err)
+	// In the logs, we encountered the following error:
+	// "Rename: operation not supported, can't rename directory 'test' with open files: operation not supported."
+	// This was translated to an "operation not supported" error at the kernel level.
+	assert.True(t.T(), strings.Contains(err.Error(), "operation not supported"))
+}
+
+func (t *FlatBucketTests) TestRenameFolderWithSameParent() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	require.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo_rename")
+	_, err = os.Stat(newDirPath)
+	require.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 4, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
+}
+
+func (t *FlatBucketTests) TestRenameFolderWithDifferentParents() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "bar", "foo_rename")
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 4, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
+}
+
+func (t *FlatBucketTests) TestRenameFolderWithOpenGCSFile() {
+	oldDirPath := path.Join(mntDir, "bar")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "bar_rename")
+	filePath := path.Join(oldDirPath, "file1.txt")
+	f, err := os.Open(filePath)
+	require.NoError(t.T(), err)
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	require.NoError(t.T(), err)
+	_, err = f.WriteString("test")
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "bad file descriptor"))
+	assert.NoError(t.T(), f.Close())
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 1, len(dirEntries))
+	assert.Equal(t.T(), "file1.txt", dirEntries[0].Name())
+	assert.False(t.T(), dirEntries[0].IsDir())
+}
+
+// Create directory foo.
+// Stat the directory foo.
+// Rename directory foo --> foo_rename
+// Stat the old directory.
+// Stat the new directory.
+// Read new directory and validate.
+// Create old directory again with same name - foo
+// Stat the directory - foo
+// Read directory again and validate it is empty.
+func (t *FlatBucketTests) TestCreateDirectoryWithSameNameAfterRename() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	require.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo_rename")
+	// Rename directory foo --> foo_rename
+	err = os.Rename(oldDirPath, newDirPath)
+	require.NoError(t.T(), err)
+	// Stat old directory.
+	_, err = os.Stat(oldDirPath)
+	require.Error(t.T(), err)
+	require.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	// Stat new directory.
+	_, err = os.Stat(newDirPath)
+	require.NoError(t.T(), err)
+	// Read new directory and validate.
+	dirEntries, err := os.ReadDir(newDirPath)
+	require.NoError(t.T(), err)
+	//require.Equal(t.T(), 5, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	require.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntriesFlatBucket)
+
+	// Create old directory again.
+	err = os.Mkdir(oldDirPath, dirPerms)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err = os.ReadDir(oldDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 0, len(dirEntries))
 }

--- a/internal/fs/flat_bucket_test.go
+++ b/internal/fs/flat_bucket_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -41,7 +40,6 @@ var expectedFooDirEntriesFlatBucket = []dirEntry{
 func TestFlatBucketTests(t *testing.T) { suite.Run(t, new(FlatBucketTests)) }
 
 func (t *FlatBucketTests) SetupSuite() {
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
 	t.serverCfg.RenameDirLimit = 20
 	t.serverCfg.ImplicitDirectories = true
 	t.fsTest.SetUpTestSuite()

--- a/internal/fs/flat_bucket_test.go
+++ b/internal/fs/flat_bucket_test.go
@@ -18,30 +18,27 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type ZonalBucketTests struct {
+type FlatBucketTests struct {
 	RenameFileTests
 	fsTest
 }
 
-func TestZonalBucketTests(t *testing.T) { suite.Run(t, new(ZonalBucketTests)) }
+func TestFlatBucketTests(t *testing.T) { suite.Run(t, new(FlatBucketTests)) }
 
-func (t *ZonalBucketTests) SetupSuite() {
-	t.serverCfg.ImplicitDirectories = false
+func (t *FlatBucketTests) SetupSuite() {
 	t.serverCfg.MetricHandle = common.NewNoopMetrics()
-	bucketType = gcs.BucketType{Zonal: true}
 	t.fsTest.SetUpTestSuite()
 }
 
-func (t *ZonalBucketTests) TearDownSuite() {
+func (t *FlatBucketTests) TearDownSuite() {
 	t.fsTest.TearDownTestSuite()
 }
 
-func (t *ZonalBucketTests) SetupTest() {
+func (t *FlatBucketTests) SetupTest() {
 	err := t.createFolders([]string{"foo/", "bar/", "foo/test2/", "foo/test/"})
 	require.NoError(t.T(), err)
 
@@ -56,6 +53,6 @@ func (t *ZonalBucketTests) SetupTest() {
 	require.NoError(t.T(), err)
 }
 
-func (t *ZonalBucketTests) TearDownTest() {
+func (t *FlatBucketTests) TearDownTest() {
 	t.fsTest.TearDown()
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2253,7 +2253,7 @@ func (fs *fileSystem) atomicRename(ctx context.Context, oldParent inode.DirInode
 	}
 
 	if err := fs.invalidateChildFileCacheIfExist(oldParent, oldName); err != nil {
-		return fmt.Errorf("atomicRename: while invalidating cache for delete file: %w", err)
+		return fmt.Errorf("invalidateChildFileCacheIfExist: while invalidating cache for renamed file: %w", err)
 	}
 
 	// Insert new file in type cache.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2213,7 +2213,7 @@ func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, oldO
 	if err != nil {
 		return fmt.Errorf("flushPendingWrites: %w", err)
 	}
-	if (oldObject.Bucket().BucketType().Hierarchical && fs.enableAtomicRenameObject) || oldObject.Bucket().BucketType().Zonal {
+	if fs.enableAtomicRenameObject || oldObject.Bucket().BucketType().Zonal {
 		return fs.renameHierarchicalFile(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
 	}
 	return fs.renameNonHierarchicalFile(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -151,7 +151,9 @@ func (t *fsTest) SetUpTestSuite() {
 		chunkTransferTimeoutSecs: 10,
 		tmpObjectPrefix:          ".gcsfuse_tmp/",
 	}
-	t.serverCfg.RenameDirLimit = RenameDirLimit
+	if t.serverCfg.RenameDirLimit == 0 {
+		t.serverCfg.RenameDirLimit = RenameDirLimit
+	}
 	t.serverCfg.SequentialReadSizeMb = SequentialReadSizeMb
 
 	if t.serverCfg.NewConfig == nil {

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -15,9 +15,7 @@
 package fs_test
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -37,8 +35,10 @@ import (
 )
 
 type HNSBucketTests struct {
+	suite.Suite
 	fsTest
 	RenameFileTests
+	RenameDirTests
 }
 
 type dirEntry struct {
@@ -58,6 +58,12 @@ var expectedFooDirEntries = []dirEntry{
 }
 
 func TestHNSBucketTests(t *testing.T) { suite.Run(t, new(HNSBucketTests)) }
+
+func (t *HNSBucketTests) SetT(testingT *testing.T) {
+	t.Suite.SetT(testingT)
+	t.RenameDirTests.SetT(testingT)
+	t.RenameFileTests.SetT(testingT)
+}
 
 func (t *HNSBucketTests) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = false
@@ -130,264 +136,6 @@ func (t *HNSBucketTests) TestDeleteImplicitDir() {
 	_, err = os.Stat(dirPath)
 	assert.Error(t.T(), err)
 	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithSrcDirectoryDoesNotExist() {
-	oldDirPath := path.Join(mntDir, "foo_not_exist")
-	newDirPath := path.Join(mntDir, "foo_rename")
-
-	err := os.Rename(oldDirPath, newDirPath)
-
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithDstDirectoryNotEmpty() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	// In the setup phase, we created file1.txt within the bar directory.
-	newDirPath := path.Join(mntDir, "bar")
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "file exists"))
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithEmptySourceDirectory() {
-	oldDirPath := path.Join(mntDir, "foo", "test2")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo_rename")
-	_, err = os.Stat(newDirPath)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 0, len(dirEntries))
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
-	oldDirPath := path.Join(mntDir, "foo", "test")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	file, err := os.OpenFile(path.Join(oldDirPath, "file4.txt"), os.O_RDWR|os.O_CREATE, filePerms)
-	assert.NoError(t.T(), err)
-	defer file.Close()
-	newDirPath := path.Join(mntDir, "bar", "foo_rename")
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.Error(t.T(), err)
-	// In the logs, we encountered the following error:
-	// "Rename: operation not supported, can't rename directory 'test' with open files: operation not supported."
-	// This was translated to an "operation not supported" error at the kernel level.
-	assert.True(t.T(), strings.Contains(err.Error(), "operation not supported"))
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithSameParent() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	require.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo_rename")
-	_, err = os.Stat(newDirPath)
-	require.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 5, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithExistingEmptyDestDirectory() {
-	oldDirPath := path.Join(mntDir, "foo", "test")
-	_, err := os.Stat(oldDirPath)
-	require.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo", "test2")
-	_, err = os.Stat(newDirPath)
-	require.NoError(t.T(), err)
-
-	// Go's Rename function does not support renaming a directory into an existing empty directory.
-	// To achieve this, we call a Python rename function as a workaround.
-	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
-	_, err = cmd.CombinedOutput()
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 1, len(dirEntries))
-	assert.Equal(t.T(), "file3.txt", dirEntries[0].Name())
-	assert.False(t.T(), dirEntries[0].IsDir())
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithDifferentParents() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "bar", "foo_rename")
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 5, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
-}
-
-func (t *HNSBucketTests) TestRenameFolderWithOpenGCSFile() {
-	oldDirPath := path.Join(mntDir, "bar")
-	_, err := os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "bar_rename")
-	filePath := path.Join(oldDirPath, "file1.txt")
-	f, err := os.Open(filePath)
-	require.NoError(t.T(), err)
-
-	err = os.Rename(oldDirPath, newDirPath)
-
-	require.NoError(t.T(), err)
-	_, err = f.WriteString("test")
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "bad file descriptor"))
-	assert.NoError(t.T(), f.Close())
-	_, err = os.Stat(oldDirPath)
-	assert.Error(t.T(), err)
-	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	_, err = os.Stat(newDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err := os.ReadDir(newDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 1, len(dirEntries))
-	assert.Equal(t.T(), "file1.txt", dirEntries[0].Name())
-	assert.False(t.T(), dirEntries[0].IsDir())
-}
-
-// Create directory foo.
-// Stat the directory foo.
-// Rename directory foo --> foo_rename
-// Stat the old directory.
-// Stat the new directory.
-// Read new directory and validate.
-// Create old directory again with same name - foo
-// Stat the directory - foo
-// Read directory again and validate it is empty.
-func (t *HNSBucketTests) TestCreateDirectoryWithSameNameAfterRename() {
-	oldDirPath := path.Join(mntDir, "foo")
-	_, err := os.Stat(oldDirPath)
-	require.NoError(t.T(), err)
-	newDirPath := path.Join(mntDir, "foo_rename")
-	// Rename directory foo --> foo_rename
-	err = os.Rename(oldDirPath, newDirPath)
-	require.NoError(t.T(), err)
-	// Stat old directory.
-	_, err = os.Stat(oldDirPath)
-	require.Error(t.T(), err)
-	require.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
-	// Stat new directory.
-	_, err = os.Stat(newDirPath)
-	require.NoError(t.T(), err)
-	// Read new directory and validate.
-	dirEntries, err := os.ReadDir(newDirPath)
-	require.NoError(t.T(), err)
-	require.Equal(t.T(), 5, len(dirEntries))
-	actualDirEntries := []dirEntry{}
-	for _, d := range dirEntries {
-		actualDirEntries = append(actualDirEntries, dirEntry{
-			name:  d.Name(),
-			isDir: d.IsDir(),
-		})
-	}
-	require.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
-
-	// Create old directory again.
-	err = os.Mkdir(oldDirPath, dirPerms)
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(oldDirPath)
-	assert.NoError(t.T(), err)
-	dirEntries, err = os.ReadDir(oldDirPath)
-	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), 0, len(dirEntries))
-}
-
-// Create directory - foo/test2
-// Create local file in directory - foo/test2/test.txt
-// Stat the local file - foo/test2/test.txt
-// Delete directory - rm -r foo/test2
-// Create directory again - foo/test2
-// Create local file with the same name in directory - foo/test2/test.txt
-// Stat the local file - foo/test2/test.txt
-func (t *HNSBucketTests) TestCreateLocalFileInSamePathAfterDeletingParentDirectory() {
-	dirPath := path.Join(mntDir, "foo", "test2")
-	filePath := path.Join(dirPath, "test.txt")
-	// Create local file in side it.
-	f1, err := os.Create(filePath)
-	defer require.NoError(t.T(), f1.Close())
-	require.NoError(t.T(), err)
-	_, err = os.Stat(filePath)
-	require.NoError(t.T(), err)
-	// Delete directory rm -r foo/test2
-	err = os.RemoveAll(dirPath)
-	assert.NoError(t.T(), err)
-	// Create directory again foo/test2
-	err = os.Mkdir(dirPath, dirPerms)
-	assert.NoError(t.T(), err)
-
-	// Create local file again.
-	f2, err := os.Create(filePath)
-	defer require.NoError(t.T(), f2.Close())
-
-	assert.NoError(t.T(), err)
-	_, err = os.Stat(filePath)
-	assert.NoError(t.T(), err)
 }
 
 // //////////////////////////////////////////////////////////////////////

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -38,7 +38,7 @@ import (
 
 type HNSBucketTests struct {
 	fsTest
-	HNSBucketCommonTest
+	RenameFileTests
 }
 
 type dirEntry struct {

--- a/internal/fs/rename_dir_test.go
+++ b/internal/fs/rename_dir_test.go
@@ -1,0 +1,293 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RenameDirTests struct {
+	suite.Suite
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *RenameDirTests) TestRenameFolderWithSrcDirectoryDoesNotExist() {
+	oldDirPath := path.Join(mntDir, "foo_not_exist")
+	newDirPath := path.Join(mntDir, "foo_rename")
+
+	err := os.Rename(oldDirPath, newDirPath)
+
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+}
+
+func (t *RenameDirTests) TestRenameFolderWithDstDirectoryNotEmpty() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	// In the setup phase, we created file1.txt within the bar directory.
+	newDirPath := path.Join(mntDir, "bar")
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "file exists"))
+}
+
+func (t *RenameDirTests) TestRenameFolderWithEmptySourceDirectory() {
+	oldDirPath := path.Join(mntDir, "foo", "test2")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo_rename")
+	_, err = os.Stat(newDirPath)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 0, len(dirEntries))
+}
+
+func (t *RenameDirTests) TestRenameFolderWithSourceDirectoryHaveLocalFiles() {
+	oldDirPath := path.Join(mntDir, "foo", "test")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	file, err := os.OpenFile(path.Join(oldDirPath, "file4.txt"), os.O_RDWR|os.O_CREATE, filePerms)
+	assert.NoError(t.T(), err)
+	defer file.Close()
+	newDirPath := path.Join(mntDir, "bar", "foo_rename")
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.Error(t.T(), err)
+	// In the logs, we encountered the following error:
+	// "Rename: operation not supported, can't rename directory 'test' with open files: operation not supported."
+	// This was translated to an "operation not supported" error at the kernel level.
+	assert.True(t.T(), strings.Contains(err.Error(), "operation not supported"))
+}
+
+func (t *RenameDirTests) TestRenameFolderWithSameParent() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	require.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo_rename")
+	_, err = os.Stat(newDirPath)
+	require.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 5, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
+}
+
+func (t *RenameDirTests) TestRenameFolderWithExistingEmptyDestDirectory() {
+	oldDirPath := path.Join(mntDir, "foo", "test")
+	_, err := os.Stat(oldDirPath)
+	require.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo", "test2")
+	_, err = os.Stat(newDirPath)
+	require.NoError(t.T(), err)
+
+	// Go's Rename function does not support renaming a directory into an existing empty directory.
+	// To achieve this, we call a Python rename function as a workaround.
+	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
+	_, err = cmd.CombinedOutput()
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 1, len(dirEntries))
+	assert.Equal(t.T(), "file3.txt", dirEntries[0].Name())
+	assert.False(t.T(), dirEntries[0].IsDir())
+}
+
+func (t *RenameDirTests) TestRenameFolderWithDifferentParents() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "bar", "foo_rename")
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 5, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	assert.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
+}
+
+func (t *RenameDirTests) TestRenameFolderWithOpenGCSFile() {
+	oldDirPath := path.Join(mntDir, "bar")
+	_, err := os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "bar_rename")
+	filePath := path.Join(oldDirPath, "file1.txt")
+	f, err := os.Open(filePath)
+	require.NoError(t.T(), err)
+
+	err = os.Rename(oldDirPath, newDirPath)
+
+	require.NoError(t.T(), err)
+	_, err = f.WriteString("test")
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "bad file descriptor"))
+	assert.NoError(t.T(), f.Close())
+	_, err = os.Stat(oldDirPath)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	_, err = os.Stat(newDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err := os.ReadDir(newDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 1, len(dirEntries))
+	assert.Equal(t.T(), "file1.txt", dirEntries[0].Name())
+	assert.False(t.T(), dirEntries[0].IsDir())
+}
+
+// Create directory foo.
+// Stat the directory foo.
+// Rename directory foo --> foo_rename
+// Stat the old directory.
+// Stat the new directory.
+// Read new directory and validate.
+// Create old directory again with same name - foo
+// Stat the directory - foo
+// Read directory again and validate it is empty.
+func (t *RenameDirTests) TestCreateDirectoryWithSameNameAfterRename() {
+	oldDirPath := path.Join(mntDir, "foo")
+	_, err := os.Stat(oldDirPath)
+	require.NoError(t.T(), err)
+	newDirPath := path.Join(mntDir, "foo_rename")
+	// Rename directory foo --> foo_rename
+	err = os.Rename(oldDirPath, newDirPath)
+	require.NoError(t.T(), err)
+	// Stat old directory.
+	_, err = os.Stat(oldDirPath)
+	require.Error(t.T(), err)
+	require.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
+	// Stat new directory.
+	_, err = os.Stat(newDirPath)
+	require.NoError(t.T(), err)
+	// Read new directory and validate.
+	dirEntries, err := os.ReadDir(newDirPath)
+	require.NoError(t.T(), err)
+	require.Equal(t.T(), 5, len(dirEntries))
+	actualDirEntries := []dirEntry{}
+	for _, d := range dirEntries {
+		actualDirEntries = append(actualDirEntries, dirEntry{
+			name:  d.Name(),
+			isDir: d.IsDir(),
+		})
+	}
+	require.ElementsMatch(t.T(), actualDirEntries, expectedFooDirEntries)
+
+	// Create old directory again.
+	err = os.Mkdir(oldDirPath, dirPerms)
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(oldDirPath)
+	assert.NoError(t.T(), err)
+	dirEntries, err = os.ReadDir(oldDirPath)
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 0, len(dirEntries))
+}
+
+// Create directory - foo/test2
+// Create local file in directory - foo/test2/test.txt
+// Stat the local file - foo/test2/test.txt
+// Delete directory - rm -r foo/test2
+// Create directory again - foo/test2
+// Create local file with the same name in directory - foo/test2/test.txt
+// Stat the local file - foo/test2/test.txt
+func (t *RenameDirTests) TestCreateLocalFileInSamePathAfterDeletingParentDirectory() {
+	dirPath := path.Join(mntDir, "foo", "test2")
+	filePath := path.Join(dirPath, "test.txt")
+	// Create local file in side it.
+	f1, err := os.Create(filePath)
+	defer require.NoError(t.T(), f1.Close())
+	require.NoError(t.T(), err)
+	_, err = os.Stat(filePath)
+	require.NoError(t.T(), err)
+	// Delete directory rm -r foo/test2
+	err = os.RemoveAll(dirPath)
+	assert.NoError(t.T(), err)
+	// Create directory again foo/test2
+	err = os.Mkdir(dirPath, dirPerms)
+	assert.NoError(t.T(), err)
+
+	// Create local file again.
+	f2, err := os.Create(filePath)
+	defer require.NoError(t.T(), f2.Close())
+
+	assert.NoError(t.T(), err)
+	_, err = os.Stat(filePath)
+	assert.NoError(t.T(), err)
+}

--- a/internal/fs/rename_file_test.go
+++ b/internal/fs/rename_file_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type HNSBucketCommonTest struct {
+type RenameFileTests struct {
 	suite.Suite
 }
 
@@ -32,7 +32,7 @@ type HNSBucketCommonTest struct {
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *HNSBucketCommonTest) TestRenameFileWithSrcFileDoesNotExist() {
+func (t *RenameFileTests) TestRenameFileWithSrcFileDoesNotExist() {
 	oldFilePath := path.Join(mntDir, "file")
 	newFilePath := path.Join(mntDir, "file_rename")
 
@@ -45,7 +45,7 @@ func (t *HNSBucketCommonTest) TestRenameFileWithSrcFileDoesNotExist() {
 	assert.True(t.T(), strings.Contains(err.Error(), "no such file or directory"))
 }
 
-func (t *HNSBucketCommonTest) TestRenameFileWithDstDestFileExist() {
+func (t *RenameFileTests) TestRenameFileWithDstDestFileExist() {
 	oldFilePath := path.Join(mntDir, "foo", "file1.txt")
 	_, err := os.Stat(oldFilePath)
 	assert.NoError(t.T(), err)
@@ -64,7 +64,7 @@ func (t *HNSBucketCommonTest) TestRenameFileWithDstDestFileExist() {
 	assert.Equal(t.T(), file1Content, string(content))
 }
 
-func (t *HNSBucketCommonTest) TestRenameFile() {
+func (t *RenameFileTests) TestRenameFile() {
 	testCases := []struct {
 		name        string
 		oldFilePath string


### PR DESCRIPTION
### Description
- Enable move object flat bucket
- Enable composite tests
- Created common test suite for RenameFile and RenameDirectory tests. Added those for hns, flat and zonal buckets.

### Link to the issue in case of a bug fix.
[b/432388929](https://b.corp.google.com/issues/432388929)

### Testing details
1. Manual - Done
2. Unit tests - Automated
3. Integration tests - Automated
4. The tessellation checkpointing run was executed successfully, with no rename failures detected.

### Any backward incompatible change? If so, please explain.
