### PR TITLE
feat(dns_cache): Guard HTTP/1 DNS cache enablement with a boolean flag

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -467,13 +467,13 @@ type GcsConnectionConfig struct {
 
 	CustomEndpoint string `yaml:"custom-endpoint"`
 
+	EnableHttpDnsCache bool `yaml:"enable-http-dns-cache"`
+
 	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
 
 	GrpcConnPoolSize int64 `yaml:"grpc-conn-pool-size"`
 
 	HttpClientTimeout time.Duration `yaml:"http-client-timeout"`
-
-	HttpDnsCacheTtlSecs int64 `yaml:"http-dns-cache-ttl-secs"`
 
 	LimitBytesPerSec float64 `yaml:"limit-bytes-per-sec"`
 
@@ -750,6 +750,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.BoolP("enable-http-dns-cache", "", false, "Enables DNS cache for HTTP/1 connections")
+
+	if err := flagSet.MarkHidden("enable-http-dns-cache"); err != nil {
+		return err
+	}
+
 	flagSet.BoolP("enable-new-reader", "", true, "Enables support for new reader implementation.")
 
 	if err := flagSet.MarkHidden("enable-new-reader"); err != nil {
@@ -859,12 +865,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
 	flagSet.DurationP("http-client-timeout", "", 0*time.Nanosecond, "The time duration that http client will wait to get response from the server. A value of 0 indicates no timeout.")
-
-	flagSet.IntP("http-dns-cache-ttl-secs", "", 0, "Sets the DNS cache TTL for HTTP/1 connection to the specified value in seconds. Special values: -1 means infinite TTL and 0 disables caching")
-
-	if err := flagSet.MarkHidden("http-dns-cache-ttl-secs"); err != nil {
-		return err
-	}
 
 	flagSet.BoolP("ignore-interrupts", "", true, "Instructs gcsfuse to ignore system interrupt signals (like SIGINT, triggered by Ctrl+C). This prevents those signals from immediately terminating gcsfuse inflight operations.")
 
@@ -1187,6 +1187,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	if err := v.BindPFlag("gcs-connection.enable-http-dns-cache", flagSet.Lookup("enable-http-dns-cache")); err != nil {
+		return err
+	}
+
 	if err := v.BindPFlag("enable-new-reader", flagSet.Lookup("enable-new-reader")); err != nil {
 		return err
 	}
@@ -1292,10 +1296,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("gcs-connection.http-client-timeout", flagSet.Lookup("http-client-timeout")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("gcs-connection.http-dns-cache-ttl-secs", flagSet.Lookup("http-dns-cache-ttl-secs")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -421,6 +421,13 @@ params:
       https://storage.googleapis.com/storage/v1.
     default: ""
 
+  - config-path: "gcs-connection.enable-http-dns-cache"
+    flag-name: "enable-http-dns-cache"
+    type: "bool"
+    usage: "Enables DNS cache for HTTP/1 connections"
+    default: false
+    hide-flag: true
+
   - config-path: "gcs-connection.experimental-enable-json-read"
     flag-name: "experimental-enable-json-read"
     type: "bool"
@@ -446,13 +453,6 @@ params:
       The time duration that http client will wait to get response from the
       server. A value of 0 indicates no timeout.
     default: "0s"
-
-  - config-path: "gcs-connection.http-dns-cache-ttl-secs"
-    flag-name: "http-dns-cache-ttl-secs"
-    type: "int"
-    usage: "Sets the DNS cache TTL for HTTP/1 connection to the specified value in seconds. Special values: -1 means infinite TTL and 0 disables caching"
-    default: "0"
-    hide-flag: true
 
   - config-path: "gcs-connection.limit-bytes-per-sec"
     flag-name: "limit-bytes-per-sec"

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -106,13 +106,6 @@ func isValidSequentialReadSizeMB(size int64) error {
 	return nil
 }
 
-func isValidHTTPDNSCacheTTLSecs(secs int64) error {
-	if secs < -1 {
-		return fmt.Errorf("the value of http-dns-cache-ttl-secs can't be less than -1")
-	}
-	return nil
-}
-
 // isTTLInSecsValid return nil error if ttlInSecs is valid.
 func isTTLInSecsValid(secs int64) error {
 	if secs < -1 {
@@ -296,10 +289,6 @@ func ValidateConfig(v isSet, config *Config) error {
 
 	if err = isValidURL(config.GcsAuth.TokenUrl); err != nil {
 		return fmt.Errorf("error parsing token-url config: %w", err)
-	}
-
-	if err = isValidHTTPDNSCacheTTLSecs(config.GcsConnection.HttpDnsCacheTtlSecs); err != nil {
-		return fmt.Errorf("error parsing http-dns-cache-ttl-secs config: %w", err)
 	}
 
 	if err = isValidSequentialReadSizeMB(config.GcsConnection.SequentialReadSizeMb); err != nil {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -480,36 +480,6 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 	}
 }
 
-func Test_isValidHTTPDNSCacheTTLSecsValid(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name string
-		secs int64
-	}{
-		{
-			name: "minus_one",
-			secs: -1,
-		},
-		{
-			name: "zero",
-			secs: 0,
-		},
-		{
-			name: "positive_value",
-			secs: 100,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.NoError(t, isValidHTTPDNSCacheTTLSecs(tc.secs))
-		})
-	}
-}
-
-func Test_isValidHTTPDNSCacheTTLSecsInvalid(t *testing.T) {
-	assert.Error(t, isValidHTTPDNSCacheTTLSecs(-2))
-}
-
 func Test_IsTtlInSecsValid_ErrorScenarios(t *testing.T) {
 	var testCases = []struct {
 		testName  string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -818,8 +818,8 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "Test http-dns-cache-ttl-secs flag.",
-			args: []string{"gcsfuse", "--http-dns-cache-ttl-secs=120", "abc", "pqr"},
+			name: "test_dns_cache",
+			args: []string{"gcsfuse", "--enable-http-dns-cache", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				GcsConnection: cfg.GcsConnectionConfig{
 					BillingProject:             "",
@@ -833,7 +833,7 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 					MaxConnsPerHost:            0,
 					MaxIdleConnsPerHost:        100,
 					SequentialReadSizeMb:       200,
-					HttpDnsCacheTtlSecs:        120,
+					EnableHttpDnsCache:         true,
 				},
 			},
 		},


### PR DESCRIPTION
### Description
Rename the erstwhile http-dns-cache-ttl-secs flag to enable-http-dns-cache which is a boolean flag. The DNS caching infrastructure will take care of handling the TTL.

### Link to the issue in case of a bug fix.
b/446170703

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
