### PR TITLE
feat(Notifier): Use notifier to invalidate stale dentry cache on clobber

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -122,6 +122,9 @@ be interacting with the file system.`)
 		NewConfig:                  newConfig,
 		MetricHandle:               metricHandle,
 	}
+	if serverCfg.NewConfig.FileSystem.ExperimentalEnableDentryCache {
+		serverCfg.Notifier = fuse.NewNotifier()
+	}
 
 	logger.Infof("Creating a new server...\n")
 	server, err := fs.NewServer(ctx, serverCfg)

--- a/common/util.go
+++ b/common/util.go
@@ -17,9 +17,13 @@ package common
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"syscall"
 )
 
 type ShutdownFn func(ctx context.Context) error
@@ -77,4 +81,43 @@ func IsKLCacheEvictionUnSupported() (bool, error) {
 	}
 
 	return false, nil
+}
+
+func CloseFile(file *os.File) {
+	if err := file.Close(); err != nil {
+		log.Fatalf("error in closing: %v", err)
+	}
+}
+
+func WriteFile(fileName string, content string) (err error) {
+	f, err := os.OpenFile(fileName, os.O_RDWR|syscall.O_DIRECT, 0600)
+	if err != nil {
+		err = fmt.Errorf("open file for write at start: %v", err)
+		return
+	}
+
+	// Closing file at the end.
+	defer CloseFile(f)
+
+	_, err = f.WriteAt([]byte(content), 0)
+
+	return
+}
+
+func ReadFile(filePath string) (content []byte, err error) {
+	f, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, 0600)
+	if err != nil {
+		err = fmt.Errorf("error in the opening the file %v", err)
+		return
+	}
+
+	// Closing file at the end.
+	defer CloseFile(f)
+
+	content, err = os.ReadFile(f.Name())
+	if err != nil {
+		err = fmt.Errorf("ReadAll: %v", err)
+		return
+	}
+	return
 }

--- a/common/util.go
+++ b/common/util.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"syscall"
 )
 
 type ShutdownFn func(ctx context.Context) error
@@ -90,7 +89,7 @@ func CloseFile(file *os.File) {
 }
 
 func WriteFile(fileName string, content string) (err error) {
-	f, err := os.OpenFile(fileName, os.O_RDWR|syscall.O_DIRECT, 0600)
+	f, err := os.OpenFile(fileName, os.O_RDWR, 0600)
 	if err != nil {
 		err = fmt.Errorf("open file for write at start: %v", err)
 		return
@@ -105,7 +104,7 @@ func WriteFile(fileName string, content string) (err error) {
 }
 
 func ReadFile(filePath string) (content []byte, err error) {
-	f, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, 0600)
+	f, err := os.OpenFile(filePath, os.O_RDONLY, 0600)
 	if err != nil {
 		err = fmt.Errorf("error in the opening the file %v", err)
 		return

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -16,6 +16,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -145,4 +146,49 @@ func TestJoinShutdownFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCloseFile(t *testing.T) {
+	// Setup
+	f, err := os.CreateTemp("", "testFile-*")
+	require.NoError(t, err)
+
+	// Close file and assert
+	assert.NotPanics(t, func() { CloseFile(f) })
+}
+
+func TestWriteFile(t *testing.T) {
+	// Setup
+	tmpFile, err := os.CreateTemp("", "testFile-*")
+	require.NoError(t, err)
+	filePath := tmpFile.Name()
+	defer os.Remove(filePath)
+	require.NoError(t, tmpFile.Close())
+
+	// Call WriteFile
+	err = WriteFile(filePath, "content")
+
+	// Assertions
+	assert.NoError(t, err)
+	data, err := ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(data))
+}
+
+func TestReadFile(t *testing.T) {
+	// Setup
+	file, err := os.CreateTemp("", "testFile-*")
+	require.NoError(t, err)
+	fileName := file.Name()
+	defer os.Remove(fileName)
+	_, err = file.WriteString("content")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	// Call ReadFile
+	content, err := ReadFile(fileName)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "content", string(content))
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1598,10 +1598,10 @@ func (fs *fileSystem) invalidateCachedEntry(childID fuseops.InodeID) error {
 	}
 	childBase := path.Base(childName.LocalName())
 
-	var parentInodeID fuseops.InodeID
-
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	var parentInodeID fuseops.InodeID
 	// Check in all maps: implicit dirs → folders → generation-backed
 	if parentInode, ok := fs.implicitDirInodes[parentName]; ok {
 		parentInodeID = parentInode.ID()

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1581,18 +1581,14 @@ func (fs *fileSystem) invalidateCachedEntry(childID fuseops.InodeID) error {
 	childInode, ok := fs.inodes[childID]
 	fs.mu.Unlock()
 	if !ok {
-		return fmt.Errorf("inode with ID %d not found", childID)
-	}
-
-	if childID == fuseops.RootInodeID {
-		return fmt.Errorf("cannot invalidate root inode %d", childID)
+		return fmt.Errorf("invalidateCachedEntry: inode with ID %d not found", childID)
 	}
 
 	childName := childInode.Name()
 	parentPath := path.Dir(childName.LocalName())
 	// If the parent path resolves to the current directory ".", it means the parent
 	// is the root of the file system.
-	if parentPath == "." || parentPath == "/" || parentPath == "" {
+	if parentPath == "." {
 		return fs.notifier.InvalidateEntry(fuseops.RootInodeID, path.Base(childInode.Name().LocalName()))
 	}
 
@@ -1611,7 +1607,7 @@ func (fs *fileSystem) invalidateCachedEntry(childID fuseops.InodeID) error {
 	} else if parentInode, ok := fs.generationBackedInodes[parentName]; ok {
 		parentInodeID = parentInode.ID()
 	} else {
-		return fmt.Errorf("failed to invalidate the entry, parent inode not found for child ID %d (parent: %s)", childID, parentName.String())
+		return fmt.Errorf("invalidateCachedEntry: failed to invalidate the entry, parent inode not found for child ID %d (parent: %s)", childID, parentName.String())
 	}
 
 	return fs.notifier.InvalidateEntry(parentInodeID, childBase)

--- a/internal/fs/inode/name.go
+++ b/internal/fs/inode/name.go
@@ -15,6 +15,7 @@
 package inode
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -125,9 +126,9 @@ func (name Name) IsDirectChildOf(parent Name) bool {
 }
 
 // ParentName returns the Name of the parent directory of the current Name.
-func (name Name) ParentName() Name {
+func (name Name) ParentName() (Name, error) {
 	if name.IsBucketRoot() {
-		panic("Root has no parent")
+		return Name{}, errors.New("root has no parent")
 	}
 
 	objectName := strings.TrimSuffix(name.objectName, "/") // normalize for dir or file
@@ -138,12 +139,12 @@ func (name Name) ParentName() Name {
 		return Name{
 			bucketName: name.bucketName,
 			objectName: "",
-		}
+		}, nil
 	}
 
 	parentObjectName := objectName[:lastSlash+1] // include trailing slash for dir
 	return Name{
 		bucketName: name.bucketName,
 		objectName: parentObjectName,
-	}
+	}, nil
 }

--- a/internal/fs/inode/name.go
+++ b/internal/fs/inode/name.go
@@ -123,3 +123,27 @@ func (name Name) IsDirectChildOf(parent Name) bool {
 	cleanDiff := strings.TrimSuffix(diff, "/")
 	return !strings.Contains(cleanDiff, "/")
 }
+
+// ParentName returns the Name of the parent directory of the current Name.
+func (name Name) ParentName() Name {
+	if name.IsBucketRoot() {
+		panic("Root has no parent")
+	}
+
+	objectName := strings.TrimSuffix(name.objectName, "/") // normalize for dir or file
+	lastSlash := strings.LastIndex(objectName, "/")
+
+	if lastSlash == -1 {
+		// Direct child of bucket root
+		return Name{
+			bucketName: name.bucketName,
+			objectName: "",
+		}
+	}
+
+	parentObjectName := objectName[:lastSlash+1] // include trailing slash for dir
+	return Name{
+		bucketName: name.bucketName,
+		objectName: parentObjectName,
+	}
+}

--- a/internal/fs/inode/name.go
+++ b/internal/fs/inode/name.go
@@ -133,7 +133,6 @@ func (name Name) ParentName() (Name, error) {
 
 	objectName := strings.TrimSuffix(name.objectName, "/") // normalize for dir or file
 	lastSlash := strings.LastIndex(objectName, "/")
-
 	if lastSlash == -1 {
 		// Direct child of bucket root
 		return Name{

--- a/internal/fs/notifier_test.go
+++ b/internal/fs/notifier_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A collection of tests to check notifier is invalidating the entry.
+package fs_test
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/jacobsa/fuse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type NotifierTest struct {
+	suite.Suite
+	fsTest
+}
+
+func TestNotifierTestSuite(t *testing.T) {
+	suite.Run(t, new(NotifierTest))
+}
+
+func (t *NotifierTest) SetupSuite() {
+	t.serverCfg.ImplicitDirectories = true
+	t.serverCfg.InodeAttributeCacheTTL = 1000 * time.Second
+	t.serverCfg.Notifier = fuse.NewNotifier()
+	t.serverCfg.NewConfig = &cfg.Config{
+		FileSystem: cfg.FileSystemConfig{
+			ExperimentalEnableDentryCache: true,
+			PreconditionErrors:            true,
+		},
+		Write: cfg.WriteConfig{
+			EnableStreamingWrites: true,
+		},
+	}
+	t.fsTest.SetUpTestSuite()
+}
+
+func (t *NotifierTest) TearDownTest() {
+	t.fsTest.TearDown()
+}
+
+func (t *NotifierTest) TearDownSuite() {
+	t.fsTest.TearDownTestSuite()
+}
+
+func (t *NotifierTest) TestWriteFileWithRootDirParent() {
+	filePath := path.Join(mntDir, "foo")
+	// Create a file in GCS.
+	_, err := storageutil.CreateObject(ctx, bucket, fileName, []byte("initial content"))
+	assert.NoError(t.T(), err)
+	// Stat file to cache its entry.
+	_, err = os.Stat(filePath)
+	assert.NoError(t.T(), err)
+	// Clobber the file in GCS. This changes the object's generation, making
+	// our file handle stale.
+	_, err = storageutil.CreateObject(ctx, bucket, fileName, []byte("modified"))
+	assert.NoError(t.T(), err)
+
+	// Attempt to write.
+	err = operations.WriteFile(filePath, "new data")
+
+	// Should return stale file handle error.
+	operations.ValidateESTALEError(t.T(), err)
+	// Attempt to write again, the entry has now been invalidated.
+	err = operations.WriteFile(filePath, "new data")
+	assert.NoError(t.T(), err)
+}
+
+func (t *NotifierTest) TestWriteFileWithNonRootDirParent() {
+	filePath := path.Join(mntDir, "dir/foo")
+	// Create a file in GCS.
+	_, err := storageutil.CreateObject(ctx, bucket, "dir/foo", []byte("initial content"))
+	assert.NoError(t.T(), err)
+	// Stat file to cache its entry.
+	_, err = os.Stat(filePath)
+	assert.NoError(t.T(), err)
+	// Clobber the file in GCS. This changes the object's generation, making
+	// our file handle stale.
+	_, err = storageutil.CreateObject(ctx, bucket, "dir/foo", []byte("modified"))
+	assert.NoError(t.T(), err)
+
+	// Attempt to write.
+	err = operations.WriteFile(filePath, "new data")
+
+	// Should return stale file handle error.
+	operations.ValidateESTALEError(t.T(), err)
+	// Attempt to write again, the entry has now been invalidated.
+	err = operations.WriteFile(filePath, "new data")
+	assert.NoError(t.T(), err)
+}
+
+func (t *NotifierTest) TestReadFileDoNotFailPersistently() {
+	filePath := path.Join(mntDir, "foo")
+	// Create a file in GCS.
+	_, err := storageutil.CreateObject(ctx, bucket, "foo", []byte("initial content"))
+	assert.NoError(t.T(), err)
+	// Stat file to cache its entry.
+	_, err = os.Stat(filePath)
+	assert.NoError(t.T(), err)
+	// Clobber the file in GCS. This changes the object's generation, making
+	// our file handle stale.
+	_, err = storageutil.CreateObject(ctx, bucket, "foo", []byte("modified"))
+	assert.NoError(t.T(), err)
+
+	// Attempt to read file.
+	_, err = operations.ReadFile(filePath)
+
+	// Should return error.
+	assert.NotNil(t.T(), err)
+	// Attempt to read again, the entry has now been invalidated.
+	_, err = operations.ReadFile(filePath)
+	assert.NoError(t.T(), err)
+}

--- a/internal/fs/notifier_test.go
+++ b/internal/fs/notifier_test.go
@@ -109,16 +109,16 @@ func (t *NotifierTest) TestWriteFileWithNonRootDirParent() {
 }
 
 func (t *NotifierTest) TestReadFileDoNotFailPersistently() {
-	filePath := path.Join(mntDir, "foo")
+	filePath := path.Join(mntDir, fileName)
 	// Create a file in GCS.
-	_, err := storageutil.CreateObject(ctx, bucket, "foo", []byte("initial content"))
+	_, err := storageutil.CreateObject(ctx, bucket, fileName, []byte("initial content"))
 	assert.NoError(t.T(), err)
 	// Stat file to cache its entry.
 	_, err = os.Stat(filePath)
 	assert.NoError(t.T(), err)
 	// Clobber the file in GCS. This changes the object's generation, making
 	// our file handle stale.
-	_, err = storageutil.CreateObject(ctx, bucket, "foo", []byte("modified"))
+	_, err = storageutil.CreateObject(ctx, bucket, fileName, []byte("modified"))
 	assert.NoError(t.T(), err)
 
 	// Attempt to read file.

--- a/internal/fs/server.go
+++ b/internal/fs/server.go
@@ -36,5 +36,8 @@ func NewServer(ctx context.Context, cfg *ServerConfig) (fuse.Server, error) {
 		fs = wrappers.WithTracing(fs)
 	}
 	fs = wrappers.WithMonitoring(fs, cfg.MetricHandle)
+	if cfg.Notifier != nil {
+		return fuse.NewServerWithNotifier(cfg.Notifier, fuseutil.NewFileSystemServer(fs)), nil
+	}
 	return fuseutil.NewFileSystemServer(fs), nil
 }


### PR DESCRIPTION
### Description

This change integrates `fuse.Notifier` to handle stale file entries when the experimental dentry cache is enabled.

When `experimental-enable-dentry-cache` is active, if a file is modified directly in GCS (clobbered), the kernel's dentry cache becomes stale. Subsequent read or write operations on that file would fail, typically with a "stale file handle" error.

This PR introduces logic to detect this specific failure (`FileClobberedError`) and uses the notifier to send an `InvalidateEntry` message to the kernel. This forces the kernel to evict the stale cache entry. As a result, the next operation on the same file will succeed, as gcsfuse will re-fetch the file's latest attributes.

This functionality is only enabled when the `experimental-enable-dentry-cache` flag is set to true.

### Link to the issue in case of a bug fix.
b/423824806

### Testing details
1.  **Manual** - NA
2.  **Unit tests** - Added fs tests.
3.  **Integration tests** - NA

### Any backward incompatible change? If so, please explain.

