### PR TITLE
refactor: inactive_stream_timeout test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -32,83 +32,85 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	kTestDirName                         = "inactiveReadTimeoutTest"
+	kTestDirName                         = "inactiveReadTimeout"
 	kOnlyDirMounted                      = "onlyDirInactiveReadTimeout"
 	kFileSize                            = 10 * 1024 * 1024 // 10 MiB
-	kChunkSizeToRead                     = 128 * 1024       // 64 KiB
+	kChunkSizeToRead                     = 128 * 1024       // 128 KiB
 	kTestFileName                        = "foo"
 	kDefaultInactiveReadTimeoutInSeconds = 1 // A short timeout for testing
-	kLogFileNameForMountedDirectoryTests = "/tmp/inactive_stream_timeout_logs/log.json"
-	kHTTP1ClientProtocol                 = "http1"
-	kGRPCClientProtocol                  = "grpc"
+	GKETempDir                           = "/gcsfuse-tmp"
 )
+
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
 
 var (
-	// Stores test directory path in the mounted path.
-	gTestDirPath string
-
-	// Used to run the test for different types of mount by modify this function.
-	gMountFunc func([]string) error
-
-	// Actual mounted directory, for dynamic mount it becomes gRootDir/<bucket_name>
-	gMountDir string
-
-	// Root directory which is mounted by gcsfuse.
-	gRootDir string
-
-	// Clients to create the object in GCS.
-	gStorageClient *storage.Client
-	gCtx           context.Context
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir string
 )
 
