### PR TITLE
ci: save failure gcsfuse logs and add more useful debug logs for e2e benchmarking package

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -57,7 +57,7 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 	}
 	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageDeleteLatency > expectedDeleteLatency {
-		b.Errorf("DeleteFile took more time on an average (%v) than expected (%v).", averageDeleteLatency, expectedDeleteLatency)
+		b.Errorf("DeleteFile took more time on average (%v) than expected (%v).", averageDeleteLatency, expectedDeleteLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -50,15 +50,14 @@ func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 	createFiles(b)
 	b.ResetTimer()
 	for i := range b.N {
-		fileName := fmt.Sprintf("a%d.txt", i)
-		filePath := path.Join(testDirPath, fileName)
+		filePath := path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))
 		if err := os.Remove(filePath); err != nil {
 			b.Errorf("error while deleting %q: %v", filePath, err)
 		}
 	}
 	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageDeleteLatency > expectedDeleteLatency {
-		b.Errorf("DeleteFile took more time on an average %v than expected (%v).", averageDeleteLatency, expectedDeleteLatency)
+		b.Errorf("DeleteFile took more time on an average (%v) than expected (%v).", averageDeleteLatency, expectedDeleteLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_delete_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_delete_test.go
@@ -49,14 +49,16 @@ func (s *benchmarkDeleteTest) TeardownB(b *testing.B) {
 func (s *benchmarkDeleteTest) Benchmark_Delete(b *testing.B) {
 	createFiles(b)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := os.Remove(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))); err != nil {
-			b.Errorf("testing error: %v", err)
+	for i := range b.N {
+		fileName := fmt.Sprintf("a%d.txt", i)
+		filePath := path.Join(testDirPath, fileName)
+		if err := os.Remove(filePath); err != nil {
+			b.Errorf("error while deleting %q: %v", filePath, err)
 		}
 	}
 	averageDeleteLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageDeleteLatency > expectedDeleteLatency {
-		b.Errorf("DeleteFile took more time (%d msec) than expected (%d msec)", averageDeleteLatency.Milliseconds(), expectedDeleteLatency.Milliseconds())
+		b.Errorf("DeleteFile took more time on an average %v than expected (%v).", averageDeleteLatency, expectedDeleteLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -58,7 +58,7 @@ func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 	}
 	averageRenameLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageRenameLatency > expectedRenameLatency {
-		b.Errorf("RenameFile took more time on an average (%v) than expected %v", averageRenameLatency, expectedRenameLatency)
+		b.Errorf("RenameFile took more time on average (%v) than expected %v", averageRenameLatency, expectedRenameLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -48,27 +48,42 @@ func (s *benchmarkRenameTest) TeardownB(b *testing.B) {
 
 func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 	createFiles(b)
-	var totalTimeElapsedTillPrevIter time.Duration
 	var maxElapsedDuration time.Duration
 	maxElapsedIteration := -1
 	b.ResetTimer()
+	// Don't start the timer yet.
+	b.StopTimer()
+
 	for i := range b.N {
 		sourceFilePath := path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))
 		dstFilePath := path.Join(testDirPath, fmt.Sprintf("b%d.txt", i))
-		if err := os.Rename(sourceFilePath, dstFilePath); err != nil {
+
+		// Manually time the operation to find the maximum latency with  highest accuracy.
+		// This happens while the benchmark's timer is paused and will not affect the average.
+		startTime := time.Now()
+
+		// Start the benchmark timer just for the os.Rename call.
+		b.StartTimer()
+		err := os.Rename(sourceFilePath, dstFilePath)
+		b.StopTimer() // Stop the timer immediately after the operation.
+
+		timeElapsedThisIter := time.Since(startTime)
+
+		// The remaining checks and calculations also happen while the timer is paused.
+		if err != nil {
 			b.Errorf("failed to rename %q to %q: %v", sourceFilePath, dstFilePath, err)
 		}
 
-		// Update maxElapsedIteration and totalTimeElapsedTillPrevIter.
-		totalTimeElapsedSoFar := b.Elapsed()
-		timeElapsedThisIter := totalTimeElapsedSoFar - totalTimeElapsedTillPrevIter
 		if maxElapsedDuration < timeElapsedThisIter {
 			maxElapsedDuration = timeElapsedThisIter
 			maxElapsedIteration = i
 		}
-		totalTimeElapsedTillPrevIter = totalTimeElapsedSoFar
 	}
-	averageRenameLatency := time.Duration(int(b.Elapsed()) / b.N)
+
+	// b.Elapsed() is the sum of the time spent only on os.Rename calls,
+	// leading to a highly accurate average latency.
+	averageRenameLatency := b.Elapsed() / time.Duration(b.N)
+
 	if averageRenameLatency > expectedRenameLatency {
 		b.Errorf("RenameFile took more time on average (%v) than expected %v", averageRenameLatency, expectedRenameLatency)
 		b.Errorf("Maximum time taken by a single iteration = %v, in iteration # %v.", maxElapsedDuration, maxElapsedIteration)

--- a/tools/integration_tests/benchmarking/benchmark_rename_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_rename_test.go
@@ -49,14 +49,16 @@ func (s *benchmarkRenameTest) TeardownB(b *testing.B) {
 func (s *benchmarkRenameTest) Benchmark_Rename(b *testing.B) {
 	createFiles(b)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := os.Rename(path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), path.Join(testDirPath, fmt.Sprintf("b%d.txt", i))); err != nil {
-			b.Errorf("testing error: %v", err)
+	for i := range b.N {
+		sourceFilePath := path.Join(testDirPath, fmt.Sprintf("a%d.txt", i))
+		dstFilePath := path.Join(testDirPath, fmt.Sprintf("b%d.txt", i))
+		if err := os.Rename(sourceFilePath, dstFilePath); err != nil {
+			b.Errorf("failed to rename %q to %q: %v", sourceFilePath, dstFilePath, err)
 		}
 	}
 	averageRenameLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageRenameLatency > expectedRenameLatency {
-		b.Errorf("RenameFile took more time (%d msec) than expected (%d msec)", averageRenameLatency.Milliseconds(), expectedRenameLatency.Milliseconds())
+		b.Errorf("RenameFile took more time on an average (%v) than expected %v", averageRenameLatency, expectedRenameLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -66,7 +66,7 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	}
 	averageStatLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageStatLatency > expectedStatLatency {
-		b.Errorf("StatFile took more time on average (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
+		b.Errorf("StatFile took more time on average (%v) than expected (%v)", averageStatLatency, expectedStatLatency)
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	var maxElapsedDuration time.Duration
 	maxElapsedIteration := -1
 	b.ResetTimer()
-	for range b.N {
+	for i := range b.N {
 		filePath := path.Join(testDirPath, "a.txt")
 		if _, err := operations.StatFile(filePath); err != nil {
 			b.Errorf("failed to stat %q: %v", filePath, err)

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -66,7 +66,7 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	filePath := path.Join(testDirPath, "a.txt")
 
 	for i := range b.N {
-		// Manually time the operation to find the maximum latest with highest accuracy.
+		// Manually time the operation to find the maximum latency with highest accuracy.
 		// This happens while the benchmark's timer is paused and will not affect the average.
 		startTime := time.Now()
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -61,12 +61,12 @@ func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	for range b.N {
 		filePath := path.Join(testDirPath, "a.txt")
 		if _, err := operations.StatFile(filePath); err != nil {
-			b.Errorf("failed to stat %s: %v", filePath, err)
+			b.Errorf("failed to stat %q: %v", filePath, err)
 		}
 	}
 	averageStatLatency := time.Duration(int(b.Elapsed()) / b.N)
 	if averageStatLatency > expectedStatLatency {
-		b.Errorf("StatFile took more time (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
+		b.Errorf("StatFile took more time on average (%d msec) than expected (%d msec)", averageStatLatency.Milliseconds(), expectedStatLatency.Milliseconds())
 	}
 }
 

--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -58,9 +58,10 @@ func createFilesToStat(b *testing.B) {
 func (s *benchmarkStatTest) Benchmark_Stat(b *testing.B) {
 	createFilesToStat(b)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if _, err := operations.StatFile(path.Join(testDirPath, "a.txt")); err != nil {
-			b.Errorf("testing error: %v", err)
+	for range b.N {
+		filePath := path.Join(testDirPath, "a.txt")
+		if _, err := operations.StatFile(filePath); err != nil {
+			b.Errorf("failed to stat %s: %v", filePath, err)
 		}
 	}
 	averageStatLatency := time.Duration(int(b.Elapsed()) / b.N)

--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -65,7 +65,7 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
 // createFiles creates the below objects in the bucket.
 // benchmarking/a{i}.txt where i is a counter based on the benchtime value.
 func createFiles(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		operations.CreateFileOfSize(1, path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), b)
 	}
 }
@@ -96,6 +96,7 @@ func TestMain(m *testing.M) {
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
 	successCode := m.Run()
+	setup.SaveLogFileInCaseOfFailure(successCode)
 
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))


### PR DESCRIPTION
### Description
This pull request focuses on enhancing the debuggability of our end-to-end benchmarking tests. My goal is to provide more actionable insights when tests fail by logging specific file paths involved in errors and ensuring gcsfuse debug logs are preserved for detailed analysis, ultimately streamlining the debugging process for CI failures.

#### Highlights

* **Enhanced Debugging Output**: I've improved the error messages for failed `delete`, `rename`, and `stat` operations within the benchmarking tests. These messages now explicitly include the file path(s) involved, which should significantly aid in quickly identifying the root cause of failures.
* **Automated Log Preservation**: I've added functionality to automatically save the gcsfuse debug logs if any benchmarking test fails. This ensures that critical diagnostic information is retained for post-mortem analysis, even when the CI run completes with errors.
* **Go Idiomatic Loop Syntax**: I've updated several `for` loops in the benchmarking tests to use the more idiomatic `for i := range b.N` or `for range b.N` syntax, improving code readability and consistency.

### Link to the issue in case of a bug fix.
[b/435089665](http://b/435089665)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit
   - [run1](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/7bbb6a27-31d3-4bdc-b88a-7d3497cc5335) - passed
   - [run2](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/a8a92b4c-06f0-4336-847a-3c634cc93685) - passed
   - [run3](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/ac15a00a-189d-48e5-8a08-13cb31b16c61) - with latest code iteration - failed purely because of the issue being fixed in https://github.com/GoogleCloudPlatform/gcsfuse/pull/3644 .

### Any backward incompatible change? If so, please explain.
