### PR TITLE
style(debug_bkt): removing unnecessary back-slash from gcs-read log

### DIFF
--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -137,7 +137,7 @@ func (b *debugBucket) BucketType() gcs.BucketType {
 }
 
 func setupReader(ctx context.Context, b *debugBucket, req *gcs.ReadObjectRequest, method string) (gcs.StorageReader, error) {
-	id, desc, start := b.startRequest("%q(%q, %v)", method, req.Name, req.Range)
+	id, desc, start := b.startRequest("%s(%q, %v)", method, req.Name, req.Range)
 
 	// Call through.
 	rc, err := b.wrapped.NewReaderWithReadHandle(ctx, req)


### PR DESCRIPTION
### Description
Removing unnecessary back-slash from gcs-read logs.


**Before:**
```text
time="02/08/2025 01:04:56.190970" severity=TRACE message="gcs: Req             0x5d: <- \"ReadWithReadHandle\"(\"10G_file\", [1526726656, 1543503872))"
```

**After:**
```text
time="02/08/2025 01:18:29.321032" severity=TRACE message="gcs: Req             0x5e: <- ReadWithReadHandle(\"10G_file\", [1543503872, 1560281088))"
```

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
