### PR TITLE
fix: install latest gcloud version in CD script tests

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -167,6 +167,7 @@ go version |& tee -a ${LOG_FILE}
 export PATH=${PATH}:/usr/local/go/bin
 git clone https://github.com/googlecloudplatform/gcsfuse |& tee -a ${LOG_FILE}
 cd gcsfuse
+bash ./perfmetrics/scripts/install_latest_gcloud.sh
 
 # Installation of crcmod is working through pip only on rhel and centos.
 # For debian and ubuntu, we are installing through sudo apt.


### PR DESCRIPTION
### Description
Install latest gcloud version and alpha component in CD script tests because managed folder tests were failing with the following error in the CD pipeline:
```
Test_helper.go:102: Error in removing permission to managed folder: failed command '/bin/bash -c gcloud alpha storage managed-folders remove-iam-policy-binding  gs://<bucket_name>/TestDirForManagedFolderTest/managedFolder1 --member=<service account name> --role=roles/storage.objectAdmin': exit status 1, You do not currently have this command group installed.  Using it         requires the installation of components: [alpha]                ERROR: (gcloud) You cannot perform this action because you do not have permission to modify the Google Cloud SDK installation directory [/usr/local/google-cloud-sdk].

```

### Link to the issue in case of a bug fix.
b/436794846

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
