### PR TITLE
fix: improve logging while unmount external mount

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -20,6 +20,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -76,7 +77,11 @@ func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 
 			err := fuse.Unmount(mountPoint)
 			if err != nil {
-				logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
+				if errors.Is(err, fuse.ErrExternallyManagedMountPoint) {
+					logger.Infof("Ignoring unmount via gcsfuse for externally managed mount point: %s", mountPoint)
+				} else {
+					logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
+				}
 			} else {
 				logger.Infof("Successfully unmounted in response to %s.", sigName)
 				return

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -80,9 +80,8 @@ func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 				if errors.Is(err, fuse.ErrExternallyManagedMountPoint) {
 					logger.Infof("Mount point %s is externally managed; gcsfuse will not unmount it.", mountPoint)
 					return
-				} else {
-					logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
 				}
+				logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
 			} else {
 				logger.Infof("Successfully unmounted in response to %s.", sigName)
 				return

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -78,7 +78,8 @@ func registerTerminatingSignalHandler(mountPoint string, c *cfg.Config) {
 			err := fuse.Unmount(mountPoint)
 			if err != nil {
 				if errors.Is(err, fuse.ErrExternallyManagedMountPoint) {
-					logger.Infof("Ignoring unmount via gcsfuse for externally managed mount point: %s", mountPoint)
+					logger.Infof("Mount point %s is externally managed; gcsfuse will not unmount it.", mountPoint)
+					return
 				} else {
 					logger.Errorf("Failed to unmount in response to %s: %v", sigName, err)
 				}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.2
 	github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec
-	github.com/jacobsa/fuse v0.0.0-20250715095703-8f8de1982c06
+	github.com/jacobsa/fuse v0.0.0-20250717091043-15503eb5696d
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtEMD2ouh8gOGIeDF9LrgXjo+9Q69RVzI=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20250715095703-8f8de1982c06 h1:QslSjXa4yR2iAZ8YxSKMKpXLblO1t2zbN/pskXGVzew=
-github.com/jacobsa/fuse v0.0.0-20250715095703-8f8de1982c06/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/fuse v0.0.0-20250717091043-15503eb5696d h1:e1rS3W2isplX97AJ/MsbTJrVohWGzqXx6nvOx3RTikk=
 github.com/jacobsa/fuse v0.0.0-20250717091043-15503eb5696d/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtE
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
 github.com/jacobsa/fuse v0.0.0-20250715095703-8f8de1982c06 h1:QslSjXa4yR2iAZ8YxSKMKpXLblO1t2zbN/pskXGVzew=
 github.com/jacobsa/fuse v0.0.0-20250715095703-8f8de1982c06/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
+github.com/jacobsa/fuse v0.0.0-20250717091043-15503eb5696d h1:e1rS3W2isplX97AJ/MsbTJrVohWGzqXx6nvOx3RTikk=
+github.com/jacobsa/fuse v0.0.0-20250717091043-15503eb5696d/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=


### PR DESCRIPTION
### Description
- Adding info unmount logs when unmount failed for externally managed mount point.
- Corresponding jacobsa/fuse change - https://github.com/jacobsa/fuse/pull/179

**Tested in GKE Environment**:
```text
I0717 16:45:04.019697       1 main.go:124] received SIGTERM signal, waiting for all the gcsfuse processes exit...
I0717 16:45:04.019728       1 main.go:127] the sidecar mounter is calling ctx.cancel
I0717 16:45:04.019768       1 sidecar_mounter.go:112] context marked as done, sleep for 5 seconds, to evaluate gcsfuse process 22 exit state
I0717 16:45:04.019778       1 sidecar_mounter.go:102] sending SIGTERM to gcsfuse process: /gcsfuse --app-name gke-gcs-fuse-csi --foreground --gid 0 --config-file /gcsfuse-tmp/.volumes/gcs-fuse-warp-test-volume/config.yaml --enable-cloud-profiling --log-severity trace --uid 0 --temp-dir /gcsfuse-buffer/.volumes/gcs-fuse-warp-test-volume/temp-dir --prometheus-port 62990 --implicit-dirs gcs-fuse-warp-test-bucket /dev/fd/3
{"timestamp":{"seconds":1752770704,"nanos":20034872},"severity":"INFO","message":"Received SIGTERM, attempting to unmount..."}
{"timestamp":{"seconds":1752770704,"nanos":20203944},"severity":"INFO","message":"Mount point /dev/fd/3 is externally managed; gcsfuse will not unmount it."}
W0717 16:45:09.021438       1 sidecar_mounter.go:115] after 5 seconds, process with id 22 has not exited, force kill the process
E0717 16:45:09.023106       1 logger.go:60] gcsfuse exited with error: signal: killed
I0717 16:45:09.023207       1 main.go:133] exiting sidecar mounter...
```
### Link to the issue in case of a bug fix.
b/431732751

### Testing details
1. Manual - Tested in GKE environment.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
