### PR TITLE
feat(bufferedread): Update block reservation logic

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -113,7 +113,11 @@ type BufferedReader struct {
 
 // NewBufferedReader returns a new bufferedReader instance.
 func NewBufferedReader(object *gcs.MinObject, bucket gcs.Bucket, config *BufferedReadConfig, globalMaxBlocksSem *semaphore.Weighted, workerPool workerpool.WorkerPool, metricHandle metrics.MetricHandle) (*BufferedReader, error) {
-	blockpool, err := block.NewPrefetchBlockPool(config.PrefetchBlockSizeBytes, config.MaxPrefetchBlockCnt, config.MinBlocksPerHandle, globalMaxBlocksSem)
+	// To optimize resource usage, reserve only the number of blocks required for
+	// the file, capped by the configured minimum.
+	totalBlocksInFile := (int64(object.Size) + config.PrefetchBlockSizeBytes - 1) / config.PrefetchBlockSizeBytes
+	blocksToReserve := min(totalBlocksInFile, config.MinBlocksPerHandle)
+	blockpool, err := block.NewPrefetchBlockPool(config.PrefetchBlockSizeBytes, config.MaxPrefetchBlockCnt, blocksToReserve, globalMaxBlocksSem)
 	if err != nil {
 		return nil, fmt.Errorf("NewBufferedReader: creating block-pool: %w", err)
 	}

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -147,6 +147,50 @@ func (t *BufferedReaderTest) TestNewBufferedReader() {
 	assert.NotNil(t.T(), reader.cancelFunc)
 }
 
+func (t *BufferedReaderTest) TestNewBufferedReaderReservesRequiredBlocks() {
+	testCases := []struct {
+		name               string
+		objectSize         uint64
+		minBlocksPerHandle int64
+		expectedReserved   int64
+	}{
+		{
+			name:               "SmallFile",
+			objectSize:         uint64(testPrefetchBlockSizeBytes) / 2, // Requires 1 block
+			minBlocksPerHandle: 5,
+			expectedReserved:   1,
+		},
+		{
+			name:               "LargeFile",
+			objectSize:         uint64(testPrefetchBlockSizeBytes) * 10, // Requires 10 blocks
+			minBlocksPerHandle: 5,
+			expectedReserved:   5,
+		},
+		{
+			name:               "ZeroSizeFile",
+			objectSize:         0, // Requires 0 blocks
+			minBlocksPerHandle: 5,
+			expectedReserved:   0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.object.Size = tc.objectSize
+			t.config.MinBlocksPerHandle = tc.minBlocksPerHandle
+			t.globalMaxBlocksSem = semaphore.NewWeighted(testGlobalMaxBlocks)
+
+			reader, err := NewBufferedReader(t.object, t.bucket, t.config, t.globalMaxBlocksSem, t.workerPool, t.metricHandle)
+
+			require.NoError(t.T(), err)
+			require.NotNil(t.T(), reader)
+			// Verify that the correct number of blocks were reserved by checking the semaphore's state.
+			assert.True(t.T(), t.globalMaxBlocksSem.TryAcquire(testGlobalMaxBlocks-tc.expectedReserved), "Should acquire remaining permits")
+			assert.False(t.T(), t.globalMaxBlocksSem.TryAcquire(1), "Should not acquire more permits")
+		})
+	}
+}
+
 func (t *BufferedReaderTest) TestNewBufferedReaderFailsWhenPoolAllocationFails() {
 	t.globalMaxBlocksSem = semaphore.NewWeighted(1)
 


### PR DESCRIPTION
### Description
This PR improves block reservation logic while creating a new block pool for buffered reader by reserving only total blocks in file if they are lesser than `MinBlocksPerHandle` and `MinBlocksPerHandle` otherwise.

### Link to the issue in case of a bug fix
b/438450612

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
