### PR TITLE
fix(b/453925111): Add a4 , a4x , tpu v7 machine list to high perf machines-list

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -192,6 +192,10 @@ var machineTypeToGroupMap = map[string]string{
 	"ct6e-standard-4t-tpu":  "high-performance",
 	"ct6e-standard-8t":      "high-performance",
 	"ct6e-standard-8t-tpu":  "high-performance",
+	"tpu7x-standard-4t":     "high-performance",
+	"tpu7x-standard-4t-tpu": "high-performance",
+	"tpu7x-ultranet-4t":     "high-performance",
+	"tpu7x-ultranet-4t-tpu": "high-performance",
 }
 
 // ApplyOptimizations modifies the config in-place with optimized values.

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -54,6 +54,10 @@ machine-type-groups:
     - "ct6e-standard-4t-tpu"
     - "ct6e-standard-8t"
     - "ct6e-standard-8t-tpu"
+    - "tpu7x-standard-4t"
+    - "tpu7x-standard-4t-tpu"
+    - "tpu7x-ultranet-4t"
+    - "tpu7x-ultranet-4t-tpu"
     # Add other machine types here as needed.
   # Add other groups here as needed
 


### PR DESCRIPTION
Taking latest list from gcloud compute machine-types list | grep a4 for a4 and a4x 
gcloud compute machine-types list | grep tpuv7 for TPU v7
All of the machines which have higher memory than previous ct5e/ct6e 4t machines are chosen.