### PR TITLE
fix: fix implicit and explicit dir tests  [GKE-GCSFuse test migration]

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -68,6 +68,9 @@ func TestMain(m *testing.M) {
 		cfg.ExplicitDir = make([]test_suite.TestConfig, 1)
 		cfg.ExplicitDir[0].TestBucket = setup.TestBucket()
 		cfg.ExplicitDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ExplicitDir[0].Configs = make([]test_suite.ConfigItem, 1)
+		cfg.ExplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs=false", "--implicit-dirs=false --client-protocol=grpc"}
+		cfg.ExplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -82,11 +82,16 @@ func TestMain(m *testing.M) {
 		}
 	}
 	if len(cfg.ImplicitDir) == 0 {
-		log.Println("No configuration found for explicit_dir tests in config. Using flags instead.")
+		log.Println("No configuration found for implicit_dir tests in config. Using flags instead.")
 		// Populate the config manually.
 		cfg.ImplicitDir = make([]test_suite.TestConfig, 1)
 		cfg.ImplicitDir[0].TestBucket = setup.TestBucket()
 		cfg.ImplicitDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ImplicitDir[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.ImplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs"}
+		cfg.ImplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ImplicitDir[0].Configs[1].Flags = []string{"--implicit-dirs --client-protocol=grpc"}
+		cfg.ImplicitDir[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
 	}
 
 	// 2. Create storage client before running tests.


### PR DESCRIPTION
### Description
The config addition was missed in the previous PRs. Adding them for backward compatability.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - manually verified that the tests work without config.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA