### PR TITLE
ci(flake-detector): Increase flake-detector timeout

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   flake-detector:
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 150
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Increase flake-detector timeout since the tests have recently started taking more time.
### Link to the issue in case of a bug fix.
b/425666186

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
