### PR TITLE
feat(block-pool): adding reserved block support in block-pool

### DIFF
--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -36,7 +36,7 @@ func TestBlockPoolTestSuite(t *testing.T) {
 }
 
 func (t *BlockPoolTest) TestInitBlockPool() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), bp)
@@ -46,28 +46,28 @@ func (t *BlockPoolTest) TestInitBlockPool() {
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForZeroBlockSize() {
-	_, err := NewGenBlockPool(0, 10, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(0, 10, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 0, 10), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForNegativeBlockSize() {
-	_, err := NewGenBlockPool(-1, 10, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(-1, 10, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, -1, 10), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForZeroMaxBlocks() {
-	_, err := NewGenBlockPool(10, 0, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(10, 0, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 10, 0), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForNegativeMaxBlocks() {
-	_, err := NewGenBlockPool(10, -1, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(10, -1, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 10, -1), err)
@@ -75,7 +75,7 @@ func (t *BlockPoolTest) TestInitBlockPoolForNegativeMaxBlocks() {
 
 // Represents when block is available on the freeBlocksCh.
 func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
@@ -93,7 +93,7 @@ func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 
 	block, err := bp.TryGet()
@@ -105,7 +105,7 @@ func (t *BlockPoolTest) TestTryGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
 
 func (t *BlockPoolTest) TestTryGetToCreateLargeBlock() {
 	// Creating block of size 1TB
-	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 
 	_, err = bp.TryGet()
@@ -116,7 +116,7 @@ func (t *BlockPoolTest) TestTryGetToCreateLargeBlock() {
 
 // Represents when block is available on the freeBlocksCh.
 func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
@@ -134,7 +134,7 @@ func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 }
 
 func (t *BlockPoolTest) TestGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 
 	block, err := bp.Get()
@@ -146,7 +146,7 @@ func (t *BlockPoolTest) TestGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
 
 func (t *BlockPoolTest) TestCreateBlockWithLargeSize() {
 	// Creating block of size 1TB
-	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 
 	_, err = bp.Get()
@@ -156,7 +156,7 @@ func (t *BlockPoolTest) TestCreateBlockWithLargeSize() {
 }
 
 func (t *BlockPoolTest) TestBlockSize() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(1024), bp.BlockSize())
@@ -182,7 +182,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func() {
-			bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(4), createBlock)
+			bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(4), createBlock)
 			require.Nil(t.T(), err)
 			blocks := make([]Block, 4)
 			for i := 0; i < 4; i++ {
@@ -209,7 +209,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannel() {
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannelWhenTotalBlocksIsZero() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(1), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(1), createBlock)
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(0), bp.totalBlocks)
 
@@ -225,7 +225,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWhenTotalBlocksIsZero() {
 func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
 	globalBlocksSem := semaphore.NewWeighted(1)
 
-	bp, err := NewGenBlockPool(1024, 3, globalBlocksSem, createBlock)
+	bp, err := NewGenBlockPool(1024, 3, 1, globalBlocksSem, createBlock)
 
 	require.Nil(t.T(), err)
 	// Validate that semaphore got acquired.
@@ -249,9 +249,9 @@ func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
 
 func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 	globalMaxBlocksSem := semaphore.NewWeighted(3)
-	bp1, err := NewGenBlockPool(1024, 3, globalMaxBlocksSem, createBlock)
+	bp1, err := NewGenBlockPool(1024, 3, 1, globalMaxBlocksSem, createBlock)
 	require.Nil(t.T(), err)
-	bp2, err := NewGenBlockPool(1024, 3, globalMaxBlocksSem, createBlock)
+	bp2, err := NewGenBlockPool(1024, 3, 1, globalMaxBlocksSem, createBlock)
 	require.Nil(t.T(), err)
 	// Create 2 blocks in bp1.
 	b1 := t.validateGetBlockIsNotBlocked(bp1)
@@ -282,7 +282,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 }
 
 func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(0), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(0), createBlock)
 
 	require.Error(t.T(), err)
 	assert.Nil(t.T(), bp)
@@ -290,7 +290,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(2), createBlock)
 	require.Nil(t.T(), err)
 	// 2 blocks can be created.
 	b1, err1 := bp.TryGet()
@@ -309,7 +309,7 @@ func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 
@@ -321,7 +321,7 @@ func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
 }
 
 func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(2), createBlock)
 	require.Nil(t.T(), err)
 
 	// 2 blocks can be created.
@@ -334,7 +334,7 @@ func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 
@@ -440,6 +440,81 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			got := bp.canAllocateBlock()
 
 			assert.Equal(t.T(), tt.expected, got)
+		})
+	}
+}
+
+func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksSuccess() {
+	tests := []struct {
+		name           string
+		reservedBlocks int64
+		maxBlocks      int64
+	}{
+		{
+			name:           "zero_reserved_blocks",
+			reservedBlocks: 0,
+			maxBlocks:      10,
+		},
+		{
+			name:           "one_reserved_block",
+			reservedBlocks: 1,
+			maxBlocks:      10,
+		},
+		{
+			name:           "two_reserved_blocks",
+			reservedBlocks: 2,
+			maxBlocks:      10,
+		},
+		{
+			name:           "max_blocks_equal_to_reserved_blocks",
+			reservedBlocks: 10,
+			maxBlocks:      10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func() {
+			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, semaphore.NewWeighted(20), createBlock)
+
+			require.NoError(t.T(), err)
+			require.NotNil(t.T(), bp)
+		})
+	}
+}
+
+func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksFailure() {
+	tests := []struct {
+		name            string
+		reservedBlocks  int64
+		maxBlocks       int64
+		globalMaxBlocks int64
+	}{
+		{
+			name:            "reserved_blocks_greater_than_max_blocks",
+			reservedBlocks:  11,
+			maxBlocks:       10,
+			globalMaxBlocks: 20,
+		},
+		{
+			name:            "negative_reserved_blocks",
+			reservedBlocks:  -1,
+			maxBlocks:       10,
+			globalMaxBlocks: 20,
+		},
+		{
+			name:            "reserved_blocks_greater_than_global_max_blocks",
+			reservedBlocks:  7,
+			maxBlocks:       7,
+			globalMaxBlocks: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func() {
+			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, semaphore.NewWeighted(tt.globalMaxBlocks), createBlock)
+
+			require.Error(t.T(), err)
+			assert.Nil(t.T(), bp)
 		})
 	}
 }

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -94,7 +94,8 @@ type BufferedReader struct {
 
 // NewBufferedReader returns a new bufferedReader instance.
 func NewBufferedReader(object *gcs.MinObject, bucket gcs.Bucket, config *BufferedReadConfig, globalMaxBlocksSem *semaphore.Weighted, workerPool workerpool.WorkerPool, metricHandle metrics.MetricHandle) (*BufferedReader, error) {
-	blockpool, err := block.NewPrefetchBlockPool(config.PrefetchBlockSizeBytes, config.MaxPrefetchBlockCnt, globalMaxBlocksSem)
+	// TODO: To pass the minimum required block-count based on the block-size.
+	blockpool, err := block.NewPrefetchBlockPool(config.PrefetchBlockSizeBytes, config.MaxPrefetchBlockCnt, 2, globalMaxBlocksSem)
 	if err != nil {
 		return nil, fmt.Errorf("NewBufferedReader: failed to create block-pool: %w", err)
 	}

--- a/internal/bufferedread/download_task_test.go
+++ b/internal/bufferedread/download_task_test.go
@@ -59,7 +59,7 @@ func (dts *DownloadTaskTestSuite) SetupTest() {
 	}
 	dts.mockBucket = new(storage.TestifyMockBucket)
 	var err error
-	dts.blockPool, err = block.NewPrefetchBlockPool(testBlockSize, 10, semaphore.NewWeighted(100))
+	dts.blockPool, err = block.NewPrefetchBlockPool(testBlockSize, 10, 1, semaphore.NewWeighted(100))
 	require.NoError(dts.T(), err, "Failed to create block pool")
 }
 

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -101,7 +101,7 @@ type CreateBWHandlerRequest struct {
 
 // NewBWHandler creates the bufferedWriteHandler struct.
 func NewBWHandler(req *CreateBWHandlerRequest) (bwh BufferedWriteHandler, err error) {
-	bp, err := block.NewBlockPool(req.BlockSize, req.MaxBlocksPerFile, req.GlobalMaxBlocksSem)
+	bp, err := block.NewBlockPool(req.BlockSize, req.MaxBlocksPerFile, 1, req.GlobalMaxBlocksSem)
 	if err != nil {
 		return
 	}

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -54,7 +54,7 @@ func TestUploadHandlerTestSuite(t *testing.T) {
 func (t *UploadHandlerTest) SetupTest() {
 	t.mockBucket = new(storagemock.TestifyMockBucket)
 	var err error
-	t.blockPool, err = block.NewBlockPool(blockSize, maxBlocks, semaphore.NewWeighted(maxBlocks))
+	t.blockPool, err = block.NewBlockPool(blockSize, maxBlocks, 1, semaphore.NewWeighted(maxBlocks))
 	require.NoError(t.T(), err)
 	t.uh = newUploadHandler(&CreateUploadHandlerRequest{
 		Object:                   nil,


### PR DESCRIPTION
### Description
Adding support to reserve x number of blocks while creation, returns error in case this number of blocks is not available in the globalMaxPool.

### Link to the issue in case of a bug fix.
TODO

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
