### PR TITLE
refactor: common functions setup and config changes test migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/readdirplus/readdirplus_with_dentry_cache_test.go
+++ b/tools/integration_tests/readdirplus/readdirplus_with_dentry_cache_test.go
@@ -53,7 +53,7 @@ func (s *ReaddirplusWithDentryCacheTest) TearDownSuite() {
 }
 
 func (s *ReaddirplusWithDentryCacheTest) SetupSuite() {
-	setupLogFilePath(s.baseTestName)
+	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/readdirplus/readdirplus_without_dentry_cache_test.go
+++ b/tools/integration_tests/readdirplus/readdirplus_without_dentry_cache_test.go
@@ -53,7 +53,7 @@ func (s *ReaddirplusWithoutDentryCacheTest) TearDownSuite() {
 }
 
 func (s *ReaddirplusWithoutDentryCacheTest) SetupSuite() {
-	setupLogFilePath(s.baseTestName)
+	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/readdirplus/setup_test.go
+++ b/tools/integration_tests/readdirplus/setup_test.go
@@ -38,6 +38,8 @@ const (
 	testDirName   = "dirForReaddirplusTest"
 	targetDirName = "target_dir"
 	GKETempDir    = "/gcsfuse-tmp"
+	// // TODO: clean this up when GKE test migration completes.
+	OldGKElogFilePath = "/tmp/readdirplus_logs/log.json"
 )
 
 var (
@@ -55,22 +57,6 @@ type env struct {
 	testDirPath   string
 	cfg           *test_suite.TestConfig
 	bucketType    string
-}
-
-func setupLogFilePath(testName string) {
-	var logFilePath string
-	if testEnv.cfg.GKEMountedDirectory != "" { // GKE path
-		mountDir = testEnv.cfg.GKEMountedDirectory
-		logFilePath = path.Join(GKETempDir, testName) + ".log"
-		if setup.ConfigFile() == "" {
-			// TODO: clean this up when GKE test migration completes.
-			logFilePath = "/tmp/readdirplus_logs/log.json"
-		}
-	} else {
-		logFilePath = path.Join(setup.TestDir(), GKETempDir, testName) + ".log"
-	}
-	testEnv.cfg.LogFile = logFilePath
-	setup.SetLogFile(logFilePath)
 }
 
 func loadLogLines(reader io.Reader) ([]string, error) {
@@ -178,7 +164,8 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+		mountDir = testEnv.cfg.GKEMountedDirectory
+		os.Exit(setup.RunTestsForMountedDirectory(mountDir, m))
 	}
 
 	// Run tests for testBucket

--- a/tools/integration_tests/readdirplus/setup_test.go
+++ b/tools/integration_tests/readdirplus/setup_test.go
@@ -185,7 +185,7 @@ func TestMain(m *testing.M) {
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 	// Override GKE specific paths with GCSFuse paths if running in GCE environment.
-	overrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
 	// Save mount and root directory variables.
 	mountDir, rootDir = setup.MntDir(), setup.MntDir()
@@ -197,13 +197,4 @@ func TestMain(m *testing.M) {
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(cfg.ReadDirPlus[0].TestBucket, testDirName))
 	os.Exit(successCode)
-}
-
-func overrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
-	for _, flags := range t.Configs {
-		for i := range flags.Flags {
-			// Iterate over the indices of the flags slice
-			flags.Flags[i] = strings.ReplaceAll(flags.Flags[i], "/gcsfuse-tmp", path.Join(GCSFuseTempDirPath, "gcsfuse-tmp"))
-		}
-	}
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -15,7 +15,6 @@
 explicit_dir:
   - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
     test_bucket: "${BUCKET_NAME}" # To be passed by both gcsfuse and gke tests
-    log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
     configs:
       - flags:
           - "--implicit-dirs=false"
@@ -29,7 +28,6 @@ explicit_dir:
 implicit_dir:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
     configs:
       - flags:
           - "--implicit-dirs"
@@ -49,7 +47,6 @@ implicit_dir:
 list_large_dir:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
     configs:
       - flags:
           - "--implicit-dirs=true --stat-cache-ttl=0 --kernel-list-cache-ttl-secs=-1"
@@ -69,7 +66,6 @@ list_large_dir:
 write_large_files:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Not Required by write large files tests
     configs:
       - flags:
           - "--enable-streaming-writes=false"
@@ -86,7 +82,6 @@ write_large_files:
 gzip:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Not Required by gzip tests
     configs:
       - flags:
           - "--sequential-read-size-mb=1 --implicit-dirs"
@@ -100,7 +95,6 @@ gzip:
 read_large_files:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file:  # Not required by read large files tests.
     configs:
       - flags:
           - "--implicit-dirs"
@@ -118,7 +112,6 @@ read_large_files:
 readonly:
   - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
     test_bucket: "${BUCKET_NAME}" # To be passed by both gcsfuse and gke tests
-    log_file: # Not required by readonly tests.
     configs:
       - flags:
           - "--o=ro --implicit-dirs=true"
@@ -135,7 +128,6 @@ rename_dir_limit:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     only_dir: "${ONLY_DIR}"
-    log_file: # Optional
     configs:
       - flags:
           - "--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc"
@@ -158,7 +150,6 @@ local_file:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     only_dir: "${ONLY_DIR}"
-    log_file: # Optional
     configs:
       - flags:
           - "--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false"
@@ -181,7 +172,6 @@ local_file:
 streaming_writes:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Not Required by streaming writes tests
     configs:
       - flags:
           - "--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --client-protocol=grpc --write-global-max-blocks=-1"
@@ -195,7 +185,6 @@ streaming_writes:
 cloud_profiler:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
     configs:
       - flags:
           # Set the 'PROFILE_LABEL' environment variable for GKE
@@ -209,7 +198,6 @@ cloud_profiler:
 requester_pays_bucket:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional flag required by some tests where log parsing is done to validate end behavior
     configs:
       - flags:
           - "--billing-project=gcs-fuse-test-ml"
@@ -223,7 +211,6 @@ read_cache:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     only_dir: "${ONLY_DIR}"
-    log_file: # Not Required by read_cache tests
     configs:
       - flags:
           - "--metadata-cache-ttl-secs=10 --file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest --log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log --log-severity=TRACE --implicit-dirs"
@@ -447,7 +434,6 @@ readdirplus:
 benchmarking:
   - test_bucket: "${BUCKET_NAME}"
     mounted_directory: "${MOUNTED_DIR}"
-    log_file: # Not required
     configs:
       - flags:
           - "--stat-cache-ttl=0"
@@ -480,7 +466,6 @@ benchmarking:
 dentry_cache:
  - mounted_directory: "${MOUNTED_DIR}"
    test_bucket: "${BUCKET_NAME}"
-   log_file: # Not Required by dentry_cache tests
    configs:
      - flags:
        - "--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=2"
@@ -510,7 +495,6 @@ dentry_cache:
 read_gcs_algo:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Not required by readonly tests.
     configs:
       - flags:
         # Do not enable fileCache as we want to test gcs read flow.
@@ -524,7 +508,6 @@ read_gcs_algo:
 interrupt:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
     configs:
       - flags:
         #TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
@@ -547,7 +530,6 @@ interrupt:
 flag_optimizations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # Optional
     configs:
       - run: TestMountFails
         flags:

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -840,3 +840,12 @@ func ExtractServiceVersionFromFlags(flags []string) string {
 	log.Fatal("Profile label should have been provided for mounted directory test.")
 	return ""
 }
+
+func OverrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
+	for _, flags := range t.Configs {
+		for i := range flags.Flags {
+			// Iterate over the indices of the flags slice
+			flags.Flags[i] = strings.ReplaceAll(flags.Flags[i], "/gcsfuse-tmp", path.Join(GCSFuseTempDirPath, "gcsfuse-tmp"))
+		}
+	}
+}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -849,3 +849,18 @@ func OverrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath str
 		}
 	}
 }
