### PR TITLE
refactor: Remove DataBuf from ReadResponse

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -266,7 +266,7 @@ func (p *BufferedReader) prepareQueueForOffset(offset int64) {
 //
 // LOCKS_EXCLUDED(p.mu)
 func (p *BufferedReader) ReadAt(ctx context.Context, inputBuf []byte, off int64) (gcsx.ReadResponse, error) {
-	resp := gcsx.ReadResponse{DataBuf: inputBuf}
+	resp := gcsx.ReadResponse{}
 	reqID := uuid.New()
 	start := time.Now()
 	initOff := off

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2861,7 +2861,6 @@ func (fs *fileSystem) ReadFile(
 	if fs.newConfig.EnableNewReader {
 		var resp gcsx.ReadResponse
 		resp, err = fh.ReadWithReadManager(ctx, op.Dst, op.Offset, fs.sequentialReadSizeMb)
-		op.Dst = resp.DataBuf
 		op.BytesRead = resp.Size
 		op.Callback = resp.Callback
 	} else {

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -172,7 +172,7 @@ func (fh *FileHandle) ReadWithReadManager(ctx context.Context, dst []byte, offse
 		// Read from inode if source generation is not authoratative
 		defer fh.inode.Unlock()
 		n, err := fh.inode.Read(ctx, dst, offset)
-		return gcsx.ReadResponse{DataBuf: dst, Size: n}, err
+		return gcsx.ReadResponse{Size: n}, err
 	}
 
 	fh.lockHandleAndRelockInode(true)

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -313,7 +313,7 @@ func (t *fileTest) Test_ReadWithReadManager_Success() {
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), len(expectedData), resp.Size)
-	assert.Equal(t.T(), expectedData, resp.DataBuf)
+	assert.Equal(t.T(), expectedData, buf[:resp.Size])
 }
 
 // Test_ReadWithReadManager_Concurrent validates concurrent read behavior using the readManager.
@@ -459,7 +459,6 @@ func (t *fileTest) Test_ReadWithReadManager_ErrorScenarios() {
 			resp, err := fh.ReadWithReadManager(t.ctx, dst, 0, 200)
 
 			assert.Zero(t.T(), resp.Size, "expected 0 bytes read")
-			assert.Nil(t.T(), resp.DataBuf, "expected output to be nil")
 			assert.True(t.T(), errors.Is(err, tc.returnErr), "expected error to match")
 			mockRM.AssertExpectations(t.T())
 		})
@@ -509,7 +508,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 	dst := make([]byte, 100)
 	objectData := []byte("fallback data")
-	object := gcs.MinObject{Name: "test_obj", Generation: 0}
+	object := gcs.MinObject{Name: "test_obj"}
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
 	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
@@ -521,7 +520,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 
 	assert.Equal(t.T(), io.EOF, err)
 	assert.Equal(t.T(), len(objectData), resp.Size)
-	assert.Equal(t.T(), objectData, resp.DataBuf[:resp.Size])
+	assert.Equal(t.T(), objectData, dst[:resp.Size])
 	mockRM.AssertExpectations(t.T())
 }
 
@@ -530,7 +529,7 @@ func (t *fileTest) Test_ReadWithReadManager_FallbackToInode() {
 func (t *fileTest) Test_Read_FallbackToInode() {
 	dst := make([]byte, 100)
 	objectData := []byte("fallback data")
-	object := gcs.MinObject{Name: "test_obj", Generation: 0}
+	object := gcs.MinObject{Name: "test_obj"}
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, nil, parent, object.Name, objectData, true)
 	fh := NewFileHandle(in, nil, false, metrics.NewNoopMetrics(), util.Read, &cfg.Config{}, nil, nil)
@@ -583,7 +582,7 @@ func (t *fileTest) Test_ReadWithReadManager_ReadManagerInvalidatedByGenerationCh
 	assert.NotNil(t.T(), fh.readManager)
 	assert.NotEqual(t.T(), oldReadManager, fh.readManager)
 	assert.Equal(t.T(), len(content2), resp.Size)
-	assert.Equal(t.T(), content2, resp.DataBuf)
+	assert.Equal(t.T(), content2, dst)
 }
 
 func (t *fileTest) Test_Read_ReaderInvalidatedByGenerationChange() {
@@ -947,7 +946,7 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), fileSize, resp.Size)
-	assert.Equal(t.T(), expectedData, resp.DataBuf)
+	assert.Equal(t.T(), expectedData, buf)
 }
 
 func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() {
@@ -991,7 +990,7 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() 
 
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), readSize, resp.Size)
-			results[index] = resp.DataBuf
+			results[index] = readBuf
 		}(i)
 	}
 	// Wait for all goroutines to finish.
