### PR TITLE
feat(mount-id): Add mount-id as a resource attribute to OTel trace exporter

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -414,7 +414,7 @@ func Mount(newConfig *cfg.Config, bucketName, mountPoint string) (err error) {
 			metricHandle = metrics.NewNoopMetrics()
 		}
 	}
-	shutdownTracingFn := monitor.SetupTracing(ctx, newConfig)
+	shutdownTracingFn := monitor.SetupTracing(ctx, newConfig, logger.MountInstanceID())
 	shutdownFn := common.JoinShutdownFunc(metricExporterShutdownFn, shutdownTracingFn)
 
 	// No-op if profiler is disabled.

--- a/internal/monitor/traceexporter.go
+++ b/internal/monitor/traceexporter.go
@@ -23,17 +23,13 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-
-	"go.opentelemetry.io/contrib/detectors/gcp"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // SetupTracing bootstraps the OpenTelemetry tracing pipeline.
-func SetupTracing(ctx context.Context, c *cfg.Config) common.ShutdownFn {
-	tp, shutdown, err := newTraceProvider(ctx, c)
+func SetupTracing(ctx context.Context, c *cfg.Config, mountID string) common.ShutdownFn {
+	tp, shutdown, err := newTraceProvider(ctx, c, mountID)
 	if err != nil {
 		logger.Errorf("error occurred while setting up tracing: %v", err)
 		return nil
@@ -46,12 +42,12 @@ func SetupTracing(ctx context.Context, c *cfg.Config) common.ShutdownFn {
 	return nil
 }
 
-func newTraceProvider(ctx context.Context, c *cfg.Config) (trace.TracerProvider, common.ShutdownFn, error) {
+func newTraceProvider(ctx context.Context, c *cfg.Config, mountID string) (trace.TracerProvider, common.ShutdownFn, error) {
 	switch c.Monitoring.ExperimentalTracingMode {
 	case "stdout":
 		return newStdoutTraceProvider()
 	case "gcptrace":
-		return newGCPCloudTraceExporter(ctx, c)
+		return newGCPCloudTraceExporter(ctx, c, mountID)
 	default:
 		return nil, nil, nil
 	}
@@ -67,20 +63,12 @@ func newStdoutTraceProvider() (trace.TracerProvider, common.ShutdownFn, error) {
 	return tp, tp.Shutdown, nil
 }
 
-func newGCPCloudTraceExporter(ctx context.Context, c *cfg.Config) (*sdktrace.TracerProvider, common.ShutdownFn, error) {
+func newGCPCloudTraceExporter(ctx context.Context, c *cfg.Config, mountID string) (*sdktrace.TracerProvider, common.ShutdownFn, error) {
 	exporter, err := cloudtrace.New()
 	if err != nil {
 		return nil, nil, err
 	}
-	res, err := resource.New(ctx,
-		// Use the GCP resource detector to detect information about the GCP platform
-		resource.WithDetectors(gcp.NewDetector()),
-		resource.WithTelemetrySDK(),
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(common.GetVersion()),
-		),
-	)
+	res, err := getResource(ctx, mountID)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Description
By reusing the getResource method, this change adds the mount-id as a resource attribute to the OpenTelemetry metrics exporter. This allows for the differentiation of traces from multiple gcsfuse mounts.

<img width="3204" height="1854" alt="image" src="https://github.com/user-attachments/assets/113f4807-26b5-493d-8a9d-e7a3fa952970" />

### Link to the issue in case of a bug fix.
b/454621353

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA


### Any backward incompatible change? If so, please explain.
No
