### PR TITLE
refactor(cmd): replace global initializers with lazy PersistentPreRunE

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,13 +148,13 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 				return fmt.Errorf("error while unmarshalling config: %w", err)
 			}
 			if err := cfg.ValidateConfig(v, mountInfo.config); err != nil {
-				return err
+				return fmt.Errorf("invalid config: %w", err)
 			}
 
 			isSet := &pflagAsIsValueSet{fs: cmd.PersistentFlags()}
 			optimizedFlags := mountInfo.config.ApplyOptimizations(isSet)
 			if err := cfg.Rationalize(v, mountInfo.config, optimizedFlags); err != nil {
-				return err
+				return fmt.Errorf("error rationalizing config: %w", err)
 			}
 			mountInfo.cliFlags = getCliFlags(cmd.PersistentFlags())
 			mountInfo.configFileFlags = getConfigFileFlags(v)


### PR DESCRIPTION
### Description
This pull request refactors the command initialization and configuration loading logic to fix a severe performance degradation in our unit tests.

The previous implementation used `cobra.OnInitialize` to register configuration functions. This is an anti-pattern for testable applications because `OnInitialize` appends to a global list of initializers, causing repeated test runs to become progressively slower as the list grows.

This change replaces the global initializer pattern with the recommended `PersistentPreRunE` lifecycle [hook](https://cobra.dev/docs/learning-resources/learning-journey/). All configuration loading, validation, and rationalization now happens within `PersistentPreRunE`. This isolates test cases and restores fast, consistent test performance.

### Old Behavior

Previously, the `newRootCmd` function used `cobra.OnInitialize` to register initialization functions. These functions were responsible for reading the config file, validating flags, and rationalizing the final configuration.

The `cobra.OnInitialize` function works by appending the provided functions to a global list of initializers within the Cobra library. In our unit tests (e.g., in `root_test.go`), we call `newRootCmd` inside a loop for each test case. This led to the following problem:

1.  With each test case, new instances of the initialization functions were appended to the global list.
2.  The list of initializers grew larger with every test that ran.
3.  When `cmd.Execute()` was called for a given test, Cobra would execute *all* functions in the global list, including duplicates from all previous tests in the same suite.
4.  This resulted in a significant and compounding increase in the time it took to run each subsequent test, making the overall test suite extremely slow.

### New Behavior

To resolve this issue, the configuration logic has been moved out of the global initialization path and into the `PersistentPreRunE` function of the root command.

`PersistentPreRunE` is a Cobra lifecycle hook that runs exactly once per command execution, right before the main `RunE` function. By placing the setup logic here, we achieve the following:

1.  **No More Global State:** The initialization is now tied to a specific command instance, not a global list.
2.  **Test Isolation:** Each call to `newRootCmd` in a test creates a fresh command. When `cmd.Execute()` is called, only the `PersistentPreRunE` for that specific instance is run.
3.  **Consistent Performance:** The initialization logic is executed once per test case, as intended. This eliminates the performance degradation and makes the unit tests consistently fast, regardless of how many test cases are in the suite.

This refactoring makes our command-line handling more robust, easier to reason about, and significantly improves the performance and reliability of our test suite.

### Link to the issue in case of a bug fix.
[b/459118811](http://b/459118811)

### Run time improvement in tests.

| Package | Run Time (Before) | Run Time (After) | Reduction |
| :--- | :--- | :--- | :--- |
| `.../gcsfuse/v3/cmd` | 497.301s | 3.123s | **494.178s** |


### Perf results

| Branch | File Size | Read BW | Write BW | RandRead BW | RandWrite BW |
| :--- | :--- | ---: | ---: | ---: | ---: |
| Master | 0.25MiB | 563.94MiB/s | 1.3MiB/s | 77.17MiB/s | 1.45MiB/s |
| PR | 0.25MiB | 574.18MiB/s | 1.33MiB/s | 81.34MiB/s | 1.13MiB/s |
| Master | 48.828MiB | 4679.08MiB/s | 82.27MiB/s | 1589.89MiB/s | 85.75MiB/s |
| PR | 48.828MiB | 4679.33MiB/s | 84.91MiB/s | 1578.92MiB/s | 87.16MiB/s |
| Master | 976.562MiB | 4684.07MiB/s | 38.19MiB/s | 1149.11MiB/s | 39.66MiB/s |
| PR | 976.562MiB | 4702.87MiB/s | 38.29MiB/s | 1244.02MiB/s | 39.19MiB/s |

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - Yes ([Zonal e2e](http://shortn/_eTneK2FDMg), [Regional e2e](http://shortn/_eTneK2FDMg))

### Any backward incompatible change? If so, please explain.
