### PR TITLE
docs: Update dev guide to include "kokoro:run" label

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -175,7 +175,7 @@ write end-to-end tests for GCSFuse.
        GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/$TEST_PACKAGE_NAME/... -p 1 -short --integrationTest -v --testbucket=$TEST_BUCKET_NAME --timeout=60m -run $TEST_NAME
        ```
 4. **Run all tests as pre-submit:** Existing GCSFuse end-to-end tests can be run
-   as a pre-submit check by adding the `execute-integration-tests` label to your
+   as a pre-submit check by adding the `execute-integration-tests` and `kokoro:run` label to your
    pull request. Ask one of your assigned code reviewers to apply this label,
    which will trigger the tests. Your reviewer will share any test failure
    details on the pull request.


### PR DESCRIPTION
### Description
Update dev guide to include `kokoro:run label` which is a requirement for KOKORO jobs to run on PRs by external contributors.

### Link to the issue in case of a bug fix.
b/435371381

### Testing details
1. Manual - manually tested on PR https://github.com/GoogleCloudPlatform/gcsfuse/pull/3603
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
