### PR TITLE
feat: Stop finalizing objects in zonal buckets

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2830,14 +2830,7 @@ func (fs *fileSystem) ReadFile(
 	defer fh.Unlock()
 	if fh.Inode().IsUsingBWH() {
 		// Flush Pending streaming writes and issue read within same inode lock.
-		// TODO(b/417136852): Remove bucket type check and call only flushFile
-		// when we start leaving zonal bucket objects unfinalized.
-		if !fh.Inode().Bucket().BucketType().Zonal {
-			err = fs.flushFile(ctx, fh.Inode())
-		} else {
-			// Flush but don't finalize, in zonal bucket.
-			err = fs.syncFile(ctx, fh.Inode())
-		}
+		err = fs.flushFile(ctx, fh.Inode())
 		if err != nil {
 			fh.Inode().Unlock()
 			return err

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -229,8 +229,12 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	wc.ProgressFunc = req.CallBack
 	// All objects in zonal buckets must be appendable.
 	wc.Append = bh.BucketType().Zonal
-	// FinalizeOnClose should be true for all writes for now.
-	wc.FinalizeOnClose = true
+	// Objects in zonal buckets should not finalized if rapid-appends is enabled.
+	if bh.enableRapidAppends && bh.BucketType().Zonal {
+		wc.FinalizeOnClose = false
+	} else {
+		wc.FinalizeOnClose = true
+	}
 
 	// Copy the contents to the writer.
 	if _, err = io.Copy(wc, req.Contents); err != nil {
@@ -262,8 +266,12 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc.ProgressFunc = callBack
 	// All objects in zonal buckets must be appendable.
 	wc.Append = bh.BucketType().Zonal
-	// FinalizeOnClose should be true for all writes for now.
-	wc.FinalizeOnClose = true
+	// Objects in zonal buckets should not finalized if rapid-appends is enabled.
+	if bh.enableRapidAppends && bh.BucketType().Zonal {
+		wc.FinalizeOnClose = false
+	} else {
+		wc.FinalizeOnClose = true
+	}
 
 	return wc, nil
 }

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -149,6 +149,7 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 		if setup.IsZonalBucketRun() {
 			// Zonal bucket writers require append-flag to be set.
 			wc.Append = true
+			// Zonal buckets with rapid appends should not finalize on close.
 			wc.FinalizeOnClose = false
 		} else {
 			return nil, fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -149,6 +149,7 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 		if setup.IsZonalBucketRun() {
 			// Zonal bucket writers require append-flag to be set.
 			wc.Append = true
+			wc.FinalizeOnClose = false
 		} else {
 			return nil, fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())
 		}


### PR DESCRIPTION
### Description
- This stops finalizing objects in rapid/zonal buckets on writes/appends.
- It currently fails because CreateObject (overwriting objects) fails for unfinalized objects.
- This change is hidden behind the experimental-rapid-appends flag.

### Link to the issue in case of a bug fix.
[b/426512250](http://b/426512250)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit - [run1](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/fa4eb865-935f-4243-b857-7ef3eb6fc764) .

### Any backward incompatible change? If so, please explain.
