### PR TITLE
docs: Update troubleshooting.md for fallback os version

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -234,3 +234,10 @@ the following operations:
   hardlinks.
 - **BatchForget:**  This is a performance optimization for batch-forgetting inodes. When this is unimplemented,
   filesystem instead utilizes individual ForgetInode calls.
+
+### Installation error: The repository does not have a Release file
+The full error log would be something like: `Error: The repository 'https://packages.cloud.google.com/apt gcsfuse-<abc> Release' does not have a Release file.`
+
+This occurs when the gcsfuse package corresponding to OS version returned by `lsb_release` (say x) is not in the [list of supported OS versions](https://cloud.google.com/storage/docs/cloud-storage-fuse/overview#frameworks-os-architectures) .
+
+**Workaround**: Install GCSFuse for the closest supported OS version (say y), by running `export GCSFUSE_REPO="gcsfuse-y"` and retrying installation. An example of this is in https://github.com/GoogleCloudPlatform/gcsfuse/issues/3779, with x=`trixie` (for debian-13), and y=`bookworm` (for debian-12).  


### PR DESCRIPTION
### Description
Add troubleshooting steps for workaround for installation ofr unsupported OS version when another close OS version is supported.

### Link to the issue in case of a bug fix.
https://github.com/GoogleCloudPlatform/gcsfuse/issues/3779

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
