### PR TITLE
refactor: removing cancelled block state

### DIFF
--- a/internal/block/prefetch_block.go
+++ b/internal/block/prefetch_block.go
@@ -33,10 +33,9 @@ type BlockStatus struct {
 type BlockState int
 
 const (
-	BlockStateInProgress        BlockState = iota // Download of this block is in progress
-	BlockStateDownloaded                          // Download of this block is complete
-	BlockStateDownloadFailed                      // Download of this block has failed
-	BlockStateDownloadCancelled                   // Download of this block has been cancelled
+	BlockStateInProgress     BlockState = iota // Download of this block is in progress
+	BlockStateDownloaded                       // Download of this block is complete
+	BlockStateDownloadFailed                   // Download of this block has failed
 )
 
 type PrefetchBlock interface {

--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -213,11 +213,6 @@ func (testSuite *PrefetchMemoryBlockTest) TestAwaitReadyNotifyVariants() {
 			notifyStatus: BlockStatus{State: BlockStateDownloadFailed},
 			wantStatus:   BlockStatus{State: BlockStateDownloadFailed},
 		},
-		{
-			name:         "AfterNotifyCancelled",
-			notifyStatus: BlockStatus{State: BlockStateDownloadCancelled},
-			wantStatus:   BlockStatus{State: BlockStateDownloadCancelled},
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -164,7 +164,7 @@ func (t *BufferedReaderTest) TestDestroyAwaitReadyError() {
 		cancel: func() {},
 	})
 
-	b.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadCancelled, Err: errors.New("test error")})
+	b.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadFailed, Err: errors.New("test error")})
 	reader.Destroy()
 
 	assert.Nil(t.T(), reader.cancelFunc)

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -71,7 +71,7 @@ func (p *DownloadTask) Execute() {
 			p.block.NotifyReady(block.BlockStatus{State: block.BlockStateDownloaded})
 		} else if errors.Is(err, context.Canceled) && p.ctx.Err() == context.Canceled {
 			logger.Tracef("Download: -> block (%s, %v) cancelled: %v.", p.object.Name, blockId, err)
-			p.block.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadCancelled})
+			p.block.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadFailed, Err: err})
 		} else {
 			logger.Errorf("Download: -> block (%s, %v) failed: %v.", p.object.Name, blockId, err)
 			p.block.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadFailed, Err: err})

--- a/internal/bufferedread/download_task_test.go
+++ b/internal/bufferedread/download_task_test.go
@@ -184,8 +184,8 @@ func (dts *DownloadTaskTestSuite) TestExecuteContextCancelledWhileReaderCreation
 	defer cancelFunc()
 	status, err := downloadBlock.AwaitReady(ctx)
 	assert.NoError(dts.T(), err)
-	assert.Equal(dts.T(), block.BlockStateDownloadCancelled, status.State)
-	assert.NoError(dts.T(), status.Err)
+	assert.Equal(dts.T(), block.BlockStateDownloadFailed, status.State)
+	assert.ErrorIs(dts.T(), status.Err, context.Canceled)
 }
 
 // ctxCancelledReader is a mock reader that simulates a context cancellation error while reading.
@@ -228,6 +228,6 @@ func (dts *DownloadTaskTestSuite) TestExecuteContextCancelledWhileReadingFromRea
 	ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second))
 	defer cancelFunc()
 	status, err := downloadBlock.AwaitReady(ctx)
-	assert.Equal(dts.T(), block.BlockStatus{State: block.BlockStateDownloadCancelled}, status)
-	assert.NoError(dts.T(), err)
+	assert.Equal(dts.T(), block.BlockStateDownloadFailed, status.State)
+	assert.ErrorIs(dts.T(), status.Err, context.Canceled)
 }


### PR DESCRIPTION
### Description
- Using BlockFailed state for BlockCancelled too, canceled state will be decided based on the error.
 
### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
