### PR TITLE
feat(metrics): Generate typed constants for metric attributes

### DIFF
--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -84,8 +84,8 @@ func (p *DownloadTask) Execute() {
 			logger.Errorf("Download: -> block (%s, %v) failed: %v.", p.object.Name, blockId, err)
 			p.block.NotifyReady(block.BlockStatus{State: block.BlockStateDownloadFailed, Err: err})
 		}
-		p.metricHandle.BufferedReadDownloadBlockLatency(p.ctx, dur, status)
-		p.metricHandle.BufferedReadScheduledBlockCount(1, status)
+		p.metricHandle.BufferedReadDownloadBlockLatency(p.ctx, dur, metrics.Status(status))
+		p.metricHandle.BufferedReadScheduledBlockCount(1, metrics.Status(status))
 	}()
 
 	start := uint64(startOff)

--- a/internal/fs/wrappers/monitoring.go
+++ b/internal/fs/wrappers/monitoring.go
@@ -226,14 +226,14 @@ func categorize(err error) string {
 
 // Records file system operation count, failed operation count and the operation latency.
 func recordOp(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time, fsErr error) {
-	metricHandle.FsOpsCount(1, method)
+	metricHandle.FsOpsCount(1, metrics.FsOp(method))
 
 	// Recording opErrorCount.
 	if fsErr != nil {
 		errCategory := categorize(fsErr)
-		metricHandle.FsOpsErrorCount(1, errCategory, method)
+		metricHandle.FsOpsErrorCount(1, metrics.FsErrorCategory(errCategory), metrics.FsOp(method))
 	}
-	metricHandle.FsOpsLatency(ctx, time.Since(start), method)
+	metricHandle.FsOpsLatency(ctx, time.Since(start), metrics.FsOp(method))
 }
 
 // WithMonitoring takes a FileSystem, returns a FileSystem with monitoring

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -208,8 +208,8 @@ func (fc *FileCacheReader) ReadAt(ctx context.Context, p []byte, offset int64) (
 }
 
 func captureFileCacheMetrics(ctx context.Context, metricHandle metrics.MetricHandle, readType string, readDataSize int, cacheHit bool, readLatency time.Duration) {
-	metricHandle.FileCacheReadCount(1, cacheHit, readType)
-	metricHandle.FileCacheReadBytesCount(int64(readDataSize), readType)
+	metricHandle.FileCacheReadCount(1, cacheHit, metrics.ReadType(readType))
+	metricHandle.FileCacheReadBytesCount(int64(readDataSize), metrics.ReadType(readType))
 	metricHandle.FileCacheReadLatencies(ctx, readLatency, cacheHit)
 }
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -26,9 +26,9 @@ import (
 
 // recordRequest records a request and its latency.
 func recordRequest(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time) {
-	metricHandle.GcsRequestCount(1, method)
+	metricHandle.GcsRequestCount(1, metrics.GcsMethod(method))
 
-	metricHandle.GcsRequestLatencies(ctx, time.Since(start), method)
+	metricHandle.GcsRequestLatencies(ctx, time.Since(start), metrics.GcsMethod(method))
 }
 
 func CaptureMultiRangeDownloaderMetrics(ctx context.Context, metricHandle metrics.MetricHandle, method string, start time.Time) {
@@ -217,7 +217,7 @@ func (mb *monitoringBucket) GCSName(obj *gcs.MinObject) string {
 
 // recordReader increments the reader count when it's opened or closed.
 func recordReader(metricHandle metrics.MetricHandle, ioMethod string) {
-	metricHandle.GcsReaderCount(1, ioMethod)
+	metricHandle.GcsReaderCount(1, metrics.IoMethod(ioMethod))
 }
 
 // Monitoring on the object reader

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -76,6 +76,6 @@ func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metr
 		val = "STALLED_READ_REQUEST"
 	}
 
-	metricHandle.GcsRetryCount(1, val)
+	metricHandle.GcsRetryCount(1, metrics.RetryErrorCategory(val))
 	return retry
 }

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -157,10 +157,10 @@ type fakeMetricHandle struct {
 	gcsRetryCountVal    string
 }
 
-func (m *fakeMetricHandle) GcsRetryCount(inc int64, val string) {
+func (m *fakeMetricHandle) GcsRetryCount(inc int64, val metrics.RetryErrorCategory) {
 	m.gcsRetryCountCalled = true
 	m.gcsRetryCountInc = inc
-	m.gcsRetryCountVal = val
+	m.gcsRetryCountVal = string(val)
 }
 
 func TestShouldRetryWithMonitoringForNonRetryableErrors(t *testing.T) {

--- a/metrics/helper.go
+++ b/metrics/helper.go
@@ -17,6 +17,6 @@ package metrics
 // CaptureGCSReadMetrics is a helper function to encapsulate the logic for recording
 // GCS read-related metrics.
 func CaptureGCSReadMetrics(mh MetricHandle, readType string, downloadBytes int64) {
-	mh.GcsReadCount(1, readType)
-	mh.GcsDownloadBytesCount(downloadBytes, readType)
+	mh.GcsReadCount(1, ReadType(readType))
+	mh.GcsDownloadBytesCount(downloadBytes, ReadType(readType))
 }

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -20,64 +20,199 @@ import (
 	"time"
 )
 
+// FsErrorCategory is a custom type for the fs_error_category attribute.
+type FsErrorCategory string
+
+const (
+	FsErrorCategoryDEVICEERRORAttr              FsErrorCategory = "DEVICE_ERROR"
+	FsErrorCategoryDIRNOTEMPTYAttr              FsErrorCategory = "DIR_NOT_EMPTY"
+	FsErrorCategoryFILEDIRERRORAttr             FsErrorCategory = "FILE_DIR_ERROR"
+	FsErrorCategoryFILEEXISTSAttr               FsErrorCategory = "FILE_EXISTS"
+	FsErrorCategoryINTERRUPTERRORAttr           FsErrorCategory = "INTERRUPT_ERROR"
+	FsErrorCategoryINVALIDARGUMENTAttr          FsErrorCategory = "INVALID_ARGUMENT"
+	FsErrorCategoryINVALIDOPERATIONAttr         FsErrorCategory = "INVALID_OPERATION"
+	FsErrorCategoryIOERRORAttr                  FsErrorCategory = "IO_ERROR"
+	FsErrorCategoryMISCERRORAttr                FsErrorCategory = "MISC_ERROR"
+	FsErrorCategoryNETWORKERRORAttr             FsErrorCategory = "NETWORK_ERROR"
+	FsErrorCategoryNOTADIRAttr                  FsErrorCategory = "NOT_A_DIR"
+	FsErrorCategoryNOTIMPLEMENTEDAttr           FsErrorCategory = "NOT_IMPLEMENTED"
+	FsErrorCategoryNOFILEORDIRAttr              FsErrorCategory = "NO_FILE_OR_DIR"
+	FsErrorCategoryPERMERRORAttr                FsErrorCategory = "PERM_ERROR"
+	FsErrorCategoryPROCESSRESOURCEMGMTERRORAttr FsErrorCategory = "PROCESS_RESOURCE_MGMT_ERROR"
+	FsErrorCategoryTOOMANYOPENFILESAttr         FsErrorCategory = "TOO_MANY_OPEN_FILES"
+)
+
+// FsOp is a custom type for the fs_op attribute.
+type FsOp string
+
+const (
+	FsOpBatchForgetAttr        FsOp = "BatchForget"
+	FsOpCreateFileAttr         FsOp = "CreateFile"
+	FsOpCreateLinkAttr         FsOp = "CreateLink"
+	FsOpCreateSymlinkAttr      FsOp = "CreateSymlink"
+	FsOpFallocateAttr          FsOp = "Fallocate"
+	FsOpFlushFileAttr          FsOp = "FlushFile"
+	FsOpForgetInodeAttr        FsOp = "ForgetInode"
+	FsOpGetInodeAttributesAttr FsOp = "GetInodeAttributes"
+	FsOpGetXattrAttr           FsOp = "GetXattr"
+	FsOpListXattrAttr          FsOp = "ListXattr"
+	FsOpLookUpInodeAttr        FsOp = "LookUpInode"
+	FsOpMkDirAttr              FsOp = "MkDir"
+	FsOpMkNodeAttr             FsOp = "MkNode"
+	FsOpOpenDirAttr            FsOp = "OpenDir"
+	FsOpOpenFileAttr           FsOp = "OpenFile"
+	FsOpReadDirAttr            FsOp = "ReadDir"
+	FsOpReadDirPlusAttr        FsOp = "ReadDirPlus"
+	FsOpReadFileAttr           FsOp = "ReadFile"
+	FsOpReadSymlinkAttr        FsOp = "ReadSymlink"
+	FsOpReleaseDirHandleAttr   FsOp = "ReleaseDirHandle"
+	FsOpReleaseFileHandleAttr  FsOp = "ReleaseFileHandle"
+	FsOpRemoveXattrAttr        FsOp = "RemoveXattr"
+	FsOpRenameAttr             FsOp = "Rename"
+	FsOpRmDirAttr              FsOp = "RmDir"
+	FsOpSetInodeAttributesAttr FsOp = "SetInodeAttributes"
+	FsOpSetXattrAttr           FsOp = "SetXattr"
+	FsOpStatFSAttr             FsOp = "StatFS"
+	FsOpSyncFSAttr             FsOp = "SyncFS"
+	FsOpSyncFileAttr           FsOp = "SyncFile"
+	FsOpUnlinkAttr             FsOp = "Unlink"
+	FsOpWriteFileAttr          FsOp = "WriteFile"
+)
+
+// GcsMethod is a custom type for the gcs_method attribute.
+type GcsMethod string
+
+const (
+	GcsMethodComposeObjectsAttr               GcsMethod = "ComposeObjects"
+	GcsMethodCopyObjectAttr                   GcsMethod = "CopyObject"
+	GcsMethodCreateAppendableObjectWriterAttr GcsMethod = "CreateAppendableObjectWriter"
+	GcsMethodCreateFolderAttr                 GcsMethod = "CreateFolder"
+	GcsMethodCreateObjectAttr                 GcsMethod = "CreateObject"
+	GcsMethodCreateObjectChunkWriterAttr      GcsMethod = "CreateObjectChunkWriter"
+	GcsMethodDeleteFolderAttr                 GcsMethod = "DeleteFolder"
+	GcsMethodDeleteObjectAttr                 GcsMethod = "DeleteObject"
+	GcsMethodFinalizeUploadAttr               GcsMethod = "FinalizeUpload"
+	GcsMethodFlushPendingWritesAttr           GcsMethod = "FlushPendingWrites"
+	GcsMethodGetFolderAttr                    GcsMethod = "GetFolder"
+	GcsMethodListObjectsAttr                  GcsMethod = "ListObjects"
+	GcsMethodMoveObjectAttr                   GcsMethod = "MoveObject"
+	GcsMethodMultiRangeDownloaderAddAttr      GcsMethod = "MultiRangeDownloader::Add"
+	GcsMethodNewMultiRangeDownloaderAttr      GcsMethod = "NewMultiRangeDownloader"
+	GcsMethodNewReaderAttr                    GcsMethod = "NewReader"
+	GcsMethodRenameFolderAttr                 GcsMethod = "RenameFolder"
+	GcsMethodStatObjectAttr                   GcsMethod = "StatObject"
+	GcsMethodUpdateObjectAttr                 GcsMethod = "UpdateObject"
+)
+
+// IoMethod is a custom type for the io_method attribute.
+type IoMethod string
+
+const (
+	IoMethodReadHandleAttr IoMethod = "ReadHandle"
+	IoMethodClosedAttr     IoMethod = "closed"
+	IoMethodOpenedAttr     IoMethod = "opened"
+)
+
+// ReadType is a custom type for the read_type attribute.
+type ReadType string
+
+const (
+	ReadTypeParallelAttr   ReadType = "Parallel"
+	ReadTypeRandomAttr     ReadType = "Random"
+	ReadTypeSequentialAttr ReadType = "Sequential"
+)
+
+// Reason is a custom type for the reason attribute.
+type Reason string
+
+const (
+	ReasonInsufficientMemoryAttr Reason = "insufficient_memory"
+	ReasonRandomReadDetectedAttr Reason = "random_read_detected"
+)
+
+// RequestType is a custom type for the request_type attribute.
+type RequestType string
+
+const (
+	RequestTypeAttr1Attr RequestType = "attr1"
+	RequestTypeAttr2Attr RequestType = "attr2"
+)
+
+// RetryErrorCategory is a custom type for the retry_error_category attribute.
+type RetryErrorCategory string
+
+const (
+	RetryErrorCategoryOTHERERRORSAttr        RetryErrorCategory = "OTHER_ERRORS"
+	RetryErrorCategorySTALLEDREADREQUESTAttr RetryErrorCategory = "STALLED_READ_REQUEST"
+)
+
+// Status is a custom type for the status attribute.
+type Status string
+
+const (
+	StatusCancelledAttr  Status = "cancelled"
+	StatusFailedAttr     Status = "failed"
+	StatusSuccessfulAttr Status = "successful"
+)
+
 // MetricHandle provides an interface for recording metrics.
 // The methods of this interface are auto-generated from metrics.yaml.
 // Each method corresponds to a metric defined in metrics.yaml.
 type MetricHandle interface {
 	// BufferedReadDownloadBlockLatency - The cumulative distribution of block download latencies, along with status: successful, cancelled, or failed.
-	BufferedReadDownloadBlockLatency(ctx context.Context, duration time.Duration, status string)
+	BufferedReadDownloadBlockLatency(ctx context.Context, latency time.Duration, status Status)
 
 	// BufferedReadFallbackTriggerCount - The cumulative number of times the BufferedReader falls back to a different reader, along with the reason: random_read_detected or insufficient_memory.
-	BufferedReadFallbackTriggerCount(inc int64, reason string)
+	BufferedReadFallbackTriggerCount(inc int64, reason Reason)
 
 	// BufferedReadReadLatency - The cumulative distribution of latencies for ReadAt calls served by the buffered reader.
-	BufferedReadReadLatency(ctx context.Context, duration time.Duration)
+	BufferedReadReadLatency(ctx context.Context, latency time.Duration)
 
 	// BufferedReadScheduledBlockCount - The cumulative number of scheduled download blocks, along with their final status: successful, cancelled, or failed.
-	BufferedReadScheduledBlockCount(inc int64, status string)
+	BufferedReadScheduledBlockCount(inc int64, status Status)
 
 	// FileCacheReadBytesCount - The cumulative number of bytes read from file cache along with read type - Sequential/Random
-	FileCacheReadBytesCount(inc int64, readType string)
+	FileCacheReadBytesCount(inc int64, readType ReadType)
 
 	// FileCacheReadCount - Specifies the number of read requests made via file cache along with type - Sequential/Random and cache hit - true/false
-	FileCacheReadCount(inc int64, cacheHit bool, readType string)
+	FileCacheReadCount(inc int64, cacheHit bool, readType ReadType)
 
 	// FileCacheReadLatencies - The cumulative distribution of the file cache read latencies along with cache hit - true/false.
-	FileCacheReadLatencies(ctx context.Context, duration time.Duration, cacheHit bool)
+	FileCacheReadLatencies(ctx context.Context, latency time.Duration, cacheHit bool)
 
 	// FsOpsCount - The cumulative number of ops processed by the file system.
-	FsOpsCount(inc int64, fsOp string)
+	FsOpsCount(inc int64, fsOp FsOp)
 
 	// FsOpsErrorCount - The cumulative number of errors generated by file system operations.
-	FsOpsErrorCount(inc int64, fsErrorCategory string, fsOp string)
+	FsOpsErrorCount(inc int64, fsErrorCategory FsErrorCategory, fsOp FsOp)
 
 	// FsOpsLatency - The cumulative distribution of file system operation latencies
-	FsOpsLatency(ctx context.Context, duration time.Duration, fsOp string)
+	FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp)
 
 	// GcsDownloadBytesCount - The cumulative number of bytes downloaded from GCS along with type - Sequential/Random
-	GcsDownloadBytesCount(inc int64, readType string)
+	GcsDownloadBytesCount(inc int64, readType ReadType)
 
 	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
 	GcsReadBytesCount(inc int64)
 
 	// GcsReadCount - Specifies the number of gcs reads made along with type - Sequential/Random
-	GcsReadCount(inc int64, readType string)
+	GcsReadCount(inc int64, readType ReadType)
 
 	// GcsReaderCount - The cumulative number of GCS object readers opened or closed.
-	GcsReaderCount(inc int64, ioMethod string)
+	GcsReaderCount(inc int64, ioMethod IoMethod)
 
 	// GcsRequestCount - The cumulative number of GCS requests processed along with the GCS method.
-	GcsRequestCount(inc int64, gcsMethod string)
+	GcsRequestCount(inc int64, gcsMethod GcsMethod)
 
 	// GcsRequestLatencies - The cumulative distribution of the GCS request latencies.
-	GcsRequestLatencies(ctx context.Context, duration time.Duration, gcsMethod string)
+	GcsRequestLatencies(ctx context.Context, latency time.Duration, gcsMethod GcsMethod)
 
 	// GcsRetryCount - The cumulative number of retry requests made to GCS.
-	GcsRetryCount(inc int64, retryErrorCategory string)
+	GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory)
 
 	// TestUpdownCounter - Test metric for updown counters.
 	TestUpdownCounter(inc int64)
 
 	// TestUpdownCounterWithAttrs - Test metric for updown counters with attributes.
-	TestUpdownCounterWithAttrs(inc int64, requestType string)
+	TestUpdownCounterWithAttrs(inc int64, requestType RequestType)
 }

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -22,46 +22,46 @@ import (
 
 type noopMetrics struct{}
 
-func (*noopMetrics) BufferedReadDownloadBlockLatency(ctx context.Context, duration time.Duration, status string) {
+func (*noopMetrics) BufferedReadDownloadBlockLatency(ctx context.Context, latency time.Duration, status Status) {
 }
 
-func (*noopMetrics) BufferedReadFallbackTriggerCount(inc int64, reason string) {}
+func (*noopMetrics) BufferedReadFallbackTriggerCount(inc int64, reason Reason) {}
 
-func (*noopMetrics) BufferedReadReadLatency(ctx context.Context, duration time.Duration) {}
+func (*noopMetrics) BufferedReadReadLatency(ctx context.Context, latency time.Duration) {}
 
-func (*noopMetrics) BufferedReadScheduledBlockCount(inc int64, status string) {}
+func (*noopMetrics) BufferedReadScheduledBlockCount(inc int64, status Status) {}
 
-func (*noopMetrics) FileCacheReadBytesCount(inc int64, readType string) {}
+func (*noopMetrics) FileCacheReadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) FileCacheReadCount(inc int64, cacheHit bool, readType string) {}
+func (*noopMetrics) FileCacheReadCount(inc int64, cacheHit bool, readType ReadType) {}
 
-func (*noopMetrics) FileCacheReadLatencies(ctx context.Context, duration time.Duration, cacheHit bool) {
+func (*noopMetrics) FileCacheReadLatencies(ctx context.Context, latency time.Duration, cacheHit bool) {
 }
 
-func (*noopMetrics) FsOpsCount(inc int64, fsOp string) {}
+func (*noopMetrics) FsOpsCount(inc int64, fsOp FsOp) {}
 
-func (*noopMetrics) FsOpsErrorCount(inc int64, fsErrorCategory string, fsOp string) {}
+func (*noopMetrics) FsOpsErrorCount(inc int64, fsErrorCategory FsErrorCategory, fsOp FsOp) {}
 
-func (*noopMetrics) FsOpsLatency(ctx context.Context, duration time.Duration, fsOp string) {}
+func (*noopMetrics) FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp) {}
 
-func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType string) {}
+func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 
-func (*noopMetrics) GcsReadCount(inc int64, readType string) {}
+func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsReaderCount(inc int64, ioMethod string) {}
+func (*noopMetrics) GcsReaderCount(inc int64, ioMethod IoMethod) {}
 
-func (*noopMetrics) GcsRequestCount(inc int64, gcsMethod string) {}
+func (*noopMetrics) GcsRequestCount(inc int64, gcsMethod GcsMethod) {}
 
-func (*noopMetrics) GcsRequestLatencies(ctx context.Context, duration time.Duration, gcsMethod string) {
+func (*noopMetrics) GcsRequestLatencies(ctx context.Context, latency time.Duration, gcsMethod GcsMethod) {
 }
 
-func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory string) {}
+func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory) {}
 
 func (*noopMetrics) TestUpdownCounter(inc int64) {}
 
-func (*noopMetrics) TestUpdownCounterWithAttrs(inc int64, requestType string) {}
+func (*noopMetrics) TestUpdownCounterWithAttrs(inc int64, requestType RequestType) {}
 
 func NewNoopMetrics() MetricHandle {
 	var n noopMetrics

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -1256,17 +1256,17 @@ type otelMetrics struct {
 }
 
 func (o *otelMetrics) BufferedReadDownloadBlockLatency(
-	ctx context.Context, latency time.Duration, status string) {
+	ctx context.Context, latency time.Duration, status Status) {
 	var record histogramRecord
 	switch status {
-	case "cancelled":
+	case StatusCancelledAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.bufferedReadDownloadBlockLatency, value: latency.Microseconds(), attributes: bufferedReadDownloadBlockLatencyStatusCancelledAttrSet}
-	case "failed":
+	case StatusFailedAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.bufferedReadDownloadBlockLatency, value: latency.Microseconds(), attributes: bufferedReadDownloadBlockLatencyStatusFailedAttrSet}
-	case "successful":
+	case StatusSuccessfulAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.bufferedReadDownloadBlockLatency, value: latency.Microseconds(), attributes: bufferedReadDownloadBlockLatencyStatusSuccessfulAttrSet}
 	default:
-		updateUnrecognizedAttribute(status)
+		updateUnrecognizedAttribute(string(status))
 		return
 	}
 
