### PR TITLE
feat(bufferedread): Limit the total workers in buffered reader by readGlobalMaxBlocks

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -214,7 +214,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 
 	if serverCfg.NewConfig.Read.EnableBufferedRead {
 		var err error
-		fs.bufferedReadWorkerPool, err = workerpool.NewStaticWorkerPoolForCurrentCPU()
+		fs.bufferedReadWorkerPool, err = workerpool.NewStaticWorkerPoolForCurrentCPU(serverCfg.NewConfig.Read.GlobalMaxBlocks)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create worker pool for buffered read: %w", err)
 		}

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -435,7 +435,7 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 			StartBlocksPerHandle: 2,
 		},
 	}
-	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU()
+	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU(20)
 	require.NoError(t.T(), err)
 	defer workerPool.Stop()
 	globalSemaphore := semaphore.NewWeighted(20) // Sufficient blocks for the test
@@ -472,7 +472,7 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() 
 			BlockSizeMb:          1,
 		},
 	}
-	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU()
+	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU(20)
 	require.NoError(t.T(), err)
 	defer workerPool.Stop()
 	globalSemaphore := semaphore.NewWeighted(20)


### PR DESCRIPTION
### Description
This PR modifies workerpool used in buffered reader to limit total workers used to `ceil(1.1*readGlobalMaxBlocks)`. Since the number of concurrent download tasks is limited by readGlobalMaxBlocks, creating more workers beyond this limit offers no performance gain and wastes resources.

### Link to the issue in case of a bug fix.
b/439146068

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
