### PR TITLE
fix(buffered_read): make awaitReady concurrent safe

### DIFF
--- a/internal/block/prefetch_block.go
+++ b/internal/block/prefetch_block.go
@@ -198,10 +198,12 @@ func (pmb *prefetchMemoryBlock) AwaitReady(ctx context.Context) (BlockStatus, er
 			return pmb.status, nil
 		}
 
-		// Close the notification channel to prevent further notifications.
-		close(pmb.notification)
-		// Save the last status for subsequent AwaitReady calls.
+		// First Save the last status for subsequent AwaitReady calls, and
+		// then close the notification channel which allows to read the last status
+		// without blocking.
+		// This is safe because NotifyReady is expected to be called only once.
 		pmb.status = val
+		close(pmb.notification)
 
 		return pmb.status, nil
 	case <-ctx.Done():


### PR DESCRIPTION
### Description
- Concurrent calls to AwaitReady with one NotifyReady lead to a synchronisation issue. NotifyReady calls add a status to the notification channel that the AwaitReady go-routine listens to.
- After the notification, the channel was closed before the status was updated correctly. Closing the channel was leading to concurrent read to pv.Status and write to pv.Status.
- Fix: update the status first, then close the notification channel to concurrent reads. 

### Link to the issue in case of a bug fix.
b/460615197

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
