### PR TITLE
refactor: readonly test package migration [GKE-GCSFuse Test migration] 

### DIFF
--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -59,12 +59,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-
-	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-
+	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -73,10 +68,10 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// 4. Build the flag sets dynamically from the config.
+	// 3. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.ExplicitDir[0], bucketType)
 
-	// 5. Run tests with the dynamically generated flags.
+	// 4. Run tests with the dynamically generated flags.
 	successCode := implicit_and_explicit_dir_setup.RunTestsForExplicitAndImplicitDir(&cfg.ExplicitDir[0], flags, m)
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -209,19 +209,10 @@ func TestMain(m *testing.M) {
 		}
 		cfg.Gzip[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
-	var err error
-
-	setup.SetBucketFromConfigFile(cfg.Gzip[0].TestBucket)
-	ctx = context.Background()
-	bucketType, err := setup.BucketType(ctx, cfg.Gzip[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-	if bucketType == setup.ZonalBucket {
-		setup.SetIsZonalBucketRun(true)
-	}
 
 	// 2. Create storage client before running tests.
+	ctx = context.Background()
+	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -230,7 +221,7 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	err = setup_testdata()
+	err := setup_testdata()
 	if err != nil {
 		log.Fatalf("Failed to setup test data: %v", err)
 	}

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -212,7 +212,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
+	bucketType := setup.BucketTestEnvironment(ctx, cfg.Gzip[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -239,7 +239,7 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.Gzip[0].MountedDirectory, m))
 	}
 
-	// Run tests for testBucket// Run tests for testBucket
+	// Run tests for testBucket.
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.Gzip[0], bucketType)
 

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ListLargeDir[0].TestBucket)
+	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ImplicitDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -89,14 +89,14 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// 4. Build the flag sets dynamically from the config.
+	// 3. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.ImplicitDir[0], bucketType)
 
-	// 5. Run tests with the dynamically generated flags.
+	// 4. Run tests with the dynamically generated flags.
 	successCode := implicit_and_explicit_dir_setup.RunTestsForExplicitAndImplicitDir(&cfg.ImplicitDir[0], flags, m)
 	setup.SaveLogFileInCaseOfFailure(successCode)
 
-	// Clean up test directory created.
+	// 5. Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -79,14 +79,8 @@ func TestMain(m *testing.M) {
 	}
 
 	// 2. Create storage client before running tests.
-	setup.SetBucketFromConfigFile(cfg.ImplicitDir[0].TestBucket)
 	testEnv.ctx = context.Background()
-
-	bucketType, err := setup.BucketType(testEnv.ctx, cfg.ImplicitDir[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-
+	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ListLargeDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -62,17 +62,8 @@ func TestMain(m *testing.M) {
 	}
 
 	// 2. Create storage client before running tests.
-	setup.SetBucketFromConfigFile(cfg.ListLargeDir[0].TestBucket)
 	ctx = context.Background()
-
-	bucketType, err := setup.BucketType(ctx, cfg.ListLargeDir[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-	if bucketType == setup.ZonalBucket {
-		setup.SetIsZonalBucketRun(true)
-	}
-
+	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -52,13 +52,13 @@ list_large_dir:
     run_on_gke: false
     configs:
       - flags:
-        - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
+          - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         compatible:
           flat: true
           hns: true
           zonal: true
       - flags:
-        - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
+          - "--client-protocol=grpc --implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
         compatible:
           flat: true
           hns: true
@@ -90,6 +90,22 @@ gzip:
       - flags:
           - "--sequential-read-size-mb=1 --implicit-dirs"
           - "--sequential-read-size-mb=1 --implicit-dirs --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+
+readonly:
+  - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
+    test_bucket: "${BUCKET_NAME}" # To be passed by both gcsfuse and gke tests
+    log_file: # Not required by readonly tests.
+    run_on_gke: false
+    configs:
+      - flags:
+          - "--o=ro --implicit-dirs=true"
+          - "--file-mode=544 --dir-mode=544 --implicit-dirs=true"
+          - "--client-protocol=grpc --o=ro --implicit-dirs=true"
+          - "--o=ro --implicit-dirs=true --cache-dir=${CACHE_DIR_PATH} --file-cache-max-size-mb=3"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
+	bucketType := setup.BucketTestEnvironment(ctx, cfg.WriteLargeFiles[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
 	}
 
-	// Run tests for testBucket// Run tests for testBucket
+	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
 

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -58,17 +58,9 @@ func TestMain(m *testing.M) {
 		cfg.WriteLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
-	setup.SetBucketFromConfigFile(cfg.WriteLargeFiles[0].TestBucket)
-	ctx = context.Background()
-	bucketType, err := setup.BucketType(ctx, cfg.WriteLargeFiles[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-	if bucketType == setup.ZonalBucket {
-		setup.SetIsZonalBucketRun(true)
-	}
-
 	// 2. Create storage client before running tests.
+	ctx = context.Background()
+	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()


### PR DESCRIPTION
### Description
This PR includes changes to migrate readonly package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

### Link to the issue in case of a bug fix.
b/439724838

### Testing details
1. Manual - manually verified both with and without config file tests work.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA