### PR TITLE
refactor(parallel random reads): Changes to start using atomic variables for shared state in read path

### DIFF
--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -326,7 +326,7 @@ func (job *Job) downloadObjectToFile(cacheFile *os.File) (err error) {
 			if newReader != nil {
 				readHandle = newReader.ReadHandle()
 			}
-			metrics.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, metrics.ReadTypeSequential, newReaderLimit-start)
+			metrics.CaptureGCSReadMetrics(job.cancelCtx, job.metricsHandle, metrics.ReadTypeNames[metrics.ReadTypeSequential], newReaderLimit-start)
 		}
 
 		maxRead := min(ReadChunkSize, newReaderLimit-start)

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -60,7 +60,7 @@ func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, e
 		}
 	}()
 
-	metrics.CaptureGCSReadMetrics(ctx, job.metricsHandle, metrics.ReadTypeParallel, end-start)
+	metrics.CaptureGCSReadMetrics(ctx, job.metricsHandle, metrics.ReadTypeNames[metrics.ReadTypeParallel], end-start)
 
 	// Use standard copy function if O_DIRECT is disabled and memory aligned
 	// buffer otherwise.

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -60,19 +61,19 @@ type GCSReader struct {
 	mrr         *MultiRangeReader
 
 	// ReadType of the reader. Will be sequential by default.
-	readType string
+	readType atomic.Int64
 
 	sequentialReadSizeMb int32
 
 	// Specifies the next expected offset for the reads. Used to distinguish between
 	// sequential and random reads.
-	expectedOffset int64
+	expectedOffset atomic.Int64
 
 	// seeks represents the number of random reads performed by the reader.
-	seeks uint64
+	seeks atomic.Uint64
 
 	// totalReadBytes is the total number of bytes read by the reader.
-	totalReadBytes uint64
+	totalReadBytes atomic.Uint64
 }
 
 type GCSReaderConfig struct {
@@ -89,7 +90,6 @@ func NewGCSReader(obj *gcs.MinObject, bucket gcs.Bucket, config *GCSReaderConfig
 		sequentialReadSizeMb: config.SequentialReadSizeMb,
 		rangeReader:          NewRangeReader(obj, bucket, config.Config, config.MetricHandle),
 		mrr:                  NewMultiRangeReader(obj, config.MetricHandle, config.MrdWrapper),
-		readType:             metrics.ReadTypeSequential,
 	}
 }
 
@@ -109,7 +109,7 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 	}
 	defer func() {
 		gr.updateExpectedOffset(offset + int64(readerResponse.Size))
-		gr.totalReadBytes += uint64(readerResponse.Size)
+		gr.totalReadBytes.Add(uint64(readerResponse.Size))
 	}()
 
 	var err error
@@ -123,8 +123,8 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 
 	// If the data can't be served from the existing reader, then we need to update the seeks.
 	// If current offset is not same as expected offset, it's a random read.
