### PR TITLE
test(metrics): Increase wait time for metrics propagation in tests

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -96,7 +96,7 @@ func createWithContents(ctx context.Context, t *testing.T, bucket gcs.Bucket, na
 }
 
 func waitForMetricsProcessing() {
-	time.Sleep(time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 }
 
 func TestLookUpInode_Metrics(t *testing.T) {

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -36,7 +36,7 @@ type metricValueMap map[string]int64
 type metricHistogramMap map[string]metricdata.HistogramDataPoint[int64]
 
 func waitForMetricsProcessing() {
-	time.Sleep(time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 }
 
 func setupOTel(ctx context.Context, t *testing.T) (*otelMetrics, *metric.ManualReader) {

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -36,7 +36,7 @@ type metricValueMap map[string]int64
 type metricHistogramMap map[string]metricdata.HistogramDataPoint[int64]
 
 func waitForMetricsProcessing() {
-	time.Sleep(time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 }
 
 func setupOTel(ctx context.Context, t *testing.T) (*otelMetrics, *metric.ManualReader) {


### PR DESCRIPTION
### Description
Increase time for metrics to propagate before the tests assert for metrics-correctness.
This is to make the tests less flaky especially on compute-constrained environments like GitHub actions.

The ideal way is to introduce a Flush method ensures correctness but requires additional instructions which could potentially cause perf degradation.

### Link to the issue in case of a bug fix.
b/459619775

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No