### PR TITLE
feat(bufferedread): Modify buffered reader to treat every first read call via buffered reader as sequential

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -188,7 +188,7 @@ func (p *BufferedReader) handleRandomRead(offset int64, handleID int64) error {
 // LOCKS_REQUIRED(p.mu)
 func (p *BufferedReader) isRandomSeek(offset int64) bool {
 	if p.blockQueue.IsEmpty() {
-		return offset != 0
+		return false
 	}
 
 	start := p.blockQueue.Peek().block.AbsStartOff()


### PR DESCRIPTION
### Description
This PR modifies buffered reader to treat every first call to read using a buffered reader as sequential irrespective of offset.

### Link to the issue in case of a bug fix.
b/439140127

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
