### PR TITLE
fix: Add flag check in accessing moveObject API for flat bucket

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2557,7 +2557,7 @@ func (fs *fileSystem) renameNonHierarchicalDir(
 
 		o := descendant.MinObject
 		// If the descendant is a directory (ExplicitDirType) or has an unknown type, handle it by cloning and deleting.
-		if descendant.Type() == metadata.ExplicitDirType || descendant.Type() == metadata.UnknownType {
+		if !fs.enableAtomicRenameObject || descendant.Type() == metadata.ExplicitDirType || descendant.Type() == metadata.UnknownType {
 			if _, err = newDir.CloneToChildFile(ctx, nameDiff, o); err != nil {
 				return fmt.Errorf("copy file %q: %w", o.Name, err)
 			}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2556,8 +2556,10 @@ func (fs *fileSystem) renameNonHierarchicalDir(
 		}
 
 		o := descendant.MinObject
-		// If the descendant is a directory (ExplicitDirType) or has an unknown type, handle it by cloning and deleting.
-		if !fs.enableAtomicRenameObject || descendant.Type() == metadata.ExplicitDirType || descendant.Type() == metadata.UnknownType {
+		// Use copy-delete if atomic rename is disabled, or if the object is a directory or of unknown type.
+		// Otherwise, for files with atomic rename enabled, use move.
+		isDirOrUnknown := descendant.Type() == metadata.ExplicitDirType || descendant.Type() == metadata.UnknownType
+		if !fs.enableAtomicRenameObject || isDirOrUnknown {
 			if _, err = newDir.CloneToChildFile(ctx, nameDiff, o); err != nil {
 				return fmt.Errorf("copy file %q: %w", o.Name, err)
 			}


### PR DESCRIPTION
### Description
Add flag check in accessing moveObject API for flat bucket in renaming directory.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Automated
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
