### PR TITLE
test(metrics-landing): Add unit test to verify metrics updates for LookUpInode

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -17,6 +17,7 @@ package fs_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
@@ -75,6 +76,10 @@ func createTestFileSystemWithMetrics(ctx context.Context, t *testing.T) (gcs.Buc
 func createWithContents(ctx context.Context, t *testing.T, bucket gcs.Bucket, name string, contents string) {
 	err := storageutil.CreateObjects(ctx, bucket, map[string][]byte{name: []byte(contents)})
 	require.NoError(t, err, "CreateObjects")
+}
+
+func waitForMetricsProcessing() {
+	time.Sleep(time.Millisecond)
 }
 
 // verifyCounterMetric finds a counter metric and verifies that the data point
@@ -185,6 +190,7 @@ func TestLookUpInode_Metrics(t *testing.T) {
 			}
 
 			err := server.LookUpInode(ctx, op)
+			waitForMetricsProcessing()
 
 			assert.Equal(t, tc.expectedError, err)
 			attrs := attribute.NewSet(attribute.String("fs_op", "LookUpInode"))


### PR DESCRIPTION
### Description
* Creates a new framework that removes kernel from the picture and takes control over triggering fs operations in GCSFuse. This helps put stronger assertions on metrics and can even be used to predict exactly how much a metric would move.
* Adds a new unit test for the `LookUpInode` method in `internal/fs/fs.go`. More to be added later.

### Link to the issue in case of a bug fix.
b/450212196, b/450211478

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