+
+func SetUpLogFilePath(testName string, GKETempDir string, OldGKElogFilePath string, cfg *test_suite.TestConfig) {
+	var logFilePath string
+	if cfg.GKEMountedDirectory != "" { // GKE path
+		logFilePath = path.Join(GKETempDir, testName) + ".log"
+		if ConfigFile() == "" {
+			// TODO: clean this up when GKE test migration completes.
+			logFilePath = OldGKElogFilePath
+		}
+	} else {
+		logFilePath = path.Join(TestDir(), GKETempDir, testName) + ".log"
+	}
+	cfg.LogFile = logFilePath
+	SetLogFile(logFilePath)
+}

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -34,7 +34,7 @@ type TestConfig struct {
 	GKEMountedDirectory     string `yaml:"mounted_directory"`
 	GCSFuseMountedDirectory string
 	TestBucket              string       `yaml:"test_bucket"`
-	LogFile                 string       `yaml:"log_file,omitempty"`
+	LogFile                 string
 	Configs                 []ConfigItem `yaml:"configs"`
 	OnlyDir                 string       `yaml:"only_dir,omitempty"`
 }

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -33,7 +33,7 @@ type BucketType struct {
 type TestConfig struct {
 	GKEMountedDirectory     string `yaml:"mounted_directory"`
 	GCSFuseMountedDirectory string
-	TestBucket              string       `yaml:"test_bucket"`
+	TestBucket              string `yaml:"test_bucket"`
 	LogFile                 string
 	Configs                 []ConfigItem `yaml:"configs"`
 	OnlyDir                 string       `yaml:"only_dir,omitempty"`


### PR DESCRIPTION
### Description
* Add a OverrideFilePathsInFlagSet function in util/setup.go
* Add a SetupLogFilePath function in util/setup.go
* Remove log_file from test_config.yaml file
* Changes in readdirplus to use the above created functions

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
