### PR TITLE
fix(buffered Read): Adding missing fields while creating read manager

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -199,6 +199,8 @@ func (fh *FileHandle) ReadWithReadManager(ctx context.Context, dst []byte, offse
 			MetricHandle:          fh.metricHandle,
 			MrdWrapper:            mrdWrapper,
 			Config:                fh.config,
+			GlobalMaxBlocksSem:    fh.globalMaxReadBlocksSem,
+			WorkerPool:            fh.bufferedReadWorkerPool,
 		})
 
 		// Release RWLock and take RLock on file handle again. Inode lock is not needed now.


### PR DESCRIPTION
### Description
We're fixing a bug in the readmanager creation. We missed passing the semaphore and worker pool during initialization; they were accidentally removed in a [recent pull request](https://github.com/GoogleCloudPlatform/gcsfuse/pull/3619).

Crash logs - https://paste.googleplex.com/5358932541046784#l=2

### Link to the issue in case of a bug fix.
[b/437383151](https://b.corp.google.com/issues/437383151)

### Testing details
1. Manual - Manually tested
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
