### PR TITLE
feat(bufferedread): adding mount config to control buffered-read feature

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -301,12 +301,6 @@ type WriteConfig struct {
 
 func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
-	flagSet.BoolP("--enable-buffered-read", "", false, "When enabled, read starts using buffer to prefetch (asynchronous and in parallel) data from GCS. This improves performance for large file sequential reads. Note: Enabling this flag can increase memory usage significantly.")
-
-	if err := flagSet.MarkHidden("--enable-buffered-read"); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
 
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
@@ -380,6 +374,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("enable-atomic-rename-object", "", true, "Enables support for atomic rename object operation on HNS bucket.")
 
 	if err := flagSet.MarkHidden("enable-atomic-rename-object"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-buffered-read", "", false, "When enabled, read starts using buffer to prefetch (asynchronous and in parallel) data from GCS. This improves performance for large file sequential reads. Note: Enabling this flag can increase memory usage significantly.")
+
+	if err := flagSet.MarkHidden("enable-buffered-read"); err != nil {
 		return err
 	}
 
@@ -623,7 +623,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("read-global-max-blocks", "", 4, "Specifies the maximum number of blocks available for buffered reads across all file-handles. The value should be >= 0 or -1 (for infinite blocks). A value of 0 disables buffered reads.")
+	flagSet.IntP("read-global-max-blocks", "", 20, "Specifies the maximum number of blocks available for buffered reads across all file-handles. The value should be >= 0 or -1 (for infinite blocks). A value of 0 disables buffered reads.")
 
 	if err := flagSet.MarkHidden("read-global-max-blocks"); err != nil {
 		return err
@@ -744,10 +744,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 
-	if err := v.BindPFlag("read.enable-buffered-read", flagSet.Lookup("--enable-buffered-read")); err != nil {
-		return err
-	}
-
 	if err := v.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access")); err != nil {
 		return err
 	}
@@ -813,6 +809,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-atomic-rename-object", flagSet.Lookup("enable-atomic-rename-object")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("read.enable-buffered-read", flagSet.Lookup("enable-buffered-read")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -377,7 +377,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-buffered-read", "", false, "When enabled, read starts using buffer to prefetch (asynchronous and in parallel) data from GCS. This improves performance for large file sequential reads. Note: Enabling this flag can increase memory usage significantly.")
+	flagSet.BoolP("enable-buffered-read", "", false, "When enabled, read starts using buffer to prefetch (asynchronous and in parallel) data from GCS. This improves performance for large file sequential reads. Note: Enabling this flag can increase the memory usage significantly.")
 
 	if err := flagSet.MarkHidden("enable-buffered-read"); err != nil {
 		return err

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -258,7 +258,17 @@ type ProfilingConfig struct {
 }
 
 type ReadConfig struct {
+	BlockSizeMb int64 `yaml:"block-size-mb"`
+
+	EnableBufferedRead bool `yaml:"enable-buffered-read"`
+
+	GlobalMaxBlocks int64 `yaml:"global-max-blocks"`
+
 	InactiveStreamTimeout time.Duration `yaml:"inactive-stream-timeout"`
+
+	MaxBlocksPerHandle int64 `yaml:"max-blocks-per-handle"`
+
+	StartBlocksPerHandle int64 `yaml:"start-blocks-per-handle"`
 }
 
 type ReadStallGcsRetriesConfig struct {
@@ -290,6 +300,12 @@ type WriteConfig struct {
 }
 
 func BuildFlagSet(flagSet *pflag.FlagSet) error {
+
+	flagSet.BoolP("--enable-buffered-read", "", false, "When enabled, read starts using buffer to prefetch (asynchronous and in parallel) data from GCS. This improves performance for large file sequential reads. Note: Enabling this flag can increase memory usage significantly.")
+
+	if err := flagSet.MarkHidden("--enable-buffered-read"); err != nil {
+		return err
+	}
 
 	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
 
@@ -601,9 +617,27 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
+	flagSet.IntP("read-block-size-mb", "", 16, "Specifies the block size for buffered reads. The value should be more than  0. This is used to read data in chunks from GCS.")
+
+	if err := flagSet.MarkHidden("read-block-size-mb"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("read-global-max-blocks", "", 4, "Specifies the maximum number of blocks available for buffered reads across all file-handles. The value should be >= 0 or -1 (for infinite blocks). A value of 0 disables buffered reads.")
+
+	if err := flagSet.MarkHidden("read-global-max-blocks"); err != nil {
+		return err
+	}
+
 	flagSet.DurationP("read-inactive-stream-timeout", "", 10000000000*time.Nanosecond, "Duration of inactivity after which an open GCS read stream is automatically closed. This helps conserve resources when a file handle remains open without active Read calls. A value of '0s' disables this timeout.")
 
 	if err := flagSet.MarkHidden("read-inactive-stream-timeout"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("read-max-blocks-per-handle", "", 20, "Specifies the maximum number of blocks to be used by a single file handle for  buffered reads. The value should be >= 0 or -1 (for infinite blocks). A value of 0 disables buffered reads.")
+
+	if err := flagSet.MarkHidden("read-max-blocks-per-handle"); err != nil {
 		return err
 	}
 
@@ -634,6 +668,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.Float64P("read-stall-req-target-percentile", "", 0.99, "Retry the request which take more than p(targetPercentile * 100) of past similar request.")
 
 	if err := flagSet.MarkHidden("read-stall-req-target-percentile"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("read-start-blocks-per-handle", "", 1, "Specifies the number of blocks to be prefetched on the first read.")
+
+	if err := flagSet.MarkHidden("read-start-blocks-per-handle"); err != nil {
 		return err
 	}
 
@@ -703,6 +743,10 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 }
 
 func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
+
+	if err := v.BindPFlag("read.enable-buffered-read", flagSet.Lookup("--enable-buffered-read")); err != nil {
+		return err
+	}
 
 	if err := v.BindPFlag("gcs-auth.anonymous-access", flagSet.Lookup("anonymous-access")); err != nil {
 		return err
@@ -1012,7 +1056,19 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	if err := v.BindPFlag("read.block-size-mb", flagSet.Lookup("read-block-size-mb")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("read.global-max-blocks", flagSet.Lookup("read-global-max-blocks")); err != nil {
+		return err
+	}
+
 	if err := v.BindPFlag("read.inactive-stream-timeout", flagSet.Lookup("read-inactive-stream-timeout")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("read.max-blocks-per-handle", flagSet.Lookup("read-max-blocks-per-handle")); err != nil {
 		return err
 	}
 
@@ -1033,6 +1089,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("gcs-retries.read-stall.req-target-percentile", flagSet.Lookup("read-stall-req-target-percentile")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("read.start-blocks-per-handle", flagSet.Lookup("read-start-blocks-per-handle")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -751,7 +751,7 @@
   usage: >-
     When enabled, read starts using buffer to prefetch (asynchronous and in parallel)
     data from GCS. This improves performance for large file sequential reads.
-    Note: Enabling this flag can increase memory usage significantly.
+    Note: Enabling this flag can increase the memory usage significantly.
   default: false
   hide-flag: true
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -746,7 +746,7 @@
   hide-flag: true
 
 - config-path: "read.enable-buffered-read"
-  flag-name: "--enable-buffered-read"
+  flag-name: "enable-buffered-read"
   type: "bool"
   usage: >-
     When enabled, read starts using buffer to prefetch (asynchronous and in parallel)
@@ -762,7 +762,7 @@
     Specifies the maximum number of blocks available for buffered reads across all file-handles.
     The value should be >= 0 or -1 (for infinite blocks).
     A value of 0 disables buffered reads.
-  default: 4
+  default: 20
   hide-flag: true
 
 - config-path: "read.inactive-stream-timeout"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -736,6 +736,35 @@
   default: false
   hide-flag: true
 
+- config-path: "read.block-size-mb"
+  flag-name: "read-block-size-mb"
+  type: "int"
+  usage: >-
+    Specifies the block size for buffered reads. The value should be more than 
+    0. This is used to read data in chunks from GCS.
+  default: 16
+  hide-flag: true
+
+- config-path: "read.enable-buffered-read"
+  flag-name: "--enable-buffered-read"
+  type: "bool"
+  usage: >-
+    When enabled, read starts using buffer to prefetch (asynchronous and in parallel)
+    data from GCS. This improves performance for large file sequential reads.
+    Note: Enabling this flag can increase memory usage significantly.
+  default: false
+  hide-flag: true
+
+- config-path: "read.global-max-blocks"
+  flag-name: "read-global-max-blocks"
+  type: "int"
+  usage: >-
+    Specifies the maximum number of blocks available for buffered reads across all file-handles.
+    The value should be >= 0 or -1 (for infinite blocks).
+    A value of 0 disables buffered reads.
+  default: 4
+  hide-flag: true
+
 - config-path: "read.inactive-stream-timeout"
   flag-name: "read-inactive-stream-timeout"
   type: "duration"
@@ -744,6 +773,24 @@
     This helps conserve resources when a file handle remains open without active Read calls.
     A value of '0s' disables this timeout.
   default: "10s"
+  hide-flag: true
+
+- config-path: "read.max-blocks-per-handle"
+  flag-name: "read-max-blocks-per-handle"
+  type: "int"
+  usage: >-
+    Specifies the maximum number of blocks to be used by a single file handle for 
+    buffered reads. The value should be >= 0 or -1 (for infinite blocks).
+    A value of 0 disables buffered reads.
+  default: 20
+  hide-flag: true
+
+- config-path: "read.start-blocks-per-handle"
+  flag-name: "read-start-blocks-per-handle"
+  type: "int"
+  usage: >-
+    Specifies the number of blocks to be prefetched on the first read.
+  default: 1
   hide-flag: true
 
 - config-path: "write.block-size-mb"

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -526,6 +526,90 @@ func Test_isValidWriteStreamingConfig_ErrorScenarios(t *testing.T) {
 	}
 }
 
+func Test_isValidBufferedReadConfig_ErrorScenarios(t *testing.T) {
+	var testCases = []struct {
+		testName string
+		read     ReadConfig
+	}{
+		{"negative_block_size", ReadConfig{
+			BlockSizeMb:          -1,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      -1,
+			MaxBlocksPerHandle:   -1,
+			StartBlocksPerHandle: 1,
+		}},
+		{"zero_block_size", ReadConfig{
+			BlockSizeMb:          0,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      -1,
+			MaxBlocksPerHandle:   -1,
+			StartBlocksPerHandle: 1,
+		}},
+		{"negative_global_max_blocks", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      -2,
+			MaxBlocksPerHandle:   -1,
+			StartBlocksPerHandle: 1,
+		}},
+		{"negative_max_blocks_per_handle", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      -1,
+			MaxBlocksPerHandle:   -2,
+			StartBlocksPerHandle: 1,
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			assert.Error(t, isValidBufferedReadConfig(&tc.read))
+		})
+	}
+}
+
+func Test_isValidBufferedReadConfig_ValidScenarios(t *testing.T) {
+	var testCases = []struct {
+		testName string
+		read     ReadConfig
+	}{
+		{"valid_config_1", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      -1,
+			MaxBlocksPerHandle:   -1,
+			StartBlocksPerHandle: 1,
+		}},
+		{"valid_config_2", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      10,
+			MaxBlocksPerHandle:   -1,
+			StartBlocksPerHandle: 1,
+		}},
+		{"valid_config_3", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   true,
+			GlobalMaxBlocks:      10,
+			MaxBlocksPerHandle:   5,
+			StartBlocksPerHandle: 1,
+		}},
+		{"valid_config_4", ReadConfig{
+			BlockSizeMb:          16,
+			EnableBufferedRead:   false,
+			GlobalMaxBlocks:      10,
+			MaxBlocksPerHandle:   5,
+			StartBlocksPerHandle: 10,
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			assert.NoError(t, isValidBufferedReadConfig(&tc.read))
+		})
+	}
+}
+
 func Test_isValidWriteStreamingConfig_SuccessScenarios(t *testing.T) {
 	var testCases = []struct {
 		testName    string

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -223,6 +223,53 @@ func TestValidateConfigFile_WriteConfig(t *testing.T) {
 	}
 }
 
+func TestValidateConfigFile_ReadConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configFile     string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name:       "Empty config file [default values].",
+			configFile: "testdata/empty_file.yaml",
+			expectedConfig: &cfg.Config{
+				Read: cfg.ReadConfig{
+					InactiveStreamTimeout: 10 * time.Second,
+					BlockSizeMb:           16,
+					EnableBufferedRead:    false,
+					GlobalMaxBlocks:       4,
+					MaxBlocksPerHandle:    20,
+					StartBlocksPerHandle:  1,
+				},
+			},
+		},
+		{
+			name:       "Valid config file.",
+			configFile: "testdata/valid_config.yaml",
+			expectedConfig: &cfg.Config{
+				Read: cfg.ReadConfig{
+					InactiveStreamTimeout: 10 * time.Second,
+					BlockSizeMb:           16,
+					EnableBufferedRead:    true,
+					MaxBlocksPerHandle:    20,
+					GlobalMaxBlocks:       40,
+					StartBlocksPerHandle:  4,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConfig, err := getConfigObjectWithConfigFile(t, tc.configFile)
+
+			if assert.NoError(t, err) {
+				assert.EqualValues(t, tc.expectedConfig.Read, gotConfig.Read)
+			}
+		})
+	}
+}
+
 func TestValidateConfigFile_InvalidConfigThrowsError(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -237,7 +237,7 @@ func TestValidateConfigFile_ReadConfig(t *testing.T) {
 					InactiveStreamTimeout: 10 * time.Second,
 					BlockSizeMb:           16,
 					EnableBufferedRead:    false,
-					GlobalMaxBlocks:       4,
+					GlobalMaxBlocks:       20,
 					MaxBlocksPerHandle:    20,
 					StartBlocksPerHandle:  1,
 				},

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -1,6 +1,11 @@
 app-name: hello
 read:
   inactive-stream-timeout: 10s
+  enable-buffered-read: true
+  global-max-blocks: 40
+  block-size-mb: 16
+  start-blocks-per-handle: 4
+  max-blocks-per-handle: 20
 write:
   create-empty-file: true
   enable-streaming-writes: true


### PR DESCRIPTION
### Description
- Currently all the buffered-red configuration flags are hidden, will make few flags visible after complete implementation.

### Link to the issue in case of a bug fix.
b/434674228

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
