### PR TITLE
ci: Preserve gcsfuse log file for e2e package concurrent_operations on failure

### DIFF
--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -93,6 +93,9 @@ func TestMain(m *testing.M) {
 	log.Println("Running static mounting tests...")
 	successCode := m.Run()
 
+	// If test failed, save the gcsfuse log files for debugging.
+	setup.SaveLogFileInCaseOfFailure(successCode)
+
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)


### PR DESCRIPTION
### Description
This is needed for debugging in case of e2e test failure. Without this, there is almost no debugging information available.

### Link to the issue in case of a bug fix.
[b/441631278](http://b/441631278)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as presubmit - [run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/32f4ebe3-9753-436c-a65f-d68f92890276)

### Any backward incompatible change? If so, please explain.
