### PR TITLE
test(optimize-profile): Add code for generating unit tests for optimize profile (generated function ApplyOptimizations)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: fmt
 	CGO_ENABLED=0 go test -timeout 5m -count 1 `go list ./... | grep -v internal/cache/...` && CGO_ENABLED=0 go test -timeout 5m -p 1 -count 1 ./internal/cache/...
 
 clean-gen:
-	rm -rf cfg/config.go
+	rm -rf cfg/config.go cfg/config_test.go
 
 clean: clean-gen
 	go clean

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -1,0 +1,611 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT EDIT MANUALLY.
+
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyOptimizations(t *testing.T) {
+	// Tests for file-cache.cache-file-for-range-read
+	t.Run("file-cache.cache-file-for-range-read", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.FileCache.CacheFileForRangeRead = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"file-cache-cache-file-for-range-read": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, false, c.FileCache.CacheFileForRangeRead)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.FileCache.CacheFileForRangeRead = false
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, false, c.FileCache.CacheFileForRangeRead)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.FileCache.CacheFileForRangeRead = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "file-cache.cache-file-for-range-read")
+			assert.Equal(t, true, c.FileCache.CacheFileForRangeRead)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.FileCache.CacheFileForRangeRead = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "file-cache.cache-file-for-range-read")
+			assert.Equal(t, true, c.FileCache.CacheFileForRangeRead)
+		})
+
+		// Test cases for machine-based optimizations
+	})
+	// Tests for implicit-dirs
+	t.Run("implicit-dirs", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"implicit-dirs": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, false, c.ImplicitDirs)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, false, c.ImplicitDirs)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-training", func(t *testing.T) {
+			c := &Config{Profile: "aiml-training"}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "implicit-dirs")
+			assert.Equal(t, true, c.ImplicitDirs)
+		})
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "implicit-dirs")
+			assert.Equal(t, true, c.ImplicitDirs)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "implicit-dirs")
+			assert.Equal(t, true, c.ImplicitDirs)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.ImplicitDirs = false
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "implicit-dirs")
+			assert.Equal(t, true, c.ImplicitDirs)
+		})
+	})
+	// Tests for file-system.kernel-list-cache-ttl-secs
+	t.Run("file-system.kernel-list-cache-ttl-secs", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.FileSystem.KernelListCacheTtlSecs = 0
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"kernel-list-cache-ttl-secs": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(0), c.FileSystem.KernelListCacheTtlSecs)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.FileSystem.KernelListCacheTtlSecs = 0
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(0), c.FileSystem.KernelListCacheTtlSecs)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.FileSystem.KernelListCacheTtlSecs = 0
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "file-system.kernel-list-cache-ttl-secs")
+			assert.Equal(t, int64(-1), c.FileSystem.KernelListCacheTtlSecs)
+		})
+
+		// Test cases for machine-based optimizations
+	})
+	// Tests for metadata-cache.negative-ttl-secs
+	t.Run("metadata-cache.negative-ttl-secs", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"metadata-cache-negative-ttl-secs": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(5), c.MetadataCache.NegativeTtlSecs)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(5), c.MetadataCache.NegativeTtlSecs)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-training", func(t *testing.T) {
+			c := &Config{Profile: "aiml-training"}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.negative-ttl-secs")
+			assert.Equal(t, int64(0), c.MetadataCache.NegativeTtlSecs)
+		})
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.negative-ttl-secs")
+			assert.Equal(t, int64(0), c.MetadataCache.NegativeTtlSecs)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.negative-ttl-secs")
+			assert.Equal(t, int64(0), c.MetadataCache.NegativeTtlSecs)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.MetadataCache.NegativeTtlSecs = 5
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.negative-ttl-secs")
+			assert.Equal(t, int64(0), c.MetadataCache.NegativeTtlSecs)
+		})
+	})
+	// Tests for metadata-cache.ttl-secs
+	t.Run("metadata-cache.ttl-secs", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"metadata-cache-ttl-secs": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(60), c.MetadataCache.TtlSecs)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(60), c.MetadataCache.TtlSecs)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-training", func(t *testing.T) {
+			c := &Config{Profile: "aiml-training"}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.ttl-secs")
+			assert.Equal(t, int64(-1), c.MetadataCache.TtlSecs)
+		})
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.ttl-secs")
+			assert.Equal(t, int64(-1), c.MetadataCache.TtlSecs)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.ttl-secs")
+			assert.Equal(t, int64(-1), c.MetadataCache.TtlSecs)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.MetadataCache.TtlSecs = 60
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.ttl-secs")
+			assert.Equal(t, int64(-1), c.MetadataCache.TtlSecs)
+		})
+	})
+	// Tests for file-system.rename-dir-limit
+	t.Run("file-system.rename-dir-limit", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.FileSystem.RenameDirLimit = 0
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"rename-dir-limit": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(0), c.FileSystem.RenameDirLimit)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.FileSystem.RenameDirLimit = 0
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(0), c.FileSystem.RenameDirLimit)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.FileSystem.RenameDirLimit = 0
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "file-system.rename-dir-limit")
+			assert.Equal(t, int64(200000), c.FileSystem.RenameDirLimit)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.FileSystem.RenameDirLimit = 0
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "file-system.rename-dir-limit")
+			assert.Equal(t, int64(200000), c.FileSystem.RenameDirLimit)
+		})
+	})
+	// Tests for metadata-cache.stat-cache-max-size-mb
+	t.Run("metadata-cache.stat-cache-max-size-mb", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"stat-cache-max-size-mb": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(33), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(33), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-training", func(t *testing.T) {
+			c := &Config{Profile: "aiml-training"}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.stat-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.stat-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.stat-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.MetadataCache.StatCacheMaxSizeMb = 33
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.stat-cache-max-size-mb")
+			assert.Equal(t, int64(1024), c.MetadataCache.StatCacheMaxSizeMb)
+		})
+	})
+	// Tests for metadata-cache.type-cache-max-size-mb
+	t.Run("metadata-cache.type-cache-max-size-mb", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"type-cache-max-size-mb": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(4), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(4), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+
+		// Test cases for profile-based optimizations
+		t.Run("profile_aiml-training", func(t *testing.T) {
+			c := &Config{Profile: "aiml-training"}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.type-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+		t.Run("profile_aiml-serving", func(t *testing.T) {
+			c := &Config{Profile: "aiml-serving"}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.type-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+		t.Run("profile_aiml-checkpointing", func(t *testing.T) {
+			c := &Config{Profile: "aiml-checkpointing"}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.type-cache-max-size-mb")
+			assert.Equal(t, int64(-1), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.MetadataCache.TypeCacheMaxSizeMb = 4
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "metadata-cache.type-cache-max-size-mb")
+			assert.Equal(t, int64(128), c.MetadataCache.TypeCacheMaxSizeMb)
+		})
+	})
+	// Tests for write.global-max-blocks
+	t.Run("write.global-max-blocks", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.Write.GlobalMaxBlocks = 4
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"write-global-max-blocks": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(4), c.Write.GlobalMaxBlocks)
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{Profile: "non_existent_profile"}
+			c.Write.GlobalMaxBlocks = 4
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+			assert.Equal(t, int64(4), c.Write.GlobalMaxBlocks)
+		})
+
+		// Test cases for profile-based optimizations
+
+		// Test cases for machine-based optimizations
+		t.Run("machine_group_high-performance", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			c := &Config{Profile: ""}
+			c.Write.GlobalMaxBlocks = 4
+			isSet := &mockIsValueSet{
+				setFlags:    map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "a2-megagpu-16g"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "write.global-max-blocks")
+			assert.Equal(t, int64(1600), c.Write.GlobalMaxBlocks)
+		})
+	})
+}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -205,8 +205,6 @@ func TestApplyOptimizations(t *testing.T) {
 			assert.Equal(t, true, c.ImplicitDirs)
 		})
 
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
-
 	})
 	// Tests for file-system.kernel-list-cache-ttl-secs
 	t.Run("file-system.kernel-list-cache-ttl-secs", func(t *testing.T) {
@@ -380,8 +378,6 @@ func TestApplyOptimizations(t *testing.T) {
 			assert.Equal(t, int64(0), c.MetadataCache.NegativeTtlSecs)
 		})
 
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
-
 	})
 	// Tests for metadata-cache.ttl-secs
 	t.Run("metadata-cache.ttl-secs", func(t *testing.T) {
@@ -500,8 +496,6 @@ func TestApplyOptimizations(t *testing.T) {
 			// Assert that the machine-based value is used.
 			assert.Equal(t, int64(-1), c.MetadataCache.TtlSecs)
 		})
-
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
 
 	})
 	// Tests for file-system.rename-dir-limit
