### PR TITLE
revert: disabling google lib auth flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -403,7 +403,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-google-lib-auth", "", true, "Enable google library authentication method to fetch the credentials")
+	flagSet.BoolP("enable-google-lib-auth", "", false, "Enable google library authentication method to fetch the credentials")
 
 	if err := flagSet.MarkHidden("enable-google-lib-auth"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -89,7 +89,7 @@
   config-path: "enable-google-lib-auth"
   type: "bool"
   usage: "Enable google library authentication method to fetch the credentials"
-  default: true
+  default: false
   hide-flag: true
 
 - config-path: "enable-hns"


### PR DESCRIPTION
### Description
We recently find an issue where enabling new auth library is having issue with RenameFolder API. Disabling the new auth flow until it gets resolved. 

### Link to the issue in case of a bug fix.
[b/442805436](https://buganizer.corp.google.com/issues/442805436)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
