### PR TITLE
fix(e2e-test): Reduce the read effort in the concurrent read-test

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -61,22 +61,22 @@ func (s *concurrentReadTest) TearDownTest() {
 ////////////////////////////////////////////////////////////////////////
 
 // Test_ConcurrentSequentialAndRandomReads tests concurrent read operations where
-// 5 goroutines read a 500MiB file sequentially and 5 goroutines read randomly.
+// 5 goroutines read a 100MiB file sequentially and 5 goroutines read randomly.
 // This test validates that concurrent sequential and random read patterns work
 // correctly without deadlocks or race conditions. It also validates data integrity
 // using CRC32 checksums for sequential reads and chunk validation for random reads.
 func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 	const (
-		fileSize        = 500 * operations.OneMiB // 500 MiB file
+		fileSize        = 100 * operations.OneMiB // 100 MiB file
 		chunkSize       = 64 * operations.OneKiB  // 64 KiB chunks for reads
 		sequentialReads = 5                       // Number of sequential readers
 		randomReads     = 5                       // Number of random readers
 	)
-	// Create a 500MiB test file
+	// Create a 100MiB test file
 	testFilePath := path.Join(testDirPathForRead, "large_test_file.bin")
 	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
 	var wg sync.WaitGroup
-	timeout := 300 * time.Second // 5 minutes timeout for 500MiB operations
+	timeout := 300 * time.Second // 5 minutes timeout for 100MiB operations
 
 	// Launch 5 sequential readers
 	for i := range sequentialReads {
@@ -134,11 +134,11 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 // with each reader handling a distinct segment of the file for comprehensive coverage.
 func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 	const (
-		fileSize    = 500 * operations.OneMiB // 500 MiB file
+		fileSize    = 100 * operations.OneMiB // 100 MiB file
 		numReaders  = 5                       // Number of concurrent readers
-		segmentSize = fileSize / numReaders   // Each reader reads 100 MiB segment
+		segmentSize = fileSize / numReaders   // Each reader reads 20 MiB segment
 	)
-	// Create a 500MiB test file
+	// Create a 100MiB test file
 	testFilePath := path.Join(testDirPathForRead, "segment_test_file.bin")
 	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
 	// Open shared file handle that will be used by all goroutines


### PR DESCRIPTION
### Description
Test_ConcurrentSegmentReadsSharedHandle fails on some of the ARM vm because of slowness. Slowness mainly happens due to lack of cpu resources on the system and different read-request size from the kernel on different system.

Two options to fix this:
1. Increase the timeout for the test from 5 min to even larger: rejected, as it will unnecessarily increase the test time.
2. Reduce the work done as part of this test - accepted, as it will test the concurrent read functionality without increasing the timeout.

### Link to the issue in case of a bug fix.
b/447905694

### Testing details
1. Manual - Tested manually.
3. Unit tests - NA
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
