### PR TITLE
refactor: dentry cache test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/dentry_cache/delete_operation_test.go
+++ b/tools/integration_tests/dentry_cache/delete_operation_test.go
@@ -39,9 +39,6 @@ type deleteOperationTest struct {
 }
 
 func (s *deleteOperationTest) SetupTest() {
-	//Truncate log file created.
-	err := os.Truncate(testEnv.cfg.LogFile, 0)
-	require.NoError(s.T(), err)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 
@@ -58,6 +55,7 @@ func (s *deleteOperationTest) SetupSuite() {
 }
 
 func (s *deleteOperationTest) TestDeleteFileWhenFileIsClobbered() {
+	testFileName := s.T().Name()
 	// Create a file with initial content directly in GCS.
 	filePath := path.Join(testEnv.testDirPath, testFileName)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
@@ -65,7 +63,7 @@ func (s *deleteOperationTest) TestDeleteFileWhenFileIsClobbered() {
 	_, err := os.Stat(filePath)
 	require.Nil(s.T(), err)
 	// Modify the object on GCS.
-	objectName := path.Join(testDirName, testFileName)
+	objectName := path.Join(testDirName, testFileName) // This is correct, objectName is relative to bucket.
 	smallContent, err := operations.GenerateRandomData(updatedContentSize)
 	require.Nil(s.T(), err)
 	require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -39,7 +39,6 @@ type notifierTest struct {
 }
 
 func (s *notifierTest) SetupTest() {
-	//Truncate log file created.
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -101,7 +101,7 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
 	// Second Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	// Therefore, the second read succeeds even before the metadata cache TTL expires. 
+	// Therefore, the second read succeeds even before the metadata cache TTL expires.
 	assert.Nil(s.T(), err)
 }
 

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -16,12 +16,18 @@ package dentry_cache
 
 import (
 	"context"
+	"log"
+	"os"
+	"path"
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
@@ -50,89 +56,91 @@ func (s *notifierTest) SetupSuite() {
 }
 
 func (s *notifierTest) TestWriteFileWithDentryCacheEnabled() {
-	// // Create a file with initial content directly in GCS.
-	// filePath := path.Join(testEnv.testDirPath, testFileName)
-	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// // Stat file to cache the entry
-	// _, err := os.Stat(filePath)
-	// require.Nil(s.T(), err)
-	// // Modify the object on GCS.
-	// objectName := path.Join(testDirName, testFileName)
-	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	// require.Nil(s.T(), err)
-	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
+	testFileName := s.T().Name()
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(testEnv.testDirPath, testFileName)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(s.T(), err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	require.Nil(s.T(), err)
+	require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// // First Write File attempt.
-	// err = operations.WriteFile(filePath, "ShouldNotWrite")
+	// First Write File attempt.
+	err = operations.WriteFile(filePath, "ShouldNotWrite")
 
-	// // First Write File attempt should fail because file has been clobbered.
-	// operations.ValidateESTALEError(s.T(), err)
-	// // Second Write File attempt.
-	// err = operations.WriteFile(filePath, "ShouldWrite")
-	// // The notifier is triggered after the first write failure, invalidating the kernel cache entry.
-	// // Therefore, the second write succeeds even before the metadata cache TTL expires.
-	// assert.Nil(s.T(), err)
+	// First Write File attempt should fail because file has been clobbered.
+	operations.ValidateESTALEError(s.T(), err)
+	// Second Write File attempt.
+	err = operations.WriteFile(filePath, "ShouldWrite")
+	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
+	// Therefore, the second write succeeds even before the metadata cache TTL expires.
+	assert.Nil(s.T(), err)
 }
 
 func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
-	// // Create a file with initial content directly in GCS.
-	// filePath := path.Join(testEnv.testDirPath, testFileName)
-	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// // Stat file to cache the entry
-	// _, err := os.Stat(filePath)
-	// require.Nil(s.T(), err)
-	// // Modify the object on GCS.
-	// objectName := path.Join(testDirName, testFileName)
-	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	// require.Nil(s.T(), err)
-	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
+	testFileName := s.T().Name()
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(testEnv.testDirPath, testFileName)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(s.T(), err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	require.Nil(s.T(), err)
+	require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// // First Read File attempt.
-	// _, err = operations.ReadFile(filePath)
-
-	// // First Read File attempt should fail because file has been clobbered.
-	// operations.ValidateESTALEError(s.T(), err)
-	// // Second Read File attempt.
-	// _, err = operations.ReadFile(filePath)
-	// // The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	// // Therefore, the second read succeeds even before the metadata cache TTL expires.
-	// assert.Nil(s.T(), err)
+	// First Read File attempt.
+	_, err = operations.ReadFile(filePath)
+	// First Read File attempt should fail because file has been clobbered.
+	operations.ValidateESTALEError(s.T(), err)
+	// Second Read File attempt.
+	_, err = operations.ReadFile(filePath)
+	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
+	// Therefore, the second read succeeds even before the metadata cache TTL expires.
+	assert.Nil(s.T(), err)
 }
 
 func (s *notifierTest) TestDeleteFileWithDentryCacheEnabled() {
-	// // Create a file with initial content directly in GCS.
-	// filePath := path.Join(testEnv.testDirPath, testFileName)
-	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// // Stat file to cache the entry
-	// _, err := os.Stat(filePath)
-	// require.Nil(s.T(), err)
-	// // Delete the object directly from GCS.
-	// objectName := path.Join(testDirName, testFileName)
-	// require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
-	// // Read File to call the notifier to invalidate entry.
-	// _, err = operations.ReadFile(filePath)
-	// // The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	// operations.ValidateESTALEError(s.T(), err)
+	testFileName := s.T().Name()
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(testEnv.testDirPath, testFileName)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(s.T(), err)
+	// Delete the object directly from GCS.
+	objectName := path.Join(testDirName, testFileName)
+	require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
+	// Read File to call the notifier to invalidate entry.
+	_, err = operations.ReadFile(filePath)
+	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
+	operations.ValidateESTALEError(s.T(), err)
 
-	// // Stat again, it should give error as entry does not exist.
-	// _, err = os.Stat(filePath)
+	// Stat again, it should give error as entry does not exist.
+	_, err = os.Stat(filePath)
 
-	// assert.NotNil(s.T(), err)
+	assert.NotNil(s.T(), err)
 }
 
 func TestNotifierTest(t *testing.T) {
-	// ts := &notifierTest{ctx: context.Background(), storageClient: testEnv.storageClient}
+	ts := &notifierTest{ctx: context.Background(), storageClient: testEnv.storageClient}
 
-	// // Run tests for mounted directory if the flag is set.
-	// if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-	// 	suite.Run(t, ts)
-	// 	return
-	// }
+	// Run tests for mounted directory if the flag is set.
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
+		return
+	}
 
-	// // Run tests for GCE environment otherwise.
-	// flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
-	// for _, ts.flags = range flagsSet {
-	// 	log.Printf("Running tests with flags: %s", ts.flags)
-	// 	suite.Run(t, ts)
-	// }
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,119 +15,124 @@
 package dentry_cache
 
 import (
-	"log"
-	"os"
-	"path"
+	"context"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type notifierTest struct {
-	flags []string
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
 	suite.Suite
 }
 
 func (s *notifierTest) SetupTest() {
-	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+	//Truncate log file created.
+	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 
 func (s *notifierTest) TearDownTest() {
-	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
-		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
-		setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
-	}
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+func (s *notifierTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *notifierTest) SetupSuite() {
+	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 
 func (s *notifierTest) TestWriteFileWithDentryCacheEnabled() {
-	// Create a file with initial content directly in GCS.
-	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Stat file to cache the entry
-	_, err := os.Stat(filePath)
-	require.Nil(s.T(), err)
-	// Modify the object on GCS.
-	objectName := path.Join(testDirName, testFileName)
-	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
+	// // Create a file with initial content directly in GCS.
+	// filePath := path.Join(testEnv.testDirPath, testFileName)
+	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// // Stat file to cache the entry
+	// _, err := os.Stat(filePath)
+	// require.Nil(s.T(), err)
+	// // Modify the object on GCS.
+	// objectName := path.Join(testDirName, testFileName)
+	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	// require.Nil(s.T(), err)
+	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// First Write File attempt.
-	err = operations.WriteFile(filePath, "ShouldNotWrite")
+	// // First Write File attempt.
+	// err = operations.WriteFile(filePath, "ShouldNotWrite")
 
-	// First Write File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
-	// Second Write File attempt.
-	err = operations.WriteFile(filePath, "ShouldWrite")
-	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
-	// Therefore, the second write succeeds even before the metadata cache TTL expires.
-	assert.Nil(s.T(), err)
+	// // First Write File attempt should fail because file has been clobbered.
+	// operations.ValidateESTALEError(s.T(), err)
+	// // Second Write File attempt.
+	// err = operations.WriteFile(filePath, "ShouldWrite")
+	// // The notifier is triggered after the first write failure, invalidating the kernel cache entry.
+	// // Therefore, the second write succeeds even before the metadata cache TTL expires.
+	// assert.Nil(s.T(), err)
 }
 
 func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
-	// Create a file with initial content directly in GCS.
-	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Stat file to cache the entry
-	_, err := os.Stat(filePath)
-	require.Nil(s.T(), err)
-	// Modify the object on GCS.
-	objectName := path.Join(testDirName, testFileName)
-	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
+	// // Create a file with initial content directly in GCS.
+	// filePath := path.Join(testEnv.testDirPath, testFileName)
+	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// // Stat file to cache the entry
+	// _, err := os.Stat(filePath)
+	// require.Nil(s.T(), err)
+	// // Modify the object on GCS.
+	// objectName := path.Join(testDirName, testFileName)
+	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	// require.Nil(s.T(), err)
+	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// First Read File attempt.
-	_, err = operations.ReadFile(filePath)
+	// // First Read File attempt.
+	// _, err = operations.ReadFile(filePath)
 
-	// First Read File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
-	// Second Read File attempt.
-	_, err = operations.ReadFile(filePath)
-	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	// Therefore, the second read succeeds even before the metadata cache TTL expires.
-	assert.Nil(s.T(), err)
+	// // First Read File attempt should fail because file has been clobbered.
+	// operations.ValidateESTALEError(s.T(), err)
+	// // Second Read File attempt.
+	// _, err = operations.ReadFile(filePath)
+	// // The notifier is triggered after the first read failure, invalidating the kernel cache entry.
+	// // Therefore, the second read succeeds even before the metadata cache TTL expires.
+	// assert.Nil(s.T(), err)
 }
 
 func (s *notifierTest) TestDeleteFileWithDentryCacheEnabled() {
-	// Create a file with initial content directly in GCS.
-	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Stat file to cache the entry
-	_, err := os.Stat(filePath)
-	require.Nil(s.T(), err)
-	// Delete the object directly from GCS.
-	objectName := path.Join(testDirName, testFileName)
-	require.Nil(s.T(), client.DeleteObjectOnGCS(ctx, storageClient, objectName))
-	// Read File to call the notifier to invalidate entry.
-	_, err = operations.ReadFile(filePath)
-	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	operations.ValidateESTALEError(s.T(), err)
+	// // Create a file with initial content directly in GCS.
+	// filePath := path.Join(testEnv.testDirPath, testFileName)
+	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// // Stat file to cache the entry
+	// _, err := os.Stat(filePath)
+	// require.Nil(s.T(), err)
+	// // Delete the object directly from GCS.
+	// objectName := path.Join(testDirName, testFileName)
+	// require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
+	// // Read File to call the notifier to invalidate entry.
+	// _, err = operations.ReadFile(filePath)
+	// // The notifier is triggered after the first read failure, invalidating the kernel cache entry.
+	// operations.ValidateESTALEError(s.T(), err)
 
-	// Stat again, it should give error as entry does not exist.
-	_, err = os.Stat(filePath)
+	// // Stat again, it should give error as entry does not exist.
+	// _, err = os.Stat(filePath)
 
-	assert.NotNil(s.T(), err)
+	// assert.NotNil(s.T(), err)
 }
 
 func TestNotifierTest(t *testing.T) {
-	ts := &notifierTest{}
+	// ts := &notifierTest{ctx: context.Background(), storageClient: testEnv.storageClient}
 
-	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		suite.Run(t, ts)
-		return
-	}
+	// // Run tests for mounted directory if the flag is set.
+	// if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+	// 	suite.Run(t, ts)
+	// 	return
+	// }
 
-	// Setup flags and run tests.
-	ts.flags = []string{"--implicit-dirs", "--experimental-enable-dentry-cache", "--metadata-cache-ttl-secs=1000"}
-	log.Printf("Running tests with flags: %s", ts.flags)
-	suite.Run(t, ts)
+	// // Run tests for GCE environment otherwise.
+	// flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	// for _, ts.flags = range flagsSet {
+	// 	log.Printf("Running tests with flags: %s", ts.flags)
+	// 	suite.Run(t, ts)
+	// }
 }

--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -101,7 +101,7 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
 	// Second Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	// Therefore, the second read succeeds even before the metadata cache TTL expires.
+	// Therefore, the second read succeeds even before the metadata cache TTL expires. 
 	assert.Nil(s.T(), err)
 }
 

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	testDirName        = "testDirForDentryCache"
-	testFileName       = "testFile"
 	initialContentSize = 5
 	updatedContentSize = 10
 )

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,6 +26,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
@@ -36,53 +37,85 @@ const (
 )
 
 var (
-	storageClient *storage.Client
-	ctx           context.Context
-	testDirPath   string
-	mountFunc     func([]string) error
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
 	rootDir string
 )
 
-func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	setup.SetMntDir(mountDir)
-	testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
+
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	if setup.TestBucket() == "" {
-		log.Print("--testbucket must be specified")
+
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.DentryCache) == 0 {
+		log.Println("No configuration found for dentry_cache tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.DentryCache = make([]test_suite.TestConfig, 1)
+		cfg.DentryCache[0].TestBucket = setup.TestBucket()
+		cfg.DentryCache[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.DentryCache[0].LogFile = setup.LogFile()
+		cfg.DentryCache[0].Configs = make([]test_suite.ConfigItem, 3)
+		cfg.DentryCache[0].Configs[0].Flags = []string{
+			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=2",
+		}
+		cfg.DentryCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.DentryCache[0].Configs[0].Run = "TestStatWithDentryCacheEnabledTest"
+		cfg.DentryCache[0].Configs[1].Flags = []string{
+			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000",
+		}
+		cfg.DentryCache[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.DentryCache[0].Configs[1].Run = "TestDeleteOperationTest"
+		cfg.DentryCache[0].Configs[2].Flags = []string{
+			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000",
+		}
+		cfg.DentryCache[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.DentryCache[0].Configs[2].Run = "TestNotifierTest"
+	}
+
+	testEnv.ctx = context.Background()
+	testEnv.cfg = &cfg.DentryCache[0]
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
+
+	// 2. Create storage client before running tests.
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Printf("Error creating storage client: %v\n", err)
 		os.Exit(1)
 	}
+	defer testEnv.storageClient.Close()
 
-	// Create common storage client to be used in test.
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
-	defer func() {
-		err := closeStorageClient()
-		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
-		}
-	}()
-
-	if setup.MountedDirectory() != "" {
-		mountDir = setup.MountedDirectory()
-		// Run tests for mounted directory if the flag is set.
-		os.Exit(m.Run())
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
-	// Else run tests for testBucket.
+
+	// Run tests for testBucket
 	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
 	mountDir, rootDir = setup.MntDir(), setup.MntDir()
 
 	log.Println("Running static mounting tests...")
-	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
 
 	os.Exit(successCode)

--- a/tools/integration_tests/dentry_cache/stat_test.go
+++ b/tools/integration_tests/dentry_cache/stat_test.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"testing"
 	"time"
-	"fmt"
 
 	"cloud.google.com/go/storage"
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,6 @@ type statWithDentryCacheEnabledTest struct {
 }
 
 func (s *statWithDentryCacheEnabledTest) SetupTest() {
-	//Truncate log file created.
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 
@@ -58,12 +56,11 @@ func (s *statWithDentryCacheEnabledTest) SetupSuite() {
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled() {
+	testFileName := s.T().Name()
 	// Create a file with initial content directly in GCS.
 	filePath := path.Join(testEnv.testDirPath, testFileName)
-	fmt.Println("withenabledtest" + filePath)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Add a small delay to allow dentry cache to get updated.
-	time.Sleep(5 * time.Second)
+
 	// Stat file to cache the entry
 	_, err := os.Stat(filePath)
 	require.Nil(s.T(), err)
@@ -87,9 +84,9 @@ func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled() {
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWhenFileIsDeletedDirectlyFromGCS() {
+	testFileName := s.T().Name()
 	// Create a file with initial content directly in GCS.
 	filePath := path.Join(testEnv.testDirPath, testFileName)
-	fmt.Println("filedeletefromGCS" + filePath)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
 	// Stat file to cache the entry
 	_, err := os.Stat(filePath)

--- a/tools/integration_tests/dentry_cache/stat_test.go
+++ b/tools/integration_tests/dentry_cache/stat_test.go
@@ -16,12 +16,20 @@ package dentry_cache
 
 import (
 	"context"
+	"log"
+	"os"
+	"path"
 	"testing"
+	"time"
+	"fmt"
 
 	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
@@ -50,67 +58,71 @@ func (s *statWithDentryCacheEnabledTest) SetupSuite() {
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled() {
-	// // Create a file with initial content directly in GCS.
-	// filePath := path.Join(testEnv.testDirPath, testFileName)
-	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// // Stat file to cache the entry
-	// _, err := os.Stat(filePath)
-	// require.Nil(s.T(), err)
-	// // Modify the object on GCS.
-	// objectName := path.Join(testDirName, testFileName)
-	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	// require.Nil(s.T(), err)
-	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(testEnv.testDirPath, testFileName)
+	fmt.Println("withenabledtest" + filePath)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// Add a small delay to allow dentry cache to get updated.
+	time.Sleep(5 * time.Second)
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(s.T(), err)
+	// Modify the object on GCS.
+	objectName := path.Join(testDirName, testFileName)
+	smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	require.Nil(s.T(), err)
+	require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// // Stat again, it should give old cached attributes.
-	// fileInfo, err := os.Stat(filePath)
+	// Stat again, it should give old cached attributes.
+	fileInfo, err := os.Stat(filePath)
 
-	// assert.Nil(s.T(), err)
-	// assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
-	// // Wait for a period more than the timeout (2 second), so that entry expires in cache.
-	// time.Sleep(2100 * time.Millisecond)
-	// // Stat again, it should give updated attributes.
-	// fileInfo, err = os.Stat(filePath)
-	// assert.Nil(s.T(), err)
-	// assert.Equal(s.T(), int64(updatedContentSize), fileInfo.Size())
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
+	// Wait for a period more than the timeout (2 second), so that entry expires in cache.
+	time.Sleep(2100 * time.Millisecond)
+	// Stat again, it should give updated attributes.
+	fileInfo, err = os.Stat(filePath)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), int64(updatedContentSize), fileInfo.Size())
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWhenFileIsDeletedDirectlyFromGCS() {
-	// // Create a file with initial content directly in GCS.
-	// filePath := path.Join(testEnv.testDirPath, testFileName)
-	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// // Stat file to cache the entry
-	// _, err := os.Stat(filePath)
-	// require.Nil(s.T(), err)
-	// // Delete the object directly from GCS.
-	// objectName := path.Join(testDirName, testFileName)
-	// require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
+	// Create a file with initial content directly in GCS.
+	filePath := path.Join(testEnv.testDirPath, testFileName)
+	fmt.Println("filedeletefromGCS" + filePath)
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// Stat file to cache the entry
+	_, err := os.Stat(filePath)
+	require.Nil(s.T(), err)
+	// Delete the object directly from GCS.
+	objectName := path.Join(testDirName, testFileName)
+	require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
 
-	// // Stat again, it should give old cached attributes rather than giving not found error.
-	// fileInfo, err := os.Stat(filePath)
+	// Stat again, it should give old cached attributes rather than giving not found error.
+	fileInfo, err := os.Stat(filePath)
 
-	// assert.Nil(s.T(), err)
-	// assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
-	// // Wait for a period more than the timeout (2 second), so that entry expires in cache.
-	// time.Sleep(2100 * time.Millisecond)
-	// // Stat again, it should give error as file does not exist.
-	// _, err = os.Stat(filePath)
-	// assert.NotNil(s.T(), err)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
+	// Wait for a period more than the timeout (2 second), so that entry expires in cache.
+	time.Sleep(2100 * time.Millisecond)
+	// Stat again, it should give error as file does not exist.
+	_, err = os.Stat(filePath)
+	assert.NotNil(s.T(), err)
 }
 
 func TestStatWithDentryCacheEnabledTest(t *testing.T) {
-	// ts := &statWithDentryCacheEnabledTest{ctx: context.Background(), storageClient: testEnv.storageClient}
+	ts := &statWithDentryCacheEnabledTest{ctx: context.Background(), storageClient: testEnv.storageClient}
 
-	// // Run tests for mounted directory if the flag is set.
-	// if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-	// 	suite.Run(t, ts)
-	// 	return
-	// }
+	// Run tests for mounted directory if the flag is set.
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
+		return
+	}
 
-	// // Run tests for GCE environment otherwise.
-	// flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
-	// for _, ts.flags = range flagsSet {
-	// 	log.Printf("Running tests with flags: %s", ts.flags)
-	// 	suite.Run(t, ts)
-	// }
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/dentry_cache/stat_test.go
+++ b/tools/integration_tests/dentry_cache/stat_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,98 +15,102 @@
 package dentry_cache
 
 import (
-	"log"
-	"os"
-	"path"
+	"context"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type statWithDentryCacheEnabledTest struct {
-	flags []string
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
 	suite.Suite
 }
 
 func (s *statWithDentryCacheEnabledTest) SetupTest() {
-	mountGCSFuseAndSetupTestDir(s.flags, testDirName)
+	//Truncate log file created.
+	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 
 func (s *statWithDentryCacheEnabledTest) TearDownTest() {
-	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
-		setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
-		setup.UnmountGCSFuseAndDeleteLogFile(rootDir)
-	}
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+func (s *statWithDentryCacheEnabledTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *statWithDentryCacheEnabledTest) SetupSuite() {
+	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWithDentryCacheEnabled() {
-	// Create a file with initial content directly in GCS.
-	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Stat file to cache the entry
-	_, err := os.Stat(filePath)
-	require.Nil(s.T(), err)
-	// Modify the object on GCS.
-	objectName := path.Join(testDirName, testFileName)
-	smallContent, err := operations.GenerateRandomData(updatedContentSize)
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), client.WriteToObject(ctx, storageClient, objectName, string(smallContent), storage.Conditions{}))
+	// // Create a file with initial content directly in GCS.
+	// filePath := path.Join(testEnv.testDirPath, testFileName)
+	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// // Stat file to cache the entry
+	// _, err := os.Stat(filePath)
+	// require.Nil(s.T(), err)
+	// // Modify the object on GCS.
+	// objectName := path.Join(testDirName, testFileName)
+	// smallContent, err := operations.GenerateRandomData(updatedContentSize)
+	// require.Nil(s.T(), err)
+	// require.Nil(s.T(), client.WriteToObject(s.ctx, s.storageClient, objectName, string(smallContent), storage.Conditions{}))
 
-	// Stat again, it should give old cached attributes.
-	fileInfo, err := os.Stat(filePath)
+	// // Stat again, it should give old cached attributes.
+	// fileInfo, err := os.Stat(filePath)
 
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
-	// Wait for a period more than the timeout (2 second), so that entry expires in cache.
-	time.Sleep(2100 * time.Millisecond)
-	// Stat again, it should give updated attributes.
-	fileInfo, err = os.Stat(filePath)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), int64(updatedContentSize), fileInfo.Size())
+	// assert.Nil(s.T(), err)
+	// assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
+	// // Wait for a period more than the timeout (2 second), so that entry expires in cache.
+	// time.Sleep(2100 * time.Millisecond)
+	// // Stat again, it should give updated attributes.
+	// fileInfo, err = os.Stat(filePath)
+	// assert.Nil(s.T(), err)
+	// assert.Equal(s.T(), int64(updatedContentSize), fileInfo.Size())
 }
 
 func (s *statWithDentryCacheEnabledTest) TestStatWhenFileIsDeletedDirectlyFromGCS() {
-	// Create a file with initial content directly in GCS.
-	filePath := path.Join(setup.MntDir(), testDirName, testFileName)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, initialContentSize, s.T())
-	// Stat file to cache the entry
-	_, err := os.Stat(filePath)
-	require.Nil(s.T(), err)
-	// Delete the object directly from GCS.
-	objectName := path.Join(testDirName, testFileName)
-	require.Nil(s.T(), client.DeleteObjectOnGCS(ctx, storageClient, objectName))
+	// // Create a file with initial content directly in GCS.
+	// filePath := path.Join(testEnv.testDirPath, testFileName)
+	// client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, initialContentSize, s.T())
+	// // Stat file to cache the entry
+	// _, err := os.Stat(filePath)
+	// require.Nil(s.T(), err)
+	// // Delete the object directly from GCS.
+	// objectName := path.Join(testDirName, testFileName)
+	// require.Nil(s.T(), client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName))
 
-	// Stat again, it should give old cached attributes rather than giving not found error.
-	fileInfo, err := os.Stat(filePath)
+	// // Stat again, it should give old cached attributes rather than giving not found error.
+	// fileInfo, err := os.Stat(filePath)
 
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
-	// Wait for a period more than the timeout (2 second), so that entry expires in cache.
-	time.Sleep(2100 * time.Millisecond)
-	// Stat again, it should give error as file does not exist.
-	_, err = os.Stat(filePath)
-	assert.NotNil(s.T(), err)
+	// assert.Nil(s.T(), err)
+	// assert.Equal(s.T(), int64(initialContentSize), fileInfo.Size())
+	// // Wait for a period more than the timeout (2 second), so that entry expires in cache.
+	// time.Sleep(2100 * time.Millisecond)
+	// // Stat again, it should give error as file does not exist.
+	// _, err = os.Stat(filePath)
+	// assert.NotNil(s.T(), err)
 }
 
 func TestStatWithDentryCacheEnabledTest(t *testing.T) {
-	ts := &statWithDentryCacheEnabledTest{}
+	// ts := &statWithDentryCacheEnabledTest{ctx: context.Background(), storageClient: testEnv.storageClient}
 
-	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		suite.Run(t, ts)
-		return
-	}
+	// // Run tests for mounted directory if the flag is set.
+	// if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+	// 	suite.Run(t, ts)
+	// 	return
+	// }
 
-	// Setup flags and run tests.
-	ts.flags = []string{"--implicit-dirs", "--experimental-enable-dentry-cache", "--metadata-cache-ttl-secs=2"}
-	log.Printf("Running tests with flags: %s", ts.flags)
-	suite.Run(t, ts)
+	// // Run tests for GCE environment otherwise.
+	// flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	// for _, ts.flags = range flagsSet {
+	// 	log.Printf("Running tests with flags: %s", ts.flags)
+	// 	suite.Run(t, ts)
+	// }
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -419,3 +419,31 @@ read_cache:
           zonal: true
         run: TestCacheFileForIncludeRegexTest
         run_on_gke: true
+
+dentry_cache:
+ - mounted_directory: "${MOUNTED_DIR}"
+   test_bucket: "pranjal-bucket-1"
+   log_file: # Not Required by dentry_cache tests
+   run_on_gke: true
+   configs:
+     - flags:
+       - "--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=2"
+       compatible:
+         flat: true
+         hns: true
+         zonal: true
+       run: TestStatWithDentryCacheEnabledTest
+     - flags:
+       - "--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000"
+       compatible:
+         flat: true
+         hns: true
+         zonal: true
+       run: TestDeleteOperationTest
+     - flags:
+       - "--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000"
+       compatible:
+         flat: true
+         hns: true
+         zonal: true
+       run: TestNotifierTest

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -422,7 +422,7 @@ read_cache:
 
 dentry_cache:
  - mounted_directory: "${MOUNTED_DIR}"
-   test_bucket: "pranjal-bucket-1"
+   test_bucket: "${BUCKET_NAME}"
    log_file: # Not Required by dentry_cache tests
    run_on_gke: true
    configs:


### PR DESCRIPTION
### Description
This PR includes changes to migrate dentry cache test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of dentry cache package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445953036](https://buganizer.corp.google.com/issues/445953036)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
