### PR TITLE
feat(buffered-read): Create a Block Queue Entry that can be used by Buffered Reader

### DIFF
--- a/internal/bufferedread/block_queue.go
+++ b/internal/bufferedread/block_queue.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufferedread
+
+import (
+	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
+)
+
+// blockQueueEntry represents a block of object data and the associated task
+// responsible for downloading it.
+type blockQueueEntry struct {
+	Block block.Block
+	Task  *DownloadTask
+}
+
+// newBlockQueueEntry creates a new entry for the block queue.
+func newBlockQueueEntry(b block.Block, t *DownloadTask) *blockQueueEntry {
+	return &blockQueueEntry{
+		Block: b,
+		Task:  t,
+	}
+}
+
+// blockQueue is a queue of blockQueueEntry instances.
+type blockQueue common.Queue[*blockQueueEntry]
+
+// newBlockQueue creates a new, empty queue for managing block download tasks.
+func newBlockQueue() blockQueue {
+	return common.NewLinkedListQueue[*blockQueueEntry]()
+}

--- a/internal/bufferedread/block_queue.go
+++ b/internal/bufferedread/block_queue.go
@@ -35,9 +35,11 @@ func newBlockQueueEntry(b block.Block, t *DownloadTask) *blockQueueEntry {
 }
 
 // blockQueue is a queue of blockQueueEntry instances.
-type blockQueue common.Queue[*blockQueueEntry]
+type blockQueue struct {
+	q common.Queue[*blockQueueEntry]
+}
 
 // newBlockQueue creates a new, empty queue for managing block download tasks.
-func newBlockQueue() blockQueue {
-	return common.NewLinkedListQueue[*blockQueueEntry]()
+func newBlockQueue() *blockQueue {
+	return &blockQueue{q: common.NewLinkedListQueue[*blockQueueEntry]()}
 }

--- a/internal/bufferedread/block_queue_entry.go
+++ b/internal/bufferedread/block_queue_entry.go
@@ -15,31 +15,14 @@
 package bufferedread
 
 import (
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
-// blockQueueEntry represents a block of object data and the associated task
-// responsible for downloading it.
+// blockQueueEntry holds a data block with a function
+// to cancel its in-flight download.
 type blockQueueEntry struct {
-	Block block.Block
-	Task  *DownloadTask
-}
-
-// newBlockQueueEntry creates a new entry for the block queue.
-func newBlockQueueEntry(b block.Block, t *DownloadTask) *blockQueueEntry {
-	return &blockQueueEntry{
-		Block: b,
-		Task:  t,
-	}
-}
-
-// blockQueue is a queue of blockQueueEntry instances.
-type blockQueue struct {
-	q common.Queue[*blockQueueEntry]
-}
-
-// newBlockQueue creates a new, empty queue for managing block download tasks.
-func newBlockQueue() *blockQueue {
-	return &blockQueue{q: common.NewLinkedListQueue[*blockQueueEntry]()}
+	block      block.Block
+	cancelFunc context.CancelFunc
 }


### PR DESCRIPTION
### Description
This PR introduces a `blockQueueEntry` for use in the buffered reader's Queue. This entry is designed to manage data blocks that are being prefetched and read.

The `blockQueueEntry` struct contains two main components:
- A `Block`, which is the destination for the downloaded data that will be read.
- A `cancelFunction`, which allows for the cancellation of a download task if the associated block is no longer needed

### Link to the issue in case of a bug fix.
b/430755847

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
