### PR TITLE
chore(ci.yml): Don't run linter on post-submit runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go


### PR DESCRIPTION
### Description
Currently, we have a host of lint issues on master which we don't plan to fix anytime soon. Until then, the post-submit ci run always fails due to lint issues. Let's stop the linter run in postsubmits until all the lint issues are fixed so that the post-submit run starts succeeding.


### Link to the issue in case of a bug fix.
b/433235596

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA