### PR TITLE
fix: fail gcsfuse e2e tests if testBucket argument is improper

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -400,11 +400,11 @@ func RunTestsForMountedDirectoryFlag(m *testing.M) {
 
 func SetUpTestDirForTestBucketFlag() {
 	testBucketName := TestBucket()
-	if TestBucketName == "" {
+	if testBucketName == "" {
 		log.Fatal("Not running TestBucket tests as --testBucket flag is not set.")
 	}
-	if strings.ContainsAny(TestBucketName, unsupportedCharactersInTestBucket) {
-		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", TestBucketName, unsupportedCharactersInTestBucket)
+	if strings.ContainsAny(testBucketName, unsupportedCharactersInTestBucket) {
+		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", testBucketName, unsupportedCharactersInTestBucket)
 	}
 	if err := SetUpTestDir(); err != nil {
 		log.Printf("setUpTestDir: %v\n", err)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -399,11 +399,12 @@ func RunTestsForMountedDirectoryFlag(m *testing.M) {
 }
 
 func SetUpTestDirForTestBucketFlag() {
-	if TestBucket() == "" {
+	testBucketName := TestBucket()
+	if TestBucketName == "" {
 		log.Fatal("Not running TestBucket tests as --testBucket flag is not set.")
 	}
-	if strings.ContainsAny(TestBucket(), unsupportedCharactersInTestBucket) {
-		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", TestBucket(), unsupportedCharactersInTestBucket)
+	if strings.ContainsAny(TestBucketName, unsupportedCharactersInTestBucket) {
+		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", TestBucketName, unsupportedCharactersInTestBucket)
 	}
 	if err := SetUpTestDir(); err != nil {
 		log.Printf("setUpTestDir: %v\n", err)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -50,14 +50,15 @@ var gcsfusePreBuiltDir = flag.String("gcsfuse_prebuilt_dir", "", "Path to the pr
 var profileLabelForMountedDirTest = flag.String("profile_label", "", "To pass profile-label for the cloud-profile test.")
 
 const (
-	FilePermission_0600      = 0600
-	DirPermission_0755       = 0755
-	Charset                  = "abcdefghijklmnopqrstuvwxyz0123456789"
-	PathEnvVariable          = "PATH"
-	GCSFuseLogFilePrefix     = "gcsfuse-failed-integration-test-logs-"
-	ProxyServerLogFilePrefix = "proxy-server-failed-integration-test-logs-"
-	zoneMatcherRegex         = "^[a-z]+-[a-z0-9]+-[a-z]$"
-	regionMatcherRegex       = "^[a-z]+-[a-z0-9]+$"
+	FilePermission_0600               = 0600
+	DirPermission_0755                = 0755
+	Charset                           = "abcdefghijklmnopqrstuvwxyz0123456789"
+	PathEnvVariable                   = "PATH"
+	GCSFuseLogFilePrefix              = "gcsfuse-failed-integration-test-logs-"
+	ProxyServerLogFilePrefix          = "proxy-server-failed-integration-test-logs-"
+	zoneMatcherRegex                  = "^[a-z]+-[a-z0-9]+-[a-z]$"
+	regionMatcherRegex                = "^[a-z]+-[a-z0-9]+$"
+	unsupportedCharactersInTestBucket = " /"
 )
 
 var (
@@ -400,6 +401,9 @@ func RunTestsForMountedDirectoryFlag(m *testing.M) {
 func SetUpTestDirForTestBucketFlag() {
 	if TestBucket() == "" {
 		log.Fatal("Not running TestBucket tests as --testBucket flag is not set.")
+	}
+	if strings.ContainsAny(TestBucket(), unsupportedCharactersInTestBucket) {
+		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", TestBucket(), unsupportedCharactersInTestBucket)
 	}
 	if err := SetUpTestDir(); err != nil {
 		log.Printf("setUpTestDir: %v\n", err)


### PR DESCRIPTION
### Description
While debugging [b/434203417](http://b/434203417), I found that we don't fail fast if the user passes `--testBucket` as `a/b` which is obviously not supported, and the test fails somewhere in some test much later making it hard to root cause. This change will make it fail at argument parsing time itself.

### Link to the issue in case of a bug fix.
[b/434203417](http://b/434203417)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
