### PR TITLE
feat(metrics): allow meter provider to be passed in NewGRPCClient

### DIFF
--- a/internal/monitor/otelexporters.go
+++ b/internal/monitor/otelexporters.go
@@ -40,7 +40,7 @@ import (
 const serviceName = "gcsfuse"
 const cloudMonitoringMetricPrefix = "custom.googleapis.com/gcsfuse/"
 
-var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/"}
+var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "grpc."}
 
 // SetupOTelMetricExporters sets up the metrics exporters
 func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config) (shutdownFn common.ShutdownFn) {

--- a/tools/integration_tests/monitoring/prom_grpc_metrics_test.go
+++ b/tools/integration_tests/monitoring/prom_grpc_metrics_test.go
@@ -1,0 +1,81 @@
+package monitoring
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// PromGrpcTest is the test suite for gRPC metrics.
+type PromGrpcMetricsTest struct {
+	suite.Suite
+	gcsfusePath string
+	mountPoint  string
+}
+
+func (testSuite *PromGrpcMetricsTest) SetupSuite() {
+	setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
+	err := setup.SetUpTestDir()
+	require.NoErrorf(testSuite.T(), err, "error while building GCSFuse: %p", err)
+}
+
+func (testSuite *PromGrpcMetricsTest) SetupTest() {
+	var err error
+	testSuite.gcsfusePath = setup.BinFile()
+	testSuite.mountPoint, err = os.MkdirTemp("", "gcsfuse_monitoring_tests")
+	require.NoError(testSuite.T(), err)
+	setPrometheusPort(testSuite.T())
+
+	err = testSuite.mount(testFlatBucket)
+	require.NoError(testSuite.T(), err)
+}
+
+func (testSuite *PromGrpcMetricsTest) TearDownTest() {
+	if err := util.Unmount(testSuite.mountPoint); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unmount failed: %v\n", err)
+	}
+	os.Remove(testSuite.mountPoint)
+}
+
+func (testSuite *PromGrpcMetricsTest) mount(bucketName string) error {
+	testSuite.T().Helper()
+	if portAvailable := isPortOpen(prometheusPort); !portAvailable {
+		require.Failf(testSuite.T(), "prometheus port is not available.", "port: %d", int64(prometheusPort))
+	}
+	cacheDir, err := os.MkdirTemp("", "gcsfuse-cache")
+	require.NoError(testSuite.T(), err)
+	testSuite.T().Cleanup(func() { _ = os.RemoveAll(cacheDir) })
+
+	// Specify client protocol to "grpc" for gRPC metrics to be emitted and captured.
+	flags := []string{"--client-protocol=grpc", fmt.Sprintf("--prometheus-port=%d", prometheusPort), "--cache-dir", cacheDir}
+	args := append(flags, bucketName, testSuite.mountPoint)
+
+	if err := mounting.MountGcsfuse(testSuite.gcsfusePath, args); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (testSuite *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
+	_, err := os.ReadFile(path.Join(testSuite.mountPoint, "hello/hello.txt"))
+	require.NoError(testSuite.T(), err)
+
+	// Assert that gRPC metrics are present.
+	assertNonZeroCountMetric(testSuite.T(), "grpc_client_attempt_started", "", "") // Pass testSuite.T()
+	assertNonZeroCountMetric(testSuite.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/ReadObject") // Pass testSuite.T()
+	assertNonZeroHistogramMetric(testSuite.T(), "grpc_client_attempt_duration_seconds", "", "") // Pass testSuite.T()
+	assertNonZeroHistogramMetric(testSuite.T(), "grpc_client_call_duration_seconds", "", "") // Pass testSuite.T()
+	assertNonZeroHistogramMetric(testSuite.T(), "grpc_client_attempt_rcvd_total_compressed_message_size_bytes", "", "") // Pass testSuite.T()
+	assertNonZeroHistogramMetric(testSuite.T(), "grpc_client_attempt_sent_total_compressed_message_size_bytes", "", "") // Pass testSuite.T()
+}
+
+func TestPromGrpcMetricsSuite(t *testing.T) {
+	suite.Run(t, new(PromGrpcMetricsTest))
+}


### PR DESCRIPTION

### Description
- Allow meter provider to be passed in to the Go SDK NewGRPCClient, using the `WithMeterProvider` client option in the Go Storage SDK
- Update monitoring prom tests for gRPC metrics

Depends on https://github.com/googleapis/google-cloud-go/pull/12668


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Tested
2. Unit tests - NA
3. Integration tests - Added

Manually tested on GKE and GCE. Integration tests are ready once https://github.com/googleapis/google-cloud-go/pull/12668 is launched
```
$ go test ./tools/integration_tests/monitoring/... --integrationTest -v 
=== RUN   TestPromGrpcMetricsSuite
{"timestamp":{"seconds":1755816146,"nanos":897136316},"severity":"INFO","message":"Building GCSFuse from source in the dir: /tmp/gcsfuse_readwrite_test_4022898957 ..."}
{"timestamp":{"seconds":1755816146,"nanos":897185786},"severity":"INFO","message":"Building build_gcsfuse at /tmp/gcsfuse_integration_tests2729044397/build_gcsfuse"}
{"timestamp":{"seconds":1755816151,"nanos":90209635},"severity":"INFO","message":"Building gcsfuse into /tmp/gcsfuse_readwrite_test_4022898957"}
=== RUN   TestPromGrpcMetricsSuite/TestStorageClientGrpcMetrics
--- PASS: TestPromGrpcMetricsSuite (33.62s)
    --- PASS: TestPromGrpcMetricsSuite/TestStorageClientGrpcMetrics (3.24s)
=== RUN   TestPromOTELSuite
{"timestamp":{"seconds":1755816180,"nanos":519715471},"severity":"INFO","message":"Building GCSFuse from source in the dir: /tmp/gcsfuse_readwrite_test_27243481 ..."}
{"timestamp":{"seconds":1755816180,"nanos":519801451},"severity":"INFO","message":"Building build_gcsfuse at /tmp/gcsfuse_integration_tests2133238605/build_gcsfuse"}
{"timestamp":{"seconds":1755816184,"nanos":711409334},"severity":"INFO","message":"Building gcsfuse into /tmp/gcsfuse_readwrite_test_27243481"}
=== RUN   TestPromOTELSuite/TestFsOpsErrorMetrics
=== RUN   TestPromOTELSuite/TestListMetrics
=== RUN   TestPromOTELSuite/TestReadMetrics
=== RUN   TestPromOTELSuite/TestStatMetrics
--- PASS: TestPromOTELSuite (36.87s)
    --- PASS: TestPromOTELSuite/TestFsOpsErrorMetrics (1.60s)
    --- PASS: TestPromOTELSuite/TestListMetrics (1.62s)
    --- PASS: TestPromOTELSuite/TestReadMetrics (1.67s)
    --- PASS: TestPromOTELSuite/TestStatMetrics (1.62s)
PASS
ok      github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/monitoring    70.543s
```
