### PR TITLE
Add wait  for file metadata to be updated for unfinalized objects

### DIFF
--- a/tools/integration_tests/benchmarking/benchmark_stat_test.go
+++ b/tools/integration_tests/benchmarking/benchmark_stat_test.go
@@ -48,7 +48,7 @@ func (s *benchmarkStatTest) TeardownB(b *testing.B) {
 // createFilesToStat creates the below object in the bucket.
 // benchmarking/a.txt
 func createFilesToStat(b *testing.B) {
-	operations.CreateFileOfSize(1, path.Join(testDirPath, "a.txt"), b)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 1, path.Join(testDirPath, "a.txt"), b)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -66,7 +66,7 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
 // benchmarking/a{i}.txt where i is a counter based on the benchtime value.
 func createFiles(b *testing.B) {
 	for i := range b.N {
-		operations.CreateFileOfSize(1, path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), b)
+		operations.CreateFileOfSize(setup.IsZonalBucketRun(), 1, path.Join(testDirPath, fmt.Sprintf("a%d.txt", i)), b)
 	}
 }
 

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -71,8 +71,8 @@ func createDirectoryStructureForTestCase(t *testing.T, testCaseDir string) {
 	// Create explicitDir structure
 	explicitDir := path.Join(testDirPath, testCaseDir, "explicitDir")
 	operations.CreateDirectory(explicitDir, t)
-	operations.CreateFileOfSize(5, path.Join(explicitDir, "file1.txt"), t)
-	operations.CreateFileOfSize(10, path.Join(explicitDir, "file2.txt"), t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 5, path.Join(explicitDir, "file1.txt"), t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 10, path.Join(explicitDir, "file2.txt"), t)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -74,7 +74,7 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 	)
 	// Create a 500MiB test file
 	testFilePath := path.Join(testDirPathForRead, "large_test_file.bin")
-	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), fileSize, testFilePath, s.T())
 	var wg sync.WaitGroup
 	timeout := 300 * time.Second // 5 minutes timeout for 500MiB operations
 
@@ -140,7 +140,7 @@ func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 	)
 	// Create a 500MiB test file
 	testFilePath := path.Join(testDirPathForRead, "segment_test_file.bin")
-	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), fileSize, testFilePath, s.T())
 	// Open shared file handle that will be used by all goroutines
 	sharedFile, err := os.Open(testFilePath)
 	require.NoError(s.T(), err, "Failed to open shared file handle")

--- a/tools/integration_tests/emulator_tests/read_stall/read_stall_test.go
+++ b/tools/integration_tests/emulator_tests/read_stall/read_stall_test.go
@@ -76,7 +76,7 @@ func (r *readStall) TearDownTest() {
 // It creates a file, reads the first byte, and asserts that the elapsed time is less than the expected stall duration.
 func (r *readStall) TestReadFirstByteStallInducedShouldCompleteInLessThanStallTime() {
 	filePath := path.Join(testDirPath, "file.txt")
-	operations.CreateFileOfSize(fileSize, filePath, r.T())
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), fileSize, filePath, r.T())
 
 	elapsedTime, err := emulator_tests.ReadFirstByte(r.T(), filePath)
 

