### PR TITLE
fix(ci): Make auto-fix workflow robust and efficient

### DIFF
--- a/.github/workflows/apply-auto-fixes.yml
+++ b/.github/workflows/apply-auto-fixes.yml
@@ -14,14 +14,38 @@ concurrency:
 
 jobs:
   apply_patch:
-    # Only run on successful completion of the 'Generate and Lint Diff' workflow
+    # Only run on successful completion of the 'Generate and Format' workflow
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - name: Check if patch artifact exists
+        id: check_artifact
+        run: |
+          # Use the GitHub API to check if the 'auto-fixes-patch' artifact exists for the triggering workflow run.
+          # The artifacts_url is a pre-authenticated API endpoint.
+          # We use jq to parse the JSON response and see if our artifact is in the list.
+          artifact_json=$(curl -s "${{ github.event.workflow_run.artifacts_url }}")
+          if echo "$artifact_json" | jq -e '.artifacts[] | select(.name == "auto-fixes-patch")' > /dev/null; then
+            echo "Patch artifact found."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "No patch artifact was uploaded."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout PR branch
+        if: steps.check_artifact.outputs.exists == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          token: ${{ secrets.CODE_AUTO_FORMAT }}
+
       - name: Download patch artifact
+        if: steps.check_artifact.outputs.exists == 'true'
         uses: actions/download-artifact@v4
         with:
           name: auto-fixes-patch
@@ -29,32 +53,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Check if patch file exists and is not empty
-        id: check_patch
-        run: |
-          if [ -s auto_fixes.patch ]; then
-            echo "patch_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "No changes to apply."
-            echo "patch_exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout PR branch
-        if: steps.check_patch.outputs.patch_exists == 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
-          token: ${{ secrets.CODE_AUTO_FORMAT }}
-
       - name: Apply patch
-        if: steps.check_patch.outputs.patch_exists == 'true'
+        if: steps.check_artifact.outputs.exists == 'true'
         run: |
           # Applying the patch will fail if it's empty, but we've already checked for that.
           git apply auto_fixes.patch
 
       - name: Commit changes
-        if: steps.check_patch.outputs.patch_exists == 'true'
+        if: steps.check_artifact.outputs.exists == 'true'
         uses: EndBug/add-and-commit@v9
         with:
           message: "style: apply auto-formatting and generation"


### PR DESCRIPTION
### Description
The `apply-auto-fixes` workflow would fail for two reasons:
1. The `actions/checkout` step would clean the workspace, deleting the
   downloaded patch file before it could be applied.
2. It would also fail if the `generate-and-format` job produced no
   changes, as the `download-artifact` step could not find a patch to
   download.

This change resolves both issues by introducing a new initial step that
uses the GitHub API to check if the `auto-fixes-patch` artifact was
actually uploaded by the triggering workflow.

The subsequent steps (checkout, download, apply, commit) are now
conditional and will only run if the artifact is found. This prevents
the workflow from failing and makes it more efficient by avoiding
unnecessary checkout and download operations when there is no work to do.


### Link to the issue in case of a bug fix.
b/461648699

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
