### PR TITLE
fix(build scripts):  fix build script  for zonal run handling

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -52,10 +52,15 @@ else
     echo "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) meets or exceeds the required version (${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}). Skipping Bash installation."
 fi
 
-if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET:-false}" == "true" ]]; then
+if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then
     echo "Running zonal e2e tests on installed package...."
     "${BASH_EXECUTABLE}" ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package --zonal
-    exit 0
+else
+    if [[ -n "${RUN_TESTS_WITH_ZONAL_BUCKET-}" ]]; then
+        echo "Warning: RUN_TESTS_WITH_ZONAL_BUCKET is set to '${RUN_TESTS_WITH_ZONAL_BUCKET}', which is not 'true'. Running regional tests."
+    else
+        echo "RUN_TESTS_WITH_ZONAL_BUCKET is not set. Running regional tests by default."
+    fi
+    echo "Running regional e2e tests on installed package...."
+    "${BASH_EXECUTABLE}" ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package
 fi
-echo "Running regional e2e tests on installed package...."
-"${BASH_EXECUTABLE}" ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package


### PR DESCRIPTION
### Description
Remove the argument handling as the script is never run using arguments for zb instead it's always run using env variable RUN_TESTS_WITH_ZONAL_BUCKET when set to true. Adding a warning log to ensure we know if the script is used unintentionally with incorrect value of env variable.
### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
Tested locally with 
```
RUN_TESTS_WITH_ZONAL_BUCKET="true" ./build.sh # zonal run
RUN_TESTS_WITH_ZONAL_BUCKET=true ./build.sh # zonal run
RUN_TESTS_WITH_ZONAL_BUCKET='true' ./build.sh # zonal run
RUN_TESTS_WITH_ZONAL_BUCKET=abcd ./build.sh # regional run
./build.sh  # regional run
```
3. Unit tests - NA
4. Integration tests - NA

Tested manual invocation: https://screenshot.googleplex.com/3wvjXLQSyzQapfX

### Any backward incompatible change? If so, please explain.
