### PR TITLE
fix(review reminder): fix auto reminder issue when PR is raised from fork gcsfuse.

### DIFF
--- a/.github/workflows/auto-pr-reminder.yml
+++ b/.github/workflows/auto-pr-reminder.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Add 'remind-reviewers' label
         uses: actions/github-script@v6


### PR DESCRIPTION
### Description
Fix permission issue with auto review reminder when PR is raised from forked gcsfuse.
Error seen in this PR https://github.com/GoogleCloudPlatform/gcsfuse/pull/3709
Error:
<img width="1220" height="1630" alt="3ZDfdVHBuQ9ybhz" src="https://github.com/user-attachments/assets/0d8623f4-7f77-4ec3-b86a-b122dc481301" />


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
