### PR TITLE
test(rapid appends): appends with concurrent file handles must be real time

### DIFF
--- a/tools/integration_tests/rapid_appends/setup_test.go
+++ b/tools/integration_tests/rapid_appends/setup_test.go
@@ -24,6 +24,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
@@ -35,6 +36,7 @@ const (
 	// Minimum content size to write in order to trigger block upload while writing ; calculated as (2*blocksize+1) mb.
 	// Block size for buffered writes is set to 1MiB.
 	contentSizeForBW = 3
+	blockSize        = operations.OneMiB
 )
 
 var (


### PR DESCRIPTION
### Description
The functional test in this PR tests the scenario when multiple concurrent file handles are opened against the same unfinalized object from the same mount( i.e. the same file inode). 
The test includes :
- File handle opened in append mode and *write* issued in order to trigger the BW flow.
- Another file handle from the same mount, opened in read plus mode , which will use the same bwh initialized in the previous step, ensuring even writes using this file handle will be real-time.

### Link to the issue in case of a bug fix.
[b/432420125](b/432420125)

### Testing details
1. Manual - Yes
`  --- PASS: TestRapidAppendsSuite/TestAppendsVisibleInRealTimeWithConcurrentRPlusHandle (1.46s)`
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
