### PR TITLE
fix(metrics): Fix duplicate updates of metrics

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -71,6 +71,7 @@ func createTestFileSystemWithMetrics(ctx context.Context, t *testing.T, enableBu
 				bucketName: bucket,
 			},
 		},
+		SequentialReadSizeMb: 200,
 	}
 	server, err := fs.NewFileSystem(ctx, serverCfg)
 	require.NoError(t, err, "NewFileSystem")
@@ -617,6 +618,8 @@ func TestReadFile_Metrics(t *testing.T) {
 	assert.NoError(t, err)
 	attrs := attribute.NewSet(attribute.String("fs_op", "ReadFile"))
 	verifyCounterMetric(t, ctx, reader, "fs/ops_count", attrs, 1)
+	verifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", "Sequential")), int64(len(content)))
+	verifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", "Sequential")), 1)
 	verifyHistogramMetric(t, ctx, reader, "fs/ops_latency", attrs, 1)
 }
 

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -734,8 +734,6 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 		return
 	}
 
-	requestedDataSize := end - offset
-	metrics.CaptureGCSReadMetrics(rr.metricHandle, metrics.ReadTypeNames[readType], requestedDataSize)
 	rr.updateExpectedOffset(offset + int64(n))
 
 	return


### PR DESCRIPTION
### Description
The gcs/read_count and gcs/download_bytes_count metrics get updated twice. Remove one of the instances so that it only gets updated once.

### Link to the issue in case of a bug fix.
b/443637302

### Testing details
1. Manual - NA
2. Unit tests - Tested
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No