### PR TITLE
ci(kokoro-logs): generate test log artifacts for Test fusion for Perf test

### DIFF
--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/presubmit.cfg
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/presubmit.cfg
@@ -15,6 +15,7 @@ action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
     regex: "gcsfuse_logs/*"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -79,6 +79,11 @@ BUCKET_NAMES=$(mktemp "/tmp/${TMP_PREFIX}_bucket_names.XXXXXX") || { log_error "
 PACKAGE_RUNTIME_STATS=$(mktemp "/tmp/${TMP_PREFIX}_package_stats_runtime.XXXXXX") || { log_error "Unable to create package stats runtime file"; exit 1; }
 RESOURCE_USAGE_FILE=$(mktemp "/tmp/${TMP_PREFIX}_system_resource_usage.XXXXXX") || { log_error "Unable to create system resource usage file"; exit 1; }
 
+KOKORO_DIR_AVAILABLE=false
+if [[ $KOKORO_ARTIFACTS_DIR = *[!\ ]* ]]; then
+  KOKORO_DIR_AVAILABLE=true
+fi
+
 # Argument Parsing and Assignments
 # Set default values for optional arguments
 SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
@@ -511,13 +516,49 @@ test_package() {
   
   # Run the package test command
   local start=$SECONDS exit_code=0 
-  if ! eval "$go_test_cmd"; then
+  local log_file=$(mktemp)
+  # Ensure the temporary log file is removed on function exit.
+  trap 'rm -f "$log_file"' RETURN
+
+  if ! eval "$go_test_cmd" > "$log_file" 2>&1; then
     exit_code=1
   fi
   local end=$SECONDS
   # Add the package stats to the file.
   echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+  
+  # Generate KOKORO artifacts(log) files.
+  generate_test_log_artifacts "$log_file" "$package_name" "$bucket_type"
+
   return "$exit_code"
+}
+
+generate_test_log_artifacts() {
+  # If KOKORO_ARTIFACTS_DIR is not set, skip artifact generation.
+  if ! ${KOKORO_DIR_AVAILABLE} ; then
+    return 0
+  fi
+
+  if [[ $# -ne 3 ]]; then
+    log_error_locked "generate_test_log_artifacts() called with incorrect number of arguments."
+    return 1
+  fi
+
+  local output_dir="${KOKORO_ARTIFACTS_DIR}/${bucket_type}/${package_name}"
+  mkdir -p "$output_dir"
+  local sponge_xml_file="${output_dir}/${package_name}_sponge_log.xml"
+  local sponge_log_file="${output_dir}/${package_name}_sponge_log.log"
+
+  # echo "XML report will be generated at ${sponge_xml_file}"
+  echo '<?xml version="1.0" encoding="UTF-8"?>' > "${sponge_xml_file}"
+  echo '<testsuites>' >> "${sponge_xml_file}"
+
+  if [ -f "$log_file" ]; then
+    cat "$log_file" > "$sponge_log_file" 2>&1
+    cat "$log_file" | go-junit-report | sed '1,2d' | sed '$d' >> "${sponge_xml_file}"
+  fi
+
+  echo '</testsuites>' >> "${sponge_xml_file}"
 }
 
 build_gcsfuse_once() {
@@ -566,6 +607,10 @@ install_packages() {
   # Install latest gcloud version.
   bash ./perfmetrics/scripts/install_latest_gcloud.sh
   export PATH="/usr/local/google-cloud-sdk/bin:$PATH"
+
+  # Install go-junit-report
+  go install github.com/jstemmer/go-junit-report/v2@latest
+  export PATH="$(go env GOPATH)/bin:$PATH"
 }
 
 # Generic function to run a group of E2E tests for a given bucket type.


### PR DESCRIPTION
### Description
This changes will generate sponge_log.log and sponge_log.xml file for Test fusion integration. Test Fusion results will help track any flaky tests.

### Link to the issue in case of a bug fix.
[444189036](https://b.corp.google.com/issues/444189036)

### Testing details
1. Manual - TODO
2. Integration tests - Check Kokoro Integration on Test fusion for the PR

### Any backward incompatible change? If so, please explain.
None of the previous run jobs will have these files generated. This will affect PRs running perf intergration tests.
