### PR TITLE
feat(dentry cache): Add integration tests for dentry cache

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -206,6 +206,8 @@ TEST_DIR_PARALLEL=(
   "negative_stat_cache"
   "streaming_writes"
   "release_version"
+  "readdirplus"
+  "dentry_cache"
 )
 
 # These tests never become parallel as they are changing bucket permissions.

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dentry_cache
+
+import (
+	"github.com/stretchr/testify/require"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+)
+
+type notifierTest struct {
+	flags []string
+}
+
+func (s *notifierTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+}
+
+func (s *notifierTest) Teardown(t *testing.T) {
+	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
+		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+		setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
+	}
+}
+
+func (s *notifierTest) TestWriteFileWithDentryCacheEnabled(t *testing.T) {
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
+	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, t)
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(t, err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
+	require.Nil(t, err)
+
+	// First Write File attempt.
+	err = operations.WriteFile(filePath, "ShouldNotWrite")
+
+	// First Write File attempt should fail because file has been clobbered.
+	assert.NotNil(t, err)
+	// Second Write File attempt.
+	err = operations.WriteFile(filePath, "ShouldWrite")
+	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
+	// Therefore, the second write succeeds even before the metadata cache TTL expires.
+	assert.Nil(t, err)
+}
+
+func (s *notifierTest) TestReadFileWithDentryCacheEnabled(t *testing.T) {
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
+	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, t)
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(t, err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
+	require.Nil(t, err)
+
+	// First Read File attempt.
+	_, err = operations.ReadFile(filePath)
+
+	// First Read File attempt should fail because file has been clobbered.
+	assert.NotNil(t, err)
+	// Second Read File attempt.
+	_, err = operations.ReadFile(filePath)
+	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
+	// Therefore, the second read succeeds even before the metadata cache TTL expires.
+	assert.Nil(t, err)
+}
+
+func TestNotifierTest(t *testing.T) {
+	ts := &notifierTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Setup flags and run tests.
+	ts.flags = []string{"--implicit-dirs", "--experimental-enable-dentry-cache", "--metadata-cache-ttl-secs=1000"}
+	log.Printf("Running tests with flags: %s", ts.flags)
+	test_setup.RunTests(t, ts)
+}

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -62,7 +62,7 @@ func (s *notifierTest) TestWriteFileWithDentryCacheEnabled(t *testing.T) {
 	err = operations.WriteFile(filePath, "ShouldNotWrite")
 
 	// First Write File attempt should fail because file has been clobbered.
-	assert.NotNil(t, err)
+	operations.ValidateESTALEError(t, err)
 	// Second Write File attempt.
 	err = operations.WriteFile(filePath, "ShouldWrite")
 	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
@@ -87,7 +87,7 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled(t *testing.T) {
 	_, err = operations.ReadFile(filePath)
 
 	// First Read File attempt should fail because file has been clobbered.
-	assert.NotNil(t, err)
+	operations.ValidateESTALEError(t, err)
 	// Second Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -15,7 +15,6 @@
 package dentry_cache
 
 import (
-	"github.com/stretchr/testify/require"
 	"log"
 	"os"
 	"path"
@@ -28,6 +27,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_setup"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type notifierTest struct {
@@ -55,8 +55,8 @@ func (s *notifierTest) TestWriteFileWithDentryCacheEnabled(t *testing.T) {
 	// Modify the object on GCS.
 	objectName := path.Join(testDirName, testFileName)
 	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
 	require.Nil(t, err)
+	require.Nil(t, client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
 
 	// First Write File attempt.
 	err = operations.WriteFile(filePath, "ShouldNotWrite")
@@ -80,8 +80,8 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled(t *testing.T) {
 	// Modify the object on GCS.
 	objectName := path.Join(testDirName, testFileName)
 	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
 	require.Nil(t, err)
+	require.Nil(t, client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
 
 	// First Read File attempt.
 	_, err = operations.ReadFile(filePath)

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -54,7 +54,10 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+	if setup.TestBucket() == "" {
+		log.Print("--testbucket must be specified")
+		os.Exit(1)
+	}
 
 	// Create common storage client to be used in test.
 	ctx = context.Background()

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides integration tests for enabling dentry cache.
+package dentry_cache
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+)
+
+const (
+	testDirName        = "testDirForDentryCache"
+	testFileName       = "testFile"
+	initialContentSize = 5
+	updatedContentSize = 10
+)
+
+var (
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	mountFunc     func([]string) error
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir string
+)
+
+func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
+	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	setup.SetMntDir(mountDir)
+	testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+}
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	// Create common storage client to be used in test.
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	if setup.MountedDirectory() != "" {
+		mountDir = setup.MountedDirectory()
+		// Run tests for mounted directory if the flag is set.
+		os.Exit(m.Run())
+	}
+	// Else run tests for testBucket.
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	// Save mount and root directory variables.
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	successCode := m.Run()
+
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/dentry_cache/stat_test.go
+++ b/tools/integration_tests/dentry_cache/stat_test.go
@@ -15,7 +15,6 @@
 package dentry_cache
 
 import (
-	"github.com/stretchr/testify/require"
 	"log"
 	"os"
 	"path"
@@ -29,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_setup"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type statWithDentryCacheEnabledTest struct {
@@ -56,8 +56,8 @@ func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled(t *testi
 	// Modify the object on GCS.
 	objectName := path.Join(testDirName, testFileName)
 	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
 	require.Nil(t, err)
+	require.Nil(t, client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
 
 	// Stat again, it should give old cached attributes.
 	fileInfo, err := os.Stat(filePath)
@@ -65,7 +65,7 @@ func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled(t *testi
 	assert.Nil(t, err)
 	assert.Equal(t, int64(initialContentSize), fileInfo.Size())
 	// Wait until entry expires in cache.
-	time.Sleep(1 * time.Second)
+	time.Sleep(1100 * time.Millisecond)
 	// Stat again, it should give updated attributes.
 	fileInfo, err = os.Stat(filePath)
 	assert.Nil(t, err)

--- a/tools/integration_tests/dentry_cache/stat_test.go
+++ b/tools/integration_tests/dentry_cache/stat_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dentry_cache
+
+import (
+	"github.com/stretchr/testify/require"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_setup"
+	"github.com/stretchr/testify/assert"
+)
+
+type statWithDentryCacheEnabledTest struct {
+	flags []string
+}
+
+func (s *statWithDentryCacheEnabledTest) Setup(t *testing.T) {
+	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+}
+
+func (s *statWithDentryCacheEnabledTest) Teardown(t *testing.T) {
+	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
+		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+		setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
+	}
+}
+
+func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled(t *testing.T) {
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
+	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, t)
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(t, err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	err = client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{})
+	require.Nil(t, err)
+
+	// Stat again, it should give old cached attributes.
+	fileInfo, err := os.Stat(filePath)
+
+	assert.Nil(t, err)
+	assert.Equal(t, int64(initialContentSize), fileInfo.Size())
+	// Wait until entry expires in cache.
+	time.Sleep(1 * time.Second)
+	// Stat again, it should give updated attributes.
+	fileInfo, err = os.Stat(filePath)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(updatedContentSize), fileInfo.Size())
+}
+
+func TestStatWithDentryCacheEnabledTest(t *testing.T) {
+	ts := &statWithDentryCacheEnabledTest{}
+
+	// Run tests for mounted directory if the flag is set.
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		test_setup.RunTests(t, ts)
+		return
+	}
+
+	// Setup flags and run tests.
+	ts.flags = []string{"--implicit-dirs", "--experimental-enable-dentry-cache", "--metadata-cache-ttl-secs=1"}
+	log.Printf("Running tests with flags: %s", ts.flags)
+	test_setup.RunTests(t, ts)
+}

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -217,6 +217,7 @@ TEST_PACKAGES_COMMON=(
   "stale_handle"
   "release_version"
   "readdirplus"
+  "dentry_cache"
 )
 
 # Test packages for regional buckets.

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -155,6 +155,8 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "write_large_files"
   "unfinalized_object"
    "release_version"
+   "readdirplus"
+   "dentry_cache"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -120,6 +120,7 @@ TEST_DIR_PARALLEL=(
   "cloud_profiler"
   "release_version"
   "readdirplus"
+  "dentry_cache"
 )
 
 # These tests never become parallel as it is changing bucket permissions.

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -684,7 +684,7 @@ rm -rf $log_dir
 # Run stat with dentry cache enabled
 test_case="TestStatWithDentryCacheEnabledTest/TestStatWithDentryCacheEnabled"
 gcsfuse --implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
-GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readdirplus/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/dentry_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
 sudo umount "$MOUNT_DIR"
 
 # Run notifier tests
@@ -694,6 +694,6 @@ test_cases=(
 )
 for test_case in "${test_cases[@]}"; do
   gcsfuse --implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
-  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readdirplus/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/dentry_cache/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
   sudo umount "$MOUNT_DIR"
 done

--- a/tools/integration_tests/run_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_tests_mounted_directory.sh
@@ -679,3 +679,21 @@ gcsfuse --implicit-dirs --experimental-enable-readdirplus --log-file $log_file -
 GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readdirplus/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
 sudo umount "$MOUNT_DIR"
 rm -rf $log_dir
+
+# Test package: dentry_cache
+# Run stat with dentry cache enabled
+test_case="TestStatWithDentryCacheEnabledTest/TestStatWithDentryCacheEnabled"
+gcsfuse --implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readdirplus/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
+sudo umount "$MOUNT_DIR"
+
+# Run notifier tests
+test_cases=(
+  "TestNotifierTest/TestReadFileWithDentryCacheEnabled"
+  "TestNotifierTest/TestWriteFileWithDentryCacheEnabled"
+)
+for test_case in "${test_cases[@]}"; do
+  gcsfuse --implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000 "$TEST_BUCKET_NAME" "$MOUNT_DIR"
+  GODEBUG=asyncpreemptoff=1 go test ./tools/integration_tests/readdirplus/... -p 1 --integrationTest -v --mountedDirectory="$MOUNT_DIR" --testbucket="$TEST_BUCKET_NAME" -run $test_case
+  sudo umount "$MOUNT_DIR"
+done


### PR DESCRIPTION
### Description
This change introduces a new e2e integration test package for the dentry cache feature, enabled by the `--experimental-enable-dentry-cache` flag.

These tests validate the correctness of the dentry cache implementation under different scenarios:

*   **Stat Cache Behavior**: A new test verifies that `os.Stat` returns cached file attributes and that these are correctly refreshed after the metadata cache TTL expires. This is covered in `stat_test.go`.
*   **Notifier Invalidation**: New tests ensure that when a cached file is modified externally on GCS, subsequent `read` and `write` operations fail initially, triggering a cache invalidation that allows the next attempt to succeed. This is covered in `notifier_test.go`.

The test execution scripts have also been updated to run these new tests.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Added

### Any backward incompatible change? If so, please explain.
