### PR TITLE
feat(bufferedread): Integrate Buffered Reader with the filesystem

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
@@ -44,8 +45,6 @@ type BufferedReadConfig struct {
 }
 
 const (
-	MiB = 1 << 20
-
 	defaultRandomReadsThreshold = 3
 	defaultPrefetchMultiplier   = 2
 )
@@ -454,7 +453,7 @@ func (p *BufferedReader) CheckInvariants() {
 	}
 
 	// The prefetch block size must be at least 1 MiB.
-	if p.config.PrefetchBlockSizeBytes < MiB {
+	if p.config.PrefetchBlockSizeBytes < util.MiB {
 		panic(fmt.Sprintf("BufferedReader: PrefetchBlockSizeBytes must be at least 1 MiB, but is %d", p.config.PrefetchBlockSizeBytes))
 	}
 

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -34,18 +34,21 @@ import (
 
 // ErrPrefetchBlockNotAvailable is returned when a block cannot be
 // acquired from the pool for prefetching. This can be used by callers to
-// implement a fallback mechanism, e.g. falling back to a direct GCS read.
+// implement a fallback mechanism, e.g. falling back to another reader.
 var ErrPrefetchBlockNotAvailable = errors.New("block for prefetching not available")
 
 type BufferedReadConfig struct {
 	MaxPrefetchBlockCnt     int64 // Maximum number of blocks that can be prefetched.
 	PrefetchBlockSizeBytes  int64 // Size of each block to be prefetched.
 	InitialPrefetchBlockCnt int64 // Number of blocks to prefetch initially.
-	PrefetchMultiplier      int64 // Multiplier for number of blocks to prefetch.
-	RandomReadsThreshold    int64 // Number of random reads after which the reader falls back to GCS reader.
 }
 
-const MiB = 1 << 20
+const (
+	MiB = 1 << 20
+
+	defaultRandomReadsThreshold = 3
+	defaultPrefetchMultiplier   = 2
+)
 
 // blockQueueEntry holds a data block with a function
 // to cancel its in-flight download.
@@ -65,7 +68,7 @@ type BufferedReader struct {
 	nextBlockIndexToPrefetch int64
 
 	// randomSeekCount is the number of random seeks performed. This is used to
-	// detect if the read pattern is random and fall back to a simpler GCS reader.
+	// detect if the read pattern is random and fall back to another reader.
 	randomSeekCount int64
 
 	// numPrefetchBlocks is the number of blocks to prefetch in the next
@@ -82,6 +85,10 @@ type BufferedReader struct {
 
 	ctx        context.Context
 	cancelFunc context.CancelFunc
+
+	prefetchMultiplier int64 // Multiplier for number of blocks to prefetch.
+
+	randomReadsThreshold int64 // Number of random reads after which the reader falls back to another reader.
 }
 
 // NewBufferedReader returns a new bufferedReader instance.
@@ -102,6 +109,8 @@ func NewBufferedReader(object *gcs.MinObject, bucket gcs.Bucket, config *Buffere
 		blockPool:                blockpool,
 		workerPool:               workerPool,
 		metricHandle:             metricHandle,
+		prefetchMultiplier:       defaultPrefetchMultiplier,
+		randomReadsThreshold:     defaultRandomReadsThreshold,
 	}
 
 	reader.ctx, reader.cancelFunc = context.WithCancel(context.Background())
@@ -111,13 +120,13 @@ func NewBufferedReader(object *gcs.MinObject, bucket gcs.Bucket, config *Buffere
 // handleRandomRead detects and handles random read patterns. A read is considered
 // random if the requested offset is outside the currently prefetched window.
 // If the number of detected random reads exceeds a configured threshold, it
-// returns a gcsx.FallbackToAnotherReader error to signal that a simpler GCS
-// reader should be used.
+// returns a gcsx.FallbackToAnotherReader error to signal that another reader
+// should be used.
 func (p *BufferedReader) handleRandomRead(offset int64) error {
-	// Exit early if we have already decided to fall back to a GCS reader. This
-	// avoids re-evaluating the read pattern on every call when the random read
-	// threshold has been met.
-	if p.randomSeekCount > p.config.RandomReadsThreshold {
+	// Exit early if we have already decided to fall back to another reader.
+	// This avoids re-evaluating the read pattern on every call when the random
+	// read threshold has been met.
+	if p.randomSeekCount > p.randomReadsThreshold {
 		return gcsx.FallbackToAnotherReader
 	}
 
@@ -139,9 +148,9 @@ func (p *BufferedReader) handleRandomRead(offset int64) error {
 		p.blockPool.Release(entry.block)
 	}
 
-	if p.randomSeekCount > p.config.RandomReadsThreshold {
-		logger.Tracef("Too many random reads for object %q (count: %d, threshold: %d); falling back to GCS reader.",
-			p.object.Name, p.randomSeekCount, p.config.RandomReadsThreshold)
+	if p.randomSeekCount > p.randomReadsThreshold {
+		logger.Tracef("Too many random reads for object %q (count: %d, threshold: %d); falling back to another reader.",
+			p.object.Name, p.randomSeekCount, p.randomReadsThreshold)
 		return gcsx.FallbackToAnotherReader
 	}
 
@@ -253,6 +262,9 @@ func (p *BufferedReader) ReadAt(ctx context.Context, inputBuf []byte, off int64)
 
 		if p.blockQueue.IsEmpty() {
 			if err = p.freshStart(off); err != nil {
+				if errors.Is(err, ErrPrefetchBlockNotAvailable) {
+					return resp, gcsx.FallbackToAnotherReader
+				}
 				err = fmt.Errorf("ReadAt: freshStart failed: %w", err)
 				break
 			}
@@ -340,7 +352,7 @@ func (p *BufferedReader) prefetch() error {
 	}
 
 	// Set the size for the next multiplicative prefetch.
-	p.numPrefetchBlocks *= p.config.PrefetchMultiplier
+	p.numPrefetchBlocks *= p.prefetchMultiplier
 
 	// Do not prefetch more than MaxPrefetchBlockCnt blocks.
 	if p.numPrefetchBlocks > p.config.MaxPrefetchBlockCnt {
@@ -451,8 +463,8 @@ func (p *BufferedReader) CheckInvariants() {
 		panic(fmt.Sprintf("BufferedReader: blockQueue length %d exceeds limit %d", p.blockQueue.Len(), p.config.MaxPrefetchBlockCnt))
 	}
 
-	// The random seek count should never exceed RandomReadsThreshold.
-	if p.randomSeekCount > p.config.RandomReadsThreshold {
-		panic(fmt.Sprintf("BufferedReader: randomSeekCount %d exceeds threshold %d", p.randomSeekCount, p.config.RandomReadsThreshold))
+	// The random seek count should never exceed randomReadsThreshold.
+	if p.randomSeekCount > p.randomReadsThreshold {
+		panic(fmt.Sprintf("BufferedReader: randomSeekCount %d exceeds threshold %d", p.randomSeekCount, p.randomReadsThreshold))
 	}
 }

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
@@ -230,13 +231,13 @@ func (t *BufferedReaderTest) TestCheckInvariantsPrefetchBlockSizeTooSmall() {
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err, "NewBufferedReader should not return error")
 
-	reader.config.PrefetchBlockSizeBytes = MiB - 1
+	reader.config.PrefetchBlockSizeBytes = util.MiB - 1
 
 	assert.Panics(t.T(), func() { reader.CheckInvariants() }, "Should panic for block size less than 1 MiB")
 }
 
 func (t *BufferedReaderTest) TestCheckInvariantsNoPanic() {
-	t.config.PrefetchBlockSizeBytes = MiB
+	t.config.PrefetchBlockSizeBytes = util.MiB
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err, "NewBufferedReader should not return error")
 

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -41,8 +41,6 @@ const (
 	testGlobalMaxBlocks         int64 = 20
 	testPrefetchBlockSizeBytes  int64 = 1024
 	testInitialPrefetchBlockCnt int64 = 2
-	testPrefetchMultiplier      int64 = 2
-	testRandomReadsThreshold    int64 = 3
 )
 
 type BufferedReaderTest struct {
@@ -113,8 +111,6 @@ func (t *BufferedReaderTest) SetupTest() {
 		MaxPrefetchBlockCnt:     testMaxPrefetchBlockCnt,
 		PrefetchBlockSizeBytes:  testPrefetchBlockSizeBytes,
 		InitialPrefetchBlockCnt: testInitialPrefetchBlockCnt,
-		PrefetchMultiplier:      testPrefetchMultiplier,
-		RandomReadsThreshold:    testRandomReadsThreshold,
 	}
 	var err error
 	t.workerPool, err = workerpool.NewStaticWorkerPool(5, 10)
@@ -200,7 +196,7 @@ func (t *BufferedReaderTest) TestCheckInvariantsRandomSeekCountExceedsThreshold(
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err, "NewBufferedReader should not return error")
 
-	reader.randomSeekCount = t.config.RandomReadsThreshold + 1
+	reader.randomSeekCount = reader.randomReadsThreshold + 1
 
 	assert.Panics(t.T(), func() { reader.CheckInvariants() })
 }
@@ -542,7 +538,6 @@ func (t *BufferedReaderTest) TestPrefetch() {
 
 func (t *BufferedReaderTest) TestPrefetchWithMultiplicativeIncrease() {
 	t.config.InitialPrefetchBlockCnt = 1
-	t.config.PrefetchMultiplier = 2
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err)
 	// First prefetch schedules 1 block.
@@ -990,7 +985,6 @@ func (t *BufferedReaderTest) TestReadAtSpanningMultipleBlocks() {
 
 func (t *BufferedReaderTest) TestReadAtSequentialReadAcrossBlocks() {
 	t.config.InitialPrefetchBlockCnt = 1
-	t.config.PrefetchMultiplier = 2
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
 	require.NoError(t.T(), err)
 	// Mock reads for all blocks that will be downloaded.
@@ -1032,9 +1026,9 @@ func (t *BufferedReaderTest) TestReadAtSequentialReadAcrossBlocks() {
 }
 
 func (t *BufferedReaderTest) TestReadAtFallsBackAfterRandomReads() {
-	t.config.RandomReadsThreshold = 2
 	t.config.InitialPrefetchBlockCnt = 1
 	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
+	reader.randomReadsThreshold = 2
 	require.NoError(t.T(), err)
 	buf := make([]byte, 10)
 	// Mock GCS calls for the first random read, which will download block 2 and prefetch block 3.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -532,7 +532,7 @@ type fileSystem struct {
 	bufferedReadWorkerPool workerpool.WorkerPool
 
 	// globalMaxReadBlocksSem is a semaphore that limits the total number of blocks
-	// that can be allocated for buffered read across all files in the file system.
+	// that can be allocated for buffered read across all files in the file-handles.
 	// This helps control the overall memory usage for buffered reads.
 	globalMaxReadBlocksSem *semaphore.Weighted
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -20,17 +20,20 @@ import (
 	"fmt"
 	"io"
 	iofs "io/fs"
-	"math"
 	"os"
 	"path"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/workerpool"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+
+	"math"
 
 	"golang.org/x/sync/semaphore"
 
@@ -205,9 +208,24 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		metricHandle:               serverCfg.MetricHandle,
 		enableAtomicRenameObject:   serverCfg.NewConfig.EnableAtomicRenameObject,
 		globalMaxWriteBlocksSem:    semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks),
+		globalMaxReadBlocksSem:     semaphore.NewWeighted(serverCfg.NewConfig.Read.GlobalMaxBlocks),
 	}
 	if serverCfg.Notifier != nil {
 		fs.notifier = serverCfg.Notifier
+	}
+
+	if serverCfg.NewConfig.Read.EnableBufferedRead {
+		var err error
+		numCPU := runtime.NumCPU()
+		totalWorkers := 3 * numCPU
+		// 10% of total workers for priority, rounded up.
+		priorityWorkers := (totalWorkers + 9) / 10
+		normalWorkers := totalWorkers - priorityWorkers
+		fs.bufferedReadWorkerPool, err = workerpool.NewStaticWorkerPool(uint32(priorityWorkers), uint32(normalWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create worker pool for buffered read: %w", err)
+		}
+		fs.bufferedReadWorkerPool.Start()
 	}
 
 	// Set up root bucket
@@ -508,6 +526,15 @@ type fileSystem struct {
 	// It is used to invalidate the kernel's dentry cache,
 	// providing feedback to the kernel about dynamic content changes.
 	notifier *fuse.Notifier
+
+	// bufferedReadWorkerPool is used for asynchronous prefetching of data for buffered reads.
+	// It executes download tasks associated with prefetch blocks.
+	bufferedReadWorkerPool workerpool.WorkerPool
+
+	// globalMaxReadBlocksSem is a semaphore that limits the total number of blocks
+	// that can be allocated for buffered read across all files in the file system.
+	// This helps control the overall memory usage for buffered reads.
+	globalMaxReadBlocksSem *semaphore.Weighted
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1624,6 +1651,9 @@ func (fs *fileSystem) Destroy() {
 	if fs.fileCacheHandler != nil {
 		_ = fs.fileCacheHandler.Destroy()
 	}
+	if fs.bufferedReadWorkerPool != nil {
+		fs.bufferedReadWorkerPool.Stop()
+	}
 }
 
 func (fs *fileSystem) StatFS(
@@ -2011,7 +2041,7 @@ func (fs *fileSystem) CreateFile(
 
 	// CreateFile() invoked to create new files, can be safely considered as filehandle
 	// opened in append mode.
-	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, util.Append, fs.newConfig)
+	fs.handles[handleID] = handle.NewFileHandle(child.(*inode.FileInode), fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, util.Append, fs.newConfig, fs.bufferedReadWorkerPool, fs.globalMaxReadBlocksSem)
 	op.Handle = handleID
 
 	fs.mu.Unlock()
@@ -2774,7 +2804,7 @@ func (fs *fileSystem) OpenFile(
 
 	// Figure out the mode in which the file is being opened.
 	openMode := util.FileOpenMode(op)
-	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, openMode, fs.newConfig)
+	fs.handles[handleID] = handle.NewFileHandle(in, fs.fileCacheHandler, fs.cacheFileForRangeRead, fs.metricHandle, openMode, fs.newConfig, fs.bufferedReadWorkerPool, fs.globalMaxReadBlocksSem)
 	op.Handle = handleID
 
 	// When we observe object generations that we didn't create, we assign them

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -145,7 +145,7 @@ func (t *fileTest) TestFileHandleWrite() {
 	parent := createDirInode(&t.bucket, &t.clock)
 	config := &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
 	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_obj", nil, false)
-	fh := NewFileHandle(in, nil, false, nil, util.Write, &cfg.Config{})
+	fh := NewFileHandle(in, nil, false, nil, util.Write, &cfg.Config{}, nil, nil)
 	data := []byte("hello")
 
 	_, err := fh.Write(t.ctx, data, 0)
@@ -168,7 +168,7 @@ func (t *fileTest) Test_Read_Success() {
 	expectedData := []byte("hello from reader")
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_reader", expectedData, false)
-	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -184,7 +184,7 @@ func (t *fileTest) Test_ReadWithReadManager_Success() {
 	expectedData := []byte("hello from readManager")
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, "test_obj_readManager", expectedData, false)
-	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 	buf := make([]byte, len(expectedData))
 	fh.inode.Lock()
 
@@ -216,7 +216,7 @@ func (t *fileTest) Test_ReadWithReadManager_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock)
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 			fh.inode.Lock()
 			mockRM := new(read_manager.MockReadManager)
 			mockRM.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ReaderResponse{}, tc.returnErr)
@@ -254,7 +254,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 			t.SetupTest()
 			parent := createDirInode(&t.bucket, &t.clock)
 			testInode := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, []byte("data"), false)
-			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+			fh := NewFileHandle(testInode, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 			fh.inode.Lock()
 			mockReader := new(gcsx.MockRandomReader)
 			mockReader.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ObjectData{}, tc.returnErr)
@@ -279,7 +279,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 	fh.inode.Lock()
 	mockRM := new(read_manager.MockReadManager)
 	mockRM.On("Destroy").Return()
@@ -301,7 +301,7 @@ func (t *fileTest) Test_Read_FallbackToInode() {
 	object := gcs.MinObject{Name: "test_obj", Generation: 0}
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
-	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{})
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
 	fh.inode.Lock()
 	mockR := new(gcsx.MockRandomReader)
 	mockR.On("Destroy").Return()
@@ -337,7 +337,7 @@ func (t *fileTest) TestOpenMode() {
 		parent := createDirInode(&t.bucket, &t.clock)
 		config := &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
 		in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_obj", nil, false)
-		fh := NewFileHandle(in, nil, false, nil, tc.openMode, &cfg.Config{})
+		fh := NewFileHandle(in, nil, false, nil, tc.openMode, &cfg.Config{}, nil, nil)
 
 		openMode := fh.OpenMode()
 
@@ -356,7 +356,7 @@ func (t *fileTest) TestFileHandle_Destroy_WithReaderAndReadManager() {
 	mockReader.On("Destroy").Once()
 	mockReadManager.On("Destroy").Once()
 	// Construct file handle with mocks
-	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config)
+	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config, nil, nil)
 	fh.reader = mockReader
 	fh.readManager = mockReadManager
 
@@ -372,7 +372,7 @@ func (t *fileTest) TestFileHandle_Destroy_WithNilReaderAndReadManager() {
 	config := &cfg.Config{}
 	fileInode := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "destroy_test_nil_obj", nil, false)
 	// Construct file handle with nils
-	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config)
+	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config, nil, nil)
 	fh.reader = nil
 	fh.readManager = nil
 
@@ -392,7 +392,7 @@ func (t *fileTest) TestFileHandle_CheckInvariants_WithNonNilReaderAndManager() {
 	// Expectations
 	mockReader.On("CheckInvariants").Once()
 	mockRM.On("CheckInvariants").Once()
-	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config)
+	fh := NewFileHandle(fileInode, nil, false, nil, util.Read, config, nil, nil)
 	fh.reader = mockReader
 	fh.readManager = mockRM
 
@@ -409,7 +409,7 @@ func (t *fileTest) TestFileHandle_CheckInvariants_WithNilReaderAndManager() {
 	config := &cfg.Config{}
 	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_check_invariants_nil", nil, false)
 
-	fh := NewFileHandle(in, nil, false, nil, util.Read, config)
+	fh := NewFileHandle(in, nil, false, nil, util.Read, config, nil, nil)
 
 	// Should not panic even if both are nil
 	assert.NotPanics(t.T(), func() {


### PR DESCRIPTION

### Description
This PR integrates the `BufferedReader` with the filesystem components to improve read performance.
The ReadManager is updated to use the BufferedReader when enabled via the `read.enable_buffered_read flag`. 

### Link to the issue in case of a bug fix.
b/435417084

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
