### PR TITLE
fix: add retry for "could not read remote repo" error in interrupt tests

### DIFF
--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -64,7 +64,8 @@ func (s *ignoreInterruptsTest) SetupTest() {
 func (s *ignoreInterruptsTest) cloneRepository() (output []byte, err error) {
 	maxAttempts := 5
 	isRetryableError := func(err error) bool {
-		return strings.Contains(strings.ToLower(err.Error()), "could not resolve host")
+		return strings.Contains(strings.ToLower(err.Error()), "could not resolve host") ||
+			strings.Contains(strings.ToLower(err.Error()), "could not read from remote repository")
 	}
 	for i := range maxAttempts {
 		output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "clone %s", repoURL)


### PR DESCRIPTION
### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
