### PR TITLE
build(csi): Build csi-driver via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,8 @@ clean-gen:
 clean: clean-gen
 	go clean
 
+build-csi: build
+	gcloud builds submit --config csi_driver_build.yml
+
 clean-all: clean-gen
 	go clean -i ./...

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 .DEFAULT_GOAL := build
 
-.PHONY: generate imports fmt vet build buildTest install test clean-gen clean clean-all
+.PHONY: generate imports fmt vet build buildTest install test clean-gen clean clean-all build-csi
 
 generate:
 	go generate ./...
@@ -46,8 +46,8 @@ clean-gen:
 clean: clean-gen
 	go clean
 
-build-csi: build
-	gcloud builds submit --config csi_driver_build.yml
-
 clean-all: clean-gen
 	go clean -i ./...
+
+build-csi: build
+	gcloud builds submit --config csi_driver_build.yml

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -90,7 +90,7 @@ steps:
     GCSFUSE_PATH=$$(cat /workspace/bucket_name)
     STAGINGVERSION=${BUILD_ID}
     STAGINGVERSION=${_IMAGE_PREFIX}-$${STAGINGVERSION:0:8}
-    REGISTRY="gcr.io/${PROJECT_ID}/${_USER}_gcsfuse-csi"
+    REGISTRY="gcr.io/${PROJECT_ID}/${_USER}-gcsfuse-csi"
     make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION}
 
 # This step cleans up the GCS bucket.

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -3,6 +3,7 @@ substitutions:
   _CSI_VERSION: 'main'
   _PLATFORMS: 'linux/amd64'
   _USER: 'cloudbuild'
+  _IMAGE_PREFIX: 'build'
 
 steps:
 # --- Build GCSFuse ---
@@ -87,7 +88,8 @@ steps:
 
     # --- Download gcsfuse binaries ---
     GCSFUSE_PATH=$$(cat /workspace/bucket_name)
-    STAGINGVERSION="build-$${{BUILD_ID}:0:8}"
+    STAGINGVERSION=${BUILD_ID}
+    STAGINGVERSION=${_IMAGE_PREFIX}-$${STAGINGVERSION:0:8}
     REGISTRY="gcr.io/${PROJECT_ID}/${_USER}_gcsfuse-csi"
     make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION}
 

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -44,7 +44,7 @@ steps:
   args:
   - '-c'
   - |
-    BUCKET_NAME="gs://${PROJECT_ID}-csibuild-$${BUILD_ID:0:8}"
+    BUCKET_NAME="gs://${PROJECT_ID}-csibuild-${BUILD_ID}"
     gcloud storage buckets create $$BUCKET_NAME
     echo $$BUCKET_NAME > /workspace/bucket_name
 

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -8,13 +8,15 @@ steps:
 # --- Build GCSFuse ---
 # This step clones the GCSFuse CSI Driver repository.
 - name: 'gcr.io/cloud-builders/git'
-  id: 'clone-csi-driver'
+  id: 'clone-csi-driver' # ID is used in waitFor below.
+  waitFor: ['-'] # This step can run concurrently with other steps that have waitFor: ['-']
   args: ['clone', '--branch', '${_CSI_VERSION}', '--depth', '1', 'https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver.git', 'csi-driver-src']
 
 # This step builds the GCSFuse binary for each platform specified in the _PLATFORMS substitution.
 # The binaries are placed in the /workspace/gcsfuse-artifacts directory.
 - name: 'golang:${_GOLANG_VERSION}'
-  id: 'build-gcsfuse'
+  id: 'build-gcsfuse' # ID is used in waitFor below.
+  waitFor: ['-'] # This step can run concurrently with other steps that have waitFor: ['-']
   entrypoint: 'bash'
   args:
   - '-c'
@@ -39,7 +41,8 @@ steps:
 # The GCSFuse CSI Driver build process needs to fetch the GCSFuse binaries from a GCS bucket.
 # This step creates a temporary GCS bucket for this purpose.
 - name: 'gcr.io/cloud-builders/gcloud'
-  id: 'create-gcs-bucket'
+  id: 'create-gcs-bucket' # ID is used in waitFor below.
+  waitFor: ['-'] # This step can run concurrently with other steps that have waitFor: ['-']
   entrypoint: 'bash'
   args:
   - '-c'
@@ -84,9 +87,9 @@ steps:
 
     # --- Download gcsfuse binaries ---
     GCSFUSE_PATH=$$(cat /workspace/bucket_name)
