### PR TITLE
refactor: local file test package migration [GKE-GCSFuse Test migration] [DONOT REVIEW: need only dir & dynamic mnt changes from other PRs]

### DIFF
--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -248,7 +248,7 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.Gzip[0].MountedDirectory, m))
 	}
 
-	// Run tests for testBucket// Run tests for testBucket
+	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.Gzip[0], bucketType)
 

--- a/tools/integration_tests/local_file/setup_test.go
+++ b/tools/integration_tests/local_file/setup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,13 +39,41 @@ import (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
-
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.LocalFile) == 0 {
+		log.Println("No configuration found for LocalFile tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.LocalFile = make([]test_suite.TestConfig, 1)
+		cfg.LocalFile[0].TestBucket = setup.TestBucket()
+		cfg.LocalFile[0].MountedDirectory = setup.MountedDirectory()
+		cfg.LocalFile[0].Configs = make([]test_suite.ConfigItem, 1)
+		cfg.LocalFile[0].Configs[0].Flags = []string{
+			// Set up flags to run tests on local file test suite.
+			// Not setting config file explicitly with 'create-empty-file: false' as it is default.
+			// Running these tests with streaming writes disabled because local file tests are already running in streaming_writes test package.
+			"--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false",
+			"--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false  --client-protocol=grpc",
+			"--implicit-dirs=false --rename-dir-limit=3 --enable-streaming-writes=false",
+			"--implicit-dirs=false --rename-dir-limit=3 --enable-streaming-writes=false --client-protocol=grpc",
+		}
+		cfg.LocalFile[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+	}
 	// set the test dir to local file test
 	testDirName = testDirLocalFileTest
+	var err error
 
-	// Create storage client before running tests.
+	setup.SetBucketFromConfigFile(cfg.LocalFile[0].TestBucket)
 	ctx = context.Background()
+	bucketType, err := setup.BucketType(ctx, cfg.LocalFile[0].TestBucket)
+	if err != nil {
+		log.Fatalf("BucketType failed: %v", err)
+	}
+	if bucketType == setup.ZonalBucket {
+		setup.SetIsZonalBucketRun(true)
+	}
+
+	// 2. Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -52,38 +81,29 @@ func TestMain(m *testing.M) {
 			log.Fatalf("closeStorageClient failed: %v", err)
 		}
 	}()
-	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	// flags to be set, as local_file tests validates content from the bucket.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		setup.RunTestsForMountedDirectoryFlag(m)
+
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as LocalFile tests validates content from the bucket.
+	if cfg.LocalFile[0].MountedDirectory != "" && cfg.LocalFile[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.LocalFile[0].MountedDirectory, m))
 	}
 
-	// Else run tests for testBucket.
-	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	// Run tests for testBucket
+	// 4. Build the flag sets dynamically from the config.
+	flags := setup.BuildFlagSets(cfg.LocalFile[0], bucketType)
+	setup.SetUpTestDirForTestBucket(cfg.LocalFile[0].TestBucket)
 
-	// Set up flags to run tests on local file test suite.
-	// Not setting config file explicitly with 'create-empty-file: false' as it is default.
-	// Running these tests with streaming writes disabled because local file tests are already running in streaming_writes test package.
-	flagsSet := [][]string{
-		{"--implicit-dirs=true", "--rename-dir-limit=3", "--enable-streaming-writes=false"},
-		{"--implicit-dirs=false", "--rename-dir-limit=3", "--enable-streaming-writes=false"}}
-
-	if !testing.Short() {
-		setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "--client-protocol=grpc")
-	}
-
-	successCode := static_mounting.RunTests(flagsSet, m)
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.LocalFile[0], flags, m)
 
 	if successCode == 0 {
-		successCode = only_dir_mounting.RunTests(flagsSet, onlyDirMounted, m)
+		successCode = only_dir_mounting.RunTestsWithConfigFile(&cfg.LocalFile[0], onlyDirMounted, m)
 	}
 
 	// Dynamic mounting tests create a bucket and perform tests on that bucket,
 	// which is not a hierarchical bucket. So we are not running those tests with
 	// hierarchical bucket.
-	if successCode == 0 && !setup.IsHierarchicalBucket(ctx, storageClient) {
-		successCode = dynamic_mounting.RunTests(ctx, storageClient, flagsSet, m)
+	if successCode == 0 && !setup.ResolveIsHierarchicalBucket(ctx, cfg.LocalFile[0].TestBucket, storageClient) {
+		successCode = dynamic_mounting.RunTests(ctx, storageClient, flags, m)
 	}
 
 	// Clean up test directory created.

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -94,3 +94,19 @@ gzip:
           flat: true
           hns: true
           zonal: true
+
+local_file:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Not Required by gzip tests
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false"
+          - "--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false  --client-protocol=grpc"
+          - "--implicit-dirs=false --rename-dir-limit=3 --enable-streaming-writes=false"
+          - "--implicit-dirs=false --rename-dir-limit=3 --enable-streaming-writes=false --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
 	}
 
-	// Run tests for testBucket// Run tests for testBucket
+	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
 


### PR DESCRIPTION
### Description
This PR includes changes to migrate local file test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of local file package so it can use config file.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
