### PR TITLE
fix: Set default universe domain in case of domain fetch failure

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -24,7 +24,7 @@ import (
 	storagev1 "google.golang.org/api/storage/v1"
 )
 
-const universeDomainDefault = "googleapis.com"
+const UniverseDomainDefault = "googleapis.com"
 
 func getUniverseDomain(ctx context.Context, contents []byte, scope string) (string, error) {
 	creds, err := google.CredentialsFromJSON(ctx, contents, scope)
@@ -70,7 +70,7 @@ func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oau
 	// For non-GDU universe domains, token exchange is impossible and services
 	// must support self-signed JWTs with scopes.
 	// Override the token source to use self-signed JWT.
-	if domain != universeDomainDefault {
+	if domain != UniverseDomainDefault {
 		// Create self signed JWT access token.
 		ts, err = google.JWTAccessTokenSourceWithScope(contents, scope)
 		if err != nil {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -49,7 +49,7 @@ func (t *AuthTest) TestGetUniverseDomainForGoogle() {
 	domain, err := getUniverseDomain(context.Background(), contents, storagev1.DevstorageFullControlScope)
 
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), universeDomainDefault, domain)
+	assert.Equal(t.T(), UniverseDomainDefault, domain)
 }
 
 func (t *AuthTest) TestGetUniverseDomainForTPC() {

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -21,6 +21,7 @@ import (
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/oauth2adapt"
 	auth2 "github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
@@ -54,7 +55,9 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 
 	domain, err := ExecuteWithRetry(ctx, retryConfig, "cred.UniverseDomain", "credentials", apiCall)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get UniverseDomain: %w", err)
+		logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)
+		// Setting default universe domain to googleapis.com in case we are unable to fetch the domain.
+		domain = auth2.UniverseDomainDefault
 	}
 
 	// Temporary Workaround: We've created a small auth object here that omits the 'quota project ID'


### PR DESCRIPTION
### Description
Sometimes  fetching universe domain failes even after retries due to network issues. Set default universe domain in case of domain fetch failure. 

### Link to the issue in case of a bug fix.
[b/456639234](https://b.corp.google.com/issues/456639234)

### Testing details
1. Manual - Tested on TPC
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
