### PR TITLE
fix(Buffered read): Make buffered read path thread safe

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -97,14 +97,16 @@ type BufferedReader struct {
 	workerPool workerpool.WorkerPool
 
 	// blockQueue is the core of the prefetching pipeline, holding blocks that are
-	// either downloaded or in the process of being downloaded. The head of the
-	// queue always contains the next block required to satisfy a read request.
+	// either downloaded or in the process of being downloaded.
 	// GUARDED by (mu)
 	blockQueue common.Queue[*blockQueueEntry]
 
-	// blockPool manages a pool of reusable PrefetchBlock buffers. Instead of
-	// allocating a new buffer for each download, the reader acquires one from
-	// this pool and releases it back when it's no longer needed.
+	// blockPool is a pool of blocks that can be reused for prefetching.
+	// It is used to avoid allocating new blocks for each prefetch operation.
+	// The pool is initialized with a maximum number of blocks that can be
+	// prefetched at a time, and it allows for efficient reuse of blocks.
+	// The pool is also responsible for managing the global limit on the number
+	// of blocks that can be allocated across all BufferedReader instances.
 	// GUARDED by (mu)
 	blockPool *block.GenBlockPool[block.PrefetchBlock]
 }

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -249,6 +249,9 @@ func (p *BufferedReader) ReadAt(ctx context.Context, inputBuf []byte, off int64)
 		return resp, nil
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	defer func() {
 		dur := time.Since(start)
 		if err == nil || errors.Is(err, io.EOF) {
@@ -256,8 +259,6 @@ func (p *BufferedReader) ReadAt(ctx context.Context, inputBuf []byte, off int64)
 		}
 	}()
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	if err = p.handleRandomRead(off); err != nil {
 		err = fmt.Errorf("BufferedReader.ReadAt: handleRandomRead: %w", err)
 		return resp, err

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -93,7 +93,8 @@ type BufferedReader struct {
 
 	randomReadsThreshold int64 // Number of random reads after which the reader falls back to another reader.
 
-	// mu synchronizes access to the buffered reader's shared state.
+	// `mu` synchronizes access to the buffered reader's shared state.
+	// All shared variables, such as the block pool and queue, require this lock before any operation.
 	mu sync.Mutex
 }
 

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -1283,7 +1283,8 @@ func (t *BufferedReaderTest) TestReadAtConcurrentReads() {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
 	results := make([][]byte, numGoroutines)
-	// Each go routine will read differt range to avoid duplicate calls for same range.
+
+	// Each go routine will read different range to avoid duplicate calls for same range.
 	// That's why we are multiplying by 3 to have offset 3 blocks apart.
 	var readIndex = 3
 	for i := 0; i < numGoroutines; i++ {
@@ -1301,6 +1302,7 @@ func (t *BufferedReaderTest) TestReadAtConcurrentReads() {
 			copy(results[index], readBuf)
 		}(i)
 	}
+
 	wg.Wait()
 	// Verify the results from all goroutines individually.
 	for i, res := range results {

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
@@ -1245,4 +1246,66 @@ func (t *BufferedReaderTest) TestReadAtSucceedsWhenBackgroundPrefetchFailsOnGCSE
 	_, err = reader.ReadAt(t.ctx, buf, 1024)
 	assert.ErrorIs(t.T(), err, gcsError)
 	assert.ErrorContains(t.T(), err, "download failed")
+}
+
+func (t *BufferedReaderTest) TestReadAtConcurrentReads() {
+	const (
+		fileSize      = 10 * util.MiB
+		numGoroutines = 3
+		blockSize     = 1 * util.MiB
+		readSize      = 1 * util.MiB
+	)
+	t.object.Size = fileSize
+	t.config.PrefetchBlockSizeBytes = blockSize
+	t.config.MaxPrefetchBlockCnt = 10
+	t.config.InitialPrefetchBlockCnt = 2 // This will prefetch 2 blocks after the initial one.
+	reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
+	require.NoError(t.T(), err)
+	// Set up mocks for all possible block reads. Because the goroutines run
+	// concurrently, we prepare mocks for all blocks that could be read or
+	// prefetched (2 blocks) and use .Maybe() to allow them to be called in
+	// any order.
+	for i := 0; i <= 8; i++ {
+		start := uint64(i * blockSize)
+		// Create content for this block using the A-Z pattern from the test helpers.
+		blockContent := make([]byte, blockSize)
+		for j := range blockContent {
+			blockContent[j] = byte('A' + ((int(start) + j) % 26))
+		}
+		t.bucket.On("NewReaderWithReadHandle",
+			mock.Anything,
+			mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+				return req.Range.Start == start
+			}),
+		).Return(&fake.FakeReader{ReadCloser: io.NopCloser(bytes.NewReader(blockContent))}, nil).Maybe()
+	}
+	t.bucket.On("Name").Return("test-bucket").Maybe()
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	results := make([][]byte, numGoroutines)
+	// Each go routine will read differt range to avoid duplicate calls for same range.
+	// That's why we are multiplying by 3 to have offset 3 blocks apart.
+	var readIndex = 3
+	for i := 0; i < numGoroutines; i++ {
+		go func(index int) {
+			defer wg.Done()
+			offset := int64(index * readIndex * readSize)
+			readBuf := make([]byte, readSize)
+
+			resp, err := reader.ReadAt(t.ctx, readBuf, offset)
+
+			require.NoError(t.T(), err)
+			require.Equal(t.T(), readSize, resp.Size)
+			// Copy the result to a new slice to avoid data races on readBuf.
+			results[index] = make([]byte, readSize)
+			copy(results[index], readBuf)
+		}(i)
+	}
+	wg.Wait()
+	// Verify the results from all goroutines individually.
+	for i, res := range results {
+		offset := int64(i * readIndex * readSize)
+		assertBufferContent(t.T(), res, offset)
+	}
+	t.bucket.AssertExpectations(t.T())
 }

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -82,7 +82,7 @@ func (p *DownloadTask) Execute() {
 	if end > p.object.Size {
 		end = p.object.Size
 	}
-	fmt.Println("Start and end in buffered readder: ", start, end)
+
 	newReader, err := p.bucket.NewReaderWithReadHandle(
 		p.ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -82,7 +82,6 @@ func (p *DownloadTask) Execute() {
 	if end > p.object.Size {
 		end = p.object.Size
 	}
-
 	newReader, err := p.bucket.NewReaderWithReadHandle(
 		p.ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -82,6 +82,7 @@ func (p *DownloadTask) Execute() {
 	if end > p.object.Size {
 		end = p.object.Size
 	}
+	fmt.Println("Start and end in buffered readder: ", start, end)
 	newReader, err := p.bucket.NewReaderWithReadHandle(
 		p.ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -450,4 +451,67 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), fileSize, n)
 	assert.Equal(t.T(), expectedData, output)
+}
+
+func (t *fileTest) Test_ReadWithReadManager_ConcurrentRangeReads() {
+	const (
+		fileSize      = 10 * 1024 * 1024 // 10 MiB
+		numGoroutines = 4
+	)
+	// Create expected data for the file.
+	expectedData := make([]byte, fileSize)
+	for i := 0; i < fileSize; i++ {
+		expectedData[i] = byte(i % 256)
+	}
+	// Setup configuration for buffered read.
+	config := &cfg.Config{
+		Read: cfg.ReadConfig{
+			EnableBufferedRead:   true,
+			MaxBlocksPerHandle:   10,
+			StartBlocksPerHandle: 2,
+		},
+	}
+	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU()
+	require.NoError(t.T(), err)
+	defer workerPool.Stop()
+	globalSemaphore := semaphore.NewWeighted(20)
+	// Create mock inode and file handle.
+	parent := createDirInode(&t.bucket, &t.clock)
+	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "read_obj", expectedData, false)
+	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, config, workerPool, globalSemaphore)
+	// Use a WaitGroup to synchronize goroutines.
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	// Use a mutex to protect shared data if necessary (e.g., a results slice).
+	var mu sync.Mutex
+	readSize := fileSize / numGoroutines
+	results := make([][]byte, numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(index int) {
+			defer wg.Done()
+			offset := int64(index * readSize)
+			readBuf := make([]byte, readSize)
+			fh.inode.Lock()
+
+			// Each goroutine use same file handle.
+			output, n, err := fh.ReadWithReadManager(context.Background(), readBuf, offset, int32(readSize))
+
+			assert.NoError(t.T(), err)
+			assert.Equal(t.T(), readSize, n)
+			mu.Lock()
+			results[index] = output
+			mu.Unlock()
+		}(i)
+	}
+	// Wait for all goroutines to finish.
+	wg.Wait()
+	// Combine the results from all goroutines.
+	combinedResult := make([]byte, 0, fileSize)
+	for _, res := range results {
+		combinedResult = append(combinedResult, res...)
+	}
+	// Final assertion: compare the combined result with the original expected data.
+	assert.Equal(t.T(), expectedData, combinedResult, "Combined result should match expected data.")
+	// Clean up the original file handle.
+	fh.Destroy()
 }

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -429,9 +429,9 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 	// Setup for Buffered Read test case
 	config := &cfg.Config{
 		Read: cfg.ReadConfig{
-			EnableBufferedRead: true,
-			MaxBlocksPerHandle: 10,
-			//BlockSizeMb:          1,
+			EnableBufferedRead:   true,
+			MaxBlocksPerHandle:   10,
+			BlockSizeMb:          1,
 			StartBlocksPerHandle: 2,
 		},
 	}
@@ -453,7 +453,7 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 	assert.Equal(t.T(), expectedData, output)
 }
 
