### PR TITLE
chore(logging): Add log for unsupported log formats

### DIFF
--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -34,9 +34,9 @@ const (
 
 const (
 	// Logging-format constants
-	LogFormatText    = "text"
-	LogFormatJSON    = "json"
-	DefaultLogFormat = LogFormatJSON
+	logFormatText    = "text"
+	logFormatJSON    = "json"
+	defaultLogFormat = logFormatJSON
 )
 
 const (

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -33,6 +33,13 @@ const (
 )
 
 const (
+	// Logging-format constants
+	LogFormatText    = "text"
+	LogFormatJSON    = "json"
+	DefaultLogFormat = LogFormatJSON
+)
+
+const (
 	// ExperimentalMetadataPrefetchOnMountDisabled is the mode without metadata-prefetch.
 	ExperimentalMetadataPrefetchOnMountDisabled = "disabled"
 	// ExperimentalMetadataPrefetchOnMountSynchronous is the prefetch-mode where mounting is not marked complete until prefetch is complete.

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -139,9 +139,9 @@ func resolveLoggingConfig(config *Config) {
 		config.Logging.Severity = "TRACE"
 	}
 
-	if config.Logging.Format != LogFormatText && config.Logging.Format != LogFormatJSON {
-		log.Printf("Unsupported log format provided: %s. Defaulting to %s log format.", config.Logging.Format, DefaultLogFormat)
-		config.Logging.Format = DefaultLogFormat // defaulting to json format
+	if config.Logging.Format != logFormatText && config.Logging.Format != logFormatJSON {
+		log.Printf("Unsupported log format provided: %s. Defaulting to %s log format.", config.Logging.Format, defaultLogFormat)
+		config.Logging.Format = defaultLogFormat // defaulting to json format
 	}
 }
 

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -134,6 +134,17 @@ func resolveFileCacheAndBufferedReadConflict(v isSet, c *Config) {
 	}
 }
 
+func resolveLoggingConfig(config *Config) {
+	if config.Debug.Fuse || config.Debug.Gcs || config.Debug.LogMutex {
+		config.Logging.Severity = "TRACE"
+	}
+
+	if config.Logging.Format != LogFormatText && config.Logging.Format != LogFormatJSON {
+		log.Printf("Unsupported log format provided: %s. Defaulting to %s log format.", config.Logging.Format, DefaultLogFormat)
+		config.Logging.Format = DefaultLogFormat // defaulting to json format
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	var err error
@@ -145,10 +156,7 @@ func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 		return err
 	}
 
-	if c.Debug.Fuse || c.Debug.Gcs || c.Debug.LogMutex {
-		c.Logging.Severity = "TRACE"
-	}
-
+	resolveLoggingConfig(c)
 	resolveStreamingWriteConfig(&c.Write)
 	resolveMetadataCacheTTL(v, &c.MetadataCache, optimizedFlags)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache, optimizedFlags)

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -670,7 +670,6 @@ func TestResolveLoggingConfig(t *testing.T) {
 		name              string
 		config            *Config
 		expectedLogFormat string
-		expectWarning     bool
 	}{
 		{
 			name: "valid_log_format_json",

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -16,7 +16,6 @@ package cfg
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"math"
 	"os"
@@ -674,34 +673,31 @@ func TestResolveLoggingConfig(t *testing.T) {
 		expectWarning     bool
 	}{
 		{
-			name: "valid log format (json)",
+			name: "valid_log_format_json",
 			config: &Config{
 				Logging: LoggingConfig{
 					Format: "json",
 				},
 			},
 			expectedLogFormat: "json",
-			expectWarning:     false,
 		},
 		{
-			name: "valid log format (text)",
+			name: "valid_log_format_text",
 			config: &Config{
 				Logging: LoggingConfig{
 					Format: "text",
 				},
 			},
 			expectedLogFormat: "text",
-			expectWarning:     false,
 		},
 		{
-			name: "invalid log format, default to json",
+			name: "invalid_log_format",
 			config: &Config{
 				Logging: LoggingConfig{
 					Format: "INVALID",
 				},
 			},
-			expectedLogFormat: DefaultLogFormat, // Should default to JSON
-			expectWarning:     true,
+			expectedLogFormat: defaultLogFormat, // Should default to JSON
 		},
 	}
 
@@ -716,12 +712,6 @@ func TestResolveLoggingConfig(t *testing.T) {
 			resolveLoggingConfig(tc.config)
 
 			assert.Equal(t, tc.expectedLogFormat, tc.config.Logging.Format)
-			logOutput := buf.String()
-			if tc.expectWarning {
-				assert.True(t, strings.Contains(logOutput, fmt.Sprintf("Unsupported log format provided: INVALID. Defaulting to %s log format.", DefaultLogFormat)))
-			} else {
-				assert.False(t, strings.Contains(logOutput, "Unsupported log format provided:"))
-			}
 		})
 	}
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -703,12 +703,6 @@ func TestResolveLoggingConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Capture log output.
-			var buf bytes.Buffer
-			log.SetOutput(&buf)
-			// Restore original logger output after test.
-			defer log.SetOutput(os.Stderr)
-
 			resolveLoggingConfig(tc.config)
 
 			assert.Equal(t, tc.expectedLogFormat, tc.config.Logging.Format)


### PR DESCRIPTION
### Description
Introduce a log message when an unsupported log format is specified, defaulting to the existing `JSON` format. This enhances logging robustness by providing feedback on invalid configurations.

### Link to the issue in case of a bug fix.
[b/328992990](https://b.corp.google.com/issues/328992990)

### Testing details
1. Manual - Tested with GKE logs ([Screenshot](https://screenshot.googleplex.com/DJTZFTrAj3xGjrh))
   * No changes observed for valid formats supported currently (`text`, `json`)
 2. Unit Tests - ✅ 

### Any backward incompatible change? If so, please explain.
None