### PR TITLE
perf(metrics): Add a flag to switch between old and new metrics implementation

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -228,6 +228,8 @@ type MetadataCacheConfig struct {
 type MetricsConfig struct {
 	CloudMetricsExportIntervalSecs int64 `yaml:"cloud-metrics-export-interval-secs"`
 
+	ExperimentalEnableEfficientMetrics bool `yaml:"experimental-enable-efficient-metrics"`
+
 	PrometheusPort int64 `yaml:"prometheus-port"`
 
 	StackdriverExportInterval time.Duration `yaml:"stackdriver-export-interval"`
@@ -410,6 +412,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")
 
 	if err := flagSet.MarkHidden("experimental-enable-dentry-cache"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("experimental-enable-efficient-metrics", "", false, "Enables a more efficient implementation of metrics")
+
+	if err := flagSet.MarkDeprecated("experimental-enable-efficient-metrics", "Experimental flag - could be removed without notice."); err != nil {
 		return err
 	}
 
@@ -805,6 +813,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.experimental-enable-dentry-cache", flagSet.Lookup("experimental-enable-dentry-cache")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.experimental-enable-efficient-metrics", flagSet.Lookup("experimental-enable-efficient-metrics")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -642,6 +642,14 @@
   usage: "Specifies the interval at which the metrics are uploaded to cloud monitoring"
   default: 0
 
+- config-path: "metrics.experimental-enable-efficient-metrics"
+  flag-name: "experimental-enable-efficient-metrics"
+  type: "bool"
+  usage: "Enables a more efficient implementation of metrics"
+  default: false
+  deprecated: true
+  deprecation-warning: "Experimental flag - could be removed without notice."
+
 - config-path: "metrics.prometheus-port"
   flag-name: "prometheus-port"
   type: "int"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1388,6 +1388,41 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 	}
 }
 
+func TestArgParsing_ExperimentalEnableEfficientMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name: "happy_case",
+			args: []string{"gcsfuse", "--experimental-enable-efficient-metrics"},
+			expectedConfig: &cfg.Config{
+				Metrics: cfg.MetricsConfig{
+					ExperimentalEnableEfficientMetrics: true,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := newRootCmd(func(cfg *cfg.Config, _, _ string) error {
+				gotConfig = cfg
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedConfig.Metrics, gotConfig.Metrics)
+			}
+		})
+	}
+}
+
 func TestArgsParsing_ProfilerFlags(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
### Description
Add a flag to switch between old and new metrics implementation.

### Link to the issue in case of a bug fix.
b/434614763

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
