### PR TITLE
feat(bufferedread): Implement ReadAt method of Buffered Reader

### DIFF
--- a/internal/block/prefetch_block.go
+++ b/internal/block/prefetch_block.go
@@ -63,7 +63,6 @@ type PrefetchBlock interface {
 	// The value indicates the status of the block:
 	// - BlockStatusDownloaded: Download of this block is complete.
 	// - BlockStatusDownloadFailed: Download of this block has failed.
-	// - BlockStatusDownloadCancelled: Download of this block has been cancelled.
 	NotifyReady(val BlockStatus)
 }
 

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -168,21 +168,21 @@ func (p *BufferedReader) prepareQueueForOffset(offset int64) {
 //
 // The read is satisfied by reading from in-memory blocks that are prefetched
 // in the background. The core logic is as follows:
-// 1. Detect if the read pattern is random. If so, and if the random read
-//    threshold is exceeded, it returns a FallbackToAnotherReader error.
-// 2. Prepare the internal block queue by discarding any stale blocks from the
-//    head of the queue that are before the requested offset.
-// 3. If the queue becomes empty (e.g., on a fresh read or a large seek), it
-//    initiates a "fresh start" to prefetch blocks starting from the current
-//    offset.
-// 4. It then enters a loop to fill the destination buffer:
-//    a. It waits for the block at the head of the queue to be downloaded.
-//    b. If the download failed or was cancelled, it returns an appropriate error.
-//    c. If successful, it copies data from the downloaded block into the buffer.
-//    d. If a block is fully consumed, it is removed from the queue, and a new
-//       prefetch operation is triggered to keep the pipeline full.
-// 5. The loop continues until the buffer is full, the end of the file is
-//    reached, or an error occurs.
+//  1. Detect if the read pattern is random. If so, and if the random read
+//     threshold is exceeded, it returns a FallbackToAnotherReader error.
+//  2. Prepare the internal block queue by discarding any stale blocks from the
+//     head of the queue that are before the requested offset.
+//  3. If the queue becomes empty (e.g., on a fresh read or a large seek), it
+//     initiates a "fresh start" to prefetch blocks starting from the current
+//     offset.
+//  4. It then enters a loop to fill the destination buffer:
+//     a. It waits for the block at the head of the queue to be downloaded.
+//     b. If the download failed or was cancelled, it returns an appropriate error.
+//     c. If successful, it copies data from the downloaded block into the buffer.
+//     d. If a block is fully consumed, it is removed from the queue, and a new
+//     prefetch operation is triggered to keep the pipeline full.
+//  5. The loop continues until the buffer is full, the end of the file is
+//     reached, or an error occurs.
 func (p *BufferedReader) ReadAt(ctx context.Context, inputBuf []byte, off int64) (gcsx.ReaderResponse, error) {
 	resp := gcsx.ReaderResponse{DataBuf: inputBuf}
 	reqID := uuid.New()

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -234,13 +234,13 @@ func (t *BufferedReaderTest) TestCheckInvariantsPrefetchBlockSizeTooSmall() {
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err, "NewBufferedReader should not return error")
 
-	reader.config.PrefetchBlockSizeBytes = (1 << 20) - 1
+	reader.config.PrefetchBlockSizeBytes = MiB - 1
 
 	assert.Panics(t.T(), func() { reader.CheckInvariants() }, "Should panic for block size less than 1 MiB")
 }
 
 func (t *BufferedReaderTest) TestCheckInvariantsNoPanic() {
-	t.config.PrefetchBlockSizeBytes = 1 << 20
+	t.config.PrefetchBlockSizeBytes = MiB
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err, "NewBufferedReader should not return error")
 

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -58,7 +58,6 @@ func NewDownloadTask(ctx context.Context, object *gcs.MinObject, bucket gcs.Buck
 // download task. The status can be one of the following:
 // - BlockStatusDownloaded: The download was successful.
 // - BlockStatusDownloadFailed: The download failed due to an error.
-// - BlockStatusDownloadCancelled: The download was cancelled due to context cancellation.
 func (p *DownloadTask) Execute() {
 	startOff := p.block.AbsStartOff()
 	blockId := startOff / p.block.Cap()


### PR DESCRIPTION
### Description
This PR implements the `ReadAt` method on BufferedReader to support reads from GCS objects, satisfying the `gcsx.Reader` interface.

The method leverages the existing prefetching mechanism to read from in-memory blocks. Key features of the implementation include:

- Random Read Detection: Identifies random read patterns and falls back to a simpler GCS reader if the configured threshold for random seeks is exceeded.
- Efficient Seek Handling: Discards stale blocks from the queue on seeks to ensure the reader starts from the correct offset.
- Continuous Prefetching: Triggers new prefetch operations as data is consumed to keep the read pipeline full and minimize latency.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/432169239

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
