### PR TITLE
fix(rapid appends): Create zero byte reader only for GCS objects

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -143,7 +144,7 @@ func (bh *bucketHandle) StatObject(ctx context.Context,
 		err = fmt.Errorf("error in fetching object attributes: %w", err)
 		return
 	}
-	if attrs.Finalized.IsZero() {
+	if attrs.Finalized.IsZero() && isGCSObject(attrs) {
 		if err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs); err != nil {
 			err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
 			return
@@ -423,7 +424,7 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 			err = fmt.Errorf("error in iterating through objects: %w", err)
 			return
 		}
-		if attrs.Finalized.IsZero() {
+		if attrs.Finalized.IsZero() && isGCSObject(attrs) {
 			if err = bh.fetchLatestSizeOfUnfinalizedObject(ctx, attrs); err != nil {
 				err = fmt.Errorf("failed to fetch the latest size of unfinalized object %q: %w", attrs.Name, err)
 				return
@@ -706,4 +707,13 @@ func (bh *bucketHandle) GCSName(obj *gcs.MinObject) string {
 
 func isStorageConditionsNotEmpty(conditions storage.Conditions) bool {
 	return conditions != (storage.Conditions{})
+}
+
+// isGCSObject determines whether the GCS resource represented by attrs is a GCS object
+// and not a folder/directory resource.
+func isGCSObject(attrs *storage.ObjectAttrs) bool {
+	if !strings.HasSuffix(attrs.Name, "/") && attrs.Prefix == "" && attrs.Name != "" {
+		return true
+	}
+	return false
 }

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1624,3 +1624,29 @@ func (testSuite *BucketHandleTest) TestCreateFolderWithGivenName() {
 	assert.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), gcs.GCSFolder(TestBucketName, &mockFolder), folder)
 }
+
+func (testSuite *BucketHandleTest) TestIsGCSObject() {
+	testCases := []struct {
+		name     string
+		attrs    *storage.ObjectAttrs
+		expected bool
+	}{
+		{
+			name:     "gcsObject",
+			attrs:    &storage.ObjectAttrs{Name: "a/b/c.txt", Prefix: ""},
+			expected: true,
+		},
+		{
+			name:     "gcsFolder",
+			attrs:    &storage.ObjectAttrs{Name: "", Prefix: "a/"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			actual := isGCSObject(tc.attrs)
+			assert.Equal(testSuite.T(), tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
### Description
The ListObjects/StatObject API for unfinalized object returns incorrect object size of 0. As a workaround, we introduced a zero-byte reader approach to correctly figure out the object size as a temporary fix. However, due to lack of proper conditions in place, we were attempting to create the reader for folders/directories as well , which led to input/output error while listing,hence, leading to E2E test failures.

Background for the condition in place:
- For GCS object, the `attrs.Name` field is the complete object name (for e.g. `a/b/c.txt`) and the prefix is empty.
- For folder like resource, the `attrs.Name` field is empty and the `attrs.Prefix` is the folder path with a trailing backslash, for e.g. a/b/

### Link to the issue in case of a bug fix.
[b/436190643](b/436190643)

### Testing details
1. Manual - Yes.
2. Unit tests - Added.
3. Integration tests - Tested as part of PR#3622.

### Any backward incompatible change? If so, please explain.