@@ -1031,20 +1030,26 @@ func (t *fileTest) Test_ReadWithReadManager_WorkloadInsightVisual() {
 
 	// Perform multiple reads and destroy the file-handle.
 	fh.inode.Lock()
-	resp1, err := fh.ReadWithReadManager(t.ctx, make([]byte, MiB), MiB, 200)
+	dst := make([]byte, MiB)
+	// First read.
+	resp1, err := fh.ReadWithReadManager(t.ctx, dst, MiB, 200)
 	require.NoError(t.T(), err)
 	require.Equal(t.T(), MiB, resp1.Size)
-	require.Equal(t.T(), content[MiB:2*MiB], resp1.DataBuf)
+	require.Equal(t.T(), content[MiB:2*MiB], dst[:resp1.Size])
+	clear(dst)
+	// Second read.
 	fh.inode.Lock()
-	resp2, err := fh.ReadWithReadManager(t.ctx, make([]byte, MiB), 0, 200)
+	resp2, err := fh.ReadWithReadManager(t.ctx, dst, 0, 200)
 	require.NoError(t.T(), err)
-	require.Equal(t.T(), MiB, resp2.Size)
-	require.Equal(t.T(), content[0:MiB], resp2.DataBuf)
+	assert.Equal(t.T(), MiB, resp2.Size)
+	assert.Equal(t.T(), content[0:MiB], dst[:resp2.Size])
+	clear(dst)
+	// Third read.
 	fh.inode.Lock()
-	resp3, err := fh.ReadWithReadManager(t.ctx, make([]byte, MiB), 2*MiB, 200)
+	resp3, err := fh.ReadWithReadManager(t.ctx, dst, 2*MiB, 200)
 	require.NoError(t.T(), err)
-	require.Equal(t.T(), MiB, resp3.Size)
-	require.Equal(t.T(), content[2*MiB:3*MiB], resp3.DataBuf)
+	assert.Equal(t.T(), MiB, resp3.Size)
+	assert.Equal(t.T(), content[2*MiB:3*MiB], dst[:resp3.Size])
 	fh.Destroy()
 
 	// Validate the output file creation for workload insight.

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -150,7 +150,6 @@ func (gr *GCSReader) ReadAt(ctx context.Context, p []byte, offset int64) (readRe
 		EndOffset:         offset + int64(len(p)),
 		ForceCreateReader: false,
 	}
-	readResponse.DataBuf = p
 	defer func() {
 		gr.updateExpectedOffset(offset + int64(readResponse.Size))
 		gr.totalReadBytes.Add(uint64(readResponse.Size))

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -44,10 +44,10 @@ const (
 // Helpers
 ////////////////////////////////////////////////////////////////////////
 
-func (t *gcsReaderTest) readAt(offset int64, size int64) (gcsx.ReadResponse, error) {
+func (t *gcsReaderTest) readAt(dst []byte, offset int64) (gcsx.ReadResponse, error) {
 	t.gcsReader.CheckInvariants()
 	defer t.gcsReader.CheckInvariants()
-	return t.gcsReader.ReadAt(t.ctx, make([]byte, size), offset)
+	return t.gcsReader.ReadAt(t.ctx, dst, offset)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -163,13 +163,14 @@ func (t *gcsReaderTest) Test_ReadAt_ExistingReaderLimitIsLessThanRequestedDataSi
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, readObjectRequest).Return(rc, nil)
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(3)
 	requestSize := 6
+	buf := make([]byte, requestSize)
 
-	readResponse, err := t.readAt(2, int64(requestSize))
+	readResponse, err := t.readAt(buf, 2)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), rc, t.gcsReader.rangeReader.reader)
 	assert.Equal(t.T(), requestSize, readResponse.Size)
-	assert.Equal(t.T(), content, string(readResponse.DataBuf[:readResponse.Size]))
+	assert.Equal(t.T(), content, string(buf[:readResponse.Size]))
 	assert.Equal(t.T(), uint64(requestSize), t.gcsReader.totalReadBytes.Load())
 	assert.Equal(t.T(), int64(2+requestSize), t.gcsReader.expectedOffset.Load())
 	assert.Equal(t.T(), expectedHandleInRequest, t.gcsReader.rangeReader.readHandle)
@@ -198,13 +199,14 @@ func (t *gcsReaderTest) Test_ReadAt_ExistingReaderLimitIsLessThanRequestedObject
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, readObjectRequest).Return(rc, nil)
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(3)
 	requestSize := 6
+	buf := make([]byte, requestSize)
 
-	readResponse, err := t.readAt(0, int64(requestSize))
+	readResponse, err := t.readAt(buf, 0)
 
 	assert.NoError(t.T(), err)
 	assert.Nil(t.T(), t.gcsReader.rangeReader.reader)
 	assert.Equal(t.T(), int(t.object.Size), readResponse.Size)
-	assert.Equal(t.T(), content, string(readResponse.DataBuf[:readResponse.Size]))
+	assert.Equal(t.T(), content, string(buf[:readResponse.Size]))
 	assert.Equal(t.T(), int64(t.object.Size), t.gcsReader.expectedOffset.Load())
 	assert.Equal(t.T(), []byte(nil), t.gcsReader.rangeReader.readHandle)
 }
