### PR TITLE
fix: gcloud installation failed on rhel machines

### DIFF
--- a/perfmetrics/scripts/install_latest_gcloud.sh
+++ b/perfmetrics/scripts/install_latest_gcloud.sh
@@ -17,6 +17,7 @@
 
 # Exit on error, treat unset variables as errors, and propagate pipeline errors.
 set -euo pipefail
+set -x
 
 if [[ $# -ne 0 ]]; then
     echo "This script requires no argument."
@@ -62,7 +63,9 @@ else
     # or permanently add this path to path variable in bashrc.
     echo 'export PATH="/usr/local/google-cloud-sdk/bin:$PATH"' >> "$HOME/.bashrc"
     echo 'export CLOUDSDK_PYTHON="$HOME/.local/python-3.11.9/bin/python3.11"' >> "$HOME/.bashrc"
+    set +u
     source "$HOME/.bashrc"
+    set -u
     echo "gcloud Version is:"
     gcloud version
     echo "Gcloud is present at: $( (which gcloud) )"

--- a/perfmetrics/scripts/upgrade_python3.sh
+++ b/perfmetrics/scripts/upgrade_python3.sh
@@ -14,7 +14,8 @@
 # limitations under the License.
 #!/bin/bash
 
-set -e
+set -euo pipefail
+set -x
 
 PYTHON_VERSION=3.11.9
 INSTALL_PREFIX="$HOME/.local/python-$PYTHON_VERSION"
@@ -62,4 +63,6 @@ echo "Python $PYTHON_VERSION installed at $INSTALL_PREFIX/bin/python3.11"
 "$INSTALL_PREFIX/bin/python3.11" --version
 
 echo 'export PATH="$HOME/.local/python-3.11.9/bin:$PATH"' >> "$HOME/.bashrc"
+set +u
 source "$HOME/.bashrc"
+set -u


### PR DESCRIPTION
### Description
The gcloud installation fails on RHEL machines with the error message: `/etc/bashrc: line 12: BASHRCSOURCED: unbound variable`. This occurs because we use set -u, which causes the pipeline to fail if an uninitialized variable is used.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
