### PR TITLE
ci(build-csi): Build arm images by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 CSI_VERSION ?= main
 GCSFUSE_VERSION ?= $(shell HASH=$$(git rev-parse --short=6 HEAD 2>/dev/null); if [ -z "$$HASH" ]; then echo "unknown"; else if [ -n "$$(git status --porcelain)" ]; then echo "$$HASH-dirty"; else echo "$$HASH"; fi; fi)
-BUILD_ARM=false
+BUILD_ARM ?= true
 STAGINGVERSION ?=
 .DEFAULT_GOAL := build
 


### PR DESCRIPTION
### Description
build-csi will now build multi-arch images that are compatible with amd as well as arm.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
