### PR TITLE
chore(optimize-profile part 2): Add top-level flag 'flags' in params.yaml

### DIFF
--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -32,7 +32,7 @@
 #
 ###################################### DOCUMENTATION ENDS ######################
 
-flags:
+params:
   - config-path: "app-name"
     flag-name: "app-name"
     type: "string"

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -41,7 +41,7 @@ type Param struct {
 
 // ParamsYAML mirrors the params.yaml file itself.
 type ParamsYAML struct {
-	Flags []Param `yaml:"flags"`
+	Params []Param `yaml:"params"`
 }
 
 func parseParamsConfig() ([]Param, error) {
@@ -55,10 +55,10 @@ func parseParamsConfig() ([]Param, error) {
 	if err = dec.Decode(&paramsYAML); err != nil {
 		return nil, err
 	}
-	if err = validateParams(paramsYAML.Flags); err != nil {
+	if err = validateParams(paramsYAML.Params); err != nil {
 		return nil, err
 	}
-	return paramsYAML.Flags, nil
+	return paramsYAML.Params, nil
 }
 
 func checkFlagName(name string) error {


### PR DESCRIPTION
### Description
This pull request refactors the `params.yaml` configuration file by introducing a top-level `flags` key to group all flag definitions. This change enhances the clarity and structure of the configuration, making it easier to manage. Corresponding updates have been made to the configuration parsing tool to accommodate this new format.
This is needed to add machine-type-groups in params.yaml and related code-generation.

- This change is as per as [design doc](https://docs.google.com/document/d/1o8iSRxYKEI5aEn09P6xrkooWrM-LOXR3yixDZu47_bU/edit?tab=t.0)
- ~Dependent on #3748~
- Followed up in #3799 

### Link to the issue in case of a bug fix.
[b/436169216](http://b/436169216)

### Highlights

* **Configuration Structure Update**: The `params.yaml` configuration file now includes a top-level `flags` key, which acts as a container for all flag definitions. This improves the organization and readability of the configuration.
* **Configuration Parsing Logic**: The `tools/config-gen/parser.go` file has been updated to correctly parse the new `params.yaml` structure. A new `ParamsConfigYAML` struct was introduced to mirror the top-level `flags` array.
* **Needed for next steps**: This is needed to add machine-type-groups in params.yaml and related code-generation.

### Testing details
1. Manual - Manually tested
2. Unit tests - NA
3. Integration tests - Not needed. Just linux-tests will suffice.

### Any backward incompatible change? If so, please explain.
