### PR TITLE
feat(bufferedread): Reduce the channel size in workerpool to 2 times Global Max Read Blocks

### DIFF
--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -120,7 +120,7 @@ func (t *BufferedReaderTest) SetupTest() {
 		RandomSeekThreshold:     testRandomSeekThreshold,
 	}
 	var err error
-	t.workerPool, err = workerpool.NewStaticWorkerPool(5, 10)
+	t.workerPool, err = workerpool.NewStaticWorkerPool(5, 10, 15)
 	require.NoError(t.T(), err, "Failed to create worker pool")
 	t.workerPool.Start()
 	t.metricHandle = metrics.NewNoopMetrics()

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -74,7 +74,7 @@ func (t *readManagerTest) readManagerConfig(fileCacheEnable bool, bufferedReadEn
 		GlobalMaxBlocksSem: semaphore.NewWeighted(20),
 	}
 	if bufferedReadEnable {
-		t.workerPool, _ = workerpool.NewStaticWorkerPool(5, 20)
+		t.workerPool, _ = workerpool.NewStaticWorkerPool(5, 20, 25)
 		t.workerPool.Start()
 		config.WorkerPool = t.workerPool
 	}

--- a/internal/workerpool/static_worker_pool.go
+++ b/internal/workerpool/static_worker_pool.go
@@ -42,7 +42,7 @@ type staticWorkerPool struct {
 }
 
 // NewStaticWorkerPool creates a new thread pool
-func NewStaticWorkerPool(priorityWorker uint32, normalWorker uint32) (*staticWorkerPool, error) {
+func NewStaticWorkerPool(priorityWorker uint32, normalWorker uint32, readGlobalMaxBlocks int64) (*staticWorkerPool, error) {
 	totalWorkers := priorityWorker + normalWorker
 	if totalWorkers == 0 {
 		return nil, fmt.Errorf("staticWorkerPool: can't create with 0 workers, priority: %d, normal: %d", priorityWorker, normalWorker)
@@ -50,13 +50,14 @@ func NewStaticWorkerPool(priorityWorker uint32, normalWorker uint32) (*staticWor
 
 	logger.Infof("staticWorkerPool: creating with %d normal, and %d priority workers.", normalWorker, priorityWorker)
 
+	// We can schedule at most readGlobalMaxBlocks tasks at any given time,
+	// so we don't need channel capacity more than that.
 	return &staticWorkerPool{
 		priorityWorker: priorityWorker,
 		normalWorker:   normalWorker,
 		stop:           make(chan bool),
-		// Keep the channel capacity large enough to handle burst of tasks.
-		priorityCh: make(chan Task, priorityWorker*200),
-		normalCh:   make(chan Task, normalWorker*5000),
+		priorityCh:     make(chan Task, 2*readGlobalMaxBlocks),
+		normalCh:       make(chan Task, 2*readGlobalMaxBlocks),
 	}, nil
 }
 
@@ -85,7 +86,7 @@ func newStaticWorkerPoolForCurrentCPU(readGlobalMaxBlocks int64, numCPU func() i
 	priorityWorkers := (totalWorkers + 9) / 10
 	normalWorkers := totalWorkers - priorityWorkers
 
-	wp, err := NewStaticWorkerPool(uint32(priorityWorkers), uint32(normalWorkers))
+	wp, err := NewStaticWorkerPool(uint32(priorityWorkers), uint32(normalWorkers), readGlobalMaxBlocks)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workerpool/static_worker_pool_test.go
+++ b/internal/workerpool/static_worker_pool_test.go
@@ -43,7 +43,7 @@ func TestNewStaticWorkerPool_Success(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pool, err := NewStaticWorkerPool(uint32(tc.priorityWorker), uint32(tc.normalWorker))
+			pool, err := NewStaticWorkerPool(uint32(tc.priorityWorker), uint32(tc.normalWorker), 100)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, pool)
@@ -55,7 +55,7 @@ func TestNewStaticWorkerPool_Success(t *testing.T) {
 }
 
 func TestNewStaticWorkerPool_Failure(t *testing.T) {
-	pool, err := NewStaticWorkerPool(0, 0)
+	pool, err := NewStaticWorkerPool(0, 0, 0)
 
 	assert.Error(t, err)
 	assert.Nil(t, pool)
@@ -63,7 +63,7 @@ func TestNewStaticWorkerPool_Failure(t *testing.T) {
 }
 
 func TestStaticWorkerPool_Start(t *testing.T) {
-	pool, err := NewStaticWorkerPool(2, 3)
+	pool, err := NewStaticWorkerPool(2, 3, 5)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 
@@ -81,7 +81,7 @@ func TestStaticWorkerPool_Start(t *testing.T) {
 }
 
 func TestStaticWorkerPool_SchedulePriorityTask(t *testing.T) {
-	pool, err := NewStaticWorkerPool(2, 3)
+	pool, err := NewStaticWorkerPool(2, 3, 5)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 	pool.Start()
@@ -97,7 +97,7 @@ func TestStaticWorkerPool_SchedulePriorityTask(t *testing.T) {
 }
 
 func TestStaticWorkerPool_ScheduleNormalTask(t *testing.T) {
-	pool, err := NewStaticWorkerPool(2, 3)
+	pool, err := NewStaticWorkerPool(2, 3, 5)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 	pool.Start()
@@ -113,7 +113,7 @@ func TestStaticWorkerPool_ScheduleNormalTask(t *testing.T) {
 }
 
 func TestStaticWorkerPool_HighNumberOfTasks(t *testing.T) {
-	pool, err := NewStaticWorkerPool(5, 10)
+	pool, err := NewStaticWorkerPool(5, 10, 15)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 	pool.Start()
@@ -132,7 +132,7 @@ func TestStaticWorkerPool_HighNumberOfTasks(t *testing.T) {
 }
 
 func TestStaticWorkerPool_ScheduleAfterStop(t *testing.T) {
-	pool, err := NewStaticWorkerPool(2, 3)
+	pool, err := NewStaticWorkerPool(2, 3, 5)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 	pool.Start()
@@ -143,7 +143,7 @@ func TestStaticWorkerPool_ScheduleAfterStop(t *testing.T) {
 }
 
 func TestStaticWorkerPool_Stop(t *testing.T) {
-	pool, err := NewStaticWorkerPool(2, 3)
+	pool, err := NewStaticWorkerPool(2, 3, 5)
 	require.NoError(t, err)
 	require.NotNil(t, pool)
 	pool.Start()


### PR DESCRIPTION
### Description
This PR reduces the channel size in workerpool to 2 times Global Max Read Blocks as at a given time at most readGlobalMaxBlocks can be scheduled. This would also help reduce around 2-3 MiBs of memory used by buffered read as seen in this [bug](https://b.corp.google.com/issues/443636263).

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/443915926

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
