### PR TITLE
fix: Kokoro tests failure

### DIFF
--- a/perfmetrics/scripts/build_and_install_gcsfuse.sh
+++ b/perfmetrics/scripts/build_and_install_gcsfuse.sh
@@ -20,18 +20,18 @@ set -e
 # --- Determine architecture (e.g., amd64, arm64) ---
 architecture=$(dpkg --print-architecture)
 
-# --- Install Docker only if not already installed ---
-if ! command -v docker &> /dev/null; then
-  echo "Installing docker..."
-  sudo mkdir -p /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-  echo \
-    "deb [arch=${architecture} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-  sudo apt-get update
-  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
+# Install Docker if it's not already present or if this is a Kokoro environment as it has old docker version.
+if ! command -v docker &> /dev/null || [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
+    echo "Installing Docker..."
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo \
+      "deb [arch=${architecture} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y
 else
-  echo "Docker is already installed. Skipping Docker installation."
+    echo "Docker is already installed. Skipping Docker installation."
 fi
 
 # --- Build and install gcsfuse ---


### PR DESCRIPTION
### Description
The Kokoro script is failing because of a recent change that skips Docker reinstallation when the software is already present. The existing, older version of Docker on the Kokoro machines is missing the necessary features.

### Link to the issue in case of a bug fix.
[b/437464330](https://buganizer.corp.google.com/issues/437464330)

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
