### PR TITLE
chore(flags): Add flag-name validations

### DIFF
--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 
 	"gopkg.in/yaml.v3"
@@ -55,7 +56,24 @@ func parseParamsConfig() ([]Param, error) {
 	return paramsConfig, nil
 }
 
+func checkFlagName(name string) error {
+	if name == "" {
+		return fmt.Errorf("flag-name cannot be empty")
+	}
+
+	// A valid name should contain only lower-case characters with hyphens as
+	// separators. It must start and end with an alphabet.
+	regex := `^[a-z]+([-_][a-z]+)*$`
+	if matched, _ := regexp.MatchString(regex, name); !matched {
+		return fmt.Errorf("flag-name %q does not conform to the regex: %s", name, regex)
+	}
+	return nil
+}
+
 func validateParam(param Param) error {
+	if err := checkFlagName(param.FlagName); err != nil {
+		return err
+	}
 	if param.IsDeprecated && param.DeprecationWarning == "" {
 		return fmt.Errorf("param %s is marked deprecated but deprecation-warning is not set", param.FlagName)
 	}

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckFlagName_Valid(t *testing.T) {
+	validNames := []string{"a", "abc", "ab-c", "ab-c-d", "a_b"}
+
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, checkFlagName(name))
+		})
+
+	}
+}
+
+func TestCheckFlagName_Invalid(t *testing.T) {
+	invalidNames := []string{"", "a-", "-a", "a--b", "a-b-", "A-b", "a.b", "1-a"}
+
+	for _, name := range invalidNames {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, checkFlagName(name))
+		})
+	}
+}


### PR DESCRIPTION
### Description
Ensure that flag-names conform to the following rules:
* It's not empty
* It only consists of lower-case characters
* It starts and ends with alphabets.
* It only has hyphens or underscores as separators.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No