### PR TITLE
ci(kokoro logs): use improved_e2e_test script for periodic kokoro runs

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,9 +22,13 @@ readonly SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 readonly RUN_TEST_ON_TPC_ENDPOINT=false
 readonly PROJECT_ID="gcs-fuse-test-ml"
 readonly BUCKET_LOCATION=us-central1
+readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.3"
 
 # This flag, if set true, will indicate to the underlying script, to customize for a presubmit-run.
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
+
+# Install required bash version for e2e script as kokoro has outdated bash versions.
+./perfmetrics/scripts/install_bash.sh "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT"
 
 # This flag, if set true, will indicate to underlying script(s) to run for zonal bucket(s) instead of non-zonal bucket(s).
 ZONAL_BUCKET_ARG=false
@@ -51,4 +55,4 @@ git checkout $commitId
 
 echo "Running e2e tests on installed package...."
 # $1 argument is refering to value of testInstalledPackage
-./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG ${ZONAL_BUCKET_ARG}
+/usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --test-installed-package=$RUN_E2E_TESTS_ON_INSTALLED_PACKAGE --skip-non-essential-tests=$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE --test-on-tpc-endpoint=$RUN_TEST_ON_TPC_ENDPOINT --presubmit=$RUN_TESTS_WITH_PRESUBMIT_FLAG --zonal=${ZONAL_BUCKET_ARG}

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -23,12 +23,16 @@ readonly RUN_TEST_ON_TPC_ENDPOINT=true
 # TPC project id
 readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
+readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.3"
 
 # This flag, if set true, will indicate to underlying script to customize for a presubmit run.
 readonly RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 
 # This flag, if set true, will indicate to underlying script to also run for zonal buckets.
 readonly RUN_TESTS_WITH_ZONAL_BUCKET=false
+
+# Install required bash version for e2e script as kokoro has outdated bash versions.
+./perfmetrics/scripts/install_bash.sh "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT"
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
@@ -58,7 +62,7 @@ gcloud config set project $PROJECT_ID
 
 set +e
 # $1 argument is refering to value of testInstalledPackage
-./tools/integration_tests/run_e2e_tests.sh $RUN_E2E_TESTS_ON_INSTALLED_PACKAGE $SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE $BUCKET_LOCATION $RUN_TEST_ON_TPC_ENDPOINT $RUN_TESTS_WITH_PRESUBMIT_FLAG ${RUN_TESTS_WITH_ZONAL_BUCKET}
+/usr/local/bin/bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --test-installed-package=$RUN_E2E_TESTS_ON_INSTALLED_PACKAGE --skip-non-essential-tests=$SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE --test-on-tpc-endpoint=$RUN_TEST_ON_TPC_ENDPOINT --presubmit=$RUN_TESTS_WITH_PRESUBMIT_FLAG --zonal=${RUN_TESTS_WITH_ZONAL_BUCKET}
 exit_code=$?
 set -e
 


### PR DESCRIPTION
### Description
This commit updates the e2e test scripts to use the improved_e2e_test script.

Bash 5.3 is a requirement for the improved script, so we install it in the kokoro environment.


### Link to the issue in case of a bug fix.
[444189036](https://b.corp.google.com/issues/444189036)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Run on the PR for sanity check.

### Any backward incompatible change? If so, please explain.
None of the previous run jobs will have these files generated. This will affect the CI intergration tests going forward.