### PR TITLE
ci: create a periodic job cofig for daily runs on 8 core machine

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master-8-cores.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/e2e-tests-master-8-cores.cfg
@@ -1,0 +1,29 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+action {
+  define_artifacts {
+    regex: "gcsfuse-failed-integration-test-logs-*"
+    strip_prefix: "github/gcsfuse/perfmetrics/scripts"
+    regex: "**/*sponge_log.*"
+    regex: "proxy*"
+  }
+}
+
+env_vars {
+  key: "PACKAGE_LEVEL_PARALLELISM"
+  value: "3"
+}
+
+build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh"


### PR DESCRIPTION
### Description
As part of louhi pipeline stabilization, we have increased the machine size from 16 to 48. This has widened the existing infra gap between GCSFuse testing flow and GKE test grid, this can lead to surprises during release where test dependent on cores can suffer, To ensure such regressions are not introduced, we are introducing a new kokoro periodic job which will be run on 8 core machines.

### Link to the issue in case of a bug fix.
b/459938372

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
