### PR TITLE
fix(deps): Pin versions for timm and safetensors in dino test

### DIFF
--- a/perfmetrics/scripts/ml_tests/pytorch/v2/dino/Dockerfile
+++ b/perfmetrics/scripts/ml_tests/pytorch/v2/dino/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/deeplearning-platform-release/pytorch-gpu.2-0.py310
 # Allow non-root users to specify the allow_other or allow_root mount options
 RUN echo "user_allow_other" > /etc/fuse.conf
 
-RUN pip3 install timm setuptools==69.5.1
+RUN pip3 install timm==1.0.19 safetensors==0.5.3 setuptools==69.5.1
 
 WORKDIR "/pytorch_dino/"
 


### PR DESCRIPTION
### Description
The PyTorch v2 DINO performance test was failing due to an unpinned dependency.

The `safetensors` package, a dependency of `timm`, was recently updated to a new version that is incompatible with the PyTorch version used in the test's Docker environment. This caused an `AttributeError` during the build.

This change pins the versions of `timm` and `safetensors` to the last known good configuration (`timm==1.0.19`, `safetensors==0.5.3`) to ensure a stable and reproducible build environment.


### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/437059728

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
