### PR TITLE
feat(dummy-io-bucket): dummyReader and NewRangeReaderWithReadHandle support

### DIFF
--- a/internal/storage/dummy_io_bucket_test.go
+++ b/internal/storage/dummy_io_bucket_test.go
@@ -17,7 +17,9 @@ package storage
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +46,7 @@ func TestNewDummyIOBucket(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := NewDummyIOBucket(tc.wrapped)
+			result := NewDummyIOBucket(tc.wrapped, dummyIOBucketParams{})
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -53,7 +55,7 @@ func TestNewDummyIOBucket(t *testing.T) {
 func TestDummyIOBucket_Name(t *testing.T) {
 	mockBucket := &TestifyMockBucket{}
 	mockBucket.On("Name").Return("test-bucket")
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 
 	result := dummyBucket.Name()
 
@@ -65,7 +67,7 @@ func TestDummyIOBucket_BucketType(t *testing.T) {
 	mockBucket := &TestifyMockBucket{}
 	expectedType := gcs.BucketType{Hierarchical: false, Zonal: false}
 	mockBucket.On("BucketType").Return(expectedType)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	result := dummyBucket.BucketType()
@@ -79,7 +81,7 @@ func TestDummyIOBucket_DeleteObject(t *testing.T) {
 	ctx := context.Background()
 	req := &gcs.DeleteObjectRequest{Name: "test-object"}
 	mockBucket.On("DeleteObject", ctx, req).Return(nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	err := dummyBucket.DeleteObject(ctx, req)
@@ -94,7 +96,7 @@ func TestDummyIOBucket_DeleteObject_Error(t *testing.T) {
 	req := &gcs.DeleteObjectRequest{Name: "test-object"}
 	expectedErr := errors.New("delete failed")
 	mockBucket.On("DeleteObject", ctx, req).Return(expectedErr)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	err := dummyBucket.DeleteObject(ctx, req)
@@ -111,7 +113,7 @@ func TestDummyIOBucket_StatObject(t *testing.T) {
 	expectedMinObj := &gcs.MinObject{Name: "test-object"}
 	expectedExtAttrs := &gcs.ExtendedObjectAttributes{}
 	mockBucket.On("StatObject", ctx, req).Return(expectedMinObj, expectedExtAttrs, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	minObj, extAttrs, err := dummyBucket.StatObject(ctx, req)
@@ -128,7 +130,7 @@ func TestDummyIOBucket_ListObjects(t *testing.T) {
 	req := &gcs.ListObjectsRequest{Prefix: "test-"}
 	expectedListing := &gcs.Listing{}
 	mockBucket.On("ListObjects", ctx, req).Return(expectedListing, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	listing, err := dummyBucket.ListObjects(ctx, req)
@@ -147,7 +149,7 @@ func TestDummyIOBucket_CopyObject(t *testing.T) {
 	}
 	expectedObj := &gcs.Object{Name: "dest-object"}
 	mockBucket.On("CopyObject", ctx, req).Return(expectedObj, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	obj, err := dummyBucket.CopyObject(ctx, req)
@@ -162,7 +164,7 @@ func TestDummyIOBucket_DeleteFolder(t *testing.T) {
 	ctx := context.Background()
 	folderName := "test-folder"
 	mockBucket.On("DeleteFolder", ctx, folderName).Return(nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	err := dummyBucket.DeleteFolder(ctx, folderName)
@@ -177,7 +179,7 @@ func TestDummyIOBucket_GetFolder(t *testing.T) {
 	folderName := "test-folder"
 	expectedFolder := &gcs.Folder{Name: folderName}
 	mockBucket.On("GetFolder", ctx, folderName).Return(expectedFolder, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	folder, err := dummyBucket.GetFolder(ctx, folderName)
@@ -193,7 +195,7 @@ func TestDummyIOBucket_CreateFolder(t *testing.T) {
 	folderName := "new-folder"
 	expectedFolder := &gcs.Folder{Name: folderName}
 	mockBucket.On("CreateFolder", ctx, folderName).Return(expectedFolder, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	folder, err := dummyBucket.CreateFolder(ctx, folderName)
@@ -208,7 +210,7 @@ func TestDummyIOBucket_GCSName(t *testing.T) {
 	obj := &gcs.MinObject{Name: "test-object"}
 	expectedName := "gcs-name"
 	mockBucket.On("GCSName", obj).Return(expectedName)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	name := dummyBucket.GCSName(obj)
@@ -226,7 +228,7 @@ func TestDummyIOBucket_MoveObject(t *testing.T) {
 	}
 	expectedObj := &gcs.Object{Name: "dest-object"}
 	mockBucket.On("MoveObject", ctx, req).Return(expectedObj, nil)
-	dummyBucket := NewDummyIOBucket(mockBucket)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
 	require.NotNil(t, dummyBucket)
 
 	obj, err := dummyBucket.MoveObject(ctx, req)
@@ -234,4 +236,145 @@ func TestDummyIOBucket_MoveObject(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedObj, obj)
 	mockBucket.AssertExpectations(t)
+}
+
+func TestDummyIOBucket_UpdateObject(t *testing.T) {
+	mockBucket := &TestifyMockBucket{}
+	ctx := context.Background()
+	req := &gcs.UpdateObjectRequest{
+		Name: "test-object",
+	}
+	expectedObj := &gcs.Object{Name: "test-object"}
+	mockBucket.On("UpdateObject", ctx, req).Return(expectedObj, nil)
+	dummyBucket := NewDummyIOBucket(mockBucket, dummyIOBucketParams{})
+	require.NotNil(t, dummyBucket)
+
+	obj, err := dummyBucket.UpdateObject(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedObj, obj)
+	mockBucket.AssertExpectations(t)
+}
+
+func TestDummyIOBucket_NewReaderWithReadHandle(t *testing.T) {
+	req := &gcs.ReadObjectRequest{
+		Name: "test-object",
+		Range: &gcs.ByteRange{
+			Start: 0,
+			Limit: 100,
+		},
+	}
+	dummyBucket := NewDummyIOBucket(&TestifyMockBucket{}, dummyIOBucketParams{readerLatency: 0})
+
+	reader, err := dummyBucket.NewReaderWithReadHandle(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, reader)
+	assert.IsType(t, &dummyReader{}, reader)
+	assert.Equal(t, uint64(100), reader.(*dummyReader).totalLen)
+	assert.Equal(t, uint64(0), reader.(*dummyReader).bytesRead)
+}
+
+func TestDummyIOBucket_NewReaderWithReadHandle_NoRange(t *testing.T) {
+	req := &gcs.ReadObjectRequest{
+		Name: "test-object",
+		// No Range specified
+	}
+	dummyBucket := NewDummyIOBucket(&TestifyMockBucket{}, dummyIOBucketParams{readerLatency: 0})
+
+	reader, err := dummyBucket.NewReaderWithReadHandle(context.Background(), req)
+
+	assert.Error(t, err)
+	assert.Nil(t, reader)
+}
+
+func TestDummyIOBucket_NewReaderWithReadHandle_InvalidRange(t *testing.T) {
+	req := &gcs.ReadObjectRequest{
+		Name: "test-object",
+		Range: &gcs.ByteRange{
+			Start: 100,
+			Limit: 50, // Invalid range: Limit < Start
+		},
+	}
+	dummyBucket := NewDummyIOBucket(&TestifyMockBucket{}, dummyIOBucketParams{readerLatency: 0})
+
+	reader, err := dummyBucket.NewReaderWithReadHandle(context.Background(), req)
+
+	assert.Error(t, err)
+	assert.Nil(t, reader)
+}
+
+func TestDummyIOBucket_NewReaderWithReadHandle_WithLatency(t *testing.T) {
+	req := &gcs.ReadObjectRequest{
+		Name: "test-object",
+		Range: &gcs.ByteRange{
+			Start: 0,
+			Limit: 100,
+		},
+	}
+	dummyBucket := NewDummyIOBucket(&TestifyMockBucket{}, dummyIOBucketParams{readerLatency: 5 * time.Millisecond})
+
+	start := time.Now()
+	reader, err := dummyBucket.NewReaderWithReadHandle(context.Background(), req)
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(5))
+	assert.NoError(t, err)
+	assert.NotNil(t, reader)
+	assert.IsType(t, &dummyReader{}, reader)
+	assert.Equal(t, uint64(100), reader.(*dummyReader).totalLen)
+	assert.Equal(t, uint64(0), reader.(*dummyReader).bytesRead)
+}
+
+// //////////////////////////////////////////////////////////////////////
+// Test for dummyReader
+// //////////////////////////////////////////////////////////////////////
+func TestDummyReader_NewDummyReader(t *testing.T) {
+	dummyReader := newDummyReader(10)
+
+	assert.Equal(t, uint64(10), dummyReader.totalLen)
+	assert.Equal(t, uint64(0), dummyReader.bytesRead)
+	assert.NotNil(t, dummyReader.readHandle)
+}
+
+func TestDummyReader_ReadFull(t *testing.T) {
+	dummyReader := newDummyReader(10)
+
+	buffer := make([]byte, 10)
+	n, err := dummyReader.Read(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, 10, n)
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, buffer)
+}
+
+func TestDummyReader_ReadPartial(t *testing.T) {
+	dummyReader := newDummyReader(10)
+
+	buffer := make([]byte, 5)
+	n, err := dummyReader.Read(buffer)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, []byte{0, 0, 0, 0, 0}, buffer)
+}
+
+func TestDummyReader_ReadBeyondEOF(t *testing.T) {
+	dummyReader := newDummyReader(10)
+	// First read 8 bytes
+	buffer1 := make([]byte, 8)
+	n1, err1 := dummyReader.Read(buffer1)
+	require.NoError(t, err1)
+	require.Equal(t, 8, n1)
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0}, buffer1)
+
+	// Then read 5 bytes, which goes beyond EOF
+	buffer2 := make([]byte, 5)
+	n2, err2 := dummyReader.Read(buffer2)
+
+	assert.Error(t, err2)
+	assert.Equal(t, io.EOF, err2)
+	assert.Equal(t, 2, n2)
+	assert.Equal(t, []byte{0, 0}, buffer2[:n2])
 }


### PR DESCRIPTION
### Description
- This PR adds dummy-reader implementation to dummy-io-bucket.
- NewRangeReaderWithReadHandle now returns dummyReader and also supports simulating network latency. In later PRs, we can consider adding support for simulating stream latency from the network.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
