### PR TITLE
fix: re-use read handle from previous read.

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -93,8 +93,7 @@ func (bh *bucketHandle) NewReaderWithReadHandle(
 	// This produces the exact same object and generation and does not check if
 	// the generation is still the newest one.
 	if req.ReadHandle != nil {
-		// TODO: b/432639555 fix code to use read handle from previous read.
-		obj = obj.ReadHandle([]byte("opaque-handle"))
+		obj = obj.ReadHandle(req.ReadHandle)
 	}
 
 	// NewRangeReader creates a "storage.Reader" object which is also io.ReadCloser since it contains both Read() and Close() methods present in io.ReadCloser interface.

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -93,7 +93,7 @@ type debugReader struct {
 	requestID uint64
 	desc      string
 	startTime time.Time
-	wrapped   io.ReadCloser
+	wrapped   gcs.StorageReader
 }
 
 func (dr *debugReader) Read(p []byte) (n int, err error) {
@@ -119,9 +119,7 @@ func (dr *debugReader) Close() (err error) {
 }
 
 func (dr *debugReader) ReadHandle() storagev2.ReadHandle {
-	// TODO: b/432639555 fix code to use read handle from previous read.
-	hd := "opaque-handle"
-	return []byte(hd)
+	return dr.wrapped.ReadHandle()
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
fix: re-use read handle from previous read.

### Link to the issue in case of a bug fix.
b/432639555

### Testing details
1. Manual - Manually verified that the code is working
2. Unit tests - NA
3. Integration tests - via KOKORO (all tests passed except TestMountTimeout/TestMountMultiRegionUSBucketWithTimeout which is a known flaky test)
4. Perf improvement - negligible for sequential reads (2%)

### Any backward incompatible change? If so, please explain.
NA