### PR TITLE
chore: clean up timeout from MRD

### DIFF
--- a/internal/gcsx/client_readers/multi_range_reader.go
+++ b/internal/gcsx/client_readers/multi_range_reader.go
@@ -19,18 +19,12 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
-	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
-
-// TimeoutForMultiRangeRead is the timeout value for multi-range read operations.
-//
-// TODO(b/385826024): Revert timeout to an appropriate value. This value is currently a placeholder and needs to be adjusted.
-const TimeoutForMultiRangeRead = time.Hour
 
 type MultiRangeReader struct {
 	gcsx.GCSReader
@@ -69,7 +63,7 @@ func NewMultiRangeReader(object *gcs.MinObject, metricHandle metrics.MetricHandl
 // Returns:
 //   - int: The number of bytes read.
 //   - error: An error if the read operation fails.
-func (mrd *MultiRangeReader) readFromMultiRangeReader(ctx context.Context, p []byte, offset, end int64, timeout time.Duration) (int, error) {
+func (mrd *MultiRangeReader) readFromMultiRangeReader(ctx context.Context, p []byte, offset, end int64) (int, error) {
 	if mrd.mrdWrapper == nil {
 		return 0, fmt.Errorf("readFromMultiRangeReader: Invalid MultiRangeDownloaderWrapper")
 	}
@@ -93,7 +87,7 @@ func (mrd *MultiRangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequ
 		return readerResponse, err
 	}
 
-	readerResponse.Size, err = mrd.readFromMultiRangeReader(ctx, req.Buffer, req.Offset, req.EndOffset, TimeoutForMultiRangeRead)
+	readerResponse.Size, err = mrd.readFromMultiRangeReader(ctx, req.Buffer, req.Offset, req.EndOffset)
 
 	return readerResponse, err
 }

--- a/internal/gcsx/client_readers/multi_range_reader.go
+++ b/internal/gcsx/client_readers/multi_range_reader.go
@@ -78,7 +78,7 @@ func (mrd *MultiRangeReader) readFromMultiRangeReader(ctx context.Context, p []b
 		mrd.mrdWrapper.IncrementRefCount()
 	}
 
-	return mrd.mrdWrapper.Read(ctx, p, offset, end, timeout, mrd.metricHandle)
+	return mrd.mrdWrapper.Read(ctx, p, offset, end, mrd.metricHandle)
 }
 
 func (mrd *MultiRangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (gcsx.ReaderResponse, error) {

--- a/internal/gcsx/client_readers/multi_range_reader_test.go
+++ b/internal/gcsx/client_readers/multi_range_reader_test.go
@@ -105,7 +105,7 @@ func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_ReadFull() {
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
 			buf := make([]byte, tc.dataSize+tc.extraSize)
 
-			bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, 0, int64(t.object.Size), TestTimeoutForMultiRangeRead)
+			bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, 0, int64(t.object.Size))
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.dataSize, bytesRead)
@@ -114,29 +114,10 @@ func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_ReadFull() {
 	}
 }
 
-func (t *multiRangeReaderTest) TestReadFromMultiRangeReaderTimeoutUnimplemented() {
-	t.multiRangeReader.isMRDInUse.Store(false)
-	dataSize := 100
-	t.object.Size = uint64(dataSize)
-	testContent := testUtil.GenerateRandomBytes(int(t.object.Size))
-	fakeMRDWrapper, err := gcsx.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{}, &cfg.Config{})
-	require.NoError(t.T(), err, "Error in creating MRDWrapper")
-	t.multiRangeReader.mrdWrapper = &fakeMRDWrapper
-	sleepTime := 10 * time.Millisecond
-	timeout := 5 * time.Millisecond
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, sleepTime)).Once()
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Once()
-	buf := make([]byte, dataSize)
-
-	_, err = t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, 0, int64(t.object.Size), timeout)
-
-	assert.NoError(t.T(), err)
-}
-
 func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_NilMRDWrapper() {
 	t.multiRangeReader.mrdWrapper = nil
 
-	bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), TestTimeoutForMultiRangeRead)
+	bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, make([]byte, t.object.Size), 0, int64(t.object.Size))
 
 	assert.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "readFromMultiRangeReader: Invalid MultiRangeDownloaderWrapper")
@@ -168,7 +149,7 @@ func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_ReadChunk() {
 		t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
 		buf := make([]byte, tc.end-tc.start)
 
-		bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, int64(tc.start), int64(tc.end), TestTimeoutForMultiRangeRead)
+		bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, int64(tc.start), int64(tc.end))
 
 		assert.NoError(t.T(), err)
 		assert.Equal(t.T(), tc.end-tc.start, bytesRead)

--- a/internal/gcsx/client_readers/multi_range_reader_test.go
+++ b/internal/gcsx/client_readers/multi_range_reader_test.go
@@ -114,7 +114,7 @@ func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_ReadFull() {
 	}
 }
 
