### PR TITLE
refactor: dynamic mount test changes [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -94,13 +94,10 @@ func (s *remountTest) TestCacheIsNotReusedOnDynamicRemount() {
 	// 1. First read: This should result in a cache miss, and the file content will be cached.
 	expectedOutcome1 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, true, s.T())
 	structuredReadLogs1 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), s.T())
-
 	// Remount GCSFuse. This should clear any in-memory cache.
 	remountGCSFuse(s.flags)
-
 	// 2. Second read (after remount): This should also result in a cache miss as the cache should be empty.
 	expectedOutcome2 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, false, s.T())
-
 	// 3. Third read (without remount): This should result in a cache hit.
 	expectedOutcome3 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, false, s.T())
 	structuredReadLogs2 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), s.T())

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -19,12 +19,10 @@ import (
 	"log"
 	"path"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/log_parser/json_parser/read_logs"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/suite"
@@ -92,41 +90,27 @@ func (s *remountTest) TestCacheIsNotReusedOnDynamicRemount() {
 	runTestsOnlyForDynamicMount(s.T())
 	testBucket1 := setup.TestBucket()
 	testFileName1 := setupFileInTestDir(s.ctx, s.storageClient, fileSize, s.T())
-	testBucket2, err := dynamic_mounting.CreateTestBucketForDynamicMounting(ctx, storageClient)
-	if err != nil {
-		s.T().Fatalf("Failed to create bucket for dynamic mounting test: %v", err)
-	}
-	defer func() {
-		if err := client.DeleteBucket(ctx, storageClient, testBucket2); err != nil {
-			s.T().Logf("Failed to delete test bucket %s.Error : %v", testBucket1, err)
-		}
-	}()
-	setup.SetDynamicBucketMounted(testBucket2)
-	defer setup.SetDynamicBucketMounted("")
-	// Introducing a sleep of 10 seconds after bucket creation to address propagation delays.
-	time.Sleep(10 * time.Second)
-	client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
-	testFileName2 := setupFileInTestDir(s.ctx, s.storageClient, fileSize, s.T())
 
-	// Reading files in different buckets.
+	// 1. First read: This should result in a cache miss, and the file content will be cached.
 	expectedOutcome1 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, true, s.T())
-	expectedOutcome2 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket2, s.ctx, s.storageClient, testFileName2, true, s.T())
 	structuredReadLogs1 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), s.T())
+
+	// Remount GCSFuse. This should clear any in-memory cache.
 	remountGCSFuse(s.flags)
-	// Reading files in different buckets again.
+
+	// 2. Second read (after remount): This should also result in a cache miss as the cache should be empty.
+	expectedOutcome2 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, false, s.T())
+
+	// 3. Third read (without remount): This should result in a cache hit.
 	expectedOutcome3 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, false, s.T())
-	expectedOutcome4 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket2, s.ctx, s.storageClient, testFileName2, false, s.T())
-	// Reading same files in different buckets again without remount.
-	expectedOutcome5 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket1, s.ctx, s.storageClient, testFileName1, false, s.T())
-	expectedOutcome6 := readFileAndValidateCacheWithGCSForDynamicMount(testBucket2, s.ctx, s.storageClient, testFileName2, false, s.T())
 	structuredReadLogs2 := read_logs.GetStructuredLogsSortedByTimestamp(setup.LogFile(), s.T())
 
+	// log1: First read -> cache miss
 	validate(expectedOutcome1, structuredReadLogs1[0], true, false, chunksRead, s.T())
-	validate(expectedOutcome2, structuredReadLogs1[1], true, false, chunksRead, s.T())
-	validate(expectedOutcome3, structuredReadLogs2[0], true, false, chunksRead, s.T())
-	validate(expectedOutcome4, structuredReadLogs2[1], true, false, chunksRead, s.T())
-	validate(expectedOutcome5, structuredReadLogs2[2], true, true, chunksRead, s.T())
-	validate(expectedOutcome6, structuredReadLogs2[3], true, true, chunksRead, s.T())
+	// log2: Second read (after remount) -> cache miss
+	validate(expectedOutcome2, structuredReadLogs2[0], true, false, chunksRead, s.T())
+	// log3: Third read -> cache hit
+	validate(expectedOutcome3, structuredReadLogs2[1], true, true, chunksRead, s.T())
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -15,18 +15,14 @@
 package dynamic_mounting
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"path"
 	"testing"
 
