### PR TITLE
refactor(metrics): Refactor metrics code into a separate package.

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/sys/unix"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -122,7 +123,7 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	}
 	return fmt.Sprintf("%s:%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled, areStreamingWritesEnabled)
 }
-func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle common.MetricHandle) (storageHandle storage.StorageHandle, err error) {
+func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle metrics.MetricHandle) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{
 		ClientProtocol:             newConfig.GcsConnection.ClientProtocol,
 		MaxConnsPerHost:            int(newConfig.GcsConnection.MaxConnsPerHost),
@@ -153,7 +154,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle c
 ////////////////////////////////////////////////////////////////////////
 
 // Mount the file system according to arguments in the supplied context.
-func mountWithArgs(bucketName string, mountPoint string, newConfig *cfg.Config, metricHandle common.MetricHandle) (mfs *fuse.MountedFileSystem, err error) {
+func mountWithArgs(bucketName string, mountPoint string, newConfig *cfg.Config, metricHandle metrics.MetricHandle) (mfs *fuse.MountedFileSystem, err error) {
 	// Enable invariant checking if requested.
 	if newConfig.Debug.ExitOnInvariantViolation {
 		locker.EnableInvariantsCheck()
@@ -392,11 +393,11 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 
 	ctx := context.Background()
 	var metricExporterShutdownFn common.ShutdownFn
-	metricHandle := common.NewNoopMetrics()
+	metricHandle := metrics.NewNoopMetrics()
 	if cfg.IsMetricsEnabled(&newConfig.Metrics) {
 		metricExporterShutdownFn = monitor.SetupOTelMetricExporters(ctx, newConfig)
-		if metricHandle, err = common.NewOTelMetrics(); err != nil {
-			metricHandle = common.NewNoopMetrics()
+		if metricHandle, err = metrics.NewOTelMetrics(); err != nil {
+			metricHandle = metrics.NewNoopMetrics()
 		}
 	}
 	shutdownTracingFn := monitor.SetupTracing(ctx, newConfig)

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -44,7 +45,7 @@ func (t *MainTest) TestCreateStorageHandle() {
 		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
 	}
 
-	storageHandle, err := createStorageHandle(newConfig, "AppName", common.NewNoopMetrics())
+	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics())
 
 	assert.Equal(t.T(), nil, err)
 	assert.NotEqual(t.T(), nil, storageHandle)
@@ -56,7 +57,7 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
 	}
 
-	storageHandle, err := createStorageHandle(newConfig, "AppName", common.NewNoopMetrics())
+	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics())
 
 	assert.Equal(t.T(), nil, err)
 	assert.NotEqual(t.T(), nil, storageHandle)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/mount"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
@@ -42,7 +42,7 @@ func mountWithStorageHandle(
 	mountPoint string,
 	newConfig *cfg.Config,
 	storageHandle storage.StorageHandle,
-	metricHandle common.MetricHandle) (mfs *fuse.MountedFileSystem, err error) {
+	metricHandle metrics.MetricHandle) (mfs *fuse.MountedFileSystem, err error) {
 	// Sanity check: make sure the temporary directory exists and is writable
 	// currently. This gives a better user experience than harder to debug EIO
 	// errors when reading files in the future.

--- a/common/util.go
+++ b/common/util.go
@@ -15,10 +15,28 @@
 package common
 
 import (
+	"context"
+	"errors"
 	"os/exec"
 	"regexp"
 	"strings"
 )
+
+type ShutdownFn func(ctx context.Context) error
+
+// JoinShutdownFunc combines the provided shutdown functions into a single function.
+func JoinShutdownFunc(shutdownFns ...ShutdownFn) ShutdownFn {
+	return func(ctx context.Context) error {
+		var err error
+		for _, fn := range shutdownFns {
+			if fn == nil {
+				continue
+			}
+			err = errors.Join(err, fn(ctx))
+		}
+		return err
+	}
+}
 
 // GetKernelVersion returns the kernel version.
 func GetKernelVersion() (string, error) {

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -29,7 +29,6 @@ import (
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -38,6 +37,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -155,7 +155,7 @@ func (cht *cacheHandleTest) SetupTest() {
 		func() {},
 		fileCacheConfig,
 		semaphore.NewWeighted(math.MaxInt64),
-		common.NewNoopMetrics(),
+		metrics.NewNoopMetrics(),
 	)
 
 	cht.cacheHandle = NewCacheHandle(readLocalFileHandle, fileDownloadJob, cht.cache, false, 0)
@@ -858,7 +858,7 @@ func (cht *cacheHandleTest) Test_SequentialRead_Parallel_Download_True() {
 		func() {},
 		fileCacheConfig,
 		semaphore.NewWeighted(math.MaxInt64),
-		common.NewNoopMetrics(),
+		metrics.NewNoopMetrics(),
 	)
 	cht.cacheHandle.fileDownloadJob = fileDownloadJob
 
@@ -893,7 +893,7 @@ func (cht *cacheHandleTest) Test_RandomRead_Parallel_Download_True() {
 		func() {},
 		fileCacheConfig,
 		semaphore.NewWeighted(math.MaxInt64),
-		common.NewNoopMetrics(),
+		metrics.NewNoopMetrics(),
 	)
 	cht.cacheHandle.fileDownloadJob = fileDownloadJob
 
@@ -928,7 +928,7 @@ func (cht *cacheHandleTest) Test_RandomRead_CacheForRangeReadFalse_And_ParallelD
 		func() {},
 		fileCacheConfig,
 		semaphore.NewWeighted(math.MaxInt64),
-		common.NewNoopMetrics(),
+		metrics.NewNoopMetrics(),
 	)
 
 	// Since, it's a random read, download job will not start.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -27,7 +27,6 @@ import (
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -36,6 +35,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -85,7 +85,7 @@ func initializeCacheHandlerTestArgs(t *testing.T, fileCacheConfig *cfg.FileCache
 
 	// Job manager
 	jobManager := downloader.NewJobManager(cache, util.DefaultFilePerm,
-		util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, fileCacheConfig, common.NewNoopMetrics())
+		util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, fileCacheConfig, metrics.NewNoopMetrics())
 
 	// Mocked cached handler object.
 	cacheHandler := NewCacheHandler(cache, jobManager, cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, fileCacheConfig.ExperimentalExcludeRegex)

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -19,12 +19,12 @@ import (
 	"os"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -61,12 +61,12 @@ type JobManager struct {
 	jobs              map[string]*Job
 	mu                locker.Locker
 	maxParallelismSem *semaphore.Weighted
-	metricHandle      common.MetricHandle
+	metricHandle      metrics.MetricHandle
 }
 
 func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.FileMode,
 	cacheDir string, sequentialReadSizeMb int32, c *cfg.FileCacheConfig,
-	metricHandle common.MetricHandle) (jm *JobManager) {
+	metricHandle metrics.MetricHandle) (jm *JobManager) {
 	maxParallelDownloads := int64(math.MaxInt64)
 	if c.MaxParallelDownloads > 0 {
 		maxParallelDownloads = c.MaxParallelDownloads

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -24,7 +24,6 @@ import (
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
@@ -32,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	. "github.com/jacobsa/ogletest"
 	"github.com/stretchr/testify/mock"
@@ -70,7 +70,7 @@ func (dt *downloaderTest) setupHelper() {
 	ExpectEq(nil, err)
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
-	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, dt.defaultFileCacheConfig, common.NewNoopMetrics())
+	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, dt.defaultFileCacheConfig, metrics.NewNoopMetrics())
 }
 
 func (dt *downloaderTest) SetUp(*TestInfo) {

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -24,13 +24,13 @@ import (
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -156,7 +156,7 @@ func TestParallelDownloads(t *testing.T) {
 				WriteBufferSize:      4 * 1024 * 1024,
 				EnableODirect:        tc.enableODirect,
 			}
-			jm := NewJobManager(cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, 2, fileCacheConfig, common.NewNoopMetrics())
+			jm := NewJobManager(cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, 2, fileCacheConfig, metrics.NewNoopMetrics())
 			job := jm.CreateJobIfNotExists(&minObj, bucket)
 			subscriberC := job.subscribe(tc.subscribedOffset)
 
@@ -199,7 +199,7 @@ func TestMultipleConcurrentDownloads(t *testing.T) {
 		MaxParallelDownloads:     2,
 		WriteBufferSize:          4 * 1024 * 1024,
 	}
-	jm := NewJobManager(cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, 2, fileCacheConfig, common.NewNoopMetrics())
+	jm := NewJobManager(cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, 2, fileCacheConfig, metrics.NewNoopMetrics())
 	job1 := jm.CreateJobIfNotExists(&minObj1, bucket)
 	job2 := jm.CreateJobIfNotExists(&minObj2, bucket)
 	s1 := job1.subscribe(10 * util.MiB)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -25,13 +25,13 @@ import (
 	"syscall"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	cacheutil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/semaphore"
 )
@@ -96,7 +96,7 @@ type Job struct {
 	// downloaded when parallel download is enabled.
 	rangeChan chan data.ObjectRange
 
-	metricsHandle common.MetricHandle
+	metricsHandle metrics.MetricHandle
 }
 
 // JobStatus represents the status of job.
@@ -122,7 +122,7 @@ func NewJob(
 	removeJobCallback func(),
 	fileCacheConfig *cfg.FileCacheConfig,
 	maxParallelismSem *semaphore.Weighted,
-	metricHandle common.MetricHandle,
+	metricHandle metrics.MetricHandle,
 ) (job *Job) {
 	job = &Job{
 		object:               object,
@@ -326,7 +326,7 @@ func (job *Job) downloadObjectToFile(cacheFile *os.File) (err error) {
 			if newReader != nil {
 				readHandle = newReader.ReadHandle()
 			}
-			common.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, common.ReadTypeSequential, newReaderLimit-start)
+			metrics.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, metrics.ReadTypeSequential, newReaderLimit-start)
 		}
 
 		maxRead := min(ReadChunkSize, newReaderLimit-start)

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -28,13 +28,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	. "github.com/jacobsa/ogletest"
 	"golang.org/x/sync/semaphore"
 )
@@ -63,7 +63,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	}
 	dt.cache = lru.NewCache(lruCacheSize)
 
-	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec, removeCallback, dt.defaultFileCacheConfig, semaphore.NewWeighted(math.MaxInt64), common.NewNoopMetrics())
+	dt.job = NewJob(&dt.object, dt.bucket, dt.cache, sequentialReadSize, dt.fileSpec, removeCallback, dt.defaultFileCacheConfig, semaphore.NewWeighted(math.MaxInt64), metrics.NewNoopMetrics())
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
 		ObjectName: objectName,

--- a/internal/cache/file/downloader/job_testify_test.go
+++ b/internal/cache/file/downloader/job_testify_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/semaphore"
 
@@ -65,7 +65,7 @@ func (t *JobTestifyTest) initReadCacheTestifyTest(objectName string, objectConte
 		DirPerm:  util.DefaultDirPerm,
 	}
 	t.cache = lru.NewCache(lruCacheSize)
-	t.job = NewJob(&t.object, t.mockBucket, t.cache, sequentialReadSize, t.fileSpec, removeCallback, t.defaultFileCacheConfig, semaphore.NewWeighted(math.MaxInt64), common.NewNoopMetrics())
+	t.job = NewJob(&t.object, t.mockBucket, t.cache, sequentialReadSize, t.fileSpec, removeCallback, t.defaultFileCacheConfig, semaphore.NewWeighted(math.MaxInt64), metrics.NewNoopMetrics())
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
 		ObjectName: objectName,

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -21,11 +21,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	cacheutil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -60,7 +60,7 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 		}
 	}()
 
-	common.CaptureGCSReadMetrics(ctx, job.metricsHandle, common.ReadTypeParallel, end-start)
+	metrics.CaptureGCSReadMetrics(ctx, job.metricsHandle, metrics.ReadTypeParallel, end-start)
 
 	// Use standard copy function if O_DIRECT is disabled and memory aligned
 	// buffer otherwise.

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
@@ -29,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fusetesting"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
@@ -479,7 +479,7 @@ func (t *MultiBucketMountCachingTest) SetUpTestSuite() {
 
 	// Enable directory type caching.
 	t.serverCfg.DirTypeCacheTTL = ttl
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 
 	// Call through.
 	t.fsTest.SetUpTestSuite()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -29,11 +29,11 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -130,7 +130,7 @@ type ServerConfig struct {
 	// NewConfig has all the config specified by the user using config-file or CLI flags.
 	NewConfig *cfg.Config
 
-	MetricHandle common.MetricHandle
+	MetricHandle metrics.MetricHandle
 }
 
 // Create a fuse file system server according to the supplied configuration.
@@ -487,7 +487,7 @@ type fileSystem struct {
 	// random file access.
 	cacheFileForRangeRead bool
 
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 
 	enableAtomicRenameObject bool
 

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
@@ -39,6 +38,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fusetesting"
 	. "github.com/jacobsa/ogletest"
@@ -169,7 +169,7 @@ func (t *fsTest) SetUpTestSuite() {
 			EnableNewReader: true,
 		}
 	}
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 
 	// Set up ownership.
 	t.serverCfg.Uid, t.serverCfg.Gid, err = perms.MyUserAndGroup()
@@ -372,7 +372,7 @@ func (bm *fakeBucketManager) ShutDown() {}
 
 func (bm *fakeBucketManager) SetUpBucket(
 	ctx context.Context,
-	name string, isMultibucketMount bool, _ common.MetricHandle) (sb gcsx.SyncerBucket, err error) {
+	name string, isMultibucketMount bool, _ metrics.MetricHandle) (sb gcsx.SyncerBucket, err error) {
 	bucket, ok := bm.buckets[name]
 	if ok {
 		sb = gcsx.NewSyncerBucket(

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -20,13 +20,13 @@ import (
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx/read_manager"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/syncutil"
 	"golang.org/x/net/context"
 )
@@ -59,7 +59,7 @@ type FileHandle struct {
 	// cacheFileForRangeRead is also valid for cache workflow, if true, object content
 	// will be downloaded for random reads as well too.
 	cacheFileForRangeRead bool
-	metricHandle          common.MetricHandle
+	metricHandle          metrics.MetricHandle
 	// openMode is used to store the mode in which the file is opened.
 	openMode util.OpenMode
 
@@ -68,7 +68,7 @@ type FileHandle struct {
 }
 
 // LOCKS_REQUIRED(fh.inode.mu)
-func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, openMode util.OpenMode, rc *cfg.ReadConfig) (fh *FileHandle) {
+func NewFileHandle(inode *inode.FileInode, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle metrics.MetricHandle, openMode util.OpenMode, rc *cfg.ReadConfig) (fh *FileHandle) {
 	fh = &FileHandle{
 		inode:                 inode,
 		fileCacheHandler:      fileCacheHandler,

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -32,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
@@ -167,7 +167,7 @@ func (t *fileTest) Test_Read_Success() {
 	expectedData := []byte("hello from reader")
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_reader", expectedData, false)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -183,7 +183,7 @@ func (t *fileTest) Test_ReadWithReadManager_Success() {
 	expectedData := []byte("hello from readManager")
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_readManager", expectedData, false)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -215,7 +215,7 @@ func (t *fileTest) Test_ReadWithReadManager_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 			fh.inode.Lock()
 			mockRM := new(read_manager.MockReadManager)
 			mockRM.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ReaderResponse{}, tc.returnErr)
@@ -253,7 +253,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 			fh.inode.Lock()
 			mockReader := new(gcsx.MockRandomReader)
 			mockReader.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ObjectData{}, tc.returnErr)
@@ -278,7 +278,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 	fh.inode.Lock()
 	mockRM := new(read_manager.MockReadManager)
 	mockRM.On("Destroy").Return()
@@ -300,7 +300,7 @@ func (t *fileTest) Test_Read_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock, "parentRoot")
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, common.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.ReadConfig{})
 	fh.inode.Lock()
 	mockR := new(gcsx.MockRandomReader)
 	mockR.On("Destroy").Return()

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -24,12 +24,12 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func (t *HNSBucketTests) SetupSuite() {
 		EnableHns:                true,
 		EnableAtomicRenameObject: true,
 	}
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	bucketType = gcs.BucketType{Hierarchical: true}
 	t.fsTest.SetUpTestSuite()
 }

--- a/internal/fs/implicit_dirs_test.go
+++ b/internal/fs/implicit_dirs_test.go
@@ -24,8 +24,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fusetesting"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
@@ -46,7 +46,7 @@ func init() {
 
 func (t *ImplicitDirsTest) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/implicit_dirs_with_cache_test.go
+++ b/internal/fs/implicit_dirs_with_cache_test.go
@@ -24,7 +24,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
 )
@@ -44,7 +44,7 @@ func init() {
 func (t *ImplicitDirsWithCacheTest) SetUpTestSuite() {
 	t.serverCfg.ImplicitDirectories = true
 	t.serverCfg.DirTypeCacheTTL = time.Minute * 3
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -18,8 +18,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/jacobsa/fuse"
@@ -62,7 +62,7 @@ type baseDirInode struct {
 	// GUARDED_BY(mu)
 	buckets map[string]gcsx.SyncerBucket
 
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
 // NewBaseDirInode returns a baseDirInode that acts as the directory of
@@ -72,7 +72,7 @@ func NewBaseDirInode(
 	name Name,
 	attrs fuseops.InodeAttributes,
 	bm gcsx.BucketManager,
-	metricHandle common.MetricHandle) (d DirInode) {
+	metricHandle metrics.MetricHandle) (d DirInode) {
 	typed := &baseDirInode{
 		id:            id,
 		name:          NewRootName(""),

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -93,7 +93,7 @@ type fakeBucketManager struct {
 
 func (bm *fakeBucketManager) SetUpBucket(
 	ctx context.Context,
-	name string, isMultibucketMount bool, _ common.MetricHandle) (sb gcsx.SyncerBucket, err error) {
+	name string, isMultibucketMount bool, _ metrics.MetricHandle) (sb gcsx.SyncerBucket, err error) {
 	bm.setupTimes++
 
 	var ok bool
@@ -125,7 +125,7 @@ func (t *BaseDirTest) resetInode() {
 			Mode: dirMode,
 		},
 		t.bm,
-		common.NewNoopMetrics())
+		metrics.NewNoopMetrics())
 
 	t.in.Lock()
 }

--- a/internal/fs/kernel_list_cache_inifinite_ttl_test.go
+++ b/internal/fs/kernel_list_cache_inifinite_ttl_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -58,7 +59,7 @@ func (t *KernelListCacheTestWithInfiniteTtl) SetupSuite() {
 		},
 	}
 	t.serverCfg.RenameDirLimit = 10
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/kernel_list_cache_test.go
+++ b/internal/fs/kernel_list_cache_test.go
@@ -31,8 +31,8 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -115,7 +115,7 @@ func (t *KernelListCacheTestWithPositiveTtl) SetupSuite() {
 		},
 	}
 	t.serverCfg.RenameDirLimit = 10
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/kernel_list_cache_zero_ttl_test.go
+++ b/internal/fs/kernel_list_cache_zero_ttl_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -45,7 +45,7 @@ func (t *KernelListCacheTestWithZeroTtl) SetupSuite() {
 		},
 	}
 	t.serverCfg.RenameDirLimit = 10
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/local_file_test.go
+++ b/internal/fs/local_file_test.go
@@ -30,10 +30,10 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fusetesting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -876,7 +876,7 @@ func (t *LocalFileTest) TestStatFailsOnNewFileAfterDeletion() {
 		},
 		Logging: cfg.DefaultLoggingConfig(),
 	}
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	filePath := path.Join(mntDir, "test.txt")
 	f1, err := os.Create(filePath)
 	require.NoError(t.T(), err)

--- a/internal/fs/parallel_dirops_test.go
+++ b/internal/fs/parallel_dirops_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -48,7 +48,7 @@ func (t *ParallelDiropsTest) SetupSuite() {
 			DisableParallelDirops: false,
 		}}
 	t.serverCfg.RenameDirLimit = 10
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/read_cache_test.go
+++ b/internal/fs/read_cache_test.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	. "github.com/jacobsa/ogletest"
 )
 
@@ -76,7 +76,7 @@ func (t *FileCacheTest) SetUpTestSuite() {
 		},
 		CacheDir: cfg.ResolvedPath(CacheDir),
 	}
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	t.fsTest.SetUpTestSuite()
 }
 

--- a/internal/fs/type_cache_test.go
+++ b/internal/fs/type_cache_test.go
@@ -27,12 +27,12 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	gcsfusefs "github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 
 	"github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/ogletest"
@@ -79,7 +79,7 @@ func (t *typeCacheTestCommon) SetUpTestSuite() {
 			TtlSecs:            ttlInSeconds,
 		},
 	}
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 
 	// Fill server-cfg from mount-config.
 	func(newConfig *cfg.Config, serverCfg *gcsfusefs.ServerConfig) {

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -20,7 +20,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 )
@@ -225,13 +225,13 @@ func categorize(err error) string {
 }
 
 // Records file system operation count, failed operation count and the operation latency.