@@ -1277,18 +1277,18 @@ func (o *otelMetrics) BufferedReadDownloadBlockLatency(
 }
 
 func (o *otelMetrics) BufferedReadFallbackTriggerCount(
-	inc int64, reason string) {
+	inc int64, reason Reason) {
 	if inc < 0 {
 		logger.Errorf("Counter metric buffered_read/fallback_trigger_count received a negative increment: %d", inc)
 		return
 	}
 	switch reason {
-	case "insufficient_memory":
+	case ReasonInsufficientMemoryAttr:
 		o.bufferedReadFallbackTriggerCountReasonInsufficientMemoryAtomic.Add(inc)
-	case "random_read_detected":
+	case ReasonRandomReadDetectedAttr:
 		o.bufferedReadFallbackTriggerCountReasonRandomReadDetectedAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(reason)
+		updateUnrecognizedAttribute(string(reason))
 		return
 	}
 }
@@ -1305,45 +1305,45 @@ func (o *otelMetrics) BufferedReadReadLatency(
 }
 
 func (o *otelMetrics) BufferedReadScheduledBlockCount(
-	inc int64, status string) {
+	inc int64, status Status) {
 	if inc < 0 {
 		logger.Errorf("Counter metric buffered_read/scheduled_block_count received a negative increment: %d", inc)
 		return
 	}
 	switch status {
-	case "cancelled":
+	case StatusCancelledAttr:
 		o.bufferedReadScheduledBlockCountStatusCancelledAtomic.Add(inc)
-	case "failed":
+	case StatusFailedAttr:
 		o.bufferedReadScheduledBlockCountStatusFailedAtomic.Add(inc)
-	case "successful":
+	case StatusSuccessfulAttr:
 		o.bufferedReadScheduledBlockCountStatusSuccessfulAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(status)
+		updateUnrecognizedAttribute(string(status))
 		return
 	}
 }
 
 func (o *otelMetrics) FileCacheReadBytesCount(
-	inc int64, readType string) {
+	inc int64, readType ReadType) {
 	if inc < 0 {
 		logger.Errorf("Counter metric file_cache/read_bytes_count received a negative increment: %d", inc)
 		return
 	}
 	switch readType {
-	case "Parallel":
+	case ReadTypeParallelAttr:
 		o.fileCacheReadBytesCountReadTypeParallelAtomic.Add(inc)
-	case "Random":
+	case ReadTypeRandomAttr:
 		o.fileCacheReadBytesCountReadTypeRandomAtomic.Add(inc)
-	case "Sequential":
+	case ReadTypeSequentialAttr:
 		o.fileCacheReadBytesCountReadTypeSequentialAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(readType)
+		updateUnrecognizedAttribute(string(readType))
 		return
 	}
 }
 
 func (o *otelMetrics) FileCacheReadCount(
-	inc int64, cacheHit bool, readType string) {
+	inc int64, cacheHit bool, readType ReadType) {
 	if inc < 0 {
 		logger.Errorf("Counter metric file_cache/read_count received a negative increment: %d", inc)
 		return
@@ -1351,26 +1351,26 @@ func (o *otelMetrics) FileCacheReadCount(
 	switch cacheHit {
 	case true:
 		switch readType {
-		case "Parallel":
+		case ReadTypeParallelAttr:
 			o.fileCacheReadCountCacheHitTrueReadTypeParallelAtomic.Add(inc)
-		case "Random":
+		case ReadTypeRandomAttr:
 			o.fileCacheReadCountCacheHitTrueReadTypeRandomAtomic.Add(inc)
-		case "Sequential":
+		case ReadTypeSequentialAttr:
 			o.fileCacheReadCountCacheHitTrueReadTypeSequentialAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(readType)
+			updateUnrecognizedAttribute(string(readType))
 			return
 		}
 	case false:
 		switch readType {
-		case "Parallel":
+		case ReadTypeParallelAttr:
 			o.fileCacheReadCountCacheHitFalseReadTypeParallelAtomic.Add(inc)
-		case "Random":
+		case ReadTypeRandomAttr:
 			o.fileCacheReadCountCacheHitFalseReadTypeRandomAtomic.Add(inc)
-		case "Sequential":
+		case ReadTypeSequentialAttr:
 			o.fileCacheReadCountCacheHitFalseReadTypeSequentialAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(readType)
+			updateUnrecognizedAttribute(string(readType))
 			return
 		}
 	}
@@ -1393,1249 +1393,1249 @@ func (o *otelMetrics) FileCacheReadLatencies(
 }
 
 func (o *otelMetrics) FsOpsCount(
-	inc int64, fsOp string) {
+	inc int64, fsOp FsOp) {
 	if inc < 0 {
 		logger.Errorf("Counter metric fs/ops_count received a negative increment: %d", inc)
 		return
 	}
 	switch fsOp {
-	case "BatchForget":
+	case FsOpBatchForgetAttr:
 		o.fsOpsCountFsOpBatchForgetAtomic.Add(inc)
-	case "CreateFile":
+	case FsOpCreateFileAttr:
 		o.fsOpsCountFsOpCreateFileAtomic.Add(inc)
-	case "CreateLink":
+	case FsOpCreateLinkAttr:
 		o.fsOpsCountFsOpCreateLinkAtomic.Add(inc)
-	case "CreateSymlink":
+	case FsOpCreateSymlinkAttr:
 		o.fsOpsCountFsOpCreateSymlinkAtomic.Add(inc)
-	case "Fallocate":
+	case FsOpFallocateAttr:
 		o.fsOpsCountFsOpFallocateAtomic.Add(inc)
-	case "FlushFile":
+	case FsOpFlushFileAttr:
 		o.fsOpsCountFsOpFlushFileAtomic.Add(inc)
-	case "ForgetInode":
+	case FsOpForgetInodeAttr:
 		o.fsOpsCountFsOpForgetInodeAtomic.Add(inc)
-	case "GetInodeAttributes":
+	case FsOpGetInodeAttributesAttr:
 		o.fsOpsCountFsOpGetInodeAttributesAtomic.Add(inc)
-	case "GetXattr":
+	case FsOpGetXattrAttr:
 		o.fsOpsCountFsOpGetXattrAtomic.Add(inc)
-	case "ListXattr":
+	case FsOpListXattrAttr:
 		o.fsOpsCountFsOpListXattrAtomic.Add(inc)
-	case "LookUpInode":
+	case FsOpLookUpInodeAttr:
 		o.fsOpsCountFsOpLookUpInodeAtomic.Add(inc)
-	case "MkDir":
+	case FsOpMkDirAttr:
 		o.fsOpsCountFsOpMkDirAtomic.Add(inc)
-	case "MkNode":
+	case FsOpMkNodeAttr:
 		o.fsOpsCountFsOpMkNodeAtomic.Add(inc)
-	case "OpenDir":
+	case FsOpOpenDirAttr:
 		o.fsOpsCountFsOpOpenDirAtomic.Add(inc)
-	case "OpenFile":
+	case FsOpOpenFileAttr:
 		o.fsOpsCountFsOpOpenFileAtomic.Add(inc)
-	case "ReadDir":
+	case FsOpReadDirAttr:
 		o.fsOpsCountFsOpReadDirAtomic.Add(inc)
-	case "ReadDirPlus":
+	case FsOpReadDirPlusAttr:
 		o.fsOpsCountFsOpReadDirPlusAtomic.Add(inc)
-	case "ReadFile":
+	case FsOpReadFileAttr:
 		o.fsOpsCountFsOpReadFileAtomic.Add(inc)
-	case "ReadSymlink":
+	case FsOpReadSymlinkAttr:
 		o.fsOpsCountFsOpReadSymlinkAtomic.Add(inc)
-	case "ReleaseDirHandle":
+	case FsOpReleaseDirHandleAttr:
 		o.fsOpsCountFsOpReleaseDirHandleAtomic.Add(inc)
-	case "ReleaseFileHandle":
+	case FsOpReleaseFileHandleAttr:
 		o.fsOpsCountFsOpReleaseFileHandleAtomic.Add(inc)
-	case "RemoveXattr":
+	case FsOpRemoveXattrAttr:
 		o.fsOpsCountFsOpRemoveXattrAtomic.Add(inc)
-	case "Rename":
+	case FsOpRenameAttr:
 		o.fsOpsCountFsOpRenameAtomic.Add(inc)
-	case "RmDir":
+	case FsOpRmDirAttr:
 		o.fsOpsCountFsOpRmDirAtomic.Add(inc)
-	case "SetInodeAttributes":
+	case FsOpSetInodeAttributesAttr:
 		o.fsOpsCountFsOpSetInodeAttributesAtomic.Add(inc)
-	case "SetXattr":
+	case FsOpSetXattrAttr:
 		o.fsOpsCountFsOpSetXattrAtomic.Add(inc)
-	case "StatFS":
+	case FsOpStatFSAttr:
 		o.fsOpsCountFsOpStatFSAtomic.Add(inc)
-	case "SyncFS":
+	case FsOpSyncFSAttr:
 		o.fsOpsCountFsOpSyncFSAtomic.Add(inc)
-	case "SyncFile":
+	case FsOpSyncFileAttr:
 		o.fsOpsCountFsOpSyncFileAtomic.Add(inc)
-	case "Unlink":
+	case FsOpUnlinkAttr:
 		o.fsOpsCountFsOpUnlinkAtomic.Add(inc)
-	case "WriteFile":
+	case FsOpWriteFileAttr:
 		o.fsOpsCountFsOpWriteFileAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(fsOp)
+		updateUnrecognizedAttribute(string(fsOp))
 		return
 	}
 }
 
 func (o *otelMetrics) FsOpsErrorCount(
-	inc int64, fsErrorCategory string, fsOp string) {
+	inc int64, fsErrorCategory FsErrorCategory, fsOp FsOp) {
 	if inc < 0 {
 		logger.Errorf("Counter metric fs/ops_error_count received a negative increment: %d", inc)
 		return
 	}
 	switch fsErrorCategory {
-	case "DEVICE_ERROR":
+	case FsErrorCategoryDEVICEERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "DIR_NOT_EMPTY":
+	case FsErrorCategoryDIRNOTEMPTYAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "FILE_DIR_ERROR":
+	case FsErrorCategoryFILEDIRERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "FILE_EXISTS":
+	case FsErrorCategoryFILEEXISTSAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "INTERRUPT_ERROR":
+	case FsErrorCategoryINTERRUPTERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "INVALID_ARGUMENT":
+	case FsErrorCategoryINVALIDARGUMENTAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "INVALID_OPERATION":
+	case FsErrorCategoryINVALIDOPERATIONAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "IO_ERROR":
+	case FsErrorCategoryIOERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "MISC_ERROR":
+	case FsErrorCategoryMISCERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "NETWORK_ERROR":
+	case FsErrorCategoryNETWORKERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "NOT_A_DIR":
+	case FsErrorCategoryNOTADIRAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "NOT_IMPLEMENTED":
+	case FsErrorCategoryNOTIMPLEMENTEDAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "NO_FILE_OR_DIR":
+	case FsErrorCategoryNOFILEORDIRAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "PERM_ERROR":
+	case FsErrorCategoryPERMERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "PROCESS_RESOURCE_MGMT_ERROR":
+	case FsErrorCategoryPROCESSRESOURCEMGMTERRORAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
-	case "TOO_MANY_OPEN_FILES":
+	case FsErrorCategoryTOOMANYOPENFILESAttr:
 		switch fsOp {
-		case "BatchForget":
+		case FsOpBatchForgetAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAtomic.Add(inc)
-		case "CreateFile":
+		case FsOpCreateFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAtomic.Add(inc)
-		case "CreateLink":
+		case FsOpCreateLinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAtomic.Add(inc)
-		case "CreateSymlink":
+		case FsOpCreateSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAtomic.Add(inc)
-		case "Fallocate":
+		case FsOpFallocateAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFallocateAtomic.Add(inc)
-		case "FlushFile":
+		case FsOpFlushFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAtomic.Add(inc)
-		case "ForgetInode":
+		case FsOpForgetInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAtomic.Add(inc)
-		case "GetInodeAttributes":
+		case FsOpGetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAtomic.Add(inc)
-		case "GetXattr":
+		case FsOpGetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetXattrAtomic.Add(inc)
-		case "ListXattr":
+		case FsOpListXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpListXattrAtomic.Add(inc)
-		case "LookUpInode":
+		case FsOpLookUpInodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAtomic.Add(inc)
-		case "MkDir":
+		case FsOpMkDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAtomic.Add(inc)
-		case "MkNode":
+		case FsOpMkNodeAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAtomic.Add(inc)
-		case "OpenDir":
+		case FsOpOpenDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAtomic.Add(inc)
-		case "OpenFile":
+		case FsOpOpenFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAtomic.Add(inc)
-		case "ReadDir":
+		case FsOpReadDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAtomic.Add(inc)
-		case "ReadDirPlus":
+		case FsOpReadDirPlusAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAtomic.Add(inc)
-		case "ReadFile":
+		case FsOpReadFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAtomic.Add(inc)
-		case "ReadSymlink":
+		case FsOpReadSymlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAtomic.Add(inc)
-		case "ReleaseDirHandle":
+		case FsOpReleaseDirHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAtomic.Add(inc)
-		case "ReleaseFileHandle":
+		case FsOpReleaseFileHandleAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAtomic.Add(inc)
-		case "RemoveXattr":
+		case FsOpRemoveXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRemoveXattrAtomic.Add(inc)
-		case "Rename":
+		case FsOpRenameAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAtomic.Add(inc)
-		case "RmDir":
+		case FsOpRmDirAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAtomic.Add(inc)
-		case "SetInodeAttributes":
+		case FsOpSetInodeAttributesAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAtomic.Add(inc)
-		case "SetXattr":
+		case FsOpSetXattrAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetXattrAtomic.Add(inc)
-		case "StatFS":
+		case FsOpStatFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpStatFSAtomic.Add(inc)
-		case "SyncFS":
+		case FsOpSyncFSAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFSAtomic.Add(inc)
-		case "SyncFile":
+		case FsOpSyncFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic.Add(inc)
-		case "Unlink":
+		case FsOpUnlinkAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic.Add(inc)
-		case "WriteFile":
+		case FsOpWriteFileAttr:
 			o.fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic.Add(inc)
 		default:
-			updateUnrecognizedAttribute(fsOp)
+			updateUnrecognizedAttribute(string(fsOp))
 			return
 		}
 	default:
-		updateUnrecognizedAttribute(fsErrorCategory)
+		updateUnrecognizedAttribute(string(fsErrorCategory))
 		return
 	}
 }
 
 func (o *otelMetrics) FsOpsLatency(
-	ctx context.Context, latency time.Duration, fsOp string) {
+	ctx context.Context, latency time.Duration, fsOp FsOp) {
 	var record histogramRecord
 	switch fsOp {
-	case "BatchForget":
+	case FsOpBatchForgetAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpBatchForgetAttrSet}
-	case "CreateFile":
+	case FsOpCreateFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpCreateFileAttrSet}
-	case "CreateLink":
+	case FsOpCreateLinkAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpCreateLinkAttrSet}
-	case "CreateSymlink":
+	case FsOpCreateSymlinkAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpCreateSymlinkAttrSet}
-	case "Fallocate":
+	case FsOpFallocateAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpFallocateAttrSet}
-	case "FlushFile":
+	case FsOpFlushFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpFlushFileAttrSet}
-	case "ForgetInode":
+	case FsOpForgetInodeAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpForgetInodeAttrSet}
-	case "GetInodeAttributes":
+	case FsOpGetInodeAttributesAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpGetInodeAttributesAttrSet}
-	case "GetXattr":
+	case FsOpGetXattrAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpGetXattrAttrSet}
-	case "ListXattr":
+	case FsOpListXattrAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpListXattrAttrSet}
-	case "LookUpInode":
+	case FsOpLookUpInodeAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpLookUpInodeAttrSet}
-	case "MkDir":
+	case FsOpMkDirAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpMkDirAttrSet}
-	case "MkNode":
+	case FsOpMkNodeAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpMkNodeAttrSet}
-	case "OpenDir":
+	case FsOpOpenDirAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpOpenDirAttrSet}
-	case "OpenFile":
+	case FsOpOpenFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpOpenFileAttrSet}
-	case "ReadDir":
+	case FsOpReadDirAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReadDirAttrSet}
-	case "ReadDirPlus":
+	case FsOpReadDirPlusAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReadDirPlusAttrSet}
-	case "ReadFile":
+	case FsOpReadFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReadFileAttrSet}
-	case "ReadSymlink":
+	case FsOpReadSymlinkAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReadSymlinkAttrSet}
-	case "ReleaseDirHandle":
+	case FsOpReleaseDirHandleAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReleaseDirHandleAttrSet}
-	case "ReleaseFileHandle":
+	case FsOpReleaseFileHandleAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpReleaseFileHandleAttrSet}
-	case "RemoveXattr":
+	case FsOpRemoveXattrAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpRemoveXattrAttrSet}
-	case "Rename":
+	case FsOpRenameAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpRenameAttrSet}
-	case "RmDir":
+	case FsOpRmDirAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpRmDirAttrSet}
-	case "SetInodeAttributes":
+	case FsOpSetInodeAttributesAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpSetInodeAttributesAttrSet}
-	case "SetXattr":
+	case FsOpSetXattrAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpSetXattrAttrSet}
-	case "StatFS":
+	case FsOpStatFSAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpStatFSAttrSet}
-	case "SyncFS":
+	case FsOpSyncFSAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpSyncFSAttrSet}
-	case "SyncFile":
+	case FsOpSyncFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpSyncFileAttrSet}
-	case "Unlink":
+	case FsOpUnlinkAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpUnlinkAttrSet}
-	case "WriteFile":
+	case FsOpWriteFileAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.fsOpsLatency, value: latency.Microseconds(), attributes: fsOpsLatencyFsOpWriteFileAttrSet}
 	default:
-		updateUnrecognizedAttribute(fsOp)
+		updateUnrecognizedAttribute(string(fsOp))
 		return
 	}
 
@@ -2646,20 +2646,20 @@ func (o *otelMetrics) FsOpsLatency(
 }
 
 func (o *otelMetrics) GcsDownloadBytesCount(
-	inc int64, readType string) {
+	inc int64, readType ReadType) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/download_bytes_count received a negative increment: %d", inc)
 		return
 	}
 	switch readType {
-	case "Parallel":
+	case ReadTypeParallelAttr:
 		o.gcsDownloadBytesCountReadTypeParallelAtomic.Add(inc)
-	case "Random":
+	case ReadTypeRandomAttr:
 		o.gcsDownloadBytesCountReadTypeRandomAtomic.Add(inc)
-	case "Sequential":
+	case ReadTypeSequentialAttr:
 		o.gcsDownloadBytesCountReadTypeSequentialAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(readType)
+		updateUnrecognizedAttribute(string(readType))
 		return
 	}
 }
@@ -2674,138 +2674,138 @@ func (o *otelMetrics) GcsReadBytesCount(
 }
 
 func (o *otelMetrics) GcsReadCount(
-	inc int64, readType string) {
+	inc int64, readType ReadType) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/read_count received a negative increment: %d", inc)
 		return
 	}
 	switch readType {
-	case "Parallel":
+	case ReadTypeParallelAttr:
 		o.gcsReadCountReadTypeParallelAtomic.Add(inc)
-	case "Random":
+	case ReadTypeRandomAttr:
 		o.gcsReadCountReadTypeRandomAtomic.Add(inc)
-	case "Sequential":
+	case ReadTypeSequentialAttr:
 		o.gcsReadCountReadTypeSequentialAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(readType)
+		updateUnrecognizedAttribute(string(readType))
 		return
 	}
 }
 
 func (o *otelMetrics) GcsReaderCount(
-	inc int64, ioMethod string) {
+	inc int64, ioMethod IoMethod) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/reader_count received a negative increment: %d", inc)
 		return
 	}
 	switch ioMethod {
-	case "ReadHandle":
+	case IoMethodReadHandleAttr:
 		o.gcsReaderCountIoMethodReadHandleAtomic.Add(inc)
-	case "closed":
+	case IoMethodClosedAttr:
 		o.gcsReaderCountIoMethodClosedAtomic.Add(inc)
-	case "opened":
+	case IoMethodOpenedAttr:
 		o.gcsReaderCountIoMethodOpenedAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(ioMethod)
+		updateUnrecognizedAttribute(string(ioMethod))
 		return
 	}
 }
 
 func (o *otelMetrics) GcsRequestCount(
-	inc int64, gcsMethod string) {
+	inc int64, gcsMethod GcsMethod) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/request_count received a negative increment: %d", inc)
 		return
 	}
 	switch gcsMethod {
-	case "ComposeObjects":
+	case GcsMethodComposeObjectsAttr:
 		o.gcsRequestCountGcsMethodComposeObjectsAtomic.Add(inc)
-	case "CopyObject":
+	case GcsMethodCopyObjectAttr:
 		o.gcsRequestCountGcsMethodCopyObjectAtomic.Add(inc)
-	case "CreateAppendableObjectWriter":
+	case GcsMethodCreateAppendableObjectWriterAttr:
 		o.gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic.Add(inc)
-	case "CreateFolder":
+	case GcsMethodCreateFolderAttr:
 		o.gcsRequestCountGcsMethodCreateFolderAtomic.Add(inc)
-	case "CreateObject":
+	case GcsMethodCreateObjectAttr:
 		o.gcsRequestCountGcsMethodCreateObjectAtomic.Add(inc)
-	case "CreateObjectChunkWriter":
+	case GcsMethodCreateObjectChunkWriterAttr:
 		o.gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic.Add(inc)
-	case "DeleteFolder":
+	case GcsMethodDeleteFolderAttr:
 		o.gcsRequestCountGcsMethodDeleteFolderAtomic.Add(inc)
-	case "DeleteObject":
+	case GcsMethodDeleteObjectAttr:
 		o.gcsRequestCountGcsMethodDeleteObjectAtomic.Add(inc)
-	case "FinalizeUpload":
+	case GcsMethodFinalizeUploadAttr:
 		o.gcsRequestCountGcsMethodFinalizeUploadAtomic.Add(inc)
-	case "FlushPendingWrites":
+	case GcsMethodFlushPendingWritesAttr:
 		o.gcsRequestCountGcsMethodFlushPendingWritesAtomic.Add(inc)
-	case "GetFolder":
+	case GcsMethodGetFolderAttr:
 		o.gcsRequestCountGcsMethodGetFolderAtomic.Add(inc)
-	case "ListObjects":
+	case GcsMethodListObjectsAttr:
 		o.gcsRequestCountGcsMethodListObjectsAtomic.Add(inc)
-	case "MoveObject":
+	case GcsMethodMoveObjectAttr:
 		o.gcsRequestCountGcsMethodMoveObjectAtomic.Add(inc)
-	case "MultiRangeDownloader::Add":
+	case GcsMethodMultiRangeDownloaderAddAttr:
 		o.gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic.Add(inc)
-	case "NewMultiRangeDownloader":
+	case GcsMethodNewMultiRangeDownloaderAttr:
 		o.gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic.Add(inc)
-	case "NewReader":
+	case GcsMethodNewReaderAttr:
 		o.gcsRequestCountGcsMethodNewReaderAtomic.Add(inc)
-	case "RenameFolder":
+	case GcsMethodRenameFolderAttr:
 		o.gcsRequestCountGcsMethodRenameFolderAtomic.Add(inc)
-	case "StatObject":
+	case GcsMethodStatObjectAttr:
 		o.gcsRequestCountGcsMethodStatObjectAtomic.Add(inc)
-	case "UpdateObject":
+	case GcsMethodUpdateObjectAttr:
 		o.gcsRequestCountGcsMethodUpdateObjectAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(gcsMethod)
+		updateUnrecognizedAttribute(string(gcsMethod))
 		return
 	}
 }
 
 func (o *otelMetrics) GcsRequestLatencies(
-	ctx context.Context, latency time.Duration, gcsMethod string) {
+	ctx context.Context, latency time.Duration, gcsMethod GcsMethod) {
 	var record histogramRecord
 	switch gcsMethod {
-	case "ComposeObjects":
+	case GcsMethodComposeObjectsAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodComposeObjectsAttrSet}
-	case "CopyObject":
+	case GcsMethodCopyObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodCopyObjectAttrSet}
-	case "CreateAppendableObjectWriter":
+	case GcsMethodCreateAppendableObjectWriterAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodCreateAppendableObjectWriterAttrSet}
-	case "CreateFolder":
+	case GcsMethodCreateFolderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodCreateFolderAttrSet}
-	case "CreateObject":
+	case GcsMethodCreateObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodCreateObjectAttrSet}
-	case "CreateObjectChunkWriter":
+	case GcsMethodCreateObjectChunkWriterAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodCreateObjectChunkWriterAttrSet}
-	case "DeleteFolder":
+	case GcsMethodDeleteFolderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodDeleteFolderAttrSet}
-	case "DeleteObject":
+	case GcsMethodDeleteObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodDeleteObjectAttrSet}
-	case "FinalizeUpload":
+	case GcsMethodFinalizeUploadAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodFinalizeUploadAttrSet}
-	case "FlushPendingWrites":
+	case GcsMethodFlushPendingWritesAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodFlushPendingWritesAttrSet}
-	case "GetFolder":
+	case GcsMethodGetFolderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodGetFolderAttrSet}
-	case "ListObjects":
+	case GcsMethodListObjectsAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodListObjectsAttrSet}
-	case "MoveObject":
+	case GcsMethodMoveObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodMoveObjectAttrSet}
-	case "MultiRangeDownloader::Add":
+	case GcsMethodMultiRangeDownloaderAddAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodMultiRangeDownloaderAddAttrSet}
-	case "NewMultiRangeDownloader":
+	case GcsMethodNewMultiRangeDownloaderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodNewMultiRangeDownloaderAttrSet}
-	case "NewReader":
+	case GcsMethodNewReaderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodNewReaderAttrSet}
-	case "RenameFolder":
+	case GcsMethodRenameFolderAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodRenameFolderAttrSet}
-	case "StatObject":
+	case GcsMethodStatObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodStatObjectAttrSet}
-	case "UpdateObject":
+	case GcsMethodUpdateObjectAttr:
 		record = histogramRecord{ctx: ctx, instrument: o.gcsRequestLatencies, value: latency.Milliseconds(), attributes: gcsRequestLatenciesGcsMethodUpdateObjectAttrSet}
 	default:
