### PR TITLE
refactor: unfinalized object test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -505,6 +505,27 @@ read_gcs_algo:
           zonal: true
         run_on_gke: true
 
+unfinalized_object:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+        - "--metadata-cache-ttl-secs=-1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestUnfinalizedObjectReadTest
+        run_on_gke: true
+      - flags:
+        - "--metadata-cache-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestUnfinalizedObjectOperationTest
+        run_on_gke: true
+
 interrupt:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -15,12 +15,16 @@
 package unfinalized_object
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
 
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
@@ -28,27 +32,68 @@ const (
 )
 
 var (
-	mountFunc func([]string) error
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
 )
 
-////////////////////////////////////////////////////////////////////////
-// TestMain
-////////////////////////////////////////////////////////////////////////
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	// flags to be set, as operations tests validates content from the bucket.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		setup.RunTestsForMountedDirectoryFlag(m)
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.UnfinalizedObject) == 0 {
+		log.Println("No configuration found for unfinalized_object tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.UnfinalizedObject = make([]test_suite.TestConfig, 1)
+		cfg.UnfinalizedObject[0].TestBucket = setup.TestBucket()
+		cfg.UnfinalizedObject[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.UnfinalizedObject[0].LogFile = setup.LogFile()
+		cfg.UnfinalizedObject[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.UnfinalizedObject[0].Configs[0].Flags = []string{
+			"--metadata-cache-ttl-secs=-1",
+		}
+		cfg.UnfinalizedObject[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.UnfinalizedObject[0].Configs[0].Run = "TestUnfinalizedObjectReadTest"
+		cfg.UnfinalizedObject[0].Configs[1].Flags = []string{
+			"--metadata-cache-ttl-secs=0",
+		}
+		cfg.UnfinalizedObject[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.UnfinalizedObject[0].Configs[1].Run = "TestUnfinalizedObjectOperationTest"
 	}
 
+	testEnv.ctx = context.Background()
+	testEnv.cfg = &cfg.UnfinalizedObject[0]
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
+
+	// 2. Create storage client before running tests.
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Printf("Error creating storage client: %v\n", err)
+		os.Exit(1)
+	}
+	defer testEnv.storageClient.Close()
+
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+	}
+
+	// Run tests for testBucket
 	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	log.Println("Running static mounting tests...")
-	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
+
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -34,6 +34,8 @@ const (
 var (
 	testEnv   env
 	mountFunc func(*test_suite.TestConfig, []string) error
+	// mount directory is where our tests run.
+	mountDir string
 )
 
 type env struct {
@@ -84,12 +86,16 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir = testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+
+	// Save mount and root directory variables.
+	mountDir = setup.MntDir()
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -53,7 +53,7 @@ func (s *unfinalizedObjectOperations) TearDownSuite() {
 
 func (s *unfinalizedObjectOperations) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if setup.MountedDirectory() == "" {
+	if testEnv.cfg.GCSFuseMountedDirectory == "" {
 		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
 	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -53,7 +53,7 @@ func (s *unfinalizedObjectOperations) TearDownSuite() {
 
 func (s *unfinalizedObjectOperations) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GCSFuseMountedDirectory == "" {
+	if testEnv.cfg.GKEMountedDirectory == "" {
 		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
 	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -53,7 +53,9 @@ func (s *unfinalizedObjectOperations) TearDownSuite() {
 
 func (s *unfinalizedObjectOperations) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	if setup.MountedDirectory() == "" {
+		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -48,7 +48,15 @@ func (t *unfinalizedObjectReads) SetupTest() {
 	t.fileName = path.Base(t.T().Name()) + setup.GenerateRandomString(5)
 }
 
-func (t *unfinalizedObjectReads) TeardownTest() {}
+func (s *unfinalizedObjectReads) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *unfinalizedObjectReads) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Test scenarios
@@ -74,34 +82,18 @@ func (t *unfinalizedObjectReads) TestUnfinalizedObjectsCanBeRead() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestUnfinalizedObjectReadTest(t *testing.T) {
-	ts := &unfinalizedObjectReads{ctx: context.Background()}
-	// Create storage client before running tests.
-	closeStorageClient := client.CreateStorageClientWithCancel(&ts.ctx, &ts.storageClient)
-	defer func() {
-		err := closeStorageClient()
-		if err != nil {
-			t.Errorf("closeStorageClient failed: %v", err)
-		}
-	}()
+	ts := &unfinalizedObjectReads{ctx: context.Background(), storageClient: testEnv.storageClient}
 
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
-	// Define flag set to run the tests.
-	flagsSet := [][]string{
-		{"--metadata-cache-ttl-secs=-1"},
-	}
-
-	// Run tests.
-	for _, flags := range flagsSet {
-		ts.flags = flags
-		setup.MountGCSFuseWithGivenMountFunc(ts.flags, mountFunc)
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
 		log.Printf("Running tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseAndDeleteLogFile(setup.MntDir())
 	}
 }

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -54,7 +54,7 @@ func (s *unfinalizedObjectReads) TearDownSuite() {
 
 func (s *unfinalizedObjectReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if setup.MountedDirectory() == "" {
+	if testEnv.cfg.GCSFuseMountedDirectory == "" {
 		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
 	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -54,7 +54,9 @@ func (s *unfinalizedObjectReads) TearDownSuite() {
 
 func (s *unfinalizedObjectReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	if setup.MountedDirectory() == "" {
+		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -54,7 +54,7 @@ func (s *unfinalizedObjectReads) TearDownSuite() {
 
 func (s *unfinalizedObjectReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GCSFuseMountedDirectory == "" {
+	if testEnv.cfg.GKEMountedDirectory == "" {
 		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
 	}
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)


### PR DESCRIPTION
### Description
This PR includes changes to migrate unfinalized obejct test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of unfinalized test package so it can use config file.

### Link to the issue in case of a bug fix.
[b/461525255](https://buganizer.corp.google.com/issues/461525255)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
