### PR TITLE
fix(buffered read): Intermittent nil pointer crash in downloadTask during Reads

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -480,8 +480,11 @@ func (p *BufferedReader) Destroy() {
 
 		// We expect a context.Canceled error here, but we wait to ensure the
 		// block's worker goroutine has finished before releasing the block.
-		if _, err := bqe.block.AwaitReady(context.TODO()); err != nil && err != context.Canceled {
-			logger.Warnf("Destroy: waiting for block on destroy: %v", err)
+		status, err := bqe.block.AwaitReady(context.TODO())
+		if err != nil {
+			logger.Warnf("Destroy: AwaitReady for block failed: %v", err)
+		} else if status.Err != nil && !errors.Is(status.Err, context.Canceled) {
+			logger.Warnf("Destroy: waiting for block on destroy: %v", status.Err)
 		}
 		p.blockPool.Release(bqe.block)
 	}


### PR DESCRIPTION
### Description
We identified a crash in GCSfuse that occurred when reading multiple files in parallel. The root cause was a where a [parent context was canceled](https://github.com/GoogleCloudPlatform/gcsfuse/blob/028357cf39b74edcbf48fc925d6adf95c755cda4/internal/bufferedread/buffered_reader.go#L478) before its child operations completed. Consequently, individual blocks were being released prematurely. If a background download task subsequently attempted to access one of these freed blocks (for example, during an [io.CopyN operation](https://github.com/GoogleCloudPlatform/gcsfuse/blob/028357cf39b74edcbf48fc925d6adf95c755cda4/internal/bufferedread/download_task.go#L102)), a crash would occur because the memory had already been deallocated.

This fix resolves the issue by ensuring that the parent context is canceled only after all queued blocks have been successfully released. As seen in the changes to buffered_reader.go, the parent cancelFunc is now called after the block queue is empty. This guarantees that background tasks have finished their work before their associated blocks are deallocated, preventing the crash.

### Link to the issue in case of a bug fix.
[b/438679986](https://b.corp.google.com/issues/438679986)

### Testing details
1. Manual - Manually verify with repro scenario(10-15 times)
2. Unit tests - Updated
3. Integration tests - It will get added soon

### Any backward incompatible change? If so, please explain.
