### PR TITLE
test(async-read): test the behavior of async read

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -179,6 +179,7 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		// Enables ReadDirPlus, allowing the kernel to retrieve directory entries and their
 		// attributes in a single operation.
 		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
+		EnableAsyncReads: true,
 	}
 
 	// GCSFuse to Jacobsa Fuse Log Level mapping:

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -2,9 +2,24 @@
 
 ## Reads
 
+### Default Reads
+
 Cloud Storage FUSE makes API calls to Cloud Storage to read an object directly, without downloading it to a local directory. A TCP connection is established, in which the entire object, or just portions as specified by the application/operating system via an offset, can be read back.
 
 Files that have not been modified are read portion by portion on demand. Cloud Storage FUSE uses a heuristic to detect when a file is being read sequentially, and will issue fewer, larger read requests to Cloud Storage in this case, increasing performance.
+
+### Buffered Reads
+
+Cloud Storage FUSE offers Buffered Read feature support to accelerate large sequential reads. Buffered Read improves throughput by intelligently prefetching the object parts asynchronously and parallely into an in-memory buffer, and serving the reads from those buffered instead from network. Asynchronous and parallel buffereing improves the throughput by saturating the network without increasing application side parallelism.
+
+This is disabled by default and can be enabled using the `--enable-buffered-read` flag or `read:enable-buffered-read: true` in the config file. Also, it is designed to operate exclusively when the file cache is disabled; if both features are enabled, the file cache takes precedence.
+
+**Memory Usage:** Buffered read can consume upto 320 MB (20 x 16MB memory blocks) memory per file-handle while reading. The memory is released once file-handle is closed or fallback to default read (for random read). Overall memory across different file-handles can be controlled using `--read-global-max-blocks` flag or `read:global-max-blocks` config. By default, `--read-global-max-blocks` is set to 40 that means Buffered-read can't consume more than (40 * 16 MB) = 640 MB memory across all file-handles. Please consider the available sysmtem memory while enabling the Buffered read or changing the `--read-global-max-blocks` flag to avoid out-of-memory (OOM) issues.
+
+**CPU Usage:** Buffered read consume more cpu than the default read path and the cpu usage will be propotional to the performance gain.
+
+**Known Limitations:**
+- **Mixed Read Patterns:** Workloads with a mix of sequential and random reads (e.g., few model serving workloads) may not see a performance benefit and could fall-back to the default read path. Future releases will include improved heuristics for these scenarios. 
 
 ## Writes
 


### PR DESCRIPTION
### Description
Try reading a 50MB file (cat 50MB > /dev/null), over a gcsfuse mount with read-ahead 4MB

