### PR TITLE
refactor: rename dir limit test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -62,16 +62,15 @@ func TestMain(m *testing.M) {
 		cfg.RenameDirLimit[0].MountedDirectory = setup.MountedDirectory()
 		cfg.RenameDirLimit[0].Configs = make([]test_suite.ConfigItem, 2)
 		cfg.RenameDirLimit[0].Configs[0].Flags = []string{
-			"--rename-dir-limit=3 --implicit-dirs",
 			"--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc",
 			"--rename-dir-limit=3",
 			"--rename-dir-limit=3 --client-protocol=grpc",
 		}
-		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": true}
+		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		cfg.RenameDirLimit[0].Configs[1].Flags = []string{
-			"--enable-hns=true",
+			"",
 		}
-		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": false}
+		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 	}
 
 	setup.SetBucketFromConfigFile(cfg.RenameDirLimit[0].TestBucket)
@@ -91,11 +90,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer storageClient.Close()
-
-	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
-		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
-		os.Exit(1)
-	}
 
 	// 4. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if cfg.RenameDirLimit[0].MountedDirectory != "" && cfg.RenameDirLimit[0].TestBucket != "" {

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const DirForRenameDirLimitTests = "dirForRenameDirLimitTests"
@@ -46,14 +47,43 @@ const onlyDirMounted = "OnlyDirMountRenameDirLimit"
 var (
 	storageClient *storage.Client
 	ctx           context.Context
+	err           error
 )
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	var err error
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.RenameDirLimit) == 0 {
+		log.Println("No configuration found for rename dir limit tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.RenameDirLimit = make([]test_suite.TestConfig, 1)
+		cfg.RenameDirLimit[0].TestBucket = setup.TestBucket()
+		cfg.RenameDirLimit[0].MountedDirectory = setup.MountedDirectory()
+		cfg.RenameDirLimit[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.RenameDirLimit[0].Configs[0].Flags = []string{
+			"--rename-dir-limit=3 --implicit-dirs",
+			"--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc",
+			"--rename-dir-limit=3",
+			"--rename-dir-limit=3 --client-protocol=grpc",
+		}
+		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": true}
+		// for HNS we have another function that generates the hnsFlagSet from another config file 
+		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": false}
+	}
 
+	setup.SetBucketFromConfigFile(cfg.RenameDirLimit[0].TestBucket)
 	ctx = context.Background()
+	bucketType, err := setup.BucketType(ctx, cfg.RenameDirLimit[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+
+	// 2. Create storage client before running tests.
 	storageClient, err = client.CreateStorageClient(ctx)
 	if err != nil {
 		log.Printf("Error creating storage client: %v\n", err)
@@ -61,32 +91,34 @@ func TestMain(m *testing.M) {
 	}
 	defer storageClient.Close()
 
-	flags := [][]string{{"--rename-dir-limit=3", "--implicit-dirs"}, {"--rename-dir-limit=3"}}
-	setup.AppendFlagsToAllFlagsInTheFlagsSet(&flags, "", "--client-protocol=grpc")
+	// 3. Flags are set for the HNS Buckets
 	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
-		flags = [][]string{hnsFlagSet}
+		cfg.RenameDirLimit[0].Configs[1].Flags = hnsFlagSet
 	}
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
 		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
 		os.Exit(1)
 	}
 
-	// Run tests for mountedDirectory only if --mountedDirectory flag is set.
-	setup.RunTestsForMountedDirectoryFlag(m)
+	// 4. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if cfg.RenameDirLimit[0].MountedDirectory != "" && cfg.RenameDirLimit[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.RenameDirLimit[0].MountedDirectory, m))
+	}
 
 	// Run tests for testBucket
-	setup.SetUpTestDirForTestBucketFlag()
+	// 5. Build the flag sets dynamically from the config.
+	flags := setup.BuildFlagSets(cfg.RenameDirLimit[0], bucketType)
+	setup.SetUpTestDirForTestBucket(cfg.RenameDirLimit[0].TestBucket)
 
-	successCode := static_mounting.RunTests(flags, m)
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.RenameDirLimit[0], flags, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flags, onlyDirMounted, m)
+		successCode = only_dir_mounting.RunTestsWithConfigFile(&cfg.RenameDirLimit[0], flags, onlyDirMounted, m)
 	}
 
 	if successCode == 0 {
-		successCode = persistent_mounting.RunTests(flags, m)
+		successCode = persistent_mounting.RunTestsWithConfigFile(&cfg.RenameDirLimit[0], flags, m)
 	}
 
 	os.Exit(successCode)

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 	}
 
-	setup.SetBucketFromConfigFile(cfg.RenameDirLimit[0].TestBucket)
+	setup.SetTestBucket(cfg.RenameDirLimit[0].TestBucket)
 	ctx = context.Background()
 	bucketType, err := setup.BucketType(ctx, cfg.RenameDirLimit[0].TestBucket)
 	if err != nil {

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -47,7 +47,6 @@ const onlyDirMounted = "OnlyDirMountRenameDirLimit"
 var (
 	storageClient *storage.Client
 	ctx           context.Context
-	err           error
 )
 
 func TestMain(m *testing.M) {
@@ -69,7 +68,7 @@ func TestMain(m *testing.M) {
 			"--rename-dir-limit=3 --client-protocol=grpc",
 		}
 		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": true}
-		// for HNS we have another function that generates the hnsFlagSet from another config file 
+		// for HNS we have another function that generates the hnsFlagSet from another config file
 		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": false}
 	}
 

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -68,7 +68,9 @@ func TestMain(m *testing.M) {
 			"--rename-dir-limit=3 --client-protocol=grpc",
 		}
 		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": true}
-		// for HNS we have another function that generates the hnsFlagSet from another config file
+		cfg.RenameDirLimit[0].Configs[1].Flags = []string{
+			"--enable-hns=true",
+		}
 		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": false}
 	}
 
@@ -89,11 +91,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer storageClient.Close()
-
-	// 3. Flags are set for the HNS Buckets
-	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
-		cfg.RenameDirLimit[0].Configs[1].Flags = hnsFlagSet
-	}
 
 	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
 		log.Print("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")

