### PR TITLE
fix: Hide flag create-empty-file on gcsfuse --help

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -329,6 +329,10 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("create-empty-file", "", false, "For a new file, it creates an empty file in Cloud Storage bucket as a hold.")
 
+	if err := flagSet.MarkHidden("create-empty-file"); err != nil {
+		return err
+	}
+
 	flagSet.StringP("custom-endpoint", "", "", "Specifies an alternative custom endpoint for fetching data. The custom endpoint must support the equivalent resources and operations as the GCS JSON endpoint, https://storage.googleapis.com/storage/v1. If a custom endpoint is not specified, GCSFuse uses the global GCS JSON API endpoint, https://storage.googleapis.com/storage/v1.")
 
 	flagSet.BoolP("debug_fs", "", false, "This flag is unused.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -836,6 +836,7 @@
   type: "bool"
   usage: "For a new file, it creates an empty file in Cloud Storage bucket as a hold."
   default: false
+  hide-flag: true
 
 - config-path: "write.enable-rapid-appends"
   flag-name: "enable-rapid-appends"


### PR DESCRIPTION
### Description
This flag is no longer advised for end user to use.

### Link to the issue in case of a bug fix.
[b/438387832](http://b/438387832)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as part of presubmit.
   - [run1](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/3f8b12ef-e973-49f5-98fa-379fc79ad732/log) - e2e non-zb - Failed with an unrelated random failure ([b/441423036](http://b/441423036))
   - [run2](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/2eb66691-2076-4842-9516-568a9611b75d) - e2e non-zb - running
5. 

### Any backward incompatible change? If so, please explain.
