### PR TITLE
test(file cache metrics): Add file cache metrics tests for sequential and random reads

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -333,7 +333,8 @@ func TestRandomReadFile_FileCacheMetrics(t *testing.T) {
 		uint64(1),
 	)
 
-	// Read at a different offset should be a cache miss.
+	// TODO(b/463220507): Add metrics for File cache miss with disabled range read.
+	// Read at a different offset should be a cache hit since file is downloaded in FileCache.
 	readOp.Offset = 8
 	err = server.ReadFile(ctx, readOp)
 	require.NoError(t, err, "ReadFile")


### PR DESCRIPTION
### Description
Added unit tests to verify file cache and GCS reader metrics for both sequential and random read scenarios.

### Link to the issue in case of a bug fix.
[462277267: Missing test coverage for File Cache metrics](https://b.corp.google.com/issues/462277267)

### Testing details
1. Manual - NA
2. Unit tests - Added new tests in [internal/fs/metrics_test.go](cci:7://file:///usr/local/google/home/alleaditya/workspace/gcsfuse/internal/fs/metrics_test.go:0:0-0:0) to verify:
   - File cache metrics (`file_cache/read_count`, `file_cache/read_bytes_count`, `file_cache/read_latencies`) for sequential and random reads.

### Any backward incompatible change? If so, please explain.
No