### PR TITLE
revert: Revert "feat(Migrate auth TPC): Make default value of flag true (#3610)"

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1131,8 +1131,8 @@ func TestArgsParsing_EnableGoogleLibAuthFlag(t *testing.T) {
 		},
 		{
 			name:                        "normal",
-			args:                        []string{"gcsfuse", "--enable-google-lib-auth=false", "abc", "pqr"},
-			expectedEnableGoogleLibAuth: false,
+			args:                        []string{"gcsfuse", "--enable-google-lib-auth=true", "abc", "pqr"},
+			expectedEnableGoogleLibAuth: true,
 		},
 	}
 

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -38,7 +38,7 @@ func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 func MountGcsfuseWithStaticMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	var defaultArg []string
 	if setup.TestOnTPCEndPoint() {
-		defaultArg = append(defaultArg,
+		defaultArg = append(defaultArg, "--custom-endpoint=storage.apis-tpczero.goog:443",
 			"--key-file=/tmp/sa.key.json")
 	}
 


### PR DESCRIPTION
### Description
- This reverts the remaining changes of #3610 which were not reverted in #3777
- This helps fix an error in e2e TPC test suite.

### Link to the issue in case of a bug fix.
[b/442950851](http://b/442950851)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as [presubmit](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/654198db-5fb1-410d-9f7b-d51195db0e9f)

### Any backward incompatible change? If so, please explain.
