### PR TITLE
build(csi): Build CSI driver with arm64 as target architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 CSI_VERSION ?= main
 GCSFUSE_VERSION ?= $(shell HASH=$$(git rev-parse --short=6 HEAD 2>/dev/null); if [ -z "$$HASH" ]; then echo "unknown"; else if [ -n "$$(git status --porcelain)" ]; then echo "$$HASH-dirty"; else echo "$$HASH"; fi; fi)
+BUILD_ARM=false
 .DEFAULT_GOAL := build
 
 .PHONY: generate imports fmt vet build buildTest install test clean-gen clean clean-all build-csi
@@ -52,4 +53,4 @@ clean-all: clean-gen
 	go clean -i ./...
 
 build-csi: build
-	gcloud builds submit --config csi_driver_build.yml --substitutions=_CSI_VERSION=$(CSI_VERSION),_GCSFUSE_VERSION=$(GCSFUSE_VERSION)
+	gcloud builds submit --config csi_driver_build.yml --substitutions=_CSI_VERSION=$(CSI_VERSION),_GCSFUSE_VERSION=$(GCSFUSE_VERSION),_BUILD_ARM=$(BUILD_ARM)

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -16,7 +16,7 @@ substitutions:
   _GOLANG_VERSION: '1.24'
   _GCSFUSE_VERSION: 'v4'
   _CSI_VERSION: 'main'
-  _PLATFORMS: 'linux/amd64'
+  _BUILD_ARM: 'false'
   _USER: 'cloudbuild'
   _IMAGE_PREFIX: 'build'
 
@@ -38,17 +38,16 @@ steps:
   - '-c'
   - |
     set -e
-    # The build command for different platforms can conflict with each other,
-    # so we build them sequentially.
-    IFS=',' read -ra PLATFORMS <<< "${_PLATFORMS}"
-    for platform in "${PLATFORMS[@]}"; do
-      os_arch=(${platform//\// })
-      os=$${os_arch[0]}
-      arch=$${os_arch[1]}
-      echo "Building GCSFuse for $${os}/$${arch}..."
-      GOOS=$${os} GOARCH=$${arch} go run tools/build_gcsfuse/main.go . . "${_GCSFUSE_VERSION}"
-      mkdir -p "/workspace/gcsfuse-artifacts/$${os}/$${arch}"
-      mv "bin/gcsfuse" "/workspace/gcsfuse-artifacts/$${os}/$${arch}/gcsfuse"
+    ARCHS="amd64"
+    if [[ "${_BUILD_ARM}" == "true" ]]; then
+      ARCHS="$$ARCHS arm64"
+    fi
+    
+    for arch in $$ARCHS; do
+      echo "Building GCSFuse for linux/$arch..."
+      GOOS=linux go run tools/build_gcsfuse/main.go --arch=$$arch . . "${_GCSFUSE_VERSION}"
+      mkdir -p "/workspace/gcsfuse-artifacts/linux/$$arch"
+      mv "bin/gcsfuse" "/workspace/gcsfuse-artifacts/linux/$$arch/gcsfuse"
       echo "Cleaning up bin and sbin directories..."
       rm -rf bin sbin
     done
@@ -106,7 +105,8 @@ steps:
     STAGINGVERSION=${BUILD_ID}
     STAGINGVERSION=${_IMAGE_PREFIX}-$${STAGINGVERSION:0:8}
     REGISTRY="gcr.io/${PROJECT_ID}/${_USER}-gcsfuse-csi"
-    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION}
+
+    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION} BUILD_ARM=${_BUILD_ARM}
 
 # This step cleans up the GCS bucket.
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/tools/build_gcsfuse/main_test.go
+++ b/tools/build_gcsfuse/main_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("Error while creating temporary directory: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	err = buildBinaries(dir, "../../", "99.88.77", nil)
+	err = buildBinaries(dir, "../../", "99.88.77", runtime.GOARCH, nil)
 	if err != nil {
 		t.Fatalf("Error while building binary: %v", err)
 	}


### PR DESCRIPTION
### Description
In addition to building sidecar for amd64 architecture alone, allow targeting arm64 as well. This can be done by executing:
`make build-csi BUILD_ARM=true`.

Note that the CSI driver doesn't provide a way to build for arm alone. So, BUILD_ARM=true would build both ARM as well as AMD images.

### Link to the issue in case of a bug fix.
b/445288764

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
