### PR TITLE
refactor: write large files test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -72,6 +72,9 @@ write_large_files:
     configs:
       - flags:
           - "--enable-streaming-writes=false"
+          # write-global-max-blocks=2 is for checking multiple file writes in parallel.
+          # concurrent_write_files_test.go- we are writing 3 files in parallel.
+          # with this config, we are giving 2 blocks to 2 files and 1 block to other file.
           - "--write-max-blocks-per-file=2 --write-global-max-blocks=2"
         compatible:
           flat: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -72,10 +72,10 @@ write_large_files:
     configs:
       - flags:
           - "--enable-streaming-writes=false"
-          # write-global-max-blocks=2 is for checking multiple file writes in parallel.
+          # write-global-max-blocks=5 is for checking multiple file writes in parallel.
           # concurrent_write_files_test.go- we are writing 3 files in parallel.
           # with this config, we are giving 2 blocks to 2 files and 1 block to other file.
-          - "--write-max-blocks-per-file=2 --write-global-max-blocks=2"
+          - "--write-max-blocks-per-file=2 --write-global-max-blocks=5"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -63,3 +63,17 @@ list_large_dir:
           flat: true
           hns: true
           zonal: false
+
+write_large_files:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--enable-streaming-writes=false"
+          - "--write-max-blocks-per-file=2 --write-global-max-blocks=2"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,13 @@
 // limitations under the License.
 
 package test_suite
+
+import (
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
 
 // BucketType represents the 'compatible' field.
 type BucketType struct {
@@ -34,4 +41,44 @@ type TestConfig struct {
 type ConfigItem struct {
 	Flags      []string        `yaml:"flags"`
 	Compatible map[string]bool `yaml:"compatible"`
+}
+
+// Config holds all test configurations parsed from the YAML file.
+type Config struct {
+	ImplicitDir           []TestConfig `yaml:"implicit_dir"`
+	ExplicitDir           []TestConfig `yaml:"explicit_dir"`
+	ListLargeDir          []TestConfig `yaml:"list_large_dir"`
+	WriteLargeFiles       []TestConfig `yaml:"write_large_files"`
+	Operations            []TestConfig `yaml:"operations"`
+	ReadLargeFiles        []TestConfig `yaml:"read_large_files"`
+	ReadOnly              []TestConfig `yaml:"readonly"`
+	ReadCache             []TestConfig `yaml:"read_cache"`
+	RenameDirLimit        []TestConfig `yaml:"rename_dir_limit"`
+	Gzip                  []TestConfig `yaml:"gzip"`
+	LocalFile             []TestConfig `yaml:"local_file"`
+	LogRotation           []TestConfig `yaml:"log_rotation"`
+	ManagedFolders        []TestConfig `yaml:"managed_folders"`
+	ConcurrentOperations  []TestConfig `yaml:"concurrent_operations"`
+	Benchmarking          []TestConfig `yaml:"benchmarking"`
+	StaleHandles          []TestConfig `yaml:"stale_handles"`
+	StreamingWrites       []TestConfig `yaml:"streaming_writes"`
+	InactiveStreamTimeout []TestConfig `yaml:"inactive_stream_timeout"`
+	CloudProfiler         []TestConfig `yaml:"cloud_profiler"`
+	KernelListCache       []TestConfig `yaml:"kernel_list_cache"`
+	ReadDirPlus           []TestConfig `yaml:"readdirplus"`
+	DentryCache           []TestConfig `yaml:"dentry_cache"`
+}
+
+// ReadConfigFile returns a Config struct from the YAML file.
+func ReadConfigFile(configFilePath string) Config {
+	var cfg Config
+	configData, err := os.ReadFile(configFilePath)
+	if err != nil {
+		log.Fatalf("could not read config file %q: %v", configFilePath, err)
+	}
+	expandedYaml := os.ExpandEnv(string(configData))
+	if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
+		log.Fatalf("Failed to parse config YAML: %v", err)
+	}
+	return cfg
 }

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -72,13 +72,15 @@ type Config struct {
 // ReadConfigFile returns a Config struct from the YAML file.
 func ReadConfigFile(configFilePath string) Config {
 	var cfg Config
-	configData, err := os.ReadFile(configFilePath)
-	if err != nil {
-		log.Fatalf("could not read config file %q: %v", configFilePath, err)
-	}
-	expandedYaml := os.ExpandEnv(string(configData))
-	if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
-		log.Fatalf("Failed to parse config YAML: %v", err)
+	if configFilePath != "" {
+		configData, err := os.ReadFile(configFilePath)
+		if err != nil {
+			log.Fatalf("could not read config file %q: %v", configFilePath, err)
+		}
+		expandedYaml := os.ExpandEnv(string(configData))
+		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
+			log.Fatalf("Failed to parse config YAML: %v", err)
+		}
 	}
 	return cfg
 }

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -36,8 +36,8 @@ const (
 )
 
 var (
-	storageClient                    *storage.Client
-	ctx                              context.Context
+	storageClient *storage.Client
+	ctx           context.Context
 )
 
 // Config holds all test configurations parsed from the YAML file.
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 			"--write-max-blocks-per-file=2 --write-global-max-blocks=2",
 		}
 		cfg.WriteLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		}
+	}
 
 	// 2. Create storage client before running tests.
 	setup.SetBucketFromConfigFile(cfg.WriteLargeFiles[0].TestBucket)
@@ -93,7 +93,7 @@ func TestMain(m *testing.M) {
 	if cfg.WriteLargeFiles[0].MountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
 	}
-	
+
 	// Run tests for testBucket// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	bucketType, err := setup.BucketType(ctx, cfg.WriteLargeFiles[0].TestBucket)
@@ -108,6 +108,6 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(cfg.WriteLargeFiles[0].TestBucket)
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.WriteLargeFiles[0], flags, m)
-	
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,17 @@
 package write_large_files
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
 
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -30,29 +35,79 @@ const (
 	WritePermission_0200 = 0200
 )
 
+var (
+	storageClient                    *storage.Client
+	ctx                              context.Context
+)
+
+// Config holds all test configurations parsed from the YAML file.
+type Config struct {
+	WriteLargeFiles []test_suite.TestConfig `yaml:"write_large_files"`
+}
+
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
+	// 1. Load and parse the common configuration.
+	var cfg Config
+	if setup.ConfigFile() != "" {
+		configData, err := os.ReadFile(setup.ConfigFile())
+		if err != nil {
+			log.Fatalf("could not read test_config.yaml: %v", err)
+		}
+		expandedYaml := os.ExpandEnv(string(configData))
+		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
+			log.Fatalf("Failed to parse config YAML: %v", err)
+		}
+	}
 	// write-global-max-blocks=2 is for checking multiple file writes in parallel.
 	// concurrent_write_files_test.go- we are writing 3 files in parallel.
 	// with this config, we are giving 2 blocks to 2 files and 1 block to other file.
-	flags := [][]string{
-		{"--enable-streaming-writes=false"},
-		{"--write-max-blocks-per-file=2", "--write-global-max-blocks=2"}}
+	if len(cfg.WriteLargeFiles) == 0 {
+		log.Println("No configuration found for write large files tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.WriteLargeFiles = make([]test_suite.TestConfig, 1)
+		cfg.WriteLargeFiles[0].TestBucket = setup.TestBucket()
+		cfg.WriteLargeFiles[0].MountedDirectory = setup.MountedDirectory()
+		cfg.WriteLargeFiles[0].Configs = make([]test_suite.ConfigItem, 1)
+		cfg.WriteLargeFiles[0].Configs[0].Flags = []string{
+			"--enable-streaming-writes=false",
+			"--write-max-blocks-per-file=2 --write-global-max-blocks=2",
+		}
+		cfg.WriteLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		}
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+	// 2. Create storage client before running tests.
+	setup.SetBucketFromConfigFile(cfg.WriteLargeFiles[0].TestBucket)
+	ctx = context.Background()
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
 
-	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
-		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
-		os.Exit(1)
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as WriteLargeFiles tests validates content from the bucket.
+	if cfg.WriteLargeFiles[0].MountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
 	}
