### PR TITLE
refactor: only dir mounting [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -157,7 +157,6 @@ rename_dir_limit:
 local_file:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    only_dir: "${ONLY_DIR}"
     log_file: # Optional
     configs:
       - flags:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -157,6 +157,7 @@ rename_dir_limit:
 local_file:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     log_file: # Optional
     configs:
       - flags:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -157,6 +157,7 @@ rename_dir_limit:
 local_file:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     log_file: # Optional
     configs:
       - flags:
@@ -221,6 +222,7 @@ requester_pays_bucket:
 read_cache:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     log_file: # Not Required by read_cache tests
     configs:
       - flags:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -133,7 +133,7 @@ readonly:
 
 rename_dir_limit:
   - mounted_directory: "${MOUNTED_DIR}"
-    test_bucket: "${BUCKET_NAME}"
+    test_bucket: "${BUCKET_NAME}/${ONLY_DIR}"
     log_file: # Optional
     configs:
       - flags:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -133,7 +133,8 @@ readonly:
 
 rename_dir_limit:
   - mounted_directory: "${MOUNTED_DIR}"
-    test_bucket: "${BUCKET_NAME}/${ONLY_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     log_file: # Optional
     configs:
       - flags:


### PR DESCRIPTION
### Description
This PR includes temporary solution/changes in config setup so that GKE can also run only dir mount tests using an environment variable.

### Link to the issue in case of a bug fix.
https://buganizer.corp.google.com/issues/454584177

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
