### PR TITLE
refactor: update parsing the yaml file & Zonal bucket case handling [GKE-GCSFuse Test migration] 

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"gopkg.in/yaml.v3"
 )
 
 const DirForExplicitDirTests = "dirForExplicitDirTests"
@@ -51,17 +50,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// 1. Load and parse the common configuration.
-	var cfg Config
-	if setup.ConfigFile() != "" {
-		configData, err := os.ReadFile(setup.ConfigFile())
-		if err != nil {
-			log.Fatalf("could not read test_config.yaml: %v", err)
-		}
-		expandedYaml := os.ExpandEnv(string(configData))
-		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
-			log.Fatalf("Failed to parse config YAML: %v", err)
-		}
-	}
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ExplicitDir) == 0 {
 		log.Println("No configuration found for explicit_dir tests in config. Using flags instead.")
 		// Populate the config manually.

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -64,6 +64,12 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
+	
+	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -73,10 +79,6 @@ func TestMain(m *testing.M) {
 	}()
 
 	// 4. Build the flag sets dynamically from the config.
-	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
 	flags := setup.BuildFlagSets(cfg.ExplicitDir[0], bucketType)
 
 	// 5. Run tests with the dynamically generated flags.

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	
+
 	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
 	if err != nil {
 		log.Fatalf("BucketType failed: %v", err)

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -30,11 +30,6 @@ import (
 
 const DirForExplicitDirTests = "dirForExplicitDirTests"
 
-// Config holds all test configurations parsed from the YAML file.
-type Config struct {
-	ExplicitDir []test_suite.TestConfig `yaml:"explicit_dir"`
-}
-
 // IMPORTANT: To prevent global variable pollution, enhance code clarity,
 // and avoid inadvertent errors. We strongly suggest that, all new package-level
 // variables (which would otherwise be declared with `var` at the package root) should

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -86,6 +86,12 @@ func TestMain(m *testing.M) {
 	// 2. Create storage client before running tests.
 	setup.SetBucketFromConfigFile(cfg.ImplicitDir[0].TestBucket)
 	testEnv.ctx = context.Background()
+
+	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ImplicitDir[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -95,10 +101,6 @@ func TestMain(m *testing.M) {
 	}()
 
 	// 4. Build the flag sets dynamically from the config.
-	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ImplicitDir[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
 	flags := setup.BuildFlagSets(cfg.ImplicitDir[0], bucketType)
 
 	// 5. Run tests with the dynamically generated flags.

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -60,11 +60,6 @@ func setupTestDir(dirName string) string {
 	return dirPath
 }
 
-// Config holds all test configurations parsed from the YAML file.
-type Config struct {
-	ImplicitDir []test_suite.TestConfig `yaml:"implicit_dir"`
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"gopkg.in/yaml.v3"
 )
 
 const ExplicitDirInImplicitDir = "explicitDirInImplicitDir"
@@ -70,17 +69,7 @@ func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// 1. Load and parse the common configuration.
-	var cfg Config
-	if setup.ConfigFile() != "" {
-		configData, err := os.ReadFile(setup.ConfigFile())
-		if err != nil {
-			log.Fatalf("could not read test_config.yaml: %v", err)
-		}
-		expandedYaml := os.ExpandEnv(string(configData))
-		if err := yaml.Unmarshal([]byte(expandedYaml), &cfg); err != nil {
-			log.Fatalf("Failed to parse config YAML: %v", err)
-		}
-	}
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ImplicitDir) == 0 {
 		log.Println("No configuration found for implicit_dir tests in config. Using flags instead.")
 		// Populate the config manually.

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -41,11 +41,6 @@ var (
 	ctx                              context.Context
 )
 
-// Config holds all test configurations parsed from the YAML file.
-type Config struct {
-	ListLargeDir []test_suite.TestConfig `yaml:"list_large_dir"`
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 


### PR DESCRIPTION
### Description:

1. refactoring to read config file by a ReadConfigFile function from test_suite package.
2. Identifying Bucket type before creating StorageClient, to prevent tests to fail for Zonal buckets

### Link to the issue in case of a bug fix.
[b/445950129](https://b.corp.google.com/issues/445950129)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
