### PR TITLE
Gargnitin/control client api timeout fix/v2

### DIFF
--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -35,6 +35,7 @@ import (
 type stallingStorageControlClient struct {
 	wrapped                      StorageControlClient
 	stallTimeForGetStorageLayout *time.Duration
+	stallTimeForFolderAPIs       *time.Duration
 }
 
 func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
@@ -49,18 +50,46 @@ func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req
 }
 
 func (s *stallingStorageControlClient) DeleteFolder(ctx context.Context, req *controlpb.DeleteFolderRequest, opts ...gax.CallOption) error {
+	if s.stallTimeForFolderAPIs != nil {
+		select {
+		case <-time.After(*s.stallTimeForFolderAPIs):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return s.wrapped.DeleteFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
+	if s.stallTimeForFolderAPIs != nil {
+		select {
+		case <-time.After(*s.stallTimeForFolderAPIs):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return s.wrapped.GetFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
+	if s.stallTimeForFolderAPIs != nil {
+		select {
+		case <-time.After(*s.stallTimeForFolderAPIs):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return s.wrapped.RenameFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
+	if s.stallTimeForFolderAPIs != nil {
+		select {
+		case <-time.After(*s.stallTimeForFolderAPIs):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return s.wrapped.CreateFolder(ctx, req, opts...)
 }
 
@@ -78,9 +107,19 @@ type StorageLayoutStallRetryWrapperTest struct {
 	ControlClientStallRetryWrapperTest
 }
 
+type AllApiStallRetryWrapperTest struct {
+	ControlClientStallRetryWrapperTest
+	// The execution time for each folder API call made through stallingClient. Can be adjusted
+	// per test.
+	stallTimeForFolderAPIs time.Duration
+}
+
 func TestControlClientWrapperTestSuite(t *testing.T) {
 	t.Run("StorageLayoutStallRetryWrapperTest", func(t *testing.T) {
 		suite.Run(t, new(StorageLayoutStallRetryWrapperTest))
+	})
+	t.Run("AllApiStallRetryWrapperTest", func(t *testing.T) {
+		suite.Run(t, new(AllApiStallRetryWrapperTest))
 	})
 }
 
@@ -94,6 +133,15 @@ func (t *StorageLayoutStallRetryWrapperTest) SetupSuite() {
 	t.stallingClient = &stallingStorageControlClient{
 		wrapped:                      t.mockRawClient,
 		stallTimeForGetStorageLayout: &t.stallTimeForGetStorageLayout,
+	}
+}
+
+func (t *AllApiStallRetryWrapperTest) SetupSuite() {
+	t.ControlClientStallRetryWrapperTest.SetupSuite()
+	t.stallingClient = &stallingStorageControlClient{
+		wrapped:                      t.mockRawClient,
+		stallTimeForGetStorageLayout: &t.stallTimeForGetStorageLayout,
+		stallTimeForFolderAPIs:       &t.stallTimeForFolderAPIs,
 	}
 }
 
@@ -194,6 +242,499 @@ func (t *StorageLayoutStallRetryWrapperTest) TestGetStorageLayout_AllAttemptsTim
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
+func (t *StorageLayoutStallRetryWrapperTest) TestGetFolder_IsNotRetried() {
+	// Arrange
+	client := withRetryOnStorageLayoutStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForGetStorageLayout = 0 // No stall for this test.
+
+	// Mock the raw client to return a retryable error once.
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+
+	// Act
+	folder, err := client.GetFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), folder)
+	assert.Equal(t.T(), retryableErr, err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutStallRetryWrapperTest) TestDeleteFolder_IsNotRetried() {
+	// Arrange
+	client := withRetryOnStorageLayoutStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForGetStorageLayout = 0 // No stall for this test.
+
+	// Mock the raw client to return a retryable error once.
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(retryableErr).Once()
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Equal(t.T(), retryableErr, err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutStallRetryWrapperTest) TestCreateFolder_IsNotRetried() {
+	// Arrange
+	client := withRetryOnStorageLayoutStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForGetStorageLayout = 0 // No stall for this test.
+
+	// Mock the raw client to return a retryable error once.
+	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+
+	// Act
+	folder, err := client.CreateFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), folder)
+	assert.Equal(t.T(), retryableErr, err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutStallRetryWrapperTest) TestRenameFolder_IsNotRetried() {
+	// Arrange
+	client := withRetryOnStorageLayoutStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForGetStorageLayout = 0 // No stall for this test.
+
+	// Mock the raw client to return a retryable error once.
+	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+
+	// Act
+	op, err := client.RenameFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), op)
+	assert.Equal(t.T(), retryableErr, err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
+	t.stallTimeForGetStorageLayout = 0 // No stall.
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedLayout, layout)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetStorageLayout_RetryableErrorThenSuccess() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForGetStorageLayout = 0 // No stall.
+
+	// First call fails, second succeeds.
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedLayout, layout)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetStorageLayout_NonRetryableError() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
+	t.stallTimeForGetStorageLayout = 0 // No stall.
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), layout)
+	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetStorageLayout_AttemptTimesOutAndThenSucceeds() {
+	// Arrange
+	// minRetryDeadline is 100us, next is 200us.
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
+
+	// Set stall time to be longer than the first attempt's timeout (100us)
+	// but shorter than the second attempt's timeout (200us).
+	t.stallTimeForGetStorageLayout = 150 * time.Microsecond
+
+	// The mock should only be called on the second attempt, which succeeds.
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedLayout, layout)
+	t.mockRawClient.AssertExpectations(t.T())
+	t.mockRawClient.AssertNumberOfCalls(t.T(), "GetStorageLayout", 1)
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut() {
+	// Arrange
+	// maxRetryDeadline is 5ms. Total budget is 10ms.
+	client := withRetryOnStall(t.stallingClient, 1000*time.Microsecond, 5000*time.Microsecond, 2, 10000*time.Microsecond)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	// Set stall time to be longer than the max attempt timeout.
+	t.stallTimeForGetStorageLayout = 6000 * time.Microsecond
+
+	// Act
+	_, err := client.GetStorageLayout(t.ctx, req)
+
+	// The mock should never be called because every attempt will time out.
+	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestDeleteFolder_SuccessOnFirstAttempt() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nil).Once()
+	t.stallTimeForFolderAPIs = 0 // No stall.
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestDeleteFolder_RetryableErrorThenSuccess() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForFolderAPIs = 0 // No stall
+
+	// First call fails, second succeeds.
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(retryableErr).Once()
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nil).Once()
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestDeleteFolder_NonRetryableError() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
+	t.stallTimeForFolderAPIs = 0 // No stall
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nonRetryableErr).Once()
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestDeleteFolder_AttemptTimesOutAndThenSucceeds() {
+	// Arrange
+	// minRetryDeadline is 100us, next is 200us.
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+
+	// Set stall time to be longer than the first attempt's timeout (100us)
+	// but shorter than the second attempt's timeout (200us).
+	t.stallTimeForFolderAPIs = 150 * time.Microsecond
+
+	// The mock should only be called on the second attempt, which succeeds.
+	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nil).Once()
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	t.mockRawClient.AssertExpectations(t.T())
+	t.mockRawClient.AssertNumberOfCalls(t.T(), "DeleteFolder", 1)
+}
+
+func (t *AllApiStallRetryWrapperTest) TestDeleteFolder_AllAttemptsTimeOut() {
+	// Arrange
+	// maxRetryDeadline is 5ms. Total budget is 10ms.
+	client := withRetryOnStall(t.stallingClient, 1000*time.Microsecond, 5000*time.Microsecond, 2, 10000*time.Microsecond)
+	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
+	// Set stall time to be longer than the max attempt timeout.
+	t.stallTimeForFolderAPIs = 6000 * time.Microsecond
+
+	// Act
+	err := client.DeleteFolder(t.ctx, req)
+
+	// The mock should never be called because every attempt will time out.
+	assert.Error(t.T(), err)
+	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestNewRetryWrapper_ParameterSanitization() {
+	// Arrange
+	var zeroDuration time.Duration
+	var negativeMultiplier = -1.0
+
+	// Act
+	client := withRetryOnStall(t.stallingClient, zeroDuration, zeroDuration, negativeMultiplier, zeroDuration)
+	wrapper, ok := client.(*storageControlClientWithRetryOnStall)
+	assert.True(t.T(), ok)
+
+	// Assert
+	assert.Equal(t.T(), defaultControlClientMinRetryDeadline, wrapper.minRetryDeadline)
+	assert.Equal(t.T(), defaultControlClientMaxRetryDeadline, wrapper.maxRetryDeadline)
+	assert.Equal(t.T(), defaultControlClientRetryMultiplier, wrapper.retryMultiplier)
+	assert.Equal(t.T(), defaultControlClientTotalRetryBudget, wrapper.totalRetryBudget)
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetFolder_SuccessOnFirstAttempt() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	expectedFolder := &controlpb.Folder{Name: "some/folder"}
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
+
+	// Act
+	folder, err := client.GetFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedFolder, folder)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetFolder_RetryableErrorThenSuccess() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	expectedFolder := &controlpb.Folder{Name: "some/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForFolderAPIs = 0 // No stall
+
+	// First call fails, second succeeds.
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
+
+	// Act
+	folder, err := client.GetFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedFolder, folder)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetFolder_NonRetryableError() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
+	t.stallTimeForFolderAPIs = 0 // No stall
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
+
+	// Act
+	folder, err := client.GetFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), folder)
+	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetFolder_AttemptTimesOutAndThenSucceeds() {
+	// Arrange
+	// minRetryDeadline is 100us, next is 200us.
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	expectedFolder := &controlpb.Folder{Name: "some/folder"}
+
+	// Set stall time to be longer than the first attempt's timeout (100us)
+	// but shorter than the second attempt's timeout (200us).
+	t.stallTimeForFolderAPIs = 150 * time.Microsecond
+
+	// The mock should only be called on the second attempt, which succeeds.
+	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
+
+	// Act
+	folder, err := client.GetFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedFolder, folder)
+	t.mockRawClient.AssertExpectations(t.T())
+	t.mockRawClient.AssertNumberOfCalls(t.T(), "GetFolder", 1)
+}
+
+func (t *AllApiStallRetryWrapperTest) TestGetFolder_AllAttemptsTimeOut() {
+	// Arrange
+	// maxRetryDeadline is 5ms. Total budget is 10ms.
+	client := withRetryOnStall(t.stallingClient, 1000*time.Microsecond, 5000*time.Microsecond, 2, 10000*time.Microsecond)
+	req := &controlpb.GetFolderRequest{Name: "some/folder"}
+	// Set execution time to be longer than the max attempt timeout.
+	t.stallTimeForFolderAPIs = 6000 * time.Microsecond
+
+	// Act
+	_, err := client.GetFolder(t.ctx, req)
+
+	// Assert: The mock should never be called because every attempt will time out.
+	assert.Error(t.T(), err)
+	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestRenameFolder_SuccessOnFirstAttempt() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
+	expectedOp := &control.RenameFolderOperation{}
+	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(expectedOp, nil).Once()
+
+	// Act
+	op, err := client.RenameFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedOp, op)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestRenameFolder_RetryableErrorThenSuccess() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
+	expectedOp := &control.RenameFolderOperation{}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForFolderAPIs = 0 // No stall
+
+	// First call fails, second succeeds.
+	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(expectedOp, nil).Once()
+
+	// Act
+	op, err := client.RenameFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedOp, op)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestRenameFolder_NonRetryableError() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
+	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
+	t.stallTimeForFolderAPIs = 0 // No stall
+	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
+
+	// Act
+	op, err := client.RenameFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), op)
+	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestCreateFolder_SuccessOnFirstAttempt() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
+	expectedFolder := &controlpb.Folder{Name: "some/folder"}
+	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
+
+	// Act
+	folder, err := client.CreateFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedFolder, folder)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestCreateFolder_RetryableErrorThenSuccess() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
+	expectedFolder := &controlpb.Folder{Name: "some/folder"}
+	retryableErr := status.Error(codes.Unavailable, "try again")
+	t.stallTimeForFolderAPIs = 0 // No stall
+
+	// First call fails, second succeeds.
+	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(nil, retryableErr).Once()
+	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
+
+	// Act
+	folder, err := client.CreateFolder(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedFolder, folder)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *AllApiStallRetryWrapperTest) TestCreateFolder_NonRetryableError() {
+	// Arrange
+	client := withRetryOnStall(t.stallingClient, 100*time.Microsecond, 500*time.Microsecond, 2, 1000*time.Microsecond)
+	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
+	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
+	t.stallTimeForFolderAPIs = 0 // No stall
+	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
+
+	// Act
+	folder, err := client.CreateFolder(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), folder)
+	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
 func (t *StorageLayoutStallRetryWrapperTest) Test_WithRetryOnStorageLayoutStallParameterSanitization() {
 	// Arrange
 	var zeroDuration time.Duration
@@ -201,6 +742,23 @@ func (t *StorageLayoutStallRetryWrapperTest) Test_WithRetryOnStorageLayoutStallP
 
 	// Act
 	client := withRetryOnStorageLayoutStall(t.stallingClient, zeroDuration, zeroDuration, negativeMultiplier, zeroDuration)
+	wrapper, ok := client.(*storageControlClientWithRetryOnStall)
+	assert.True(t.T(), ok)
+
+	// Assert
+	assert.Equal(t.T(), defaultControlClientMinRetryDeadline, wrapper.minRetryDeadline)
+	assert.Equal(t.T(), defaultControlClientMaxRetryDeadline, wrapper.maxRetryDeadline)
+	assert.Equal(t.T(), defaultControlClientRetryMultiplier, wrapper.retryMultiplier)
+	assert.Equal(t.T(), defaultControlClientTotalRetryBudget, wrapper.totalRetryBudget)
+}
+
+func (t *AllApiStallRetryWrapperTest) Test_WithRetryOnAllApiStallParameterSanitization() {
+	// Arrange
+	var zeroDuration time.Duration
+	var negativeMultiplier = -1.0
+
+	// Act
+	client := withRetryOnStall(t.stallingClient, zeroDuration, zeroDuration, negativeMultiplier, zeroDuration)
 	wrapper, ok := client.(*storageControlClientWithRetryOnStall)
 	assert.True(t.T(), ok)
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -374,10 +374,16 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		storageBucketHandle = storageBucketHandle.UserProject(billingProject)
 	}
 
