### PR TITLE
refactor: gzip test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -249,18 +249,18 @@ func TestMain(m *testing.M) {
 	}()
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	// flags to be set, as WriteLargeFiles tests validates content from the bucket.
-	if cfg.WriteLargeFiles[0].MountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
+	// flags to be set, as Gzip tests validates content from the bucket.
+	if cfg.Gzip[0].MountedDirectory != "" && cfg.Gzip[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.Gzip[0].MountedDirectory, m))
 	}
 
 	// Run tests for testBucket// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
+	flags := setup.BuildFlagSets(cfg.Gzip[0], bucketType)
 
-	setup.SetUpTestDirForTestBucket(cfg.WriteLargeFiles[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(cfg.Gzip[0].TestBucket)
 
-	successCode := static_mounting.RunTestsWithConfigFile(&cfg.WriteLargeFiles[0], flags, m)
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Gzip[0], flags, m)
 
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -230,12 +230,6 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
-
-	if setup.TestBucket() == "" && setup.MountedDirectory() != "" {
-		log.Fatal("Please pass the name of bucket mounted at mountedDirectory to --testBucket flag.")
-	}
-
 	err = setup_testdata()
 	if err != nil {
 		log.Fatalf("Failed to setup test data: %v", err)

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -80,3 +80,17 @@ write_large_files:
           flat: true
           hns: true
           zonal: true
+
+gzip:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--sequential-read-size-mb=1 --implicit-dirs"
+          - "--sequential-read-size-mb=1 --implicit-dirs --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -67,7 +67,7 @@ list_large_dir:
 write_large_files:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
+    log_file: # Not Required by write large files tests
     run_on_gke: false
     configs:
       - flags:
@@ -84,7 +84,7 @@ write_large_files:
 gzip:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
+    log_file: # Not Required by gzip tests
     run_on_gke: false
     configs:
       - flags:


### PR DESCRIPTION
### Description
This PR includes changes to migrate gzip test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of gzip package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445942883](https://b.corp.google.com/issues/445942883)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
