### PR TITLE
feat(Migrate auth TPC): Make default value of flag true

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -395,7 +395,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-google-lib-auth", "", false, "Enable google library authentication method to fetch the credentials")
+	flagSet.BoolP("enable-google-lib-auth", "", true, "Enable google library authentication method to fetch the credentials")
 
 	if err := flagSet.MarkHidden("enable-google-lib-auth"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -89,7 +89,7 @@
   config-path: "enable-google-lib-auth"
   type: "bool"
   usage: "Enable google library authentication method to fetch the credentials"
-  default: false
+  default: true
   hide-flag: true
 
 - config-path: "enable-hns"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1109,12 +1109,12 @@ func TestArgsParsing_EnableGoogleLibAuthFlag(t *testing.T) {
 		{
 			name:                        "default",
 			args:                        []string{"gcsfuse", "abc", "pqr"},
-			expectedEnableGoogleLibAuth: false,
+			expectedEnableGoogleLibAuth: true,
 		},
 		{
 			name:                        "normal",
-			args:                        []string{"gcsfuse", "--enable-google-lib-auth=true", "abc", "pqr"},
-			expectedEnableGoogleLibAuth: true,
+			args:                        []string{"gcsfuse", "--enable-google-lib-auth=false", "abc", "pqr"},
+			expectedEnableGoogleLibAuth: false,
 		},
 	}
 

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -26,7 +26,7 @@ import (
 func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	var defaultArg []string
 	if setup.TestOnTPCEndPoint() {
-		defaultArg = append(defaultArg, "--custom-endpoint=storage.apis-tpczero.goog:443",
+		defaultArg = append(defaultArg,
 			"--key-file=/tmp/sa.key.json")
 	}
 


### PR DESCRIPTION
### Description
Make default value of flag(enable-google-lib-auth) true with valid testing.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual 
     i. GCS - GCE - Done(both http/gRPC)
     ii. GCS - GKE - Done(both http/gRPC)
     iii. TPC - GCE
     iv. TPC - GKE
3. Unit tests - Automated
4. Integration tests - Automated
5. Checkpoint tests - [b/437030559](https://b.corp.google.com/issues/437030559)
6. Benchmark perf tests - [Sheet link](https://docs.google.com/spreadsheets/d/1eZjSDxaX-vpzkFI3bPphDanrYtYA7koc_mCQP34Dh7Q/edit)
7. Perf tests
<img width="1272" height="576" alt="4rMHS5ZUBeofdBE" src="https://github.com/user-attachments/assets/e5246af3-55fb-4dce-9916-d87bdc645d9f" />


### Any backward incompatible change? If so, please explain.
