### PR TITLE
fix(storageutil): make waitWithJitter method deterministic when context is already cancelled

### DIFF
--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -70,6 +70,11 @@ func (b *exponentialBackoff) nextDuration() time.Duration {
 // The jitter adds randomness to the backoff duration to prevent the thundering herd problem.
 // This is similar to how gax-retries backoff after each failed retry.
 func (b *exponentialBackoff) waitWithJitter(ctx context.Context) error {
+	// If the context is already cancelled, return immediately.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	nextDuration := b.nextDuration()
 	jitteryBackoffDuration := time.Duration(1 + rand.Int63n(int64(nextDuration)))
 	select {


### PR DESCRIPTION
### Description
Ensure context is checked beforehand to ensure proper error is returned if the context is already cancelled. See more details on the b/446816512

## Fixes this test flakiness and few other of similar pattern
https://github.com/GoogleCloudPlatform/gcsfuse/blob/3d9975c14adeccaaac47b91dae67340e97836cc1/internal/storage/storageutil/retry_test.go#L86-L106
### Link to the issue in case of a bug fix.
b/446816512

### Testing details
1. Manual - Done
2. Unit tests - 2000 runs of this test didn't gave any error.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
