### PR TITLE
docs(benchmark): Update GCSFuse benchmark numbers for v3.4.3

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # GCSFuse Performance Benchmarks
 
-[fio](https://fio.readthedocs.io/en/latest/) is used to perform load tests on
+[FIO](https://fio.readthedocs.io/en/latest/) is used to perform load tests on
 GCSFuse. The tables below show performance metrics of GCSFuse for different
 workloads for the given test setup:
 


### PR DESCRIPTION
### Description
Updating GCSFuse benchmark numbers for v3.4.3 as per experiments in [go/gcs-fuse-reproducible-benchmarks](http://goto.google.com/gcs-fuse-reproducible-benchmarks)

Click [here](https://github.com/GoogleCloudPlatform/gcsfuse/blob/meet2mky/publish-numbers-for-v3.4.3/docs/benchmarks.md) to see how it looks in markdown.

### Link to the issue in case of a bug fix.
[b/415727864](http://b/415727864)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
