### PR TITLE
fix: bucket name while identifying Bucket Type for only-dir mount tests

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -559,6 +559,8 @@ const HNSBucket = "hns"
 const ZonalBucket = "zonal"
 
 func BucketType(ctx context.Context, testBucket string) (bucketType string, err error) {
+	// For only-dir mounts bucket name is passed as <test_bucket>/<only_dir> by GKE.
+	testBucket = strings.Split(testBucket, "/")[0]
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	storageClient, err := storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())


### PR DESCRIPTION
### Description
This change resolves an issue where the only-dir argument was not being properly handled in GCSFuse tests following a refactoring of the config-file logic. Bucket names passed by GKE, which can be in the format <bucket_name>/<only_dir_mounted>, were not being parsed correctly. This has now been addressed.

### Link to the issue in case of a bug fix.
b/445614904

### Testing details
1. Manual - tests have been validated in GKE environment during the last release
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