--- a/tools/integration_tests/rename_dir_limit/rename_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_test.go
@@ -80,7 +80,7 @@ func TestRenameDirectoryWithTwoFiles(t *testing.T) {
 // As --rename-directory-limit = 3, and the number of objects in the directory is two,
 // which is greater than the limit, the operation should get fail.
 func TestRenameDirectoryWithFourFiles(t *testing.T) {
-	if setup.IsHierarchicalBucket(ctx, storageClient) {
+	if setup.ResolveIsHierarchicalBucket(ctx, setup.TestBucket(), storageClient) {
 		t.SkipNow()
 	}
 	testDir := setup.SetupTestDirectory(DirForRenameDirLimitTests)
@@ -134,7 +134,7 @@ func TestRenameDirectoryWithTwoFilesAndOneEmptyDirectory(t *testing.T) {
 // As --rename-directory-limit = 3, and the number of objects in the directory is Four,
 // which is greater than the limit, the operation should get fail.
 func TestRenameDirectoryWithTwoFilesAndOneNonEmptyDirectory(t *testing.T) {
-	if setup.IsHierarchicalBucket(ctx, storageClient) {
+	if setup.ResolveIsHierarchicalBucket(ctx, setup.TestBucket(), storageClient) {
 		t.SkipNow()
 	}
 	testDir := setup.SetupTestDirectory(DirForRenameDirLimitTests)

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -125,11 +125,8 @@ rename_dir_limit:
           flat: true
           hns: false
           zonal: true
-      - flags:
-          # - "--rename-dir-limit=3 --implicit-dirs"
-          # - "--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc"
-          # - "--rename-dir-limit=3"
-          # - "--rename-dir-limit=3 --client-protocol=grpc"
+      - flags: 
+        - "--enable-hns=true"
         compatible:
           flat: false
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -117,17 +117,16 @@ rename_dir_limit:
     run_on_gke: false
     configs:
       - flags:
-          - "--rename-dir-limit=3 --implicit-dirs"
           - "--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc"
           - "--rename-dir-limit=3"
           - "--rename-dir-limit=3 --client-protocol=grpc"
         compatible:
           flat: true
           hns: false
-          zonal: true
+          zonal: false
       - flags: 
-        - "--enable-hns=true"
+        - ""
         compatible:
           flat: false
           hns: true
-          zonal: false
+          zonal: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -110,6 +110,7 @@ readonly:
           flat: true
           hns: true
           zonal: true
+
 rename_dir_limit:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -110,3 +110,27 @@ readonly:
           flat: true
           hns: true
           zonal: true
+rename_dir_limit:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--rename-dir-limit=3 --implicit-dirs"
+          - "--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc"
+          - "--rename-dir-limit=3"
+          - "--rename-dir-limit=3 --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: false
+          zonal: true
+      - flags:
+          # - "--rename-dir-limit=3 --implicit-dirs"
+          # - "--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc"
+          # - "--rename-dir-limit=3"
+          # - "--rename-dir-limit=3 --client-protocol=grpc"
+        compatible:
+          flat: false
+          hns: true
+          zonal: false

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -22,15 +22,27 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"golang.org/x/net/context"
 )
 
+// Deprecated: Use MountGcsfuseWithOnlyDirMountingWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func MountGcsfuseWithOnlyDir(flags []string) (err error) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
+	}
+	return MountGcsfuseWithOnlyDirWithConfigFile(config, flags)
+}
+
+func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{"--only-dir",
 		setup.OnlyDirMounted(),
 		"--log-severity=trace",
 		"--log-file=" + setup.LogFile(),
-		setup.TestBucket(),
+		config.TestBucket,
 		setup.MntDir()}
 
 	for i := 0; i < len(defaultArg); i++ {
@@ -42,9 +54,9 @@ func MountGcsfuseWithOnlyDir(flags []string) (err error) {
 	return err
 }
 
-func mountGcsFuseForFlagsAndExecuteTests(flags [][]string, m *testing.M) (successCode int) {
+func mountGcsFuseForFlagsAndExecuteTests(config *test_suite.TestConfig, flags [][]string, m *testing.M) (successCode int) {
 	for i := 0; i < len(flags); i++ {
-		if err := MountGcsfuseWithOnlyDir(flags[i]); err != nil {
+		if err := MountGcsfuseWithOnlyDirWithConfigFile(config, flags[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running only dir mounting tests with flags: %s", flags[i])
@@ -56,7 +68,7 @@ func mountGcsFuseForFlagsAndExecuteTests(flags [][]string, m *testing.M) (succes
 	return
 }
 
-func executeTestsForOnlyDirMounting(flags [][]string, dirName string, m *testing.M) (successCode int) {
+func executeTestsForOnlyDirMounting(config *test_suite.TestConfig, flags [][]string, dirName string, m *testing.M) (successCode int) {
 	ctx := context.Background()
 	storageClient, err := client.CreateStorageClient(ctx)
 	if err != nil {
@@ -74,7 +86,7 @@ func executeTestsForOnlyDirMounting(flags [][]string, dirName string, m *testing
 	if err != nil {
 		log.Println("Error deleting object on GCS: %w", err)
 	}
-	successCode = mountGcsFuseForFlagsAndExecuteTests(flags, m)
+	successCode = mountGcsFuseForFlagsAndExecuteTests(config, flags, m)
 	if successCode != 0 {
 		return
 	}
@@ -82,7 +94,7 @@ func executeTestsForOnlyDirMounting(flags [][]string, dirName string, m *testing
 	// Test scenario when only-dir-mounted directory pre-exists in bucket.
 	client.SetupTestDirectory(ctx, storageClient, dirName)
 
-	successCode = mountGcsFuseForFlagsAndExecuteTests(flags, m)
+	successCode = mountGcsFuseForFlagsAndExecuteTests(config, flags, m)
 	err = client.DeleteAllObjectsWithPrefix(ctx, storageClient, dirName)
 	if err != nil {
 		log.Println("Error deleting object on GCS: %w", err)
@@ -93,10 +105,21 @@ func executeTestsForOnlyDirMounting(flags [][]string, dirName string, m *testing
 	return
 }
 
+// Deprecated: Use RunTestsWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flags [][]string, dirName string, m *testing.M) (successCode int) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
+	}
+	return RunTestsWithConfigFile(config, flags, dirName, m)
+}
+
+func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, dirName string, m *testing.M) (successCode int) {
 	log.Println("Running only dir mounting tests...")
 
-	successCode = executeTestsForOnlyDirMounting(flags, dirName, m)
+	successCode = executeTestsForOnlyDirMounting(config, flagsSet, dirName, m)
 
 	log.Printf("Test log: %s\n", setup.LogFile())
 


### PR DESCRIPTION
### Description
This PR includes changes to migrate read dir limit package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of rename dir limit package so it can use config file.

### Link to the issue in case of a bug fix.
[b/439724878](https://b.corp.google.com/issues/439724878)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
