### PR TITLE
build(build-csi): Add .gcloudignore to reduce the amount of data transferred for CSI build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,6 +1,4 @@
 .gcloudignore
-# If you would like to upload your .git directory, .gitignore file or
-# files from your .gitignore file, remove the corresponding line below:
 .git
 .gitignore
 #!include:.gitignore


### PR DESCRIPTION
### Description
This reduces the amount of data from more than 69M to 4M.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