-type gcsfuseTestFlags struct {
-	cliFlags            []string
-	inactiveReadTimeout time.Duration
-	fileName            string
-	clientProtocol      string
-}
-
-func setupFile(ctx context.Context, storageClient *storage.Client, fileName string, fileSize int, t *testing.T) string {
-	t.Helper()
-	client.SetupFileInTestDirectory(ctx, storageClient, kTestDirName, fileName, int64(fileSize), t)
-	return path.Join(gTestDirPath, fileName)
-}
-
-func loadLogLines(reader io.Reader) ([]string, error) {
-	content, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
+func setupLogFilePath(testName string) {
+	var logFilePath string
+	logFilePath = path.Join(setup.TestDir(), GKETempDir, testName) + ".log"
+	if testEnv.cfg.GKEMountedDirectory != "" { // GKE path
+		mountDir = testEnv.cfg.GKEMountedDirectory
+		logFilePath = path.Join(GKETempDir, testName) + ".log"
+		if setup.ConfigFile() == "" {
+			// TODO: clean this up when GKE test migration completes.
+			logFilePath = path.Join(GKETempDir, testName) + ".log"
+		}
+	} else {
+		logFilePath = path.Join(setup.TestDir(), "gcsfuse-tmp", testName) + ".log"
 	}
-	return strings.Split(string(content), "\n"), nil
+	// Create the directory for the log file if it doesn't exist.
+	if err := os.MkdirAll(path.Dir(logFilePath), 0755); err != nil {
+		log.Fatalf("Failed to create log directory: %v", err)
+	}
+	testEnv.cfg.LogFile = logFilePath
 }
 
-// validateInactiveReaderClosedLog checks if the "Closing reader for object ... due to inactivity"
-// log message is present (or absent) for the given objectName, b/w the [startTime, endTime] interval.
-// Also expects based on the shouldBePresent value.
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+	setup.SetMntDir(mountDir)
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, kTestDirName)
+	// testEnv.testDirPath = path.Join(mountDir, kTestDirName)
+	// client.SetupTestDirectory(testEnv.ctx, testEnv.storageClient, kTestDirName)
+}
+
 func validateInactiveReaderClosedLog(t *testing.T, logFile, objectName string, shouldBePresent bool, startTime, endTime time.Time) {
 	t.Helper()
-	// Be specific about the object name in the expected message.
 	expectedMsgSubstring := fmt.Sprintf("Closing reader for object %q due to inactivity.", objectName)
 
 	file, err := os.Open(logFile)
 	require.NoError(t, err, "Failed to open log file")
 	defer file.Close()
 
-	logLines, err := loadLogLines(file)
+	content, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("Failed to read log file: %v", err)
+	}
+	logLines := strings.Split(string(content), "\n")
+
 	require.NoError(t, err, "Failed to read log file")
 
 	found := false
 	for _, line := range logLines {
-		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line) // Assuming read_logs can parse general log lines too or a more generic parser is available.
-		// If parsing fails, it might be a non-JSON line or a different structured log.
-		// For this specific message, we expect it to be in the "Message" field of a structured log.
-
+		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line)
 		if err == nil && logEntry != nil {
-			// Check if the log entry's timestamp is within the expected window.
 			if (logEntry.Timestamp.After(startTime) || logEntry.Timestamp.Equal(startTime)) &&
 				(logEntry.Timestamp.Before(endTime) || logEntry.Timestamp.Equal(endTime)) {
 				if strings.Contains(logEntry.Message, expectedMsgSubstring) {
@@ -126,77 +128,90 @@ func validateInactiveReaderClosedLog(t *testing.T, logFile, objectName string, s
 	}
 }
 
-func mountGCSFuseAndSetupTestDir(ctx context.Context, flags []string, storageClient *storage.Client, testDirName string) {
-	setup.MountGCSFuseWithGivenMountFunc(flags, gMountFunc)
-	setup.SetMntDir(gMountDir)
-	gTestDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
-}
-
-// createConfigFile generate mount config.yaml.
-func createConfigFile(flags *gcsfuseTestFlags) string {
-	mountConfig := map[string]any{
-		"read": map[string]any{
-			"inactive-stream-timeout": flags.inactiveReadTimeout.String(),
-		},
-		"gcs-connection": map[string]any{
-			"client-protocol": flags.clientProtocol,
-		},
-		"logging": map[string]any{
-			"file-path": setup.LogFile(),
-			"format":    "json", // Ensure JSON logs for easier parsing
-		},
-	}
-	return setup.YAMLConfigFile(mountConfig, flags.fileName)
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	// Create common storage client to be used in test.
-	gCtx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&gCtx, &gStorageClient)
-	defer func() {
-		err := closeStorageClient()
-		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
+	// 1. read config file
+	configFile := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(configFile.InactiveStreamTimeout) == 0 {
+		log.Println("No configuration found for inactive_stream_timeout tests in config. Using default flags.")
+		configFile.InactiveStreamTimeout = make([]test_suite.TestConfig, 1)
+		testEnv.cfg = &configFile.InactiveStreamTimeout[0]
+		testEnv.cfg.TestBucket = setup.TestBucket()
+		testEnv.cfg.LogFile = setup.LogFile()
+		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
+
+		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 2)
+		testEnv.cfg.Configs[0].Flags = []string{
+			"--read-inactive-stream-timeout=1s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log",
+			"--read-inactive-stream-timeout=1s --client-protocol=grpc --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log",
 		}
-	}()
+		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[0].Run = "TestTimeoutEnabledSuite"
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+		testEnv.cfg.Configs[1].Flags = []string{
+			"--read-inactive-stream-timeout=0s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log",
+		}
+		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[1].Run = "TestTimeoutDisabledSuite"
+	}
+	testEnv.cfg = &configFile.InactiveStreamTimeout[0]
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
-	if setup.MountedDirectory() != "" {
-		gMountDir = setup.MountedDirectory()
-		setup.SetLogFile(kLogFileNameForMountedDirectoryTests)
-		// Run tests for mounted directory if the flag is set.
-		os.Exit(m.Run())
+	// 2. Create common storage client to be used in test.
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Fatalf("client.CreateStorageClient: %v", err)
+	}
+	defer testEnv.storageClient.Close()
+
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
-	// Else run tests for testBucket.
-	setup.SetUpTestDirForTestBucketFlag()
+	// Run tests for testBucket
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	// Override GKE specific paths with GCSFuse paths if running in GCE environment.
+	overrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
+
+	// Save mount and root directory variables.
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
 
 	log.Println("Running static mounting tests...")
-	// MountDir and RootDir will be same for static mount.
-	gMountDir, gRootDir = setup.MntDir(), setup.MntDir()
-	gMountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
 
 	if successCode == 0 {
 		log.Println("Running dynamic mounting tests...")
-		// For dyanamic mount - gMountDir = gRootDir + <bucket_name>
-		gMountDir = path.Join(setup.MntDir(), setup.TestBucket())
-		gMountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		// Save mount directory variable to have path of bucket to run tests.
+		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
 		successCode = m.Run()
 	}
 
 	if successCode == 0 {
 		log.Println("Running only dir mounting tests...")
 		setup.SetOnlyDirMounted(kOnlyDirMounted + "/")
-		gMountDir = gRootDir
-		gMountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		mountDir = rootDir
+		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
 		successCode = m.Run()
-		setup.CleanupDirectoryOnGCS(gCtx, gStorageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), kTestDirName))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), "TestTimeoutEnabledSuite"))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), "TestTimeoutDisabledSuite"))
 	}
 