-	if gr.expectedOffset != 0 && gr.expectedOffset != offset {
-		gr.seeks++
+	if gr.expectedOffset.Load() != 0 && gr.expectedOffset.Load() != offset {
+		gr.seeks.Add(1)
 	}
 
 	// If we don't have a reader, determine whether to read from RangeReader or MultiRangeReader.
@@ -149,7 +149,7 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 // readerType specifies the go-sdk interface to use for reads.
 func (gr *GCSReader) readerType(start int64, end int64, bucketType gcs.BucketType) ReaderType {
 	bytesToBeRead := end - start
-	if gr.readType == metrics.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
+	if gr.readType.Load() == metrics.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
 		return MultiRangeReaderType
 	}
 	return RangeReaderType
@@ -176,9 +176,9 @@ func (gr *GCSReader) getReadInfo(start int64, size int64) (int64, error) {
 // determineEnd calculates the end position for a read operation based on the current read pattern.
 func (gr *GCSReader) determineEnd(start int64) int64 {
 	end := int64(gr.object.Size)
-	if gr.seeks >= minSeeksForRandom {
-		gr.readType = metrics.ReadTypeRandom
-		averageReadBytes := gr.totalReadBytes / gr.seeks
+	if gr.seeks.Load() >= minSeeksForRandom {
+		gr.readType.Store(metrics.ReadTypeRandom)
+		averageReadBytes := gr.totalReadBytes.Load() / gr.seeks.Load()
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MB) + 1) * MB)
 			if randomReadSize < minReadSize {
@@ -206,7 +206,7 @@ func (gr *GCSReader) limitEnd(start, currentEnd int64) int64 {
 }
 
 func (gr *GCSReader) updateExpectedOffset(offset int64) {
-	gr.expectedOffset = offset
+	gr.expectedOffset.Store(offset)
 }
 
 func (gr *GCSReader) Destroy() {

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -123,7 +123,7 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.R
 
 	// If the data can't be served from the existing reader, then we need to update the seeks.
 	// If current offset is not same as expected offset, it's a random read.
-	if gr.expectedOffset.Load() != 0 && gr.expectedOffset.Load() != offset {
+	if expectedOffset := gr.expectedOffset.Load(); expectedOffset != 0 && expectedOffset != offset {
 		gr.seeks.Add(1)
 	}
 
@@ -176,9 +176,9 @@ func (gr *GCSReader) getReadInfo(start int64, size int64) (int64, error) {
 // determineEnd calculates the end position for a read operation based on the current read pattern.
 func (gr *GCSReader) determineEnd(start int64) int64 {
 	end := int64(gr.object.Size)
-	if gr.seeks.Load() >= minSeeksForRandom {
+	if seeks := gr.seeks.Load(); seeks >= minSeeksForRandom { {
 		gr.readType.Store(metrics.ReadTypeRandom)
-		averageReadBytes := gr.totalReadBytes.Load() / gr.seeks.Load()
+		averageReadBytes := gr.totalReadBytes.Load() / seeks
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MB) + 1) * MB)
 			if randomReadSize < minReadSize {

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -176,7 +176,7 @@ func (gr *GCSReader) getReadInfo(start int64, size int64) (int64, error) {
 // determineEnd calculates the end position for a read operation based on the current read pattern.
 func (gr *GCSReader) determineEnd(start int64) int64 {
 	end := int64(gr.object.Size)
-	if seeks := gr.seeks.Load(); seeks >= minSeeksForRandom { {
+	if seeks := gr.seeks.Load(); seeks >= minSeeksForRandom {
 		gr.readType.Store(metrics.ReadTypeRandom)
 		averageReadBytes := gr.totalReadBytes.Load() / seeks
 		if averageReadBytes < maxReadSize {

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -60,7 +60,7 @@ type RangeReader struct {
 	readHandle []byte
 	cancel     func()
 
-	readType     string
+	readType     int64
 	config       *cfg.Config
 	metricHandle metrics.MetricHandle
 }
@@ -131,7 +131,7 @@ func (rr *RangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (
 // readFromRangeReader reads using the NewReader interface of go-sdk. It uses
 // the existing reader if available, otherwise makes a call to GCS.
 // Before calling this method we have to use invalidateReaderIfMisalignedOrTooSmall to get the reader start at the correct position.
-func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset int64, end int64, readType string) (int, error) {
+func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset int64, end int64, readType int64) (int, error) {
 	var err error
 	// If we don't have a reader, start a read operation.
 	if rr.reader == nil {
@@ -187,7 +187,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 	}
 
 	requestedDataSize := end - offset
-	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeNames[readType], requestedDataSize)
 
 	return n, err
 }
@@ -281,7 +281,7 @@ func (rr *RangeReader) startRead(start int64, end int64) error {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeSequential, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeNames[metrics.ReadTypeSequential], requestedDataSize)
 
 	return nil
 }

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -406,7 +406,7 @@ func (t *rangeReaderTest) Test_ReadFromRangeReader_WhenReaderReturnedMoreData() 
 			}
 			t.rangeReader.cancel = func() {}
 
-			n, err := t.rangeReader.readFromRangeReader(t.ctx, make([]byte, 10), 0, 10, "unhandled")
+			n, err := t.rangeReader.readFromRangeReader(t.ctx, make([]byte, 10), 0, 10, metrics.ReadTypeUnknown)
 
 			assert.Error(t.T(), err)
 			assert.Zero(t.T(), n)
@@ -535,7 +535,7 @@ func (t *rangeReaderTest) Test_ReadFromRangeReader_WhenAllDataFromReaderIsRead()
 			t.rangeReader.cancel = func() {}
 			buf := make([]byte, dataSize)
 
-			n, err := t.rangeReader.readFromRangeReader(t.ctx, buf, 4, 10, "unhandled")
+			n, err := t.rangeReader.readFromRangeReader(t.ctx, buf, 4, 10, metrics.ReadTypeUnknown)
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), dataSize, n)
@@ -578,7 +578,7 @@ func (t *rangeReaderTest) Test_ReadFromRangeReader_WhenReaderHasLessDataThanRequ
 			t.rangeReader.cancel = func() {}
 			buf := make([]byte, 10)
 
-			n, err := t.rangeReader.readFromRangeReader(t.ctx, buf, 0, 10, "unhandled")
+			n, err := t.rangeReader.readFromRangeReader(t.ctx, buf, 0, 10, metrics.ReadTypeUnknown)
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), dataSize, n)

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -121,7 +121,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 		if isSequential {
 			readType = metrics.ReadTypeSequential
 		}
-		captureFileCacheMetrics(ctx, fc.metricHandle, readType, bytesRead, cacheHit, executionTime)
+		captureFileCacheMetrics(ctx, fc.metricHandle, metrics.ReadTypeNames[readType], bytesRead, cacheHit, executionTime)
 	}()
 
 	// Create fileCacheHandle if not already.

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -109,9 +110,6 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 		bucket:                bucket,
 		start:                 -1,
 		limit:                 -1,
-		seeks:                 0,
-		totalReadBytes:        0,
-		readType:              metrics.ReadTypeSequential,
 		sequentialReadSizeMb:  sequentialReadSizeMb,
 		fileCacheHandler:      fileCacheHandler,
 		cacheFileForRangeRead: cacheFileForRangeRead,
@@ -141,11 +139,11 @@ type randomReader struct {
 	// reads from cache.
 	start          int64
 	limit          int64
-	seeks          uint64
-	totalReadBytes uint64
+	seeks          atomic.Uint64
+	totalReadBytes atomic.Uint64
 
 	// ReadType of the reader. Will be sequential by default.
-	readType string
+	readType atomic.Int64
 
 	sequentialReadSizeMb int32
 
@@ -178,7 +176,7 @@ type randomReader struct {
 
 	// Specifies the next expected offset for the reads. Used to distinguish between
 	// sequential and random reads.
-	expectedOffset int64
+	expectedOffset atomic.Int64
 }
 
 func (rr *randomReader) CheckInvariants() {
@@ -251,7 +249,7 @@ func (rr *randomReader) tryReadingFromFileCache(ctx context.Context,
 		if isSeq {
 			readType = metrics.ReadTypeSequential
 		}
-		captureFileCacheMetrics(ctx, rr.metricHandle, readType, n, cacheHit, executionTime)
+		captureFileCacheMetrics(ctx, rr.metricHandle, metrics.ReadTypeNames[readType], n, cacheHit, executionTime)
 	}()
 
 	// Create fileCacheHandle if not already.
@@ -361,14 +359,14 @@ func (rr *randomReader) ReadAt(
 	}
 
 	if rr.reader != nil {
-		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, -1, rr.readType)
+		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, -1, rr.readType.Load())
 		return
 	}
 
 	// If the data can't be served from the existing reader, then we need to update the seeks.
 	// If current offset is not same as expected offset, its a random read.
-	if rr.expectedOffset != 0 && rr.expectedOffset != offset {
-		rr.seeks++
+	if rr.expectedOffset.Load() != 0 && rr.expectedOffset.Load() != offset {
+		rr.seeks.Add(1)
 	}
 
 	// If we don't have a reader, determine whether to read from NewReader or MRR.
@@ -378,9 +376,9 @@ func (rr *randomReader) ReadAt(
 		return
 	}
 
-	readerType := readerType(rr.readType, offset, end, rr.bucket.BucketType())
+	readerType := readerType(rr.readType.Load(), offset, end, rr.bucket.BucketType())
 	if readerType == RangeReader {
-		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, end, rr.readType)
+		objectData.Size, err = rr.readFromRangeReader(ctx, p, offset, end, rr.readType.Load())
 		return
 	}
 
@@ -513,7 +511,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	rr.limit = end
 
 	requestedDataSize := end - start
-	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeSequential, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeNames[metrics.ReadTypeSequential], requestedDataSize)
 
 	return
 }
@@ -550,9 +548,9 @@ func (rr *randomReader) getReadInfo(
 	// optimise for random reads. Random reads will read data in chunks of
 	// (average read size in bytes rounded up to the next MiB).
 	end = int64(rr.object.Size)
-	if rr.seeks >= minSeeksForRandom {
-		rr.readType = metrics.ReadTypeRandom
-		averageReadBytes := rr.totalReadBytes / rr.seeks
+	if rr.seeks.Load() >= minSeeksForRandom {
+		rr.readType.Store(metrics.ReadTypeRandom)
+		averageReadBytes := rr.totalReadBytes.Load() / rr.seeks.Load()
 		if averageReadBytes < maxReadSize {
 			randomReadSize := int64(((averageReadBytes / MiB) + 1) * MiB)
 			if randomReadSize < minReadSize {
@@ -579,7 +577,7 @@ func (rr *randomReader) getReadInfo(
 }
 
 // readerType specifies the go-sdk interface to use for reads.
-func readerType(readType string, start int64, end int64, bucketType gcs.BucketType) ReaderType {
+func readerType(readType int64, start int64, end int64, bucketType gcs.BucketType) ReaderType {
 	bytesToBeRead := end - start
 	if readType == metrics.ReadTypeRandom && bytesToBeRead < maxReadSize && bucketType.Zonal {
 		return MultiRangeReader
@@ -589,7 +587,7 @@ func readerType(readType string, start int64, end int64, bucketType gcs.BucketTy
 
 // readFromRangeReader reads using the NewReader interface of go-sdk. Its uses
 // the existing reader if available, otherwise makes a call to GCS.
-func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offset int64, end int64, readType string) (n int, err error) {
+func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offset int64, end int64, readType int64) (n int, err error) {
 	// If we don't have a reader, start a read operation.
 	if rr.reader == nil {
 		err = rr.startRead(offset, end)
@@ -603,7 +601,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 	// it as possible.
 	n, err = rr.readFull(ctx, p)
 	rr.start += int64(n)
-	rr.totalReadBytes += uint64(n)
+	rr.totalReadBytes.Add(uint64(n))
 
 	// Sanity check.
 	if rr.start > rr.limit {
@@ -646,7 +644,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 	}
 
 	requestedDataSize := end - offset
-	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, readType, requestedDataSize)
+	metrics.CaptureGCSReadMetrics(ctx, rr.metricHandle, metrics.ReadTypeNames[readType], requestedDataSize)
 	rr.updateExpectedOffset(offset + int64(n))
 
 	return
@@ -663,7 +661,7 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 	}
 
 	bytesRead, err = rr.mrdWrapper.Read(ctx, p, offset, end, timeout, rr.metricHandle)
-	rr.totalReadBytes += uint64(bytesRead)
+	rr.totalReadBytes.Add(uint64(bytesRead))
 	rr.updateExpectedOffset(offset + int64(bytesRead))
 	return
 }
@@ -678,5 +676,5 @@ func (rr *randomReader) closeReader() {
 }
 
 func (rr *randomReader) updateExpectedOffset(offset int64) {
-	rr.expectedOffset = offset
+	rr.expectedOffset.Store(offset)
 }

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -141,14 +141,14 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Sequential() {
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), metrics.ReadTypeSequential, t.rr.wrapped.readType)
+			assert.Equal(t.T(), metrics.ReadTypeSequential, t.rr.wrapped.readType.Load())
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
 }
 
 func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
-	t.rr.wrapped.seeks = 2
+	t.rr.wrapped.seeks.Store(2)
 	var testCases = []struct {
 		testName       string
 		expectedEnd    int64
@@ -170,11 +170,11 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
 	for _, tc := range testCases {
 		t.Run(tc.testName, func() {
 			t.object.Size = tc.objectSize
-			t.rr.wrapped.totalReadBytes = tc.totalReadBytes
+			t.rr.wrapped.totalReadBytes.Store(tc.totalReadBytes)
 			end, err := t.rr.wrapped.getReadInfo(tc.start, 10)
 
 			assert.NoError(t.T(), err)
-			assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType)
+			assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType.Load())
 			assert.Equal(t.T(), tc.expectedEnd, end)
 		})
 	}
@@ -183,7 +183,7 @@ func (t *RandomReaderStretchrTest) Test_ReadInfo_Random() {
 func (t *RandomReaderStretchrTest) Test_ReaderType() {
 	testCases := []struct {
 		name       string
-		readType   string
+		readType   int64
 		start      int64
 		end        int64
 		bucketType gcs.BucketType
@@ -277,7 +277,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIs
 			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, readObjectRequest).Return(rc, nil).Times(1)
 			buf := make([]byte, dataSize)
 
-			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, int64(t.object.Size), "unhandled")
+			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, int64(t.object.Size), metrics.ReadTypeUnknown)
 
 			t.mockBucket.AssertExpectations(t.T())
 			assert.NoError(t.T(), err)
@@ -288,7 +288,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIs
 			assert.Nil(t.T(), t.rr.wrapped.cancel)
 			assert.Equal(t.T(), int64(5), t.rr.wrapped.start)
 			assert.Equal(t.T(), int64(5), t.rr.wrapped.limit)
-			assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset)
+			assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset.Load())
 		})
 	}
 }
@@ -296,7 +296,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIs
 func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIsNotNil() {
 	t.rr.wrapped.start = 4
 	t.rr.wrapped.limit = 10
-	t.rr.wrapped.totalReadBytes = 4
+	t.rr.wrapped.totalReadBytes.Store(4)
 	t.object.Size = 10
 	dataSize := 4
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -305,7 +305,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIs
 	t.rr.wrapped.cancel = func() {}
 	buf := make([]byte, dataSize)
 
-	n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 4, 8, "unhandled")
+	n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 4, 8, metrics.ReadTypeUnknown)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), dataSize, n)
@@ -314,8 +314,8 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenExistingReaderIs
 	assert.NotNil(t.T(), t.rr.wrapped.cancel)
 	assert.Equal(t.T(), int64(8), t.rr.wrapped.start)
 	assert.Equal(t.T(), int64(10), t.rr.wrapped.limit)
