### PR TITLE
fix: Handle Symlink scenario in rename

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -825,6 +825,7 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 		in = inode.NewSymlinkInode(
 			id,
 			ic.FullName,
+			ic.Bucket,
 			ic.MinObject,
 			fuseops.InodeAttributes{
 				Uid:  fs.uid,
@@ -2240,15 +2241,15 @@ func (fs *fileSystem) Rename(
 	newParent := fs.dirInodeOrDie(op.NewParent)
 	fs.mu.Unlock()
 
-	if oldInode, ok := oldParent.(inode.BucketOwnedInode); !ok {
+	if oldParentInode, ok := oldParent.(inode.BucketOwnedInode); !ok {
 		// The old parent is not owned by any bucket, which means it's the base
 		// directory that holds all the buckets' root directories. So, this op
 		// is to rename a bucket, which is not supported.
 		return fmt.Errorf("rename a bucket: %w", syscall.ENOTSUP)
 	} else {
 		// The target path must exist in the same bucket.
-		oldBucket := oldInode.Bucket().Name()
-		if newInode, ok := newParent.(inode.BucketOwnedInode); !ok || oldBucket != newInode.Bucket().Name() {
+		oldBucket := oldParentInode.Bucket().Name()
+		if newParentInode, ok := newParent.(inode.BucketOwnedInode); !ok || oldBucket != newParentInode.Bucket().Name() {
 			return fmt.Errorf("move out of bucket %q: %w", oldBucket, syscall.ENOTSUP)
 		}
 	}
@@ -2276,26 +2277,33 @@ func (fs *fileSystem) Rename(
 		}
 		return fs.renameNonHierarchicalDir(ctx, oldParent, op.OldName, newParent, op.NewName)
 	}
-	childFileInode, ok := child.(*inode.FileInode)
-	if !ok {
-		return fmt.Errorf("child inode (id %v) is neither file nor directory inode", child.ID())
-	}
-	// TODO(b/402335988): Fix rename flow for local files when streaming writes is disabled.
-	// If object to be renamed is a local file inode and streaming writes are disabled, rename operation is not supported.
-	if childFileInode.IsLocal() && !fs.newConfig.Write.EnableStreamingWrites {
-		return fmt.Errorf("cannot rename open file %q: %w", op.OldName, syscall.ENOTSUP)
-	}
-	return fs.renameFile(ctx, op, childFileInode, oldParent, newParent)
+
+	return fs.renameFile(ctx, op, childBktOwned, oldParent, newParent)
 }
 
 // LOCKS_EXCLUDED(oldParent)
 // LOCKS_EXCLUDED(newParent)
-func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, oldObject *inode.FileInode, oldParent, newParent inode.DirInode) error {
-	updatedMinObject, err := fs.flushPendingWrites(ctx, oldObject)
-	if err != nil {
-		return fmt.Errorf("flushPendingWrites: %w", err)
+func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, child inode.BucketOwnedInode, oldParent, newParent inode.DirInode) error {
+	var updatedMinObject *gcs.MinObject
+	var err error
+
+	switch c := child.(type) {
+	case *inode.FileInode:
+		// TODO(b/402335988): Fix rename flow for local files when streaming writes is disabled.
+		// If object to be renamed is a local file inode and streaming writes are disabled, rename operation is not supported.
+		if c.IsLocal() && !fs.newConfig.Write.EnableStreamingWrites {
+			return fmt.Errorf("cannot rename open file %q: %w", op.OldName, syscall.ENOTSUP)
+		}
+		updatedMinObject, err = fs.flushPendingWrites(ctx, c)
+		if err != nil {
+			return fmt.Errorf("flushPendingWrites: %w", err)
+		}
+	case *inode.SymlinkInode:
+		updatedMinObject = c.Source()
+	default:
+		return fmt.Errorf("child inode (id %v) is not a file or symlink inode", child.ID())
 	}
-	if fs.enableAtomicRenameObject || oldObject.Bucket().BucketType().Zonal {
+	if fs.enableAtomicRenameObject || child.Bucket().BucketType().Zonal {
 		return fs.atomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
 	}
 	return fs.nonAtomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)


### PR DESCRIPTION
### Description
A recent refactoring of the `Rename` operation in `internal/fs/fs.go` introduced an issue that prevented sym links from being renamed.

The new implementation incorrectly assumed that all inodes being renamed would implement the `inode.BucketOwnedInode` interface. Since `SymlinkInode` did not, any attempt to rename a symlink would fail with the error: `Rename: input/output error, child inode (id <X>) is not owned by any bucket`.

This change resolves the issue by making `SymlinkInode` implement the `BucketOwnedInode` interface. This involves:
1.  Adding a `bucket` field to `SymlinkInode`.
2.  Updating the `NewSymlinkInode` function and its call sites to correctly propagate bucket information.
3.  Adding logic within the `Rename` function to correctly handle symlinks as bucket-owned inodes.

With this fix, renaming symbolic links now works as expected.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/436756784

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