-func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_TimeoutExceeded() {
+func (t *multiRangeReaderTest) TestReadFromMultiRangeReaderTimeoutUnimplemented() {
 	t.multiRangeReader.isMRDInUse.Store(false)
 	dataSize := 100
 	t.object.Size = uint64(dataSize)
@@ -130,29 +130,7 @@ func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_TimeoutExceeded() {
 
 	_, err = t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, 0, int64(t.object.Size), timeout)
 
-	assert.Error(t.T(), err)
-	assert.ErrorContains(t.T(), err, "timeout")
-}
-
-func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_TimeoutNotExceeded() {
-	t.multiRangeReader.isMRDInUse.Store(false)
-	dataSize := 100
-	t.object.Size = uint64(dataSize)
-	testContent := testUtil.GenerateRandomBytes(int(t.object.Size))
-	fakeMRDWrapper, err := gcsx.NewMultiRangeDownloaderWrapperWithClock(t.mockBucket, t.object, &clock.FakeClock{}, &cfg.Config{})
-	require.NoError(t.T(), err, "Error in creating MRDWrapper")
-	t.multiRangeReader.mrdWrapper = &fakeMRDWrapper
-	sleepTime := 2 * time.Millisecond
-	timeout := 5 * time.Millisecond
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, sleepTime)).Once()
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Once()
-	buf := make([]byte, dataSize)
-
-	bytesRead, err := t.multiRangeReader.readFromMultiRangeReader(t.ctx, buf, 0, int64(t.object.Size), timeout)
-
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), dataSize, bytesRead)
-	assert.Equal(t.T(), testContent[:dataSize], buf[:bytesRead])
 }
 
 func (t *multiRangeReaderTest) Test_ReadFromMultiRangeReader_NilMRDWrapper() {

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -194,8 +194,7 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) ensureMultiRangeDownloader() (err
 }
 
 // Reads the data using MultiRangeDownloader.
-func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []byte,
-	startOffset int64, endOffset int64, timeout time.Duration, metricHandle metrics.MetricHandle) (bytesRead int, err error) {
+func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []byte, startOffset int64, endOffset int64, metricHandle metrics.MetricHandle) (bytesRead int, err error) {
 	// Bidi Api with 0 as read_limit means no limit whereas we do not want to read anything with empty buffer.
 	// Hence, handling it separately.
 	if len(buf) == 0 {
@@ -242,8 +241,6 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 
 	if !mrdWrapper.config.FileSystem.IgnoreInterrupts {
 		select {
-		case <-time.After(timeout):
-			err = fmt.Errorf("timeout")
 		case <-ctx.Done():
 			err = ctx.Err()
 		case res := <-done:

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -159,7 +159,7 @@ func (t *mrdWrapperTest) Test_Read() {
 			t.mrdWrapper.Wrapped = nil
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond))
 
-			bytesRead, err := t.mrdWrapper.Read(context.Background(), buf, int64(tc.start), int64(tc.end), 10*time.Millisecond, metrics.NewNoopMetrics())
+			bytesRead, err := t.mrdWrapper.Read(context.Background(), buf, int64(tc.start), int64(tc.end), metrics.NewNoopMetrics())
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.end-tc.start, bytesRead)
@@ -172,19 +172,9 @@ func (t *mrdWrapperTest) Test_Read_ErrorInCreatingMRD() {
 	t.mrdWrapper.Wrapped = nil
 	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("Error in creating MRD")).Once()
 
-	bytesRead, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
+	bytesRead, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics())
 
 	assert.ErrorContains(t.T(), err, "MultiRangeDownloaderWrapper::Read: Error in creating MultiRangeDownloader")
-	assert.Equal(t.T(), 0, bytesRead)
-}
-
-func (t *mrdWrapperTest) Test_Read_Timeout() {
-	t.mrdWrapper.Wrapped = nil
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, t.mrdTimeout+2*time.Millisecond), nil).Once()
-
-	bytesRead, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
-
-	assert.ErrorContains(t.T(), err, "timeout")
 	assert.Equal(t.T(), 0, bytesRead)
 }
 
@@ -195,7 +185,7 @@ func (t *mrdWrapperTest) TestReadContextCancelledWithInterruptsEnabled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
+	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics())
 
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "context canceled")
@@ -208,7 +198,7 @@ func (t *mrdWrapperTest) TestReadContextCancelledWithInterruptsDisabled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
+	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics())
 
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), 100, bytesRead)
@@ -218,7 +208,7 @@ func (t *mrdWrapperTest) Test_Read_EOF() {
 	t.mrdWrapper.Wrapped = nil
 	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleepAndDefaultError(t.object, t.objectData, time.Microsecond, io.EOF), nil).Once()
 
-	_, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
+	_, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics())
 
 	assert.ErrorIs(t.T(), err, io.EOF)
 }
@@ -227,7 +217,7 @@ func (t *mrdWrapperTest) Test_Read_Error() {
 	t.mrdWrapper.Wrapped = nil
 	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleepAndDefaultError(t.object, t.objectData, time.Microsecond, fmt.Errorf("Error")), nil).Once()
 
-	bytesRead, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), t.mrdTimeout, metrics.NewNoopMetrics())
+	bytesRead, err := t.mrdWrapper.Read(context.Background(), make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics())
 
 	assert.ErrorContains(t.T(), err, "error in Add call")
 	assert.Equal(t.T(), 0, bytesRead)

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -750,7 +750,7 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 		rr.mrdWrapper.IncrementRefCount()
 	}
 
-	bytesRead, err = rr.mrdWrapper.Read(ctx, p, offset, end, timeout, rr.metricHandle)
+	bytesRead, err = rr.mrdWrapper.Read(ctx, p, offset, end, rr.metricHandle)
 	rr.totalReadBytes.Add(uint64(bytesRead))
 	rr.updateExpectedOffset(offset + int64(bytesRead))
 	return


### PR DESCRIPTION
### Description
timeout is currently unused in MRD flow. Cleanup timeout value from the code while we decide how to implement it properly.

### Link to the issue in case of a bug fix.
b/435356759

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