Logs:
```
time="29/08/2025 12:16:39.485174" severity=TRACE message="fuse_debug: Op 0x0000000a        connection.go:548] -> LookUpInode (inode 3)"
time="29/08/2025 12:16:39.485289" severity=TRACE message="fuse_debug: Op 0x0000000c        connection.go:453] <- OpenFile (inode 3, PID 2049824)"
time="29/08/2025 12:16:39.485378" severity=TRACE message="fuse_debug: Op 0x0000000c        connection.go:548] -> OpenFile (handle 0)"
time="29/08/2025 12:16:39.485610" severity=TRACE message="fuse_debug: Op 0x0000000e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 0, 524288 bytes)"
time="29/08/2025 12:16:39.485690" severity=TRACE message="gcs: Req              0x5: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [0, 52428800))"
time="29/08/2025 12:16:39.567828" severity=TRACE message="fuse_debug: Op 0x0000000e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.568563" severity=TRACE message="fuse_debug: Op 0x00000010        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 524288, 1048576 bytes)"
time="29/08/2025 12:16:39.569294" severity=TRACE message="fuse_debug: Op 0x00000012        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 1572864, 1048576 bytes)"
time="29/08/2025 12:16:39.569355" severity=TRACE message="fuse_debug: Op 0x00000014        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 2621440, 1048576 bytes)"
time="29/08/2025 12:16:39.572837" severity=TRACE message="fuse_debug: Op 0x00000010        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.574327" severity=TRACE message="fuse_debug: Op 0x00000016        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 3670016, 1048576 bytes)"
time="29/08/2025 12:16:39.574360" severity=TRACE message="fuse_debug: Op 0x00000018        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 4718592, 1048576 bytes)"
time="29/08/2025 12:16:39.574434" severity=TRACE message="fuse_debug: Op 0x0000001a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 5767168, 1048576 bytes)"
time="29/08/2025 12:16:39.574459" severity=TRACE message="fuse_debug: Op 0x0000001c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 6815744, 1048576 bytes)"
time="29/08/2025 12:16:39.582014" severity=TRACE message="fuse_debug: Op 0x00000012        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.588290" severity=TRACE message="fuse_debug: Op 0x00000014        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.590817" severity=TRACE message="fuse_debug: Op 0x0000001e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 7864320, 1048576 bytes)"
time="29/08/2025 12:16:39.590906" severity=TRACE message="fuse_debug: Op 0x00000020        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 8912896, 1048576 bytes)"
time="29/08/2025 12:16:39.590925" severity=TRACE message="fuse_debug: Op 0x00000022        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 9961472, 1048576 bytes)"
time="29/08/2025 12:16:39.590962" severity=TRACE message="fuse_debug: Op 0x00000024        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 11010048, 1048576 bytes)"
time="29/08/2025 12:16:39.591034" severity=TRACE message="fuse_debug: Op 0x00000026        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 12058624, 1048576 bytes)"
time="29/08/2025 12:16:39.653622" severity=TRACE message="fuse_debug: Op 0x00000016        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.659323" severity=TRACE message="fuse_debug: Op 0x00000018        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.666653" severity=TRACE message="fuse_debug: Op 0x0000001a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.668487" severity=TRACE message="fuse_debug: Op 0x0000001c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.674709" severity=TRACE message="fuse_debug: Op 0x00000028        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 13107200, 1048576 bytes)"
time="29/08/2025 12:16:39.674830" severity=TRACE message="fuse_debug: Op 0x0000002a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 14155776, 1048576 bytes)"
time="29/08/2025 12:16:39.674869" severity=TRACE message="fuse_debug: Op 0x0000002c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 15204352, 1048576 bytes)"
time="29/08/2025 12:16:39.674891" severity=TRACE message="fuse_debug: Op 0x0000002e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 16252928, 1048576 bytes)"
time="29/08/2025 12:16:39.679092" severity=TRACE message="gcs: Req              0x5: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [0, 52428800)) (193.383625ms): OK"
time="29/08/2025 12:16:39.679167" severity=TRACE message="gcs: Req              0x6: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [7864320, 52428800))"
time="29/08/2025 12:16:39.679551" severity=TRACE message="fuse_debug: Op 0x00000020        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.727063" severity=TRACE message="fuse_debug: Op 0x0000001e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.744625" severity=TRACE message="fuse_debug: Op 0x00000022        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.779031" severity=TRACE message="fuse_debug: Op 0x00000026        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.779235" severity=TRACE message="gcs: Req              0x6: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [7864320, 52428800)) (100.052776ms): OK"
time="29/08/2025 12:16:39.779297" severity=TRACE message="gcs: Req              0x7: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [11010048, 52428800))"
time="29/08/2025 12:16:39.834020" severity=TRACE message="fuse_debug: Op 0x00000024        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.836308" severity=TRACE message="fuse_debug: Op 0x00000030        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 17301504, 1048576 bytes)"
time="29/08/2025 12:16:39.836364" severity=TRACE message="fuse_debug: Op 0x00000032        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 18350080, 1048576 bytes)"
time="29/08/2025 12:16:39.836381" severity=TRACE message="fuse_debug: Op 0x00000034        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 19398656, 1048576 bytes)"
time="29/08/2025 12:16:39.836396" severity=TRACE message="fuse_debug: Op 0x00000036        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 20447232, 1048576 bytes)"
time="29/08/2025 12:16:39.836410" severity=TRACE message="fuse_debug: Op 0x00000038        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 21495808, 1048576 bytes)"
time="29/08/2025 12:16:39.847223" severity=TRACE message="fuse_debug: Op 0x0000002a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.847344" severity=TRACE message="gcs: Req              0x7: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [11010048, 52428800)) (68.026029ms): OK"
time="29/08/2025 12:16:39.847377" severity=TRACE message="gcs: Req              0x8: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [13107200, 52428800))"
time="29/08/2025 12:16:39.897793" severity=TRACE message="fuse_debug: Op 0x00000028        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.932148" severity=TRACE message="fuse_debug: Op 0x0000002c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.941387" severity=TRACE message="fuse_debug: Op 0x0000002e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.943686" severity=TRACE message="fuse_debug: Op 0x0000003a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 22544384, 1048576 bytes)"
time="29/08/2025 12:16:39.943736" severity=TRACE message="fuse_debug: Op 0x0000003c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 23592960, 1048576 bytes)"
time="29/08/2025 12:16:39.943756" severity=TRACE message="fuse_debug: Op 0x0000003e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 24641536, 1048576 bytes)"
time="29/08/2025 12:16:39.943772" severity=TRACE message="fuse_debug: Op 0x00000040        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 25690112, 1048576 bytes)"
time="29/08/2025 12:16:39.946772" severity=TRACE message="fuse_debug: Op 0x00000030        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.956631" severity=TRACE message="fuse_debug: Op 0x00000034        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:39.957316" severity=TRACE message="gcs: Req              0x8: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [13107200, 52428800)) (109.906647ms): OK"
time="29/08/2025 12:16:39.957358" severity=TRACE message="gcs: Req              0x9: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [18350080, 52428800))"
time="29/08/2025 12:16:40.010189" severity=TRACE message="fuse_debug: Op 0x00000032        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.024153" severity=TRACE message="fuse_debug: Op 0x00000036        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.033804" severity=TRACE message="fuse_debug: Op 0x00000038        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.036006" severity=TRACE message="fuse_debug: Op 0x00000042        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 26738688, 1048576 bytes)"
time="29/08/2025 12:16:40.036072" severity=TRACE message="fuse_debug: Op 0x00000044        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 27787264, 1048576 bytes)"
time="29/08/2025 12:16:40.036095" severity=TRACE message="fuse_debug: Op 0x00000046        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 28835840, 1048576 bytes)"
time="29/08/2025 12:16:40.036110" severity=TRACE message="fuse_debug: Op 0x00000048        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 29884416, 1048576 bytes)"
time="29/08/2025 12:16:40.036141" severity=TRACE message="fuse_debug: Op 0x0000004a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 30932992, 1048576 bytes)"
time="29/08/2025 12:16:40.044991" severity=TRACE message="fuse_debug: Op 0x0000003a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.048563" severity=TRACE message="fuse_debug: Op 0x0000003c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.054515" severity=TRACE message="fuse_debug: Op 0x0000003e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.059471" severity=TRACE message="fuse_debug: Op 0x00000040        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.061846" severity=TRACE message="fuse_debug: Op 0x0000004c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 31981568, 1048576 bytes)"
time="29/08/2025 12:16:40.061894" severity=TRACE message="fuse_debug: Op 0x0000004e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 33030144, 1048576 bytes)"
time="29/08/2025 12:16:40.061909" severity=TRACE message="fuse_debug: Op 0x00000050        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 34078720, 1048576 bytes)"
time="29/08/2025 12:16:40.061932" severity=TRACE message="fuse_debug: Op 0x00000052        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 35127296, 1048576 bytes)"
time="29/08/2025 12:16:40.065242" severity=TRACE message="fuse_debug: Op 0x00000042        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.069582" severity=TRACE message="fuse_debug: Op 0x00000044        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.075008" severity=TRACE message="fuse_debug: Op 0x00000046        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.080845" severity=TRACE message="fuse_debug: Op 0x00000048        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.086149" severity=TRACE message="fuse_debug: Op 0x0000004a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.088359" severity=TRACE message="fuse_debug: Op 0x00000054        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 36175872, 1048576 bytes)"
time="29/08/2025 12:16:40.088411" severity=TRACE message="fuse_debug: Op 0x00000056        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 37224448, 1048576 bytes)"
time="29/08/2025 12:16:40.088436" severity=TRACE message="fuse_debug: Op 0x00000058        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 38273024, 1048576 bytes)"
time="29/08/2025 12:16:40.088455" severity=TRACE message="fuse_debug: Op 0x0000005a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 39321600, 1048576 bytes)"
time="29/08/2025 12:16:40.088471" severity=TRACE message="fuse_debug: Op 0x0000005c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 40370176, 1048576 bytes)"
time="29/08/2025 12:16:40.091979" severity=TRACE message="fuse_debug: Op 0x0000004c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.096591" severity=TRACE message="fuse_debug: Op 0x0000004e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.101457" severity=TRACE message="fuse_debug: Op 0x00000050        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.107043" severity=TRACE message="fuse_debug: Op 0x00000052        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.109385" severity=TRACE message="fuse_debug: Op 0x0000005e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 41418752, 1048576 bytes)"
time="29/08/2025 12:16:40.109419" severity=TRACE message="fuse_debug: Op 0x00000060        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 42467328, 1048576 bytes)"
time="29/08/2025 12:16:40.109436" severity=TRACE message="fuse_debug: Op 0x00000062        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 43515904, 1048576 bytes)"
time="29/08/2025 12:16:40.109451" severity=TRACE message="fuse_debug: Op 0x00000064        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 44564480, 1048576 bytes)"
time="29/08/2025 12:16:40.110968" severity=TRACE message="fuse_debug: Op 0x00000054        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.115615" severity=TRACE message="fuse_debug: Op 0x00000056        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.120110" severity=TRACE message="fuse_debug: Op 0x00000058        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.125445" severity=TRACE message="fuse_debug: Op 0x0000005a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.129367" severity=TRACE message="fuse_debug: Op 0x0000005c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.131231" severity=TRACE message="fuse_debug: Op 0x00000066        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 45613056, 1048576 bytes)"
time="29/08/2025 12:16:40.131284" severity=TRACE message="fuse_debug: Op 0x00000068        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 46661632, 1048576 bytes)"
time="29/08/2025 12:16:40.131303" severity=TRACE message="fuse_debug: Op 0x0000006a        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 47710208, 1048576 bytes)"
time="29/08/2025 12:16:40.131320" severity=TRACE message="fuse_debug: Op 0x0000006c        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 48758784, 1048576 bytes)"
time="29/08/2025 12:16:40.131333" severity=TRACE message="fuse_debug: Op 0x0000006e        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 49807360, 1048576 bytes)"
time="29/08/2025 12:16:40.134814" severity=TRACE message="fuse_debug: Op 0x0000005e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.138923" severity=TRACE message="fuse_debug: Op 0x00000060        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.143408" severity=TRACE message="fuse_debug: Op 0x00000062        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.146501" severity=TRACE message="fuse_debug: Op 0x00000064        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.152311" severity=TRACE message="fuse_debug: Op 0x00000068        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.152603" severity=TRACE message="gcs: Req              0x9: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [18350080, 52428800)) (195.134044ms): OK"
time="29/08/2025 12:16:40.152663" severity=TRACE message="gcs: Req              0xa: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [45613056, 52428800))"
time="29/08/2025 12:16:40.207553" severity=TRACE message="fuse_debug: Op 0x00000066        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.214848" severity=TRACE message="fuse_debug: Op 0x0000006a        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.223076" severity=TRACE message="fuse_debug: Op 0x0000006e        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.223271" severity=TRACE message="gcs: Req              0xa: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [45613056, 52428800)) (70.588778ms): OK"
time="29/08/2025 12:16:40.223300" severity=TRACE message="gcs: Req              0xb: <- ReadWithReadHandle(\"fio_test_files/file_9.bin\", [48758784, 52428800))"
time="29/08/2025 12:16:40.269918" severity=TRACE message="fuse_debug: Op 0x0000006c        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.270794" severity=TRACE message="fuse_debug: Op 0x00000070        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 50855936, 524288 bytes)"
time="29/08/2025 12:16:40.275551" severity=TRACE message="fuse_debug: Op 0x00000070        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.276029" severity=TRACE message="fuse_debug: Op 0x00000072        connection.go:453] <- ReadFile (inode 3, PID 2049824, handle 0, offset 51380224, 1048576 bytes)"
time="29/08/2025 12:16:40.278939" severity=TRACE message="gcs: Req              0xb: -> ReadWithReadHandle(\"fio_test_files/file_9.bin\", [48758784, 52428800)) (55.629978ms): OK"
time="29/08/2025 12:16:40.278982" severity=TRACE message="fuse_debug: Op 0x00000072        connection.go:548] -> ReadFile ()"
time="29/08/2025 12:16:40.279443" severity=TRACE message="fuse_debug: Op 0x00000074        connection.go:453] <- FlushFile (inode 3, PID 2049824)"
time="29/08/2025 12:16:40.279514" severity=TRACE message="fuse_debug: Op 0x00000074        connection.go:548] -> FlushFile ()"
time="29/08/2025 12:16:40.279584" severity=TRACE message="fuse_debug: Op 0x00000076        connection.go:453] <- ReleaseFileHandle (PID 0, handle 0)"
time="29/08/2025 12:16:40.279635" severity=TRACE message="fuse_debug: Op 0x00000076        connection.go:548] -> ReleaseFileHandle ()"

```

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
