### PR TITLE
fix: Fix custom-endpoint format in help doc

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -670,7 +670,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. The custom endpoint must support the equivalent resources and operations as the GCS JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified, GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
+	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data.  The custom endpoint must support resources equivalent to storage.googleapis.com:443.  If a custom endpoint is not specified, GCSFuse uses the default endpoint, which is storage.googleapis.com:443.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -670,7 +670,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data.  The custom endpoint must support resources equivalent to storage.googleapis.com:443.  If a custom endpoint is not specified, GCSFuse uses the default endpoint, which is storage.googleapis.com:443.")
+	flagSet.StringP("custom-endpoint", "", "", "To specify a custom storage endpoint, ensure it supports the same resources as the default storage.googleapis.com:443 and includes the port number.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -414,11 +414,9 @@ params:
     flag-name: "custom-endpoint"
     type: "string"
     usage: >-
-      Specifies an alternative custom endpoint for fetching data. The custom endpoint
-      must support the equivalent resources and operations as the GCS JSON endpoint,
-      https://storage.googleapis.com/storage/v1. If a custom endpoint is not
-      specified, GCSFuse uses the global GCS JSON API endpoint,
-      https://storage.googleapis.com/storage/v1.
+      Specifies an alternative custom endpoint for fetching data. 
+      The custom endpoint must support resources equivalent to storage.googleapis.com:443. 
+      If a custom endpoint is not specified, GCSFuse uses the default endpoint, which is storage.googleapis.com:443.
     default: ""
 
   - config-path: "gcs-connection.enable-http-dns-cache"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -414,9 +414,7 @@ params:
     flag-name: "custom-endpoint"
     type: "string"
     usage: >-
-      Specifies an alternative custom endpoint for fetching data. 
-      The custom endpoint must support resources equivalent to storage.googleapis.com:443. 
-      If a custom endpoint is not specified, GCSFuse uses the default endpoint, which is storage.googleapis.com:443.
+      To specify a custom storage endpoint, ensure it supports the same resources as the default storage.googleapis.com:443 and includes the port number.
     default: ""
 
   - config-path: "gcs-connection.enable-http-dns-cache"


### PR DESCRIPTION
### Description
The help documentation for the GCS Fuse `--custom-endpoint` flag is causing user confusion and leading to mount failures because it does not specify the correct endpoint format.
Ref issue - https://github.com/GoogleCloudPlatform/gcsfuse/issues/3705

I recently found(b/429928623) that, standard URL formats results in errors. The only format that has been found to work reliably is `storage.<UNIVERSE_DOMAIN>:443`. Update the documentation with this URL format.

### Link to the issue in case of a bug fix.
[b/440981458](https://b.corp.google.com/issues/440981458)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
