### PR TITLE
refactor: cloud profiler test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -86,10 +86,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if cfg.CloudProfiler[0].GKEMountedDirectory != "" {
-		if setup.ProfileLabelForMountedDirTest() == "" {
-			log.Fatal("Profile label should have been provided for mounted directory test.")
-		}
-		testServiceVersion = setup.ProfileLabelForMountedDirTest()
+		testServiceVersion = setup.ExtractServiceVersionFromFlags(cfg.CloudProfiler[0].Configs[0].Flags)
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].GKEMountedDirectory, m))
 	}
 

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -57,16 +57,15 @@ func TestMain(m *testing.M) {
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.CloudProfiler) == 0 {
 		log.Println("No configuration found for cloud profiler tests in config. Using flags instead.")
-		if setup.ProfileLabelForMountedDirTest() == "" {
-			log.Fatal("Profile label should have been provided for mounted directory test.")
-		}
+		
 		var testServiceVersion string
-		if setup.MountedDirectory() != ""
-		{
+		if setup.MountedDirectory() != "" {
+			if setup.ProfileLabelForMountedDirTest() == "" {
+				log.Fatal("Profile label should have been provided for mounted directory test.")
+			}
 			testServiceVersion = setup.ProfileLabelForMountedDirTest()
 		}
-		else 
-		{
+		else {
 			testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 		}
 		// Populate the config manually.

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -70,9 +70,9 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].MountedDirectory = setup.MountedDirectory()
 		cfg.CloudProfiler[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.CloudProfiler[0].Configs[0].Flags = []string{
-			"--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap",
+			"--enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap",
 		}
-		testServiceVersionFlag := fmt.Sprintf(" --profiling-label=%s", testServiceVersion)
+		testServiceVersionFlag := fmt.Sprintf(" --cloud-profiler-label=%s", testServiceVersion)
 		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testServiceVersionFlag
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
@@ -113,11 +113,11 @@ func TestMain(m *testing.M) {
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
 
-	// Iterating over flagSets and updating any empty "--profiling-label=" flags.
+	// Iterating over flagSets and updating any empty "--cloud-profiler-label=" flags.
 	for i := range flags {
 		for j := range flags[i] {
-			if flags[i][j] == "--profiling-label=" {
-				flags[i][j] = fmt.Sprintf("--profiling-label=%s", testServiceVersion)
+			if flags[i][j] == "--cloud-profiler-label=" {
+				flags[i][j] = fmt.Sprintf("--cloud-profiler-label=%s", testServiceVersion)
 			}
 		}
 	}

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -41,9 +41,9 @@ const (
 )
 
 var (
-	storageClient *storage.Client
+	storageClient      *storage.Client
 	testServiceVersion string
-	ctx context.Context
+	ctx                context.Context
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testServiceVersionFlag
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
-	
+
 	setup.SetBucketFromConfigFile(cfg.CloudProfiler[0].TestBucket)
 	ctx = context.Background()
 	bucketType, err := setup.BucketType(ctx, cfg.CloudProfiler[0].TestBucket)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -63,8 +63,6 @@ func TestMain(m *testing.M) {
 				log.Fatal("Profile label should have been provided for mounted directory test.")
 			}
 			testServiceVersion = setup.ProfileLabelForMountedDirTest()
-		} else {
-			testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 		}
 		// Populate the config manually.
 		cfg.CloudProfiler = make([]test_suite.TestConfig, 1)
@@ -111,18 +109,18 @@ func TestMain(m *testing.M) {
 	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
 
-	// Iterating over flagSets and updating any empty "--profiling-label=" flags.
-	for i := range flagSets {
-		for j := range flagSets[i] {
-			if flagSets[i][j] == "--profiling-label=" {
-				flagSets[i][j] = fmt.Sprintf(" --profiling-label=%s", testServiceVersion)
-			}
-		}
-	}
-
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
+
+	// Iterating over flagSets and updating any empty "--profiling-label=" flags.
+	for i := range flags {
+		for j := range flags[i] {
+			if flags[i][j] == "--profiling-label=" {
+				flags[i][j] = fmt.Sprintf("--profiling-label=%s", testServiceVersion)
+			}
+		}
+	}
 	setup.SetUpTestDirForTestBucket(cfg.CloudProfiler[0].TestBucket)
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.CloudProfiler[0], flags, m)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
@@ -40,7 +41,9 @@ const (
 )
 
 var (
+	storageClient *storage.Client
 	testServiceVersion string
+	ctx context.Context
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -50,8 +53,38 @@ var (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	var storageClient *storage.Client
-	ctx := context.Background()
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.CloudProfiler) == 0 {
+		log.Println("No configuration found for write large files tests in config. Using flags instead.")
+		if setup.ProfileLabelForMountedDirTest() == "" {
+			log.Fatal("Profile label should have been provided for mounted directory test.")
+		}
+		testServiceVersion = setup.ProfileLabelForMountedDirTest()
+		// Populate the config manually.
+		cfg.CloudProfiler = make([]test_suite.TestConfig, 1)
+		cfg.CloudProfiler[0].TestBucket = setup.TestBucket()
+		cfg.CloudProfiler[0].MountedDirectory = setup.MountedDirectory()
+		cfg.CloudProfiler[0].Configs = make([]test_suite.ConfigItem, 1)
+		cfg.CloudProfiler[0].Configs[0].Flags = []string{
+			"--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap",
+		}
+		testServiceVersionFlag := fmt.Sprintf(" --profiling-label=%s", testServiceVersion)
+		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testServiceVersionFlag
+		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+	}
+	
+	setup.SetBucketFromConfigFile(cfg.CloudProfiler[0].TestBucket)
+	ctx = context.Background()
+	bucketType, err := setup.BucketType(ctx, cfg.CloudProfiler[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+
+	// 2. Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -65,19 +98,25 @@ func TestMain(m *testing.M) {
 			log.Fatal("Profile label should have been provided for mounted directory test.")
 		}
 		testServiceVersion = setup.ProfileLabelForMountedDirTest()
-		setup.RunTestsForMountedDirectoryFlag(m)
+		setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].MountedDirectory, m)
 	}
 
-	// Else run tests for testBucket.
-	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as CloudProfiler tests validates content from the bucket.
+	if cfg.CloudProfiler[0].MountedDirectory != "" && cfg.CloudProfiler[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].MountedDirectory, m))
+	}
+
+	// Run tests for testBucket// Run tests for testBucket
+	// 4. Build the flag sets dynamically from the config.
+	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
+
+	setup.SetUpTestDirForTestBucket(cfg.CloudProfiler[0].TestBucket)
+
 	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
-
-	flags := [][]string{
-		{"--enable-cloud-profiler", "--cloud-profiler-cpu", "--cloud-profiler-heap", "--cloud-profiler-goroutines", "--cloud-profiler-mutex", "--cloud-profiler-allocated-heap", fmt.Sprintf("--cloud-profiler-label=%s", testServiceVersion)},
-	}
 	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
-	successCode := static_mounting.RunTests(flags, m)
+
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.CloudProfiler[0], flags, m)
 
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -57,15 +57,13 @@ func TestMain(m *testing.M) {
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.CloudProfiler) == 0 {
 		log.Println("No configuration found for cloud profiler tests in config. Using flags instead.")
-		
-		var testServiceVersion string
+
 		if setup.MountedDirectory() != "" {
 			if setup.ProfileLabelForMountedDirTest() == "" {
 				log.Fatal("Profile label should have been provided for mounted directory test.")
 			}
 			testServiceVersion = setup.ProfileLabelForMountedDirTest()
-		}
-		else {
+		} else {
 			testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 		}
 		// Populate the config manually.
@@ -80,6 +78,7 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testServiceVersionFlag
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
+
 	setup.SetBucketFromConfigFile(cfg.CloudProfiler[0].TestBucket)
 	ctx = context.Background()
 	bucketType, err := setup.BucketType(ctx, cfg.CloudProfiler[0].TestBucket)
@@ -105,13 +104,13 @@ func TestMain(m *testing.M) {
 			log.Fatal("Profile label should have been provided for mounted directory test.")
 		}
 		testServiceVersion = setup.ProfileLabelForMountedDirTest()
-		os.exit(setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].MountedDirectory, m))
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].MountedDirectory, m))
 	}
 
 	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
