### PR TITLE
refactor: read gcs algo test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/read_gcs_algo/read_gcs_algo_test.go
+++ b/tools/integration_tests/read_gcs_algo/read_gcs_algo_test.go
@@ -15,28 +15,67 @@
 package read_gcs_algo
 
 import (
+	"context"
+	"log"
 	"os"
 	"testing"
 
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const OneMB = 1024 * 1024
 const DirForReadAlgoTests = "dirForReadAlgoTests"
 
+var (
+	storageClient *storage.Client
+	ctx           context.Context
+)
+
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.ReadGCSAlgo) == 0 {
+		log.Println("No configuration found for list large dir tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.ReadGCSAlgo = make([]test_suite.TestConfig, 1)
+		cfg.ReadGCSAlgo[0].TestBucket = setup.TestBucket()
+		cfg.ReadGCSAlgo[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.ReadGCSAlgo[0].Configs = make([]test_suite.ConfigItem, 2)
+		// Do not enable fileCache as we want to test gcs read flow.
+		cfg.ReadGCSAlgo[0].Configs[0].Flags = []string{"--implicit-dirs=true"}
+		cfg.ReadGCSAlgo[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+	}
 
-	// Run tests for mountedDirectory only if --mountedDirectory flag is set.
-	setup.RunTestsForMountedDirectoryFlag(m)
+	// 2. Create storage client before running tests.
+	ctx = context.Background()
+	bucketType := setup.TestEnvironment(ctx, &cfg.ReadGCSAlgo[0])
+	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
+
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as ReadGCSAlgo tests validates content from the bucket.
+	if cfg.ReadGCSAlgo[0].GKEMountedDirectory != "" && cfg.ReadGCSAlgo[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadGCSAlgo[0].GKEMountedDirectory, m))
+	}
 
 	// Run tests for testBucket
-	setup.SetUpTestDirForTestBucketFlag()
-	// Do not enable fileCache as we want to test gcs read flow.
-	mountConfigFlags := [][]string{{"--implicit-dirs=true"}}
-	successCode := static_mounting.RunTests(mountConfigFlags, m)
+	// 4. Build the flag sets dynamically from the config.
+	flags := setup.BuildFlagSets(cfg.ReadGCSAlgo[0], bucketType, "")
+
+	setup.SetUpTestDirForTestBucket(&cfg.ReadGCSAlgo[0])
+
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ReadGCSAlgo[0], flags, m)
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -450,3 +450,16 @@ dentry_cache:
          hns: true
          zonal: true
        run: TestNotifierTest
+
+read_gcs_algo:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Not required by readonly tests.
+    configs:
+      - flags:
+          - "--implicit-dirs=true"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: true

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -72,6 +72,12 @@ type Config struct {
 	ReadDirPlus           []TestConfig `yaml:"readdirplus"`
 	DentryCache           []TestConfig `yaml:"dentry_cache"`
 	RequesterPaysBucket   []TestConfig `yaml:"requester_pays_bucket"`
+	ReadGCSAlgo           []TestConfig `yaml:"read_gcs_algo"`
+	Interrupt             []TestConfig `yaml:"interrupt"`
+	UnfinalizedObject     []TestConfig `yaml:"unfinalized_object"`
+	RapidAppends          []TestConfig `yaml:"rapid_appends"`
+	MountTimeout          []TestConfig `yaml:"mount_timeout"`
+	Monitoring            []TestConfig `yaml:"monitoring"`
 }
 
 func processTestConfigs(configs []TestConfig) {
@@ -106,6 +112,12 @@ func (c *Config) postProcessConfig() {
 	processTestConfigs(c.KernelListCache)
 	processTestConfigs(c.ReadDirPlus)
 	processTestConfigs(c.DentryCache)
+	processTestConfigs(c.ReadGCSAlgo)
+	processTestConfigs(c.Interrupt)
+	processTestConfigs(c.UnfinalizedObject)
+	processTestConfigs(c.RapidAppends)
+	processTestConfigs(c.MountTimeout)
+	processTestConfigs(c.Monitoring)
 }
 
 // ReadConfigFile returns a Config struct from the YAML file.


### PR DESCRIPTION
### Description
This PR includes changes to migrate read gcs algo test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of read gcs algo cache package so it can use config file.

### Link to the issue in case of a bug fix.
[b/454550408](https://buganizer.corp.google.com/issues/454550408)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
