### PR TITLE
test(metrics-landing): Add metrics tests for all GCSFuse FS operations

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -240,7 +240,7 @@ func TestReadFile_BufferedReadMetrics(t *testing.T) {
 
 func TestGetInodeAttributes_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.GetInodeAttributesOp{
 		Inode: fuseops.RootInodeID,
@@ -257,7 +257,7 @@ func TestGetInodeAttributes_Metrics(t *testing.T) {
 
 func TestRemoveXattr_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -284,7 +284,7 @@ func TestRemoveXattr_Metrics(t *testing.T) {
 
 func TestListXattr_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -310,7 +310,7 @@ func TestListXattr_Metrics(t *testing.T) {
 
 func TestSetXattr_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -338,7 +338,7 @@ func TestSetXattr_Metrics(t *testing.T) {
 
 func TestGetXattr_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -365,7 +365,7 @@ func TestGetXattr_Metrics(t *testing.T) {
 
 func TestFallocate_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -400,7 +400,7 @@ func TestFallocate_Metrics(t *testing.T) {
 
 func TestCreateLink_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -428,7 +428,7 @@ func TestCreateLink_Metrics(t *testing.T) {
 
 func TestStatFS_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.StatFSOp{}
 
@@ -443,7 +443,7 @@ func TestStatFS_Metrics(t *testing.T) {
 
 func TestReleaseFileHandle_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "")
@@ -473,7 +473,7 @@ func TestReleaseFileHandle_Metrics(t *testing.T) {
 
 func TestFlushFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "")
@@ -504,7 +504,7 @@ func TestFlushFile_Metrics(t *testing.T) {
 
 func TestSyncFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "")
@@ -529,7 +529,7 @@ func TestSyncFile_Metrics(t *testing.T) {
 
 func TestWriteFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "")
@@ -562,7 +562,7 @@ func TestWriteFile_Metrics(t *testing.T) {
 
 func TestReadSymlink_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	symlinkName := "test"
 	target := "target"
@@ -588,7 +588,7 @@ func TestReadSymlink_Metrics(t *testing.T) {
 
 func TestReadFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	content := "test content"
@@ -622,7 +622,7 @@ func TestReadFile_Metrics(t *testing.T) {
 
 func TestOpenFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -647,7 +647,7 @@ func TestOpenFile_Metrics(t *testing.T) {
 
 func TestReleaseDirHandle_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	openOp := &fuseops.OpenDirOp{
 		Inode: fuseops.RootInodeID,
@@ -669,7 +669,7 @@ func TestReleaseDirHandle_Metrics(t *testing.T) {
 
 func TestReadDirPlus_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	openOp := &fuseops.OpenDirOp{
 		Inode: fuseops.RootInodeID,
@@ -696,7 +696,7 @@ func TestReadDirPlus_Metrics(t *testing.T) {
 
 func TestReadDir_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	openOp := &fuseops.OpenDirOp{
 		Inode: fuseops.RootInodeID,
@@ -721,7 +721,7 @@ func TestReadDir_Metrics(t *testing.T) {
 
 func TestOpenDir_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.OpenDirOp{
 		Inode: fuseops.RootInodeID,
@@ -738,7 +738,7 @@ func TestOpenDir_Metrics(t *testing.T) {
 
 func TestForgetInode_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -764,7 +764,7 @@ func TestForgetInode_Metrics(t *testing.T) {
 
 func TestRename_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	oldName := "old"
 	newName := "new"
@@ -787,7 +787,7 @@ func TestRename_Metrics(t *testing.T) {
 
 func TestUnlink_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")
@@ -807,7 +807,7 @@ func TestUnlink_Metrics(t *testing.T) {
 
 func TestRmDir_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	dirName := "test"
 	mkDirOp := &fuseops.MkDirOp{
@@ -832,7 +832,7 @@ func TestRmDir_Metrics(t *testing.T) {
 
 func TestCreateSymlink_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.CreateSymlinkOp{
 		Parent: fuseops.RootInodeID,
@@ -851,7 +851,7 @@ func TestCreateSymlink_Metrics(t *testing.T) {
 
 func TestCreateFile_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.CreateFileOp{
 		Parent: fuseops.RootInodeID,
@@ -869,7 +869,7 @@ func TestCreateFile_Metrics(t *testing.T) {
 
 func TestMkNode_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.MkNodeOp{
 		Parent: fuseops.RootInodeID,
@@ -887,7 +887,7 @@ func TestMkNode_Metrics(t *testing.T) {
 
 func TestMkDir_Metrics(t *testing.T) {
 	ctx := context.Background()
-	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	_, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	op := &fuseops.MkDirOp{
 		Parent: fuseops.RootInodeID,
@@ -905,7 +905,7 @@ func TestMkDir_Metrics(t *testing.T) {
 
 func TestSetInodeAttributes_Metrics(t *testing.T) {
 	ctx := context.Background()
-	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t)
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, false)
 	server = wrappers.WithMonitoring(server, mh)
 	fileName := "test"
 	createWithContents(ctx, t, bucket, fileName, "test")


### PR DESCRIPTION
### Description
This change extends the metrics test suite in internal/fs/metrics_test.go to cover all GCSFuse FS operations. Previously, only the LookUpInode operation was tested. This change adds tests for all other operations, including file and directory operations, symlinks, and extended attributes.

- Added a comprehensive suite of new tests to internal/fs/metrics_test.go to verify that the correct metrics are emitted for each FS operation.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No