### PR TITLE
feat(Migrate Auth TPC): Function for creating credentials/tokenSource/UniverseDomain and add option for client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	cloud.google.com/go/auth v0.16.1
+	cloud.google.com/go/auth/oauth2adapt v0.2.8
 	cloud.google.com/go/compute/metadata v0.7.0
 	cloud.google.com/go/iam v1.5.2
 	cloud.google.com/go/profiler v0.4.2
@@ -56,7 +57,6 @@ require (
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go v0.121.2 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
 	cloud.google.com/go/pubsub v1.49.0 // indirect

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -101,3 +101,7 @@ func (ts proxyTokenSource) Token() (token *oauth2.Token, err error) {
 func NewTokenSourceFromURL(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
 	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 }
+
+func GetTokenSourceFromTokenUrl(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
+	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
+}

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -102,6 +102,6 @@ func NewTokenSourceFromURL(ctx context.Context, tokenUrl string, reuseTokenFromU
 	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 }
 
-func GetTokenSourceFromTokenUrl(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
+func NewTokenSourceFromURL(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
 	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 }

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -101,7 +101,3 @@ func (ts proxyTokenSource) Token() (token *oauth2.Token, err error) {
 func NewTokenSourceFromURL(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
 	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
 }
-
-func NewTokenSourceFromURL(ctx context.Context, tokenUrl string, reuseTokenFromUrl bool) (tokenSrc oauth2.TokenSource, err error) {
-	return newProxyTokenSource(ctx, tokenUrl, reuseTokenFromUrl)
-}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -32,11 +32,11 @@ var (
 
 // createTokenSourceFromTokenUrl returns a token source using tokenUrl and reuse flag.
 // Returns nil if tokenUrl is empty.
-func createTokenSourceFromTokenUrl(tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
+func createTokenSourceFromTokenUrl(ctx context.Context, tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
 	if tokenUrl == "" {
 		return nil, nil
 	}
-	return auth2.NewTokenSourceFromURL(context.Background(), tokenUrl, reuse)
+	return auth2.NewTokenSourceFromURL(ctx, tokenUrl, reuse)
 }
 
 // createCredentials returns credentials from the provided key file.
@@ -46,9 +46,13 @@ func createCredentials(keyFile string) (*auth.Credentials, error) {
 
 // ConfigureClientAuth returns a token source using either token URL or fallback to key file/ADC.
 // It also updates clientOpts via pointer, so changes are visible to the caller.
-func ConfigureClientAuth(config *StorageClientConfig, clientOpts *[]option.ClientOption) (oauth2.TokenSource, error) {
+func ConfigureClientAuth(ctx context.Context, config *StorageClientConfig, clientOpts *[]option.ClientOption) (oauth2.TokenSource, error) {
+	if clientOpts == nil {
+		return nil, fmt.Errorf("clientOpts cannot be nil")
+	}
+
 	// Try token source via token URL.
-	tokenSrc, err := createTokenSourceFromTokenUrlFn(config.TokenUrl, config.ReuseTokenFromUrl)
+	tokenSrc, err := createTokenSourceFromTokenUrlFn(ctx, config.TokenUrl, config.ReuseTokenFromUrl)
 	if err != nil {
 		return nil, fmt.Errorf("while fetching token source: %w", err)
 	}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storageutil
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/auth/oauth2adapt"
+	auth2 "github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
+
+var (
+	createTokenSourceFromTokenUrlFn = createTokenSourceFromTokenUrl
+	createCredentialsFn             = createCredentials
+)
+
+// createTokenSourceFromTokenUrl returns a token source using tokenUrl and reuse flag.
+// Returns nil if tokenUrl is empty.
+func createTokenSourceFromTokenUrl(tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
+	if tokenUrl == "" {
+		return nil, nil
+	}
+	return auth2.NewTokenSourceFromURL(context.Background(), tokenUrl, reuse)
+}
+
+// createCredentials returns credentials from the provided key file.
+func createCredentials(keyFile string) (*auth.Credentials, error) {
+	return auth2.GetCredentials(keyFile)
+}
+
+// ConfigureClientAuth returns a token source using either token URL or fallback to key file/ADC.
+// It also updates clientOpts via pointer, so changes are visible to the caller.
+func ConfigureClientAuth(config *StorageClientConfig, clientOpts *[]option.ClientOption) (oauth2.TokenSource, error) {
+	// Try token source via token URL.
+	tokenSrc, err := createTokenSourceFromTokenUrlFn(config.TokenUrl, config.ReuseTokenFromUrl)
+	if err != nil {
+		return nil, fmt.Errorf("while fetching token source: %w", err)
+	}
+
+	if tokenSrc != nil {
+		*clientOpts = append(*clientOpts, option.WithTokenSource(tokenSrc))
+		return tokenSrc, nil
+	}
+
+	// Fallback to credentials.
+	cred, err := createCredentialsFn(config.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("while fetching credentials: %w", err)
+	}
+
+	tokenSrc = oauth2adapt.TokenSourceFromTokenProvider(cred.TokenProvider)
+
+	domain, err := cred.UniverseDomain(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get UniverseDomain: %w", err)
+	}
+
+	*clientOpts = append(*clientOpts, option.WithUniverseDomain(domain), option.WithAuthCredentials(cred))
+
+	return tokenSrc, nil
+}

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/auth"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
@@ -33,23 +33,23 @@ func resetInjectedFunctions() {
 func TestCreateCredentials(t *testing.T) {
 	cred, err := createCredentials("testdata/key.json")
 
-	require.NoError(t, err)
-	require.NotNil(t, cred)
+	assert.NoError(t, err)
+	assert.NotNil(t, cred)
 }
 
 func Test_CreateTokenSourceFromTokenUrl(t *testing.T) {
 	t.Run("empty token URL returns nil", func(t *testing.T) {
 		tokenSrc, err := createTokenSourceFromTokenUrl("", false)
-		require.NoError(t, err)
-		require.Nil(t, tokenSrc)
+		assert.NoError(t, err)
+		assert.Nil(t, tokenSrc)
 	})
 
 	t.Run("valid token URL returns token source", func(t *testing.T) {
 		// Ideally, you'd mock auth2.GetTokenSourceFromTokenUrl.
 		// For now, assume it works or wrap it in an interface for testability.
 		tokenSrc, err := createTokenSourceFromTokenUrl("https://example.com/token", false)
-		require.NoError(t, err)
-		require.NotNil(t, tokenSrc)
+		assert.NoError(t, err)
+		assert.NotNil(t, tokenSrc)
 	})
 }
 
@@ -63,9 +63,9 @@ func Test_CreateCredentialForClient_TokenUrlPreferredSuccess(t *testing.T) {
 
 	tokenSrc, err := ConfigureClientAuth(config, &clientOpts)
 
-	require.NoError(t, err)
-	require.NotNil(t, tokenSrc)
-	require.Len(t, clientOpts, 1) // Only tokenSource option attached
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.Len(t, clientOpts, 1) // Only tokenSource option attached
 }
 
 func Test_ConfigureClientAuth_TokenUrlPreferredError(t *testing.T) {
@@ -78,8 +78,8 @@ func Test_ConfigureClientAuth_TokenUrlPreferredError(t *testing.T) {
 
 	_, err := ConfigureClientAuth(config, &clientOpts)
 
-	require.ErrorContains(t, err, "simulated token source error")
-	require.Empty(t, clientOpts)
+	assert.ErrorContains(t, err, "simulated token source error")
+	assert.Empty(t, clientOpts)
 }
 
 func TestCreateCredentialForClient_FallbackToKeyFile_Success(t *testing.T) {
@@ -91,9 +91,9 @@ func TestCreateCredentialForClient_FallbackToKeyFile_Success(t *testing.T) {
 
 	tokenSrc, err := ConfigureClientAuth(config, &clientOpts)
 
-	require.NoError(t, err)
-	require.NotNil(t, tokenSrc)
-	require.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
 }
 
 func TestConfigureClientAuth_FallbackToKeyFile_Error(t *testing.T) {
@@ -111,6 +111,6 @@ func TestConfigureClientAuth_FallbackToKeyFile_Error(t *testing.T) {
 
 	_, err := ConfigureClientAuth(config, &clientOpts)
 
-	require.Error(t, err)
-	require.Empty(t, clientOpts)
+	assert.Error(t, err)
+	assert.Empty(t, clientOpts)
 }

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storageutil
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/auth"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
+
+// --- Helper to reset after test ---
+func resetInjectedFunctions() {
+	createTokenSourceFromTokenUrlFn = createTokenSourceFromTokenUrl
+	createCredentialsFn = createCredentials
+}
+
+func TestCreateCredentials(t *testing.T) {
+	cred, err := createCredentials("testdata/key.json")
+
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
+func Test_CreateTokenSourceFromTokenUrl(t *testing.T) {
+	t.Run("empty token URL returns nil", func(t *testing.T) {
+		tokenSrc, err := createTokenSourceFromTokenUrl("", false)
+		require.NoError(t, err)
+		require.Nil(t, tokenSrc)
+	})
+
+	t.Run("valid token URL returns token source", func(t *testing.T) {
+		// Ideally, you'd mock auth2.GetTokenSourceFromTokenUrl.
+		// For now, assume it works or wrap it in an interface for testability.
+		tokenSrc, err := createTokenSourceFromTokenUrl("https://example.com/token", false)
+		require.NoError(t, err)
+		require.NotNil(t, tokenSrc)
+	})
+}
+
+func Test_CreateCredentialForClient_TokenUrlPreferredSuccess(t *testing.T) {
+	var clientOpts []option.ClientOption
+	config := &StorageClientConfig{
+		TokenUrl:          "https://example.com/token",
+		ReuseTokenFromUrl: false,
+		KeyFile:           "/path/to/keyfile.json",
+	}
+
+	tokenSrc, err := ConfigureClientAuth(config, &clientOpts)
+
+	require.NoError(t, err)
+	require.NotNil(t, tokenSrc)
+	require.Len(t, clientOpts, 1) // Only tokenSource option attached
+}
+
+func Test_ConfigureClientAuth_TokenUrlPreferredError(t *testing.T) {
+	createTokenSourceFromTokenUrlFn = func(tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
+		return nil, errors.New("simulated token source error")
+	}
+	defer resetInjectedFunctions()
+	config := &StorageClientConfig{TokenUrl: "fake-url"}
+	var clientOpts []option.ClientOption
+
+	_, err := ConfigureClientAuth(config, &clientOpts)
+
+	require.ErrorContains(t, err, "simulated token source error")
+	require.Empty(t, clientOpts)
+}
+
+func TestCreateCredentialForClient_FallbackToKeyFile_Success(t *testing.T) {
+	var clientOpts []option.ClientOption
+	config := &StorageClientConfig{
+		TokenUrl: "", // triggers fallback
+		KeyFile:  "testdata/key.json",
+	}
+
+	tokenSrc, err := ConfigureClientAuth(config, &clientOpts)
+
+	require.NoError(t, err)
+	require.NotNil(t, tokenSrc)
+	require.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
+}
+
+func TestConfigureClientAuth_FallbackToKeyFile_Error(t *testing.T) {
+	createTokenSourceFromTokenUrlFn = func(tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
+		return nil, nil
+	}
+	createCredentialsFn = func(keyFile string) (*auth.Credentials, error) {
+		return &auth.Credentials{
+			TokenProvider: nil,
+		}, errors.New("error in getting credentials")
+	}
+	defer resetInjectedFunctions()
+	config := &StorageClientConfig{TokenUrl: "", KeyFile: "fake-key"}
+	var clientOpts []option.ClientOption
+
+	_, err := ConfigureClientAuth(config, &clientOpts)
+
+	require.Error(t, err)
+	require.Empty(t, clientOpts)
+}

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -38,7 +38,7 @@ func Test_GetClientAuthOptionsAndToken_TokenUrlPreferredSuccess(t *testing.T) {
 	config := &StorageClientConfig{
 		TokenUrl:          server.URL,
 		ReuseTokenFromUrl: false,
-		KeyFile:           "/path/to/keyfile.json",
+		KeyFile:           "testdata/key.json",
 	}
 
 	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
@@ -51,9 +51,10 @@ func Test_GetClientAuthOptionsAndToken_TokenUrlPreferredSuccess(t *testing.T) {
 func Test_GetClientAuthOptionsAndToken_TokenUrlPreferredError(t *testing.T) {
 	config := &StorageClientConfig{TokenUrl: ":"}
 
-	clientOpts, _, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.Error(t, err)
+	assert.Nil(t, tokenSrc)
 	assert.Empty(t, clientOpts)
 }
 
@@ -74,9 +75,9 @@ func Test_GetClientAuthOptionsAndToken_FallbackToKeyFileError(t *testing.T) {
 	config := &StorageClientConfig{TokenUrl: "", KeyFile: "fake-key"}
 	var clientOpts []option.ClientOption
 
-	clientOpts, ts, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.Error(t, err)
-	assert.Nil(t, ts)
+	assert.Nil(t, tokenSrc)
 	assert.Empty(t, clientOpts)
 }

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -16,40 +16,20 @@ package storageutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"cloud.google.com/go/auth"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
-
-////////////////////////////////////////////////////////////////////////
-// Helpers
-////////////////////////////////////////////////////////////////////////
-
-func resetInjectedFunctions() {
-	createTokenSourceFromTokenUrlFn = createTokenSourceFromTokenUrl
-	createCredentialsFn = createCredentials
-}
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func TestCreateCredentials(t *testing.T) {
-	cred, err := createCredentials("testdata/key.json")
-
-	assert.NoError(t, err)
-	assert.NotNil(t, cred)
-}
-
-func Test_CreateCredentialForClient_TokenUrlPreferredSuccess(t *testing.T) {
-	var clientOpts []option.ClientOption
+func Test_GetClientAuthOptionsAndToken_TokenUrlPreferredSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `{"access_token":"dummy-token","token_type":"Bearer"}`)
@@ -61,64 +41,42 @@ func Test_CreateCredentialForClient_TokenUrlPreferredSuccess(t *testing.T) {
 		KeyFile:           "/path/to/keyfile.json",
 	}
 
-	tokenSrc, err := ConfigureClientAuth(context.TODO(), config, &clientOpts)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tokenSrc)
 	assert.Len(t, clientOpts, 1) // Only tokenSource option attached
 }
 
-func Test_ConfigureClientAuth_TokenUrlPreferredError(t *testing.T) {
-	createTokenSourceFromTokenUrlFn = func(ctx context.Context, tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
-		return nil, errors.New("simulated token source error")
-	}
-	defer resetInjectedFunctions()
-	config := &StorageClientConfig{TokenUrl: "fake-url"}
-	var clientOpts []option.ClientOption
+func Test_GetClientAuthOptionsAndToken_TokenUrlPreferredError(t *testing.T) {
+	config := &StorageClientConfig{TokenUrl: ":"}
 
-	_, err := ConfigureClientAuth(context.TODO(), config, &clientOpts)
+	clientOpts, _, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "simulated token source error")
 	assert.Empty(t, clientOpts)
 }
 
-func Test_ConfigureClientAuth_NilClientOption(t *testing.T) {
-	config := &StorageClientConfig{TokenUrl: "fake-url"}
-
-	_, err := ConfigureClientAuth(context.TODO(), config, nil)
-
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "clientOpts cannot be nil")
-}
-
-func Test_CreateCredentialForClient_FallbackToKeyFileSuccess(t *testing.T) {
-	var clientOpts []option.ClientOption
+func Test_GetClientAuthOptionsAndToken_FallbackToKeyFileSuccess(t *testing.T) {
 	config := &StorageClientConfig{
 		TokenUrl: "", // triggers fallback
 		KeyFile:  "testdata/key.json",
 	}
 
-	tokenSrc, err := ConfigureClientAuth(context.TODO(), config, &clientOpts)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tokenSrc)
 	assert.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
 }
 
-func Test_ConfigureClientAuth_FallbackToKeyFileError(t *testing.T) {
-	createTokenSourceFromTokenUrlFn = func(ctx context.Context, tokenUrl string, reuse bool) (oauth2.TokenSource, error) {
-		return nil, nil
-	}
-	createCredentialsFn = func(keyFile string) (*auth.Credentials, error) {
-		return nil, errors.New("error in getting credentials")
-	}
-	defer resetInjectedFunctions()
+func Test_GetClientAuthOptionsAndToken_FallbackToKeyFileError(t *testing.T) {
 	config := &StorageClientConfig{TokenUrl: "", KeyFile: "fake-key"}
 	var clientOpts []option.ClientOption
 
-	_, err := ConfigureClientAuth(context.TODO(), config, &clientOpts)
+	clientOpts, ts, err := GetClientAuthOptionsAndToken(context.TODO(), config)
 
 	assert.Error(t, err)
+	assert.Nil(t, ts)
 	assert.Empty(t, clientOpts)
 }

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -28,11 +28,18 @@ import (
 	"google.golang.org/api/option"
 )
 
-// --- Helper to reset after test ---
+////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////
+
 func resetInjectedFunctions() {
 	createTokenSourceFromTokenUrlFn = createTokenSourceFromTokenUrl
 	createCredentialsFn = createCredentials
 }
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
 
 func TestCreateCredentials(t *testing.T) {
 	cred, err := createCredentials("testdata/key.json")
@@ -71,8 +78,18 @@ func Test_ConfigureClientAuth_TokenUrlPreferredError(t *testing.T) {
 
 	_, err := ConfigureClientAuth(context.TODO(), config, &clientOpts)
 
+	assert.Error(t, err)
 	assert.ErrorContains(t, err, "simulated token source error")
 	assert.Empty(t, clientOpts)
+}
+
+func Test_ConfigureClientAuth_NilClientOption(t *testing.T) {
+	config := &StorageClientConfig{TokenUrl: "fake-url"}
+
+	_, err := ConfigureClientAuth(context.TODO(), config, nil)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "clientOpts cannot be nil")
 }
 
 func Test_CreateCredentialForClient_FallbackToKeyFileSuccess(t *testing.T) {

--- a/internal/storage/storageutil/testdata/key.json
+++ b/internal/storage/storageutil/testdata/key.json
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "project_id",
+  "private_key_id": "private_key_id",
+  "private_key": "private_key",
+  "client_email": "client_email",
+  "client_id": "client_id",
+  "auth_uri": "auth_uri",
+  "token_uri": "token_uri",
+  "auth_provider_x509_cert_url": "auth_provider_x509_cert_url",
+  "client_x509_cert_url": "client_x509_cert_url",
+  "universe_domain": "googleapis.com"
+}


### PR DESCRIPTION
### Description
- Created a function to fetch credentials/tokenSource/UniverseDomain and return them as client options.
- The function also returns the token source, as it will be necessary for the HTTP client to append it in the Transport layer.

### Link to the issue in case of a bug fix.
[b/432654490](https://b.corp.google.com/issues/432654490)

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
