### PR TITLE
test(buffered-read): adding log parser utility required for buffered-read e2e test

### DIFF
--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser.go
@@ -1,0 +1,257 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_logs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+)
+
+var readFileRegex = regexp.MustCompile(`fuse_debug: Op (0x[0-9a-fA-F]+)\s+connection\.go:\d+\] <- ReadFile \(inode (\d+), PID (\d+), handle (\d+), offset (\d+), (\d+) bytes\)`)
+var readAtReqRegex = regexp.MustCompile(`([a-f0-9-]+) <- ReadAt\(([^:]+):/([^,]+), (\d+), (\d+), (\d+), (\d+)\)`)
+var readAtSimpleRespRegex = regexp.MustCompile(`([a-f0-9-]+) -> ReadAt\(\): Ok\(([0-9.]+(?:s|ms|µs))\)`)
+
+// ParseBufferedReadLogsFromLogReader parses buffered read logs from an io.Reader and
+// returns a map of BufferedReadLogEntry keyed by file handle.
+// BufferedReadLogEntry contains the common read log information and a slice of
+// BufferedReadChunkData representing the chunk read from buffered reader.
+// Example:
+//
+//	{
+//	  "25": {
+//	    "CommonReadLog": {
+//	      "Handle": 25,
+//	      "StartTimeSeconds": 1704444226,
+//	      "StartTimeNanos": 937309952,
+//	      "ProcessID": 2270282,
+//	      "InodeID": 2,
+//	      "BucketName": "bucket_name",
+//	      "ObjectName": "object/name"
+//	    },
+//	    "Chunks": [
+//	      {
+//	        "StartTimeSeconds": 1704444226,
+//	        "StartTimeNanos": 937457664,
+//	        "RequestID": "310f589d-20bf",
+//	        "Offset": 0,
+//	        "Size": 26214,
+//	        "BlockIndex": 0,
+//	        "ExecutionTime": "1.907320375s"
+//	      },
+//	      ...
+//	    ]
+//	  },
+//	  ...
+//	}
+func ParseBufferedReadLogsFromLogReader(reader io.Reader) (map[int64]*BufferedReadLogEntry, error) {
+	// file-handle to BufferedReadLogEntry map
+	bufferedReadLogsMap := make(map[int64]*BufferedReadLogEntry)
+
+	// opReverseMap is used to map request ID to handle and chunk index.
+	opReverseMap := make(map[string]*handleAndChunkIndex)
+
+	lines, err := loadLogLines(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load log lines: %v", err)
+	}
+
+	for _, line := range lines {
+		if err := filterAndParseLogLineForBufferedRead(line, bufferedReadLogsMap, opReverseMap); err != nil {
+			return nil, fmt.Errorf("filterAndParseLogLineForBufferedRead failed for %s: %v", line, err)
+		}
+	}
+
+	return bufferedReadLogsMap, nil
+}
+
+// filterAndParseLogLineForBufferedRead filters and parses a log line for buffered read logs.
+func filterAndParseLogLineForBufferedRead(
+	logLine string,
+	bufferedReadLogsMap map[int64]*BufferedReadLogEntry,
+	opReverseMap map[string]*handleAndChunkIndex) error {
+
+	jsonLog := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(logLine), &jsonLog); err != nil {
+		log.Printf("filterAndParseLogLineForBufferedRead: failed to unmarshal log line: %s, error: %v", logLine, err)
+		return nil // Silently ignore the bufferedReadLogsMap which are not in JSON format.
+	}
+
+	if _, ok := jsonLog["timestamp"]; !ok {
+		return fmt.Errorf("filterAndParseLogLineForBufferedRead: log line does not contain timestamp: %s", logLine)
+	}
+	timestampSeconds := int64(jsonLog["timestamp"].(map[string]interface{})["seconds"].(float64))
+	timestampNanos := int64(jsonLog["timestamp"].(map[string]interface{})["nanos"].(float64))
+
+	// Log message is expected to be in the "message" field.
+	if _, ok := jsonLog["message"]; !ok {
+		return fmt.Errorf("filterAndParseLogLineForBufferedRead: log line does not contain message: %s", logLine)
+	}
+	logMessage := jsonLog["message"].(string)
+
+	// Parse the logs based on type.
+	switch {
+	case strings.Contains(logMessage, "<- ReadFile"):
+		if err := parseReadFileLogsUsingRegex(timestampSeconds, timestampNanos, logMessage, bufferedReadLogsMap); err != nil {
+			return fmt.Errorf("parseReadFileLog failed: %v", err)
+		}
+	case strings.Contains(logMessage, "<- ReadAt("):
+		if err := parseReadAtRequestLog(timestampSeconds, timestampNanos, logMessage, bufferedReadLogsMap, opReverseMap); err != nil {
+			return fmt.Errorf("parseReadAtLog failed: %v", err)
+		}
+	case strings.Contains(logMessage, "-> ReadAt("):
+		if err := parseReadAtResponseLog(logMessage, bufferedReadLogsMap, opReverseMap); err != nil {
+			return fmt.Errorf("parseReadAtResponseLog failed: %v", err)
+		}
+	}
+	return nil
+}
+
+// parseReadFileLogsUsingRegex parses the ReadFile log using regex and updates the bufferedReadLogsMap map.
+// It extracts the handle, PID, inode ID from the log message.
+func parseReadFileLogsUsingRegex(
+	startTimeStampSec, startTimeStampNanos int64,
+	logMessage string,
+	bufferedReadLogsMap map[int64]*BufferedReadLogEntry) error {
+
+	matches := readFileRegex.FindStringSubmatch(logMessage)
+	if len(matches) != 7 {
+		return fmt.Errorf("invalid ReadFile log format: %s", logMessage)
+	}
+
+	handle, err := parseToInt64(matches[4])
+	if err != nil {
+		return fmt.Errorf("invalid handle: %v", err)
+	}
+	pid, err := parseToInt64(matches[3])
+	if err != nil {
+		return fmt.Errorf("invalid process ID: %v", err)
+	}
+	inodeID, err := parseToInt64(matches[2])
+	if err != nil {
+		return fmt.Errorf("invalid inode ID: %v", err)
+	}
+
+	// ReadFile log entries can come multiple times.
+	// Check if log entry exists in the map for file handle.
+	// If log entry doesn't exist, add it to the map.
+	_, ok := bufferedReadLogsMap[handle]
+	if !ok {
+		bufferedReadLogsMap[handle] = &BufferedReadLogEntry{
+			CommonReadLog: CommonReadLog{
+				Handle:           handle,
+				StartTimeSeconds: startTimeStampSec,
+				StartTimeNanos:   startTimeStampNanos,
+				ProcessID:        pid,
+				InodeID:          inodeID,
+			},
+			Chunks: []BufferedReadChunkData{},
+		}
+	}
+	return nil
+}
+
+// parseReadAtRequestLog parses the ReadAt request log and updates the bufferedReadLogsMap map.
+// It extracts the request ID, offset, size, and block index from the log message.
+// It also populates the bucket and object name if they are not already set in the BufferedReadLogEntry.
+func parseReadAtRequestLog(
+	startTimeStampSec, startTimeStampNanos int64,
+	logMessage string,
+	bufferedReadLogsMap map[int64]*BufferedReadLogEntry,
+	opReverseMap map[string]*handleAndChunkIndex) error {
+
+	matches := readAtReqRegex.FindStringSubmatch(logMessage)
+	if len(matches) != 8 {
+		return fmt.Errorf("invalid ReadAt log format: %s", logMessage)
+	}
+
+	handle, err := parseToInt64(matches[4]) // "1072693248"
+	if err != nil {
+		return fmt.Errorf("invalid handle: %v", err)
+	}
+
+	logEntry, ok := bufferedReadLogsMap[handle]
+	if !ok || logEntry == nil {
+		return fmt.Errorf("BufferedReadLogEntry for handle %d not found", handle)
+	}
+
+	if logEntry.BucketName == "" || logEntry.ObjectName == "" {
+		logEntry.BucketName = matches[2] // "bucket_name"
+		logEntry.ObjectName = matches[3] // "object/name"
+	}
+
+	requestID := matches[1] // "37623d67-b6ee"
+
+	offset, err := parseToInt64(matches[5]) // "0"
+	if err != nil {
+		return fmt.Errorf("invalid offset: %v", err)
+	}
+	size, err := parseToInt64(matches[6]) // "1048576"
+	if err != nil {
+		return fmt.Errorf("invalid size: %v", err)
+	}
+	blockIndex, err := parseToInt64(matches[7]) // "63"
+	if err != nil {
+		return fmt.Errorf("invalid block index: %v", err)
+	}
+
+	chunkData := BufferedReadChunkData{
+		StartTimeSeconds: startTimeStampSec,
+		StartTimeNanos:   startTimeStampNanos,
+		RequestID:        requestID,
+		Offset:           offset,
+		Size:             size,
+		BlockIndex:       blockIndex,
+		ExecutionTime:    "", // Execution time will be filled in the response log.
+	}
+	logEntry.Chunks = append(logEntry.Chunks, chunkData)
+	opReverseMap[requestID] = &handleAndChunkIndex{handle: handle, chunkIndex: len(logEntry.Chunks) - 1}
+	return nil
+}
+
+// parseReadAtResponseLog parses the ReadAt response log and updates the bufferedReadLogsMap map.
+// It extracts the request ID and execution time from the log message.
+// It updates the corresponding chunk in the bufferedReadLogsMap map with the execution time.
+// The request ID is looked up in the opReverseMap to find the corresponding handle and chunk index.
+func parseReadAtResponseLog(
+	logMessage string,
+	bufferedReadLogsMap map[int64]*BufferedReadLogEntry,
+	opReverseMap map[string]*handleAndChunkIndex) error {
+
+	matches := readAtSimpleRespRegex.FindStringSubmatch(logMessage)
+	if len(matches) != 3 {
+		return fmt.Errorf("invalid simple ReadAt response log format: %s", logMessage)
+	}
+
+	requestID := matches[1]     // "d88d347c-1b8c"
+	executionTime := matches[2] // "179.94µs"
+
+	// Look up the request in the reverse map
+	handleAndChunk, exists := opReverseMap[requestID]
+	if !exists {
+		return fmt.Errorf("request ID %s not found in reverse map", requestID)
+	}
+
+	// Update the execution time in the corresponding chunk
+	logEntry := bufferedReadLogsMap[handleAndChunk.handle]
+	if logEntry != nil && handleAndChunk.chunkIndex < len(logEntry.Chunks) {
+		logEntry.Chunks[handleAndChunk.chunkIndex].ExecutionTime = executionTime
+	}
+
+	return nil
+}

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/buffered_read_log_parser_test.go
@@ -1,0 +1,203 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_logs_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/log_parser/json_parser/read_logs"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBufferedReadLogsFromLogReaderSuccessful(t *testing.T) {
+	setup.IgnoreTestIfIntegrationTestFlagIsSet(t)
+
+	tests := []struct {
+		name     string // Name of the test case
+		reader   io.Reader
+		expected map[int64]*read_logs.BufferedReadLogEntry
+	}{
+		{
+			name: "Test buffered read logs with 1 chunk",
+			reader: bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":733110719},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:453] <- ReadFile (inode 2, PID 564246, handle 0, offset 34603008, 1048576 bytes)"}
+{"timestamp":{"seconds":1754207548,"nanos":733199657},"severity":"TRACE","message":"2e4645d9-19a8 <- ReadAt(princer-working-dirs:/10G_file, 0, 34603008, 1048576, 2)"}
+{"timestamp":{"seconds":1754207548,"nanos":733417812},"severity":"TRACE","message":"2e4645d9-19a8 -> ReadAt(): Ok(223.643µs)"}
+{"timestamp":{"seconds":1754207548,"nanos":733444394},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:548] -> ReadFile ()"}`),
+			),
+			expected: map[int64]*read_logs.BufferedReadLogEntry{
+				0: {
+					CommonReadLog: read_logs.CommonReadLog{
+						Handle:           0,
+						StartTimeSeconds: 1754207548,
+						StartTimeNanos:   733110719,
+						ProcessID:        564246,
+						InodeID:          2,
+						BucketName:       "princer-working-dirs",
+						ObjectName:       "10G_file",
+					},
+					Chunks: []read_logs.BufferedReadChunkData{
+						{
+							StartTimeSeconds: 1754207548,
+							StartTimeNanos:   733199657,
+							RequestID:        "2e4645d9-19a8",
+							Offset:           34603008,
+							Size:             1048576,
+							BlockIndex:       2,
+							ExecutionTime:    "223.643µs",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test buffered read logs with multiple chunks",
+			reader: bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":733110719},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:453] <- ReadFile (inode 2, PID 564246, handle 0, offset 34603008, 1048576 bytes)"}
+{"timestamp":{"seconds":1754207548,"nanos":733199657},"severity":"TRACE","message":"2e4645d9-19a8 <- ReadAt(princer-working-dirs:/10G_file, 0, 34603008, 1048576, 2)"}
+{"timestamp":{"seconds":1754207548,"nanos":733417812},"severity":"TRACE","message":"2e4645d9-19a8 -> ReadAt(): Ok(223.643µs)"}
+{"timestamp":{"seconds":1754207548,"nanos":733444394},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:548] -> ReadFile ()"}
+{"timestamp":{"seconds":1754207548,"nanos":733776221},"severity":"TRACE","message":"fuse_debug: Op 0x00000050        connection.go:453] <- ReadFile (inode 2, PID 564246, handle 0, offset 35651584, 1048576 bytes)"}
+{"timestamp":{"seconds":1754207548,"nanos":733853084},"severity":"TRACE","message":"a8517095-54c0 <- ReadAt(princer-working-dirs:/10G_file, 0, 35651584, 1048576, 2)"}
+{"timestamp":{"seconds":1754207548,"nanos":734027808},"severity":"TRACE","message":"a8517095-54c0 -> ReadAt(): Ok(173.476µs)"}
+{"timestamp":{"seconds":1754207548,"nanos":734048914},"severity":"TRACE","message":"fuse_debug: Op 0x00000050        connection.go:548] -> ReadFile ()"}
+{"timestamp":{"seconds":1754207548,"nanos":734299231},"severity":"TRACE","message":"fuse_debug: Op 0x00000052        connection.go:453] <- ReadFile (inode 2, PID 564246, handle 0, offset 36700160, 1048576 bytes)"}
+{"timestamp":{"seconds":1754207548,"nanos":734358133},"severity":"TRACE","message":"4e8b1c9c-0012 <- ReadAt(princer-working-dirs:/10G_file, 0, 36700160, 1048576, 2)"}
+{"timestamp":{"seconds":1754207548,"nanos":734532341},"severity":"TRACE","message":"4e8b1c9c-0012 -> ReadAt(): Ok(179.8µs)"}`),
+			),
+			expected: map[int64]*read_logs.BufferedReadLogEntry{
+				0: {
+					CommonReadLog: read_logs.CommonReadLog{
+						Handle:           0,
+						StartTimeSeconds: 1754207548,
+						StartTimeNanos:   733110719,
+						ProcessID:        564246,
+						InodeID:          2,
+						BucketName:       "princer-working-dirs",
+						ObjectName:       "10G_file",
+					},
+					Chunks: []read_logs.BufferedReadChunkData{
+						{
+							StartTimeSeconds: 1754207548,
+							StartTimeNanos:   733199657,
+							RequestID:        "2e4645d9-19a8",
+							Offset:           34603008,
+							Size:             1048576,
+							BlockIndex:       2,
+							ExecutionTime:    "223.643µs",
+						},
+						{
+							StartTimeSeconds: 1754207548,
+							StartTimeNanos:   733853084,
+							RequestID:        "a8517095-54c0",
+							Offset:           35651584,
+							Size:             1048576,
+							BlockIndex:       2,
+							ExecutionTime:    "173.476µs",
+						},
+						{
+							StartTimeSeconds: 1754207548,
+							StartTimeNanos:   734358133,
+							RequestID:        "4e8b1c9c-0012",
+							Offset:           36700160,
+							Size:             1048576,
+							BlockIndex:       2,
+							ExecutionTime:    "179.8µs",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test buffered read logs with no parsable logs",
+			reader: bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":742190759},"severity":"TRACE","message":"Scheduling block: (10G_file, 9, false)."}
+{"timestamp":{"seconds":1754207548,"nanos":742296187},"severity":"TRACE","message":"Scheduling block: (10G_file, 10, false)."}
+{"timestamp":{"seconds":1754207548,"nanos":742300356},"severity":"TRACE","message":"Download: <- block (10G_file, 9)."}
+{"timestamp":{"seconds":1754207548,"nanos":742315339},"severity":"TRACE","message":"Scheduling block: (10G_file, 11, false)."}
+{"timestamp":{"seconds":1754207548,"nanos":742323114},"severity":"TRACE","message":"Scheduling block: (10G_file, 12, false)."}`),
+			),
+			expected: make(map[int64]*read_logs.BufferedReadLogEntry),
+		},
+		{
+			name:     "Test buffered read logs with no JSON logs",
+			reader:   bytes.NewReader([]byte(`hello 123`)),
+			expected: make(map[int64]*read_logs.BufferedReadLogEntry),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := read_logs.ParseBufferedReadLogsFromLogReader(tc.reader)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual, fmt.Sprintf("Expected: %v, Actual: %v", tc.expected, actual))
+		})
+	}
+}
+
+func TestBufferedReadLogsFromLogReaderUnsuccessful(t *testing.T) {
+	setup.IgnoreTestIfIntegrationTestFlagIsSet(t)
+
+	tests := []struct {
+		name        string // Name of the test case
+		reader      io.Reader
+		errorString string
+	}{
+		{
+			name: "Test buffered read logs without Read File log",
+			reader: bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":733199657},"severity":"TRACE","message":"2e4645d9-19a8 <- ReadAt(princer-working-dirs:/10G_file, 0, 34603008, 1048576, 2)"}
+{"timestamp":{"seconds":1754207548,"nanos":733417812},"severity":"TRACE","message":"2e4645d9-19a8 -> ReadAt(): Ok(223.643µs)"}
+{"timestamp":{"seconds":1754207548,"nanos":733444394},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:548] -> ReadFile ()"}`),
+			),
+			errorString: "BufferedReadLogEntry for handle 0 not found",
+		},
+		{
+			name: "Test buffered read logs response log without request log",
+			reader: bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":733110719},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:453] <- ReadFile (inode 2, PID 564246, handle 0, offset 34603008, 1048576 bytes)"}
+{"timestamp":{"seconds":1754207548,"nanos":733417812},"severity":"TRACE","message":"2e4645d9-19a8 -> ReadAt(): Ok(223.643µs)"}
+{"timestamp":{"seconds":1754207548,"nanos":733444394},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:548] -> ReadFile ()"}`),
+			),
+			errorString: "request ID 2e4645d9-19a8 not found in reverse map",
+		},
+		{
+			name:        "Test invalid read file log - invalid Inode ID",
+			reader:      bytes.NewReader([]byte(`{"timestamp":{"seconds":1754207548,"nanos":733110719},"severity":"TRACE","message":"fuse_debug: Op 0x0000004e        connection.go:453] <- ReadFile (inode abc, PID 564246, handle 0, offset 34603008, 1048576 bytes)"}`)),
+			errorString: "parseReadFileLog failed: invalid ReadFile log",
+		},
+		{
+			name:        "Test invalid read file log - invalid PID",
+			reader:      bytes.NewReader([]byte(`{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity": "TRACE", "message": "fuse_debug: Op 0x00000182        connection.go:415] <- ReadFile (inode 6, PID abc, handle 29, offset 0, 4096 bytes)"}`)),
+			errorString: "parseReadFileLog failed: invalid ReadFile log format",
+		},
+		{
+			name:        "Test invalid read file log - invalid Handle",
+			reader:      bytes.NewReader([]byte(`{"timestamp": {"seconds": 1704458059, "nanos": 975956234}, "severity": "TRACE", "message": "fuse_debug: Op 0x00000182        connection.go:415] <- ReadFile (inode 6, PID 2382526, handle abc, offset 0, 4096 bytes)"}`)),
+			errorString: "parseReadFileLog failed: invalid ReadFile log format",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := read_logs.ParseBufferedReadLogsFromLogReader(tc.reader)
+
+			require.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), tc.errorString), fmt.Sprintf("Unexpected error: %s", err))
+		})
+	}
+}

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/helpers.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/helpers.go
@@ -64,12 +64,14 @@ func parseReadFileLog(startTimeStampSec, startTimeStampNanos int64, logs []strin
 	_, ok := structuredLogs[handle]
 	if !ok {
 		structuredLogs[handle] = &StructuredReadLogEntry{
-			Handle:           handle,
-			StartTimeSeconds: startTimeStampSec,
-			StartTimeNanos:   startTimeStampNanos,
-			ProcessID:        pid,
-			InodeID:          inodeID,
-			Chunks:           []ReadChunkData{},
+			CommonReadLog: CommonReadLog{
+				Handle:           handle,
+				StartTimeSeconds: startTimeStampSec,
+				StartTimeNanos:   startTimeStampNanos,
+				ProcessID:        pid,
+				InodeID:          inodeID,
+			},
+			Chunks: []ReadChunkData{},
 		}
 	}
 	return nil

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/json_read_log_parser_test.go
@@ -75,13 +75,15 @@ func TestParseLogFileSuccessful(t *testing.T) {
 			),
 			expected: map[int64]*read_logs.StructuredReadLogEntry{
 				handleId: {
-					Handle:           handleId,
-					StartTimeSeconds: readTimestampSeconds,
-					StartTimeNanos:   readTimestampNanos,
-					ProcessID:        pid,
-					InodeID:          inodeId,
-					BucketName:       bucketName,
-					ObjectName:       fileName,
+					CommonReadLog: read_logs.CommonReadLog{
+						Handle:           handleId,
+						StartTimeSeconds: readTimestampSeconds,
+						StartTimeNanos:   readTimestampNanos,
+						ProcessID:        pid,
+						InodeID:          inodeId,
+						BucketName:       bucketName,
+						ObjectName:       fileName,
+					},
 					Chunks: []read_logs.ReadChunkData{
 						chunkData,
 					},
@@ -105,13 +107,15 @@ func TestParseLogFileSuccessful(t *testing.T) {
 			),
 			expected: map[int64]*read_logs.StructuredReadLogEntry{
 				29: {
-					Handle:           29,
-					StartTimeSeconds: readTimestampSeconds,
-					StartTimeNanos:   readTimestampNanos,
-					ProcessID:        pid,
-					InodeID:          inodeId,
-					BucketName:       bucketName,
-					ObjectName:       fileName,
+					CommonReadLog: read_logs.CommonReadLog{
+						Handle:           29,
+						StartTimeSeconds: readTimestampSeconds,
+						StartTimeNanos:   readTimestampNanos,
+						ProcessID:        pid,
+						InodeID:          inodeId,
+						BucketName:       bucketName,
+						ObjectName:       fileName,
+					},
 					Chunks: []read_logs.ReadChunkData{
 						chunkData, chunkData, chunkData,
 					},

--- a/tools/integration_tests/util/log_parser/json_parser/read_logs/structure.go
+++ b/tools/integration_tests/util/log_parser/json_parser/read_logs/structure.go
@@ -18,8 +18,7 @@ import (
 	"time"
 )
 
-// StructuredReadLogEntry stores the structured format to be created from logs.
-type StructuredReadLogEntry struct {
+type CommonReadLog struct {
 	Handle           int64
 	StartTimeSeconds int64
 	StartTimeNanos   int64
@@ -27,6 +26,12 @@ type StructuredReadLogEntry struct {
 	InodeID          int64
 	BucketName       string
 	ObjectName       string
+}
+
+// StructuredReadLogEntry stores the structured format to be created from logs.
+type StructuredReadLogEntry struct {
+	CommonReadLog
+
 	// It can be safely assumed that the Chunks will be sorted on timestamp as logs
 	// are parsed in the order of timestamps.
 	Chunks []ReadChunkData
@@ -73,4 +78,20 @@ type handleAndChunkIndex struct {
 type LogEntry struct {
 	Timestamp time.Time `json:"time"`
 	Message   string    `json:"message"`
+}
+
+type BufferedReadLogEntry struct {
+	CommonReadLog
+
+	Chunks []BufferedReadChunkData
+}
+
+type BufferedReadChunkData struct {
+	StartTimeSeconds int64
+	StartTimeNanos   int64
+	RequestID        string
+	Offset           int64
+	Size             int64
+	BlockIndex       int64
+	ExecutionTime    string
 }


### PR DESCRIPTION
### Description
- Implementing parser for buffered read logs. This will be required to write e2e test for buffered-read feature.

### Link to the issue in case of a bug fix.
b/436123285

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
