### PR TITLE
refactor: implicit_dir test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -16,11 +16,31 @@ explicit_dir:
   - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
     test_bucket: "${BUCKET_NAME}" # To be passed by both gcsfuse and gke tests
     log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
-    flags:
-      - "--implicit-dirs=false"
-      - "--implicit-dirs=false --client-protocol=grpc"
-    compatible: # Bucket type to run these tests with
-      - flat: true
-      - hns: false
-      - zonal: false
     run_on_gke: false
+    configs:
+      - flags:
+          - "--implicit-dirs=false"
+          - "--implicit-dirs=false --client-protocol=grpc"
+        compatible: # Bucket type to run these tests with
+          flat: true
+          hns: false
+          zonal: false
+
+implicit_dir:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--implicit-dirs"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+      - flags:
+          - "--implicit-dirs --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: false

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	storage "cloud.google.com/go/storage"
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
@@ -47,10 +47,15 @@ const SecondFileInExplicitDirectory = "fileInExplicitDir2"
 const FileInImplicitDirectory = "fileInImplicitDir1"
 const FileInImplicitSubDirectory = "fileInImplicitDir2"
 
-func RunTestsForExplicitDir(config *test_suite.TestConfig, flags [][]string, m *testing.M) int {
+func RunTestsForExplicitAndImplicitDir(config *test_suite.TestConfig, flags [][]string, m *testing.M) int {
 	if config == nil {
 		log.Println("config is nil")
 		return 1
+	}
+
+	if len(flags) == 0 {
+		log.Println("flags empty: no tests to run")
+		return 0
 	}
 
 	if config.MountedDirectory != "" && config.TestBucket != "" {
@@ -69,28 +74,6 @@ func RunTestsForExplicitDir(config *test_suite.TestConfig, flags [][]string, m *
 
 	if successCode == 0 {
 		successCode = persistent_mounting.RunTestsWithConfigFile(config, flags, m)
-	}
-	return successCode
-}
-
-func RunTestsForImplicitDirAndExplicitDir(flags [][]string, m *testing.M) int {
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
-
-	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
-		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
-		os.Exit(1)
-	}
-
-	// Run tests for mountedDirectory only if --mountedDirectory and --testbucket flag is set.
-	setup.RunTestsForMountedDirectoryFlag(m)
-
-	// Run tests for testBucket only if --testbucket flag is set.
-	setup.SetUpTestDirForTestBucketFlag()
-
-	successCode := static_mounting.RunTests(flags, m)
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flags, m)
 	}
 	return successCode
 }

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -26,7 +26,12 @@ type TestConfig struct {
 	MountedDirectory string       `yaml:"mounted_directory"`
 	TestBucket       string       `yaml:"test_bucket"`
 	LogFile          string       `yaml:"log_file,omitempty"`
-	Flags            []string     `yaml:"flags"`
-	Compatible       []BucketType `yaml:"compatible"`
 	RunOnGKE         bool         `yaml:"run_on_gke"`
+	Configs          []ConfigItem `yaml:"configs"`
+}
+
+// ConfigItem defines the variable parts of each test run.
+type ConfigItem struct {
+	Flags      []string        `yaml:"flags"`
+	Compatible map[string]bool `yaml:"compatible"`
 }


### PR DESCRIPTION
### Description
This PR includes changes to migrate implicit_dir package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

Changes include:
- changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
- Migration of implicit dir package so it can use config file.
- Created common method to fetch bucket type.
- Changes to the config structure so different flagset can run with different bucket types.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
implicir_dir and explicit_dir test package stopped working after this change without config file. This was fixed in PR #3706 