-	assert.Equal(t.T(), uint64(8), t.rr.wrapped.totalReadBytes)
-	assert.Equal(t.T(), int64(8), t.rr.wrapped.expectedOffset)
+	assert.Equal(t.T(), uint64(8), t.rr.wrapped.totalReadBytes.Load())
+	assert.Equal(t.T(), int64(8), t.rr.wrapped.expectedOffset.Load())
 }
 
 func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenAllDataFromReaderIsRead() {
@@ -337,7 +337,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenAllDataFromReade
 		t.Run(tc.name, func() {
 			t.rr.wrapped.start = 4
 			t.rr.wrapped.limit = 10
-			t.rr.wrapped.totalReadBytes = 4
+			t.rr.wrapped.totalReadBytes.Store(4)
 			t.object.Size = 10
 			dataSize := 6
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -349,7 +349,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenAllDataFromReade
 			t.rr.wrapped.cancel = func() {}
 			buf := make([]byte, dataSize)
 
-			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 4, 10, "unhandled")
+			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 4, 10, metrics.ReadTypeUnknown)
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), dataSize, n)
@@ -358,8 +358,8 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenAllDataFromReade
 			assert.Nil(t.T(), t.rr.wrapped.cancel)
 			assert.Equal(t.T(), int64(10), t.rr.wrapped.start)
 			assert.Equal(t.T(), int64(10), t.rr.wrapped.limit)
