### PR TITLE
fix(metrics): prevent panic when recording histograms with no attributes

### DIFF
--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -2723,7 +2723,11 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		go func() {
 			defer wg.Done()
 			for record := range ch {
-				record.instrument.Record(record.ctx, record.value, record.attributes)
+				if record.attributes != nil {
+					record.instrument.Record(record.ctx, record.value, record.attributes)
+				} else {
+					record.instrument.Record(record.ctx, record.value)
+				}
 			}
 		}()
 	}

--- a/tools/metrics-gen/otel_metrics.tpl
+++ b/tools/metrics-gen/otel_metrics.tpl
@@ -103,7 +103,11 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
     go func() {
 	  defer wg.Done()
 	  for record := range ch {
-		record.instrument.Record(record.ctx, record.value, record.attributes)
+		if record.attributes != nil {
+            record.instrument.Record(record.ctx, record.value, record.attributes)
+        } else {
+            record.instrument.Record(record.ctx, record.value)
+        }
 	  }
 	}()
   }


### PR DESCRIPTION
### Description
This PR fixes the nil pointer dereference panic that occurs when recording a histogram-based metric that has no defined attributes.

Previously, when a histogram metric without attributes was recorded, the `histogramRecord` was sent to the processing channel with a `nil` value for the `attributes` field. The worker goroutine would then pass this `nil` value to `instrument.Record()`, causing a panic inside the OpenTelemetry SDK which does not expect a nil `RecordOption`.

This PR introduces a check to handle this case. If `record.attributes` is `nil`, the `Record()` method is called without the attributes argument, which is the correct way to record a metric with no attributes. This prevents the panic and ensures that attribute-less histograms are recorded correctly.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/439994266

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