-	
-	// Run tests for testBucket// Run tests for testBucket
+
+	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
 

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -79,8 +79,9 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
-	setup.SetBucketFromConfigFile(cfg.CloudProfiler[0].TestBucket)
+	setup.SetTestBucket(cfg.CloudProfiler[0].TestBucket)
 	ctx = context.Background()
+
 	bucketType, err := setup.BucketType(ctx, cfg.CloudProfiler[0].TestBucket)
 	if err != nil {
 		log.Fatalf("BucketType failed: %v", err)
@@ -113,7 +114,6 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
-
 	setup.SetUpTestDirForTestBucket(cfg.CloudProfiler[0].TestBucket)
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.CloudProfiler[0], flags, m)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -111,16 +111,9 @@ func TestMain(m *testing.M) {
 
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
+	cfg.CloudProfiler[0].Configs[0].Flags[0] = strings.ReplaceAll(cfg.CloudProfiler[0].Configs[0].Flags[0], "--cloud-profiler-label=", fmt.Sprintf("--cloud-profiler-label=%s", testServiceVersion))
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)
 
-	// Iterating over flagSets and updating any empty "--cloud-profiler-label=" flags.
-	for i := range flags {
-		for j := range flags[i] {
-			if flags[i][j] == "--cloud-profiler-label=" {
-				flags[i][j] = fmt.Sprintf("--cloud-profiler-label=%s", testServiceVersion)
-			}
-		}
-	}
 	setup.SetUpTestDirForTestBucket(cfg.CloudProfiler[0].TestBucket)
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.CloudProfiler[0], flags, m)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -111,6 +111,15 @@ func TestMain(m *testing.M) {
 	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
 	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
 
+	// Iterating over flagSets and updating any empty "--profiling-label=" flags.
+	for i := range flagSets {
+		for j := range flagSets[i] {
+			if flagSets[i][j] == "--profiling-label=" {
+				flagSets[i][j] = fmt.Sprintf(" --profiling-label=%s", testServiceVersion)
+			}
+		}
+	}
+
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType)

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -172,7 +172,7 @@ cloud_profiler:
     configs:
       - flags:
            # Set the 'PROFILE_LABEL' environment variable for GKE
-          - "--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap --profiling-label=${PROFILE_LABEL}"
+          - "--enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap --cloud-profiler-label=${PROFILE_LABEL}"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -163,3 +163,16 @@ streaming_writes:
           flat: true
           hns: true
           zonal: true
+
+cloud_profiler:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap --profiling-label=${PROFILE_LABEL}" # Set the 'PROFILE_LABEL' environment variable
+        compatible:
+          flat: true
+          hns: true
+          zonal: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -168,11 +168,11 @@ cloud_profiler:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     log_file: # Optional
-    profile_label_for_mounted_dir_test: # Optional for not mounted dir test
     run_on_gke: false
     configs:
       - flags:
-          - "--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap --profiling-label=${PROFILE_LABEL}" # Set the 'PROFILE_LABEL' environment variable
+           # Set the 'PROFILE_LABEL' environment variable for GKE
+          - "--enable-cloud-profiling --profiling-cpu --profiling-heap --profiling-goroutines --profiling-mutex --profiling-allocated-heap --profiling-label=${PROFILE_LABEL}"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -168,6 +168,7 @@ cloud_profiler:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     log_file: # Optional
+    profile_label_for_mounted_dir_test: # Optional for not mounted dir test
     run_on_gke: false
     configs:
       - flags:

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -47,7 +47,6 @@ var integrationTest = flag.Bool("integrationTest", false, "Run tests only when t
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
 var gcsfusePreBuiltDir = flag.String("gcsfuse_prebuilt_dir", "", "Path to the pre-built GCSFuse directory containing bin/gcsfuse and sbin/mount.gcsfuse.")
-var profileLabelForMountedDirTest = flag.String("profile_label", "", "To pass profile-label for the cloud-profile test.")
 var configFile = flag.String("config-file", "", "Common GCSFuse config file to run tests with.")
 
 const (
@@ -152,11 +151,6 @@ func SetOnlyDirMounted(onlyDirValue string) {
 // DynamicBucketMounted returns the name of the bucket in case of dynamic mount.
 func DynamicBucketMounted() string {
 	return dynamicBucketMounted
-}
-
-// ProfileLabelForMountedDirTest returns the profile-label required for cloud-profiler test package.
-func ProfileLabelForMountedDirTest() string {
-	return *profileLabelForMountedDirTest
 }
 
 // SetDynamicBucketMounted sets the name of the bucket in case of dynamic mount.
@@ -796,4 +790,20 @@ func GetGCERegion(gceZone string) (string, error) {
 		return region, fmt.Errorf("zone %q returned by GCE metadata server is not a valid zone-string: %w", region, err)
 	}
 	return region, nil
+}
+
+// ExtractServiceVersionFromFlags parses the cloud-profiler-label from a slice of flag strings.
+func ExtractServiceVersionFromFlags(flags []string) string {
+	// Regex to find --cloud-profiler-label=some_value or --cloud-profiler-label some_value
+	re := regexp.MustCompile(`--cloud-profiler-label[=\s]([^\s]+)`)
+	for _, flagSet := range flags {
+		matches := re.FindStringSubmatch(flagSet)
+		// matches[0] is the full match, e.g., "--cloud-profiler-label=v1"
+		// matches[1] is the first capturing group, e.g., "v1"
+		if len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	log.Fatal("Profile label should have been provided for mounted directory test.")
+	return ""
 }

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -36,7 +36,6 @@ type TestConfig struct {
 	LogFile                       string       `yaml:"log_file,omitempty"`
 	RunOnGKE                      bool         `yaml:"run_on_gke"`
 	Configs                       []ConfigItem `yaml:"configs"`
-	ProfileLabelForMountedDirTest string       `yaml:"profile_label_for_mounted_dir_test,omitempty"`
 }
 
 // ConfigItem defines the variable parts of each test run.

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -30,12 +30,12 @@ type BucketType struct {
 
 // TestConfig represents the common configuration for test packages.
 type TestConfig struct {
-	GKEMountedDirectory           string `yaml:"mounted_directory"`
-	GCSFuseMountedDirectory       string
-	TestBucket                    string       `yaml:"test_bucket"`
-	LogFile                       string       `yaml:"log_file,omitempty"`
-	RunOnGKE                      bool         `yaml:"run_on_gke"`
-	Configs                       []ConfigItem `yaml:"configs"`
+	GKEMountedDirectory     string `yaml:"mounted_directory"`
+	GCSFuseMountedDirectory string
+	TestBucket              string       `yaml:"test_bucket"`
+	LogFile                 string       `yaml:"log_file,omitempty"`
+	RunOnGKE                bool         `yaml:"run_on_gke"`
+	Configs                 []ConfigItem `yaml:"configs"`
 }
 
 // ConfigItem defines the variable parts of each test run.

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -30,12 +30,13 @@ type BucketType struct {
 
 // TestConfig represents the common configuration for test packages.
 type TestConfig struct {
-	GKEMountedDirectory     string `yaml:"mounted_directory"`
-	GCSFuseMountedDirectory string
-	TestBucket              string       `yaml:"test_bucket"`
-	LogFile                 string       `yaml:"log_file,omitempty"`
-	RunOnGKE                bool         `yaml:"run_on_gke"`
-	Configs                 []ConfigItem `yaml:"configs"`
+	GKEMountedDirectory           string `yaml:"mounted_directory"`
+	GCSFuseMountedDirectory       string
+	TestBucket                    string       `yaml:"test_bucket"`
+	LogFile                       string       `yaml:"log_file,omitempty"`
+	RunOnGKE                      bool         `yaml:"run_on_gke"`
+	Configs                       []ConfigItem `yaml:"configs"`
+	ProfileLabelForMountedDirTest string       `yaml:"profile_label_for_mounted_dir_test,omitempty"`
 }
 
 // ConfigItem defines the variable parts of each test run.


### PR DESCRIPTION
### Description
This PR includes changes to migrate cloud profiler package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of operations package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445951569](https://buganizer.corp.google.com/issues/445951569)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
