### PR TITLE
docs(benchmarks): The old configuration generates some weirdly nested files. Fix it.

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -30,7 +30,7 @@ openfiles=1
 # Change "read" to "randread" to test random reads.
 rw=read 
 thread=1
-filename_format=$jobname.$jobnum/$filenum
+filename_format=$jobname.$jobnum.$filenum
 
 [experiment]
 stonewall


### PR DESCRIPTION
While I understand that ideally, the perf results need to be regenerated, I don't have the bandwidth to do that at the moment. But I also didn't want to leave it in its current state since it'd get lost and the subsequent benchmarks will be generated incorrectly.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
