### PR TITLE
refactor: list large dir test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -72,7 +72,6 @@ func TestMain(m *testing.M) {
 		cfg.ListLargeDir[0].Configs[0].Flags = []string{"--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"}
 		cfg.ListLargeDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ListLargeDir[0].Configs[1].Flags = []string{
-			"--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1",
 			"--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1",
 		}
 		cfg.ListLargeDir[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -16,19 +16,17 @@
 package list_large_dir
 
 import (
-    "context"
-    "log"
-    "os"
-    "testing"
-    "fmt"
-    "strings"
+	"context"
+	"log"
+	"os"
+	"testing"
 
-    "cloud.google.com/go/storage"
-    "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-    "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
-    "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-    "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-    "gopkg.in/yaml.v3"
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"gopkg.in/yaml.v3"
 )
 
 const prefixFileInDirectoryWithTwelveThousandFiles = "fileInDirectoryWithTwelveThousandFiles"
@@ -39,77 +37,78 @@ const numberOfImplicitDirsInDirectoryWithTwelveThousandFiles = 100
 const numberOfExplicitDirsInDirectoryWithTwelveThousandFiles = 100
 
 var (
-    directoryWithTwelveThousandFiles = "directoryWithTwelveThousandFiles" + setup.GenerateRandomString(5)
-    storageClient                    *storage.Client
-    ctx                              context.Context
+	directoryWithTwelveThousandFiles = "directoryWithTwelveThousandFiles" + setup.GenerateRandomString(5)
+	storageClient                    *storage.Client
+	ctx                              context.Context
 )
 
 // Config holds all test configurations parsed from the YAML file.
 type Config struct {
-    ListLargeDir []test_suite.TestConfig `yaml:"list_large_dir"`
+	ListLargeDir []test_suite.TestConfig `yaml:"list_large_dir"`
 }
 
 func TestMain(m *testing.M) {
-    setup.ParseSetUpFlags()
+	setup.ParseSetUpFlags()
 
-    // 1. Load and parse the common configuration.
-    var cfg Config
-    if setup.ConfigFile() != "" {
-        configData, err := os.ReadFile(setup.ConfigFile())
-        if err != nil {
-            log.Fatalf("could not read test_config.yaml: %v", err)
-        }
-        expandedYaml := os.ExpandEnv(string(configData))
-        if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
-            log.Fatalf("Failed to parse config YAML: %v", err)
-        }
-    }
-    if len(cfg.ListLargeDir) == 0 {
-        log.Println("No configuration found for list large dir tests in config. Using flags instead.")
-        // Populate the config manually.
-        cfg.ListLargeDir = make([]test_suite.TestConfig, 1)
-        cfg.ListLargeDir[0].TestBucket = setup.TestBucket()
-        // TODO : use yaml file and manually input the flags.
-        cfg.ListLargeDir[0].Flags = []string{
-            // "--enable-atomic-rename-object=true",
-            // "--experimental-enable-json-read=true",
-            // "--client-protocol=grpc --implicit-dirs=true --enable-atomic-rename-object=true",
-            // "--experimental-enable-json-read=true --enable-atomic-rename-object=true",
-            // "--create-empty-file=true --enable-atomic-rename-object=true",
-            // "--metadata-cache-ttl-secs=0 --enable-streaming-writes=false",
-            // "--kernel-list-cache-ttl-secs=-1 --implicit-dirs=true",
-        }
-    }
+	// 1. Load and parse the common configuration.
+	var cfg Config
+	if setup.ConfigFile() != "" {
+		configData, err := os.ReadFile(setup.ConfigFile())
+		if err != nil {
+			log.Fatalf("could not read test_config.yaml: %v", err)
+		}
+		expandedYaml := os.ExpandEnv(string(configData))
+		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
+			log.Fatalf("Failed to parse config YAML: %v", err)
+		}
+	}
+	if len(cfg.ListLargeDir) == 0 {
+		log.Println("No configuration found for list large dir tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.ListLargeDir = make([]test_suite.TestConfig, 1)
+		cfg.ListLargeDir[0].TestBucket = setup.TestBucket()
+		cfg.ListLargeDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ListLargeDir[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.ListLargeDir[0].Configs[0].Flags = []string{"--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"}
+		cfg.ListLargeDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ListLargeDir[0].Configs[1].Flags = []string{
+			"--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1",
+			"--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1",
+		}
+		cfg.ListLargeDir[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+	}
 
-    // 2. Create storage client before running tests.
-    setup.SetBucketFromConfigFile(cfg.ListLargeDir[0].TestBucket)
-    ctx = context.Background()
-    closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
-    defer func() {
-        err := closeStorageClient()
-        if err != nil {
-            log.Fatalf("closeStorageClient failed: %v", err)
-        }
-    }()
-    defer storageClient.Close()
+	// 2. Create storage client before running tests.
+	setup.SetBucketFromConfigFile(cfg.ListLargeDir[0].TestBucket)
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
 
-    // 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-    // flags to be set, as ListLargeDir tests validates content from the bucket.
-    if cfg.ListLargeDir[0].MountedDirectory != "" && cfg.ListLargeDir[0].TestBucket != "" {
-        os.Exit(setup.RunTestsForMountedDirectory(cfg.ListLargeDir[0].MountedDirectory, m))
-    }
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as ListLargeDir tests validates content from the bucket.
+	if cfg.ListLargeDir[0].MountedDirectory != "" && cfg.ListLargeDir[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.ListLargeDir[0].MountedDirectory, m))
+	}
 
-    // flags := [][]string{{"--implicit-dirs", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"}}
-    // // Don't run for grpc if -short flat is passed.
-    // // Don't run for grpc for zonal bucket as zonal buckets by default use grpc.
-    // if !testing.Short() && !setup.IsZonalBucketRun() {
-    //  flags = append(flags, []string{"--client-protocol=grpc", "--implicit-dirs=true", "--stat-cache-ttl=0", "--kernel-list-cache-ttl-secs=-1"})
-    // }
+	// Run tests for testBucket
+	// 4. Build the flag sets dynamically from the config.
+	bucketType, err := setup.BucketType(ctx, cfg.ListLargeDir[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+	flags := setup.BuildFlagSets(cfg.ListLargeDir[0], bucketType)
 
-    setup.SetUpTestDirForTestBucket(cfg.ListLargeDir[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(cfg.ListLargeDir[0].TestBucket)
 
-    successCode := static_mounting.RunTestsWithConfigFile(&cfg.ListLargeDir[0],flags, m)
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ListLargeDir[0], flags, m)
 
-    os.Exit(successCode)
+	os.Exit(successCode)
 }
-

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -59,7 +59,6 @@ list_large_dir:
           zonal: true
       - flags:
         - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
-        - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -44,3 +44,22 @@ implicit_dir:
           flat: true
           hns: true
           zonal: false
+
+list_large_dir:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
+    run_on_gke: false
+    configs:
+      - flags:
+        - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+      - flags:
+        - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: false

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -58,6 +58,7 @@ list_large_dir:
           hns: true
           zonal: true
       - flags:
+        - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         compatible:
           flat: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -58,7 +58,7 @@ list_large_dir:
           hns: true
           zonal: true
       - flags:
-        - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
+        - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -93,6 +93,10 @@ func IsZonalBucketRun() bool {
 	return *isZonalBucketRun
 }
 
+func SetIsZonalBucketRun(val bool) {
+	*isZonalBucketRun = val
+}
+
 func IsIntegrationTest() bool {
 	return *integrationTest
 }


### PR DESCRIPTION
### Description
This PR includes changes to migrate list large dir package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of operations package so it can use config file.

### Link to the issue in case of a bug fix.
[b/439727980](https://b.corp.google.com/issues/439727980)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