@@ -736,8 +730,6 @@ func TestApplyOptimizations(t *testing.T) {
 			assert.Equal(t, int64(1024), c.MetadataCache.StatCacheMaxSizeMb)
 		})
 
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
-
 	})
 	// Tests for metadata-cache.type-cache-max-size-mb
 	t.Run("metadata-cache.type-cache-max-size-mb", func(t *testing.T) {
@@ -856,8 +848,6 @@ func TestApplyOptimizations(t *testing.T) {
 			// Assert that the machine-based value is used.
 			assert.Equal(t, int64(128), c.MetadataCache.TypeCacheMaxSizeMb)
 		})
-
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
 
 	})
 	// Tests for write.global-max-blocks

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -25,16 +25,29 @@ import (
 func TestApplyOptimizations(t *testing.T) {
 	// Tests for file-cache.cache-file-for-range-read
 	t.Run("file-cache.cache-file-for-range-read", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		nonDefaultValue := !(false)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.FileCache.CacheFileForRangeRead = false
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"file-cache-cache-file-for-range-read": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.FileCache.CacheFileForRangeRead = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"file-cache-cache-file-for-range-read": true,
+					"machine-type":                         true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, false, c.FileCache.CacheFileForRangeRead)
+			assert.NotContains(t, optimizedFlags, "file-cache.cache-file-for-range-read")
+			assert.Equal(t, nonDefaultValue, c.FileCache.CacheFileForRangeRead)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -78,16 +91,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for implicit-dirs
 	t.Run("implicit-dirs", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		nonDefaultValue := !(false)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.ImplicitDirs = false
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"implicit-dirs": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.ImplicitDirs = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"implicit-dirs": true,
+					"machine-type":  true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, false, c.ImplicitDirs)
+			assert.NotContains(t, optimizedFlags, "implicit-dirs")
+			assert.Equal(t, nonDefaultValue, c.ImplicitDirs)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -155,16 +181,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for file-system.kernel-list-cache-ttl-secs
 	t.Run("file-system.kernel-list-cache-ttl-secs", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.FileSystem.KernelListCacheTtlSecs = 0
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"kernel-list-cache-ttl-secs": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.FileSystem.KernelListCacheTtlSecs = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"kernel-list-cache-ttl-secs": true,
+					"machine-type":               true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(0), c.FileSystem.KernelListCacheTtlSecs)
+			assert.NotContains(t, optimizedFlags, "file-system.kernel-list-cache-ttl-secs")
+			assert.Equal(t, nonDefaultValue, c.FileSystem.KernelListCacheTtlSecs)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -198,16 +237,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for metadata-cache.negative-ttl-secs
 	t.Run("metadata-cache.negative-ttl-secs", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.MetadataCache.NegativeTtlSecs = 5
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"metadata-cache-negative-ttl-secs": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.MetadataCache.NegativeTtlSecs = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"metadata-cache-negative-ttl-secs": true,
+					"machine-type":                     true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(5), c.MetadataCache.NegativeTtlSecs)
+			assert.NotContains(t, optimizedFlags, "metadata-cache.negative-ttl-secs")
+			assert.Equal(t, nonDefaultValue, c.MetadataCache.NegativeTtlSecs)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -275,16 +327,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for metadata-cache.ttl-secs
 	t.Run("metadata-cache.ttl-secs", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.MetadataCache.TtlSecs = 60
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"metadata-cache-ttl-secs": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.MetadataCache.TtlSecs = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"metadata-cache-ttl-secs": true,
+					"machine-type":            true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(60), c.MetadataCache.TtlSecs)
+			assert.NotContains(t, optimizedFlags, "metadata-cache.ttl-secs")
+			assert.Equal(t, nonDefaultValue, c.MetadataCache.TtlSecs)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -352,16 +417,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for file-system.rename-dir-limit
 	t.Run("file-system.rename-dir-limit", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.FileSystem.RenameDirLimit = 0
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"rename-dir-limit": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.FileSystem.RenameDirLimit = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"rename-dir-limit": true,
+					"machine-type":     true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(0), c.FileSystem.RenameDirLimit)
+			assert.NotContains(t, optimizedFlags, "file-system.rename-dir-limit")
+			assert.Equal(t, nonDefaultValue, c.FileSystem.RenameDirLimit)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -409,16 +487,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for metadata-cache.stat-cache-max-size-mb
 	t.Run("metadata-cache.stat-cache-max-size-mb", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.MetadataCache.StatCacheMaxSizeMb = 33
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"stat-cache-max-size-mb": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.MetadataCache.StatCacheMaxSizeMb = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"stat-cache-max-size-mb": true,
+					"machine-type":           true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(33), c.MetadataCache.StatCacheMaxSizeMb)
+			assert.NotContains(t, optimizedFlags, "metadata-cache.stat-cache-max-size-mb")
+			assert.Equal(t, nonDefaultValue, c.MetadataCache.StatCacheMaxSizeMb)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -486,16 +577,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for metadata-cache.type-cache-max-size-mb
 	t.Run("metadata-cache.type-cache-max-size-mb", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.MetadataCache.TypeCacheMaxSizeMb = 4
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"type-cache-max-size-mb": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.MetadataCache.TypeCacheMaxSizeMb = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"type-cache-max-size-mb": true,
+					"machine-type":           true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(4), c.MetadataCache.TypeCacheMaxSizeMb)
+			assert.NotContains(t, optimizedFlags, "metadata-cache.type-cache-max-size-mb")
+			assert.Equal(t, nonDefaultValue, c.MetadataCache.TypeCacheMaxSizeMb)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.
@@ -563,16 +667,29 @@ func TestApplyOptimizations(t *testing.T) {
 	})
 	// Tests for write.global-max-blocks
 	t.Run("write.global-max-blocks", func(t *testing.T) {
-		// Test case 1: User has set the flag, no optimization should be applied.
+		// Define a non-default value for testing user-set flags.
+		const nonDefaultValue = int64(98765)
+
+		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			c := &Config{}
-			c.Write.GlobalMaxBlocks = 4
-			isSet := &mockIsValueSet{setFlags: map[string]bool{"write-global-max-blocks": true}}
+			c := &Config{
+				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+			}
+			c.Write.GlobalMaxBlocks = nonDefaultValue // Set the non-default value.
+			isSet := &mockIsValueSet{
+				setFlags: map[string]bool{
+					"write-global-max-blocks": true,
+					"machine-type":            true, // A machine type that would otherwise cause optimization.
+				},
+				stringFlags: map[string]string{
+					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
+				},
+			}
 
 			optimizedFlags := c.ApplyOptimizations(isSet)
 
-			assert.Empty(t, optimizedFlags)
-			assert.Equal(t, int64(4), c.Write.GlobalMaxBlocks)
+			assert.NotContains(t, optimizedFlags, "write.global-max-blocks")
+			assert.Equal(t, nonDefaultValue, c.Write.GlobalMaxBlocks)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -93,7 +93,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			nonDefaultValue := !(false)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-training", // A profile that would otherwise cause optimization.
 			}
 			c.ImplicitDirs = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -268,7 +268,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-training", // A profile that would otherwise cause optimization.
 			}
 			c.MetadataCache.NegativeTtlSecs = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -389,7 +389,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-training", // A profile that would otherwise cause optimization.
 			}
 			c.MetadataCache.TtlSecs = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -510,7 +510,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-checkpointing", // A profile that would otherwise cause optimization.
 			}
 			c.FileSystem.RenameDirLimit = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -624,7 +624,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-training", // A profile that would otherwise cause optimization.
 			}
 			c.MetadataCache.StatCacheMaxSizeMb = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -745,7 +745,7 @@ func TestApplyOptimizations(t *testing.T) {
 		t.Run("user_set", func(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "aiml-training", // A profile that would otherwise cause optimization.
 			}
 			c.MetadataCache.TypeCacheMaxSizeMb = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{
@@ -864,25 +864,6 @@ func TestApplyOptimizations(t *testing.T) {
 	t.Run("write.global-max-blocks", func(t *testing.T) {
 		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			const nonDefaultValue = int64(98765)
-			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
-			}
-			c.Write.GlobalMaxBlocks = nonDefaultValue // Set a non-default value.
-			isSet := &mockIsValueSet{
-				setFlags: map[string]bool{
-					"write-global-max-blocks": true,
-					"machine-type":            true, // A machine type that would otherwise cause optimization.
-				},
-				stringFlags: map[string]string{
-					"machine-type": "a2-megagpu-16g", // From the "high-performance" group.
-				},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.NotContains(t, optimizedFlags, "write.global-max-blocks")
-			assert.Equal(t, nonDefaultValue, c.Write.GlobalMaxBlocks)
 		})
 
 		// Test case 2: No profile or machine-based optimization match.

--- a/cfg/optimize_test.go
+++ b/cfg/optimize_test.go
@@ -33,10 +33,6 @@ type mockIsValueSet struct {
 	stringFlags map[string]string
 }
 
-func (m *mockIsValueSet) IsValueSet(flag string) bool {
-	return m.setFlags[flag]
-}
-
 func (m *mockIsValueSet) IsSet(flag string) bool {
 	return m.setFlags[flag]
 }

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -143,7 +143,7 @@ func main() {
 		},
 			generatedFilePath, templateFilePath)
 		if err != nil {
-			panic(fmt.Sprintf("failed to generate file %q", generatedFilePath))
+			panic(fmt.Sprintf("failed to generate file %q: %v", generatedFilePath, err))
 		}
 	}
 }

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -29,19 +29,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg/shared"
 )
 
