### PR TITLE
ci(debug e2e failure): Enable trace logs in e2e package mount-timeout

### DIFF
--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -160,8 +160,8 @@ func (testSuite *MountTimeoutTest) mountOrTimeout(bucketName, clientProtocol str
 	}()
 
 	// Iterating 10 times to account for randomness in time taken to mount.
-	args := []string{"--client-protocol", clientProtocol, "--log-file=" + logFile, bucketName, testSuite.dir}
-	for i := 0; i < iterations; i++ {
+	args := []string{"--client-protocol", clientProtocol, "--log-severity=trace", "--log-file=" + logFile, bucketName, testSuite.dir}
+	for i := range iterations {
 		start := time.Now()
 		if err = mounting.MountGcsfuse(testSuite.gcsfusePath, args); err != nil {
 			err = fmt.Errorf("mount failed for bucket %q (client protocol: %s) on attempt#%v: %w", bucketName, clientProtocol, i, err)


### PR DESCRIPTION
### Description
Enable debug log in e2e test package mount-timeout to debug failures.

### Link to the issue in case of a bug fix.
[b/442353614](http://b/442353614)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as presubmit.

### Any backward incompatible change? If so, please explain.
