### PR TITLE
feat(optimize profile): make the flag --profile visible in gcsfuse --help

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -944,10 +944,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("profile", "", "", "The name of the profile to apply. e.g. aiml-training, aiml-serving, aiml-checkpointing")
 
-	if err := flagSet.MarkHidden("profile"); err != nil {
-		return err
-	}
-
 	flagSet.IntP("prometheus-port", "", 0, "Expose Prometheus metrics endpoint on this port and a path of /metrics.")
 
 	flagSet.IntP("read-block-size-mb", "", 16, "Specifies the block size for buffered reads. The value should be more than 0. This is used to read data in chunks from GCS.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -856,7 +856,6 @@ params:
     type: "string"
     usage: "The name of the profile to apply. e.g. aiml-training, aiml-serving, aiml-checkpointing"
     default: ""
-    hide-flag: true
 
   - config-path: "read.block-size-mb"
     flag-name: "read-block-size-mb"


### PR DESCRIPTION
### Description
Make the flag `--profile` visible in `gcsfuse --help` .

### Link to the issue in case of a bug fix.
[b/446805375](http://b/446805375)

### Testing details
1. Manual - Tested manually. The flag now shows up on `gcsfuse --help` as 
   ```sh
   gcsfuse$ go run . --help | grep -i profile
      --profile string                               The name of the profile to apply. e.g. aiml-training, aiml-serving, aiml-checkpointing
   ```
3. Unit tests - NA
4. Integration tests - Ran as presubmit
   - [run](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/8316d438-f3dd-4cdd-83d4-ec17b007fdf5) - e2e non-zb

### Any backward incompatible change? If so, please explain.
