### PR TITLE
fix: Handle SIGTERM irrespective of unmount status

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -84,7 +84,7 @@ func registerTerminatingSignalHandler(mountPoint string) {
 			//On signal receive wait in background and give 30 second for unmount to finish
 			//and then exit, so application is closed.
 			go func() {
-				logger.Warnf("Received %s, waiting for %d sec to let system gracefully unmount before killing the process", sigName, WaitTimeOnSignalReceive)
+				logger.Warnf("Received %s, waiting for %s to let system gracefully unmount before killing the process", sigName, WaitTimeOnSignalReceive)
 				time.Sleep(WaitTimeOnSignalReceive)
 				logger.Warnf("killing goroutines and exit")
 				//Forcefully exit to 0 so that caller get success on forcefull exit also.


### PR DESCRIPTION
### Description
When we are returning from the go routine for signal handler, instead of return we should os.Exit with background thread with sleep 30sec alongside unmount. so that unconditionally the process terminates and does not get stuck in the main thread (What is the suspicion for delay reproduced during internal tests go/gcsfuse-sigterm-handling).

### Link to the issue in case of a bug fix.
b/449182561

### Testing details
1. Manual - [Test doc](http://goto.google.com/gcsfuse-sigterm-handling)
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain. No