--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -161,7 +161,7 @@ func (s *ignoreInterruptsTest) TestGitCommitWithChanges() {
 	setGithubUserConfig()
 
 	filePath := path.Join(testDirPath, repoName, testFileName)
-	operations.CreateFileOfSize(util.MiB, filePath, s.T())
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), util.MiB, filePath, s.T())
 	output, err := gitAdd(filePath)
 	if err != nil {
 		s.T().Errorf("Git add failed: %s: %v", string(output), err)

--- a/tools/integration_tests/log_rotation/logrotate_logfile_test.go
+++ b/tools/integration_tests/log_rotation/logrotate_logfile_test.go
@@ -48,7 +48,7 @@ func runOperationsOnFileTillLogRotation(t *testing.T, wg *sync.WaitGroup, fileNa
 	// Setup file with 5 MiB content in test directory.
 	testDirPath := path.Join(setup.MntDir(), testDirName)
 	filePath := path.Join(testDirPath, fileName)
-	operations.CreateFileWithContent(filePath, filePerms, string(randomData), t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), filePath, filePerms, string(randomData), t)
 
 	// Keep performing operations in mounted directory until log file is rotated.
 	var lastLogFileSize int64 = 0

--- a/tools/integration_tests/operations/copy_file_test.go
+++ b/tools/integration_tests/operations/copy_file_test.go
@@ -28,7 +28,7 @@ func TestCopyFile(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -59,7 +59,7 @@ func TestFileAttributes(t *testing.T) {
 	// Ref: https://github.com/golang/go/issues/33510
 	preCreateTime := time.Now().Add(-operations.TimeSlop)
 	fileName := path.Join(testDir, tempFileName)
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 	postCreateTime := time.Now().Add(+operations.TimeSlop)
 
 	// The file size in createTempFile() is BytesWrittenInFile bytes

--- a/tools/integration_tests/operations/move_file_test.go
+++ b/tools/integration_tests/operations/move_file_test.go
@@ -113,8 +113,8 @@ func TestMoveFileWithDestFileExist(t *testing.T) {
 	srcFilePath := path.Join(testDir, "move1.txt")
 	destFilePath := path.Join(testDir, "move2.txt")
 	// Create the source and dest file with some content.
-	operations.CreateFileWithContent(srcFilePath, setup.FilePermission_0600, Content, t)
-	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, "Hello from dest file", t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), srcFilePath, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), destFilePath, setup.FilePermission_0600, "Hello from dest file", t)
 
 	// Move the file.
 	err := operations.Move(srcFilePath, destFilePath)

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -62,10 +62,10 @@ func createDirStructure(t *testing.T) testDirStrucure {
 	operations.CreateDirectory(explicitDir1, t)
 	tds.file1InExplicitDir1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 := path.Join(explicitDir1, tds.file1InExplicitDir1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 5, filePath1, t)
 	tds.file2InExplicitDir1Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 := path.Join(explicitDir1, tds.file2InExplicitDir1Name)
-	operations.CreateFileOfSize(10, filePath2, t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 10, filePath2, t)
 
 	// Create explicitDir2 structure
 	tds.explicitDir2Name = "explicitDir2-" + setup.GenerateRandomString(5)
@@ -73,14 +73,14 @@ func createDirStructure(t *testing.T) testDirStrucure {
 	operations.CreateDirectory(explicitDir2, t)
 	tds.file1InExplicitDir2Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(explicitDir2, tds.file1InExplicitDir2Name)
-	operations.CreateFileOfSize(11, filePath1, t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 11, filePath1, t)
 
 	tds.file1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(tds.testDir, tds.file1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 5, filePath1, t)
 	tds.file2Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 = path.Join(tds.testDir, tds.file2Name)
-	operations.CreateFileOfSize(3, filePath2, t)
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), 3, filePath2, t)
 
 	return tds
 }

--- a/tools/integration_tests/operations/rename_file_test.go
+++ b/tools/integration_tests/operations/rename_file_test.go
@@ -31,7 +31,7 @@ func TestRenameFile(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -124,7 +124,7 @@ func TestWriteAtEndOfFile(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	err := operations.WriteFileInAppendMode(fileName, "line 3\n")
 	if err != nil {
@@ -140,7 +140,7 @@ func TestWriteAtStartOfFile(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	err := operations.WriteFile(fileName, "line 4\n")
 	if err != nil {
@@ -156,7 +156,7 @@ func TestWriteAtRandom(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	f, err := os.OpenFile(fileName, os.O_WRONLY|syscall.O_DIRECT, setup.FilePermission_0600)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestCreateFile(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 
 	// Stat the file to check if it exists.
 	if _, err := os.Stat(fileName); err != nil {
@@ -197,7 +197,7 @@ func TestAppendFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
 	// Append to the file.
 	err := operations.WriteFileInAppendMode(fileName, appendContent)
@@ -215,7 +215,7 @@ func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(setup.IsZonalBucketRun(), fileName, setup.FilePermission_0600, Content, t)
 	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
 	// Over-write the file.
 	fh, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -56,7 +56,7 @@ func (s *localModificationTest) TearDownTest() {
 
 func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss() {
 	testFileName := testDirName + setup.GenerateRandomString(testFileNameSuffixLength)
-	operations.CreateFileOfSize(fileSize, path.Join(testDirPath, testFileName), s.T())
+	operations.CreateFileOfSize(setup.IsZonalBucketRun(), fileSize, path.Join(testDirPath, testFileName), s.T())
 
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, true, s.T())

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -645,19 +645,20 @@ func SyncFileShouldThrowError(t *testing.T, file *os.File) {
 	}
 }
 
-func CreateFileWithContent(filePath string, filePerms os.FileMode, content string, t testing.TB) {
+func CreateFileWithContent(isZonal bool, filePath string, filePerms os.FileMode, content string, t testing.TB) {
 	fh := CreateFile(filePath, filePerms, t)
 	WriteAt(content, 0, fh, t)
 	CloseFileShouldNotThrowError(t, fh)
+	WaitForSizeUpdate(isZonal)
 }
 
 // CreateFileOfSize creates a file of given size with random data.
-func CreateFileOfSize(fileSize int64, filePath string, t testing.TB) {
+func CreateFileOfSize(isZonal bool, fileSize int64, filePath string, t testing.TB) {
 	randomData, err := GenerateRandomData(fileSize)
 	if err != nil {
 		t.Errorf("operations.GenerateRandomData: %v", err)
 	}
-	CreateFileWithContent(filePath, FilePermission_0600, string(randomData), t)
+	CreateFileWithContent(isZonal, filePath, FilePermission_0600, string(randomData), t)
 }
 
 // CalculateCRC32 calculates and returns the CRC-32 checksum of the data from the provided Reader.


### PR DESCRIPTION
Waiting for file metadata to be updated for unfinalized objects on the GCS side after file is created