-			assert.Equal(t.T(), uint64(10), t.rr.wrapped.totalReadBytes)
-			assert.Equal(t.T(), int64(10), t.rr.wrapped.expectedOffset)
+			assert.Equal(t.T(), uint64(10), t.rr.wrapped.totalReadBytes.Load())
+			assert.Equal(t.T(), int64(10), t.rr.wrapped.expectedOffset.Load())
 			expectedReadHandle := tc.readHandle
 			assert.Equal(t.T(), expectedReadHandle, t.rr.wrapped.readHandle)
 		})
@@ -385,7 +385,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderHasLessDat
 		t.Run(tc.name, func() {
 			t.rr.wrapped.start = 0
 			t.rr.wrapped.limit = 6
-			t.rr.wrapped.totalReadBytes = 0
+			t.rr.wrapped.totalReadBytes.Store(0)
 			dataSize := 6
 			testContent := testutil.GenerateRandomBytes(dataSize)
 			rc := &fake.FakeReader{
@@ -396,7 +396,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderHasLessDat
 			t.rr.wrapped.cancel = func() {}
 			buf := make([]byte, 10)
 
-			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, "unhandled")
+			n, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, metrics.ReadTypeUnknown)
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), dataSize, n)
@@ -405,8 +405,8 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderHasLessDat
 			assert.Nil(t.T(), t.rr.wrapped.cancel)
 			assert.Equal(t.T(), int64(dataSize), t.rr.wrapped.start)
 			assert.Equal(t.T(), int64(dataSize), t.rr.wrapped.limit)
-			assert.Equal(t.T(), uint64(dataSize), t.rr.wrapped.totalReadBytes)
-			assert.Equal(t.T(), int64(dataSize), t.rr.wrapped.expectedOffset)
+			assert.Equal(t.T(), uint64(dataSize), t.rr.wrapped.totalReadBytes.Load())
+			assert.Equal(t.T(), int64(dataSize), t.rr.wrapped.expectedOffset.Load())
 			expectedReadHandle := tc.readHandle
 			assert.Equal(t.T(), expectedReadHandle, t.rr.wrapped.readHandle)
 		})
@@ -432,7 +432,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderReturnedMo
 		t.Run(tc.name, func() {
 			t.rr.wrapped.start = 0
 			t.rr.wrapped.limit = 6
-			t.rr.wrapped.totalReadBytes = 0
+			t.rr.wrapped.totalReadBytes.Store(0)
 			dataSize := 8
 			testContent := testutil.GenerateRandomBytes(dataSize)
 			rc := &fake.FakeReader{
@@ -443,15 +443,15 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderReturnedMo
 			t.rr.wrapped.cancel = func() {}
 			buf := make([]byte, 10)
 
-			_, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, "unhandled")
+			_, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, metrics.ReadTypeUnknown)
 
 			assert.True(t.T(), strings.Contains(err.Error(), "extra bytes: 2"))
 			assert.Nil(t.T(), t.rr.wrapped.reader)
 			assert.Nil(t.T(), t.rr.wrapped.cancel)
 			assert.Equal(t.T(), int64(-1), t.rr.wrapped.start)
 			assert.Equal(t.T(), int64(-1), t.rr.wrapped.limit)
-			assert.Equal(t.T(), uint64(8), t.rr.wrapped.totalReadBytes)
-			assert.Equal(t.T(), int64(0), t.rr.wrapped.expectedOffset)
+			assert.Equal(t.T(), uint64(8), t.rr.wrapped.totalReadBytes.Load())
+			assert.Equal(t.T(), int64(0), t.rr.wrapped.expectedOffset.Load())
 			expectedReadHandle := tc.readHandle
 			assert.Equal(t.T(), expectedReadHandle, t.rr.wrapped.readHandle)
 		})
