### PR TITLE
ci: fail fast in utility CreateDirectoryWithNFiles

### DIFF
--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -17,7 +17,9 @@ package operations
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -92,8 +94,8 @@ func RenameDir(dirName string, newDirName string) (err error) {
 
 func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string, t *testing.T) {
 	err := os.Mkdir(dirPath, FilePermission_0777)
-	if err != nil && !strings.Contains(err.Error(), "file exists") {
-		t.Fatalf("Error in creating directory: %v", err)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		t.Fatalf("Error in creating directory %q: %v", dirPath, err)
 	}
 
 	for i := 1; i <= numberOfFiles; i++ {
@@ -102,7 +104,7 @@ func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string,
 		filePath := path.Join(dirPath, prefix+strconv.Itoa(i))
 		file, err := os.Create(filePath)
 		if err != nil {
-			t.Fatalf("Create file at %q: %v", dirPath, err)
+			t.Fatalf("Failed to create file %q: %v", filePath, err)
 		}
 
 		// Closing file at the end.

--- a/tools/integration_tests/util/operations/dir_operations.go
+++ b/tools/integration_tests/util/operations/dir_operations.go
@@ -93,7 +93,7 @@ func RenameDir(dirName string, newDirName string) (err error) {
 func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string, t *testing.T) {
 	err := os.Mkdir(dirPath, FilePermission_0777)
 	if err != nil && !strings.Contains(err.Error(), "file exists") {
-		t.Errorf("Error in creating directory: %v", err)
+		t.Fatalf("Error in creating directory: %v", err)
 	}
 
 	for i := 1; i <= numberOfFiles; i++ {
@@ -102,7 +102,7 @@ func CreateDirectoryWithNFiles(numberOfFiles int, dirPath string, prefix string,
 		filePath := path.Join(dirPath, prefix+strconv.Itoa(i))
 		file, err := os.Create(filePath)
 		if err != nil {
-			t.Errorf("Create file at %q: %v", dirPath, err)
+			t.Fatalf("Create file at %q: %v", dirPath, err)
 		}
 
 		// Closing file at the end.


### PR DESCRIPTION
### Description
In this utility, don't proceed with file creation, if the parent directory failed to create. And
similarly, don't try to close file handle if file
creation itself failed first.

These are needed to avoid
- confusing and misleading error logs
- run time wasted in dependent operations for failed operations

I discovered this while debugging b/434203417 with @ChrisThePattyEater .

### Link to the issue in case of a bug fix.
[b/434203417](http://b/434203417)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