-	setup.CleanupDirectoryOnGCS(gCtx, gStorageClient, path.Join(setup.TestBucket(), kTestDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), kTestDirName))
 	os.Exit(successCode)
+}
+
+func overrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
+	for _, flags := range t.Configs {
+		for i := range flags.Flags {
+			// Iterate over the indices of the flags slice
+			flags.Flags[i] = strings.ReplaceAll(flags.Flags[i], "/gcsfuse-tmp", path.Join(GCSFuseTempDirPath, "gcsfuse-tmp"))
+		}
+	}
 }

--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -41,8 +41,7 @@ const (
 	kOnlyDirMounted                      = "onlyDirInactiveReadTimeout"
 	kFileSize                            = 10 * 1024 * 1024 // 10 MiB
 	kChunkSizeToRead                     = 128 * 1024       // 128 KiB
-	kTestFileName                        = "foo"
-	kDefaultInactiveReadTimeoutInSeconds = 1 // A short timeout for testing
+	kDefaultInactiveReadTimeoutInSeconds = 1                // A short timeout for testing
 	GKETempDir                           = "/gcsfuse-tmp"
 	OldGKElogFilePath                    = "/tmp/inactive_stream_timeout_logs/log.json"
 )
@@ -64,14 +63,9 @@ var (
 	rootDir string
 )
 
-func SetupNestedTestDir(path string, permission os.FileMode, t *testing.T) {
-	err := os.MkdirAll(path, permission)
-	require.NoError(t, err)
-}
-
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	// In case of GKE, the test directory is not created by the test.
+	// In case of GKE, the mount directory is not created by the test.
 	if testEnv.cfg.GKEMountedDirectory != "" {
 		setup.SetMntDir(testEnv.cfg.GKEMountedDirectory)
 	}
@@ -196,8 +190,7 @@ func TestMain(m *testing.M) {
 		mountDir = rootDir
 		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
 		successCode = m.Run()
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), "TestTimeoutEnabledSuite"))
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), "TestTimeoutDisabledSuite"))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted()))
 	}
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), kTestDirName))

--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -46,7 +46,6 @@ func (s *timeoutEnabledSuite) SetupTest() {
 	gcsDir := path.Join(kTestDirName, s.T().Name())
 	testEnv.testDirPath = path.Join(mountDir, gcsDir)
 	SetupNestedTestDir(testEnv.testDirPath, 0755, s.T())
-	setup.CleanupDirectoryOnGCS(s.ctx, s.storageClient, gcsDir)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, gcsDir, kTestFileName, kFileSize, s.T())
 }
 
@@ -55,7 +54,6 @@ func (s *timeoutEnabledSuite) TearDownSuite() {
 }
 
 func (s *timeoutEnabledSuite) TearDownTest() {
-	setup.CleanupDirectoryOnGCS(s.ctx, s.storageClient, path.Join(kTestDirName, s.T().Name()))
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 

--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -127,18 +127,14 @@ func TestTimeoutEnabledSuite(t *testing.T) {
 		storageClient: testEnv.storageClient,
 		baseTestName:  t.Name(),
 	}
-	//setupLogFile(t.Name())
 	// Run tests for mounted directory if the flag is set.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		// flags := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())[0]
-		// ts.flags = flags
 		suite.Run(t, ts)
 		return
 	}
 
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, ts.flags = range flagsSet {
-		// ts.flags = flags
 		log.Printf("Running inactive_read_timeout tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
 	}

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -46,7 +46,6 @@ func (s *timeoutDisabledSuite) SetupTest() {
 	gcsDir := path.Join(kTestDirName, s.T().Name())
 	testEnv.testDirPath = path.Join(mountDir, gcsDir)
 	SetupNestedTestDir(testEnv.testDirPath, 0755, s.T())
-	setup.CleanupDirectoryOnGCS(s.ctx, s.storageClient, gcsDir)
 	client.SetupFileInTestDirectory(s.ctx, s.storageClient, gcsDir, kTestFileName, kFileSize, s.T())
 }
 
@@ -55,7 +54,6 @@ func (s *timeoutDisabledSuite) TearDownSuite() {
 }
 
 func (s *timeoutDisabledSuite) TearDownTest() {
-	setup.CleanupDirectoryOnGCS(s.ctx, s.storageClient, path.Join(kTestDirName, s.T().Name()))
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/require"
@@ -32,18 +33,25 @@ type timeoutDisabledSuite struct {
 	flags         []string
 	storageClient *storage.Client
 	ctx           context.Context
+	baseTestName  string
 	suite.Suite
 }
 
+func (s *timeoutDisabledSuite) SetupSuite() {
+	setupLogFilePath(s.baseTestName)
+	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
+}
+
 func (s *timeoutDisabledSuite) SetupTest() {
-	mountGCSFuseAndSetupTestDir(s.ctx, s.flags, s.storageClient, kTestDirName)
+	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, path.Join(kTestDirName, s.T().Name()))
+}
+
+func (s *timeoutDisabledSuite) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 }
 
 func (s *timeoutDisabledSuite) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