-const (
-	configTemplate            = "config.tpl"
-	configTestTemplate        = "config_test.tpl"
-	typeTemplate              = "type.tpl"
-	defaultPermission         = 0644
-	generatedFileHeader       = "// GENERATED CODE - DO NOT EDIT MANUALLY.\n"
-	generatedConfigGoFile     = "config.go"
-	generatedConfigTestGoFile = "config_test.go"
-	generatedTypeGoFile       = "type.go"
-	templatePath              = "templates"
-	yamlPath                  = "cfg/params.yaml"
-)
-
 var (
 	outDir      = flag.String("outDir", "", "Output directory where the auto-generated files are to be placed")
 	paramsFile  = flag.String("paramsFile", "", "Params YAML file")

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -29,6 +29,19 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg/shared"
 )
 
+const (
+	configTemplate            = "config.tpl"
+	configTestTemplate        = "config_test.tpl"
+	typeTemplate              = "type.tpl"
+	defaultPermission         = 0644
+	generatedFileHeader       = "// GENERATED CODE - DO NOT EDIT MANUALLY.\n"
+	generatedConfigGoFile     = "config.go"
+	generatedConfigTestGoFile = "config_test.go"
+	generatedTypeGoFile       = "type.go"
+	templatePath              = "templates"
+	yamlPath                  = "cfg/params.yaml"
+)
+
 var (
 	outDir      = flag.String("outDir", "", "Output directory where the auto-generated files are to be placed")
 	paramsFile  = flag.String("paramsFile", "", "Params YAML file")
@@ -140,6 +153,18 @@ func main() {
 	},
 		path.Join(*outDir, "config.go"),
 		path.Join(*templateDir, "config.tpl"))