+	// For Zonal buckets, wrap the control client with a retry-on-stall mechanism for more resilient folder operations.
+	controlClient := sh.storageControlClient
+	if bucketType.Zonal && sh.storageControlClient != nil {
+		controlClient = withRetryOnStall(sh.storageControlClient, defaultControlClientMinRetryDeadline, defaultControlClientMaxRetryDeadline, defaultControlClientRetryMultiplier, defaultControlClientTotalRetryBudget)
+	}
+
 	bh = &bucketHandle{
 		bucket:             storageBucketHandle,
 		bucketName:         bucketName,
-		controlClient:      sh.storageControlClient,
+		controlClient:      controlClient,
 		bucketType:         bucketType,
 		enableRapidAppends: enableRapidAppends,
 	}


### PR DESCRIPTION
### Description
- This is a reopen of https://github.com/GoogleCloudPlatform/gcsfuse/pull/3682 which got unintentionally closed.
- This extends #3561 (created as a split from the same for easy of review)

This pull request extends existing functionality to introduce a retry mechanism for stalled Folder API calls specifically for zonal buckets. It builds upon the work done in #3561.

**Key Changes:**

*   **`internal/storage/control_client_wrapper.go`**: A new field `enableStallRetriesOnAllCalls` is added to the `storageControlClientWithRetryOnStall` struct. The `DeleteFolder`, `GetFolder`, `RenameFolder`, and `CreateFolder` methods are modified to conditionally apply a retry logic (`executeWithStallRetry`) if this new flag is enabled. A new wrapper function `withRetryOnStall` is introduced to enable this behavior for all API calls.
*   **`internal/storage/control_client_wrapper_test.go`**: The test suite is significantly expanded. The `stallingStorageControlClient` now includes a `stallTimeForFolderAPIs` field to simulate stalls for folder operations. New test cases are added under `AllApiStallRetryWrapperTest` to thoroughly verify the retry mechanism for all Folder APIs (Delete, Get, Rename, Create) under various conditions (success, retryable errors, non-retryable errors, and timeouts). Additionally, tests are included to confirm that Folder APIs are *not* retried when only `GetStorageLayout` retry is enabled.
*   **`internal/storage/storage_handle.go`**: The `BucketHandle` method is updated to apply the new `withRetryOnStall` wrapper to the `storageControlClient` specifically when dealing with `Zonal` bucket types.

### Link to the issue in case of a bug fix.
[b/432458611](http://b/432458611)
[b/434621770](http://b/434621770)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
