### PR TITLE
ci: Fix bash installation/version-check errors in e2e

### DIFF
--- a/perfmetrics/scripts/install_bash.sh
+++ b/perfmetrics/scripts/install_bash.sh
@@ -77,8 +77,33 @@ if ! install_bash >"$INSTALLATION_LOG" 2>&1; then
     rm -f "$INSTALLATION_LOG"
     exit 1
 else
-    echo "Bash ${BASH_VERSION} installed successfully."
-    echo "Checking bash version at ${INSTALL_DIR}bin/bash:"
-    "${INSTALL_DIR}bin/bash" --version
+    echo "Bash ${BASH_VERSION} installation command finished."
+    EXPECTED_BASH_PATH="${INSTALL_DIR}bin/bash"
+
+    if [ -f "${EXPECTED_BASH_PATH}" ]; then
+        echo "Bash binary was created at the expected path: ${EXPECTED_BASH_PATH}"
+        if [[ ":$PATH:" == *":${INSTALL_DIR}bin:"* ]]; then
+            echo "The directory ${INSTALL_DIR}bin is in the PATH."
+        else
+            echo "Warning: The directory ${INSTALL_DIR}bin is NOT in the PATH."
+        fi
+    else
+        echo "Warning: Bash binary not found at the expected path: ${EXPECTED_BASH_PATH}"
+    fi
+
+    echo "Verifying 'bash' is accessible via the PATH..."
+    # Clear the shell's command hash to ensure we find the new one if it was just installed to the path.
+    hash -r
+    if ! command -v bash &> /dev/null; then
+        echo "Error: No 'bash' executable found in the PATH. Cannot proceed."
+        rm -f "$INSTALLATION_LOG"
+        exit 1
+    else
+        SYSTEM_BASH_PATH=$(which bash)
+        echo "The 'bash' command resolves to: ${SYSTEM_BASH_PATH}"
+        echo "Version of this bash is:"
+        "${SYSTEM_BASH_PATH}" --version
+    fi
+
     rm -f "$INSTALLATION_LOG"
 fi

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -119,7 +119,7 @@ then
 
   echo "Running e2e tests on zonal bucket(s) ..."
   # $1 argument is refering to value of testInstalledPackage.
-  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --zonal --track-resource-usage
+  bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --zonal --track-resource-usage
 fi
 
 # Execute integration tests on non-zonal bucket(s).
@@ -130,7 +130,7 @@ then
 
   echo "Running e2e tests on non-zonal bucket(s) ..."
   # $1 argument is refering to value of testInstalledPackage.
-  /usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --track-resource-usage
+  bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --track-resource-usage
 fi
 
 # Execute package build tests.


### PR DESCRIPTION
### Description
Sometimes bash installation isn't working as expected, as it is installing bash at a location other than the expected location `/usr/local/bin/bash` even after saying that `bash installation succeeding` . This is clear in the following logs 
  - from [run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/42fafa34-3bbc-4753-b8b5-8a345693875c/log) 
```
Installing Go version 1.24.5 to /usr/local
Go version 1.24.5 installed successfully.
Go version is: 
go version go1.24.5 linux/amd64
Go is present at: /usr/local/go/bin/go
Installing bash version 5.1 to /usr/local/bin/bash
Bash 5.1 installed successfully.
Checking bash version at /usr/local/bin/bash:
./perfmetrics/scripts/install_bash.sh: line 82: /usr/local/bin/bash: No such file or directory
```
  - from [run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/2cc3ee01-8108-4f60-9fa8-99c43ba04517/log) -with some additional debug logs added
```sh
Installing bash version 5.1 to /usr/local/bin/bash
Bash 5.1 installation command finished.
Warning: Bash binary not found at the expected path: /usr/local/bin/bash
Verifying 'bash' is accessible via the PATH...
The 'bash' command resolves to: /usr/bin/bash
Version of this bash is:
GNU bash, version 5.0.17(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
```

This fix does the following:
- Changes the hard-coded path of bash for version check after bash installation, if bash installation succeeded, instead use the bash available in `$PATH`.
- Changes the hard-coded path of bash for use for running e2e tests, if bash installation succeeded, instead use the bash available in `$PATH`.
- Crashes if bash did not exist in `PATH` at all.
- This bug was causing failures in the e2e presubmit runs in #3561 and #3601 . Examples: [run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/42fafa34-3bbc-4753-b8b5-8a345693875c/log), and [run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/5dd2402d-45eb-4e82-96d1-ae8a6bedca22/log).

I am not sure about the source of the bug, so only fixing the symptom.

### Link to the issue in case of a bug fix.
[b/438135166](http://b/438135166)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as presubmit
   - [run1]()(http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/64b3ad0f-6849-4c1c-a5da-589be1f8be3f) - zb e2e - passed
5. 

### Any backward incompatible change? If so, please explain.
