### PR TITLE
fix(Random Reader Refactoring): Read Manager Not Destroyed/Checked with File Handle

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -236,6 +236,7 @@ func (fh *FileHandle) checkInvariants() {
 		fh.reader.CheckInvariants()
 	}
 
+	// INVARIANT: If readManager != nil, readManager.CheckInvariants() doesn't panic.
 	if fh.readManager != nil {
 		fh.readManager.CheckInvariants()
 	}


### PR DESCRIPTION
### Description
I've identified two issues with read manager instance of file handle during sequential read tests on TPU with Orbax:
1. The read manager wasn't being destroyed when the file handle was destroyed.
2. The read manager's invariant wasn't being checked when the file handle's reader invariant was checked.

These oversights caused readers to remain open for an additional 20 seconds due to inactivity, instead of being properly closed with ReleaseFileHandle calls. 

#### Possible reason:
This behavior is particularly problematic with the gRPC protocol, where a single TCP connection can manage multiple open streams. Unlike HTTP, which typically handles one stream per TCP connection, gRPC's ability to multiplex streams means that unclosed readers can lead to resource contention or performance degradation across several concurrent operations.

#### Validation
-  Before this fix Bw - 9GiB/s
-  After this fix Bw - 14.1 GiB/s(same as old reader implementation)

### Link to the issue in case of a bug fix.
[b/434091576](https://b.corp.google.com/issues/434091576) 

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Automated
4. Perf tests - 

<img width="1276" height="574" alt="9KzWRBJNEmTxUYc" src="https://github.com/user-attachments/assets/99d4a1ec-7381-40b2-b292-17e8abdd3b28" />

### Any backward incompatible change? If so, please explain.