-func (t *fileTest) Test_ReadWithReadManager_ConcurrentRangeReads() {
+func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() {
 	const (
 		fileSize      = 10 * 1024 * 1024 // 10 MiB
 		numGoroutines = 4

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -455,8 +455,8 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 
 func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() {
 	const (
-		fileSize      = 10 * 1024 * 1024 // 10 MiB
-		numGoroutines = 4
+		fileSize      = 9 * 1024 * 1024 // 9 MiB
+		numGoroutines = 3
 	)
 	// Create expected data for the file.
 	expectedData := make([]byte, fileSize)
@@ -483,8 +483,6 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() 
 	// Use a WaitGroup to synchronize goroutines.
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
-	// Use a mutex to protect shared data if necessary (e.g., a results slice).
-	var mu sync.Mutex
 	readSize := fileSize / numGoroutines
 	results := make([][]byte, numGoroutines)
 	for i := 0; i < numGoroutines; i++ {
@@ -499,9 +497,7 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() 
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), readSize, n)
-			mu.Lock()
 			results[index] = output
-			mu.Unlock()
 		}(i)
 	}
 	// Wait for all goroutines to finish.

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -429,9 +429,9 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 	// Setup for Buffered Read test case
 	config := &cfg.Config{
 		Read: cfg.ReadConfig{
-			EnableBufferedRead:   true,
-			MaxBlocksPerHandle:   10,
-			BlockSizeMb:          1,
+			EnableBufferedRead: true,
+			MaxBlocksPerHandle: 10,
+			//BlockSizeMb:          1,
 			StartBlocksPerHandle: 2,
 		},
 	}
@@ -469,6 +469,7 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentRangeReads() {
 			EnableBufferedRead:   true,
 			MaxBlocksPerHandle:   10,
 			StartBlocksPerHandle: 2,
+			BlockSizeMb:          1,
 		},
 	}
 	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU()


### PR DESCRIPTION
### Description
Following the recent removal of file-handle-level locks, the buffered read path is no longer thread-safe. Consequently, running multiple goroutines on the same file handle can lead to issues due to shared resources. Adding locks in buffered Read readAt method to make it thread safe. Also adding unit test to validate the same.

### Link to the issue in case of a bug fix.
[b/438091542](https://b.corp.google.com/issues/438091542)

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
