### PR TITLE
chore(semantics): update streaming writes memory usage guidance to 96MiB

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -51,7 +51,7 @@ such as checkpoints. Streaming writes can be enabled using `--enable-streaming-w
 `write:enable-streaming-writes:true` in the config file (Default starting GCSFuse v3.0.0).
 
 **Memory Usage:** Each file opened for streaming writes will consume
-approximately 64MiB of RAM during the upload process. This memory is released
+approximately 96MiB of RAM during the upload process. This memory is released
 when the file handle is closed. This should be considered when planning resource
 allocation for applications using streaming writes.
 


### PR DESCRIPTION
### Description
Same as PR title. 
For rationale see [go/gcs-fuse-memory-usage-streaming-writes](http://goto.google.com/gcs-fuse-memory-usage-streaming-writes)

### Link to the issue in case of a bug fix.
b/455782293

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
