### PR TITLE
fix(e2e random error): Retry on failed to resolve host github.com

### DIFF
--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -20,6 +20,7 @@ package interrupt
 import (
 	"log"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
@@ -58,8 +59,24 @@ func (s *ignoreInterruptsTest) SetupTest() {
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-func cloneRepository() ([]byte, error) {
-	return operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "clone %s", repoURL)
+func (s *ignoreInterruptsTest) cloneRepository() (output []byte, err error) {
+	s.T().Helper()
+	maxAttempts := 5
+	isRetryableError := func(err error) bool {
+		return strings.Contains(strings.ToLower(err.Error()), "could not resolve host")
+	}
+	for range maxAttempts {
+		output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "clone %s", repoURL)
+
+		if err == nil {
+			break
+		} else if isRetryableError(err) {
+			s.T().Logf("failed to clone %q with stdout = %q and retryable error = %v", repoURL, string(output), err)
+		} else {
+			s.T().Fatalf("failed to clone %q with stdout = %q and non-retryable error = %v", repoURL, string(output), err)
+		}
+	}
+	return
 }
 
 func checkoutBranch(branchName string) ([]byte, error) {
@@ -99,7 +116,7 @@ func setGithubUserConfig() {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *ignoreInterruptsTest) TestGitClone() {
-	output, err := cloneRepository()
+	output, err := s.cloneRepository()
 
 	if err != nil {
 		s.T().Errorf("Git clone failed: %s: %v", string(output), err)
@@ -107,7 +124,7 @@ func (s *ignoreInterruptsTest) TestGitClone() {
 }
 
 func (s *ignoreInterruptsTest) TestGitCheckout() {
-	_, err := cloneRepository()
+	_, err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}
@@ -120,7 +137,7 @@ func (s *ignoreInterruptsTest) TestGitCheckout() {
 }
 
 func (s *ignoreInterruptsTest) TestGitEmptyCommit() {
-	_, err := cloneRepository()
+	_, err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}
@@ -134,7 +151,7 @@ func (s *ignoreInterruptsTest) TestGitEmptyCommit() {
 }
 
 func (s *ignoreInterruptsTest) TestGitCommitWithChanges() {
-	_, err := cloneRepository()
+	_, err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}

--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -18,6 +18,7 @@
 package interrupt
 
 import (
+	"fmt"
 	"log"
 	"path"
 	"strings"
@@ -59,8 +60,8 @@ func (s *ignoreInterruptsTest) SetupTest() {
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-func (s *ignoreInterruptsTest) cloneRepository() (output []byte, err error) {
-	s.T().Helper()
+func (s *ignoreInterruptsTest) cloneRepository() (err error) {
+	var output []byte
 	maxAttempts := 5
 	isRetryableError := func(err error) bool {
 		return strings.Contains(strings.ToLower(err.Error()), "could not resolve host")
@@ -73,10 +74,10 @@ func (s *ignoreInterruptsTest) cloneRepository() (output []byte, err error) {
 		} else if isRetryableError(err) {
 			s.T().Logf("failed to clone %q with stdout = %q and retryable error = %v", repoURL, string(output), err)
 		} else {
-			s.T().Fatalf("failed to clone %q with stdout = %q and non-retryable error = %v", repoURL, string(output), err)
+			return fmt.Errorf("failed to clone %q with stdout = %q and non-retryable error = %v", repoURL, string(output), err)
 		}
 	}
-	return
+	return err
 }
 
 func checkoutBranch(branchName string) ([]byte, error) {
@@ -116,15 +117,15 @@ func setGithubUserConfig() {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *ignoreInterruptsTest) TestGitClone() {
-	output, err := s.cloneRepository()
+	err := s.cloneRepository()
 
 	if err != nil {
-		s.T().Errorf("Git clone failed: %s: %v", string(output), err)
+		s.T().Errorf("Git clone failed: %v", err)
 	}
 }
 
 func (s *ignoreInterruptsTest) TestGitCheckout() {
-	_, err := s.cloneRepository()
+	err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}
@@ -137,7 +138,7 @@ func (s *ignoreInterruptsTest) TestGitCheckout() {
 }
 
 func (s *ignoreInterruptsTest) TestGitEmptyCommit() {
-	_, err := s.cloneRepository()
+	err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}
@@ -151,7 +152,7 @@ func (s *ignoreInterruptsTest) TestGitEmptyCommit() {
 }
 
 func (s *ignoreInterruptsTest) TestGitCommitWithChanges() {
-	_, err := s.cloneRepository()
+	err := s.cloneRepository()
 	if err != nil {
 		s.T().Errorf("cloneRepository() failed: %v", err)
 	}


### PR DESCRIPTION
### Description
Retry on failed to resolve host 'github.com' in e2e test `interrupt`.

### Link to the issue in case of a bug fix.
[b/443696923](http://b/443696923)

### Testing details
1. Manual - tested manually. Sample log below.
```sh
{"timestamp":{"seconds":1757403839,"nanos":634340643},"severity":"INFO","message":"File system has been successfully mounted."}
+ set +x
+ GODEBUG=asyncpreemptoff=1
+ go test . -test.timeout 5400s -test.parallel 1 --integrationTest -test.v --testbucket=gargnitin-test-hns-asiase1 -test.run '.*/TestGitClone' --gcsfuse_prebuilt_dir /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/tasks/adhoc/20250906-git-clone-test/src/gcsfuse github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/interrupt --mountedDirectory=/usr/local/google/home/gargnitin/work/test_buckets/gargnitin-test-hns-asiase1-mount
{"timestamp":{"seconds":1757403841,"nanos":604043659},"severity":"INFO","message":"Using GCSFuse from pre-built directory specified by --gcsfuse_prebuilt_dir flag: /usr/local/google/home/gargnitin/work/cloud/storage/client/gcsfuse/tasks/adhoc/20250906-git-clone-test/src/gcsfuse"}
{"timestamp":{"seconds":1757403841,"nanos":604291019},"severity":"INFO","message":"Running static mounting tests..."}
{"timestamp":{"seconds":1757403841,"nanos":906075798},"severity":"INFO","message":"Running static mounting tests with flags: [--config-file=/tmp/gcsfuse_readwrite_test_3294490042/default_ignore_interrupts.yaml --enable-streaming-writes=false]"}
=== RUN   TestIgnoreInterrupts
=== RUN   TestIgnoreInterrupts/TestGitClone
    git_clone_test.go:76: failed to clone "https://github.com2/gcsfuse-github-machine-user-bot/test-repository.git" with stdout = "" and retryable error = failed command '/bin/bash -c git clone https://github.com2/gcsfuse-github-machine-user-bot/test-repository.git': exit status 128, Cloning into 'test-repository'...
        fatal: unable to access 'https://github.com2/gcsfuse-github-machine-user-bot/test-repository.git/': Could not resolve host: github.com2
--- PASS: TestIgnoreInterrupts (28.11s)
    --- PASS: TestIgnoreInterrupts/TestGitClone (28.11s)
PASS
{"timestamp":{"seconds":1757403870,"nanos":334759493},"severity":"INFO","message":"Running static mounting tests with flags: [--enable-streaming-writes=true]"}
=== RUN   TestIgnoreInterrupts
=== RUN   TestIgnoreInterrupts/TestGitClone
--- PASS: TestIgnoreInterrupts (22.32s)
    --- PASS: TestIgnoreInterrupts/TestGitClone (22.32s)
PASS
{"timestamp":{"seconds":1757403892,"nanos":663531388},"severity":"INFO","message":"Test log: /tmp/gcsfuse_readwrite_test_3294490042/gcsfuse.log"}
ok      github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/interrupt     51.217s
```
3. Unit tests - NA
4. Integration tests - Passed as presubmit.
6. 

### Any backward incompatible change? If so, please explain.