@@ -468,10 +468,10 @@ func (t *RandomReaderStretchrTest) Test_ReadFromRangeReader_WhenReaderReturnedEO
 	t.rr.wrapped.cancel = func() {}
 	buf := make([]byte, 10)
 
-	_, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, "unhandled")
+	_, err := t.rr.wrapped.readFromRangeReader(t.rr.ctx, buf, 0, 10, metrics.ReadTypeUnknown)
 
 	assert.True(t.T(), strings.Contains(err.Error(), "skipping 4 bytes"))
-	assert.Equal(t.T(), int64(0), t.rr.wrapped.expectedOffset)
+	assert.Equal(t.T(), int64(0), t.rr.wrapped.expectedOffset.Load())
 }
 
 func (t *RandomReaderStretchrTest) Test_ExistingReader_WrongOffset() {
@@ -556,8 +556,8 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ExistingReaderLimitIsLessThanRequ
 	require.Equal(t.T(), rc, t.rr.wrapped.reader)
 	require.Equal(t.T(), requestSize, data.Size)
 	require.Equal(t.T(), "abcdef", string(buf[:data.Size]))
-	assert.Equal(t.T(), uint64(requestSize), t.rr.wrapped.totalReadBytes)
-	assert.Equal(t.T(), int64(2+requestSize), t.rr.wrapped.expectedOffset)
+	assert.Equal(t.T(), uint64(requestSize), t.rr.wrapped.totalReadBytes.Load())
+	assert.Equal(t.T(), int64(2+requestSize), t.rr.wrapped.expectedOffset.Load())
 	assert.Equal(t.T(), expectedHandleInRequest, t.rr.wrapped.readHandle)
 }
 
@@ -591,8 +591,8 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ExistingReaderLimitIsLessThanRequ
 	require.Nil(t.T(), t.rr.wrapped.reader)
 	require.Equal(t.T(), int(t.object.Size), data.Size)
 	require.Equal(t.T(), "abcde", string(buf[:data.Size]))
-	assert.Equal(t.T(), t.object.Size, t.rr.wrapped.totalReadBytes)
-	assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset)
+	assert.Equal(t.T(), t.object.Size, t.rr.wrapped.totalReadBytes.Load())
+	assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset.Load())
 	assert.Equal(t.T(), []byte(nil), t.rr.wrapped.readHandle)
 }
 
@@ -633,7 +633,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 		dataSize          int
 		bucketType        gcs.BucketType
 		readRanges        [][]int
