### PR TITLE
ci: fix only-dir testing in implicit_dir test package

### DIFF
--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -73,12 +73,14 @@ func TestMain(m *testing.M) {
 
 	flagsSet := [][]string{{"--implicit-dirs"}}
 
-	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(testEnv.ctx, testEnv.storageClient); err == nil {
-		flagsSet = append(flagsSet, hnsFlagSet)
-	}
+	if !setup.IsZonalBucketRun() {
+		if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(testEnv.ctx, testEnv.storageClient); err == nil {
+			flagsSet = append(flagsSet, hnsFlagSet)
+		}
 
-	if !testing.Short() {
-		flagsSet = append(flagsSet, []string{"--client-protocol=grpc", "--implicit-dirs=true"})
+		if !testing.Short() {
+			flagsSet = append(flagsSet, []string{"--client-protocol=grpc", "--implicit-dirs=true"})
+		}
 	}
 
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flagsSet, m)

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -73,13 +73,15 @@ func TestMain(m *testing.M) {
 
 	flagsSet := [][]string{{"--implicit-dirs"}}
 
+	// No need to run enable-hns and client-protocol GRPC configuration for ZB,
+	// as those are both by default enabled for ZB.
 	if !setup.IsZonalBucketRun() {
 		if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(testEnv.ctx, testEnv.storageClient); err == nil {
 			flagsSet = append(flagsSet, hnsFlagSet)
 		}
 
 		if !testing.Short() {
-			flagsSet = append(flagsSet, []string{"--client-protocol=grpc", "--implicit-dirs=true"})
+			flagsSet = append(flagsSet, []string{"--client-protocol=grpc", "--implicit-dirs"})
 		}
 	}
 

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -82,6 +82,7 @@ func TestMain(m *testing.M) {
 	}
 
 	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flagsSet, m)
+	setup.SaveLogFileInCaseOfFailure(successCode)
 
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -171,7 +171,7 @@ func WriteToObject(ctx context.Context, client *storage.Client, object, content 
 		return fmt.Errorf("Failed to open writer for object %q: %w", object, err)
 	}
 	if _, err := io.WriteString(wc, content); err != nil {
-		return fmt.Errorf("io.WriteSTring failed for object %q: %w", object, err)
+		return fmt.Errorf("io.WriteString failed for object %q: %w", object, err)
 	}
 	if err := wc.Close(); err != nil {
 		return fmt.Errorf("Writer.Close failed for object %q: %w", object, err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -168,13 +168,13 @@ func WriteToObject(ctx context.Context, client *storage.Client, object, content 
 	// Upload an object with storage.Writer.
 	wc, err := NewWriter(ctx, o, client)
 	if err != nil {
-		return fmt.Errorf("Failed to open writer for object %q: %w", o.ObjectName(), err)
+		return fmt.Errorf("Failed to open writer for object %q: %w", object, err)
 	}
 	if _, err := io.WriteString(wc, content); err != nil {
-		return fmt.Errorf("io.WriteSTring: %w", err)
+		return fmt.Errorf("io.WriteSTring failed for object %q: %w", object, err)
 	}
 	if err := wc.Close(); err != nil {
-		return fmt.Errorf("Writer.Close: %w", err)
+		return fmt.Errorf("Writer.Close failed for object %q: %w", object, err)
 	}
 
 	return nil

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	storage "cloud.google.com/go/storage"
@@ -80,10 +81,9 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 // testdataCreateObjects is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
 // Note: testDirWithBucketName is of the form <bucket>/<object-name>.
-func testdataCreateObjects(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithBucketName string) {
+func testdataCreateObjects(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithoutBucketName string) {
 	t.Helper()
-
-	bucketName, testDirWithoutBucketName := operations.SplitBucketNameAndDirPath(t, testDirWithBucketName)
+	bucketName, _, _ := strings.Cut(setup.TestBucket(), "/")
 
 	objectName := path.Join(testDirWithoutBucketName, ImplicitDirectory, FileInImplicitDirectory)
 	err := client.CreateObjectOnGCS(ctx, storageClient, objectName, "This is from directory fileInImplicitDir1 file implicitDirectory")
@@ -108,7 +108,7 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 
 	// Create implicit directory in bucket for testing.
-	testdataCreateObjects(ctx, t, storageClient, path.Join(setup.TestBucket(), testDir))
+	testdataCreateObjects(ctx, t, storageClient, testDir)
 }
 
 func CreateImplicitDirectoryStructure(testDir string) {

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -80,9 +80,10 @@ func RemoveAndCheckIfDirIsDeleted(dirPath string, dirName string, t *testing.T) 
 
 // testdataCreateObjects is equivalent of the script tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/testdata/create_objects.sh .
 // That script uses gcloud, but this function instead uses go client library.
-// Note: testDirWithBucketName is of the form <bucket>/<object-name>.
 func testdataCreateObjects(ctx context.Context, t *testing.T, storageClient *storage.Client, testDirWithoutBucketName string) {
 	t.Helper()
+	// Following is needed for error log, and because
+	// TestBucket can be of the form <bucket>/<onlydir> .
 	bucketName, _, _ := strings.Cut(setup.TestBucket(), "/")
 
 	objectName := path.Join(testDirWithoutBucketName, ImplicitDirectory, FileInImplicitDirectory)

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -173,6 +173,6 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 	// CreateExplicitDirectoryStructure writes files using GCSFuse.
 	CreateExplicitDirectoryStructure(testDir, t)
 
-	dirPathInBucket := path.Join(setup.TestBucket(), testDir, ExplicitDirectory)
+	dirPathInBucket := path.Join(testDir, ExplicitDirectory)
 	testdataCreateObjects(ctx, t, storageClient, dirPathInBucket)
 }

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -58,7 +58,7 @@ const (
 	ProxyServerLogFilePrefix          = "proxy-server-failed-integration-test-logs-"
 	zoneMatcherRegex                  = "^[a-z]+-[a-z0-9]+-[a-z]$"
 	regionMatcherRegex                = "^[a-z]+-[a-z0-9]+$"
-	unsupportedCharactersInTestBucket = " /"
+	unsupportedCharactersInTestBucket = " "
 )
 
 var (


### PR DESCRIPTION
### Description

#### Short context
- Fix for [b/434203417](http://b/434203417) (more details in [b/issues/434203417#comment23](http://b/issues/434203417#comment23))
- Re-allow `/` in `--testBucket` argument as it's needed for gke testing for allowing `only-dir` testing.
- Don't run duplicate tests for ZB-run (`enable-hns` and `grpc`)
- Enhance error logs with object names

#### Summary of Changes

This pull request primarily addresses a CI issue related to `only-dir` testing in GKE environments by enabling the use of forward slashes in the `--testBucket` argument. This change necessitated a refactoring of the test setup for implicit and explicit directories to correctly handle these new path structures. Minor improvements to error logging and test configuration for different bucket types were also included.

#### Highlights

* **Test Bucket Path Flexibility**: I've updated the test setup to allow the `/` character in the `--testBucket` argument. This is crucial for GKE testing scenarios where `only-dir` testing requires specifying a path within a bucket, rather than just a top-level bucket name. This change is implemented by removing `/` from the `unsupportedCharactersInTestBucket` constant.
* **Implicit Directory Test Setup Refinement**: I've refactored the `implicit_dir_test` package to align with the new `--testBucket` behavior. This includes adjusting how bucket names and directory paths are extracted and passed to object creation functions, ensuring that relative paths within the specified test bucket are handled correctly.
* **Conditional Test Flag Application**: In `implicit_dir_test.go`, I've added a condition to only apply Hierarchical Namespace (HNS) flags and gRPC client protocol flags if the test is not running against a zonal bucket. This prevents potential issues or unnecessary configurations in zonal bucket environments.
* **Improved Error Messaging and Logging**: I've enhanced error messages in `storage_client.go` to include the object name, providing more context for debugging. Additionally, I've added a call to `setup.SaveLogFileInCaseOfFailure` in `implicit_dir_test.go` to automatically save test logs if a test run fails.

### Link to the issue in case of a bug fix.
[b/434203417](http://b/434203417)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit - [run1](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/96394021-2862-4e61-846d-2beca61ed148/summary) .

### Any backward incompatible change? If so, please explain.