@@ -220,12 +222,13 @@ func (t *gcsReaderTest) Test_ReadAt_ExistingReaderIsFine() {
 	t.gcsReader.rangeReader.limit = 5
 	requestSize := 3
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(3)
+	buf := make([]byte, requestSize)
 
-	readResponse, err := t.readAt(2, int64(requestSize))
+	readResponse, err := t.readAt(buf, 2)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), 3, readResponse.Size)
-	assert.Equal(t.T(), content, string(readResponse.DataBuf[:readResponse.Size]))
+	assert.Equal(t.T(), content, string(buf[:readResponse.Size]))
 	assert.Equal(t.T(), uint64(5), t.gcsReader.totalReadBytes.Load())
 	assert.Equal(t.T(), int64(5), t.gcsReader.expectedOffset.Load())
 	assert.Equal(t.T(), []byte("fake"), t.gcsReader.rangeReader.readHandle)
@@ -263,14 +266,15 @@ func (t *gcsReaderTest) Test_ExistingReader_WrongOffset() {
 			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(rc, nil).Times(1)
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(3)
 			requestSize := 6
+			buf := make([]byte, requestSize)
 
-			readResponse, err := t.readAt(0, int64(requestSize))
+			readResponse, err := t.readAt(buf, 0)
 
 			t.mockBucket.AssertExpectations(t.T())
 			assert.NoError(t.T(), err)
 			assert.Nil(t.T(), t.gcsReader.rangeReader.reader)
 			assert.Equal(t.T(), int(t.object.Size), readResponse.Size)
-			assert.Equal(t.T(), content, string(readResponse.DataBuf[:readResponse.Size]))
+			assert.Equal(t.T(), content, string(buf[:readResponse.Size]))
 			assert.Equal(t.T(), []byte(nil), t.gcsReader.rangeReader.readHandle)
 		})
 	}
