### PR TITLE
feat(bufferedread):  Handle -1 for read.global-max-blocks as infinite

### DIFF
--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -134,6 +134,12 @@ func resolveFileCacheAndBufferedReadConflict(v isSet, c *Config) {
 	}
 }
 
+func resolveReadConfig(r *ReadConfig) {
+	if r.GlobalMaxBlocks == -1 {
+		r.GlobalMaxBlocks = math.MaxInt32
+	}
+}
+
 func resolveLoggingConfig(config *Config) {
 	if config.Debug.Fuse || config.Debug.Gcs || config.Debug.LogMutex {
 		config.Logging.Severity = "TRACE"
@@ -159,6 +165,7 @@ func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	}
 
 	resolveLoggingConfig(c)
+	resolveReadConfig(&c.Read)
 	resolveStreamingWriteConfig(&c.Write)
 	resolveMetadataCacheTTL(v, &c.MetadataCache, optimizedFlags)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache, optimizedFlags)

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -69,6 +69,43 @@ func TestRationalizeCustomEndpointSuccessful(t *testing.T) {
 	}
 }
 
+func TestRationalize_ReadConfig(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		config                  *Config
+		expectedGlobalMaxBlocks int64
+	}{
+		{
+			name: "global-max-blocks is -1",
+			config: &Config{
+				Read: ReadConfig{
+					GlobalMaxBlocks: -1,
+				},
+			},
+			expectedGlobalMaxBlocks: math.MaxInt32,
+		},
+		{
+			name: "global-max-blocks is not -1",
+			config: &Config{
+				Read: ReadConfig{
+					GlobalMaxBlocks: 100,
+				},
+			},
+			expectedGlobalMaxBlocks: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Rationalize(&mockIsSet{}, tc.config, []string{})
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedGlobalMaxBlocks, tc.config.Read.GlobalMaxBlocks)
+			}
+		})
+	}
+}
+
 func TestRationalizeCustomEndpointUnsuccessful(t *testing.T) {
 	testCases := []struct {
 		name   string


### PR DESCRIPTION
### Description
This PR handles the -1 value for `read.global-max-blocks`. When this parameter is set to -1, it will be interpreted as an infinite value and set to `math.MaxInt32`.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/448271034

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
