### PR TITLE
feat(dnscache): Create a round-robin slice

### DIFF
--- a/roundrobinslice/round_robin_slice.go
+++ b/roundrobinslice/round_robin_slice.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roundrobinslice
+
+import "sync"
+
+// RoundRobin provides thread-safe, round-robin access to elements of a slice.
+// The underlying slice is treated as immutable.
+type RoundRobin[T any] struct {
+	mu    sync.Mutex
+	items []T
+	// current is the index of the element last returned by Get().
+	// It is initialized to len(items) - 1 so that the first call to Get()
+	// returns items[0].
+	current int
+}
+
+// New creates a new RoundRobin instance with the provided slice of items.
+// It expects the slice to be immutable for performance reasons.
+// If the slice is empty, Get() will always return the zero value of T and false.
+func New[T any](items []T) *RoundRobin[T] {
+	// Create a copy of the slice to ensure immutability from external modifications.
+
+	// To make the first call to Get() return items[0].
+	idx := -1
+	if len(items) > 0 {
+		idx = len(items) - 1
+	}
+
+	return &RoundRobin[T]{
+		items:   items,
+		current: idx,
+	}
+}
+
+// Get returns the next element from the slice in a round-robin fashion.
+// It returns the element and a boolean indicating if the slice was non-empty.
+// If the slice is empty, it returns the zero value for T and false.
+func (rr *RoundRobin[T]) Get() (T, bool) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+
+	if len(rr.items) == 0 {
+		var zero T
+		return zero, false
+	}
+
+	// Advance to the next index.
+	rr.current = (rr.current + 1) % len(rr.items)
+	return rr.items[rr.current], true
+}

