### PR TITLE
ci(perf_test): Add support to dump logs for Perf tests

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -59,7 +59,7 @@ git fetch origin -q
 
 function execute_perf_test() {
   mkdir -p gcs
-  GCSFUSE_FLAGS="--implicit-dirs --prometheus-port=48341"
+  GCSFUSE_FLAGS="--implicit-dirs --prometheus-port=48341 --log-file=${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs.txt"
   BUCKET_NAME=presubmit-perf-tests
   MOUNT_POINT=gcs
   # The VM will itself exit if the gcsfuse mount fails.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/presubmit.cfg
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/presubmit.cfg
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
-    regex: "gcsfuse_logs/*"
+    regex: "gcsfuse-logs*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }


### PR DESCRIPTION
Add support to dump logs for Perf tests.

### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
