### PR TITLE
fix: Retry git clone tests on error

### DIFF
--- a/tools/integration_tests/interrupt/git_clone_test.go
+++ b/tools/integration_tests/interrupt/git_clone_test.go
@@ -65,7 +65,7 @@ func (s *ignoreInterruptsTest) cloneRepository() (output []byte, err error) {
 	maxAttempts := 5
 	isRetryableError := func(err error) bool {
 		lowerErr := strings.ToLower(err.Error())
-		return strings.Contains(lowerErr, "could not resolve host") || strings.Contains(lowerErr, "could not read from remote repository")
+		return strings.Contains(lowerErr, "could not resolve host") || strings.Contains(lowerErr, "could not read from remote repository") || strings.Contains(lowerErr, "failed to connect to github.com")
 	}
 	for i := range maxAttempts {
 		output, err = operations.ExecuteToolCommandfInDirectory(testDirPath, tool, "clone %s", repoURL)


### PR DESCRIPTION
### Description
Retry git clone tests on error "could not connect to github.com" in interrupt test package

### Link to the issue in case of a bug fix.
[b/459622006](http://b/459622006)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran as presubmit

### Any backward incompatible change? If so, please explain.