+	if err != nil {
+		panic(err)
+	}
+
+	err = write(templateData{
+		FlagTemplateData:      fd,
+		TypeTemplateData:      td,
+		MachineTypeToGroupMap: machineTypeToGroupMap,
+		Backticks:             "`",
+	},
+		path.Join(*outDir, "config_test.go"),
+		path.Join(*templateDir, "config_test.tpl"))
 	if err != nil {
 		panic(err)
 	}

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -41,6 +41,7 @@ type templateData struct {
 	TypeTemplateData      []typeTemplateData
 	FlagTemplateData      []flagTemplateData
 	MachineTypeToGroupMap map[string]string
+	MachineTypeGroups     map[string][]string
 	// Back-ticks are not supported in templates. So, passing as a parameter.
 	Backticks string
 }
@@ -139,6 +140,7 @@ func main() {
 			FlagTemplateData:      fd,
 			TypeTemplateData:      td,
 			MachineTypeToGroupMap: machineTypeToGroupMap,
+			MachineTypeGroups:     paramsYAML.MachineTypeGroups,
 			Backticks:             "`",
 		},
 			generatedFilePath, templateFilePath)

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -145,28 +145,19 @@ func main() {
 	// Create a map from given machine type to all the machine type groups that it belongs to.
 	machineTypeToGroupMap := invertMachineTypeGroups(paramsYAML.MachineTypeGroups)
 
-	err = write(templateData{
-		FlagTemplateData:      fd,
-		TypeTemplateData:      td,
-		MachineTypeToGroupMap: machineTypeToGroupMap,
-		Backticks:             "`",
-	},
-		path.Join(*outDir, "config.go"),
-		path.Join(*templateDir, "config.tpl"))
-	if err != nil {
-		panic(err)
-	}
-
-	err = write(templateData{
-		FlagTemplateData:      fd,
-		TypeTemplateData:      td,
-		MachineTypeToGroupMap: machineTypeToGroupMap,
-		Backticks:             "`",
-	},
-		path.Join(*outDir, "config_test.go"),
-		path.Join(*templateDir, "config_test.tpl"))
-	if err != nil {
-		panic(err)
+	for _, rootFileName := range []string{"config", "config_test"} {
+		generatedFilePath := path.Join(*outDir, rootFileName+".go")
+		templateFilePath := path.Join(*templateDir, rootFileName+".tpl")
+		err = write(templateData{
+			FlagTemplateData:      fd,
+			TypeTemplateData:      td,
+			MachineTypeToGroupMap: machineTypeToGroupMap,
+			Backticks:             "`",
+		},
+			generatedFilePath, templateFilePath)
+		if err != nil {
+			panic(fmt.Sprintf("failed to generate file %q", generatedFilePath))
+		}
 	}
 }
 

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -28,222 +28,148 @@ func TestApplyOptimizations(t *testing.T) {
     {{- $flag := . }}
 	// Tests for {{ $flag.ConfigPath }}
 	t.Run("{{$flag.ConfigPath}}", func(t *testing.T) {
-		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
-		t.Run("user_set", func(t *testing.T) {
-			{{- if and .Optimizations (or (eq $flag.GoType "int64") (eq $flag.GoType "bool") (eq $flag.GoType "string") (eq $flag.GoType "float64")) }}
-			{{- $profileName := "" -}}
-			{{- if .Optimizations.Profiles -}}
-			{{- $profile := index .Optimizations.Profiles 0 -}}
-			{{- $profileName = $profile.Name -}}
-			{{- end }}
-			{{- $machineTypeForOptimisation := "a2-megagpu-16g" -}}
-			{{- $machineTypeComment := "From the \"high-performance\" group." -}}
-			{{- if .Optimizations.MachineBasedOptimization -}}
-				{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
-				{{- $foundMachineType := "" -}}
-				{{- range $mt, $group := $.MachineTypeToGroupMap -}}
-					{{- if and (not $foundMachineType) (eq $group $mbo.Group) -}}
-						{{- $foundMachineType = $mt -}}
-					{{- end -}}
-				{{- end -}}
-				{{- if $foundMachineType -}}
-					{{- $machineTypeForOptimisation = $foundMachineType -}}
-					{{- $machineTypeComment = printf "From the %q group." $mbo.Group -}}
-				{{- end -}}
-			{{- end }}
-			{{- if eq $flag.GoType "int64" }}
-			const nonDefaultValue = int64(98765)
-			{{- else if eq $flag.GoType "bool" }}
-			nonDefaultValue := !({{$flag.DefaultValue}})
-			{{- else if eq $flag.GoType "string" }}
-			nonDefaultValue := {{$flag.DefaultValue}} + "-non-default"
-			{{- else if eq $flag.GoType "float64" }}
-			nonDefaultValue := {{$flag.DefaultValue}} + 1.23
-			{{- end }}
-			c := &Config{
-				Profile: "{{$profileName}}", // A profile that would otherwise cause optimization.
-			}
-			c.{{$flag.GoPath}} = nonDefaultValue // Set a non-default value.
-			isSet := &mockIsValueSet{
-				setFlags: map[string]bool{
-					"{{$flag.FlagName}}": true,
-					"machine-type":       true, // A machine type that would otherwise cause optimization.
+		testCases := []struct {
+			name            string
+			config          Config
+			isSet           *mockIsValueSet
+			expectOptimized bool
+			expectedValue   any
+		}{
+			{
+				name: "user_set",
+				config: Config{
+					{{- if .Optimizations.Profiles }}
+					{{- $profile := index .Optimizations.Profiles 0 }}
+					Profile: "{{$profile.Name}}",
+					{{- end }}
 				},
-				stringFlags: map[string]string{
-					"machine-type": "{{$machineTypeForOptimisation}}", // {{ $machineTypeComment }}
+				isSet: &mockIsValueSet{
+					setFlags: map[string]bool{
+						"{{$flag.FlagName}}": true,
+						"machine-type":       true,
+					},
+					{{- if .Optimizations.MachineBasedOptimization }}
+					{{- $mbo := index .Optimizations.MachineBasedOptimization 0 }}
+					{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 }}
+					stringFlags: map[string]string{
+						"machine-type": "{{$machineType}}",
+					},
+					{{- end }}
 				},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.NotContains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			assert.Equal(t, nonDefaultValue, c.{{$flag.GoPath}})
-			{{- end }}
-		})
-
-		// Test case 2: No profile or machine-based optimization match.
-		t.Run("no_optimization", func(t *testing.T) {
-			c := &Config{ Profile: "non_existent_profile" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{
-				setFlags:  map[string]bool{"machine-type": true},
-				stringFlags: map[string]string{"machine-type": "low-end-machine"}, // A machine type not in any group
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Empty(t, optimizedFlags)
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{$flag.DefaultValue}}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{$flag.DefaultValue}}, c.{{$flag.GoPath}})
-			{{- end }}
-		})
-
-		// Test cases for profile-based optimizations
+				expectOptimized: false,
+				expectedValue:
+				{{- if eq $flag.GoType "int64" }} int64(98765),
+				{{- else if eq $flag.GoType "bool" }} !({{$flag.DefaultValue}}),
+				{{- else if eq $flag.GoType "string" }} {{$flag.DefaultValue}} + "-non-default",
+				{{- else if eq $flag.GoType "float64" }} {{$flag.DefaultValue}} + 1.23,
+				{{- else }} // compilation error: unhandled type '{{$flag.GoType}}' in test generation for {{$flag.ConfigPath}}
+				{{- end }}
+			},
+			{
+				name:   "no_optimization",
+				config: Config{Profile: "non_existent_profile"},
+				isSet: &mockIsValueSet{
+					setFlags:    map[string]bool{"machine-type": true},
+					stringFlags: map[string]string{"machine-type": "low-end-machine"},
+				},
+				expectOptimized: false,
+				expectedValue:   {{$flag.DefaultValue}},
+			},
 		{{- range .Optimizations.Profiles }}
-		t.Run("profile_{{.Name}}", func(t *testing.T) {
-			c := &Config{ Profile: "{{.Name}}" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{ formatValue .Value }}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{ formatValue .Value }}, c.{{$flag.GoPath}})
-			{{- end }}
-		})
+			{
+				name:            "profile_{{.Name}}",
+				config:          Config{Profile: "{{.Name}}"},
+				isSet:           &mockIsValueSet{setFlags: map[string]bool{}},
+				expectOptimized: true,
+				expectedValue:   {{.Value}},
+			},
 		{{- end }}
-
-		// Test cases for machine-based optimizations
 		{{- range .Optimizations.MachineBasedOptimization }}
-        {{- $mbo := . }}
-		t.Run("machine_group_{{$mbo.Group}}", func(t *testing.T) {
-			// Find a machine type from the group to use in the test
-			{{ $machineType := "" -}}
-			{{- range $mt, $group := $.MachineTypeToGroupMap -}}
-			    {{- if and (not $machineType) (eq $group $mbo.Group) -}}
-			        {{- $machineType = $mt -}}
-			    {{- end -}}
-			{{- end -}}
-			c := &Config{ Profile: "" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{
-				setFlags:  map[string]bool{"machine-type": true},
-				stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{ formatValue $mbo.Value }}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{ formatValue $mbo.Value }}, c.{{$flag.GoPath}})
-			{{- end }}
-		})
+			{{- $mbo := . }}
+			{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 }}
+			{
+				name:   "machine_group_{{$mbo.Group}}",
+				config: Config{Profile: ""},
+				isSet: &mockIsValueSet{
+					setFlags:    map[string]bool{"machine-type": true},
+					stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
+				},
+				expectOptimized: true,
+				expectedValue:   {{$mbo.Value}},
+			},
 		{{- end }}
-
 		{{- if and .Optimizations.Profiles .Optimizations.MachineBasedOptimization }}
-		// Test case: Profile optimization should override machine-based optimization.
-		t.Run("profile_overrides_machine_type", func(t *testing.T) {
 			{{- $profile := index .Optimizations.Profiles 0 -}}
 			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
-			// Find a machine type from the group to use in the test
-			{{ $machineType := "" -}}
-			{{- range $mt, $group := $.MachineTypeToGroupMap -}}
-				{{- if and (not $machineType) (eq $group $mbo.Group) -}}
-					{{- $machineType = $mt -}}
-				{{- end -}}
-			{{- end -}}
-			c := &Config{ Profile: "{{$profile.Name}}" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{
-				setFlags:  map[string]bool{"machine-type": true},
-				stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			// Assert that the profile value is used, not the machine-based one.
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{ formatValue $profile.Value }}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{ formatValue $profile.Value }}, c.{{$flag.GoPath}})
-			{{- end }}
-		})
+			{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 }}
+			{
+				name:   "profile_overrides_machine_type",
+				config: Config{Profile: "{{$profile.Name}}"},
+				isSet: &mockIsValueSet{
+					setFlags:    map[string]bool{"machine-type": true},
+					stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
+				},
+				expectOptimized: true,
+				expectedValue:   {{$profile.Value}},
+			},
 		{{- end }}
-
 		{{- if .Optimizations.MachineBasedOptimization }}
-		// Test case: Fallback to machine-based optimization when profile is non-existent.
-		t.Run("fallback_to_machine_type_with_non_existent_profile", func(t *testing.T) {
 			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
-			// Find a machine type from the group to use in the test
-			{{ $machineType := "" -}}
-			{{- range $mt, $group := $.MachineTypeToGroupMap -}}
-				{{- if and (not $machineType) (eq $group $mbo.Group) -}}
-					{{- $machineType = $mt -}}
+			{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 -}}
+			{
+				name:   "fallback_to_machine_type_with_non_existent_profile",
+				config: Config{Profile: "non_existent_profile"},
+				isSet: &mockIsValueSet{
+					setFlags:    map[string]bool{"machine-type": true},
+					stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
+				},
+				expectOptimized: true,
+				expectedValue:   {{$mbo.Value}},
+			},
+			{{- $unrelatedProfile := "aiml-training" -}}
+			{{- $hasRuleForUnrelatedProfile := false -}}
+			{{- range .Optimizations.Profiles -}}
+				{{- if eq .Name $unrelatedProfile -}}
+					{{- $hasRuleForUnrelatedProfile = true -}}
 				{{- end -}}
 			{{- end -}}
-			c := &Config{ Profile: "non_existent_profile" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{
-				setFlags:  map[string]bool{"machine-type": true},
-				stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			// Assert that the machine-based value is used.
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{ formatValue $mbo.Value }}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{ formatValue $mbo.Value }}, c.{{$flag.GoPath}})
+			{{- if not $hasRuleForUnrelatedProfile -}}
+			{
+				name:   "fallback_to_machine_type_when_aiml-training_is_unrelated",
+				config: Config{Profile: "{{$unrelatedProfile}}"},
+				isSet: &mockIsValueSet{
+					setFlags:    map[string]bool{"machine-type": true},
+					stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
+				},
+				expectOptimized: true,
+				expectedValue:   {{$mbo.Value}},
+			},
 			{{- end }}
-		})
-
-		{{ $unrelatedProfile := "aiml-training" -}}
-		{{- $hasRuleForUnrelatedProfile := false -}}
-		{{- range .Optimizations.Profiles -}}
-			{{- if eq .Name $unrelatedProfile -}}
-				{{- $hasRuleForUnrelatedProfile = true -}}
-			{{- end -}}
-		{{- end -}}
-		{{- if not $hasRuleForUnrelatedProfile -}}
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
-		t.Run("fallback_to_machine_type_with_unrelated_profile", func(t *testing.T) {
-			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
-			// Find a machine type from the group to use in the test
-			{{ $machineType := "" -}}
-			{{- range $mt, $group := $.MachineTypeToGroupMap -}}
-				{{- if and (not $machineType) (eq $group $mbo.Group) -}}
-					{{- $machineType = $mt -}}
-				{{- end -}}
-			{{- end -}}
-			c := &Config{ Profile: "{{$unrelatedProfile}}" }
-			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
-			isSet := &mockIsValueSet{
-				setFlags:  map[string]bool{"machine-type": true},
-				stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
-			}
-
-			optimizedFlags := c.ApplyOptimizations(isSet)
-
-			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
-			// Assert that the machine-based value is used.
-			{{- if eq $flag.GoType "int64" }}
-			assert.Equal(t, int64({{ formatValue $mbo.Value }}), c.{{$flag.GoPath}})
-			{{- else }}
-			assert.Equal(t, {{ formatValue $mbo.Value }}, c.{{$flag.GoPath}})
-			{{- end }}
-		})
-		{{- end -}}
 		{{- end }}
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// We need a copy of the config for each test case.
+				c := tc.config
+				// Set the default or non-default value on the config object.
+				if tc.name == "user_set" {
+					c.{{$flag.GoPath}} = tc.expectedValue.({{$flag.GoType}})
+				} else {
+					c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
+				}
+
+				optimizedFlags := c.ApplyOptimizations(tc.isSet)
+
+				if tc.expectOptimized {
+					assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
+				} else {
+					assert.NotContains(t, optimizedFlags, "{{$flag.ConfigPath}}")
+				}
+				// Use EqualValues to handle the int vs int64 type mismatch for default values.
+				assert.EqualValues(t, tc.expectedValue, c.{{$flag.GoPath}})
+			})
+		}
 	})
 {{- end }}
 {{- end }}

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -30,14 +30,15 @@ func TestApplyOptimizations(t *testing.T) {
 	t.Run("{{$flag.ConfigPath}}", func(t *testing.T) {
 		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			{{- if or (eq $flag.GoType "int64") (eq $flag.GoType "bool") }}
+			{{- if and .Optimizations.Profiles (or (eq $flag.GoType "int64") (eq $flag.GoType "bool")) }}
+			{{- $profile := index .Optimizations.Profiles 0 -}}
 			{{- if eq $flag.GoType "int64" }}
 			const nonDefaultValue = int64(98765)
 			{{- else if eq $flag.GoType "bool" }}
 			nonDefaultValue := !({{$flag.DefaultValue}})
 			{{- end }}
 			c := &Config{
-				Profile: "aiml-serving", // A profile that would otherwise cause optimization.
+				Profile: "{{$profile.Name}}", // A profile that would otherwise cause optimization.
 			}
 			c.{{$flag.GoPath}} = nonDefaultValue // Set a non-default value.
 			isSet := &mockIsValueSet{

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -1,0 +1,116 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT EDIT MANUALLY.
+
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyOptimizations(t *testing.T) {
+{{- range .FlagTemplateData }}
+{{- if .Optimizations }}
+    {{- $flag := . }}
+	// Tests for {{ $flag.ConfigPath }}
+	t.Run("{{$flag.ConfigPath}}", func(t *testing.T) {
+		// Test case 1: User has set the flag, no optimization should be applied.
+		t.Run("user_set", func(t *testing.T) {
+			c := &Config{}
+			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
+			isSet := &mockIsValueSet{setFlags: map[string]bool{"{{$flag.FlagName}}": true}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+            {{- if eq $flag.GoType "int64" }}
+			assert.Equal(t, int64({{$flag.DefaultValue}}), c.{{$flag.GoPath}})
+            {{- else }}
+			assert.Equal(t, {{$flag.DefaultValue}}, c.{{$flag.GoPath}})
+            {{- end }}
+		})
+
+		// Test case 2: No profile or machine-based optimization match.
+		t.Run("no_optimization", func(t *testing.T) {
+			c := &Config{ Profile: "non_existent_profile" }
+			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
+			isSet := &mockIsValueSet{
+				setFlags:  map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "n1-standard-1"}, // A machine type not in any group
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Empty(t, optimizedFlags)
+            {{- if eq $flag.GoType "int64" }}
+			assert.Equal(t, int64({{$flag.DefaultValue}}), c.{{$flag.GoPath}})
+            {{- else }}
+			assert.Equal(t, {{$flag.DefaultValue}}, c.{{$flag.GoPath}})
+            {{- end }}
+		})
+
+		// Test cases for profile-based optimizations
+		{{- range .Optimizations.Profiles }}
+		t.Run("profile_{{.Name}}", func(t *testing.T) {
+			c := &Config{ Profile: "{{.Name}}" }
+			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
+			isSet := &mockIsValueSet{setFlags: map[string]bool{}}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
+            {{- if eq $flag.GoType "int64" }}
+			assert.Equal(t, int64({{ formatValue .Value }}), c.{{$flag.GoPath}})
+            {{- else }}
+			assert.Equal(t, {{ formatValue .Value }}, c.{{$flag.GoPath}})
+            {{- end }}
+		})
+		{{- end }}
+
+		// Test cases for machine-based optimizations
+		{{- range .Optimizations.MachineBasedOptimization }}
+        {{- $mbo := . }}
+		t.Run("machine_group_{{$mbo.Group}}", func(t *testing.T) {
+			// Find a machine type from the group to use in the test
+			{{ $machineType := "" -}}
+			{{- range $mt, $group := $.MachineTypeToGroupMap -}}
+			    {{- if and (not $machineType) (eq $group $mbo.Group) -}}
+			        {{- $machineType = $mt -}}
+			    {{- end -}}
+			{{- end -}}
+			c := &Config{ Profile: "" }
+			c.{{$flag.GoPath}} = {{$flag.DefaultValue}}
+			isSet := &mockIsValueSet{
+				setFlags:  map[string]bool{"machine-type": true},
+				stringFlags: map[string]string{"machine-type": "{{$machineType}}"},
+			}
+
+			optimizedFlags := c.ApplyOptimizations(isSet)
+
+			assert.Contains(t, optimizedFlags, "{{$flag.ConfigPath}}")
+            {{- if eq $flag.GoType "int64" }}
+			assert.Equal(t, int64({{ formatValue $mbo.Value }}), c.{{$flag.GoPath}})
+            {{- else }}
+			assert.Equal(t, {{ formatValue $mbo.Value }}, c.{{$flag.GoPath}})
+            {{- end }}
+		})
+		{{- end }}
+	})
+{{- end }}
+{{- end }}
+}
+

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -207,7 +207,6 @@ func TestApplyOptimizations(t *testing.T) {
 			{{- end }}
 		})
 
-		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
 		{{ $unrelatedProfile := "aiml-training" -}}
 		{{- $hasRuleForUnrelatedProfile := false -}}
 		{{- range .Optimizations.Profiles -}}
@@ -216,6 +215,7 @@ func TestApplyOptimizations(t *testing.T) {
 			{{- end -}}
 		{{- end -}}
 		{{- if not $hasRuleForUnrelatedProfile -}}
+		// Test case: Fallback to machine-based optimization when a profile is set, but has no rule for THIS flag.
 		t.Run("fallback_to_machine_type_with_unrelated_profile", func(t *testing.T) {
 			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
 			// Find a machine type from the group to use in the test

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -30,7 +30,7 @@ func TestApplyOptimizations(t *testing.T) {
 	t.Run("{{$flag.ConfigPath}}", func(t *testing.T) {
 		// Test case 1: User has set the flag to a non-default value; optimizations should be ignored FOR THAT FLAG.
 		t.Run("user_set", func(t *testing.T) {
-			{{- if and .Optimizations (or (eq $flag.GoType "int64") (eq $flag.GoType "bool")) }}
+			{{- if and .Optimizations (or (eq $flag.GoType "int64") (eq $flag.GoType "bool") (eq $flag.GoType "string") (eq $flag.GoType "float64")) }}
 			{{- $profileName := "" -}}
 			{{- if .Optimizations.Profiles -}}
 			{{- $profile := index .Optimizations.Profiles 0 -}}
@@ -55,6 +55,10 @@ func TestApplyOptimizations(t *testing.T) {
 			const nonDefaultValue = int64(98765)
 			{{- else if eq $flag.GoType "bool" }}
 			nonDefaultValue := !({{$flag.DefaultValue}})
+			{{- else if eq $flag.GoType "string" }}
+			nonDefaultValue := {{$flag.DefaultValue}} + "-non-default"
+			{{- else if eq $flag.GoType "float64" }}
+			nonDefaultValue := {{$flag.DefaultValue}} + 1.23
 			{{- end }}
 			c := &Config{
 				Profile: "{{$profileName}}", // A profile that would otherwise cause optimization.


### PR DESCRIPTION
### Description
- ~Dependent on #3799~
- This adds code to auto-generate unit test file `cfg/config_test.go` from the given (new) template file `toos/config-gen/template/config_test.tpl`, similar to how `cfg/config_test.go` is generated from  `toos/config-gen/template/config_test.tpl` using `go generate`.
- This generated file `cfg/config_test.go` unit tests the newly added `ApplyOptimizations` function implemented in the generated file `cfg/config_test.go` for all the flags optimized/overriden in various situations e.g. user-config set or not set, machine-type set or not set, `--profile` set or not set, optimization defined or not defined etc.
- There is no change to any actual gcsfuse library code. The only change is to how the code-gen tool works, and the added generation of the unit test file `cfg/config_test.go` . 

This pull request enhances the development workflow by implementing an automated system for generating unit tests for the `ApplyOptimizations` function. This change ensures that the complex logic for applying configuration optimizations, based on user settings, profiles, and machine types, is thoroughly and consistently tested. The update primarily affects the code generation tooling and test infrastructure, adding robustness without altering the core gcsfuse library code.

#### Highlights

* **Automated Unit Test Generation**: Introduced a new mechanism to automatically generate unit tests for the `ApplyOptimizations` function, ensuring comprehensive test coverage for various flag optimization scenarios.
* **New Test Template**: Added a new Go template file (`tools/config-gen/templates/config_test.tpl`) that defines the structure and content for the generated `cfg/config_test.go` unit tests.
* **Code Generation Tool Update**: The `tools/config-gen/main.go` tool has been updated to utilize the new template, enabling it to generate the `cfg/config_test.go` file alongside the existing `cfg/config.go`.
* **Makefile Integration**: The `Makefile` was modified to include the newly generated `cfg/config_test.go` file in the `clean-gen` target, ensuring proper cleanup of generated artifacts.

### Link to the issue in case of a bug fix.
[b/436169032](http://b/436169032)

### Testing details
1. Manual - Ran manually
2. Unit tests - Ran as part of presubmit
3. Integration tests - Not needed

### Any backward incompatible change? If so, please explain.
