### PR TITLE
feat(read-ahead): add capability to set max-read-ahead for gcsfuse mount

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -952,7 +952,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	flagSet.IntP("max-read-ahead-kb", "", 1024, "Max read ahead in KiB by kernel while performing reads.")
+	flagSet.IntP("max-read-ahead-kb", "", 0, "Sets max kernel-read-ahead for the mount in KiB. 0 means system default. Requires sudo permission to set this value, otherwise the value will be ignored and system default will be used.")
 
 	if err := flagSet.MarkHidden("max-read-ahead-kb"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -353,7 +353,10 @@ params:
   - config-path: "file-system.max-read-ahead-kb"
     flag-name: "max-read-ahead-kb"
     type: "int"
-    usage: "Max read ahead in KiB by kernel while performing reads."
+    usage: >-
+      Sets max kernel-read-ahead for the mount in KiB. 0 means system default.
+      Requires sudo permission to set this value, otherwise the value will be ignored
+      and system default will be used.
     default: "0"
     hide-flag: true
   

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -592,6 +592,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 					TempDir:                "",
 					PreconditionErrors:     true,
 					Uid:                    -1,
+					MaxReadAheadKb:         0,
 				},
 			},
 		},
@@ -611,6 +612,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 					TempDir:                "",
 					PreconditionErrors:     true,
 					Uid:                    -1,
+					MaxReadAheadKb:         0,
 				},
 			},
 		},
@@ -630,6 +632,7 @@ func TestValidateConfigFile_FileSystemConfigSuccessful(t *testing.T) {
 					TempDir:                cfg.ResolvedPath(path.Join(hd, "temp")),
 					PreconditionErrors:     false,
 					Uid:                    8,
+					MaxReadAheadKb:         1024,
 				},
 				GcsConnection: cfg.GcsConnectionConfig{
 					EnableHttpDnsCache: true,

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -217,10 +217,6 @@ func getDeviceMajorMinor(mountPoint string) (major uint32, minor uint32, err err
 		return
 	}
 
-	logger.Infof("File info: %+v %s\n", fileInfo, mountPoint)
-	logger.Infof("file sys: %+v\n", fileInfo.Sys())
-	logger.Infof("file sys type: %T\n", fileInfo.Sys())
-
 	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
 		err = fmt.Errorf("fileInfo.Sys() is not of type *syscall.Stat_t")
@@ -233,7 +229,7 @@ func getDeviceMajorMinor(mountPoint string) (major uint32, minor uint32, err err
 	return
 }
 
-// setMaxReadAhead sets the read ahead value for the filesystem mounted at
+// setMaxReadAhead sets the kernel-read-ahead for the filesystem mounted at
 // the given mountPoint to readAheadKb.
 func setMaxReadAhead(mountPoint string, readAheadKb int) error {
 	major, minor, err := getDeviceMajorMinor(mountPoint)
@@ -242,10 +238,8 @@ func setMaxReadAhead(mountPoint string, readAheadKb int) error {
 	}
 
 	sysPath := filepath.Join("/sys/class/bdi", fmt.Sprintf("%d:%d", major, minor), "read_ahead_kb")
-	data := fmt.Sprintf("%d\n", readAheadKb)
-
 	cmd := exec.Command("sudo", "-n", "tee", sysPath)
-	cmd.Stdin = strings.NewReader(data)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d\n", readAheadKb))
 
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -483,17 +483,17 @@ func (t *MainTest) TestForwardedEnvVars_NotPassedWhenUnset() {
 
 func (t *MainTest) TestGetDeviceMajorMinor() {
 	testCases := []struct {
-		name           string
-		mountPoint    string
-		expectedErr   bool
+		name        string
+		mountPoint  string
+		expectedErr bool
 	}{
 		{
-			name:         "Existing mount point",
+			name:        "Existing mount point",
 			mountPoint:  "/tmp",
 			expectedErr: false,
 		},
 		{
-			name:         "Non-existing mount point",
+			name:        "Non-existing mount point",
 			mountPoint:  "/path/to/non/existing/mountpoint",
 			expectedErr: true,
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1120,6 +1120,40 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test file system max-read-ahead-kb flag enabled.",
+			args: []string{"gcsfuse", "--max-read-ahead-kb=1024", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					DirMode:            0755,
+					FileMode:           0644,
+					FuseOptions:        []string{},
+					Gid:                -1,
+					IgnoreInterrupts:   true,
+					ODirect:            false,
+					PreconditionErrors: true,
+					Uid:                -1,
+					MaxReadAheadKb:     1024,
+				},
+			},
+		},
+		{
+			name: "Test file system max-read-ahead-kb flag disabled.",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					DirMode:            0755,
+					FileMode:           0644,
+					FuseOptions:        []string{},
+					Gid:                -1,
+					IgnoreInterrupts:   true,
+					ODirect:            false,
+					PreconditionErrors: true,
+					Uid:                -1,
+					MaxReadAheadKb:     0,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -63,6 +63,7 @@ file-system:
   rename-dir-limit: 10
   temp-dir: ~/temp
   precondition-errors: false
+  max-read-ahead-kb: 1024
 list:
   enable-empty-managed-folders: true
 enable-hns: false

--- a/internal/logger/slog_helper.go
+++ b/internal/logger/slog_helper.go
@@ -88,7 +88,7 @@ func addPrefixToMessage(a *slog.Attr, prefix string) {
 	// Add prefix to the message.
 	message := a.Value.Any().(string)
 	var sb strings.Builder
-	// sb.WriteString(prefix)
+	sb.WriteString(prefix)
 	sb.WriteString(message)
 	a.Value = slog.StringValue(sb.String())
 }
@@ -101,8 +101,7 @@ func addPrefixToMessage(a *slog.Attr, prefix string) {
 func customiseTimeFormat(a *slog.Attr, format string) {
 	currTime := a.Value.Any().(time.Time).Round(0)
 	if format == textFormat {
-		// a.Value = slog.StringValue(currTime.Round(0).Format("02/01/2006 03:04:05.000000"))
-		a.Value = slog.StringValue("")
+		a.Value = slog.StringValue(currTime.Round(0).Format("02/01/2006 03:04:05.000000"))
 	} else {
 		*a = slog.Group(timestampKey, secondsKey, currTime.Unix(), nanosKey, currTime.Nanosecond())
 	}


### PR DESCRIPTION
### Description
- Adding support to increase read-ahead for gcsfuse under a private flag.

### Link to the issue in case of a bug fix.
b/455926280


### Testing details
1. Manual - Yes, on GCE vm.
2. Unit tests - Added.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