-	if setup.MountedDirectory() == "" { // Only unmount if not using a pre-mounted directory
-		setup.UnmountGCSFuseAndDeleteLogFile(gRootDir)
-	}
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -53,8 +61,9 @@ func (s *timeoutDisabledSuite) TearDownTest() {
 func (s *timeoutDisabledSuite) TestNoReaderCloser() {
 	timeoutDuration := kDefaultInactiveReadTimeoutInSeconds * time.Second
 	gcsFileName := path.Join(kTestDirName, kTestFileName)
-	mountFilePath := setupFile(s.ctx, s.storageClient, kTestFileName, kFileSize, s.T())
+	mountFilePath := path.Join(testEnv.testDirPath, kTestFileName) // testEnv.testDirPath is /tmp/.../mnt/inactiveReadTimeout
 
+	log.Printf("Attempting to open file for reading: %s", mountFilePath)
 	// 1. Open file.
 	fileHandle, err := operations.OpenFileAsReadonly(mountFilePath)
 	require.NoError(s.T(), err)
@@ -71,7 +80,7 @@ func (s *timeoutDisabledSuite) TestNoReaderCloser() {
 	endTimeWait := time.Now()
 
 	// 4. Shouldn't be any `Close reader logs...`.
-	validateInactiveReaderClosedLog(s.T(), setup.LogFile(), gcsFileName, false, endTimeRead, endTimeWait)
+	validateInactiveReaderClosedLog(s.T(), testEnv.cfg.LogFile, gcsFileName, false, endTimeRead, endTimeWait)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -79,30 +88,20 @@ func (s *timeoutDisabledSuite) TestNoReaderCloser() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestTimeoutDisabledSuite(t *testing.T) {
-	ts := &timeoutDisabledSuite{ctx: context.Background(), storageClient: gStorageClient}
-
+	ts := &timeoutDisabledSuite{}
+	//setupLogFile(t.Name())
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		// flags := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())[0]
+		// ts.flags = flags
 		suite.Run(t, ts)
 		return
 	}
 
-	flagsSet := []gcsfuseTestFlags{
-		{ // Test with timeout disabled
-			inactiveReadTimeout: 0 * time.Second, // Disable timeout
-			clientProtocol:      kHTTP1ClientProtocol,
-			fileName:            "zero_timeout.yaml",
-		},
-	}
-
-	for _, flags := range flagsSet {
-		configFilePath := createConfigFile(&flags)
-		ts.flags = []string{"--config-file=" + configFilePath}
-		if flags.cliFlags != nil {
-			ts.flags = append(ts.flags, flags.cliFlags...)
-		}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		// ts.flags = flags
 		log.Printf("Running inactive_read_timeout tests with flags: %s", ts.flags)
-
 		suite.Run(t, ts)
 	}
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -454,6 +454,30 @@ readdirplus:
         run: TestReaddirplusWithoutDentryCacheTest
         run_on_gke: true
 
+inactive_stream_timeout:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    log_file: # 
+    configs:
+      - flags:
+        - "--read-inactive-stream-timeout=1s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
+        - "--read-inactive-stream-timeout=1s --client-protocol=grpc --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestTimeoutEnabledSuite
+        run_on_gke: true
+      - flags:
+        - "--read-inactive-stream-timeout=0s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestTimeoutDisabledSuite
+        run_on_gke: true
+
+
 benchmarking:
   - test_bucket: "${BUCKET_NAME}"
     mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -457,7 +457,6 @@ readdirplus:
 inactive_stream_timeout:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # 
     configs:
       - flags:
         - "--read-inactive-stream-timeout=1s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"


### PR DESCRIPTION
### Description
This PR includes changes to migrate inactive_stream_timeout test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of inactive_stream_timeout package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445952891](https://buganizer.corp.google.com/issues/445952891)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
