### PR TITLE
fix: pass HOME dir to gcsfuse binary when executed via peristent mounting

### DIFF
--- a/tools/mount_gcsfuse/main.go
+++ b/tools/mount_gcsfuse/main.go
@@ -268,6 +268,7 @@ func run(args []string) (err error) {
 	// Run gcsfuse.
 	cmd := exec.Command(gcsfusePath, gcsfuseArgs...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", path.Dir(fusermountPath)))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
 
 	// Pass through the https_proxy/http_proxy environment variable,
 	// in case the host requires a proxy server to reach the GCS endpoint.


### PR DESCRIPTION
### Description
This change passes the HOME environment variable to the gcsfuse binary when it is executed via persistent mounting. This allows gcsfuse to access user-specific configurations located in the home directory like application default credentials stored at well known path - `~/.config/gcloud/application_default_credentials.json`.

### Link to the issue in case of a bug fix.
b/445889317

### Testing details
1. Manual - Manually verified that the tests now pick up application default credentials when test runner executes the binary.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
