### PR TITLE
test(e2e): Lazily create bucket in e2e script

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -318,9 +318,7 @@ create_bucket() {
     acquire_lock "$BUCKET_CREATION_LOCK_FILE"
     eval "$bucket_cmd" > "$bucket_cmd_log" 2>&1
     local status=$?
-    if [ $status -eq 0 ]; then
-      sleep "$DELAY_BETWEEN_BUCKET_CREATION" # have 6 seconds gap between creating buckets.
-    fi
+    sleep "$DELAY_BETWEEN_BUCKET_CREATION" # have 6 seconds gap between creating buckets.
     release_lock "$BUCKET_CREATION_LOCK_FILE"
     if [ $status -eq 0 ]; then
       break


### PR DESCRIPTION
### Description
Lazily create buckets in e2e script. As this script is planned to be used in the release cd pipeline. This change would prevent multiple bucket creation at once from multiple VM(s) when the same script is ran.

Note: Simplified few methods, Fixed the sponge file names as per the guidance https://screenshot.googleplex.com/D5acsLHtXE7GVn7.

### Link to the issue in case of a bug fix.
b/457909538

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
