### PR TITLE
fix: Fix broken e2e test in unfinalized_object package

### DIFF
--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 	"path"
-	"syscall"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -121,15 +120,14 @@ func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCanBeRenamedIfCreated
 	operations.ValidateESTALEError(t.T(), err)
 }
 
-func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCantBeRenamedIfCreatedFromDifferentMount() {
+func (t *unfinalizedObjectOperations) TestUnfinalizedObjectCanBeRenamedIfCreatedFromDifferentMount() {
 	size := operations.MiB
 	_ = client.CreateUnfinalizedObject(t.ctx, t.T(), t.storageClient, path.Join(testDirName, t.fileName), setup.GenerateRandomString(size))
 
 	// Overwrite unfinalized object.
 	err := operations.RenameFile(path.Join(t.testDirPath, t.fileName), path.Join(t.testDirPath, "New"+t.fileName))
 
-	require.Error(t.T(), err)
-	assert.ErrorContains(t.T(), err, syscall.EIO.Error())
+	require.NoError(t.T(), err)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
Fixed test
TestUnfinalizedObjectOperationTest/TestUnfinalizedObjectCantBeRenamedIfCreatedFromDifferentMount

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as presubmit
   - [run1](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/bc026967-99e4-453a-acc7-ea09a7898913/summary) - e2e zb - passed
5. 

### Any backward incompatible change? If so, please explain.
