### PR TITLE
feat(block-pool): adding tryGet similar to Get() but doesn't block execution when block-pool is full

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -103,6 +103,33 @@ func (bp *GenBlockPool[T]) Get() (T, error) {
 	}
 }
 
+// TryGet returns a block if available, or an error if no blocks can be allocated.
+// It returns an existing block if it's ready for reuse or creates a new one if required.
+// Not thread-safe, calling from multiple goroutines may lead to memory leaks because
+// of race conditions.
+func (bp *GenBlockPool[T]) TryGet() (T, error) {
+	select {
+	case b := <-bp.freeBlocksCh:
+		// Reset the block for reuse.
+		b.Reuse()
+		return b, nil
+
+	default:
+		if bp.canAllocateBlock() {
+			b, err := bp.createBlockFunc(bp.blockSize)
+			if err != nil {
+				var zero T
+				return zero, err
+			}
+
+			bp.totalBlocks++
+			return b, nil
+		}
+		var zero T
+		return zero, CantAllocateAnyBlockError
+	}
+}
+
 // canAllocateBlock checks if a new block can be allocated.
 func (bp *GenBlockPool[T]) canAllocateBlock() bool {
 	// If max blocks limit is reached, then no more blocks can be allocated.

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -16,7 +16,6 @@ package block
 
 import (
 	"fmt"
-	"io"
 	"testing"
 	"time"
 
@@ -81,15 +80,6 @@ func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
 	require.Nil(t.T(), err)
-	content := []byte("hi")
-	n, err := b.Write(content)
-	require.Equal(t.T(), 2, n)
-	require.Nil(t.T(), err)
-	// Validating the content of the block
-	require.Equal(t.T(), int64(0), b.(*memoryBlock).readSeek)
-	output, err := io.ReadAll(b)
-	require.Nil(t.T(), err)
-	require.Equal(t.T(), content, output)
 	bp.freeBlocksCh <- b
 	// Setting totalBlocks same as maxBlocks to ensure no new blocks are created.
 	bp.totalBlocks = 10
@@ -131,15 +121,6 @@ func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
 	require.Nil(t.T(), err)
-	content := []byte("hi")
-	n, err := b.Write(content)
-	require.Equal(t.T(), 2, n)
-	require.Nil(t.T(), err)
-	// Validating the content of the block
-	require.Equal(t.T(), int64(0), b.(*memoryBlock).readSeek)
-	output, err := io.ReadAll(b)
-	require.Nil(t.T(), err)
-	require.Equal(t.T(), content, output)
 	bp.freeBlocksCh <- b
 	// Setting totalBlocks same as maxBlocks to ensure no new blocks are created.
 	bp.totalBlocks = 10
@@ -314,7 +295,7 @@ func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 
@@ -339,7 +320,7 @@ func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -75,6 +75,56 @@ func (t *BlockPoolTest) TestInitBlockPoolForNegativeMaxBlocks() {
 }
 
 // Represents when block is available on the freeBlocksCh.
+func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	require.Nil(t.T(), err)
+	// Creating a block with some data and send it to blockCh.
+	b, err := createBlock(2)
+	require.Nil(t.T(), err)
+	content := []byte("hi")
+	n, err := b.Write(content)
+	require.Equal(t.T(), 2, n)
+	require.Nil(t.T(), err)
+	// Validating the content of the block
+	require.Equal(t.T(), int64(0), b.(*memoryBlock).readSeek)
+	output, err := io.ReadAll(b)
+	require.Nil(t.T(), err)
+	require.Equal(t.T(), content, output)
+	bp.freeBlocksCh <- b
+	// Setting totalBlocks same as maxBlocks to ensure no new blocks are created.
+	bp.totalBlocks = 10
+
+	block, err := bp.TryGet()
+
+	require.Nil(t.T(), err)
+	require.NotNil(t.T(), block)
+	// This ensures the block is reset.
+	assert.Equal(t.T(), int64(0), block.Size())
+}
+
+func (t *BlockPoolTest) TestTryGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	require.Nil(t.T(), err)
+
+	block, err := bp.TryGet()
+
+	require.Nil(t.T(), err)
+	require.NotNil(t.T(), block)
+	assert.Equal(t.T(), int64(0), block.Size())
+}
+
+func (t *BlockPoolTest) TestTryGetToCreateLargeBlock() {
+	// Creating block of size 1TB
+	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, semaphore.NewWeighted(10), createBlock)
+	require.Nil(t.T(), err)
+
+	_, err = bp.TryGet()
+
+	require.NotNil(t.T(), err)
+	assert.Equal(t.T(), "mmap error: cannot allocate memory", err.Error())
+}
+
+// Represents when block is available on the freeBlocksCh.
 func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
@@ -242,6 +292,37 @@ func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
 	require.Error(t.T(), err)
 	assert.Nil(t.T(), bp)
 	assert.ErrorContains(t.T(), err, CantAllocateAnyBlockError.Error())
+}
+
+func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	require.Nil(t.T(), err)
+	// 2 blocks can be created.
+	b1, err1 := bp.TryGet()
+	require.Nil(t.T(), err1)
+	require.NotNil(t.T(), b1)
+	b2, err2 := bp.TryGet()
+	require.Nil(t.T(), err2)
+	require.NotNil(t.T(), b2)
+
+	b3, err3 := bp.TryGet()
+
+	require.Nil(t.T(), b3)
+	require.NotNil(t.T(), err3)
+	require.ErrorIs(t.T(), err3, CantAllocateAnyBlockError)
+	require.Equal(t.T(), int64(2), bp.totalBlocks)
+}
+
+func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
+	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	require.Nil(t.T(), err)
+	bp.totalBlocks = 10
+
+	b, err := bp.TryGet()
+
+	require.NotNil(t.T(), err)
+	assert.Equal(t.T(), CantAllocateAnyBlockError, err)
+	require.Nil(t.T(), b)
 }
 
 func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {


### PR DESCRIPTION
### Description
- Adding a new method TryGet in the block-pool, which doesn't block the call in case block-pool limit is reached. Instead returns an error.
- Existing `Get` method is blocks the execution in case block-pool limit is reached.

### Link to the issue in case of a bug fix.
b/435631891

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