-    STAGING_VERSION="build-$${BUILD_ID:0:8}"
+    STAGINGVERSION="build-$${{BUILD_ID}:0:8}"
     REGISTRY="gcr.io/${PROJECT_ID}/${_USER}_gcsfuse-csi"
-    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGING_VERSION=$${STAGING_VERSION}
+    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION}
 
 # This step cleans up the GCS bucket.
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -1,0 +1,104 @@
+substitutions:
+  _GOLANG_VERSION: '1.24'
+  _CSI_VERSION: 'main'
+  _PLATFORMS: 'linux/amd64'
+  _USER: 'cloudbuild'
+
+steps:
+# --- Build GCSFuse ---
+# This step clones the GCSFuse CSI Driver repository.
+- name: 'gcr.io/cloud-builders/git'
+  id: 'clone-csi-driver'
+  args: ['clone', '--branch', '${_CSI_VERSION}', '--depth', '1', 'https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver.git', 'csi-driver-src']
+
+# This step builds the GCSFuse binary for each platform specified in the _PLATFORMS substitution.
+# The binaries are placed in the /workspace/gcsfuse-artifacts directory.
+- name: 'golang:${_GOLANG_VERSION}'
+  id: 'build-gcsfuse'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    set -e
+    # The build command for different platforms can conflict with each other,
+    # so we build them sequentially.
+    IFS=',' read -ra PLATFORMS <<< "${_PLATFORMS}"
+    for platform in "${PLATFORMS[@]}"; do
+      os_arch=(${platform//\// })
+      os=$${os_arch[0]}
+      arch=$${os_arch[1]}
+      echo "Building GCSFuse for $${os}/$${arch}..."
+      GOOS=$${os} GOARCH=$${arch} go run tools/build_gcsfuse/main.go . . v4
+      mkdir -p "/workspace/gcsfuse-artifacts/$${os}/$${arch}"
+      mv "bin/gcsfuse" "/workspace/gcsfuse-artifacts/$${os}/$${arch}/gcsfuse"
+      echo "Cleaning up bin and sbin directories..."
+      rm -rf bin sbin
+    done
+
+# --- Store GCSFuse binaries in GCS ---
+# The GCSFuse CSI Driver build process needs to fetch the GCSFuse binaries from a GCS bucket.
+# This step creates a temporary GCS bucket for this purpose.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'create-gcs-bucket'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    BUCKET_NAME="gs://${PROJECT_ID}-csibuild-$${BUILD_ID:0:8}"
+    gcloud storage buckets create $$BUCKET_NAME
+    echo $$BUCKET_NAME > /workspace/bucket_name
+
+# This step uploads the GCSFuse binaries to the GCS bucket.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'upload-gcsfuse-binaries'
+  waitFor: ['create-gcs-bucket', 'build-gcsfuse']
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    BUCKET_NAME=$$(cat /workspace/bucket_name)
+    gcloud storage cp -r /workspace/gcsfuse-artifacts/* $$BUCKET_NAME/
+
+# --- Build and Push GCSFuse CSI Driver Image ---
+
+# Step 1: Build and Push GCSFuse CSI Driver Image
+# This step builds the GCSFuse CSI Driver image and pushes it to the registry.
+# It uses the docker builder and installs gcloud to get the credential helper.
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'build-and-push-csi-driver'
+  waitFor: ['upload-gcsfuse-binaries', 'clone-csi-driver']
+  dir: 'csi-driver-src'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    set -e
+    # --- Install gcloud ---
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    apt-get update && apt-get install -y google-cloud-cli kubectl
+
+    # --- Authenticate Docker ---
+    gcloud auth configure-docker gcr.io --quiet
+
+    # --- Download gcsfuse binaries ---
+    GCSFUSE_PATH=$$(cat /workspace/bucket_name)
+    STAGING_VERSION="build-$${BUILD_ID:0:8}"
+    REGISTRY="gcr.io/${PROJECT_ID}/${_USER}_gcsfuse-csi"
+    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGING_VERSION=$${STAGING_VERSION}
+
+# This step cleans up the GCS bucket.
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'cleanup-gcs-bucket'
+  waitFor: ['build-and-push-csi-driver']
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    BUCKET_NAME=$$(cat /workspace/bucket_name)
+    gcloud storage rm -r $$BUCKET_NAME
+
+options:
+  # Using a more powerful machine is recommended for multi-platform builds.
+  machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
### Description
Now in order to build a CSI driver from local changes, one simply needs to run `make build-csi` from project root.

### Link to the issue in case of a bug fix.
b/445288764

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
