### PR TITLE
test: Fixing errors in concurrent listing package

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -383,6 +383,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileEdit() {
 			// Create file
 			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
 			require.Nil(s.T(), err)
+			time.Sleep(time.Second)
 
 			// Edit file (append some data)
 			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, setup.FilePermission_0600)
@@ -444,6 +445,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations() {
 			// Create file
 			err := os.WriteFile(filePath, []byte("Hello, world!"), setup.FilePermission_0600)
 			require.Nil(s.T(), err)
+			time.Sleep(time.Second)
 
 			// Edit file (append some data)
 			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, setup.FilePermission_0600)


### PR DESCRIPTION
Adding sleep after writing to a file to ensure that append works properly.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Done

### Any backward incompatible change? If so, please explain.
