### PR TITLE
fix: CleanupDirectoryOnGCS not cleaning up buckets

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -512,7 +512,8 @@ func SetupTestDirectoryRecursive(testDirName string) string {
 
 // CleanupDirectoryOnGCS cleans up the object/directory path passed in parameter.
 func CleanupDirectoryOnGCS(ctx context.Context, client *storage.Client, directoryPathOnGCS string) {
-	bucket, dirPath := GetBucketAndObjectBasedOnTypeOfMount(directoryPathOnGCS)
+	bucketAndDirPath := strings.Split(directoryPathOnGCS, "/")
+	bucket, dirPath := bucketAndDirPath[0], bucketAndDirPath[1]
 	bucketHandle := client.Bucket(bucket)
 
 	it := bucketHandle.Objects(ctx, &storage.Query{Prefix: dirPath + "/"})


### PR DESCRIPTION
### Description
CleanupDirectoryOnGCS was broken in PR#1959 due to using test bucket, etc in the client. The function received full object path in the parameter earlier. Fixing it.
TODO: We should deprecate this function in the long run to use `client.CleanupObjectsWithPrefix` instead

### Link to the issue in case of a bug fix.
b/459382944

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA