### PR TITLE
feat(bufferedread): Add buffered read config to useragent

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -104,7 +104,7 @@ func getUserAgent(appName string, config string) string {
 }
 
 func getConfigForUserAgent(mountConfig *cfg.Config) string {
-	// Minimum configuration details created in a bitset fashion. Right now, its restricted only to File Cache Settings.
+	// Minimum configuration details created in a bitset fashion.
 	isFileCacheEnabled := "0"
 	if cfg.IsFileCacheEnabled(mountConfig) {
 		isFileCacheEnabled = "1"
@@ -121,7 +121,11 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	if mountConfig.Write.EnableStreamingWrites {
 		areStreamingWritesEnabled = "1"
 	}
-	return fmt.Sprintf("%s:%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled, areStreamingWritesEnabled)
+	isBufferedReadEnabled := "0"
+	if mountConfig.Read.EnableBufferedRead {
+		isBufferedReadEnabled = "1"
+	}
+	return fmt.Sprintf("%s:%s:%s:%s:%s", isFileCacheEnabled, isFileCacheForRangeReadEnabled, isParallelDownloadsEnabled, areStreamingWritesEnabled, isBufferedReadEnabled)
 }
 func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle metrics.MetricHandle) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -70,7 +70,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsSet() {
 
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
 
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s AppName (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0:0)", common.GetVersion()))
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
 
@@ -79,7 +79,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarIsNotSet() {
 
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
 
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion()))
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
 
@@ -88,7 +88,7 @@ func (t *MainTest) TestGetUserAgentConfigWithNoFileCache() {
 
 	userAgent := getUserAgent("AppName", getConfigForUserAgent(mountConfig))
 
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion()))
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
 
@@ -106,7 +106,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: 0,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache disabled where maxsize is set but cache dir is not set.",
@@ -115,7 +115,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: -1,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache enabled but random read disabled.",
@@ -125,7 +125,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					MaxSizeMb: -1,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache and random read enabled.",
@@ -136,7 +136,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					CacheFileForRangeRead: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache disabled and enable parallel downloads set.",
@@ -147,7 +147,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache and parallel downloads enabled.",
@@ -158,7 +158,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:0:0)", common.GetVersion())),
 		},
 		{
 			name: "Config with file cache, random reads and parallel downloads enabled.",
@@ -170,7 +170,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 					EnableParallelDownloads: true,
 				},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:1:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:1:0:0)", common.GetVersion())),
 		},
 		{
 			name: "streaming_writes_enabled",
@@ -183,7 +183,7 @@ func (t *MainTest) TestGetUserAgentConfig() {
 				},
 				Write: cfg.WriteConfig{EnableStreamingWrites: true},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:1)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:1:1:0)", common.GetVersion())),
 		},
 		{
 			name: "streaming_writes_disabled",
@@ -196,7 +196,32 @@ func (t *MainTest) TestGetUserAgentConfig() {
 				},
 				Write: cfg.WriteConfig{EnableStreamingWrites: false},
 			},
-			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0)", common.GetVersion())),
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:1:0:0:0)", common.GetVersion())),
+		},
+		{
+			name: "buffered_read_enabled",
+			mountConfig: &cfg.Config{
+				Read: cfg.ReadConfig{EnableBufferedRead: true},
+			},
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:1)", common.GetVersion())),
+		},
+		{
+			name: "buffered_read_disabled",
+			mountConfig: &cfg.Config{
+				Read: cfg.ReadConfig{EnableBufferedRead: false},
+			},
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:0:0:0:0:0)", common.GetVersion())),
+		},
+		{
+			name: "file_cache_enabled_and_buffered_read_enabled",
+			mountConfig: &cfg.Config{
+				CacheDir:  "/cache/path",
+				FileCache: cfg.FileCacheConfig{MaxSizeMb: -1},
+				Read:      cfg.ReadConfig{EnableBufferedRead: true},
+			},
+			// Note: getConfigForUserAgent runs before config rationalization, which
+			// would disable buffered-read when file-cache is enabled.
+			expectedUserAgent: strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-AppName) (Cfg:1:0:0:0:1)", common.GetVersion())),
 		},
 	}
 
@@ -215,7 +240,7 @@ func (t *MainTest) TestGetUserAgentWhenMetadataImageTypeEnvVarSetAndAppNameNotSe
 
 	userAgent := getUserAgent("", getConfigForUserAgent(mountConfig))
 
-	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0)", common.GetVersion()))
+	expectedUserAgent := strings.TrimSpace(fmt.Sprintf("gcsfuse/%s (GPN:gcsfuse-DLVM) (Cfg:0:0:0:0:0)", common.GetVersion()))
 	assert.Equal(t.T(), expectedUserAgent, userAgent)
 }
 


### PR DESCRIPTION
### Description
To track usage of buffered read config, added a bitset for buffered read to user agent. This is a temporary change until we find a better way to track usage.

### Link to the issue in case of a bug fix.
b/441658865

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
