### PR TITLE
test(storageutil): reduce flakiness caused by shorter timeout buffer in test

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,1 +1,0 @@
-ok  	github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil	104.179s


### PR DESCRIPTION
### Description
Remove flakiness in test due to race between the stall duration and context timeout. 1ms is not enough and prone to race conditions where context deadline is not propagated quick enough. Running the original test with `--count=1000` fails almost always.
### Link to the issue in case of a bug fix.
b/446816512

### Testing details
1. Manual - Done
2. Unit tests - Tested whole `retry_test.go` file many times with --count=10000 and it passed.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