-func recordOp(ctx context.Context, metricHandle common.MetricHandle, method string, start time.Time, fsErr error) {
+func recordOp(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time, fsErr error) {
 	metricHandle.OpsCount(ctx, 1, method)
 
 	// Recording opErrorCount.
 	if fsErr != nil {
 		errCategory := categorize(fsErr)
-		metricHandle.OpsErrorCount(ctx, 1, common.FSOpsErrorCategory{
+		metricHandle.OpsErrorCount(ctx, 1, metrics.FSOpsErrorCategory{
 			FSOps:         method,
 			ErrorCategory: errCategory,
 		})
@@ -241,7 +241,7 @@ func recordOp(ctx context.Context, metricHandle common.MetricHandle, method stri
 
 // WithMonitoring takes a FileSystem, returns a FileSystem with monitoring
 // on the counts of requests per API.
-func WithMonitoring(fs fuseutil.FileSystem, metricHandle common.MetricHandle) fuseutil.FileSystem {
+func WithMonitoring(fs fuseutil.FileSystem, metricHandle metrics.MetricHandle) fuseutil.FileSystem {
 	return &monitoring{
 		wrapped:      fs,
 		metricHandle: metricHandle,
@@ -250,7 +250,7 @@ func WithMonitoring(fs fuseutil.FileSystem, metricHandle common.MetricHandle) fu
 
 type monitoring struct {
 	wrapped      fuseutil.FileSystem
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
 func (fs *monitoring) Destroy() {

--- a/internal/fs/zonal_bucket_test.go
+++ b/internal/fs/zonal_bucket_test.go
@@ -17,8 +17,8 @@ package fs_test
 import (
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -32,7 +32,7 @@ func TestZonalBucketTests(t *testing.T) { suite.Run(t, new(ZonalBucketTests)) }
 
 func (t *ZonalBucketTests) SetupSuite() {
 	t.serverCfg.ImplicitDirectories = false
-	t.serverCfg.MetricHandle = common.NewNoopMetrics()
+	t.serverCfg.MetricHandle = metrics.NewNoopMetrics()
 	bucketType = gcs.BucketType{Zonal: true}
 	t.fsTest.SetUpTestSuite()
 }

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/canned"
@@ -31,6 +30,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/timeutil"
 )
 
@@ -72,7 +72,7 @@ type BucketConfig struct {
 type BucketManager interface {
 	SetUpBucket(
 		ctx context.Context,
-		name string, isMultibucketMount bool, metricHandle common.MetricHandle) (b SyncerBucket, err error)
+		name string, isMultibucketMount bool, metricHandle metrics.MetricHandle) (b SyncerBucket, err error)
 
 	// Shuts down the bucket manager and its buckets
 	ShutDown()
@@ -161,7 +161,7 @@ func (bm *bucketManager) SetUpBucket(
 	ctx context.Context,
 	name string,
 	isMultibucketMount bool,
-	metricHandle common.MetricHandle,
+	metricHandle metrics.MetricHandle,
 ) (sb SyncerBucket, err error) {
 	var b gcs.Bucket
 	// Set up the appropriate backing bucket.

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -22,9 +22,9 @@ import (
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	. "github.com/jacobsa/ogletest"
 	"github.com/stretchr/testify/mock"
 )
@@ -107,7 +107,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethod() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, false, common.NewNoopMetrics())
+	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, false, metrics.NewNoopMetrics())
 
 	ExpectNe(nil, bucket.Syncer)
 	ExpectEq(nil, err)
@@ -131,7 +131,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethod_IsMultiBucketMountTrue() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, true, common.NewNoopMetrics())
+	bucket, err := bm.SetUpBucket(context.Background(), TestBucketName, true, metrics.NewNoopMetrics())
 
 	ExpectNe(nil, bucket.Syncer)
 	ExpectEq(nil, err)
@@ -155,7 +155,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false, common.NewNoopMetrics())
+	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false, metrics.NewNoopMetrics())
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))
@@ -180,7 +180,7 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist_IsMultiB
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
-	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, true, common.NewNoopMetrics())
+	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, true, metrics.NewNoopMetrics())
 
 	AssertNe(nil, err)
 	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -21,9 +21,9 @@ import (
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 // ReaderType represents different types of go-sdk gcs readers.
@@ -76,7 +76,7 @@ type GCSReader struct {
 }
 
 type GCSReaderConfig struct {
-	MetricHandle         common.MetricHandle
+	MetricHandle         metrics.MetricHandle
 	MrdWrapper           *gcsx.MultiRangeDownloaderWrapper
 	SequentialReadSizeMb int32
 	ReadConfig           *cfg.ReadConfig
@@ -89,7 +89,7 @@ func NewGCSReader(obj *gcs.MinObject, bucket gcs.Bucket, config *GCSReaderConfig
 		sequentialReadSizeMb: config.SequentialReadSizeMb,
 		rangeReader:          NewRangeReader(obj, bucket, config.ReadConfig, config.MetricHandle),
 		mrr:                  NewMultiRangeReader(obj, config.MetricHandle, config.MrdWrapper),
-		readType:             common.ReadTypeSequential,
+		readType:             metrics.ReadTypeSequential,
 	}
 }
 
@@ -149,7 +149,7 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 // readerType specifies the go-sdk interface to use for reads.
 func (gr *GCSReader) readerType(start int64, end int64, bucketType gcs.BucketType) ReaderType {
 	bytesToBeRead := end - start
-	if gr.readType == common.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
+	if gr.readType == metrics.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
 		return MultiRangeReaderType
 	}
 	return RangeReaderType
@@ -177,7 +177,7 @@ func (gr *GCSReader) getReadInfo(start int64, size int64) (int64, error) {
 func (gr *GCSReader) determineEnd(start int64) int64 {
 	end := int64(gr.object.Size)
 	if gr.seeks >= minSeeksForRandom {
-		gr.readType = common.ReadTypeRandom
+		gr.readType = metrics.ReadTypeRandom
 		averageReadBytes := gr.totalReadBytes / gr.seeks
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MB) + 1) * MB)

--- a/internal/gcsx/client_readers/multi_range_reader.go
+++ b/internal/gcsx/client_readers/multi_range_reader.go
@@ -20,10 +20,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 // TimeoutForMultiRangeRead is the timeout value for multi-range read operations.
@@ -42,10 +42,10 @@ type MultiRangeReader struct {
 	// boolean variable to determine if MRD is being used or not.
 	isMRDInUse bool
 
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
-func NewMultiRangeReader(object *gcs.MinObject, metricHandle common.MetricHandle, mrdWrapper *gcsx.MultiRangeDownloaderWrapper) *MultiRangeReader {
+func NewMultiRangeReader(object *gcs.MinObject, metricHandle metrics.MetricHandle, mrdWrapper *gcsx.MultiRangeDownloaderWrapper) *MultiRangeReader {
 	return &MultiRangeReader{
 		object:       object,
 		metricHandle: metricHandle,

--- a/internal/gcsx/client_readers/multi_range_reader_test.go
+++ b/internal/gcsx/client_readers/multi_range_reader_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/clock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testUtil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -67,7 +67,7 @@ func (t *multiRangeReaderTest) SetupTest() {
 		Size:       17,
 		Generation: 1234,
 	}
-	t.multiRangeReader = NewMultiRangeReader(t.object, common.NewNoopMetrics(), nil)
+	t.multiRangeReader = NewMultiRangeReader(t.object, metrics.NewNoopMetrics(), nil)
 }
 
 func (t *multiRangeReaderTest) TearDownTest() {

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -22,11 +22,11 @@ import (
 	"math"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 const (
@@ -62,10 +62,10 @@ type RangeReader struct {
 
 	readType     string
 	readConfig   *cfg.ReadConfig
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
-func NewRangeReader(object *gcs.MinObject, bucket gcs.Bucket, readConfig *cfg.ReadConfig, metricHandle common.MetricHandle) *RangeReader {
+func NewRangeReader(object *gcs.MinObject, bucket gcs.Bucket, readConfig *cfg.ReadConfig, metricHandle metrics.MetricHandle) *RangeReader {
 	return &RangeReader{
 		object:       object,
 		bucket:       bucket,
@@ -187,7 +187,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 	}
 
 	requestedDataSize := end - offset
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
 
 	return n, err
 }
@@ -279,7 +279,7 @@ func (rr *RangeReader) startRead(start int64, end int64) error {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, common.ReadTypeSequential, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeSequential, requestedDataSize)
 
 	return nil
 }

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -24,13 +24,13 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testUtil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -64,7 +64,7 @@ func (t *rangeReaderTest) SetupTest() {
 		Generation: 1234,
 	}
 	t.mockBucket = new(storage.TestifyMockBucket)
-	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, common.NewNoopMetrics())
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, metrics.NewNoopMetrics())
 	t.ctx = context.Background()
 }
 
@@ -146,11 +146,11 @@ func (t *rangeReaderTest) Test_NewRangeReader() {
 		Generation: 4321,
 	}
 
-	reader := NewRangeReader(object, t.mockBucket, nil, common.NewNoopMetrics())
+	reader := NewRangeReader(object, t.mockBucket, nil, metrics.NewNoopMetrics())
 
 	assert.Equal(t.T(), object, reader.object)
 	assert.Equal(t.T(), t.mockBucket, reader.bucket)
-	assert.Equal(t.T(), common.NewNoopMetrics(), reader.metricHandle)
+	assert.Equal(t.T(), metrics.NewNoopMetrics(), reader.metricHandle)
 	assert.Equal(t.T(), int64(-1), reader.start)
 	assert.Equal(t.T(), int64(-1), reader.limit)
 }

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	cacheUtil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 )
 
@@ -54,10 +54,10 @@ type FileCacheReader struct {
 	// using fileCacheHandler for the given object and bucket.
 	fileCacheHandle *file.CacheHandle
 
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
-func NewFileCacheReader(o *gcs.MinObject, bucket gcs.Bucket, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle) *FileCacheReader {
+func NewFileCacheReader(o *gcs.MinObject, bucket gcs.Bucket, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle metrics.MetricHandle) *FileCacheReader {
 	return &FileCacheReader{
 		object:                o,
 		bucket:                bucket,
@@ -117,9 +117,9 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 
 		logger.Tracef("%.13v -> %s", requestID, requestOutput)
 
-		readType := common.ReadTypeRandom
+		readType := metrics.ReadTypeRandom
 		if isSequential {
-			readType = common.ReadTypeSequential
+			readType = metrics.ReadTypeSequential
 		}
 		captureFileCacheMetrics(ctx, fc.metricHandle, readType, bytesRead, cacheHit, executionTime)
 	}()
@@ -207,8 +207,8 @@ func (fc *FileCacheReader) ReadAt(ctx context.Context, p []byte, offset int64) (
 	return readerResponse, err
 }
 
-func captureFileCacheMetrics(ctx context.Context, metricHandle common.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
-	metricHandle.FileCacheReadCount(ctx, 1, common.CacheHitReadType{
+func captureFileCacheMetrics(ctx context.Context, metricHandle metrics.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
+	metricHandle.FileCacheReadCount(ctx, 1, metrics.CacheHitReadType{
 		ReadType: readType,
 		CacheHit: cacheHit,
 	})

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -35,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -90,10 +90,10 @@ func (t *fileCacheReaderTest) SetupTest() {
 	t.mockBucket = new(storage.TestifyMockBucket)
 	t.cacheDir = path.Join(os.Getenv("HOME"), "test_cache_dir")
 	lruCache := lru.NewCache(cacheMaxSize)
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, common.NewNoopMetrics())
+	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, metrics.NewNoopMetrics())
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
-	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
-	t.reader_unfinalized_object = NewFileCacheReader(t.unfinalized_object, t.mockBucket, t.cacheHandler, true, common.NewNoopMetrics())
+	t.reader = NewFileCacheReader(t.object, t.mockBucket, t.cacheHandler, true, metrics.NewNoopMetrics())
+	t.reader_unfinalized_object = NewFileCacheReader(t.unfinalized_object, t.mockBucket, t.cacheHandler, true, metrics.NewNoopMetrics())
 	t.ctx = context.Background()
 }
 

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/clock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/monitor"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 )
 
@@ -186,7 +186,7 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) ensureMultiRangeDownloader() (err
 
 // Reads the data using MultiRangeDownloader.
 func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []byte,
-	startOffset int64, endOffset int64, timeout time.Duration, metricHandle common.MetricHandle) (bytesRead int, err error) {
+	startOffset int64, endOffset int64, timeout time.Duration, metricHandle metrics.MetricHandle) (bytesRead int, err error) {
 	// Bidi Api with 0 as read_limit means no limit whereas we do not want to read anything with empty buffer.
 	// Hence, handling it separately.
 	if len(buf) == 0 {

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	cacheutil "github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 	"golang.org/x/net/context"
 )
@@ -103,7 +103,7 @@ const (
 
 // NewRandomReader create a random reader for the supplied object record that
 // reads using the given bucket.
-func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle common.MetricHandle, mrdWrapper *MultiRangeDownloaderWrapper, config *cfg.ReadConfig) RandomReader {
+func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32, fileCacheHandler *file.CacheHandler, cacheFileForRangeRead bool, metricHandle metrics.MetricHandle, mrdWrapper *MultiRangeDownloaderWrapper, config *cfg.ReadConfig) RandomReader {
 	return &randomReader{
 		object:                o,
 		bucket:                bucket,
@@ -111,7 +111,7 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 		limit:                 -1,
 		seeks:                 0,
 		totalReadBytes:        0,
-		readType:              common.ReadTypeSequential,
+		readType:              metrics.ReadTypeSequential,
 		sequentialReadSizeMb:  sequentialReadSizeMb,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
@@ -172,7 +172,7 @@ type randomReader struct {
 	// boolean variable to determine if MRD is being used or not.
 	isMRDInUse bool
 
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 
 	config *cfg.ReadConfig
 
@@ -247,9 +247,9 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		// Here rr.fileCacheHandle will not be nil since we return from the above in those cases.
 		logger.Tracef("%.13v -> %s", requestId, requestOutput)
 
-		readType := common.ReadTypeRandom
+		readType := metrics.ReadTypeRandom
 		if isSeq {
-			readType = common.ReadTypeSequential
+			readType = metrics.ReadTypeSequential
 		}
 		captureFileCacheMetrics(ctx, rr.metricHandle, readType, n, cacheHit, executionTime)
 	}()
@@ -511,7 +511,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, common.ReadTypeSequential, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeSequential, requestedDataSize)
 
 	return
 }
@@ -549,7 +549,7 @@ func (rr *randomReader) getReadInfo(
 	// (average read size in bytes rounded up to the next MiB).
 	end = int64(rr.object.Size)
 	if rr.seeks >= minSeeksForRandom {
-		rr.readType = common.ReadTypeRandom
+		rr.readType = metrics.ReadTypeRandom
 		averageReadBytes := rr.totalReadBytes / rr.seeks
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MiB) + 1) * MiB)
@@ -579,7 +579,7 @@ func (rr *randomReader) getReadInfo(
 // readerType specifies the go-sdk interface to use for reads.
 func readerType(readType string, start int64, end int64, bucketType gcs.BucketType) ReaderType {
 	bytesToBeRead := end - start
-	if readType == common.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
+	if readType == metrics.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
 		return MultiRangeReader
 	}
 	return RangeReader
@@ -644,7 +644,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 	}
 
 	requestedDataSize := end - offset
-	common.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
 	rr.updateExpectedOffset(offset + int64(n))
 
 	return

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -36,6 +35,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -79,7 +79,7 @@ func (t *RandomReaderStretchrTest) SetupTest() {
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
 
 	// Set up the reader.
-	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, common.NewNoopMetrics(), nil, nil)
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, metrics.NewNoopMetrics(), nil, nil)
 	t.rr.wrapped = rr.(*randomReader)
 }
 
@@ -141,7 +141,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Sequential() {
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), common.ReadTypeSequential, t.rr.wrapped.readType)
+			assert.Equal(t.T(), metrics.ReadTypeSequential, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -174,7 +174,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), common.ReadTypeRandom, t.rr.wrapped.readType)
+			assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType)
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -191,7 +191,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 	}{
 		{
 			name:       "ZonalBucketRandomRead",
-			readType:   common.ReadTypeRandom,
+			readType:   metrics.ReadTypeRandom,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -199,7 +199,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "ZonalBucketRandomReadLargerThan8MB",
-			readType:   common.ReadTypeRandom,
+			readType:   metrics.ReadTypeRandom,
 			start:      0,
 			end:        9 * MiB,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -207,7 +207,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "ZonalBucketSequentialRead",
-			readType:   common.ReadTypeSequential,
+			readType:   metrics.ReadTypeSequential,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: true},
@@ -215,7 +215,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "RegularBucketRandomRead",
-			readType:   common.ReadTypeRandom,
+			readType:   metrics.ReadTypeRandom,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: false},
@@ -223,7 +223,7 @@ func (t *RandomReaderStretchrTest) Test_ReaderType() {
 		},
 		{
 			name:       "RegularBucketSequentialRead",
-			readType:   common.ReadTypeSequential,
+			readType:   metrics.ReadTypeSequential,
 			start:      50,
 			end:        68,
 			bucketType: gcs.BucketType{Zonal: false},
@@ -641,7 +641,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
+			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -649,7 +649,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeSequential},
+			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -657,7 +657,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
+			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 		{
@@ -665,7 +665,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{common.ReadTypeSequential, common.ReadTypeSequential, common.ReadTypeRandom, common.ReadTypeRandom, common.ReadTypeRandom},
+			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 	}
@@ -676,7 +676,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
 			t.rr.wrapped.seeks = 0
-			t.rr.wrapped.readType = common.ReadTypeSequential
+			t.rr.wrapped.readType = metrics.ReadTypeSequential
 			t.rr.wrapped.expectedOffset = 0
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -706,7 +706,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 	t.rr.wrapped.reader = nil
 	t.rr.wrapped.isMRDInUse = false
 	t.rr.wrapped.seeks = 0
-	t.rr.wrapped.readType = common.ReadTypeSequential
+	t.rr.wrapped.readType = metrics.ReadTypeSequential
 	t.rr.wrapped.expectedOffset = 0
 	t.rr.wrapped.totalReadBytes = 0
 	t.object.Size = 20 * MiB
@@ -737,7 +737,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 		_, err := t.rr.wrapped.ReadAt(t.rr.ctx, buf, int64(readRange[0]))
 
 		assert.NoError(t.T(), err)
-		assert.Equal(t.T(), common.ReadTypeRandom, t.rr.wrapped.readType)
+		assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType)
 		assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset)
 		assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks)
 	}

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -37,6 +36,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/oglemock"
@@ -181,11 +181,11 @@ func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	lruCache := lru.NewCache(cacheMaxSize)
 	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{
 		EnableCrc: false,
-	}, common.NewNoopMetrics())
+	}, metrics.NewNoopMetrics())
 	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
 
 	// Set up the reader.
-	rr := NewRandomReader(t.object, t.bucket, sequentialReadSizeInMb, nil, false, common.NewNoopMetrics(), nil, nil)
+	rr := NewRandomReader(t.object, t.bucket, sequentialReadSizeInMb, nil, false, metrics.NewNoopMetrics(), nil, nil)
 	t.rr.wrapped = rr.(*randomReader)
 }
 
@@ -536,7 +536,7 @@ func (t *RandomReaderTest) UpgradesSequentialReads_NoExistingReader() {
 	t.object.Size = 1 << 40
 	const readSize = 1 * MiB
 	// Set up the custom randomReader.
-	rr := NewRandomReader(t.object, t.bucket, readSize/MiB, nil, false, common.NewNoopMetrics(), nil, nil)
+	rr := NewRandomReader(t.object, t.bucket, readSize/MiB, nil, false, metrics.NewNoopMetrics(), nil, nil)
 	t.rr.wrapped = rr.(*randomReader)
 
 	// Simulate a previous exhausted reader that ended at the offset from which

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -20,11 +20,11 @@ import (
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	clientReaders "github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx/client_readers"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 type ReadManager struct {
@@ -41,7 +41,7 @@ type ReadManagerConfig struct {
 	SequentialReadSizeMB  int32
 	FileCacheHandler      *file.CacheHandler
 	CacheFileForRangeRead bool
-	MetricHandle          common.MetricHandle
+	MetricHandle          metrics.MetricHandle
 	MrdWrapper            *gcsx.MultiRangeDownloaderWrapper
 	ReadConfig            *cfg.ReadConfig
 }

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -26,7 +26,6 @@ import (
 	"testing/iotest"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -38,6 +37,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testUtil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -57,13 +57,13 @@ func (t *readManagerTest) readManagerConfig(fileCacheEnable bool) *ReadManagerCo
 	config := &ReadManagerConfig{
 		SequentialReadSizeMB:  sequentialReadSizeInMb,
 		CacheFileForRangeRead: false,
-		MetricHandle:          common.NewNoopMetrics(),
+		MetricHandle:          metrics.NewNoopMetrics(),
 		MrdWrapper:            nil,
 	}
 	if fileCacheEnable {
 		cacheDir := path.Join(os.Getenv("HOME"), "test_cache_dir")
 		lruCache := lru.NewCache(cacheMaxSize)
-		jobManager := downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, common.NewNoopMetrics())
+		jobManager := downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, sequentialReadSizeInMb, &cfg.FileCacheConfig{EnableCrc: false}, metrics.NewNoopMetrics())
 		config.FileCacheHandler = file.NewCacheHandler(lruCache, jobManager, cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "")
 	} else {
 		config.FileCacheHandler = nil

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -20,23 +20,23 @@ import (
 	"time"
 
 	storagev2 "cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 // recordRequest records a request and its latency.
-func recordRequest(ctx context.Context, metricHandle common.MetricHandle, method string, start time.Time) {
+func recordRequest(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time) {
 	metricHandle.GCSRequestCount(ctx, 1, method)
 
 	metricHandle.GCSRequestLatency(ctx, time.Since(start), method)
 }
 
-func CaptureMultiRangeDownloaderMetrics(ctx context.Context, metricHandle common.MetricHandle, method string, start time.Time) {
+func CaptureMultiRangeDownloaderMetrics(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time) {
 	recordRequest(ctx, metricHandle, method, start)
 }
 
 // NewMonitoringBucket returns a gcs.Bucket that exports metrics for monitoring
-func NewMonitoringBucket(b gcs.Bucket, m common.MetricHandle) gcs.Bucket {
+func NewMonitoringBucket(b gcs.Bucket, m metrics.MetricHandle) gcs.Bucket {
 	return &monitoringBucket{
 		wrapped:      b,
 		metricHandle: m,
@@ -45,7 +45,7 @@ func NewMonitoringBucket(b gcs.Bucket, m common.MetricHandle) gcs.Bucket {
 
 type monitoringBucket struct {
 	wrapped      gcs.Bucket
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
 func (mb *monitoringBucket) Name() string {
@@ -216,12 +216,12 @@ func (mb *monitoringBucket) GCSName(obj *gcs.MinObject) string {
 }
 
 // recordReader increments the reader count when it's opened or closed.
-func recordReader(ctx context.Context, metricHandle common.MetricHandle, ioMethod string) {
+func recordReader(ctx context.Context, metricHandle metrics.MetricHandle, ioMethod string) {
 	metricHandle.GCSReaderCount(ctx, 1, ioMethod)
 }
 
 // Monitoring on the object reader
-func newMonitoringReadCloser(ctx context.Context, object string, rc gcs.StorageReader, metricHandle common.MetricHandle) gcs.StorageReader {
+func newMonitoringReadCloser(ctx context.Context, object string, rc gcs.StorageReader, metricHandle metrics.MetricHandle) gcs.StorageReader {
 	recordReader(ctx, metricHandle, "opened")
 	return &monitoringReadCloser{
 		ctx:          ctx,
@@ -235,7 +235,7 @@ type monitoringReadCloser struct {
 	ctx          context.Context
 	object       string
 	wrapped      gcs.StorageReader
-	metricHandle common.MetricHandle
+	metricHandle metrics.MetricHandle
 }
 
 func (mrc *monitoringReadCloser) Read(p []byte) (n int, err error) {

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
@@ -59,7 +59,7 @@ type StorageClientConfig struct {
 
 	ReadStallRetryConfig cfg.ReadStallGcsRetriesConfig
 
-	MetricHandle common.MetricHandle
+	MetricHandle metrics.MetricHandle
 }
 
 func CreateHttpClient(storageClientConfig *StorageClientConfig) (httpClient *http.Client, err error) {

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 
 	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -61,7 +61,7 @@ func ShouldRetry(err error) (b bool) {
 	return
 }
 
-func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle common.MetricHandle) bool {
+func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metrics.MetricHandle) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/common"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
@@ -150,7 +150,7 @@ func TestShouldRetryReturnsTrueForUnauthenticatedGrpcErrors(t *testing.T) {
 }
 
 type fakeMetricHandle struct {
-	common.MetricHandle
+	metrics.MetricHandle
 
 	gcsRetryCountCalled bool
 	gcsRetryCountInc    int64
@@ -181,7 +181,7 @@ func TestShouldRetryWithMonitoringForNonRetryableErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeMetrics := &fakeMetricHandle{
-				MetricHandle: common.NewNoopMetrics(),
+				MetricHandle: metrics.NewNoopMetrics(),
 			}
 
 			shouldRetry := ShouldRetryWithMonitoring(context.Background(), tc.err, fakeMetrics)
@@ -215,7 +215,7 @@ func TestShouldRetryWithMonitoringForRetryableErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeMetrics := &fakeMetricHandle{
-				MetricHandle: common.NewNoopMetrics(),
+				MetricHandle: metrics.NewNoopMetrics(),
 			}
 
 			shouldRetry := ShouldRetryWithMonitoring(context.Background(), tc.err, fakeMetrics)

--- a/metrics/constants.go
+++ b/metrics/constants.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+const (
+	ReadTypeSequential = "Sequential"
+	ReadTypeRandom     = "Random"
+	ReadTypeParallel   = "Parallel"
+)

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package metrics
 
 import (
 	"context"

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package metrics
 
 import (
 	"context"

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package metrics
 
 import (
 	"context"

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,28 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package metrics
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
 )
 
-type ShutdownFn func(ctx context.Context) error
-
 // The default time buckets for latency metrics.
 // The unit can however change for different units i.e. for one metric the unit could be microseconds and for another it could be milliseconds.
 var defaultLatencyDistribution = metric.WithExplicitBucketBoundaries(1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
-
-const (
-	ReadTypeSequential = "Sequential"
-	ReadTypeRandom     = "Random"
-	ReadTypeParallel   = "Parallel"
-)
 
 // Pair of CacheHit and ReadType attributes
 type CacheHitReadType struct {
@@ -45,20 +36,6 @@ type CacheHitReadType struct {
 type FSOpsErrorCategory struct {
 	FSOps         string
 	ErrorCategory string
-}
-
-// JoinShutdownFunc combines the provided shutdown functions into a single function.
-func JoinShutdownFunc(shutdownFns ...ShutdownFn) ShutdownFn {
-	return func(ctx context.Context) error {
-		var err error
-		for _, fn := range shutdownFns {
-			if fn == nil {
-				continue
-			}
-			err = errors.Join(err, fn(ctx))
-		}
-		return err
-	}
 }
 
 // MetricAttr represents the attributes associated with a metric.

--- a/metrics/telemetry_test.go
+++ b/metrics/telemetry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package metrics
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,70 +24,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
-
-func TestJoinShutdownFunc(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name         string
-		fns          []ShutdownFn
-		expectedErrs []string
-	}{
-		{
-			name:         "normal",
-			fns:          []ShutdownFn{func(_ context.Context) error { return nil }},
-			expectedErrs: nil,
-		},
-		{
-			name:         "one_err",
-			fns:          []ShutdownFn{func(_ context.Context) error { return fmt.Errorf("err") }},
-			expectedErrs: []string{"err"},
-		},
-		{
-			name: "two_err",
-			fns: []ShutdownFn{
-				func(_ context.Context) error { return fmt.Errorf("err1") },
-				func(_ context.Context) error { return fmt.Errorf("err2") },
-			},
-			expectedErrs: []string{"err1", "err2"},
-		},
-		{
-			name: "two_err_one_normal",
-			fns: []ShutdownFn{
-				func(_ context.Context) error { return fmt.Errorf("err1") },
-				func(_ context.Context) error { return nil },
-				func(_ context.Context) error { return fmt.Errorf("err2") },
-			},
-			expectedErrs: []string{"err1", "err2"},
-		},
-		{
-			name: "nil",
-			fns: []ShutdownFn{
-				func(_ context.Context) error { return fmt.Errorf("err1") },
-				nil,
-				func(_ context.Context) error { return fmt.Errorf("err2") },
-			},
-			expectedErrs: []string{"err1", "err2"},
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := JoinShutdownFunc(tc.fns...)(context.Background())
-
-			if len(tc.expectedErrs) == 0 {
-				assert.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				for _, e := range tc.expectedErrs {
-					assert.ErrorContains(t, err, e)
-				}
-			}
-		})
-	}
-}
 
 type int64DataPoint struct {
 	v    int64


### PR DESCRIPTION
### Description
**Refactoring: Metrics Package**: All metrics-related code has been refactored and moved from the general-purpose common package into a new, dedicated metrics package. This includes core metrics implementations like `noop_metrics`, `otel_metrics`, and `telemetry`.
**Code Organization Improvement**: This change significantly improves the separation of concerns within the codebase by isolating metrics logic, making the project structure cleaner and more maintainable.
Import Path Updates: Numerous files across the repository have been updated to reflect the new package structure, changing import paths from `github.com/googlecloudplatform/gcsfuse/v3/common` to `github.com/googlecloudplatform/gcsfuse/v3/metrics` where metrics functionalities are used.
**Utility Function Relocation**: General utility functions and types, specifically `ShutdownFn` and `JoinShutdownFunc`, previously located within the metrics telemetry file, have been moved to `common/util.go` for better logical grouping.
**Constants Relocation**: Constants defining read types (`ReadTypeSequential`, `ReadTypeRandom`, `ReadTypeParallel`) have been extracted from the metrics telemetry file and placed into a new dedicated file, `metrics/constants.go`.

### Link to the issue in case of a bug fix.
b/433133585

### Testing details
1. Manual - NA
2. Unit tests - Covered by existing tests.
3. Integration tests - Covered by existing tests.

### Any backward incompatible change? If so, please explain.
No