--- a/roundrobinslice/round_robin_slice.go
+++ b/roundrobinslice/round_robin_slice.go
@@ -31,8 +31,6 @@ type RoundRobin[T any] struct {
 // It expects the slice to be immutable for performance reasons.
 // If the slice is empty, Get() will always return the zero value of T and false.
 func New[T any](items []T) *RoundRobin[T] {
-	// Create a copy of the slice to ensure immutability from external modifications.
-
 	// To make the first call to Get() return items[0].
 	idx := -1
 	if len(items) > 0 {

--- a/roundrobinslice/round_robin_slice_test.go
+++ b/roundrobinslice/round_robin_slice_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roundrobinslice
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_Empty(t *testing.T) {
+	rr := New[int](nil)
+	assert.NotNil(t, rr)
+	val, ok := rr.Get()
+	assert.False(t, ok)
+	assert.Equal(t, 0, val)
+
+	rr = New([]int{})
+	assert.NotNil(t, rr)
+	val, ok = rr.Get()
+	assert.False(t, ok)
+	assert.Equal(t, 0, val)
+}
+
+func TestGet_SingleElement(t *testing.T) {
+	rr := New([]int{42})
+
+	// First Get
+	val, ok := rr.Get()
+	assert.True(t, ok)
+	assert.Equal(t, 42, val)
+
+	// Second Get
+	val, ok = rr.Get()
+	assert.True(t, ok)
+	assert.Equal(t, 42, val)
+}
+
+func TestGet_MultipleElements(t *testing.T) {
+	items := []string{"a", "b", "c"}
+	rr := New(items)
+
+	expectedSequence := []string{"a", "b", "c"}
+
+	// First cycle
+	for i, expected := range expectedSequence {
+		val, ok := rr.Get()
+		assert.True(t, ok, fmt.Sprintf("Cycle 1, Iteration %d", i))
+		assert.Equal(t, expected, val, fmt.Sprintf("Cycle 1, Iteration %d", i))
+	}
+
+	// Second cycle
+	for i, expected := range expectedSequence {
+		val, ok := rr.Get()
+		assert.True(t, ok, fmt.Sprintf("Cycle 2, Iteration %d", i))
+		assert.Equal(t, expected, val, fmt.Sprintf("Cycle 2, Iteration %d", i))
+	}
+}
+
+func TestGet_ThreadSafety(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	rr := New(items)
+	numGoroutines := 10
+	getsPerGoroutine := 100
+	totalGets := numGoroutines * getsPerGoroutine
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	results := make(chan int, totalGets)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < getsPerGoroutine; j++ {
+				val, ok := rr.Get()
+				if ok {
+					results <- val
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	assert.Equal(t, totalGets, len(results))
+
+	// We can check the distribution
+	counts := make(map[int]int)
+	for val := range results {
+		counts[val]++
+	}
+
+	// Each item should appear exactly `totalGets / len(items)` times.
+	expectedCount := totalGets / len(items)
+	assert.Equal(t, len(items), len(counts))
+	for _, item := range items {
+		assert.Equal(t, expectedCount, counts[item], "Distribution of item %d should be even", item)
+	}
+}
+
+func TestGet_Structs(t *testing.T) {
+	type myStruct struct {
+		ID   int
+		Name string
+	}
+
+	items := []myStruct{
+		{1, "one"},
+		{2, "two"},
+	}
+	rr := New(items)
+
+	val, ok := rr.Get()
+	assert.True(t, ok)
+	assert.Equal(t, items[0], val)
+
+	val, ok = rr.Get()
+	assert.True(t, ok)
+	assert.Equal(t, items[1], val)
+
+	val, ok = rr.Get()
+	assert.True(t, ok)
+	assert.Equal(t, items[0], val)
+}

--- a/roundrobinslice/round_robin_slice_test.go
+++ b/roundrobinslice/round_robin_slice_test.go
@@ -15,59 +15,67 @@
 package roundrobinslice
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNew_Empty(t *testing.T) {
-	rr := New[int](nil)
-	assert.NotNil(t, rr)
+func TestNew_NilSlice(t *testing.T) {
+	var items []int // nil
+
+	rr := New(items)
 	val, ok := rr.Get()
+
+	assert.NotNil(t, rr)
 	assert.False(t, ok)
 	assert.Equal(t, 0, val)
+}
 
-	rr = New([]int{})
+func TestNew_EmptySlice(t *testing.T) {
+	items := []int{}
+
+	rr := New(items)
+	val, ok := rr.Get()
+
 	assert.NotNil(t, rr)
-	val, ok = rr.Get()
 	assert.False(t, ok)
 	assert.Equal(t, 0, val)
 }
 
 func TestGet_SingleElement(t *testing.T) {
-	rr := New([]int{42})
+	items := []int{42}
+	rr := New(items)
 
-	// First Get
 	val, ok := rr.Get()
-	assert.True(t, ok)
-	assert.Equal(t, 42, val)
 
-	// Second Get
-	val, ok = rr.Get()
 	assert.True(t, ok)
 	assert.Equal(t, 42, val)
+}
+
+func TestGet_SingleElement_MultipleTimes(t *testing.T) {
+	items := []int{42}
+	rr := New(items)
+
+	// Call Get multiple times to ensure it consistently returns the single element.
+	for range 3 {
+		val, ok := rr.Get()
+
+		assert.True(t, ok)
+		assert.Equal(t, 42, val)
+	}
 }
 
 func TestGet_MultipleElements(t *testing.T) {
 	items := []string{"a", "b", "c"}
 	rr := New(items)
+	expectedSequence := []string{"a", "b", "c", "a", "b", "c"}
 
-	expectedSequence := []string{"a", "b", "c"}
-
-	// First cycle
 	for i, expected := range expectedSequence {
 		val, ok := rr.Get()
-		assert.True(t, ok, fmt.Sprintf("Cycle 1, Iteration %d", i))
-		assert.Equal(t, expected, val, fmt.Sprintf("Cycle 1, Iteration %d", i))
-	}
 
-	// Second cycle
-	for i, expected := range expectedSequence {
-		val, ok := rr.Get()
-		assert.True(t, ok, fmt.Sprintf("Cycle 2, Iteration %d", i))
-		assert.Equal(t, expected, val, fmt.Sprintf("Cycle 2, Iteration %d", i))
+		assert.True(t, ok, "Iteration %d: Get should succeed", i)
+		assert.Equal(t, expected, val, "Iteration %d: Incorrect value", i)
 	}
 }
 
@@ -77,16 +85,14 @@ func TestGet_ThreadSafety(t *testing.T) {
 	numGoroutines := 10
 	getsPerGoroutine := 100
 	totalGets := numGoroutines * getsPerGoroutine
-
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
-
 	results := make(chan int, totalGets)
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < getsPerGoroutine; j++ {
+			for range getsPerGoroutine {
 				val, ok := rr.Get()
 				if ok {
 					results <- val
@@ -94,23 +100,21 @@ func TestGet_ThreadSafety(t *testing.T) {
 			}
 		}()
 	}
-
 	wg.Wait()
 	close(results)
 
 	assert.Equal(t, totalGets, len(results))
-
-	// We can check the distribution
+	// Check the distribution.
 	counts := make(map[int]int)
 	for val := range results {
 		counts[val]++
 	}
-
 	// Each item should appear exactly `totalGets / len(items)` times.
+	//assert.Equal(t, totalGets, len(results))
 	expectedCount := totalGets / len(items)
 	assert.Equal(t, len(items), len(counts))
 	for _, item := range items {
-		assert.Equal(t, expectedCount, counts[item], "Distribution of item %d should be even", item)
+		assert.Equal(t, expectedCount, counts[item])
 	}
 }
 
@@ -119,22 +123,18 @@ func TestGet_Structs(t *testing.T) {
 		ID   int
 		Name string
 	}
-
 	items := []myStruct{
 		{1, "one"},
 		{2, "two"},
 	}
 	rr := New(items)
+	// Check for wrap-around.
+	expectedSequence := []myStruct{items[0], items[1], items[0]}
 
-	val, ok := rr.Get()
-	assert.True(t, ok)
-	assert.Equal(t, items[0], val)
+	for i, expected := range expectedSequence {
+		val, ok := rr.Get()
 
-	val, ok = rr.Get()
-	assert.True(t, ok)
-	assert.Equal(t, items[1], val)
-
-	val, ok = rr.Get()
-	assert.True(t, ok)
-	assert.Equal(t, items[0], val)
+		assert.True(t, ok, "Iteration %d: Get should succeed", i)
+		assert.Equal(t, expected, val, "Iteration %d: Incorrect value", i)
+	}
 }


### PR DESCRIPTION
### Description
This datastructure will be used to store the list of IP addresses returned by the DNS lookup in the DNS cache. Using round-robin through the multiple IP addresses ensure that the load gets distributed.

### Link to the issue in case of a bug fix.
b/437295275

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
