### PR TITLE
feat(bufferedread): Add freshStart and prefetch methods to Buffered Reader

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -104,45 +104,38 @@ func NewBufferedReader(object *gcs.MinObject, bucket gcs.Bucket, config *Buffere
 }
 
 func (p *BufferedReader) prefetch() error {
-	// Do not schedule more blocks if the queue is already at capacity.
-	availableCapacity := p.config.MaxPrefetchBlockCnt - int64(p.blockQueue.Len())
-	if availableCapacity <= 0 {
+	// Do not schedule more blocks if the prefetch queue has reached its maximum configured size.
+	availableSlots := p.config.MaxPrefetchBlockCnt - int64(p.blockQueue.Len())
+	if availableSlots <= 0 {
 		return nil
 	}
-
-	// Determine the number of blocks for this prefetch operation, respecting
-	// both the multiplicative growth and the available capacity.
-	blockCountToPrefetch := min(p.numPrefetchBlocks, availableCapacity)
+	blockCountToPrefetch := min(p.numPrefetchBlocks, availableSlots)
 	if blockCountToPrefetch <= 0 {
 		return nil
 	}
 
-	logger.Tracef("Prefetching %d blocks", blockCountToPrefetch)
+	logger.Debugf("Prefetching %d blocks", blockCountToPrefetch)
 
 	for i := int64(0); i < blockCountToPrefetch; i++ {
-		if p.nextBlockIndexToPrefetch >= p.maxBlockCount() {
+		if p.nextBlockIndexToPrefetch >= p.totalBlockCount() {
 			break
 		}
 		if err := p.scheduleNextBlock(false); err != nil {
 			return fmt.Errorf("failed to schedule block index %d: %v", p.nextBlockIndexToPrefetch, err)
 		}
 	}
+
 	// Set the size for the next multiplicative prefetch.
 	p.numPrefetchBlocks *= p.config.PrefetchMultiplier
+
+	// Ensure the number of blocks for the next prefetch does not exceed the configured maximum.
 	if p.numPrefetchBlocks > p.config.MaxPrefetchBlockCnt {
 		p.numPrefetchBlocks = p.config.MaxPrefetchBlockCnt
 	}
 	return nil
 }
 
-func (p *BufferedReader) maxBlockCount() int64 {
-	if p.config.PrefetchBlockSizeBytes <= 0 {
-
-		// A non-positive chunk size is an invalid configuration.
-		// Log a warning and return 0 to prevent division by zero.
-		logger.Warnf("Invalid PrefetchChunkSizeBytes (%d); must be positive.", p.config.PrefetchBlockSizeBytes)
-		return 0
-	}
+func (p *BufferedReader) totalBlockCount() int64 {
 	return (int64(p.object.Size) + p.config.PrefetchBlockSizeBytes - 1) / p.config.PrefetchBlockSizeBytes
 }
 
@@ -151,29 +144,19 @@ func (p *BufferedReader) freshStart(currentOffset int64) error {
 	p.nextBlockIndexToPrefetch = blockIndex
 
 	// Determine the number of blocks for the initial prefetch.
-	numToPrefetch := p.config.InitialPrefetchBlockCnt
-	if numToPrefetch <= 0 {
-		numToPrefetch = 1 // Default to at least 1.
+	p.numPrefetchBlocks = min(p.config.InitialPrefetchBlockCnt, p.config.MaxPrefetchBlockCnt)
+
+	// Schedule the first block as urgent.
+	if err := p.scheduleNextBlock(true); err != nil {
+		return fmt.Errorf("initial scheduling failed: %w", err)
 	}
 
-	// But don't prefetch more than the total capacity.
-	numToPrefetch = min(numToPrefetch, p.config.MaxPrefetchBlockCnt)
-
-	// Schedule the initial blocks.
-	for i := int64(0); i < numToPrefetch; i++ {
-		if p.nextBlockIndexToPrefetch >= p.maxBlockCount() {
-			break
-		}
-
-		// The first block is considered urgent to unblock the current read.
-		isUrgent := (i == 0)
-		if err := p.scheduleNextBlock(isUrgent); err != nil {
-			return fmt.Errorf("initial scheduling failed: %w", err)
-		}
+	// Prefetch the initial blocks.
+	if err := p.prefetch(); err != nil {
+		return fmt.Errorf("freshStart: prefetch failed: %w", err)
 	}
 	return nil
 }
-
 
 // scheduleNextBlock schedules the next block for prefetch.
 func (p *BufferedReader) scheduleNextBlock(urgent bool) error {

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -502,7 +502,7 @@ func (t *BufferedReaderTest) TestPrefetchWithMultiplicativeIncrease() {
 	bqe1 := reader.blockQueue.Pop()
 	_, err1 := bqe1.block.AwaitReady(t.ctx)
 	require.NoError(t.T(), err1)
-	// Second prefetch schedules 2 blocks due to multiplicative increase.
+	// Second prefetch should schedule 2 blocks due to multiplicative increase.
 	t.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.AnythingOfType("*gcs.ReadObjectRequest")).Return(createFakeReader(t.T(), int(testPrefetchBlockSizeBytes)), nil).Once()
 	t.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.AnythingOfType("*gcs.ReadObjectRequest")).Return(createFakeReader(t.T(), int(testPrefetchBlockSizeBytes)), nil).Once()
 


### PR DESCRIPTION

### Description
This PR implements `prefetch` and `freshStart` methods that will be used by Buffered Reader to prefetch the data in prefetch blocks.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/432168690

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
