### PR TITLE
docs(known issues): Update known issue docs with GPG failed check error with GCSFuse installation 

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,6 +8,8 @@ This document lists known issues and bugs in GCSFuse, their impact, and the rele
 | :--- | :--- | :--- |
 | GCSFuse can hang when repeatedly writing to the same file using gRPC. | Applications that perform frequent writes to the same file may experience deadlocks. | [#2784](https://github.com/GoogleCloudPlatform/gcsfuse/issues/2784) |
 | An "Input/Output error" can occur when repeatedly writing to an existing file using gRPC. | This can lead to data corruption or incomplete writes. | [#2783](https://github.com/GoogleCloudPlatform/gcsfuse/issues/2783) |
+| `Error: GPG check FAILED` while installing GCSFuse on newer OS with strict cryptographic policies |This interrupts GCSFuse installation on certain OS (e.g., Rocky Linux 10, Red Hat Enterprise Linux 10). | [#3874](https://github.com/GoogleCloudPlatform/gcsfuse/issues/3874) |
+
 
 ## Resolved Issues
 


### PR DESCRIPTION
### Description
This PR is to update the known issues with the recent issue with GCSFuse installation as raised here [#3874](https://github.com/GoogleCloudPlatform/gcsfuse/issues/3874) 
### Link to the issue in case of a bug fix.
[b/450495678](https://b.corp.google.com/issues/450495678)
### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
