### PR TITLE
ci(kokoro): copy sponge logs to artifacts to gcsfuse kokoro bucket

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -19,6 +19,7 @@ action {
     regex: "gcsfuse-logs-fio-flat.txt"
     regex: "gcsfuse-logs-ls-flat.txt"
     regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/checkpoint-tests.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/checkpoint-tests.cfg
@@ -15,6 +15,7 @@
 action {
   define_artifacts {
     regex: "gcsfuse_logs/*"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master-zb.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master-zb.cfg
@@ -16,6 +16,7 @@ action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
+    regex: "**/*sponge_log.*"
     regex: "proxy*"
   }
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master.cfg
@@ -16,6 +16,7 @@ action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
     regex: "proxy-server-failed-integration-test-logs-*"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-release.cfg
@@ -16,6 +16,7 @@ action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
     regex: "proxy-server-failed-integration-test-logs-*"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-tpc.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-tpc.cfg
@@ -15,6 +15,7 @@
 action {
   define_artifacts {
     regex: "gcsfuse-failed-integration-test-logs-*"
+    regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }
 }


### PR DESCRIPTION
### Description
In order for Test fusion to ingest logs and XML files, Kokoro generated sponge.log and sponge.xml files needs to be copied to the artifacts directory. For GCSFuse, this directory is the [gcsfuse-kokoro-logs bucket](https://pantheon.corp.google.com/storage/browser/gcsfuse-kokoro-logs)

### Link to the issue in case of a bug fix.
[444189036](https://b.corp.google.com/issues/444189036)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Integrations tests run on submit.

### Any backward incompatible change? If so, please explain.
None
The upcoming CI integration tests will be impacted since none of the previous run jobs will generate these files.