### PR TITLE
Style(Fixit): Updated sync error logs to include ObjectName

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1213,10 +1213,8 @@ func (fs *fileSystem) syncFile(
 
 	// Sync the inode.
 	gcsSynced, err := f.Sync(ctx)
-	objectName := f.Source().Name
 	if err != nil {
-		err = fmt.Errorf("FileInode.Sync(%s): %w", objectName, err)
-
+		err = fmt.Errorf("FileInode.Sync: %w", err)
 		// If the inode was local file inode, treat it as unlinked.
 		fs.mu.Lock()
 		delete(fs.localFileInodes, f.Name())
@@ -2945,10 +2943,11 @@ func (fs *fileSystem) SyncFile(
 	defer file.Unlock()
 
 	// Sync it.
+	objectName := file.Source().Name
 	if err := fs.syncFile(ctx, file); err != nil {
+		err = fmt.Errorf("syncFile(%s): %w", objectName, err)
 		return err
 	}
-
 	return
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2943,9 +2943,8 @@ func (fs *fileSystem) SyncFile(
 	defer file.Unlock()
 
 	// Sync it.
-	objectName := file.Source().Name
 	if err := fs.syncFile(ctx, file); err != nil {
-		err = fmt.Errorf("syncFile(%s): %w", objectName, err)
+		err = fmt.Errorf("syncFile: %w", err)
 		return err
 	}
 	return

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1213,8 +1213,10 @@ func (fs *fileSystem) syncFile(
 
 	// Sync the inode.
 	gcsSynced, err := f.Sync(ctx)
+	objectName := f.Source().Name
 	if err != nil {
-		err = fmt.Errorf("FileInode.Sync: %w", err)
+		err = fmt.Errorf("FileInode.Sync(%s): %w", objectName, err)
+
 		// If the inode was local file inode, treat it as unlinked.
 		fs.mu.Lock()
 		delete(fs.localFileInodes, f.Name())

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -232,17 +232,17 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	wc.Append = bh.BucketType().Zonal
 	// FinalizeOnClose should be true for all writes for now.
 	wc.FinalizeOnClose = true
-
+	objectName := req.Name
 	// Copy the contents to the writer.
 	if _, err = io.Copy(wc, req.Contents); err != nil {
-		err = fmt.Errorf("error in io.Copy: %w", err)
+		err = fmt.Errorf("error in io.Copy(%s): %w", objectName, err)
 		return
 	}
 
 	// We can't use defer to close the writer, because we need to close the
 	// writer successfully before calling Attrs() method of writer.
 	if err = wc.Close(); err != nil {
-		err = fmt.Errorf("error in closing writer : %w", err)
+		err = fmt.Errorf("error in closing writer(%s) : %w", objectName, err)
 		return
 	}
 


### PR DESCRIPTION
### Description
This feature improves error logs by adding the complete file path where an I/O operation failed, providing instant context for quicker debugging without needing verbose logging.

```
{"timestamp":{"seconds":1753956220,"nanos":210752211},"severity":"TRACE","message":"gcs: Req             0x2f: -> CreateObject(\"main_folder/a/aaa/bbb.txt\") (414.18µs): error in io.Copy(main_folder/a/aaa/bbb.txt): error"}
{"timestamp":{"seconds":1753956220,"nanos":210789791},"severity":"ERROR","message":"FlushFile: input/output error, FileInode.Sync: SyncObject: create: CreateObject: error in io.Copy(main_folder/a/aaa/bbb.txt): error"}
```

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/428146816

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
