### PR TITLE
refactor: Migrate mount function to configs

### DIFF
--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -124,15 +124,15 @@ func TestMain(m *testing.M) {
 	}
 
 	// Else run tests for testBucket.
-	setup.SetUpTestDirForTestBucket(setup.TestBucket())
+	setup.SetUpTestDirForTestBucketFlag()
 	rootDir = setup.MntDir()
 
 	// Set up the static mounting function.
 	mountFunc = func(flags []string) error {
 		config := &test_suite.TestConfig{
-			TestBucket:       setup.TestBucket(),
-			MountedDirectory: setup.MountedDirectory(),
-			LogFile:          setup.LogFile(),
+			TestBucket:          setup.TestBucket(),
+			GKEMountedDirectory: setup.MountedDirectory(),
+			LogFile:             setup.LogFile(),
 		}
 		return static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
 	}

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -130,9 +130,10 @@ func TestMain(m *testing.M) {
 	// Set up the static mounting function.
 	mountFunc = func(flags []string) error {
 		config := &test_suite.TestConfig{
-			TestBucket:          setup.TestBucket(),
-			GKEMountedDirectory: setup.MountedDirectory(),
-			LogFile:             setup.LogFile(),
+			TestBucket:              setup.TestBucket(),
+			GKEMountedDirectory:     setup.MountedDirectory(),
+			GCSFuseMountedDirectory: setup.MntDir(),
+			LogFile:                 setup.LogFile(),
 		}
 		return static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
 	}

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -52,9 +52,10 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string, t *testing.
 		testDirPathForRead = setup.MountedDirectory()
 	} else {
 		config := &test_suite.TestConfig{
-			TestBucket:          setup.TestBucket(),
-			GKEMountedDirectory: setup.MountedDirectory(),
-			LogFile:             setup.LogFile(),
+			TestBucket:              setup.TestBucket(),
+			GCSFuseMountedDirectory: setup.MntDir(),
+			GKEMountedDirectory:     setup.MountedDirectory(),
+			LogFile:                 setup.LogFile(),
 		}
 		if err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags); err != nil {
 			t.Fatalf("Failed to mount GCS FUSE: %v", err)

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -52,9 +52,9 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string, t *testing.
 		testDirPathForRead = setup.MountedDirectory()
 	} else {
 		config := &test_suite.TestConfig{
-			TestBucket:       setup.TestBucket(),
-			MountedDirectory: setup.MountedDirectory(),
-			LogFile:          setup.LogFile(),
+			TestBucket:          setup.TestBucket(),
+			GKEMountedDirectory: setup.MountedDirectory(),
+			LogFile:             setup.LogFile(),
 		}
 		if err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags); err != nil {
 			t.Fatalf("Failed to mount GCS FUSE: %v", err)

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.ExplicitDir = make([]test_suite.TestConfig, 1)
 		cfg.ExplicitDir[0].TestBucket = setup.TestBucket()
-		cfg.ExplicitDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ExplicitDir[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ExplicitDir[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.ExplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs=false", "--implicit-dirs=false --client-protocol=grpc"}
 		cfg.ExplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ExplicitDir[0].TestBucket)
+	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.ExplicitDir[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()

--- a/tools/integration_tests/grpc_validation/setup_test.go
+++ b/tools/integration_tests/grpc_validation/setup_test.go
@@ -144,9 +144,7 @@ func TestMain(m *testing.M) {
 		log.Println("Skipping test package : grpc_validation since this is a presubmit test run")
 		os.Exit(0)
 	}
-	if err := setup.SetUpTestDir(); err != nil {
-		log.Fatalf("Failed to setup GCSFuse package. Error: %v", err)
-	}
+	setup.SetUpTestDirForTestBucketFlag()
 
 	// Creating a common storage client for the test
 	ctx = context.Background()

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -201,7 +201,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.Gzip = make([]test_suite.TestConfig, 1)
 		cfg.Gzip[0].TestBucket = setup.TestBucket()
-		cfg.Gzip[0].MountedDirectory = setup.MountedDirectory()
+		cfg.Gzip[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.Gzip[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.Gzip[0].Configs[0].Flags = []string{
 			"--sequential-read-size-mb=1 --implicit-dirs",
@@ -212,7 +212,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.Gzip[0].TestBucket)
+	bucketType := setup.TestEnvironment(ctx, &cfg.Gzip[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -235,15 +235,15 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as Gzip tests validates content from the bucket.
-	if cfg.Gzip[0].MountedDirectory != "" && cfg.Gzip[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.Gzip[0].MountedDirectory, m))
+	if cfg.Gzip[0].GKEMountedDirectory != "" && cfg.Gzip[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.Gzip[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket.
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.Gzip[0], bucketType)
 
-	setup.SetUpTestDirForTestBucket(cfg.Gzip[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.Gzip[0])
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Gzip[0], flags, m)
 

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.ImplicitDir = make([]test_suite.TestConfig, 1)
 		cfg.ImplicitDir[0].TestBucket = setup.TestBucket()
-		cfg.ImplicitDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ImplicitDir[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ImplicitDir[0].Configs = make([]test_suite.ConfigItem, 2)
 		cfg.ImplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs"}
 		cfg.ImplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(testEnv.ctx, cfg.ImplicitDir[0].TestBucket)
+	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.ImplicitDir[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.ListLargeDir = make([]test_suite.TestConfig, 1)
 		cfg.ListLargeDir[0].TestBucket = setup.TestBucket()
-		cfg.ListLargeDir[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ListLargeDir[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ListLargeDir[0].Configs = make([]test_suite.ConfigItem, 2)
 		cfg.ListLargeDir[0].Configs[0].Flags = []string{"--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"}
 		cfg.ListLargeDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.ListLargeDir[0].TestBucket)
+	bucketType := setup.TestEnvironment(ctx, &cfg.ListLargeDir[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -74,15 +74,15 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as ListLargeDir tests validates content from the bucket.
-	if cfg.ListLargeDir[0].MountedDirectory != "" && cfg.ListLargeDir[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.ListLargeDir[0].MountedDirectory, m))
+	if cfg.ListLargeDir[0].GKEMountedDirectory != "" && cfg.ListLargeDir[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.ListLargeDir[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.ListLargeDir[0], bucketType)
 
-	setup.SetUpTestDirForTestBucket(cfg.ListLargeDir[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.ListLargeDir[0])
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ListLargeDir[0], flags, m)
 

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -90,7 +90,7 @@ func isHNSTestRun(t *testing.T) bool {
 
 func (testSuite *PromTest) SetupSuite() {
 	setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
-	err := setup.SetUpTestDir()
+	_, err := setup.SetUpTestDir()
 	require.NoErrorf(testSuite.T(), err, "error while building GCSFuse: %p", err)
 }
 

--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.ReadLargeFiles = make([]test_suite.TestConfig, 1)
 		cfg.ReadLargeFiles[0].TestBucket = setup.TestBucket()
-		cfg.ReadLargeFiles[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ReadLargeFiles[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ReadLargeFiles[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.ReadLargeFiles[0].Configs[0].Flags = []string{
 			"--implicit-dirs",
@@ -66,9 +66,8 @@ func TestMain(m *testing.M) {
 		cfg.ReadLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
-	setup.SetTestBucket(cfg.ReadLargeFiles[0].TestBucket)
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.ReadLargeFiles[0].TestBucket)
+	bucketType := setup.TestEnvironment(ctx, &cfg.ReadLargeFiles[0])
 
 	// 2. Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
@@ -81,8 +80,8 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as ReadLargeFiles tests validates content from the bucket.
-	if cfg.ReadLargeFiles[0].MountedDirectory != "" && cfg.ReadLargeFiles[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadLargeFiles[0].MountedDirectory, m))
+	if cfg.ReadLargeFiles[0].GKEMountedDirectory != "" && cfg.ReadLargeFiles[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadLargeFiles[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket.
@@ -90,7 +89,7 @@ func TestMain(m *testing.M) {
 	flags := setup.BuildFlagSets(cfg.ReadLargeFiles[0], bucketType)
 	flags = setup.AddCacheDirToFlags(flags, "read-large-files")
 
-	setup.SetUpTestDirForTestBucket(cfg.ReadLargeFiles[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.ReadLargeFiles[0])
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ReadLargeFiles[0], flags, m)
 

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.ReadOnly = make([]test_suite.TestConfig, 1)
 		cfg.ReadOnly[0].TestBucket = setup.TestBucket()
-		cfg.ReadOnly[0].MountedDirectory = setup.MountedDirectory()
+		cfg.ReadOnly[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ReadOnly[0].Configs = make([]test_suite.ConfigItem, 1)
 		cacheDirPath := path.Join(os.TempDir(), "cache-dir-readonly-"+setup.GenerateRandomString(4))
 		cfg.ReadOnly[0].Configs[0].Flags = []string{
@@ -123,7 +123,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// 2. Create storage client before running tests.
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.ReadOnly[0].TestBucket)
+	bucketType := setup.TestEnvironment(ctx, &cfg.ReadOnly[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -139,14 +139,14 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set.
-	if cfg.ReadOnly[0].MountedDirectory != "" && cfg.ReadOnly[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadOnly[0].MountedDirectory, m))
+	if cfg.ReadOnly[0].GKEMountedDirectory != "" && cfg.ReadOnly[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadOnly[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.ReadOnly[0], bucketType)
-	setup.SetUpTestDirForTestBucket(cfg.ReadOnly[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.ReadOnly[0])
 
 	// 5. Run tests.
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ReadOnly[0], flags, m)

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -77,7 +77,8 @@ func TestMain(m *testing.M) {
 	bucketType := setup.TestEnvironment(ctx, &cfg.RenameDirLimit[0])
 
 	// 2. Create storage client before running tests.
-	storageClient, err := client.CreateStorageClient(ctx)
+	var err error
+	storageClient, err = client.CreateStorageClient(ctx)
 	if err != nil {
 		log.Printf("Error creating storage client: %v\n", err)
 		os.Exit(1)

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.RenameDirLimit = make([]test_suite.TestConfig, 1)
 		cfg.RenameDirLimit[0].TestBucket = setup.TestBucket()
-		cfg.RenameDirLimit[0].MountedDirectory = setup.MountedDirectory()
+		cfg.RenameDirLimit[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.RenameDirLimit[0].Configs = make([]test_suite.ConfigItem, 2)
 		cfg.RenameDirLimit[0].Configs[0].Flags = []string{
 			"--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc",
@@ -73,33 +73,26 @@ func TestMain(m *testing.M) {
 		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 	}
 
-	setup.SetTestBucket(cfg.RenameDirLimit[0].TestBucket)
 	ctx = context.Background()
-	bucketType, err := setup.BucketType(ctx, cfg.RenameDirLimit[0].TestBucket)
-	if err != nil {
-		log.Fatalf("BucketType failed: %v", err)
-	}
-	if bucketType == setup.ZonalBucket {
-		setup.SetIsZonalBucketRun(true)
-	}
+	bucketType := setup.TestEnvironment(ctx, &cfg.RenameDirLimit[0])
 
 	// 2. Create storage client before running tests.
-	storageClient, err = client.CreateStorageClient(ctx)
+	storageClient, err := client.CreateStorageClient(ctx)
 	if err != nil {
 		log.Printf("Error creating storage client: %v\n", err)
 		os.Exit(1)
 	}
 	defer storageClient.Close()
 
-	// 4. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	if cfg.RenameDirLimit[0].MountedDirectory != "" && cfg.RenameDirLimit[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.RenameDirLimit[0].MountedDirectory, m))
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if cfg.RenameDirLimit[0].GKEMountedDirectory != "" && cfg.RenameDirLimit[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.RenameDirLimit[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
-	// 5. Build the flag sets dynamically from the config.
+	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.RenameDirLimit[0], bucketType)
-	setup.SetUpTestDirForTestBucket(cfg.RenameDirLimit[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.RenameDirLimit[0])
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.RenameDirLimit[0], flags, m)
 

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -178,9 +178,9 @@ func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx context.Context, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:          setup.TestBucket(),
+		GKEMountedDirectory: setup.MountedDirectory(),
+		LogFile:             setup.LogFile(),
 	}
 	return RunTestsForDifferentAuthMethods(ctx, config, storageClient, testFlagSet, permission, m)
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -52,9 +52,14 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error in fetching project id: %v", err))
 	}
+	if strings.Contains(id, "cloudtop") {
+		id = WhitelistedGcpProjects[0]
+	}
+
 	// return if active GCP project is not in whitelisted gcp projects
 	if !slices.Contains(WhitelistedGcpProjects, id) {
 		log.Printf("The active GCP project is not one of: %s. So the credentials test will not run.", strings.Join(WhitelistedGcpProjects, ", "))
+		return
 	}
 
 	// Service account id format is name@project-id.iam.gserviceaccount.com
@@ -127,8 +132,8 @@ func RevokePermission(ctx context.Context, storageClient *storage.Client, servic
 
 func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
 	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
-	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
-	defer RevokePermission(ctx, storageClient, serviceAccount, permission, setup.TestBucket())
+	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
+	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
 	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
@@ -178,9 +183,10 @@ func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx context.Context, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
-		TestBucket:          setup.TestBucket(),
-		GKEMountedDirectory: setup.MountedDirectory(),
-		LogFile:             setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return RunTestsForDifferentAuthMethods(ctx, config, storageClient, testFlagSet, permission, m)
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -53,13 +53,13 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 		setup.LogAndExit(fmt.Sprintf("Error in fetching project id: %v", err))
 	}
 	if strings.Contains(id, "cloudtop") {
+		// In cloudtop environments, well known path is used for auth. So explicitly set the project as whitelisted.
 		id = WhitelistedGcpProjects[0]
 	}
 
 	// return if active GCP project is not in whitelisted gcp projects
 	if !slices.Contains(WhitelistedGcpProjects, id) {
 		log.Printf("The active GCP project is not one of: %s. So the credentials test will not run.", strings.Join(WhitelistedGcpProjects, ", "))
-		return
 	}
 
 	// Service account id format is name@project-id.iam.gserviceaccount.com

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -30,9 +30,10 @@ import (
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func MountGcsfuseWithOnlyDir(flags []string) (err error) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return MountGcsfuseWithOnlyDirWithConfigFile(config, flags)
 }
@@ -41,9 +42,9 @@ func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags 
 	defaultArg := []string{"--only-dir",
 		setup.OnlyDirMounted(),
 		"--log-severity=trace",
-		"--log-file=" + setup.LogFile(),
+		"--log-file=" + config.LogFile,
 		config.TestBucket,
-		setup.MntDir()}
+		config.GCSFuseMountedDirectory}
 
 	for i := 0; i < len(defaultArg); i++ {
 		flags = append(flags, defaultArg[i])
@@ -109,9 +110,10 @@ func executeTestsForOnlyDirMounting(config *test_suite.TestConfig, flags [][]str
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flags [][]string, dirName string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return RunTestsWithConfigFile(config, flags, dirName, m)
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -42,11 +42,11 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 
 func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{config.TestBucket,
-		setup.MntDir(),
+		config.GCSFuseMountedDirectory,
 		"-o",
 		"log_severity=trace",
 		"-o",
-		"log_file=" + setup.LogFile(),
+		"log_file=" + config.LogFile,
 	}
 
 	persistentMountingArgs := makePersistentMountingArgs(flags)
@@ -81,9 +81,10 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return RunTestsWithConfigFile(config, flagsSet, m)
 }
@@ -91,6 +92,6 @@ func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running persistent mounting tests...")
 	successCode = executeTestsForPersistentMountingWithConfigFile(config, flagsSet, m)
-	log.Printf("Test log: %s\n", setup.LogFile())
+	log.Printf("Test log: %s\n", config.LogFile)
 	return successCode
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -87,6 +87,6 @@ func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running static mounting tests...")
 	successCode = executeTestsForStaticMounting(config, flagsSet, m)
-	log.Printf("Test log: %s\n", setup.LogFile())
+	log.Printf("Test log: %s\n", config.LogFile)
 	return successCode
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -28,9 +28,9 @@ import (
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
 }
@@ -43,9 +43,9 @@ func MountGcsfuseWithStaticMountingWithConfigFile(config *test_suite.TestConfig,
 	}
 
 	defaultArg = append(defaultArg, "--log-severity=trace",
-		"--log-file="+setup.LogFile(),
+		"--log-file="+config.LogFile,
 		config.TestBucket,
-		setup.MntDir())
+		config.GCSFuseMountedDirectory)
 
 	for i := 0; i < len(defaultArg); i++ {
 		flags = append(flags, defaultArg[i])
@@ -76,9 +76,10 @@ func executeTestsForStaticMounting(config *test_suite.TestConfig, flagsSet [][]s
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
 	config := &test_suite.TestConfig{
-		TestBucket:       setup.TestBucket(),
-		MountedDirectory: setup.MountedDirectory(),
-		LogFile:          setup.LogFile(),
+		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
 	}
 	return RunTestsWithConfigFile(config, flagsSet, m)
 }

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -29,6 +29,7 @@ import (
 func MountGcsfuseWithStaticMounting(flags []string) (err error) {
 	config := &test_suite.TestConfig{
 		TestBucket:              setup.TestBucket(),
+		GKEMountedDirectory:     setup.MountedDirectory(),
 		GCSFuseMountedDirectory: setup.MntDir(),
 		LogFile:                 setup.LogFile(),
 	}

--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -58,8 +58,8 @@ func RunTestsForExplicitAndImplicitDir(config *test_suite.TestConfig, flags [][]
 		return 0
 	}
 
-	if config.MountedDirectory != "" && config.TestBucket != "" {
-		successCode := setup.RunTestsForMountedDirectory(config.MountedDirectory, m)
+	if config.GKEMountedDirectory != "" && config.TestBucket != "" {
+		successCode := setup.RunTestsForMountedDirectory(config.GKEMountedDirectory, m)
 		return successCode
 	}
 
@@ -68,7 +68,7 @@ func RunTestsForExplicitAndImplicitDir(config *test_suite.TestConfig, flags [][]
 		log.Print("pass test bucket to run the tests")
 		return 1
 	}
-	setup.SetUpTestDirForTestBucket(config.TestBucket)
+	setup.SetUpTestDirForTestBucket(config)
 
 	successCode := static_mounting.RunTestsWithConfigFile(config, flags, m)
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -175,11 +175,13 @@ func CompareFileContents(t *testing.T, fileName string, fileContent string) {
 	}
 }
 
-func SetUpTestDir() error {
+// SetUpTestDir creates a test directory, builds GCSFuse into it and returns it's path.
+// This function also creates the mountDir at path testDir/mnt.
+func SetUpTestDir() (string, error) {
 	var err error
 	testDir, err = os.MkdirTemp("", "gcsfuse_readwrite_test_")
 	if err != nil {
-		return fmt.Errorf("TempDir: %w", err)
+		return "", fmt.Errorf("TempDir: %w", err)
 	}
 
 	// Order of priority to choose GCSFuse installation to run the tests
@@ -199,21 +201,21 @@ func SetUpTestDir() error {
 		sbinFile = filepath.Join(prebuiltDir, "sbin/mount.gcsfuse")
 
 		if _, statErr := os.Stat(binFile); statErr != nil {
-			return fmt.Errorf("gcsfuse binary from --gcsfuse_prebuilt_dir not found at %s: %w", binFile, statErr)
+			return "", fmt.Errorf("gcsfuse binary from --gcsfuse_prebuilt_dir not found at %s: %w", binFile, statErr)
 		}
 		if _, statErr := os.Stat(sbinFile); statErr != nil {
-			return fmt.Errorf("mount helper from --gcsfuse_prebuilt_dir not found at %s: %w", sbinFile, statErr)
+			return "", fmt.Errorf("mount helper from --gcsfuse_prebuilt_dir not found at %s: %w", sbinFile, statErr)
 		}
 		// Set PATH to include the bin directory of the pre-built gcsfuse
 		err = os.Setenv(PathEnvVariable, filepath.Dir(binFile)+string(filepath.ListSeparator)+os.Getenv(PathEnvVariable))
 		if err != nil {
-			return fmt.Errorf("error setting PATH for --gcsfuse_prebuilt_dir: %v", err.Error())
+			return "", fmt.Errorf("error setting PATH for --gcsfuse_prebuilt_dir: %v", err.Error())
 		}
 	} else {
 		log.Printf("Building GCSFuse from source in the dir: %s ...", testDir)
 		err = util.BuildGcsfuse(testDir)
 		if err != nil {
-			return fmt.Errorf("BuildGcsfuse(%q): %w", TestDir(), err)
+			return "", fmt.Errorf("BuildGcsfuse(%q): %w", TestDir(), err)
 		}
 		binFile = path.Join(TestDir(), "bin/gcsfuse")
 		sbinFile = path.Join(TestDir(), "sbin/mount.gcsfuse")
@@ -223,18 +225,16 @@ func SetUpTestDir() error {
 		// Setting PATH so that executable is found in test directory.
 		err := os.Setenv(PathEnvVariable, path.Join(TestDir(), "bin")+string(filepath.ListSeparator)+os.Getenv(PathEnvVariable))
 		if err != nil {
-			return fmt.Errorf("error in setting PATH environment variable: %v", err.Error())
+			return "", fmt.Errorf("error in setting PATH environment variable: %v", err.Error())
 		}
 	}
 
-	logFile = path.Join(TestDir(), "gcsfuse.log")
 	mntDir = path.Join(TestDir(), "mnt")
-
 	err = os.Mkdir(mntDir, 0755)
 	if err != nil {
-		return fmt.Errorf("Mkdir(%q): %v", MntDir(), err)
+		return "", fmt.Errorf("Mkdir(%q): %v", MntDir(), err)
 	}
-	return nil
+	return TestDir(), nil
 }
 
 func UnMount() error {
@@ -345,7 +345,15 @@ func ParseSetUpFlags() {
 }
 
 func ConfigFile() string {
-	return *configFile
+	if *configFile == "" {
+		return ""
+	}
+
+	absPath, err := filepath.Abs(*configFile)
+	if err != nil {
+		log.Fatalf("error decoding config file path: %v", err)
+	}
+	return absPath
 }
 
 func IgnoreTestIfIntegrationTestFlagIsSet(t *testing.T) {
@@ -406,24 +414,37 @@ func RunTestsForMountedDirectory(mountedDirectory string, m *testing.M) int {
 	return ExecuteTest(m)
 }
 
-// Deprecated: Use SetUpTestDirForTestBucket instead.
+// SetUpTestDirForTestBucketFlag is Deprecated: Use SetUpTestDirForTestBucket instead.
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
 func SetUpTestDirForTestBucketFlag() {
-	SetUpTestDirForTestBucket(TestBucket())
+	cfg := &test_suite.TestConfig{
+		GKEMountedDirectory:     MountedDirectory(),
+		GCSFuseMountedDirectory: MntDir(),
+		TestBucket:              TestBucket(),
+		LogFile:                 LogFile(),
+	}
+	SetUpTestDirForTestBucket(cfg)
 }
 
-func SetUpTestDirForTestBucket(testBucket string) {
-	testBucketName := testBucket
-	if testBucketName == "" {
+// SetUpTestDirForTestBucket creates a test directory with GCSFuse binaries, mount point, log file, etc.
+// Test config is passed by reference so it can set the LogFile, mountPath variables in the config
+func SetUpTestDirForTestBucket(cfg *test_suite.TestConfig) {
+	if cfg.TestBucket == "" {
 		log.Fatal("Not running TestBucket tests as --testBucket flag is not set.")
 	}
-	if strings.ContainsAny(testBucketName, unsupportedCharactersInTestBucket) {
-		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", testBucketName, unsupportedCharactersInTestBucket)
+	if strings.ContainsAny(cfg.TestBucket, unsupportedCharactersInTestBucket) {
+		log.Fatalf("Passed testBucket %q contains one or more of the following unsupported character(s): %q", cfg.TestBucket, unsupportedCharactersInTestBucket)
 	}
-	if err := SetUpTestDir(); err != nil {
+	testDirPath, err := SetUpTestDir()
+	if err != nil {
 		log.Printf("setUpTestDir: %v\n", err)
 		os.Exit(1)
 	}
+
+	cfg.GCSFuseMountedDirectory = path.Join(testDirPath, "mnt")
+	cfg.LogFile = path.Join(TestDir(), "gcsfuse.log")
+	// TODO: clean up this global variable up after migration is complete.
+	SetLogFile(cfg.LogFile)
 }
 
 func SetUpLogDirForTestDirTests(logDirName string) (logDir string) {
@@ -541,11 +562,12 @@ func ResolveIsHierarchicalBucket(ctx context.Context, testBucket string, storage
 	return false
 }
 
-// BucketTestEnvironment sets the global testBucket and isZonalBucket variable
-// based on the bucket type.
-func BucketTestEnvironment(ctx context.Context, bucketName string) string {
-	SetTestBucket(bucketName)
-	bucketType, err := BucketType(ctx, bucketName)
+// TestEnvironment sets the global variables like test bucket, mount point, log file and isZonalBucket variable
+// based on the bucket type. Also returns the bucket type.
+func TestEnvironment(ctx context.Context, cfg *test_suite.TestConfig) string {
+	// TODO: clean up SetGlobalVars after migration completes.
+	SetGlobalVars(cfg)
+	bucketType, err := BucketType(ctx, cfg.TestBucket)
 	if err != nil {
 		log.Fatalf("BucketType failed: %v", err)
 	}
@@ -613,9 +635,10 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string) [][]string {
 	return dynamicFlags
 }
 
-// SetTestBucket sets the testBucket global variable.
-func SetTestBucket(bucketName string) {
-	testBucket = &bucketName
+func SetGlobalVars(cfg *test_suite.TestConfig) {
+	testBucket = &cfg.TestBucket
+	logFile = cfg.LogFile
+	mntDir = cfg.GKEMountedDirectory
 }
 
 // Explicitly set the enable-hns config flag to true when running tests on the HNS bucket.

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -30,11 +30,12 @@ type BucketType struct {
 
 // TestConfig represents the common configuration for test packages.
 type TestConfig struct {
-	MountedDirectory string       `yaml:"mounted_directory"`
-	TestBucket       string       `yaml:"test_bucket"`
-	LogFile          string       `yaml:"log_file,omitempty"`
-	RunOnGKE         bool         `yaml:"run_on_gke"`
-	Configs          []ConfigItem `yaml:"configs"`
+	GKEMountedDirectory     string `yaml:"mounted_directory"`
+	GCSFuseMountedDirectory string
+	TestBucket              string       `yaml:"test_bucket"`
+	LogFile                 string       `yaml:"log_file,omitempty"`
+	RunOnGKE                bool         `yaml:"run_on_gke"`
+	Configs                 []ConfigItem `yaml:"configs"`
 }
 
 // ConfigItem defines the variable parts of each test run.

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		// Populate the config manually.
 		cfg.WriteLargeFiles = make([]test_suite.TestConfig, 1)
 		cfg.WriteLargeFiles[0].TestBucket = setup.TestBucket()
-		cfg.WriteLargeFiles[0].MountedDirectory = setup.MountedDirectory()
+		cfg.WriteLargeFiles[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.WriteLargeFiles[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.WriteLargeFiles[0].Configs[0].Flags = []string{
 			"--enable-streaming-writes=false",
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	ctx = context.Background()
-	bucketType := setup.BucketTestEnvironment(ctx, cfg.WriteLargeFiles[0].TestBucket)
+	bucketType := setup.TestEnvironment(ctx, &cfg.WriteLargeFiles[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -71,15 +71,15 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as WriteLargeFiles tests validates content from the bucket.
-	if cfg.WriteLargeFiles[0].MountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].MountedDirectory, m))
+	if cfg.WriteLargeFiles[0].GKEMountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType)
 
-	setup.SetUpTestDirForTestBucket(cfg.WriteLargeFiles[0].TestBucket)
+	setup.SetUpTestDirForTestBucket(&cfg.WriteLargeFiles[0])
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.WriteLargeFiles[0], flags, m)
 


### PR DESCRIPTION
### Description
This pull request refactors the integration test framework to use a centralized configuration for mounting gcsfuse. Previously, mounting functions used global flags, making tests harder to maintain.

This is also part of GCSFuse GKE test migration to a common config.

The key changes in this PR are:

- The mounting functions have been updated to accept a TestConfig struct.
- The MountedDirectory field in TestConfig has been renamed to GKEMountedDirectory for clarity. A new GCSFuseMountedDirectory field has been added for the gcsfuse mount point.
- Also changed config file to accept relative path.

### Link to the issue in case of a bug fix.
b/445873072

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
