### PR TITLE
refactor(bufferedread): Make Download Task private

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -465,14 +465,14 @@ func (p *BufferedReader) scheduleBlockWithIndex(b block.PrefetchBlock, blockInde
 	}
 
 	ctx, cancel := context.WithCancel(p.ctx)
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          ctx,
 		object:       p.object,
 		bucket:       p.bucket,
 		block:        b,
 		readHandle:   p.readHandle,
 		metricHandle: p.metricHandle,
-	})
+	}
 
 	logger.Tracef("Scheduling block: (%s, %d, %t).", p.object.Name, blockIndex, urgent)
 	p.blockQueue.Push(&blockQueueEntry{

--- a/internal/bufferedread/download_task.go
+++ b/internal/bufferedread/download_task.go
@@ -45,27 +45,6 @@ type downloadTask struct {
 	readHandle []byte
 }
 
-// downloadTaskOptions holds the dependencies for a DownloadTask.
-type downloadTaskOptions struct {
-	ctx          context.Context
-	object       *gcs.MinObject
-	bucket       gcs.Bucket
-	block        block.PrefetchBlock
-	readHandle   []byte
-	metricHandle metrics.MetricHandle
-}
-
-func newDownloadTask(opts *downloadTaskOptions) *downloadTask {
-	return &downloadTask{
-		ctx:          opts.ctx,
-		object:       opts.object,
-		bucket:       opts.bucket,
-		block:        opts.block,
-		readHandle:   opts.readHandle,
-		metricHandle: opts.metricHandle,
-	}
-}
-
 // Execute implements the workerpool.Task interface. It downloads the data from
 // the GCS object to the block.
 // After completion, it notifies the block consumer about the status of the

--- a/internal/bufferedread/download_task_test.go
+++ b/internal/bufferedread/download_task_test.go
@@ -78,14 +78,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteSuccess() {
 	require.Nil(dts.T(), err)
 	err = downloadBlock.SetAbsStartOff(0)
 	require.Nil(dts.T(), err)
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          context.Background(),
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	testContent := testutil.GenerateRandomBytes(testBlockSize)
 	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	readObjectRequest := &gcs.ReadObjectRequest{
@@ -116,14 +116,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteError() {
 	require.Nil(dts.T(), err)
 	err = downloadBlock.SetAbsStartOff(0)
 	require.Nil(dts.T(), err)
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          context.Background(),
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	readObjectRequest := &gcs.ReadObjectRequest{
 		Name:       dts.object.Name,
 		Generation: dts.object.Generation,
@@ -152,14 +152,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteContextDeadlineExceededByServerTrea
 	require.Nil(dts.T(), err)
 	taskCtx, taskCancelFunc := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer taskCancelFunc() // Ensure the context is cancelled after the test.
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          taskCtx,
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	readObjectRequest := &gcs.ReadObjectRequest{
 		Name:       dts.object.Name,
 		Generation: dts.object.Generation,
@@ -188,14 +188,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteContextCancelledWhileReaderCreation
 	err = downloadBlock.SetAbsStartOff(0)
 	require.Nil(dts.T(), err)
 	taskCtx, taskCancelFunc := context.WithCancel(context.TODO())
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          taskCtx,
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	rc := &fake.FakeReader{ReadCloser: getReadCloser(nil)} // No content since context is cancelled
 	readObjectRequest := &gcs.ReadObjectRequest{
 		Name:       dts.object.Name,
@@ -240,14 +240,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteContextCancelledWhileReadingFromRea
 	err = downloadBlock.SetAbsStartOff(0)
 	require.Nil(dts.T(), err)
 	taskCtx, taskCancelFunc := context.WithCancel(context.TODO())
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          taskCtx,
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	rc := &fake.FakeReader{ReadCloser: new(ctxCancelledReader)}
 	readObjectRequest := &gcs.ReadObjectRequest{
 		Name:       dts.object.Name,
@@ -277,14 +277,14 @@ func (dts *DownloadTaskTestSuite) TestExecuteClobbered() {
 	require.Nil(dts.T(), err)
 	err = downloadBlock.SetAbsStartOff(0)
 	require.Nil(dts.T(), err)
-	task := newDownloadTask(&downloadTaskOptions{
+	task := &downloadTask{
 		ctx:          context.Background(),
 		object:       dts.object,
 		bucket:       dts.mockBucket,
 		block:        downloadBlock,
 		readHandle:   nil,
 		metricHandle: dts.metricHandle,
-	})
+	}
 	// Simulate NewReaderWithReadHandle returning a NotFoundError.
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("object not found")}
 	readObjectRequest := &gcs.ReadObjectRequest{


### PR DESCRIPTION
### Description
This PR refactors the `DownloadTask` to make it private to the `bufferedread` package. 

This change encapsulates the download task's implementation within the `bufferedread` package, improving modularity.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
