### PR TITLE
fix(cd scripts): use uname -m to get the platform architecture in release pipeline machines

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -145,7 +145,7 @@ then
 else
 #  For rhel and centos
     # uname can be aarch or x86_64
-    uname=$(uname -i)
+    uname=$(uname -m)
 
     if [[ $uname == "x86_64" ]]; then
       architecture="amd64"


### PR DESCRIPTION
### Description
Same as title
### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes, this is more robust as uname -i returns unknown for newer rhel/centos/rocky-linux-10 series.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
