### PR TITLE
revert(enable-write-stall): enable write stall in streaming writes

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -258,8 +258,7 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc := &ObjectWriter{obj.NewWriter(ctx)}
 	wc.ChunkSize = chunkSize
 	wc.Writer = storageutil.SetAttrsInWriter(wc.Writer, req)
-	// TODO(b/424091803): Uncomment once chunk transfer timeout issue in resumable uploads is fixed in dependencies.
-	// wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
+	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	wc.ProgressFunc = callBack
 	// All objects in zonal buckets must be appendable.
 	wc.Append = bh.BucketType().Zonal

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -101,10 +101,9 @@ func TestChunkTransferTimeoutInfinity(t *testing.T) {
 }
 
 func TestChunkTransferTimeout(t *testing.T) {
-	// TODO(b/424091803): Enable streaming writes once chunk transfer timeout issue in resumable uploads is fixed in dependencies.
 	flagSets := [][]string{
-		{"--enable-streaming-writes=false"},
-		{"--enable-streaming-writes=false", "--chunk-transfer-timeout-secs=5"},
+		{},
+		{"--chunk-transfer-timeout-secs=5"},
 	}
 
 	stallScenarios := []struct {


### PR DESCRIPTION
### Description
Enabling write stall in streaming writes path which was disabled in https://github.com/GoogleCloudPlatform/gcsfuse/pull/3404. As bug in dependency has been fixed and upgraded in GCSFuse.

### Link to the issue in case of a bug fix.
b/424091803

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit tests on zb and regional

### Any backward incompatible change? If so, please explain.
