### PR TITLE
feat(bufferedread): Add ReadAtSlice for zero-copy reads from PrefetchBlock

### DIFF
--- a/internal/block/prefetch_block_test.go
+++ b/internal/block/prefetch_block_test.go
@@ -122,6 +122,54 @@ func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReadAtEOF() {
 	assert.Equal(testSuite.T(), []byte("world"), readBuffer[0:n])
 }
 
+func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReadAtSliceSuccess() {
+	pmb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	_, err = pmb.Write(content)
+	require.Nil(testSuite.T(), err)
+
+	slice, err := pmb.ReadAtSlice(6, 5) // Read "world"
+
+	assert.NoError(testSuite.T(), err)
+	assert.Equal(testSuite.T(), []byte("world"), slice)
+}
+
+func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReadAtSliceEOF() {
+	pmb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	content := []byte("hello world")
+	_, err = pmb.Write(content)
+	require.Nil(testSuite.T(), err)
+
+	slice, err := pmb.ReadAtSlice(6, 15) // Read "world" and beyond
+
+	assert.Equal(testSuite.T(), io.EOF, err)
+	assert.Equal(testSuite.T(), []byte("world"), slice)
+}
+
+func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReadAtSliceWithNegativeOffset() {
+	pmb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	_, err = pmb.Write([]byte("hello world"))
+	require.Nil(testSuite.T(), err)
+
+	_, err = pmb.ReadAtSlice(-1, 5)
+
+	assert.Error(testSuite.T(), err)
+}
+
+func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockReadAtSliceWithOffsetOutOfBounds() {
+	pmb, err := createPrefetchBlock(12)
+	require.Nil(testSuite.T(), err)
+	_, err = pmb.Write([]byte("hello"))
+	require.Nil(testSuite.T(), err)
+
+	_, err = pmb.ReadAtSlice(5, 1) // Offset is equal to size, which is out of bounds
+
+	assert.Error(testSuite.T(), err)
+}
+
 func (testSuite *PrefetchMemoryBlockTest) TestPrefetchMemoryBlockAbsStartOffsetPanicsOnEmptyBlock() {
 	pmb, err := createPrefetchBlock(12)
 	require.Nil(testSuite.T(), err)


### PR DESCRIPTION
### Description
This PR introduces the `ReadAtSlice` method to the `PrefetchBlock` interface and its implementation for `prefetchMemoryBlock`. This new method provides a zero-copy way to read data from the block, returning a slice of the underlying buffer. This avoids an extra memory copy and should improve performance in read-heavy workloads.

### Link to the issue in case of a bug fix.
b/459435081

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
