### PR TITLE
style(fixit): Update precondition/clobbered error logs to include ObjectName

### DIFF
--- a/internal/fs/gcsfuse_errors/gcsfuse_errors.go
+++ b/internal/fs/gcsfuse_errors/gcsfuse_errors.go
@@ -21,11 +21,12 @@ import (
 // FileClobberedError represents a file clobbering scenario where a file was
 // modified or deleted while it was being accessed.
 type FileClobberedError struct {
-	Err error
+	Err      error
+	FileName string
 }
 
 func (fce *FileClobberedError) Error() string {
-	return fmt.Sprintf("The file was modified or deleted by another process, possibly due to concurrent modification: %v", fce.Err)
+	return fmt.Sprintf("The file %q was modified or deleted by another process, possibly due to concurrent modification: %v", fce.FileName, fce.Err)
 }
 
 func (fce *FileClobberedError) Unwrap() error {

--- a/internal/fs/gcsfuse_errors/gcsfuse_errors_test.go
+++ b/internal/fs/gcsfuse_errors/gcsfuse_errors_test.go
@@ -25,24 +25,30 @@ import (
 func TestFileClobberedError(t *testing.T) {
 	testCases := []struct {
 		name       string
+		fileName   string
 		err        error
 		wantErrMsg string
 	}{
 		{
 			name:       "with_underlying_error",
+			fileName:   "foo.txt",
 			err:        fmt.Errorf("some error"),
-			wantErrMsg: "The file was modified or deleted by another process, possibly due to concurrent modification: some error",
+			wantErrMsg: "The file \"foo.txt\" was modified or deleted by another process, possibly due to concurrent modification: some error",
 		},
 		{
 			name:       "without_underlying_error",
+			fileName:   "bar.txt",
 			err:        nil,
-			wantErrMsg: "The file was modified or deleted by another process, possibly due to concurrent modification: <nil>",
+			wantErrMsg: "The file \"bar.txt\" was modified or deleted by another process, possibly due to concurrent modification: <nil>",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clobberedErr := &FileClobberedError{Err: tc.err}
+			clobberedErr := &FileClobberedError{
+				Err:      tc.err,
+				FileName: tc.fileName,
+			}
 
 			gotErrMsg := clobberedErr.Error()
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -263,6 +263,7 @@ func (f *FileInode) openReader(ctx context.Context) (io.ReadCloser, error) {
 	if errors.As(err, &notFoundError) {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("NewReader: %w", err),
+			FileName: f.src.Name,
 		}
 	}
 	if err != nil {
@@ -626,6 +627,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	if errors.As(err, &preconditionErr) {
 		return false, &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("f.bwh.Write(): %w", err),
+			FileName: f.src.Name,
 		}
 	}
 	// Fall back to temp file for Out-Of-Order Writes.
@@ -654,6 +656,7 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 	if errors.As(err, &preconditionErr) {
 		return &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("f.bwh.Flush(): %w", err),
+			FileName: f.src.Name,
 		}
 	}
 	if err != nil {
@@ -677,6 +680,7 @@ func (f *FileInode) SyncPendingBufferedWrites() (gcsSynced bool, err error) {
 	if errors.As(err, &preconditionErr) {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("f.bwh.Sync(): %w", err),
+			FileName: f.src.Name,
 		}
 		return
 	}
@@ -797,6 +801,7 @@ func (f *FileInode) fetchLatestGcsObject(ctx context.Context) (*gcs.Object, erro
 	if isClobbered {
 		return nil, &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("file was clobbered"),
+			FileName: f.src.Name,
 		}
 	}
 	return latestGcsObj, nil
@@ -859,6 +864,7 @@ func (f *FileInode) syncUsingContent(ctx context.Context) error {
 	if errors.As(err, &preconditionErr) {
 		return &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("SyncObject: %w", err),
+			FileName: f.src.Name,
 		}
 	}
 

--- a/internal/fs/wrappers/error_mapping_test.go
+++ b/internal/fs/wrappers/error_mapping_test.go
@@ -95,6 +95,7 @@ func (testSuite *ErrorMapping) TestUnAuthenticatedHttpGoogleApiError() {
 func (testSuite *ErrorMapping) TestFileClobberedErrorWithPreconditionErrCfg() {
 	clobberedErr := &gcsfuse_errors.FileClobberedError{
 		Err: fmt.Errorf("some error"),
+		FileName: "foo.txt",
 	}
 
 	gotErrno := errno(clobberedErr, true)
@@ -105,6 +106,7 @@ func (testSuite *ErrorMapping) TestFileClobberedErrorWithPreconditionErrCfg() {
 func (testSuite *ErrorMapping) TestFileClobberedErrorWithoutPreconditionErrCfg() {
 	clobberedErr := &gcsfuse_errors.FileClobberedError{
 		Err: fmt.Errorf("some error"),
+		FileName: "foo.txt",
 	}
 
 	gotErrno := errno(clobberedErr, false)

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -265,6 +265,7 @@ func (rr *RangeReader) startRead(start int64, end int64) error {
 	if errors.As(err, &notFoundError) {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("NewReader: %w", err),
+			FileName: rr.object.Name,
 		}
 		cancel()
 		return err

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -497,6 +497,7 @@ func (rr *randomReader) startRead(start int64, end int64) (err error) {
 	if errors.As(err, &notFoundError) {
 		err = &gcsfuse_errors.FileClobberedError{
 			Err: fmt.Errorf("NewReader: %w", err),
+			FileName: rr.object.Name,
 		}
 		return
 	}


### PR DESCRIPTION
### Description
This PR adds object names in error logs of FileClobbered method, providing instant context for quicker debugging.


#### Sample Log:
```
"The file \"a/b/c/foo.txt\" was modified or deleted by another process, possibly due to concurrent modification: some error"
```
### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/347849094

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - Ran and passed as 

### Any backward incompatible change? If so, please explain.