-		updateUnrecognizedAttribute(gcsMethod)
+		updateUnrecognizedAttribute(string(gcsMethod))
 		return
 	}
 
@@ -2816,18 +2816,18 @@ func (o *otelMetrics) GcsRequestLatencies(
 }
 
 func (o *otelMetrics) GcsRetryCount(
-	inc int64, retryErrorCategory string) {
+	inc int64, retryErrorCategory RetryErrorCategory) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/retry_count received a negative increment: %d", inc)
 		return
 	}
 	switch retryErrorCategory {
-	case "OTHER_ERRORS":
+	case RetryErrorCategoryOTHERERRORSAttr:
 		o.gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic.Add(inc)
-	case "STALLED_READ_REQUEST":
+	case RetryErrorCategorySTALLEDREADREQUESTAttr:
 		o.gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(retryErrorCategory)
+		updateUnrecognizedAttribute(string(retryErrorCategory))
 		return
 	}
 }
@@ -2838,14 +2838,14 @@ func (o *otelMetrics) TestUpdownCounter(
 }
 
 func (o *otelMetrics) TestUpdownCounterWithAttrs(
-	inc int64, requestType string) {
+	inc int64, requestType RequestType) {
 	switch requestType {
-	case "attr1":
+	case RequestTypeAttr1Attr:
 		o.testUpdownCounterWithAttrsRequestTypeAttr1Atomic.Add(inc)
-	case "attr2":
+	case RequestTypeAttr2Attr:
 		o.testUpdownCounterWithAttrsRequestTypeAttr2Atomic.Add(inc)
 	default:
-		updateUnrecognizedAttribute(requestType)
+		updateUnrecognizedAttribute(string(requestType))
 		return
 	}
 }

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -132,22 +132,22 @@ func TestBufferedReadDownloadBlockLatency(t *testing.T) {
 	tests := []struct {
 		name      string
 		latencies []time.Duration
-		status    string
+		status    Status
 	}{
 		{
 			name:      "status_cancelled",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			status:    "cancelled",
+			status:    Status("cancelled"),
 		},
 		{
 			name:      "status_failed",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			status:    "failed",
+			status:    Status("failed"),
 		},
 		{
 			name:      "status_successful",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			status:    "successful",
+			status:    Status("successful"),
 		},
 	}
 
@@ -169,7 +169,7 @@ func TestBufferedReadDownloadBlockLatency(t *testing.T) {
 			require.True(t, ok, "buffered_read/download_block_latency metric not found")
 
 			attrs := []attribute.KeyValue{
-				attribute.String("status", tc.status),
+				attribute.String("status", string(tc.status)),
 			}
 			s := attribute.NewSet(attrs...)
 			expectedKey := s.Encoded(encoder)
@@ -190,7 +190,7 @@ func TestBufferedReadFallbackTriggerCount(t *testing.T) {
 		{
 			name: "reason_insufficient_memory",
 			f: func(m *otelMetrics) {
-				m.BufferedReadFallbackTriggerCount(5, "insufficient_memory")
+				m.BufferedReadFallbackTriggerCount(5, Reason("insufficient_memory"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("reason", "insufficient_memory")): 5,
@@ -199,7 +199,7 @@ func TestBufferedReadFallbackTriggerCount(t *testing.T) {
 		{
 			name: "reason_random_read_detected",
 			f: func(m *otelMetrics) {
-				m.BufferedReadFallbackTriggerCount(5, "random_read_detected")
+				m.BufferedReadFallbackTriggerCount(5, Reason("random_read_detected"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("reason", "random_read_detected")): 5,
@@ -207,9 +207,9 @@ func TestBufferedReadFallbackTriggerCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.BufferedReadFallbackTriggerCount(5, "insufficient_memory")
-				m.BufferedReadFallbackTriggerCount(2, "random_read_detected")
-				m.BufferedReadFallbackTriggerCount(3, "insufficient_memory")
+				m.BufferedReadFallbackTriggerCount(5, Reason("insufficient_memory"))
+				m.BufferedReadFallbackTriggerCount(2, Reason("random_read_detected"))
+				m.BufferedReadFallbackTriggerCount(3, Reason("insufficient_memory"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "insufficient_memory")): 8,
 				attribute.NewSet(attribute.String("reason", "random_read_detected")): 2,
@@ -218,8 +218,8 @@ func TestBufferedReadFallbackTriggerCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.BufferedReadFallbackTriggerCount(-5, "insufficient_memory")
-				m.BufferedReadFallbackTriggerCount(2, "insufficient_memory")
+				m.BufferedReadFallbackTriggerCount(-5, Reason("insufficient_memory"))
+				m.BufferedReadFallbackTriggerCount(2, Reason("insufficient_memory"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "insufficient_memory")): 2},
 		},
@@ -284,7 +284,7 @@ func TestBufferedReadScheduledBlockCount(t *testing.T) {
 		{
 			name: "status_cancelled",
 			f: func(m *otelMetrics) {
-				m.BufferedReadScheduledBlockCount(5, "cancelled")
+				m.BufferedReadScheduledBlockCount(5, Status("cancelled"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("status", "cancelled")): 5,
@@ -293,7 +293,7 @@ func TestBufferedReadScheduledBlockCount(t *testing.T) {
 		{
 			name: "status_failed",
 			f: func(m *otelMetrics) {
-				m.BufferedReadScheduledBlockCount(5, "failed")
+				m.BufferedReadScheduledBlockCount(5, Status("failed"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("status", "failed")): 5,
@@ -302,7 +302,7 @@ func TestBufferedReadScheduledBlockCount(t *testing.T) {
 		{
 			name: "status_successful",
 			f: func(m *otelMetrics) {
-				m.BufferedReadScheduledBlockCount(5, "successful")
+				m.BufferedReadScheduledBlockCount(5, Status("successful"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("status", "successful")): 5,
@@ -310,9 +310,9 @@ func TestBufferedReadScheduledBlockCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.BufferedReadScheduledBlockCount(5, "cancelled")
-				m.BufferedReadScheduledBlockCount(2, "failed")
-				m.BufferedReadScheduledBlockCount(3, "cancelled")
+				m.BufferedReadScheduledBlockCount(5, Status("cancelled"))
+				m.BufferedReadScheduledBlockCount(2, Status("failed"))
+				m.BufferedReadScheduledBlockCount(3, Status("cancelled"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("status", "cancelled")): 8,
 				attribute.NewSet(attribute.String("status", "failed")): 2,
@@ -321,8 +321,8 @@ func TestBufferedReadScheduledBlockCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.BufferedReadScheduledBlockCount(-5, "cancelled")
-				m.BufferedReadScheduledBlockCount(2, "cancelled")
+				m.BufferedReadScheduledBlockCount(-5, Status("cancelled"))
+				m.BufferedReadScheduledBlockCount(2, Status("cancelled"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("status", "cancelled")): 2},
 		},
@@ -362,7 +362,7 @@ func TestFileCacheReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadBytesCount(5, "Parallel")
+				m.FileCacheReadBytesCount(5, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Parallel")): 5,
@@ -371,7 +371,7 @@ func TestFileCacheReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Random",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadBytesCount(5, "Random")
+				m.FileCacheReadBytesCount(5, ReadType("Random"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Random")): 5,
@@ -380,7 +380,7 @@ func TestFileCacheReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadBytesCount(5, "Sequential")
+				m.FileCacheReadBytesCount(5, ReadType("Sequential"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Sequential")): 5,
@@ -388,9 +388,9 @@ func TestFileCacheReadBytesCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadBytesCount(5, "Parallel")
-				m.FileCacheReadBytesCount(2, "Random")
-				m.FileCacheReadBytesCount(3, "Parallel")
+				m.FileCacheReadBytesCount(5, ReadType("Parallel"))
+				m.FileCacheReadBytesCount(2, ReadType("Random"))
+				m.FileCacheReadBytesCount(3, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 8,
 				attribute.NewSet(attribute.String("read_type", "Random")): 2,
@@ -399,8 +399,8 @@ func TestFileCacheReadBytesCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadBytesCount(-5, "Parallel")
-				m.FileCacheReadBytesCount(2, "Parallel")
+				m.FileCacheReadBytesCount(-5, ReadType("Parallel"))
+				m.FileCacheReadBytesCount(2, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 2},
 		},
@@ -440,7 +440,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_true_read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, true, "Parallel")
+				m.FileCacheReadCount(5, true, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")): 5,
@@ -449,7 +449,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_true_read_type_Random",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, true, "Random")
+				m.FileCacheReadCount(5, true, ReadType("Random"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")): 5,
@@ -458,7 +458,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_true_read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, true, "Sequential")
+				m.FileCacheReadCount(5, true, ReadType("Sequential"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Sequential")): 5,
@@ -467,7 +467,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_false_read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, false, "Parallel")
+				m.FileCacheReadCount(5, false, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Parallel")): 5,
@@ -476,7 +476,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_false_read_type_Random",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, false, "Random")
+				m.FileCacheReadCount(5, false, ReadType("Random"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Random")): 5,
@@ -485,7 +485,7 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "cache_hit_false_read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, false, "Sequential")
+				m.FileCacheReadCount(5, false, ReadType("Sequential"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Sequential")): 5,
@@ -493,9 +493,9 @@ func TestFileCacheReadCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(5, true, "Parallel")
-				m.FileCacheReadCount(2, true, "Random")
-				m.FileCacheReadCount(3, true, "Parallel")
+				m.FileCacheReadCount(5, true, ReadType("Parallel"))
+				m.FileCacheReadCount(2, true, ReadType("Random"))
+				m.FileCacheReadCount(3, true, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")): 8,
 				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")): 2,
@@ -504,8 +504,8 @@ func TestFileCacheReadCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.FileCacheReadCount(-5, true, "Parallel")
-				m.FileCacheReadCount(2, true, "Parallel")
+				m.FileCacheReadCount(-5, true, ReadType("Parallel"))
+				m.FileCacheReadCount(2, true, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")): 2},
 		},
@@ -593,7 +593,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "BatchForget")
+				m.FsOpsCount(5, FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "BatchForget")): 5,
@@ -602,7 +602,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "CreateFile")
+				m.FsOpsCount(5, FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "CreateFile")): 5,
@@ -611,7 +611,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "CreateLink")
+				m.FsOpsCount(5, FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "CreateLink")): 5,
@@ -620,7 +620,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "CreateSymlink")
+				m.FsOpsCount(5, FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "CreateSymlink")): 5,
@@ -629,7 +629,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "Fallocate")
+				m.FsOpsCount(5, FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "Fallocate")): 5,
@@ -638,7 +638,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "FlushFile")
+				m.FsOpsCount(5, FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "FlushFile")): 5,
@@ -647,7 +647,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ForgetInode")
+				m.FsOpsCount(5, FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ForgetInode")): 5,
@@ -656,7 +656,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "GetInodeAttributes")
+				m.FsOpsCount(5, FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -665,7 +665,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "GetXattr")
+				m.FsOpsCount(5, FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "GetXattr")): 5,
@@ -674,7 +674,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ListXattr")
+				m.FsOpsCount(5, FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ListXattr")): 5,
@@ -683,7 +683,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "LookUpInode")
+				m.FsOpsCount(5, FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "LookUpInode")): 5,
@@ -692,7 +692,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "MkDir")
+				m.FsOpsCount(5, FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "MkDir")): 5,
@@ -701,7 +701,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "MkNode")
+				m.FsOpsCount(5, FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "MkNode")): 5,
@@ -710,7 +710,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "OpenDir")
+				m.FsOpsCount(5, FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "OpenDir")): 5,
@@ -719,7 +719,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "OpenFile")
+				m.FsOpsCount(5, FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "OpenFile")): 5,
@@ -728,7 +728,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReadDir")
+				m.FsOpsCount(5, FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReadDir")): 5,
@@ -737,7 +737,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReadDirPlus")
+				m.FsOpsCount(5, FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -746,7 +746,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReadFile")
+				m.FsOpsCount(5, FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReadFile")): 5,
@@ -755,7 +755,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReadSymlink")
+				m.FsOpsCount(5, FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReadSymlink")): 5,
@@ -764,7 +764,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReleaseDirHandle")
+				m.FsOpsCount(5, FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -773,7 +773,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "ReleaseFileHandle")
+				m.FsOpsCount(5, FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -782,7 +782,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "RemoveXattr")
+				m.FsOpsCount(5, FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "RemoveXattr")): 5,
@@ -791,7 +791,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "Rename")
+				m.FsOpsCount(5, FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "Rename")): 5,
@@ -800,7 +800,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "RmDir")
+				m.FsOpsCount(5, FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "RmDir")): 5,
@@ -809,7 +809,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "SetInodeAttributes")
+				m.FsOpsCount(5, FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -818,7 +818,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "SetXattr")
+				m.FsOpsCount(5, FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "SetXattr")): 5,
@@ -827,7 +827,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "StatFS")
+				m.FsOpsCount(5, FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "StatFS")): 5,
@@ -836,7 +836,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "SyncFS")
+				m.FsOpsCount(5, FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "SyncFS")): 5,
@@ -845,7 +845,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "SyncFile")
+				m.FsOpsCount(5, FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "SyncFile")): 5,
@@ -854,7 +854,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "Unlink")
+				m.FsOpsCount(5, FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "Unlink")): 5,
@@ -863,7 +863,7 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "WriteFile")
+				m.FsOpsCount(5, FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_op", "WriteFile")): 5,
@@ -871,9 +871,9 @@ func TestFsOpsCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(5, "BatchForget")
-				m.FsOpsCount(2, "CreateFile")
-				m.FsOpsCount(3, "BatchForget")
+				m.FsOpsCount(5, FsOp("BatchForget"))
+				m.FsOpsCount(2, FsOp("CreateFile"))
+				m.FsOpsCount(3, FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("fs_op", "BatchForget")): 8,
 				attribute.NewSet(attribute.String("fs_op", "CreateFile")): 2,
@@ -882,8 +882,8 @@ func TestFsOpsCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.FsOpsCount(-5, "BatchForget")
-				m.FsOpsCount(2, "BatchForget")
+				m.FsOpsCount(-5, FsOp("BatchForget"))
+				m.FsOpsCount(2, FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("fs_op", "BatchForget")): 2},
 		},
