### PR TITLE
docs(buffered-read): adding buffered-read feature in semantic doc

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -2,9 +2,24 @@
 
 ## Reads
 
+### Default Reads
+
 Cloud Storage FUSE makes API calls to Cloud Storage to read an object directly, without downloading it to a local directory. A TCP connection is established, in which the entire object, or just portions as specified by the application/operating system via an offset, can be read back.
 
 Files that have not been modified are read portion by portion on demand. Cloud Storage FUSE uses a heuristic to detect when a file is being read sequentially, and will issue fewer, larger read requests to Cloud Storage in this case, increasing performance.
+
+### Buffered Reads
+
+Cloud Storage FUSE offers Buffered Read feature support to accelerate large sequential reads. Buffered Read improves throughput by intelligently prefetching the object parts asynchronously and parallely into an in-memory buffer, and serving the reads from those buffered instead from network. Asynchronous and parallel buffereing improves the throughput by saturating the network without increasing application side parallelism.
+
+This is disabled by default and can be enabled using the `--enable-buffered-read` flag or `read:enable-buffered-read: true` in the config file. Also, it is designed to operate exclusively when the file cache is disabled; if both features are enabled, the file cache takes precedence.
+
+**Memory Usage:** Buffered read can consume upto 320 MB (20 x 16MB memory blocks) memory per file-handle while reading. The memory is released once file-handle is closed or fallback to default read (for random read). Overall memory across different file-handles can be controlled using `--read-global-max-blocks` flag or `read:global-max-blocks` config. By default, `--read-global-max-blocks` is set to 40 that means Buffered-read can't consume more than (40 * 16 MB) = 640 MB memory across all file-handles. Please consider the available sysmtem memory while enabling the Buffered read or changing the `--read-global-max-blocks` flag to avoid out-of-memory (OOM) issues.
+
+**CPU Usage:** Buffered read consume more cpu than the default read path and the cpu usage will be propotional to the performance gain.
+
+**Known Limitations:**
+- **Mixed Read Patterns:** Workloads with a mix of sequential and random reads (e.g., few model serving workloads) may not see a performance benefit and could fall-back to the default read path. Future releases will include improved heuristics for these scenarios. 
 
 ## Writes
 


### PR DESCRIPTION
### Description
Adding buffered read feature in semantic docs

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
