### PR TITLE
refactor: explicit_dir test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,15 +19,23 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"gopkg.in/yaml.v3"
 )
 
 const DirForExplicitDirTests = "dirForExplicitDirTests"
+
+// Config holds all test configurations parsed from the YAML file.
+type Config struct {
+	ExplicitDir []test_suite.TestConfig `yaml:"explicit_dir"`
+}
 
 // IMPORTANT: To prevent global variable pollution, enhance code clarity,
 // and avoid inadvertent errors. We strongly suggest that, all new package-level
@@ -42,7 +50,29 @@ var testEnv env
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	// Create storage client before running tests.
+
+	// 1. Load and parse the common configuration.
+	var cfg Config
+	if setup.ConfigFile() != "" {
+		configData, err := os.ReadFile(setup.ConfigFile())
+		if err != nil {
+			log.Fatalf("could not read test_config.yaml: %v", err)
+		}
+		expandedYaml := os.ExpandEnv(string(configData))
+		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
+			log.Fatalf("Failed to parse config YAML: %v", err)
+		}
+	}
+	if len(cfg.ExplicitDir) == 0 {
+		log.Println("No configuration found for explicit_dir tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.ExplicitDir = make([]test_suite.TestConfig, 1)
+		cfg.ExplicitDir[0].TestBucket = setup.TestBucket()
+		cfg.ExplicitDir[0].Flags = []string{"--implicit-dirs=false", "--implicit-dirs=false --client-protocol=grpc"}
+		cfg.ExplicitDir[0].MountedDirectory = setup.MountedDirectory()
+	}
+
+	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
@@ -54,18 +84,18 @@ func TestMain(m *testing.M) {
 
 	// These tests will not run on HNS buckets because the "--implicit-dirs=false" flag does not function similarly to how it does on FLAT buckets.
 	// Note that HNS buckets do not have the concept of implicit directories.
-	if setup.IsHierarchicalBucket(testEnv.ctx, testEnv.storageClient) {
+	if setup.ResolveIsHierarchicalBucket(testEnv.ctx, cfg.ExplicitDir[0].TestBucket, testEnv.storageClient) {
 		log.Println("These tests will not run on HNS buckets.")
 		return
 	}
 
-	flags := [][]string{{"--implicit-dirs=false"}}
-
-	if !testing.Short() {
-		flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=false"})
+	// 4. Build the flag sets dynamically from the config.
+	var flags [][]string
+	for _, flagString := range cfg.ExplicitDir[0].Flags {
+		flags = append(flags, strings.Fields(flagString))
 	}
 
-	successCode := implicit_and_explicit_dir_setup.RunTestsForImplicitDirAndExplicitDir(flags, m)
-
+	// 5. Run tests with the dynamically generated flags.
+	successCode := implicit_and_explicit_dir_setup.RunTestsForExplicitDir(&cfg.ExplicitDir[0], flags, m)
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+explicit_dir:
+  - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
+    test_bucket: "${BUCKET_NAME}" # To be passed by both gcsfuse and gke tests
+    log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
+    flags:
+      - "--implicit-dirs=false"
+      - "--implicit-dirs=false --client-protocol=grpc"
+    compatible: # Bucket type to run these tests with
+      - flat: true
+      - hns: false
+      - zonal: false
+    run_on_gke: false

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 // Change e.g --log_severity=trace to log_severity=trace
@@ -39,8 +40,8 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 	return
 }
 
-func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
-	defaultArg := []string{setup.TestBucket(),
+func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
+	defaultArg := []string{config.TestBucket,
 		setup.MntDir(),
 		"-o",
 		"log_severity=trace",
@@ -60,11 +61,11 @@ func mountGcsfuseWithPersistentMounting(flags []string) (err error) {
 	return err
 }
 
-func executeTestsForPersistentMounting(flagsSet [][]string, m *testing.M) (successCode int) {
+func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	var err error
 
 	for i := 0; i < len(flagsSet); i++ {
-		if err = mountGcsfuseWithPersistentMounting(flagsSet[i]); err != nil {
+		if err = mountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])
@@ -76,12 +77,19 @@ func executeTestsForPersistentMounting(flagsSet [][]string, m *testing.M) (succe
 	return
 }
 
+// Deprecated: Use RunTestsWithConfigFile instead.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
+	}
+	return RunTestsWithConfigFile(config, flagsSet, m)
+}
+
+func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running persistent mounting tests...")
-
-	successCode = executeTestsForPersistentMounting(flagsSet, m)
-
+	successCode = executeTestsForPersistentMountingWithConfigFile(config, flagsSet, m)
 	log.Printf("Test log: %s\n", setup.LogFile())
-
 	return successCode
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -78,6 +78,7 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 }
 
 // Deprecated: Use RunTestsWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
 		TestBucket:       setup.TestBucket(),

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -21,9 +21,20 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
+// Deprecated: Use MountGcsfuseWithStaticMountingWithConfigFile instead.
 func MountGcsfuseWithStaticMounting(flags []string) (err error) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
+	}
+	return MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
+}
+
+func MountGcsfuseWithStaticMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	var defaultArg []string
 	if setup.TestOnTPCEndPoint() {
 		defaultArg = append(defaultArg, "--custom-endpoint=storage.apis-tpczero.goog:443",
@@ -32,7 +43,7 @@ func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 
 	defaultArg = append(defaultArg, "--log-severity=trace",
 		"--log-file="+setup.LogFile(),
-		setup.TestBucket(),
+		config.TestBucket,
 		setup.MntDir())
 
 	for i := 0; i < len(defaultArg); i++ {
@@ -44,11 +55,11 @@ func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	return err
 }
 
-func executeTestsForStaticMounting(flagsSet [][]string, m *testing.M) (successCode int) {
+func executeTestsForStaticMounting(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	var err error
 
 	for i := 0; i < len(flagsSet); i++ {
-		if err = MountGcsfuseWithStaticMounting(flagsSet[i]); err != nil {
+		if err = MountGcsfuseWithStaticMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running static mounting tests with flags: %s", flagsSet[i])
@@ -60,12 +71,19 @@ func executeTestsForStaticMounting(flagsSet [][]string, m *testing.M) (successCo
 	return
 }
 
+// Deprecated: Use RunTestsWithConfigFile instead.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
+	}
+	return RunTestsWithConfigFile(config, flagsSet, m)
+}
+
+func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running static mounting tests...")
-
-	successCode = executeTestsForStaticMounting(flagsSet, m)
-
+	successCode = executeTestsForStaticMounting(config, flagsSet, m)
 	log.Printf("Test log: %s\n", setup.LogFile())
-
 	return successCode
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Deprecated: Use MountGcsfuseWithStaticMountingWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	config := &test_suite.TestConfig{
 		TestBucket:       setup.TestBucket(),
@@ -72,6 +73,7 @@ func executeTestsForStaticMounting(config *test_suite.TestConfig, flagsSet [][]s
 }
 
 // Deprecated: Use RunTestsWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
 		TestBucket:       setup.TestBucket(),

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -395,6 +395,7 @@ func ExitWithFailureIfMountedDirectoryIsSetOrTestBucketIsNotSet() {
 }
 
 // Deprecated: Use RunTestsForMountedDirectory instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTestsForMountedDirectoryFlag(m *testing.M) {
 	// Execute tests for the mounted directory.
 	if *mountedDirectory != "" {
@@ -416,6 +417,7 @@ func RunTestsForMountedDirectory(mountedDirectory string, m *testing.M) int {
 }
 
 // Deprecated: Use SetUpTestDirForTestBucket instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func SetUpTestDirForTestBucketFlag() {
 	SetUpTestDirForTestBucket(TestBucket())
 }
@@ -532,6 +534,7 @@ func AreBothMountedDirectoryAndTestBucketFlagsSet() bool {
 }
 
 // Deprecated: use ResolveIsHierarchicalBucket instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func IsHierarchicalBucket(ctx context.Context, storageClient *storage.Client) bool {
 	return ResolveIsHierarchicalBucket(ctx, TestBucket(), storageClient)
 }

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_suite
+
+// BucketType represents the 'compatible' field.
+type BucketType struct {
+	Flat  bool `yaml:"flat"`
+	Hns   bool `yaml:"hns"`
+	Zonal bool `yaml:"zonal"`
+}
+
+// TestConfig represents the common configuration for test packages.
+type TestConfig struct {
+	MountedDirectory string       `yaml:"mounted_directory"`
+	TestBucket       string       `yaml:"test_bucket"`
+	LogFile          string       `yaml:"log_file,omitempty"`
+	Flags            []string     `yaml:"flags"`
+	Compatible       []BucketType `yaml:"compatible"`
+	RunOnGKE         bool         `yaml:"run_on_gke"`
+}


### PR DESCRIPTION
### Description
This PR includes changes to migrate explicit_dir package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.
 
**Changes include:**
1. config file flag addition.
2. refactoring to use config file by test methods.
3. changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
4. Migration of explicit dir package so it can use config file.

### Link to the issue in case of a bug fix.
b/430184649

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
5. Unit tests - NA
6. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA