### PR TITLE
feat(bufferedread): Update severity of log "scheduleNextBlock: could not get block from pool" from warning to trace

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -443,7 +443,7 @@ func (p *BufferedReader) scheduleNextBlock(urgent bool) error {
 		// can't get a block. For the buffered reader, this is a recoverable
 		// condition that should either trigger a fallback to another reader (for
 		// urgent reads) or be ignored (for background prefetches).
-		logger.Warnf("scheduleNextBlock: could not get block from pool (urgent=%t): %v", urgent, err)
+		logger.Tracef("scheduleNextBlock: could not get block from pool (urgent=%t): %v", urgent, err)
 		return ErrPrefetchBlockNotAvailable
 	}
 


### PR DESCRIPTION
### Description
This PR updates severity of log "scheduleNextBlock: could not get block from pool" from warning to trace as this is seen very frequently and increases the noise in logs.

### Link to the issue in case of a bug fix.
b/441240923

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