@@ -923,7 +923,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -932,7 +932,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -941,7 +941,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -950,7 +950,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -959,7 +959,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -968,7 +968,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -977,7 +977,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -986,7 +986,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -995,7 +995,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -1004,7 +1004,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -1013,7 +1013,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -1022,7 +1022,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -1031,7 +1031,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -1040,7 +1040,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -1049,7 +1049,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -1058,7 +1058,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -1067,7 +1067,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -1076,7 +1076,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -1085,7 +1085,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -1094,7 +1094,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -1103,7 +1103,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -1112,7 +1112,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -1121,7 +1121,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -1130,7 +1130,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -1139,7 +1139,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -1148,7 +1148,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -1157,7 +1157,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -1166,7 +1166,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -1175,7 +1175,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -1184,7 +1184,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -1193,7 +1193,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DEVICE_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -1202,7 +1202,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "BatchForget")): 5,
@@ -1211,7 +1211,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateFile")): 5,
@@ -1220,7 +1220,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateLink")): 5,
@@ -1229,7 +1229,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -1238,7 +1238,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Fallocate")): 5,
@@ -1247,7 +1247,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "FlushFile")): 5,
@@ -1256,7 +1256,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -1265,7 +1265,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -1274,7 +1274,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetXattr")): 5,
@@ -1283,7 +1283,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ListXattr")): 5,
@@ -1292,7 +1292,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -1301,7 +1301,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkDir")): 5,
@@ -1310,7 +1310,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkNode")): 5,
@@ -1319,7 +1319,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenDir")): 5,
@@ -1328,7 +1328,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenFile")): 5,
@@ -1337,7 +1337,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDir")): 5,
@@ -1346,7 +1346,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -1355,7 +1355,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadFile")): 5,
@@ -1364,7 +1364,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -1373,7 +1373,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -1382,7 +1382,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -1391,7 +1391,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -1400,7 +1400,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Rename")): 5,
@@ -1409,7 +1409,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RmDir")): 5,
@@ -1418,7 +1418,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -1427,7 +1427,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetXattr")): 5,
@@ -1436,7 +1436,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "StatFS")): 5,
@@ -1445,7 +1445,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFS")): 5,
@@ -1454,7 +1454,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFile")): 5,
@@ -1463,7 +1463,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Unlink")): 5,
@@ -1472,7 +1472,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_DIR_NOT_EMPTY_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DIR_NOT_EMPTY", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("DIR_NOT_EMPTY"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "WriteFile")): 5,
@@ -1481,7 +1481,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -1490,7 +1490,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -1499,7 +1499,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -1508,7 +1508,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -1517,7 +1517,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -1526,7 +1526,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -1535,7 +1535,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -1544,7 +1544,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -1553,7 +1553,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -1562,7 +1562,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -1571,7 +1571,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -1580,7 +1580,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -1589,7 +1589,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -1598,7 +1598,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -1607,7 +1607,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -1616,7 +1616,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -1625,7 +1625,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -1634,7 +1634,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -1643,7 +1643,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -1652,7 +1652,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -1661,7 +1661,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -1670,7 +1670,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -1679,7 +1679,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -1688,7 +1688,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -1697,7 +1697,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -1706,7 +1706,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -1715,7 +1715,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -1724,7 +1724,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -1733,7 +1733,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -1742,7 +1742,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -1751,7 +1751,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_DIR_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_DIR_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_DIR_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -1760,7 +1760,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "BatchForget")): 5,
@@ -1769,7 +1769,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateFile")): 5,
@@ -1778,7 +1778,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateLink")): 5,
@@ -1787,7 +1787,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -1796,7 +1796,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Fallocate")): 5,
@@ -1805,7 +1805,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "FlushFile")): 5,
@@ -1814,7 +1814,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -1823,7 +1823,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -1832,7 +1832,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetXattr")): 5,
@@ -1841,7 +1841,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ListXattr")): 5,
@@ -1850,7 +1850,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -1859,7 +1859,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkDir")): 5,
@@ -1868,7 +1868,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkNode")): 5,
@@ -1877,7 +1877,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenDir")): 5,
@@ -1886,7 +1886,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenFile")): 5,
@@ -1895,7 +1895,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDir")): 5,
@@ -1904,7 +1904,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -1913,7 +1913,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadFile")): 5,
@@ -1922,7 +1922,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -1931,7 +1931,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -1940,7 +1940,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -1949,7 +1949,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -1958,7 +1958,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Rename")): 5,
@@ -1967,7 +1967,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RmDir")): 5,
@@ -1976,7 +1976,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -1985,7 +1985,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetXattr")): 5,
@@ -1994,7 +1994,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "StatFS")): 5,
@@ -2003,7 +2003,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFS")): 5,
@@ -2012,7 +2012,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFile")): 5,
@@ -2021,7 +2021,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Unlink")): 5,
@@ -2030,7 +2030,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_FILE_EXISTS_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "FILE_EXISTS", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("FILE_EXISTS"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "WriteFile")): 5,
@@ -2039,7 +2039,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -2048,7 +2048,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -2057,7 +2057,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -2066,7 +2066,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -2075,7 +2075,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -2084,7 +2084,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -2093,7 +2093,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -2102,7 +2102,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -2111,7 +2111,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -2120,7 +2120,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -2129,7 +2129,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -2138,7 +2138,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -2147,7 +2147,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -2156,7 +2156,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -2165,7 +2165,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -2174,7 +2174,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -2183,7 +2183,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -2192,7 +2192,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -2201,7 +2201,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -2210,7 +2210,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -2219,7 +2219,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -2228,7 +2228,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -2237,7 +2237,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -2246,7 +2246,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -2255,7 +2255,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -2264,7 +2264,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -2273,7 +2273,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -2282,7 +2282,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -2291,7 +2291,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -2300,7 +2300,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -2309,7 +2309,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INTERRUPT_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INTERRUPT_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INTERRUPT_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -2318,7 +2318,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "BatchForget")): 5,
@@ -2327,7 +2327,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateFile")): 5,
@@ -2336,7 +2336,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateLink")): 5,
@@ -2345,7 +2345,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -2354,7 +2354,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Fallocate")): 5,
@@ -2363,7 +2363,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "FlushFile")): 5,
@@ -2372,7 +2372,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -2381,7 +2381,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -2390,7 +2390,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetXattr")): 5,
@@ -2399,7 +2399,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ListXattr")): 5,
@@ -2408,7 +2408,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -2417,7 +2417,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkDir")): 5,
@@ -2426,7 +2426,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkNode")): 5,
@@ -2435,7 +2435,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenDir")): 5,
@@ -2444,7 +2444,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenFile")): 5,
@@ -2453,7 +2453,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDir")): 5,
@@ -2462,7 +2462,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -2471,7 +2471,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadFile")): 5,
@@ -2480,7 +2480,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -2489,7 +2489,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -2498,7 +2498,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -2507,7 +2507,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -2516,7 +2516,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Rename")): 5,
@@ -2525,7 +2525,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RmDir")): 5,
@@ -2534,7 +2534,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -2543,7 +2543,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetXattr")): 5,
@@ -2552,7 +2552,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "StatFS")): 5,
@@ -2561,7 +2561,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFS")): 5,
@@ -2570,7 +2570,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFile")): 5,
@@ -2579,7 +2579,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Unlink")): 5,
@@ -2588,7 +2588,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_ARGUMENT_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_ARGUMENT", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_ARGUMENT"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "WriteFile")): 5,
@@ -2597,7 +2597,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "BatchForget")): 5,
@@ -2606,7 +2606,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateFile")): 5,
@@ -2615,7 +2615,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateLink")): 5,
@@ -2624,7 +2624,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -2633,7 +2633,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Fallocate")): 5,
@@ -2642,7 +2642,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "FlushFile")): 5,
@@ -2651,7 +2651,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -2660,7 +2660,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -2669,7 +2669,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetXattr")): 5,
@@ -2678,7 +2678,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ListXattr")): 5,
@@ -2687,7 +2687,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -2696,7 +2696,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkDir")): 5,
@@ -2705,7 +2705,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkNode")): 5,
@@ -2714,7 +2714,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenDir")): 5,
@@ -2723,7 +2723,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenFile")): 5,
@@ -2732,7 +2732,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDir")): 5,
@@ -2741,7 +2741,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -2750,7 +2750,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadFile")): 5,
@@ -2759,7 +2759,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -2768,7 +2768,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -2777,7 +2777,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -2786,7 +2786,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -2795,7 +2795,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Rename")): 5,
@@ -2804,7 +2804,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RmDir")): 5,
@@ -2813,7 +2813,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -2822,7 +2822,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetXattr")): 5,
@@ -2831,7 +2831,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "StatFS")): 5,
@@ -2840,7 +2840,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFS")): 5,
@@ -2849,7 +2849,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFile")): 5,
@@ -2858,7 +2858,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Unlink")): 5,
@@ -2867,7 +2867,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_INVALID_OPERATION_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "INVALID_OPERATION", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("INVALID_OPERATION"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "WriteFile")): 5,
@@ -2876,7 +2876,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -2885,7 +2885,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -2894,7 +2894,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -2903,7 +2903,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -2912,7 +2912,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -2921,7 +2921,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -2930,7 +2930,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -2939,7 +2939,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -2948,7 +2948,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -2957,7 +2957,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -2966,7 +2966,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -2975,7 +2975,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -2984,7 +2984,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -2993,7 +2993,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -3002,7 +3002,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -3011,7 +3011,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -3020,7 +3020,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -3029,7 +3029,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -3038,7 +3038,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -3047,7 +3047,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -3056,7 +3056,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -3065,7 +3065,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -3074,7 +3074,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -3083,7 +3083,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -3092,7 +3092,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -3101,7 +3101,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -3110,7 +3110,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -3119,7 +3119,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -3128,7 +3128,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -3137,7 +3137,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -3146,7 +3146,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_IO_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "IO_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("IO_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -3155,7 +3155,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -3164,7 +3164,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -3173,7 +3173,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -3182,7 +3182,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -3191,7 +3191,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -3200,7 +3200,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -3209,7 +3209,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -3218,7 +3218,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -3227,7 +3227,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -3236,7 +3236,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -3245,7 +3245,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -3254,7 +3254,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -3263,7 +3263,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -3272,7 +3272,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -3281,7 +3281,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -3290,7 +3290,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -3299,7 +3299,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -3308,7 +3308,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -3317,7 +3317,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -3326,7 +3326,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -3335,7 +3335,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -3344,7 +3344,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -3353,7 +3353,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -3362,7 +3362,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -3371,7 +3371,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -3380,7 +3380,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -3389,7 +3389,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -3398,7 +3398,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -3407,7 +3407,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -3416,7 +3416,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -3425,7 +3425,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_MISC_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "MISC_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("MISC_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -3434,7 +3434,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -3443,7 +3443,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -3452,7 +3452,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -3461,7 +3461,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -3470,7 +3470,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -3479,7 +3479,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -3488,7 +3488,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -3497,7 +3497,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -3506,7 +3506,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -3515,7 +3515,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -3524,7 +3524,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -3533,7 +3533,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -3542,7 +3542,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -3551,7 +3551,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -3560,7 +3560,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -3569,7 +3569,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -3578,7 +3578,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -3587,7 +3587,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -3596,7 +3596,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -3605,7 +3605,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -3614,7 +3614,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -3623,7 +3623,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -3632,7 +3632,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -3641,7 +3641,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -3650,7 +3650,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -3659,7 +3659,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -3668,7 +3668,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -3677,7 +3677,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -3686,7 +3686,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -3695,7 +3695,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -3704,7 +3704,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NETWORK_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NETWORK_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NETWORK_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -3713,7 +3713,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -3722,7 +3722,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -3731,7 +3731,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -3740,7 +3740,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -3749,7 +3749,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -3758,7 +3758,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -3767,7 +3767,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -3776,7 +3776,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -3785,7 +3785,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -3794,7 +3794,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -3803,7 +3803,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -3812,7 +3812,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkDir")): 5,
@@ -3821,7 +3821,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkNode")): 5,
@@ -3830,7 +3830,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -3839,7 +3839,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -3848,7 +3848,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -3857,7 +3857,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -3866,7 +3866,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -3875,7 +3875,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -3884,7 +3884,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -3893,7 +3893,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -3902,7 +3902,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -3911,7 +3911,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Rename")): 5,
@@ -3920,7 +3920,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RmDir")): 5,
@@ -3929,7 +3929,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -3938,7 +3938,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -3947,7 +3947,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "StatFS")): 5,
@@ -3956,7 +3956,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -3965,7 +3965,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -3974,7 +3974,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Unlink")): 5,
@@ -3983,7 +3983,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_A_DIR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_A_DIR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_A_DIR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -3992,7 +3992,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "BatchForget")): 5,
@@ -4001,7 +4001,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateFile")): 5,
@@ -4010,7 +4010,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateLink")): 5,
@@ -4019,7 +4019,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -4028,7 +4028,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Fallocate")): 5,
@@ -4037,7 +4037,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "FlushFile")): 5,
@@ -4046,7 +4046,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -4055,7 +4055,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -4064,7 +4064,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetXattr")): 5,
@@ -4073,7 +4073,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ListXattr")): 5,
@@ -4082,7 +4082,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -4091,7 +4091,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkDir")): 5,
@@ -4100,7 +4100,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkNode")): 5,
@@ -4109,7 +4109,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenDir")): 5,
@@ -4118,7 +4118,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenFile")): 5,
@@ -4127,7 +4127,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDir")): 5,
@@ -4136,7 +4136,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -4145,7 +4145,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadFile")): 5,
@@ -4154,7 +4154,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -4163,7 +4163,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -4172,7 +4172,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -4181,7 +4181,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -4190,7 +4190,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Rename")): 5,
@@ -4199,7 +4199,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RmDir")): 5,
@@ -4208,7 +4208,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -4217,7 +4217,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetXattr")): 5,
@@ -4226,7 +4226,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "StatFS")): 5,
@@ -4235,7 +4235,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFS")): 5,
@@ -4244,7 +4244,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFile")): 5,
@@ -4253,7 +4253,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Unlink")): 5,
@@ -4262,7 +4262,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NOT_IMPLEMENTED_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NOT_IMPLEMENTED", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NOT_IMPLEMENTED"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "WriteFile")): 5,
@@ -4271,7 +4271,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -4280,7 +4280,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -4289,7 +4289,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -4298,7 +4298,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -4307,7 +4307,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -4316,7 +4316,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -4325,7 +4325,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -4334,7 +4334,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -4343,7 +4343,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -4352,7 +4352,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -4361,7 +4361,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -4370,7 +4370,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkDir")): 5,
@@ -4379,7 +4379,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkNode")): 5,
@@ -4388,7 +4388,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -4397,7 +4397,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -4406,7 +4406,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -4415,7 +4415,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -4424,7 +4424,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -4433,7 +4433,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -4442,7 +4442,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -4451,7 +4451,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -4460,7 +4460,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -4469,7 +4469,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Rename")): 5,
@@ -4478,7 +4478,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RmDir")): 5,
@@ -4487,7 +4487,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -4496,7 +4496,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -4505,7 +4505,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "StatFS")): 5,
@@ -4514,7 +4514,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -4523,7 +4523,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -4532,7 +4532,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Unlink")): 5,
@@ -4541,7 +4541,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_NO_FILE_OR_DIR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "NO_FILE_OR_DIR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("NO_FILE_OR_DIR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -4550,7 +4550,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -4559,7 +4559,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -4568,7 +4568,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -4577,7 +4577,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -4586,7 +4586,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -4595,7 +4595,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -4604,7 +4604,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -4613,7 +4613,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -4622,7 +4622,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -4631,7 +4631,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -4640,7 +4640,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -4649,7 +4649,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -4658,7 +4658,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -4667,7 +4667,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -4676,7 +4676,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -4685,7 +4685,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -4694,7 +4694,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -4703,7 +4703,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -4712,7 +4712,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -4721,7 +4721,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -4730,7 +4730,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -4739,7 +4739,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -4748,7 +4748,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -4757,7 +4757,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -4766,7 +4766,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -4775,7 +4775,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -4784,7 +4784,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -4793,7 +4793,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -4802,7 +4802,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -4811,7 +4811,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -4820,7 +4820,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PERM_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PERM_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PERM_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -4829,7 +4829,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "BatchForget")): 5,
@@ -4838,7 +4838,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateFile")): 5,
@@ -4847,7 +4847,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateLink")): 5,
@@ -4856,7 +4856,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -4865,7 +4865,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Fallocate")): 5,
@@ -4874,7 +4874,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "FlushFile")): 5,
@@ -4883,7 +4883,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -4892,7 +4892,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -4901,7 +4901,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetXattr")): 5,
@@ -4910,7 +4910,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ListXattr")): 5,
@@ -4919,7 +4919,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -4928,7 +4928,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkDir")): 5,
@@ -4937,7 +4937,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkNode")): 5,
@@ -4946,7 +4946,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenDir")): 5,
@@ -4955,7 +4955,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenFile")): 5,
@@ -4964,7 +4964,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDir")): 5,
@@ -4973,7 +4973,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -4982,7 +4982,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadFile")): 5,
@@ -4991,7 +4991,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -5000,7 +5000,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -5009,7 +5009,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -5018,7 +5018,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -5027,7 +5027,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Rename")): 5,
@@ -5036,7 +5036,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RmDir")): 5,
@@ -5045,7 +5045,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -5054,7 +5054,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetXattr")): 5,
@@ -5063,7 +5063,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "StatFS")): 5,
@@ -5072,7 +5072,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFS")): 5,
@@ -5081,7 +5081,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFile")): 5,
@@ -5090,7 +5090,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Unlink")): 5,
@@ -5099,7 +5099,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_PROCESS_RESOURCE_MGMT_ERROR_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "PROCESS_RESOURCE_MGMT_ERROR", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("PROCESS_RESOURCE_MGMT_ERROR"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "WriteFile")): 5,
@@ -5108,7 +5108,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_BatchForget",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "BatchForget")): 5,
@@ -5117,7 +5117,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_CreateFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "CreateFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("CreateFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateFile")): 5,
@@ -5126,7 +5126,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_CreateLink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "CreateLink")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("CreateLink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateLink")): 5,
@@ -5135,7 +5135,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_CreateSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "CreateSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("CreateSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateSymlink")): 5,
@@ -5144,7 +5144,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_Fallocate",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "Fallocate")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("Fallocate"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Fallocate")): 5,
@@ -5153,7 +5153,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_FlushFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "FlushFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("FlushFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "FlushFile")): 5,
@@ -5162,7 +5162,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ForgetInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ForgetInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ForgetInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ForgetInode")): 5,
@@ -5171,7 +5171,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_GetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "GetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("GetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetInodeAttributes")): 5,
@@ -5180,7 +5180,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_GetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "GetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("GetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetXattr")): 5,
@@ -5189,7 +5189,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ListXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ListXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ListXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ListXattr")): 5,
@@ -5198,7 +5198,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_LookUpInode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "LookUpInode")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("LookUpInode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "LookUpInode")): 5,
@@ -5207,7 +5207,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_MkDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "MkDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("MkDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkDir")): 5,
@@ -5216,7 +5216,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_MkNode",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "MkNode")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("MkNode"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkNode")): 5,
@@ -5225,7 +5225,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_OpenDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "OpenDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("OpenDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenDir")): 5,
@@ -5234,7 +5234,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_OpenFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "OpenFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("OpenFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenFile")): 5,
@@ -5243,7 +5243,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReadDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReadDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReadDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDir")): 5,
@@ -5252,7 +5252,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReadDirPlus",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReadDirPlus")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReadDirPlus"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDirPlus")): 5,
@@ -5261,7 +5261,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReadFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReadFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReadFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadFile")): 5,
@@ -5270,7 +5270,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReadSymlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReadSymlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReadSymlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadSymlink")): 5,
@@ -5279,7 +5279,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReleaseDirHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReleaseDirHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReleaseDirHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseDirHandle")): 5,
@@ -5288,7 +5288,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_ReleaseFileHandle",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "ReleaseFileHandle")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("ReleaseFileHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseFileHandle")): 5,
@@ -5297,7 +5297,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_RemoveXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "RemoveXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("RemoveXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RemoveXattr")): 5,
@@ -5306,7 +5306,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_Rename",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "Rename")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("Rename"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Rename")): 5,
@@ -5315,7 +5315,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_RmDir",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "RmDir")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("RmDir"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RmDir")): 5,
@@ -5324,7 +5324,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_SetInodeAttributes",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "SetInodeAttributes")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("SetInodeAttributes"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetInodeAttributes")): 5,
@@ -5333,7 +5333,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_SetXattr",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "SetXattr")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("SetXattr"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetXattr")): 5,
@@ -5342,7 +5342,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_StatFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "StatFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("StatFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "StatFS")): 5,
@@ -5351,7 +5351,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_SyncFS",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "SyncFS")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("SyncFS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFS")): 5,
@@ -5360,7 +5360,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_SyncFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "SyncFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("SyncFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFile")): 5,
@@ -5369,7 +5369,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_Unlink",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "Unlink")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("Unlink"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Unlink")): 5,
@@ -5378,7 +5378,7 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "fs_error_category_TOO_MANY_OPEN_FILES_fs_op_WriteFile",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "TOO_MANY_OPEN_FILES", "WriteFile")
+				m.FsOpsErrorCount(5, FsErrorCategory("TOO_MANY_OPEN_FILES"), FsOp("WriteFile"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "WriteFile")): 5,
@@ -5386,9 +5386,9 @@ func TestFsOpsErrorCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(5, "DEVICE_ERROR", "BatchForget")
-				m.FsOpsErrorCount(2, "DEVICE_ERROR", "CreateFile")
-				m.FsOpsErrorCount(3, "DEVICE_ERROR", "BatchForget")
+				m.FsOpsErrorCount(5, FsErrorCategory("DEVICE_ERROR"), FsOp("BatchForget"))
+				m.FsOpsErrorCount(2, FsErrorCategory("DEVICE_ERROR"), FsOp("CreateFile"))
+				m.FsOpsErrorCount(3, FsErrorCategory("DEVICE_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")): 8,
 				attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")): 2,