+	
+	// Run tests for testBucket// Run tests for testBucket
+	// 4. Build the flag sets dynamically from the config.
+	bucketType, err := setup.BucketType(ctx, cfg.WriteLargeFiles[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
 
-	// Run tests for mountedDirectory only if --mountedDirectory flag is set.
-	setup.RunTestsForMountedDirectoryFlag(m)
+	setup.SetUpTestDirForTestBucket(cfg.WriteLargeFiles[0].TestBucket)
 
-	// Run tests for testBucket
-	setup.SetUpTestDirForTestBucketFlag()
-
-	successCode := static_mounting.RunTests(flags, m)
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.WriteLargeFiles[0], flags, m)
+	
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -43,10 +43,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// 1. Load and parse the common configuration.
-	var cfg test_suite.Config
-	if setup.ConfigFile() != "" {
-		cfg = test_suite.ReadConfigFile(setup.ConfigFile())
-	}
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.WriteLargeFiles) == 0 {
 		log.Println("No configuration found for write large files tests in config. Using flags instead.")
 		// Populate the config manually.
@@ -61,9 +58,17 @@ func TestMain(m *testing.M) {
 		cfg.WriteLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
-	// 2. Create storage client before running tests.
 	setup.SetBucketFromConfigFile(cfg.WriteLargeFiles[0].TestBucket)
 	ctx = context.Background()
+	bucketType, err := setup.BucketType(ctx, cfg.WriteLargeFiles[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+
+	// 2. Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -80,13 +85,6 @@ func TestMain(m *testing.M) {
 
 	// Run tests for testBucket// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
-	bucketType, err := setup.BucketType(ctx, cfg.WriteLargeFiles[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-	if bucketType == setup.ZonalBucket {
-		setup.SetIsZonalBucketRun(true)
-	}
 	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
 
 	setup.SetUpTestDirForTestBucket(cfg.WriteLargeFiles[0].TestBucket)

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 		cfg.WriteLargeFiles[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.WriteLargeFiles[0].Configs[0].Flags = []string{
 			"--enable-streaming-writes=false",
-			"--write-max-blocks-per-file=2 --write-global-max-blocks=2",
+			"--write-max-blocks-per-file=2 --write-global-max-blocks=5",
 		}
 		cfg.WriteLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -40,29 +39,14 @@ var (
 	ctx           context.Context
 )
 
-// Config holds all test configurations parsed from the YAML file.
-type Config struct {
-	WriteLargeFiles []test_suite.TestConfig `yaml:"write_large_files"`
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// 1. Load and parse the common configuration.
-	var cfg Config
+	var cfg test_suite.Config
 	if setup.ConfigFile() != "" {
-		configData, err := os.ReadFile(setup.ConfigFile())
-		if err != nil {
-			log.Fatalf("could not read test_config.yaml: %v", err)
-		}
-		expandedYaml := os.ExpandEnv(string(configData))
-		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
-			log.Fatalf("Failed to parse config YAML: %v", err)
-		}
+		cfg = test_suite.ReadConfigFile(setup.ConfigFile())
 	}
-	// write-global-max-blocks=2 is for checking multiple file writes in parallel.
-	// concurrent_write_files_test.go- we are writing 3 files in parallel.
-	// with this config, we are giving 2 blocks to 2 files and 1 block to other file.
 	if len(cfg.WriteLargeFiles) == 0 {
 		log.Println("No configuration found for write large files tests in config. Using flags instead.")
 		// Populate the config manually.


### PR DESCRIPTION
### Description
This PR includes changes to migrate write large files package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of operations package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445945379](https://b.corp.google.com/issues/445945379)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
