### PR TITLE
fix(caching): Invalidate fast stat cache on NotFoundError

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -15,6 +15,7 @@
 package caching
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -214,6 +215,11 @@ func (b *fastStatBucket) NewReaderWithReadHandle(
 	ctx context.Context,
 	req *gcs.ReadObjectRequest) (rd gcs.StorageReader, err error) {
 	rd, err = b.wrapped.NewReaderWithReadHandle(ctx, req)
+
+	var notFoundError *gcs.NotFoundError
+	if errors.As(err, &notFoundError) {
+		b.invalidate(req.Name)
+	}
 	return
 }
 


### PR DESCRIPTION
### Description
This change addresses an issue where the fastStatBucket cache entry was not being invalidated when a read operation failed because the underlying GCS object was not found.

When a ReadFile operation encountered a gcs.NotFoundError, it would correctly return a "stale NFS file handle" error. However, the stale metadata remained in the cache. This caused subsequent lookups for the same file to succeed, leading to a loop of failed read attempts.

This PR fixes the behavior by explicitly checking for gcs.NotFoundError after a read attempt and invalidating the cache entry if the error is present.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/433184217

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
