### PR TITLE
refactor(block): return early io.EOF while reading from block

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -88,6 +88,11 @@ func (m *memoryBlock) Read(bytes []byte) (int, error) {
 	n := copy(bytes, m.buffer[m.readSeek:m.offset.end])
 	m.readSeek += int64(n)
 
+	// If readSeek is beyond the end of the block, return EOF early.
+	if m.readSeek >= m.offset.end {
+		return n, io.EOF
+	}
+
 	return n, nil
 }
 

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -198,7 +198,7 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockReadWithReadBufferMoreThanBlock
 
 	n, err = mb.Read(readBuffer)
 
-	require.NoError(testSuite.T(), err)
+	require.Error(testSuite.T(), io.EOF, err)
 	require.Equal(testSuite.T(), 11, n) // Read should return all bytes written.
 }
 
@@ -258,7 +258,9 @@ func (testSuite *MemoryBlockTest) TestMemoryBlockSeek() {
 			require.Equal(t, tt.expectedOffset, offset)
 			readBuffer := make([]byte, 5)
 			n, err = mb.Read(readBuffer)
-			require.Nil(t, err)
+			require.Condition(t, func() bool {
+				return err == nil || errors.Is(err, io.EOF)
+			}, "Read err can be nil or io.EOF")
 			require.Equal(t, 5, n)
 			assert.Equal(t, tt.expectedOutput, string(readBuffer))
 		})


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
