### PR TITLE
test(rapid appends): Appends to finalized object is not visible on GCS till Close()

### DIFF
--- a/tools/integration_tests/rapid_appends/appends_test.go
+++ b/tools/integration_tests/rapid_appends/appends_test.go
@@ -201,6 +201,39 @@ func (t *RapidAppendsSuite) TestContentAppendedInNonAppendModeNotVisibleTillClos
 	assert.Equal(t.T(), expectedContent, contentAfterClose)
 }
 
+func (t *RapidAppendsSuite) TestAppendsToFinalizedObjectNotVisibleUntilClose() {
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	// Create Finalized Object in the GCS bucket.
+	client.CreateObjectInGCSTestDir(
+		ctx, storageClient, testDirName, t.fileName, initialContent, t.T())
+	defer func() {
+		err := os.Remove(path.Join(primaryMntTestDirPath, t.fileName))
+		require.NoError(t.T(), err)
+	}()
+
+	// Append to the finalized object from the primary mount.
+	filePath := path.Join(primaryMntTestDirPath, t.fileName)
+	fh, err := os.OpenFile(filePath, os.O_APPEND|os.O_RDWR|syscall.O_DIRECT, operations.FilePermission_0600)
+	require.NoError(t.T(), err)
+	_, err = fh.Write([]byte(appendContent))
+	require.NoError(t.T(), err)
+
+	// Read the object from secondary mount to validate that appended content is yet not visible on GCS.
+	secondaryPath := path.Join(secondaryMntTestDirPath, t.fileName)
+	contentBeforeClose, err := operations.ReadFile(secondaryPath)
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), initialContent, string(contentBeforeClose))
+
+	// Close the file handle used for appending.
+	require.NoError(t.T(), fh.Close())
+
+	// Read the object from secondary mount to validate that appended content is now visible on GCS.
+	expectedContent := initialContent + appendContent
+	contentAfterClose, err := operations.ReadFile(secondaryPath)
+	require.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedContent, string(contentAfterClose))
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/rapid_appends/appends_test.go
+++ b/tools/integration_tests/rapid_appends/appends_test.go
@@ -208,10 +208,11 @@ func (t *RapidAppendsSuite) TestAppendsToFinalizedObjectNotVisibleUntilClose() {
 		ctx, storageClient, testDirName, t.fileName, initialContent, t.T())
 
 	// Append to the finalized object from the primary mount.
+	data := setup.GenerateRandomString(contentSizeForBW * operations.OneMiB)
 	filePath := path.Join(primaryMntTestDirPath, t.fileName)
 	fh, err := os.OpenFile(filePath, os.O_APPEND|os.O_RDWR|syscall.O_DIRECT, operations.FilePermission_0600)
 	require.NoError(t.T(), err)
-	_, err = fh.Write([]byte(appendContent))
+	_, err = fh.Write([]byte(data))
 	require.NoError(t.T(), err)
 
 	// Read from back-door to validate that appended content is yet not visible on GCS.
@@ -223,7 +224,7 @@ func (t *RapidAppendsSuite) TestAppendsToFinalizedObjectNotVisibleUntilClose() {
 	require.NoError(t.T(), fh.Close())
 
 	// Read from back-door to validate that appended content is now visible on GCS.
-	expectedContent := initialContent + appendContent
+	expectedContent := initialContent + data
 	contentAfterClose, err := client.ReadObjectFromGCS(ctx, storageClient, path.Join(testDirName, t.fileName))
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), expectedContent, string(contentAfterClose))


### PR DESCRIPTION
### Description
The functional test introduced in this PR asserts that the appends made to finalized object will not be real time i.e. not immediately available for reads. This is so because real time appends is a feature of unfinalized object only. 

Write behavior for finalized object will be similar to objects in regional bucket.

### Link to the issue in case of a bug fix.
[b/432141061](b/432141061)

### Testing details
1. Manual - Yes.
`--- PASS: TestRapidAppendsSuite/TestAppendsToFinalizedObjectNotVisibleUntilClose (1.36s)`
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
