### PR TITLE
chore(dependency): upgrade go version to 1.24.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.24.6-alpine AS builder
+FROM golang:1.24.10-alpine AS builder
 
 RUN apk add git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse/v3
 
-go 1.24.6
+go 1.24.10
 
 require (
 	cloud.google.com/go/auth v0.16.5

--- a/perfmetrics/scripts/install_go.sh
+++ b/perfmetrics/scripts/install_go.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 if [[ $# -ne 1 ]]; then
     echo "This script requires exactly one argument."
     echo "Usage: $0 <go-version>"
-    echo "Example: $0 1.24.6"
+    echo "Example: $0 1.24.10"
     exit 1
 fi
 

--- a/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
+++ b/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
@@ -23,9 +23,9 @@ sudo apt-get update
 echo "Installing git"
 sudo apt-get install git
 # Install Golang.
-#wget -O go_tar.tar.gz https://go.dev/dl/go1.24.6.linux-amd64.tar.gz -q
+#wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-amd64.tar.gz -q
 architecture=$(dpkg --print-architecture)
-wget -O go_tar.tar.gz https://go.dev/dl/go1.24.6.linux-${architecture}.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 # Install latest gcloud version for compatability with HNS bucket.

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -21,7 +21,7 @@ readonly EXECUTE_INTEGRATION_TEST_LABEL_ON_ZB="execute-integration-tests-on-zb"
 readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly EXECUTE_CHECKPOINT_TEST_LABEL="execute-checkpoint-test"
 readonly BUCKET_LOCATION=us-west4
-readonly GO_VERSION="1.24.6"
+readonly GO_VERSION="1.24.10"
 readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
 readonly INSTALL_BASH_VERSION="5.3" # Using 5.3 for installation as bash 5.1 has an installation bug.
 

--- a/perfmetrics/scripts/read_cache/setup.sh
+++ b/perfmetrics/scripts/read_cache/setup.sh
@@ -64,7 +64,7 @@ sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GRO
 cd -
 
 # Install and validate go.
-version=1.24.6
+version=1.24.10
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go
 tar -xzf go_tar.tar.gz && sudo mv go /usr/local

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -253,7 +253,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.24.6.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.24.6 as gcsfuse-package
+FROM golang:1.24.10 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -52,7 +52,7 @@ fi
 log_info "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 
 # Constants
-readonly GO_VERSION="1.24.6"
+readonly GO_VERSION="1.24.10"
 readonly DEFAULT_PROJECT_ID="gcs-fuse-test-ml"
 readonly TPCZERO_PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly TPC_BUCKET_LOCATION="u-us-prp1"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -252,7 +252,7 @@ function upgrade_gcloud_version() {
 
 function install_packages() {
   # Install required go version.
-  ./perfmetrics/scripts/install_go.sh "1.24.6"
+  ./perfmetrics/scripts/install_go.sh "1.24.10"
   export PATH="/usr/local/go/bin:$PATH"
   
   sudo apt-get update

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -27,7 +27,7 @@ RUN if [ "${ARCHITECTURE}" != "amd64" ] && [ "${ARCHITECTURE}" != "arm64" ]; the
     exit 1; \
 fi
 
-RUN wget -O go_tar.tar.gz https://go.dev/dl/go1.24.6.linux-${ARCHITECTURE}.tar.gz -q
+RUN wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${ARCHITECTURE}.tar.gz -q
 RUN rm -rf /usr/local/go
 RUN tar -C /usr/local -xzf go_tar.tar.gz
 RUN PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
### Description
go version upgrade from 1.24.6 to 1.24.10 ( [Diff](https://github.com/golang/go/compare/go1.24.6...go1.24.10) )

Holding off upgrade to 1.25.* version until it is thoroughly vetted. 

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