@@ -337,7 +341,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateReadType() {
 			for i, readRange := range tc.readRanges {
 				t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(&fake.FakeReader{ReadCloser: getReadCloser(testContent)}, nil).Once()
 
-				_, err = t.readAt(int64(readRange[0]), int64(readRange[1]-readRange[0]))
+				_, err = t.readAt(make([]byte, readRange[1]-readRange[0]), int64(readRange[0]))
 
 				assert.NoError(t.T(), err)
 				assert.Equal(t.T(), tc.expectedReadTypes[i], t.gcsReader.readType.Load())
@@ -803,13 +807,14 @@ func (t *gcsReaderTest) Test_ReadAt_WithAndWithoutReadConfig() {
 			}
 			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, expectedReadObjectRequest).Return(rc, nil).Once()
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false}).Times(3)
+			buf := make([]byte, readLength)
 
-			objectData, err := t.readAt(readOffset, int64(readLength))
+			objectData, err := t.readAt(buf, readOffset)
 
 			t.mockBucket.AssertExpectations(t.T())
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), readLength, objectData.Size)
-			assert.Equal(t.T(), fakeReaderContent[:readLength], objectData.DataBuf[:objectData.Size]) // Ensure buffer is populated correctly
+			assert.Equal(t.T(), fakeReaderContent[:readLength], buf[:objectData.Size]) // Ensure buffer is populated correctly
 			assert.NotNil(t.T(), t.gcsReader.rangeReader.reader, "Reader should be active as partial data read from the requested range.")
 			assert.NotNil(t.T(), t.gcsReader.rangeReader.cancel)
 			assert.Equal(t.T(), int64(readLength), t.gcsReader.rangeReader.start)
@@ -852,7 +857,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 		t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond))
 		buf := make([]byte, readRange[1]-readRange[0])
 
-		_, err := t.gcsReader.ReadAt(t.ctx, buf, int64(readRange[0]))
+		_, err := t.readAt(buf, int64(readRange[0]))
 
 		assert.NoError(t.T(), err)
 		assert.Equal(t.T(), uint64(seeks), t.gcsReader.seeks.Load())

--- a/internal/gcsx/client_readers/multi_range_reader.go
+++ b/internal/gcsx/client_readers/multi_range_reader.go
@@ -76,11 +76,10 @@ func (mrd *MultiRangeReader) readFromMultiRangeReader(ctx context.Context, p []b
 }
 
 func (mrd *MultiRangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (gcsx.ReadResponse, error) {
-	readResponse := gcsx.ReadResponse{
-		DataBuf: req.Buffer,
-		Size:    0,
-	}
-	var err error
+	var (
+		readResponse gcsx.ReadResponse
+		err          error
+	)
 
 	if req.Offset >= int64(mrd.object.Size) {
 		err = io.EOF

--- a/internal/gcsx/client_readers/multi_range_reader_test.go
+++ b/internal/gcsx/client_readers/multi_range_reader_test.go
@@ -47,11 +47,11 @@ type multiRangeReaderTest struct {
 	multiRangeReader *MultiRangeReader
 }
 
-func (t *multiRangeReaderTest) readAt(offset int64, size int64) (gcsx.ReadResponse, error) {
+func (t *multiRangeReaderTest) readAt(dst []byte, offset int64) (gcsx.ReadResponse, error) {
 	req := &gcsx.GCSReaderRequest{
 		Offset:    offset,
-		EndOffset: offset + size,
-		Buffer:    make([]byte, size),
+		EndOffset: offset + int64(len(dst)),
+		Buffer:    dst,
 	}
 	return t.multiRangeReader.ReadAt(t.ctx, req)
 }
@@ -188,13 +188,14 @@ func (t *multiRangeReaderTest) Test_ReadAt_MRDRead() {
 			t.multiRangeReader.mrdWrapper = &fakeMRDWrapper
 			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, testContent, time.Microsecond)).Times(1)
 			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true}).Times(1)
+			buf := make([]byte, tc.bytesToRead)
 
-			readResponse, err := t.readAt(int64(tc.offset), int64(tc.bytesToRead))
+			readResponse, err := t.readAt(buf, int64(tc.offset))
 
 			t.mockBucket.AssertNotCalled(t.T(), "NewReaderWithReadHandle", mock.Anything)
 			assert.NoError(t.T(), err)
 			assert.Equal(t.T(), tc.bytesToRead, readResponse.Size)
-			assert.Equal(t.T(), testContent[tc.offset:tc.offset+tc.bytesToRead], readResponse.DataBuf[:readResponse.Size])
+			assert.Equal(t.T(), testContent[tc.offset:tc.offset+tc.bytesToRead], buf[:readResponse.Size])
 		})
 	}
 }
