### PR TITLE
feat(buffered-read): use blockPool's tryGet (unblocking) instead Get to 

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -383,8 +383,7 @@ func (p *BufferedReader) freshStart(currentOffset int64) error {
 
 // scheduleNextBlock schedules the next block for prefetch.
 func (p *BufferedReader) scheduleNextBlock(urgent bool) error {
-	// TODO(b/426060431): Replace Get() with TryGet(). Assuming, the current blockPool.Get() gets blocked if block is not available.
-	b, err := p.blockPool.Get()
+	b, err := p.blockPool.TryGet()
 	if err != nil || b == nil {
 		if err != nil {
 			logger.Warnf("scheduleNextBlock: failed to get block from pool: %v", err)


### PR DESCRIPTION
### Description
- Using TryGet (unblocking) instead of Get (blocking) to avoid deadlock when blockPool is fully utilized.

### Link to the issue in case of a bug fix.
b/433678041

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
