### PR TITLE
ci(lint): Prevent lint from timing out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@032fa5c5e48499f06cf9d32c02149bfac1284239
       with:
-        args: -E=goimports,unused --timeout 2m0s
+        args: -E=goimports,unused --timeout 3m0s
         only-new-issues: true
 


### PR DESCRIPTION
### Description
Lint has recently started timing out. It's possibly because of the amount of code being added. Let's increase it and see if this helps.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
