### PR TITLE
refactor: interrupt test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/interrupt/interrupt_test.go
+++ b/tools/integration_tests/interrupt/interrupt_test.go
@@ -60,7 +60,6 @@ func TestMain(m *testing.M) {
 		}
 		cfg.Interrupt[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.Interrupt[0].Configs[1].Flags = []string{
-			// TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
 			"--enable-streaming-writes=true",
 		}
 		cfg.Interrupt[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}

--- a/tools/integration_tests/interrupt/interrupt_test.go
+++ b/tools/integration_tests/interrupt/interrupt_test.go
@@ -25,10 +25,16 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
 	testDirName = "InterruptTest"
+)
+
+var (
+	storageClient *storage.Client
+	ctx           context.Context
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -38,8 +44,31 @@ const (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	var storageClient *storage.Client
-	ctx := context.Background()
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.Interrupt) == 0 {
+		log.Println("No configuration found for interrupt tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.Interrupt = make([]test_suite.TestConfig, 1)
+		cfg.Interrupt[0].TestBucket = setup.TestBucket()
+		cfg.Interrupt[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.Interrupt[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.Interrupt[0].Configs[0].Flags = []string{
+			"--implicit-dirs=true --enable-streaming-writes=false",
+			"--ignore-interrupts=true --enable-streaming-writes=false",
+			"--ignore-interrupts=false --enable-streaming-writes=false",
+		}
+		cfg.Interrupt[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.Interrupt[0].Configs[1].Flags = []string{
+			// TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
+			"--enable-streaming-writes=true",
+		}
+		cfg.Interrupt[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+	}
+
+	// 2. Create storage client before running tests.
+	ctx = context.Background()
+	bucketType := setup.TestEnvironment(ctx, &cfg.Interrupt[0])
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -48,30 +77,21 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	setup.RunTestsForMountedDirectoryFlag(m)
-
-	// Else run tests for testBucket.
-	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
-
-	// Set up flags to run tests on.
-	yamlContent1 := map[string]any{
-		"file-system": map[string]any{
-			"ignore-interrupts": true,
-		},
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	// flags to be set, as Interrupt tests validates content from the bucket.
+	if cfg.Interrupt[0].GKEMountedDirectory != "" && cfg.Interrupt[0].TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(cfg.Interrupt[0].GKEMountedDirectory, m))
 	}
-	yamlContent2 := map[string]any{} // test default
-	flags := [][]string{
-		{"--implicit-dirs=true", "--enable-streaming-writes=false"},
-		{"--config-file=" + setup.YAMLConfigFile(yamlContent1, "ignore_interrupts.yaml"), "--enable-streaming-writes=false"},
-		{"--config-file=" + setup.YAMLConfigFile(yamlContent2, "default_ignore_interrupts.yaml"), "--enable-streaming-writes=false"}}
-	// TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
-	if !setup.IsZonalBucketRun() {
-		flags = append(flags, []string{"--enable-streaming-writes=true"})
-	}
-	successCode := static_mounting.RunTests(flags, m)
 
-	// Clean up test directory created.
+	// Run tests for testBucket
+	// 4. Build the flag sets dynamically from the config.
+	flags := setup.BuildFlagSets(cfg.Interrupt[0], bucketType, "")
+
+	setup.SetUpTestDirForTestBucket(&cfg.Interrupt[0])
+
+	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Interrupt[0], flags, m)
+
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
+
 }

--- a/tools/integration_tests/read_gcs_algo/read_gcs_algo_test.go
+++ b/tools/integration_tests/read_gcs_algo/read_gcs_algo_test.go
@@ -47,7 +47,6 @@ func TestMain(m *testing.M) {
 		cfg.ReadGCSAlgo[0].TestBucket = setup.TestBucket()
 		cfg.ReadGCSAlgo[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ReadGCSAlgo[0].Configs = make([]test_suite.ConfigItem, 2)
-		// Do not enable fileCache as we want to test gcs read flow.
 		cfg.ReadGCSAlgo[0].Configs[0].Flags = []string{"--implicit-dirs=true"}
 		cfg.ReadGCSAlgo[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -489,6 +489,7 @@ read_gcs_algo:
     log_file: # Not required by readonly tests.
     configs:
       - flags:
+        # Do not enable fileCache as we want to test gcs read flow.
           - "--implicit-dirs=true"
         compatible:
           flat: true
@@ -502,6 +503,7 @@ interrupt:
     log_file: # Optional
     configs:
       - flags:
+        #TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
           - "--enable-streaming-writes=true"
         compatible:
           flat: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -495,3 +495,25 @@ read_gcs_algo:
           hns: true
           zonal: true
         run_on_gke: true
+
+interrupt:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # Optional
+    configs:
+      - flags:
+          - "--enable-streaming-writes=true"
+        compatible:
+          flat: true
+          hns: true
+          zonal: false
+        run_on_gke: true
+      - flags:
+          - "--implicit-dirs=true --enable-streaming-writes=false"
+          - "--ignore-interrupts=true --enable-streaming-writes=false"
+          - "--ignore-interrupts=false --enable-streaming-writes=false"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: true


### PR DESCRIPTION
### Description
This PR includes changes to migrate interrupt test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of interrupt package so it can use config file.

### Link to the issue in case of a bug fix.
[b/454549489](https://buganizer.corp.google.com/issues/454549489)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