@@ -202,7 +203,7 @@ func (t *multiRangeReaderTest) Test_ReadAt_MRDRead() {
 func (t *multiRangeReaderTest) Test_ReadAt_InvalidOffset() {
 	t.object.Size = 50
 
-	_, err := t.readAt(65, int64(t.object.Size))
+	_, err := t.readAt(make([]byte, t.object.Size), 65)
 
 	assert.True(t.T(), errors.Is(err, io.EOF), "expected %v error got %v", io.EOF, err)
 }

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -112,11 +112,10 @@ func (rr *RangeReader) closeReader() {
 }
 
 func (rr *RangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (gcsx.ReadResponse, error) {
-	readResponse := gcsx.ReadResponse{
-		DataBuf: req.Buffer,
-		Size:    0,
-	}
-	var err error
+	var (
+		readResponse gcsx.ReadResponse
+		err          error
+	)
 
 	if req.ForceCreateReader && rr.reader != nil {
 		rr.closeReader()

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -92,11 +92,11 @@ func getReader(size int) *fake.FakeReader {
 	}
 }
 
-func (t *rangeReaderTest) readAt(offset int64, size int64) (gcsx.ReadResponse, error) {
+func (t *rangeReaderTest) readAt(dst []byte, offset int64) (gcsx.ReadResponse, error) {
 	req := &gcsx.GCSReaderRequest{
 		Offset:    offset,
-		EndOffset: offset + size,
-		Buffer:    make([]byte, size),
+		EndOffset: offset + int64(len(dst)),
+		Buffer:    dst,
 	}
 	t.rangeReader.checkInvariants()
 	defer t.rangeReader.checkInvariants()
@@ -266,8 +266,9 @@ func (t *rangeReaderTest) Test_ReadAt_ReadFailsWithTimeoutError() {
 	r := iotest.OneByteReader(iotest.TimeoutReader(strings.NewReader(content)))
 	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 	t.mockNewReaderWithHandleCallForTestBucket(0, uint64(len(content)), rc)
+	buf := make([]byte, len(content))
 
-	readResponse, err := t.readAt(0, int64(len(content)))
+	readResponse, err := t.readAt(buf, 0)
 
 	assert.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "timeout")
@@ -281,12 +282,13 @@ func (t *rangeReaderTest) Test_ReadAt_SuccessfulRead() {
 	content := []byte("hello world")
 	r := &fake.FakeReader{ReadCloser: getReadCloser(content)}
 	t.mockNewReaderWithHandleCallForTestBucket(uint64(offset), uint64(offset+size), r)
+	buf := make([]byte, size)
 
-	resp, err := t.readAt(offset, size)
+	resp, err := t.readAt(buf, offset)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(size), resp.Size)
-	assert.Equal(t.T(), content[:size], resp.DataBuf)
+	assert.Equal(t.T(), content[:size], buf[:resp.Size])
 	t.mockBucket.AssertExpectations(t.T())
 }
 
@@ -296,8 +298,9 @@ func (t *rangeReaderTest) Test_ReadAt_PartialReadWithEOF() {
 	partialReader := io.NopCloser(iotest.ErrReader(io.EOF)) // Simulates early EOF
 	r := &fake.FakeReader{ReadCloser: partialReader}
 	t.mockNewReaderWithHandleCallForTestBucket(uint64(offset), uint64(offset+size), r)
+	buf := make([]byte, size)
 
-	resp, err := t.readAt(offset, size)
+	resp, err := t.readAt(buf, offset)
 
 	assert.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "reader returned early by skipping")
@@ -310,7 +313,7 @@ func (t *rangeReaderTest) Test_ReadAt_StartReadNotFound() {
 	size := int64(5)
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, &gcs.NotFoundError{}).Once()
 
-	resp, err := t.readAt(offset, size)
+	resp, err := t.readAt(make([]byte, size), offset)
 
 	var fcErr *gcsfuse_errors.FileClobberedError
 	assert.ErrorAs(t.T(), err, &fcErr)
@@ -323,7 +326,7 @@ func (t *rangeReaderTest) Test_ReadAt_StartReadUnexpectedError() {
 	size := int64(5)
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, errors.New("network error")).Once()
 
-	resp, err := t.readAt(offset, size)
+	resp, err := t.readAt(make([]byte, size), offset)
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), resp.Size)
@@ -485,17 +488,18 @@ func (t *rangeReaderTest) Test_ReadAt_DoesntPropagateCancellationAfterReturning(
 	t.rangeReader.cancel = func() { close(cancelCalled) }
 	ctx, cancel := context.WithCancel(context.Background())
 	bufSize := 2
+	buf := make([]byte, bufSize)
 
 	// Successfully read two bytes using a context whose cancellation we control.
 	readResponse, err := t.rangeReader.ReadAt(ctx, &gcsx.GCSReaderRequest{
-		Buffer:    make([]byte, bufSize),
+		Buffer:    buf,
 		Offset:    0,
 		EndOffset: 2,
 	})
 
 	assert.Nil(t.T(), err)
 	assert.Equal(t.T(), bufSize, readResponse.Size)
-	assert.Equal(t.T(), content[:bufSize], string(readResponse.DataBuf[:readResponse.Size]))
+	assert.Equal(t.T(), content[:bufSize], string(buf[:readResponse.Size]))
 	// If we cancel the calling context now, it should not cause the underlying
 	// read context to be cancelled.
 	cancel()
@@ -606,12 +610,13 @@ func (t *rangeReaderTest) Test_ReadAt_ReaderNotExhausted() {
 	t.rangeReader.limit = 4
 	t.rangeReader.cancel = func() {}
 	var bufSize int64 = 2
+	buf := make([]byte, bufSize)
 
 	// Read two bytes.
-	resp, err := t.readAt(offset, bufSize)
+	resp, err := t.readAt(buf, offset)
 
 	assert.NoError(t.T(), err)
-	assert.Equal(t.T(), content[:bufSize], string(resp.DataBuf[:resp.Size]))
+	assert.Equal(t.T(), content[:bufSize], string(buf[:resp.Size]))
 	assert.Zero(t.T(), cc.closeCount)
 	assert.Equal(t.T(), rc, t.rangeReader.reader)
 	assert.Equal(t.T(), offset+bufSize, t.rangeReader.start)
@@ -624,8 +629,9 @@ func (t *rangeReaderTest) Test_ReadAt_ShortRead() {
 	shortContent := []byte("hello")
 	r := &fake.FakeReader{ReadCloser: getReadCloser(shortContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(uint64(offset), uint64(offset+size), r)
+	buf := make([]byte, size)
 
-	resp, err := t.readAt(offset, size)
+	resp, err := t.readAt(buf, offset)
 
 	assert.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "reader returned early by skipping 5 bytes: short read")
@@ -656,7 +662,7 @@ func (t *rangeReaderTest) Test_ReadAt_ForceCreateReader() {
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(readSize), resp1.Size)
-	assert.Equal(t.T(), content1[:readSize], resp1.DataBuf)
+	assert.Equal(t.T(), content1[:readSize], req1.Buffer)
 	assert.NotNil(t.T(), t.rangeReader.reader) // Reader should be active
 	firstReader := t.rangeReader.reader
 
@@ -677,7 +683,7 @@ func (t *rangeReaderTest) Test_ReadAt_ForceCreateReader() {
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(readsize2), resp2.Size)
-	assert.Equal(t.T(), content2[:readsize2], resp2.DataBuf)
+	assert.Equal(t.T(), content2[:readsize2], req2.Buffer)
 	assert.NotNil(t.T(), t.rangeReader.reader) // New reader should not be nil
 	secondReader := t.rangeReader.reader
 	assert.NotEqual(t.T(), firstReader, secondReader)

--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -176,10 +176,7 @@ func (fc *FileCacheReader) tryReadingFromFileCache(ctx context.Context, p []byte
 }
 
 func (fc *FileCacheReader) ReadAt(ctx context.Context, p []byte, offset int64) (ReadResponse, error) {
-	readResponse := ReadResponse{
-		DataBuf: p,
-		Size:    0,
-	}
+	var readResponse ReadResponse
 
 	if offset >= int64(fc.object.Size) {
 		return readResponse, io.EOF

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -1080,7 +1080,7 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_MRDRead() {
 			assert.NoError(t.T(), err)
 			assert.Nil(t.T(), t.rr.wrapped.reader)
 			assert.Equal(t.T(), tc.bytesToRead, objData.Size)
-			assert.Equal(t.T(), testContent[tc.offset:tc.offset+tc.bytesToRead], objData.DataBuf[:objData.Size])
+			assert.Equal(t.T(), testContent[tc.offset:tc.offset+tc.bytesToRead], buf[:objData.Size])
 			if tc.bytesToRead != 0 {
 				assert.Equal(t.T(), int64(tc.offset+tc.bytesToRead), t.rr.wrapped.expectedOffset.Load())
 			}

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -572,8 +572,8 @@ func (t *RandomReaderTest) UpgradesSequentialReads_NoExistingReader() {
 
 	// Check the state now.
 	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectEq(data, string(objectData.DataBuf))
+	AssertEq(nil, err)
+	ExpectEq(data, string(buf))
 	ExpectEq(1+readSize, t.rr.wrapped.start)
 	ExpectEq(1+readSize, t.rr.wrapped.limit)
 }

--- a/internal/gcsx/reader.go
+++ b/internal/gcsx/reader.go
@@ -48,9 +48,6 @@ type GCSReaderRequest struct {
 // ReadResponse represents the response returned as part of a ReadAt call.
 // It includes the actual data read and its size.
 type ReadResponse struct {
-	// DataBuf contains the bytes read from the object.
-	DataBuf []byte
-
 	// Size indicates how many bytes were read into DataBuf.
 	Size int
 


### PR DESCRIPTION
### Description
This PR removes the `DataBuf` field from the `ReadResponse` struct. This is because the `DataBuf` field is redundant, as the same slice is passed to `ReadAt` methods and written to, and the caller already has access to the modified slice. This change simplifies the code by removing the need for repeated assignments.

#### Original Rationale for Adding `DataBuf`
The initial design for integrating the multi-range downloader considered an optimization to achieve a "single data copy" and avoid extra data copies between the Go SDK, GCSFuse, and the FUSE kernel. The plan was to use a reusable buffer within GCSFuse, which would be passed to the Go SDK's multi-range downloader. The `DataBuf` field was part of this design to hold a reference to the data that would be returned to the FUSE layer.

#### Justification for Removal
The optimization for a single data copy using a reusable buffer is not being implemented in the current scope for the private preview. The current implementation passes a destination slice to the read methods, and the data from GCS is written directly into this slice.

In Go, slices are reference types that point to an underlying array. When a slice is passed to a function, any modifications to the underlying data are visible to the caller. Since our read methods write directly into the provided slice, the caller already has the data.

Given this, returning the data buffer in the `ReadResponse` is redundant. This PR removes the `DataBuf` field to simplify the `ReadResponse` struct and the associated code, making it more aligned with the current implementation.

### Link to the issue in case of a bug fix.
b/458976462

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