-	"cloud.google.com/go/compute/metadata"
-	"cloud.google.com/go/storage"
-
-	client_util "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const PrefixBucketForDynamicMountingTest = "gcsfuse-dynamic-mounting-test-"
@@ -71,24 +67,16 @@ func runTestsOnGivenMountedTestBucket(bucketName string, flags [][]string, rootM
 	return
 }
 
-func executeTestsForDynamicMounting(flags [][]string, createdBucket string, m *testing.M) (successCode int) {
+func executeTestsForDynamicMounting(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	rootMntDir := setup.MntDir()
 
 	// In dynamic mounting all the buckets mounted in mntDir which user has permission.
 	// mntDir - bucket1, bucket2, bucket3, ...
-	// We will test on passed testBucket and one created bucket.
 
 	// SetDynamicBucketMounted to the passed test bucket.
-	setup.SetDynamicBucketMounted(setup.TestBucket())
-	// Test on testBucket
-	successCode = runTestsOnGivenMountedTestBucket(setup.TestBucket(), flags, rootMntDir, m)
+	setup.SetDynamicBucketMounted(config.TestBucket)
+	successCode = runTestsOnGivenMountedTestBucket(config.TestBucket, flagsSet, rootMntDir, m)
 
-	// Test on created bucket.
-	// SetDynamicBucketMounted to the mounted bucket.
-	setup.SetDynamicBucketMounted(createdBucket)
-	if successCode == 0 {
-		successCode = runTestsOnGivenMountedTestBucket(createdBucket, flags, rootMntDir, m)
-	}
 	// Reset SetDynamicBucketMounted to empty after tests are done.
 	setup.SetDynamicBucketMounted("")
 
@@ -97,60 +85,20 @@ func executeTestsForDynamicMounting(flags [][]string, createdBucket string, m *t
 	return
 }
 
-func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string, err error) {
-	projectID, err := metadata.ProjectIDWithContext(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get project ID of instance: %v", err)
+// Deprecated: Use RunTestsWithConfigFile instead.
+// TODO(b/438068132): cleanup deprecated methods after migration is complete.
+func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
+	config := &test_suite.TestConfig{
+		TestBucket:       setup.TestBucket(),
+		MountedDirectory: setup.MountedDirectory(),
+		LogFile:          setup.LogFile(),
 	}
-
-	// Create bucket handle and attributes
-	storageClassAndLocation := &storage.BucketAttrs{
-		Location: "us-west1",
-	}
-
-	if setup.IsZonalBucketRun() {
-		storageClassAndLocation.StorageClass = "RAPID"
-		gceZone, err := setup.GetGCEZone(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed to find the GCE zone of the VM: %w", err)
-		}
-		gceRegion, err := setup.GetGCERegion(gceZone)
-		if err != nil {
-			return "", fmt.Errorf("failed to find the GCE region of the VM: %w", err)
-		}
-		storageClassAndLocation.Location = gceRegion
-		storageClassAndLocation.CustomPlacementConfig = &storage.CustomPlacementConfig{DataLocations: []string{gceZone}}
-		storageClassAndLocation.HierarchicalNamespace = &storage.HierarchicalNamespace{
-			Enabled: true,
-		}
-		storageClassAndLocation.UniformBucketLevelAccess = storage.UniformBucketLevelAccess{
-			Enabled: true,
-		}
-	}
-
-	bucketName = PrefixBucketForDynamicMountingTest + setup.GenerateRandomString(5)
-	bucket := client.Bucket(bucketName)
-	if err := bucket.Create(ctx, projectID, storageClassAndLocation); err != nil {
-		return "", fmt.Errorf("failed to create bucket: %v", err)
-	}
-	return
+	return RunTestsWithConfigFile(config, flagsSet, m)
 }
 
-func RunTests(ctx context.Context, client *storage.Client, flags [][]string, m *testing.M) (successCode int) {
+func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running dynamic mounting tests...")
-
-	createdBucket, err := CreateTestBucketForDynamicMounting(ctx, client)
-	if err != nil {
-		log.Fatalf("Failed to create bucket for dynamic mounting test: %v", err)
-	}
-
-	successCode = executeTestsForDynamicMounting(flags, createdBucket, m)
-
+	successCode = executeTestsForDynamicMounting(config, flagsSet, m)
 	log.Printf("Test log: %s\n", setup.LogFile())
-
-	if err := client_util.DeleteBucket(ctx, client, createdBucket); err != nil {
-		log.Fatalf("Failed to delete the created bucket for dynamic mounting test: %s. Error: %v", createdBucket, err)
-	}
-
 	return successCode
 }

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -70,6 +70,24 @@ func runTestsOnGivenMountedTestBucket(bucketName string, flags [][]string, rootM
 	return
 }
 
+func executeTestsForDynamicMounting(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
+	rootMntDir := setup.MntDir()
+
+	// In dynamic mounting all the buckets mounted in mntDir which user has permission.
+	// mntDir - bucket1, bucket2, bucket3, ...
+
+	// SetDynamicBucketMounted to the passed test bucket.
+	setup.SetDynamicBucketMounted(config.TestBucket)
+	successCode = runTestsOnGivenMountedTestBucket(config.TestBucket, flagsSet, rootMntDir, m)
+
+	// Reset SetDynamicBucketMounted to empty after tests are done.
+	setup.SetDynamicBucketMounted("")
+
+	// Setting back the original mntDir after testing.
+	setup.SetMntDir(rootMntDir)
+	return
+}
+
 // Deprecated: Not required
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string, err error) {
@@ -108,24 +126,6 @@ func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Cli
 	if err := bucket.Create(ctx, projectID, storageClassAndLocation); err != nil {
 		return "", fmt.Errorf("failed to create bucket: %v", err)
 	}
-	return
-}
-
-func executeTestsForDynamicMounting(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
-	rootMntDir := setup.MntDir()
-
-	// In dynamic mounting all the buckets mounted in mntDir which user has permission.
-	// mntDir - bucket1, bucket2, bucket3, ...
-
-	// SetDynamicBucketMounted to the passed test bucket.
-	setup.SetDynamicBucketMounted(config.TestBucket)
-	successCode = runTestsOnGivenMountedTestBucket(config.TestBucket, flagsSet, rootMntDir, m)
-
-	// Reset SetDynamicBucketMounted to empty after tests are done.
-	setup.SetDynamicBucketMounted("")
-
-	// Setting back the original mntDir after testing.
-	setup.SetMntDir(rootMntDir)
 	return
 }
 

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"testing"
 
-	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -85,47 +84,6 @@ func executeTestsForDynamicMounting(config *test_suite.TestConfig, flagsSet [][]
 
 	// Setting back the original mntDir after testing.
 	setup.SetMntDir(rootMntDir)
-	return
-}
-
-// Deprecated: Not required
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func CreateTestBucketForDynamicMounting(ctx context.Context, client *storage.Client) (bucketName string, err error) {
-	projectID, err := metadata.ProjectIDWithContext(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get project ID of instance: %v", err)
-	}
-
-	// Create bucket handle and attributes
-	storageClassAndLocation := &storage.BucketAttrs{
-		Location: "us-west1",
-	}
-
-	if setup.IsZonalBucketRun() {
-		storageClassAndLocation.StorageClass = "RAPID"
-		gceZone, err := setup.GetGCEZone(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed to find the GCE zone of the VM: %w", err)
-		}
-		gceRegion, err := setup.GetGCERegion(gceZone)
-		if err != nil {
-			return "", fmt.Errorf("failed to find the GCE region of the VM: %w", err)
-		}
-		storageClassAndLocation.Location = gceRegion
-		storageClassAndLocation.CustomPlacementConfig = &storage.CustomPlacementConfig{DataLocations: []string{gceZone}}
-		storageClassAndLocation.HierarchicalNamespace = &storage.HierarchicalNamespace{
-			Enabled: true,
-		}
-		storageClassAndLocation.UniformBucketLevelAccess = storage.UniformBucketLevelAccess{
-			Enabled: true,
-		}
-	}
-
-	bucketName = PrefixBucketForDynamicMountingTest + setup.GenerateRandomString(5)
-	bucket := client.Bucket(bucketName)
-	if err := bucket.Create(ctx, projectID, storageClassAndLocation); err != nil {
-		return "", fmt.Errorf("failed to create bucket: %v", err)
-	}
 	return
 }
 


### PR DESCRIPTION
### Description
This PR includes changes in dynamic mounting file, such that other files can now use it with the config struct defined.

### Link to the issue in case of a bug fix.
[b/445950340](https://b.corp.google.com/issues/445950340)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
