### PR TITLE
fix(dentry cache): mounted dir case correction for dentry cache package

### DIFF
--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -54,7 +54,7 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	if setup.MountedDirectory() == "" {
+	if testEnv.cfg.GKEMountedDirectory == "" {
 		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
 	}
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -54,7 +54,9 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	if setup.MountedDirectory() == "" {
+		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	}
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
@@ -103,6 +105,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir = testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 


### PR DESCRIPTION
### Description
**Issue:** GKE integration tests failed because the GCS FUSE mount directory was being erased.

**Cause:** The function responsible for setting up the test environment was unconditionally resetting the mount directory path. This action erased the correct path that had been configured for the GKE test, causing the test to fail as it could no longer find the mounted directory.

**Solution:** A check was added to only set the mount directory path if it wasn't already configured.

### Link to the issue in case of a bug fix.
[b/464448423](https://buganizer.corp.google.com/issues/464448423)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - 
3. Integration tests - via KOKORO