-		expectedReadTypes []string
+		expectedReadTypes []int64
 		expectedSeeks     []int
 	}{
 		{
@@ -641,7 +641,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
+			expectedReadTypes: []int64{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -649,7 +649,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 10}, {10, 20}, {20, 35}, {35, 50}},
-			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
+			expectedReadTypes: []int64{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeSequential},
 			expectedSeeks:     []int{0, 0, 0, 0, 0},
 		},
 		{
@@ -657,7 +657,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: false},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
+			expectedReadTypes: []int64{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 		{
@@ -665,7 +665,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			dataSize:          100,
 			bucketType:        gcs.BucketType{Zonal: true},
 			readRanges:        [][]int{{0, 50}, {30, 40}, {10, 20}, {20, 30}, {30, 40}},
-			expectedReadTypes: []string{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
+			expectedReadTypes: []int64{metrics.ReadTypeSequential, metrics.ReadTypeSequential, metrics.ReadTypeRandom, metrics.ReadTypeRandom, metrics.ReadTypeRandom},
 			expectedSeeks:     []int{0, 1, 2, 2, 2},
 		},
 	}
@@ -675,9 +675,9 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 			assert.Equal(t.T(), len(tc.readRanges), len(tc.expectedReadTypes), "Test Parameter Error: readRanges and expectedReadTypes should have same length")
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
-			t.rr.wrapped.seeks = 0
-			t.rr.wrapped.readType = metrics.ReadTypeSequential
-			t.rr.wrapped.expectedOffset = 0
+			t.rr.wrapped.seeks.Store(0)
+			t.rr.wrapped.readType.Store(metrics.ReadTypeSequential)
+			t.rr.wrapped.expectedOffset.Store(0)
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
@@ -693,9 +693,9 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 				_, err := t.rr.wrapped.ReadAt(t.rr.ctx, buf, int64(readRange[0]))
 
 				assert.NoError(t.T(), err)
-				assert.Equal(t.T(), tc.expectedReadTypes[i], t.rr.wrapped.readType)
-				assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset)
-				assert.Equal(t.T(), uint64(tc.expectedSeeks[i]), t.rr.wrapped.seeks)
+				assert.Equal(t.T(), tc.expectedReadTypes[i], t.rr.wrapped.readType.Load())
+				assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset.Load())
+				assert.Equal(t.T(), uint64(tc.expectedSeeks[i]), t.rr.wrapped.seeks.Load())
 			}
 		})
 	}
@@ -705,10 +705,10 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateReadType() {
 func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 	t.rr.wrapped.reader = nil
 	t.rr.wrapped.isMRDInUse = false
-	t.rr.wrapped.seeks = 0
-	t.rr.wrapped.readType = metrics.ReadTypeSequential
-	t.rr.wrapped.expectedOffset = 0
-	t.rr.wrapped.totalReadBytes = 0
+	t.rr.wrapped.seeks.Store(0)
+	t.rr.wrapped.readType.Store(metrics.ReadTypeSequential)
+	t.rr.wrapped.expectedOffset.Store(0)
+	t.rr.wrapped.totalReadBytes.Store(0)
 	t.object.Size = 20 * MiB
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true})
 	testContent := testutil.GenerateRandomBytes(int(t.object.Size))
@@ -725,7 +725,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 	seeks := 1
 	_, err = t.rr.wrapped.ReadAt(t.rr.ctx, buf, 12*MiB)
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks)
+	assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks.Load())
 
 	readRanges := [][]int{{11 * MiB, 15 * MiB}, {12 * MiB, 14 * MiB}, {10 * MiB, 12 * MiB}, {9 * MiB, 11 * MiB}, {8 * MiB, 10 * MiB}}
 	// Series of random reads to check if seeks are updated correctly and MRD is invoked always
@@ -737,9 +737,9 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_ValidateZonalRandomReads() {
 		_, err := t.rr.wrapped.ReadAt(t.rr.ctx, buf, int64(readRange[0]))
 
 		assert.NoError(t.T(), err)
-		assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType)
-		assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset)
-		assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks)
+		assert.Equal(t.T(), metrics.ReadTypeRandom, t.rr.wrapped.readType.Load())
+		assert.Equal(t.T(), int64(readRange[1]), t.rr.wrapped.expectedOffset.Load())
+		assert.Equal(t.T(), uint64(seeks), t.rr.wrapped.seeks.Load())
 	}
 }
 
@@ -768,8 +768,8 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 		t.Run(tc.name, func() {
 			t.rr.wrapped.reader = nil
 			t.rr.wrapped.isMRDInUse = false
-			t.rr.wrapped.expectedOffset = 10
-			t.rr.wrapped.seeks = minSeeksForRandom + 1
+			t.rr.wrapped.expectedOffset.Store(10)
+			t.rr.wrapped.seeks.Store(minSeeksForRandom + 1)
 			t.object.Size = uint64(tc.dataSize)
 			testContent := testutil.GenerateRandomBytes(int(t.object.Size))
 			fakeMRDWrapper, err := NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{})
@@ -787,7 +787,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 			assert.Equal(t.T(), tc.bytesToRead, objData.Size)
 			assert.Equal(t.T(), testContent[tc.offset:tc.offset+tc.bytesToRead], objData.DataBuf[:objData.Size])
 			if tc.bytesToRead != 0 {
-				assert.Equal(t.T(), int64(tc.offset+tc.bytesToRead), t.rr.wrapped.expectedOffset)
+				assert.Equal(t.T(), int64(tc.offset+tc.bytesToRead), t.rr.wrapped.expectedOffset.Load())
 			}
 		})
 	}
@@ -829,7 +829,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadFull() {
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.dataSize, bytesRead)
 			assert.Equal(t.T(), testContent[:tc.dataSize], buf[:bytesRead])
-			assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset)
+			assert.Equal(t.T(), int64(t.object.Size), t.rr.wrapped.expectedOffset.Load())
 		})
 	}
 }
@@ -865,7 +865,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFromMultiRangeReader_ReadChunk() {
 		assert.NoError(t.T(), err)
 		assert.Equal(t.T(), tc.end-tc.start, bytesRead)
 		assert.Equal(t.T(), testContent[tc.start:tc.end], buf[:bytesRead])
-		assert.Equal(t.T(), int64(tc.end), t.rr.wrapped.expectedOffset)
+		assert.Equal(t.T(), int64(tc.end), t.rr.wrapped.expectedOffset.Load())
 	}
 }
 

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -467,13 +467,13 @@ func (t *RandomReaderTest) UpgradeReadsToAverageSize() {
 	const readSize = 2 * minReadSize
 
 	// Simulate an existing reader at a mismatched offset.
-	t.rr.wrapped.seeks = numReads
-	t.rr.wrapped.totalReadBytes = totalReadBytes
+	t.rr.wrapped.seeks.Store(numReads)
+	t.rr.wrapped.totalReadBytes.Store(totalReadBytes)
 	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
 	t.rr.wrapped.cancel = func() {}
 	t.rr.wrapped.start = 2
 	t.rr.wrapped.limit = 5
-	t.rr.wrapped.expectedOffset = 2
+	t.rr.wrapped.expectedOffset.Store(2)
 
 	// The bucket should be asked to read expectedBytesToRead bytes.
 	r := strings.NewReader(strings.Repeat("x", expectedBytesToRead))

--- a/metrics/constants.go
+++ b/metrics/constants.go
@@ -15,7 +15,15 @@
 package metrics
 
 const (
-	ReadTypeSequential = "Sequential"
-	ReadTypeRandom     = "Random"
-	ReadTypeParallel   = "Parallel"
+	ReadTypeUnknown    int64 = -1
+	ReadTypeSequential int64 = 0
+	ReadTypeRandom     int64 = 1
+	ReadTypeParallel   int64 = 2
 )
+
+var ReadTypeNames = map[int64]string{
+	ReadTypeUnknown:    "Unhandled",
+	ReadTypeSequential: "Sequential",
+	ReadTypeRandom:     "Random",
+	ReadTypeParallel:   "Parallel",
+}


### PR DESCRIPTION
This pull request introduces significant changes to how shared state variables are managed within the GCS read path, specifically for GCSReader and randomReader components. By migrating these variables to use Go's sync/atomic package, the PR lays the groundwork for future performance optimizations by enabling the removal of traditional locks for random reads, benefiting parallel random read operations from same file handle on Zonal Buckets. The changes ensure thread-safe access to critical counters and flags, improving the robustness and scalability of the read operations.

Highlights
Concurrency Improvement: Replaced standard variable types (string, int64, uint64) with their sync/atomic counterparts (atomic.Int64, atomic.Uint64) for shared state variables like readType, expectedOffset, seeks, and totalReadBytes within GCSReader and randomReader structs. This change is a prerequisite for removing locks from random reads for Zonal Buckets (ZB).

Atomic Operations Adoption: Updated all direct assignments (=) and arithmetic operations (+=, ++) on these shared variables to use the appropriate atomic methods (.Store(), .Load(), .Add()) to ensure thread-safe access without explicit locking.

Metrics Integration Update: Modified metrics.CaptureGCSReadMetrics calls across various files to use a new metrics.ReadTypeNames map. This map provides string representations for the ReadType constants, which have been converted from string to int64 types to align with the use of atomic.Int64.

Metric Constants Refinement: The metrics/constants.go file was updated to redefine ReadTypeSequential, ReadTypeRandom, and ReadTypeParallel as int64 constants, and a new ReadTypeUnknown constant was introduced. A ReadTypeNames map was added to provide human-readable string names for these int64 constants.

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - Done

### Any backward incompatible change? If so, please explain.
No backward compatible changes
