### PR TITLE
fix(bash installation): use latest bash 5.3 and improve logging in case of error.

### DIFF
--- a/perfmetrics/scripts/install_bash.sh
+++ b/perfmetrics/scripts/install_bash.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 if [[ $# -ne 1 ]]; then
     echo "This script requires exactly one argument."
     echo "Usage: $0 <bash-version>"
-    echo "Example: $0 5.1"
+    echo "Example: $0 5.3"
     exit 1
 fi
 
@@ -60,7 +60,7 @@ install_bash() {
     tar -xzf "bash-${BASH_VERSION}.tar.gz"
     cd "bash-${BASH_VERSION}"
     ./configure --prefix="$INSTALL_DIR" --enable-readline
-    make -s
+    make -s -j"$(nproc 2>/dev/null || echo 1)"
     sudo make install
 
     popd

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -22,7 +22,7 @@ readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly EXECUTE_CHECKPOINT_TEST_LABEL="execute-checkpoint-test"
 readonly BUCKET_LOCATION=us-west4
 readonly GO_VERSION="1.24.5"
-readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
+readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.3"
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)


### PR DESCRIPTION
### Description
Bash version 5.1 had an issue with installation from source with parallel 
build (ref: https://bugs.gentoo.org/921535). Updated the bash version to more latest 5.3 version and modified the script to improve failure logging and use `set -euo pipefail` within the install block and report failure if any of the commands fail.
### Link to the issue in case of a bug fix.
[b/438135166](http://b/438135166)
### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - as part of presubmit runs

### Any backward incompatible change? If so, please explain.
NA