@@ -5397,8 +5397,8 @@ func TestFsOpsErrorCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.FsOpsErrorCount(-5, "DEVICE_ERROR", "BatchForget")
-				m.FsOpsErrorCount(2, "DEVICE_ERROR", "BatchForget")
+				m.FsOpsErrorCount(-5, FsErrorCategory("DEVICE_ERROR"), FsOp("BatchForget"))
+				m.FsOpsErrorCount(2, FsErrorCategory("DEVICE_ERROR"), FsOp("BatchForget"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")): 2},
 		},
@@ -5433,162 +5433,162 @@ func TestFsOpsLatency(t *testing.T) {
 	tests := []struct {
 		name      string
 		latencies []time.Duration
-		fsOp      string
+		fsOp      FsOp
 	}{
 		{
 			name:      "fs_op_BatchForget",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "BatchForget",
+			fsOp:      FsOp("BatchForget"),
 		},
 		{
 			name:      "fs_op_CreateFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "CreateFile",
+			fsOp:      FsOp("CreateFile"),
 		},
 		{
 			name:      "fs_op_CreateLink",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "CreateLink",
+			fsOp:      FsOp("CreateLink"),
 		},
 		{
 			name:      "fs_op_CreateSymlink",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "CreateSymlink",
+			fsOp:      FsOp("CreateSymlink"),
 		},
 		{
 			name:      "fs_op_Fallocate",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "Fallocate",
+			fsOp:      FsOp("Fallocate"),
 		},
 		{
 			name:      "fs_op_FlushFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "FlushFile",
+			fsOp:      FsOp("FlushFile"),
 		},
 		{
 			name:      "fs_op_ForgetInode",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ForgetInode",
+			fsOp:      FsOp("ForgetInode"),
 		},
 		{
 			name:      "fs_op_GetInodeAttributes",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "GetInodeAttributes",
+			fsOp:      FsOp("GetInodeAttributes"),
 		},
 		{
 			name:      "fs_op_GetXattr",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "GetXattr",
+			fsOp:      FsOp("GetXattr"),
 		},
 		{
 			name:      "fs_op_ListXattr",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ListXattr",
+			fsOp:      FsOp("ListXattr"),
 		},
 		{
 			name:      "fs_op_LookUpInode",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "LookUpInode",
+			fsOp:      FsOp("LookUpInode"),
 		},
 		{
 			name:      "fs_op_MkDir",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "MkDir",
+			fsOp:      FsOp("MkDir"),
 		},
 		{
 			name:      "fs_op_MkNode",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "MkNode",
+			fsOp:      FsOp("MkNode"),
 		},
 		{
 			name:      "fs_op_OpenDir",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "OpenDir",
+			fsOp:      FsOp("OpenDir"),
 		},
 		{
 			name:      "fs_op_OpenFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "OpenFile",
+			fsOp:      FsOp("OpenFile"),
 		},
 		{
 			name:      "fs_op_ReadDir",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReadDir",
+			fsOp:      FsOp("ReadDir"),
 		},
 		{
 			name:      "fs_op_ReadDirPlus",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReadDirPlus",
+			fsOp:      FsOp("ReadDirPlus"),
 		},
 		{
 			name:      "fs_op_ReadFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReadFile",
+			fsOp:      FsOp("ReadFile"),
 		},
 		{
 			name:      "fs_op_ReadSymlink",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReadSymlink",
+			fsOp:      FsOp("ReadSymlink"),
 		},
 		{
 			name:      "fs_op_ReleaseDirHandle",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReleaseDirHandle",
+			fsOp:      FsOp("ReleaseDirHandle"),
 		},
 		{
 			name:      "fs_op_ReleaseFileHandle",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "ReleaseFileHandle",
+			fsOp:      FsOp("ReleaseFileHandle"),
 		},
 		{
 			name:      "fs_op_RemoveXattr",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "RemoveXattr",
+			fsOp:      FsOp("RemoveXattr"),
 		},
 		{
 			name:      "fs_op_Rename",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "Rename",
+			fsOp:      FsOp("Rename"),
 		},
 		{
 			name:      "fs_op_RmDir",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "RmDir",
+			fsOp:      FsOp("RmDir"),
 		},
 		{
 			name:      "fs_op_SetInodeAttributes",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "SetInodeAttributes",
+			fsOp:      FsOp("SetInodeAttributes"),
 		},
 		{
 			name:      "fs_op_SetXattr",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "SetXattr",
+			fsOp:      FsOp("SetXattr"),
 		},
 		{
 			name:      "fs_op_StatFS",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "StatFS",
+			fsOp:      FsOp("StatFS"),
 		},
 		{
 			name:      "fs_op_SyncFS",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "SyncFS",
+			fsOp:      FsOp("SyncFS"),
 		},
 		{
 			name:      "fs_op_SyncFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "SyncFile",
+			fsOp:      FsOp("SyncFile"),
 		},
 		{
 			name:      "fs_op_Unlink",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "Unlink",
+			fsOp:      FsOp("Unlink"),
 		},
 		{
 			name:      "fs_op_WriteFile",
 			latencies: []time.Duration{100 * time.Microsecond, 200 * time.Microsecond},
-			fsOp:      "WriteFile",
+			fsOp:      FsOp("WriteFile"),
 		},
 	}
 
@@ -5610,7 +5610,7 @@ func TestFsOpsLatency(t *testing.T) {
 			require.True(t, ok, "fs/ops_latency metric not found")
 
 			attrs := []attribute.KeyValue{
-				attribute.String("fs_op", tc.fsOp),
+				attribute.String("fs_op", string(tc.fsOp)),
 			}
 			s := attribute.NewSet(attrs...)
 			expectedKey := s.Encoded(encoder)
@@ -5631,7 +5631,7 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.GcsDownloadBytesCount(5, "Parallel")
+				m.GcsDownloadBytesCount(5, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Parallel")): 5,
@@ -5640,7 +5640,7 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Random",
 			f: func(m *otelMetrics) {
-				m.GcsDownloadBytesCount(5, "Random")
+				m.GcsDownloadBytesCount(5, ReadType("Random"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Random")): 5,
@@ -5649,7 +5649,7 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.GcsDownloadBytesCount(5, "Sequential")
+				m.GcsDownloadBytesCount(5, ReadType("Sequential"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Sequential")): 5,
@@ -5657,9 +5657,9 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsDownloadBytesCount(5, "Parallel")
-				m.GcsDownloadBytesCount(2, "Random")
-				m.GcsDownloadBytesCount(3, "Parallel")
+				m.GcsDownloadBytesCount(5, ReadType("Parallel"))
+				m.GcsDownloadBytesCount(2, ReadType("Random"))
+				m.GcsDownloadBytesCount(3, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 8,
 				attribute.NewSet(attribute.String("read_type", "Random")): 2,
@@ -5668,8 +5668,8 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsDownloadBytesCount(-5, "Parallel")
-				m.GcsDownloadBytesCount(2, "Parallel")
+				m.GcsDownloadBytesCount(-5, ReadType("Parallel"))
+				m.GcsDownloadBytesCount(2, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 2},
 		},
@@ -5734,7 +5734,7 @@ func TestGcsReadCount(t *testing.T) {
 		{
 			name: "read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.GcsReadCount(5, "Parallel")
+				m.GcsReadCount(5, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Parallel")): 5,
@@ -5743,7 +5743,7 @@ func TestGcsReadCount(t *testing.T) {
 		{
 			name: "read_type_Random",
 			f: func(m *otelMetrics) {
-				m.GcsReadCount(5, "Random")
+				m.GcsReadCount(5, ReadType("Random"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Random")): 5,
@@ -5752,7 +5752,7 @@ func TestGcsReadCount(t *testing.T) {
 		{
 			name: "read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.GcsReadCount(5, "Sequential")
+				m.GcsReadCount(5, ReadType("Sequential"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Sequential")): 5,
@@ -5760,9 +5760,9 @@ func TestGcsReadCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsReadCount(5, "Parallel")
-				m.GcsReadCount(2, "Random")
-				m.GcsReadCount(3, "Parallel")
+				m.GcsReadCount(5, ReadType("Parallel"))
+				m.GcsReadCount(2, ReadType("Random"))
+				m.GcsReadCount(3, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 8,
 				attribute.NewSet(attribute.String("read_type", "Random")): 2,
@@ -5771,8 +5771,8 @@ func TestGcsReadCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsReadCount(-5, "Parallel")
-				m.GcsReadCount(2, "Parallel")
+				m.GcsReadCount(-5, ReadType("Parallel"))
+				m.GcsReadCount(2, ReadType("Parallel"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 2},
 		},
@@ -5812,7 +5812,7 @@ func TestGcsReaderCount(t *testing.T) {
 		{
 			name: "io_method_ReadHandle",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "ReadHandle")
+				m.GcsReaderCount(5, IoMethod("ReadHandle"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("io_method", "ReadHandle")): 5,
@@ -5821,7 +5821,7 @@ func TestGcsReaderCount(t *testing.T) {
 		{
 			name: "io_method_closed",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "closed")
+				m.GcsReaderCount(5, IoMethod("closed"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("io_method", "closed")): 5,
@@ -5830,7 +5830,7 @@ func TestGcsReaderCount(t *testing.T) {
 		{
 			name: "io_method_opened",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "opened")
+				m.GcsReaderCount(5, IoMethod("opened"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("io_method", "opened")): 5,
@@ -5838,9 +5838,9 @@ func TestGcsReaderCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "ReadHandle")
-				m.GcsReaderCount(2, "closed")
-				m.GcsReaderCount(3, "ReadHandle")
+				m.GcsReaderCount(5, IoMethod("ReadHandle"))
+				m.GcsReaderCount(2, IoMethod("closed"))
+				m.GcsReaderCount(3, IoMethod("ReadHandle"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "ReadHandle")): 8,
 				attribute.NewSet(attribute.String("io_method", "closed")): 2,
@@ -5849,8 +5849,8 @@ func TestGcsReaderCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(-5, "ReadHandle")
-				m.GcsReaderCount(2, "ReadHandle")
+				m.GcsReaderCount(-5, IoMethod("ReadHandle"))
+				m.GcsReaderCount(2, IoMethod("ReadHandle"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "ReadHandle")): 2},
 		},
@@ -5890,7 +5890,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_ComposeObjects",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "ComposeObjects")
+				m.GcsRequestCount(5, GcsMethod("ComposeObjects"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")): 5,
@@ -5899,7 +5899,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_CopyObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "CopyObject")
+				m.GcsRequestCount(5, GcsMethod("CopyObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "CopyObject")): 5,
@@ -5908,7 +5908,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_CreateAppendableObjectWriter",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "CreateAppendableObjectWriter")
+				m.GcsRequestCount(5, GcsMethod("CreateAppendableObjectWriter"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")): 5,
@@ -5917,7 +5917,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_CreateFolder",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "CreateFolder")
+				m.GcsRequestCount(5, GcsMethod("CreateFolder"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "CreateFolder")): 5,
@@ -5926,7 +5926,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_CreateObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "CreateObject")
+				m.GcsRequestCount(5, GcsMethod("CreateObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "CreateObject")): 5,
@@ -5935,7 +5935,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_CreateObjectChunkWriter",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "CreateObjectChunkWriter")
+				m.GcsRequestCount(5, GcsMethod("CreateObjectChunkWriter"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")): 5,
@@ -5944,7 +5944,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_DeleteFolder",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "DeleteFolder")
+				m.GcsRequestCount(5, GcsMethod("DeleteFolder"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")): 5,
@@ -5953,7 +5953,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_DeleteObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "DeleteObject")
+				m.GcsRequestCount(5, GcsMethod("DeleteObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "DeleteObject")): 5,
@@ -5962,7 +5962,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_FinalizeUpload",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "FinalizeUpload")
+				m.GcsRequestCount(5, GcsMethod("FinalizeUpload"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")): 5,
@@ -5971,7 +5971,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_FlushPendingWrites",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "FlushPendingWrites")
+				m.GcsRequestCount(5, GcsMethod("FlushPendingWrites"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")): 5,
@@ -5980,7 +5980,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_GetFolder",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "GetFolder")
+				m.GcsRequestCount(5, GcsMethod("GetFolder"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "GetFolder")): 5,
@@ -5989,7 +5989,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_ListObjects",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "ListObjects")
+				m.GcsRequestCount(5, GcsMethod("ListObjects"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "ListObjects")): 5,
@@ -5998,7 +5998,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_MoveObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "MoveObject")
+				m.GcsRequestCount(5, GcsMethod("MoveObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "MoveObject")): 5,
@@ -6007,7 +6007,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_MultiRangeDownloader::Add",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "MultiRangeDownloader::Add")
+				m.GcsRequestCount(5, GcsMethod("MultiRangeDownloader::Add"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")): 5,
@@ -6016,7 +6016,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_NewMultiRangeDownloader",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "NewMultiRangeDownloader")
+				m.GcsRequestCount(5, GcsMethod("NewMultiRangeDownloader"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")): 5,
@@ -6025,7 +6025,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_NewReader",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "NewReader")
+				m.GcsRequestCount(5, GcsMethod("NewReader"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "NewReader")): 5,
@@ -6034,7 +6034,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_RenameFolder",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "RenameFolder")
+				m.GcsRequestCount(5, GcsMethod("RenameFolder"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "RenameFolder")): 5,
@@ -6043,7 +6043,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_StatObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "StatObject")
+				m.GcsRequestCount(5, GcsMethod("StatObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "StatObject")): 5,
@@ -6052,7 +6052,7 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "gcs_method_UpdateObject",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "UpdateObject")
+				m.GcsRequestCount(5, GcsMethod("UpdateObject"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("gcs_method", "UpdateObject")): 5,
@@ -6060,9 +6060,9 @@ func TestGcsRequestCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(5, "ComposeObjects")
-				m.GcsRequestCount(2, "CopyObject")
-				m.GcsRequestCount(3, "ComposeObjects")
+				m.GcsRequestCount(5, GcsMethod("ComposeObjects"))
+				m.GcsRequestCount(2, GcsMethod("CopyObject"))
+				m.GcsRequestCount(3, GcsMethod("ComposeObjects"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")): 8,
 				attribute.NewSet(attribute.String("gcs_method", "CopyObject")): 2,
@@ -6071,8 +6071,8 @@ func TestGcsRequestCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsRequestCount(-5, "ComposeObjects")
-				m.GcsRequestCount(2, "ComposeObjects")
+				m.GcsRequestCount(-5, GcsMethod("ComposeObjects"))
+				m.GcsRequestCount(2, GcsMethod("ComposeObjects"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")): 2},
 		},
@@ -6107,102 +6107,102 @@ func TestGcsRequestLatencies(t *testing.T) {
 	tests := []struct {
 		name      string
 		latencies []time.Duration
-		gcsMethod string
+		gcsMethod GcsMethod
 	}{
 		{
 			name:      "gcs_method_ComposeObjects",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "ComposeObjects",
+			gcsMethod: GcsMethod("ComposeObjects"),
 		},
 		{
 			name:      "gcs_method_CopyObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "CopyObject",
+			gcsMethod: GcsMethod("CopyObject"),
 		},
 		{
 			name:      "gcs_method_CreateAppendableObjectWriter",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "CreateAppendableObjectWriter",
+			gcsMethod: GcsMethod("CreateAppendableObjectWriter"),
 		},
 		{
 			name:      "gcs_method_CreateFolder",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "CreateFolder",
+			gcsMethod: GcsMethod("CreateFolder"),
 		},
 		{
 			name:      "gcs_method_CreateObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "CreateObject",
+			gcsMethod: GcsMethod("CreateObject"),
 		},
 		{
 			name:      "gcs_method_CreateObjectChunkWriter",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "CreateObjectChunkWriter",
+			gcsMethod: GcsMethod("CreateObjectChunkWriter"),
 		},
 		{
 			name:      "gcs_method_DeleteFolder",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "DeleteFolder",
+			gcsMethod: GcsMethod("DeleteFolder"),
 		},
 		{
 			name:      "gcs_method_DeleteObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "DeleteObject",
+			gcsMethod: GcsMethod("DeleteObject"),
 		},
 		{
 			name:      "gcs_method_FinalizeUpload",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "FinalizeUpload",
+			gcsMethod: GcsMethod("FinalizeUpload"),
 		},
 		{
 			name:      "gcs_method_FlushPendingWrites",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "FlushPendingWrites",
+			gcsMethod: GcsMethod("FlushPendingWrites"),
 		},
 		{
 			name:      "gcs_method_GetFolder",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "GetFolder",
+			gcsMethod: GcsMethod("GetFolder"),
 		},
 		{
 			name:      "gcs_method_ListObjects",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "ListObjects",
+			gcsMethod: GcsMethod("ListObjects"),
 		},
 		{
 			name:      "gcs_method_MoveObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "MoveObject",
+			gcsMethod: GcsMethod("MoveObject"),
 		},
 		{
 			name:      "gcs_method_MultiRangeDownloader::Add",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "MultiRangeDownloader::Add",
+			gcsMethod: GcsMethod("MultiRangeDownloader::Add"),
 		},
 		{
 			name:      "gcs_method_NewMultiRangeDownloader",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "NewMultiRangeDownloader",
+			gcsMethod: GcsMethod("NewMultiRangeDownloader"),
 		},
 		{
 			name:      "gcs_method_NewReader",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "NewReader",
+			gcsMethod: GcsMethod("NewReader"),
 		},
 		{
 			name:      "gcs_method_RenameFolder",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "RenameFolder",
+			gcsMethod: GcsMethod("RenameFolder"),
 		},
 		{
 			name:      "gcs_method_StatObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "StatObject",
+			gcsMethod: GcsMethod("StatObject"),
 		},
 		{
 			name:      "gcs_method_UpdateObject",
 			latencies: []time.Duration{100 * time.Millisecond, 200 * time.Millisecond},
-			gcsMethod: "UpdateObject",
+			gcsMethod: GcsMethod("UpdateObject"),
 		},
 	}
 
@@ -6224,7 +6224,7 @@ func TestGcsRequestLatencies(t *testing.T) {
 			require.True(t, ok, "gcs/request_latencies metric not found")
 
 			attrs := []attribute.KeyValue{
-				attribute.String("gcs_method", tc.gcsMethod),
+				attribute.String("gcs_method", string(tc.gcsMethod)),
 			}
 			s := attribute.NewSet(attrs...)
 			expectedKey := s.Encoded(encoder)
@@ -6245,7 +6245,7 @@ func TestGcsRetryCount(t *testing.T) {
 		{
 			name: "retry_error_category_OTHER_ERRORS",
 			f: func(m *otelMetrics) {
-				m.GcsRetryCount(5, "OTHER_ERRORS")
+				m.GcsRetryCount(5, RetryErrorCategory("OTHER_ERRORS"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")): 5,
@@ -6254,7 +6254,7 @@ func TestGcsRetryCount(t *testing.T) {
 		{
 			name: "retry_error_category_STALLED_READ_REQUEST",
 			f: func(m *otelMetrics) {
-				m.GcsRetryCount(5, "STALLED_READ_REQUEST")
+				m.GcsRetryCount(5, RetryErrorCategory("STALLED_READ_REQUEST"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")): 5,
@@ -6262,9 +6262,9 @@ func TestGcsRetryCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsRetryCount(5, "OTHER_ERRORS")
-				m.GcsRetryCount(2, "STALLED_READ_REQUEST")
-				m.GcsRetryCount(3, "OTHER_ERRORS")
+				m.GcsRetryCount(5, RetryErrorCategory("OTHER_ERRORS"))
+				m.GcsRetryCount(2, RetryErrorCategory("STALLED_READ_REQUEST"))
+				m.GcsRetryCount(3, RetryErrorCategory("OTHER_ERRORS"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")): 8,
 				attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")): 2,
@@ -6273,8 +6273,8 @@ func TestGcsRetryCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsRetryCount(-5, "OTHER_ERRORS")
-				m.GcsRetryCount(2, "OTHER_ERRORS")
+				m.GcsRetryCount(-5, RetryErrorCategory("OTHER_ERRORS"))
+				m.GcsRetryCount(2, RetryErrorCategory("OTHER_ERRORS"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")): 2},
 		},
@@ -6339,7 +6339,7 @@ func TestTestUpdownCounterWithAttrs(t *testing.T) {
 		{
 			name: "request_type_attr1",
 			f: func(m *otelMetrics) {
-				m.TestUpdownCounterWithAttrs(5, "attr1")
+				m.TestUpdownCounterWithAttrs(5, RequestType("attr1"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("request_type", "attr1")): 5,
@@ -6348,7 +6348,7 @@ func TestTestUpdownCounterWithAttrs(t *testing.T) {
 		{
 			name: "request_type_attr2",
 			f: func(m *otelMetrics) {
-				m.TestUpdownCounterWithAttrs(5, "attr2")
+				m.TestUpdownCounterWithAttrs(5, RequestType("attr2"))
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("request_type", "attr2")): 5,
@@ -6356,9 +6356,9 @@ func TestTestUpdownCounterWithAttrs(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.TestUpdownCounterWithAttrs(5, "attr1")
-				m.TestUpdownCounterWithAttrs(2, "attr2")
-				m.TestUpdownCounterWithAttrs(3, "attr1")
+				m.TestUpdownCounterWithAttrs(5, RequestType("attr1"))
+				m.TestUpdownCounterWithAttrs(2, RequestType("attr2"))
+				m.TestUpdownCounterWithAttrs(3, RequestType("attr1"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("request_type", "attr1")): 8,
 				attribute.NewSet(attribute.String("request_type", "attr2")): 2,
@@ -6367,8 +6367,8 @@ func TestTestUpdownCounterWithAttrs(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.TestUpdownCounterWithAttrs(-5, "attr1")
-				m.TestUpdownCounterWithAttrs(2, "attr1")
+				m.TestUpdownCounterWithAttrs(-5, RequestType("attr1"))
+				m.TestUpdownCounterWithAttrs(2, RequestType("attr1"))
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("request_type", "attr1")): -3},
 		},

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -54,10 +54,18 @@ type AttrValuePair struct {
 // AttrCombination is a list of AttrValuePairs.
 type AttrCombination []AttrValuePair
 
+// DistinctAttr represents a unique attribute with all its possible values.
+type DistinctAttr struct {
+	TypeName      string   // e.g., ReadType
+	AttributeName string   // e.g., read_type
+	Values        []string // e.g., ["sequential", "random"]
+}
+
 // Data structure to pass to the template.
 type TemplateData struct {
 	Metrics          []Metric
 	AttrCombinations map[string][]AttrCombination
+	DistinctAttrs    []DistinctAttr
 }
 
 // Helper functions for the template.
@@ -67,6 +75,7 @@ var funcMap = template.FuncMap{
 	"getVarName":                  getVarName,
 	"getAtomicName":               getAtomicName,
 	"getGoType":                   getGoType,
+	"getAttrConstName":            getAttrConstName,
 	"getUnitMethod":               getUnitMethod,
 	"joinInts":                    joinInts,
 	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
@@ -125,14 +134,15 @@ func getAtomicName(metricName string, combo AttrCombination) string {
 }
 
 func getGoType(t string) string {
-	switch t {
-	case "string":
-		return "string"
-	case "bool":
-		return "bool"
-	default:
-		return "interface{}"
+	// If the type is not a primitive, it's a custom attribute type.
+	if t != "string" && t != "bool" {
+		return toPascal(t)
 	}
+	return t
+}
+
+func getAttrConstName(typeName, valueName string) string {
+	return toPascal(typeName) + toPascal(valueName) + "Attr"
 }
 
 func getUnitMethod(unit string) string {
@@ -174,8 +184,8 @@ func getTestName(combo AttrCombination) string {
 func getTestFuncArgs(combo AttrCombination) string {
 	var parts []string
 	for _, pair := range combo {
-		if pair.Type == "string" {
-			parts = append(parts, `"`+pair.Value+`"`)
+		if pair.Type != "bool" {
+			parts = append(parts, fmt.Sprintf(`%s("%s")`, toPascal(pair.Type), pair.Value))
 		} else {
 			parts = append(parts, pair.Value)
 		}
@@ -187,7 +197,7 @@ func getTestFuncArgs(combo AttrCombination) string {
 func getExpectedAttrs(combo AttrCombination) string {
 	var parts []string
 	for _, pair := range combo {
-		if pair.Type == "string" {
+		if pair.Type != "bool" {
 			parts = append(parts, fmt.Sprintf(`attribute.String("%s", "%s")`, pair.Name, pair.Value))
 		} else { // bool
 			parts = append(parts, fmt.Sprintf(`attribute.Bool("%s", %s)`, pair.Name, pair.Value))
@@ -232,9 +242,10 @@ func generateCombinations(attributes []Attribute) []AttrCombination {
 	combsOfRest := generateCombinations(remainingAttrs)
 
 	var firstAttrValues []AttrValuePair
-	if firstAttr.Type == "string" {
+	if firstAttr.Type != "bool" {
 		for _, v := range firstAttr.Values {
-			firstAttrValues = append(firstAttrValues, AttrValuePair{Name: firstAttr.Name, Type: "string", Value: v})
+			// The type of the attribute is now the custom type, not "string".
+			firstAttrValues = append(firstAttrValues, AttrValuePair{Name: firstAttr.Name, Type: firstAttr.Type, Value: v})
 		}
 	} else if firstAttr.Type == "bool" {
 		firstAttrValues = append(firstAttrValues, AttrValuePair{Name: firstAttr.Name, Type: "bool", Value: "true"})
@@ -253,7 +264,7 @@ func generateCombinations(attributes []Attribute) []AttrCombination {
 
 func handleDefaultInSwitchCase(level int, attrName string, builder *strings.Builder) {
 	builder.WriteString(fmt.Sprintf("%sdefault:\n", strings.Repeat("\t", level+2)))
-	builder.WriteString(fmt.Sprintf("%supdateUnrecognizedAttribute(%s)\n", strings.Repeat("\t", level+3), toCamel(attrName)))
+	builder.WriteString(fmt.Sprintf("%supdateUnrecognizedAttribute(string(%s))\n", strings.Repeat("\t", level+3), toCamel(attrName)))
 	builder.WriteString(fmt.Sprintf("%sreturn\n", strings.Repeat("\t", level+3)))
 }
 
@@ -293,6 +304,25 @@ func validateMetric(m Metric) error {
 		}
 		if a.Type == "bool" && len(a.Values) != 0 {
 			return fmt.Errorf("values should not be present for bool attribute %q in metric %q", a.Name, m.Name)
+		}
+	}
+	return nil
+}
+
+// validateAttributeConstants checks if any two attributes would resolve to the
+// same constant name.
+func validateAttributeConstants(attrs []DistinctAttr) error {
+	constNames := make(map[string]string)
+	for _, attr := range attrs {
+		for _, val := range attr.Values {
+			constName := getAttrConstName(attr.TypeName, val)
+			if originalAttr, ok := constNames[constName]; ok {
+				return fmt.Errorf(
+					"constant name collision: attribute %q with value %q and attribute %q "+
+						"both generate constant %q",
+					attr.AttributeName, val, originalAttr, constName)
+			}
+			constNames[constName] = attr.AttributeName
 		}
 	}
 	return nil
@@ -373,22 +403,23 @@ func buildSwitches(metric Metric) string {
 		builder.WriteString(fmt.Sprintf("%sswitch %s {\n", indent, toCamel(attr.Name)))
 
 		var values []string
-		if attr.Type == "string" {
-			values = attr.Values
-		} else { // bool
+		isBool := attr.Type == "bool"
+		if isBool {
 			values = []string{"true", "false"}
+		} else {
+			values = attr.Values
 		}
 
 		for _, val := range values {
 			caseVal := val
-			if attr.Type == "string" {
-				caseVal = `"` + val + `"`
+			if !isBool {
+				caseVal = getAttrConstName(attr.Type, val)
 			}
 			builder.WriteString(fmt.Sprintf("%scase %s:\n", strings.Repeat("\t", level+2), caseVal))
 			currentCombo := append(combo, AttrValuePair{Name: attr.Name, Type: attr.Type, Value: val})
 			recorder(level+1, currentCombo)
 		}
-		if attr.Type == "string" {
+		if !isBool {
 			handleDefaultInSwitchCase(level, attr.Name, &builder)
 		}
 		builder.WriteString(fmt.Sprintf("%s}\n", indent))
@@ -442,18 +473,68 @@ func main() {
 		}
 	}
 
-	attrCombinations := make(map[string][]AttrCombination)
+	// Find all distinct string attributes to generate types and constants for them.
+	distinctAttrsMap := make(map[string]map[string]bool) // map[attrName]map[value]bool
 	for _, m := range metrics {
-		attrCombinations[m.Name] = generateCombinations(m.Attributes)
+		for _, attr := range m.Attributes {
+			// We only generate constants for string attributes.
+			if attr.Type == "string" {
+				if _, ok := distinctAttrsMap[attr.Name]; !ok {
+					distinctAttrsMap[attr.Name] = make(map[string]bool)
+				}
+				for _, val := range attr.Values {
+					distinctAttrsMap[attr.Name][val] = true
+				}
+			}
+		}
+	}
+	var distinctAttrs []DistinctAttr
+	for attrName, valuesMap := range distinctAttrsMap {
+		var values []string
+		for val := range valuesMap {
+			values = append(values, val)
+		}
+		sort.Strings(values)
+		distinctAttrs = append(distinctAttrs, DistinctAttr{
+			TypeName:      toPascal(attrName),
+			AttributeName: attrName,
+			Values:        values,
+		})
+	}
+	// Sort for deterministic output.
+	sort.Slice(distinctAttrs, func(i, j int) bool {
+		return distinctAttrs[i].AttributeName < distinctAttrs[j].AttributeName
+	})
+
+	if err := validateAttributeConstants(distinctAttrs); err != nil {
+		log.Fatalf("error validating attribute constants: %v", err)
+	}
+
+	// In the template data, update the attribute type to be the custom type name
+	// for the distinct attributes. This allows the templates to generate the
+	// correct type in function signatures.
+	for i, m := range metrics {
+		for j, attr := range m.Attributes {
+			if _, isDistinct := distinctAttrsMap[attr.Name]; isDistinct {
+				metrics[i].Attributes[j].Type = attr.Name
+			}
+		}
 	}
 
 	// Create the directory if it doesn't exist
 	if err := os.MkdirAll(*outputDir, 0755); err != nil {
 		log.Fatalf("error creating output directory: %v", err)
 	}
+
+	attrCombinations := make(map[string][]AttrCombination)
+	for _, m := range metrics {
+		attrCombinations[m.Name] = generateCombinations(m.Attributes)
+	}
+
 	data := TemplateData{
 		Metrics:          metrics,
 		AttrCombinations: attrCombinations,
+		DistinctAttrs:    distinctAttrs,
 	}
 	createFile(&data, fmt.Sprintf("%s/metric_handle.go", *outputDir), "metric_handle.tpl")
 	createFile(&data, fmt.Sprintf("%s/noop_metrics.go", *outputDir), "noop_metrics.tpl")

--- a/tools/metrics-gen/metric_handle.tpl
+++ b/tools/metrics-gen/metric_handle.tpl
@@ -20,6 +20,17 @@ import (
 	"time"
 )
 
+{{range .DistinctAttrs}}
+{{- $attr := . -}}
+// {{.TypeName}} is a custom type for the {{.AttributeName}} attribute.
+type {{.TypeName}} string
+const (
+{{- range .Values}}
+	{{getAttrConstName $attr.TypeName .}} {{$attr.TypeName}} = "{{.}}"
+{{- end}}
+)
+{{end}}
+
 // MetricHandle provides an interface for recording metrics.
 // The methods of this interface are auto-generated from metrics.yaml.
 // Each method corresponds to a metric defined in metrics.yaml.
@@ -30,7 +41,7 @@ type MetricHandle interface {
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, duration time.Duration
+			ctx context.Context, latency time.Duration
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/noop_metrics.tpl
+++ b/tools/metrics-gen/noop_metrics.tpl
@@ -26,7 +26,7 @@ type noopMetrics struct {}
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, duration time.Duration
+			ctx context.Context, latency time.Duration
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/otel_metrics.tpl
+++ b/tools/metrics-gen/otel_metrics.tpl
@@ -38,7 +38,7 @@ var (
 {{- range $combination := (index $.AttrCombinations $metric.Name)}}
 	{{getVarName $metric.Name $combination}} = metric.WithAttributeSet(attribute.NewSet(
 		{{- range $pair := $combination -}}
-			attribute.{{if eq $pair.Type "string"}}String{{else}}Bool{{end}}("{{$pair.Name}}", {{if eq $pair.Type "string"}}"{{$pair.Value}}"{{else}}{{$pair.Value}}{{end}}),
+			attribute.{{if eq $pair.Type "bool"}}Bool{{else}}String{{end}}("{{$pair.Name}}", {{if eq $pair.Type "bool"}}{{$pair.Value}}{{else}}"{{$pair.Value}}"{{end}}),
 		{{- end -}}
 	))
 {{- end -}}

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -243,7 +243,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			name:      "{{getTestName $combination}}",
 			latencies: []time.Duration{100 * time.{{getLatencyUnit $metric.Unit}}, 200 * time.{{getLatencyUnit $metric.Unit}}},
 			{{- range $pair := $combination}}
-			{{toCamel $pair.Name}}: {{if eq $pair.Type "string"}}"{{$pair.Value}}"{{else}}{{$pair.Value}}{{end}},
+			{{toCamel $pair.Name}}: {{if eq $pair.Type "bool"}}{{$pair.Value}}{{else}}{{getGoType $pair.Type}}("{{$pair.Value}}"){{end}},
 			{{- end}}
 		},
 		{{- end}}
@@ -268,7 +268,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 
 			attrs := []attribute.KeyValue{
 				{{- range .Attributes}}
-				attribute.{{if eq .Type "string"}}String{{else}}Bool{{end}}("{{.Name}}", tc.{{toCamel .Name}}),
+				attribute.{{if eq .Type "bool"}}Bool("{{.Name}}", tc.{{toCamel .Name}}){{else}}String("{{.Name}}", string(tc.{{toCamel .Name}})){{end}},
 				{{- end}}
 			}
 			s := attribute.NewSet(attrs...)


### PR DESCRIPTION
This change introduces a new mechanism to generate strongly-typed constants for metric attributes defined in `metrics.yaml`. This improves type safety and reduces the chances of errors caused by using free strings.

The key changes are:
- The metrics generator (`tools/metrics-gen/main.go`) now parses all distinct string attributes and generates a new type and a set of constants for each.
- The generated `MetricHandle` interface and its implementations now use these new custom types in function signatures.
- The OpenTelemetry implementation has been updated to use the new typed constants.
- Validation has been added to prevent naming collisions between generated constants.

### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
