### PR TITLE
chore(rapid appends): Enable rapid appends flag by default

### DIFF
--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -822,19 +822,18 @@
   usage: "For a new file, it creates an empty file in Cloud Storage bucket as a hold."
   default: false
 
+- config-path: "write.enable-rapid-appends"
+  flag-name: "enable-rapid-appends"
+  type: "bool"
+  usage: "Enables support for appends to unfinalized object using streaming writes"
+  default: true
+
 - config-path: "write.enable-streaming-writes"
   flag-name: "enable-streaming-writes"
   type: "bool"
   usage: "Enables streaming uploads during write file operation."
   default: true
   hide-flag: false
-
-- config-path: "write.experimental-enable-rapid-appends"
-  flag-name: "write-experimental-enable-rapid-appends"
-  type: "bool"
-  usage: "Enables support for appends to unfinalized object using streaming writes"
-  default: false
-  hide-flag: true
 
 - config-path: "write.global-max-blocks"
   flag-name: "write-global-max-blocks"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -194,7 +194,9 @@ func TestValidateConfigFile_WriteConfig(t *testing.T) {
 					BlockSizeMb:           32 * util.MiB,
 					EnableStreamingWrites: true,
 					GlobalMaxBlocks:       4,
-					MaxBlocksPerFile:      1},
+					MaxBlocksPerFile:      1,
+					EnableRapidAppends:    true,
+				},
 			},
 		},
 		{

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -99,7 +99,7 @@ be interacting with the file system.`)
 		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.
 		ChunkTransferTimeoutSecs:           newConfig.GcsRetries.ChunkTransferTimeoutSecs,
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
-		ExperimentalEnableRapidAppends:     newConfig.Write.ExperimentalEnableRapidAppends,
+		ExperimentalEnableRapidAppends:     newConfig.Write.EnableRapidAppends,
 	}
 	bm := gcsx.NewBucketManager(bucketCfg, storageHandle)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -311,8 +311,8 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteMaxBlocksPerFile:          1,
 		},
 		{
-			name:                                   "Test experimental-enable-rapid-appends flag true.",
-			args:                                   []string{"gcsfuse", "--write-experimental-enable-rapid-appends", "abc", "pqr"},
+			name:                                   "Test enable-rapid-appends flag true.",
+			args:                                   []string{"gcsfuse", "--enable-rapid-appends", "abc", "pqr"},
 			expectedCreateEmptyFile:                false,
 			expectedEnableStreamingWrites:          true,
 			expectedExperimentalEnableRapidAppends: true,

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -12,6 +12,7 @@ write:
   global-max-blocks: 20
   block-size-mb: 10
   max-blocks-per-file: 2
+  enable-rapid-appends: false
 file-cache:
   cache-file-for-range-read: true
   download-chunk-size-mb: 300

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2931,7 +2931,7 @@ func (fs *fileSystem) WriteFile(
 		}
 		return err
 	}
-	if fs.newConfig.Write.ExperimentalEnableRapidAppends {
+	if fs.newConfig.Write.EnableRapidAppends {
 		// Serve the request via the file handle.
 		gcsSynced, err = fh.Write(ctx, op.Data, op.Offset)
 	} else {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -1064,7 +1064,7 @@ func (f *FileInode) areBufferedWritesSupported(openMode util.OpenMode, obj *gcs.
 	if f.local || obj.Size == 0 {
 		return true
 	}
-	if !f.config.Write.ExperimentalEnableRapidAppends {
+	if !f.config.Write.EnableRapidAppends {
 		return false
 	}
 	if openMode == util.Append && f.bucket.BucketType().Zonal && obj.Finalized.IsZero() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -246,7 +246,7 @@ func (t *FileTest) TestAreBufferedWritesSupported() {
 		object.Finalized = tc.finalized
 		t.backingObj = storageutil.ConvertObjToMinObject(object)
 		t.createInode()
-		t.in.config.Write.ExperimentalEnableRapidAppends = true
+		t.in.config.Write.EnableRapidAppends = true
 
 		isSupported := t.in.areBufferedWritesSupported(tc.openMode, object)
 
@@ -1898,9 +1898,9 @@ func getWriteConfig() *cfg.WriteConfig {
 
 func getWriteConfigWithEnabledRapidAppends() *cfg.WriteConfig {
 	return &cfg.WriteConfig{
-		MaxBlocksPerFile:               10,
-		BlockSizeMb:                    10,
-		EnableStreamingWrites:          true,
-		ExperimentalEnableRapidAppends: true,
+		MaxBlocksPerFile:      10,
+		BlockSizeMb:           10,
+		EnableStreamingWrites: true,
+		EnableRapidAppends:    true,
 	}
 }

--- a/tools/integration_tests/rapid_appends/appends_test.go
+++ b/tools/integration_tests/rapid_appends/appends_test.go
@@ -42,7 +42,7 @@ func (t *DualMountAppendsSuite) TestAppendSessionInvalidatedByAnotherClientUponT
 	const initialContent = "dummy content"
 	const appendContent = "appended content"
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		var err error
 		func() {
@@ -99,7 +99,7 @@ func (t *SingleMountAppendsSuite) TestContentAppendedInNonAppendModeNotVisibleTi
 	t.T().Skip()
 
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		func() {
 			t.mountPrimaryMount(flags)
@@ -143,7 +143,7 @@ func (t *SingleMountAppendsSuite) TestContentAppendedInNonAppendModeNotVisibleTi
 func (t *SingleMountAppendsSuite) TestAppendsToFinalizedObjectNotVisibleUntilClose() {
 	const initialContent = "dummy content"
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		func() {
 			t.mountPrimaryMount(flags)
@@ -184,7 +184,7 @@ func (t *SingleMountAppendsSuite) TestAppendsToFinalizedObjectNotVisibleUntilClo
 func (t *SingleMountAppendsSuite) TestAppendsVisibleInRealTimeWithConcurrentRPlusHandle() {
 	const initialContent = "dummy content"
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		func() {
 			t.mountPrimaryMount(flags)
@@ -238,7 +238,7 @@ func (t *SingleMountAppendsSuite) TestRandomWritesVisibleAfterCloseWithConcurren
 
 	const initialContent = "dummy content"
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		func() {
 			t.mountPrimaryMount(flags)
@@ -291,7 +291,7 @@ func (t *SingleMountAppendsSuite) TestFallbackHappensWhenNonAppendHandleDoesFirs
 	t.T().Skip()
 
 	for _, flags := range [][]string{
-		{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"},
+		{"--enable-rapid-appends=true", "--write-block-size-mb=1"},
 	} {
 		func() {
 			t.mountPrimaryMount(flags)
@@ -336,7 +336,7 @@ func (t *SingleMountAppendsSuite) TestFallbackHappensWhenNonAppendHandleDoesFirs
 
 func (t *SingleMountAppendsSuite) TestKernelShouldSeeUpdatedSizeOnAppends() {
 	const initialContent = "dummy content"
-	flags := []string{"--write-experimental-enable-rapid-appends=true", "--write-block-size-mb=1"}
+	flags := []string{"--enable-rapid-appends=true", "--write-block-size-mb=1"}
 	log.Printf("Running test with flags: %v", flags)
 
 	testCases := []struct {

--- a/tools/integration_tests/rapid_appends/reads_after_appends_test.go
+++ b/tools/integration_tests/rapid_appends/reads_after_appends_test.go
@@ -108,19 +108,19 @@ func (t *CommonAppendsSuite) TestAppendsAndReads() {
 		// all cache disabled
 		enableMetadataCache: false,
 		enableFileCache:     false,
-		flags:               []string{"--write-experimental-enable-rapid-appends=true", "--write-global-max-blocks=-1", "--metadata-cache-ttl-secs=0"},
+		flags:               []string{"--enable-rapid-appends=true", "--write-global-max-blocks=-1", "--metadata-cache-ttl-secs=0"},
 	}, {
 		enableMetadataCache: true,
 		enableFileCache:     false,
-		flags:               []string{"--write-experimental-enable-rapid-appends=true", "--write-global-max-blocks=-1", metadataCacheEnableFlag},
+		flags:               []string{"--enable-rapid-appends=true", "--write-global-max-blocks=-1", metadataCacheEnableFlag},
 	}, {
 		enableMetadataCache: true,
 		enableFileCache:     true,
-		flags:               []string{"--write-experimental-enable-rapid-appends=true", "--write-global-max-blocks=-1", metadataCacheEnableFlag, "--file-cache-max-size-mb=-1", fileCacheDirFlag()},
+		flags:               []string{"--enable-rapid-appends=true", "--write-global-max-blocks=-1", metadataCacheEnableFlag, "--file-cache-max-size-mb=-1", fileCacheDirFlag()},
 	}, {
 		enableMetadataCache: false,
 		enableFileCache:     true,
-		flags:               []string{"--write-experimental-enable-rapid-appends=true", "--write-global-max-blocks=-1", "--metadata-cache-ttl-secs=0", "--file-cache-max-size-mb=-1", fileCacheDirFlag()},
+		flags:               []string{"--enable-rapid-appends=true", "--write-global-max-blocks=-1", "--metadata-cache-ttl-secs=0", "--file-cache-max-size-mb=-1", fileCacheDirFlag()},
 	}} {
 		func() {
 			t.mountPrimaryMount(scenario.flags)

--- a/tools/integration_tests/rapid_appends/suites_test.go
+++ b/tools/integration_tests/rapid_appends/suites_test.go
@@ -39,7 +39,7 @@ type mountPoint struct {
 
 var (
 	// TODO(b/432179045): `--write-global-max-blocks=-1` is needed right now because of a bug in global semaphore release.
-	secondaryMountFlags = []string{"--write-experimental-enable-rapid-appends=true", "--write-global-max-blocks=-1"}
+	secondaryMountFlags = []string{"--enable-rapid-appends=true", "--write-global-max-blocks=-1"}
 )
 
 // //////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -54,20 +54,15 @@ func (t *unfinalizedObjectOperations) TeardownTest() {}
 // Test scenarios
 ////////////////////////////////////////////////////////////////////////
 
-func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedOutsideOfMountReports0Size() {
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCreatedOutsideOfMountReportsNonZeroSize() {
 	size := operations.MiB
 	writer := client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, t.fileName), setup.GenerateRandomString(size))
+	defer writer.Close()
 
 	statRes, err := operations.StatFile(path.Join(t.testDirPath, t.fileName))
 
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), t.fileName, (*statRes).Name())
-	assert.EqualValues(t.T(), 0, (*statRes).Size())
-	// After object is finalized, correct size should be reported.
-	err = writer.Close()
-	require.NoError(t.T(), err)
-	statRes, err = operations.StatFile(path.Join(t.testDirPath, t.fileName))
-	require.NoError(t.T(), err)
 	assert.EqualValues(t.T(), size, (*statRes).Size())
 }
 


### PR DESCRIPTION
### Description
Enabling the experimental rapid-appends flag by default. As a consequence of this, the default attempt to append to unfinalized objects will be via streaming-writes flow, instead of legacy flow. The behavior can be modified by passing
`--enable-rapid-appends=false`


### Link to the issue in case of a bug fix.
[b/435591910](b/435591910)
### Testing details
1. Manual - yes
2. Unit tests - Pre-existing.
3. Integration tests - Automated.

### Any backward incompatible change? If so, please explain.

