### PR TITLE
feat(reduce-large-prefetch): heuristic based prefetching strategy

### DIFF
--- a/internal/gcsx/reader_predictor/reader_predictor.go
+++ b/internal/gcsx/reader_predictor/reader_predictor.go
@@ -19,6 +19,22 @@ import (
 	"sync"
 )
 
+func init() {
+	// Initialize the default predictor.
+	defaultPredictor = NewHeuristicReaderPredictor()
+}
+
+var defaultPredictor ReaderPredictor
+
+func ProcessInput(input PredictorInput) {
+	// Record the read type in the default predictor.
+	defaultPredictor.RecordRead(input)
+}
+
+func Predict() ReadType {
+	return defaultPredictor.PredictReadType()
+}
+
 type ReadType int64
 
 const (

--- a/internal/gcsx/reader_predictor/reader_predictor.go
+++ b/internal/gcsx/reader_predictor/reader_predictor.go
@@ -1,0 +1,113 @@
+// Create a read predictor which will take input prediction input and provide a method to predict if the pattern was sequential or random.
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader_predictor
+
+import (
+	"sync"
+)
+
+type ReadType int64
+
+const (
+	Sequential ReadType = iota
+	Random
+)
+
+type PredictorInput interface {
+	Score() float64
+}
+
+type ReaderPredictor interface {
+	RecordRead(PredictorInput)
+	PredictReadType() ReadType
+}
+
+type heuristicReaderPredictor struct {
+	runningScore float64
+	decayFactor  float64 // Not used in this implementation, but can be used for future enhancements.
+	mu           sync.RWMutex
+}
+
+func NewHeuristicReaderPredictor() ReaderPredictor {
+	return &heuristicReaderPredictor{
+		runningScore: 0.5,
+		decayFactor:  0.8,
+		mu:           sync.RWMutex{},
+	}
+}
+
+func (p *heuristicReaderPredictor) RecordRead(input PredictorInput) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.runningScore = p.runningScore*(1-p.decayFactor) + p.decayFactor*input.Score()
+}
+
+func (p *heuristicReaderPredictor) PredictReadType() ReadType {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.runningScore > 0.7 {
+		return Random
+	}
+	return Sequential
+}
+
+type readerPredictorInput struct {
+	PredictorInput
+	readType ReadType
+}
+
+func (r *readerPredictorInput) Score() float64 {
+	if r.readType == Sequential {
+		return 0.001
+	}
+	return 0.999
+}
+
+func NewReaderPredictorInput(readType ReadType) PredictorInput {
+	return &readerPredictorInput{
+		readType: readType,
+	}
+}
+
+type sizePredictorInput struct {
+	PredictorInput
+	objectSize int64 // Size of the object in bytes.
+}
+
+func (r *sizePredictorInput) Score() float64 {
+	if r.objectSize < 1024 {
+		return 0.001
+	}
+
+	if r.objectSize < 1048576 { // Less than 1 MB
+		return 0.01
+	}
+
+	if r.objectSize < 10485760 {
+		return 0.2
+	}
+
+	// Otherwise, it can be anything.
+	return 0.5
+}
+
+func NewSizePredictorInput(objectSize int64) PredictorInput {
+	return &sizePredictorInput{
+		objectSize: objectSize,
+	}
+}

--- a/internal/gcsx/reader_predictor/reader_predictor_test.go
+++ b/internal/gcsx/reader_predictor/reader_predictor_test.go
@@ -120,6 +120,7 @@ func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_SmallFile() {
 
 	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
 }
+
 func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_LargeFile() {
 	predictor := NewHeuristicReaderPredictor()
 

--- a/internal/gcsx/reader_predictor/reader_predictor_test.go
+++ b/internal/gcsx/reader_predictor/reader_predictor_test.go
@@ -1,0 +1,133 @@
+// Create a read predictor which will take input prediction input and provide a method to predict if the pattern was sequential or random.
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader_predictor
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const EPS = 0.000001
+
+type HeuristicReaderPredictorSuite struct {
+	suite.Suite
+}
+
+func TestHeuristicReaderPredictorSuite(t *testing.T) {
+	suite.Run(t, new(HeuristicReaderPredictorSuite))
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestHeuristicReaderPredictor() {
+	predictor := NewHeuristicReaderPredictor()
+
+	assert.NotNil(hrp.T(), predictor)
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestRecordRead() {
+	predictor := NewHeuristicReaderPredictor()
+
+	input := NewReaderPredictorInput(Sequential)
+	predictor.RecordRead(input)
+
+	assert.True(hrp.T(), math.Abs(0.5*0.2+0.001*0.8-predictor.(*heuristicReaderPredictor).runningScore) < EPS)
+	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_Random() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of random reads
+	for i := 0; i < 10; i++ {
+		input := NewReaderPredictorInput(Random)
+		predictor.RecordRead(input)
+	}
+
+	assert.Equal(hrp.T(), Random, predictor.PredictReadType())
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_Sequential() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of sequential reads
+	for i := 0; i < 10; i++ {
+		input := NewReaderPredictorInput(Sequential)
+		predictor.RecordRead(input)
+	}
+
+	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_MixReadSequential() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of random reads
+	for i := 0; i < 5; i++ {
+		input := NewReaderPredictorInput(Random)
+		predictor.RecordRead(input)
+	}
+
+	// Now simulate more sequential reads
+	for i := 0; i < 10; i++ {
+		input := NewReaderPredictorInput(Sequential)
+		predictor.RecordRead(input)
+	}
+
+	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_MixReadRandom() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of sequential reads
+	for i := 0; i < 5; i++ {
+		input := NewReaderPredictorInput(Sequential)
+		predictor.RecordRead(input)
+	}
+
+	// Now simulate more random reads
+	for i := 0; i < 10; i++ {
+		input := NewReaderPredictorInput(Random)
+		predictor.RecordRead(input)
+	}
+
+	assert.Equal(hrp.T(), Random, predictor.PredictReadType())
+}
+
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_SmallFile() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of sequential reads
+	for i := 0; i < 10; i++ {
+		sizePredictorInput := NewSizePredictorInput(1 << 20) // 1 MB
+		predictor.RecordRead(sizePredictorInput)
+	}
+
+	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
+}
+func (hrp *HeuristicReaderPredictorSuite) TestPredictReadType_LargeFile() {
+	predictor := NewHeuristicReaderPredictor()
+
+	// Simulate a series of sequential reads
+	for i := 0; i < 10; i++ {
+		sizePredictorInput := NewSizePredictorInput(1 << 30) // 1 GB
+		predictor.RecordRead(sizePredictorInput)
+	}
+
+	assert.Equal(hrp.T(), Sequential, predictor.PredictReadType())
+}


### PR DESCRIPTION
### Description
- There are two main prefetch strategy: (a) sequential friendly (start with high prefetch and switch to small in case of random read) (b) random read friendly (start with small prefetch and increase the prefetch in case of sequential read).

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
