### PR TITLE
feat(gcsx): Introduce ReadRequest for a more extensible Reader interface

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2863,7 +2863,11 @@ func (fs *fileSystem) ReadFile(
 
 	if fs.newConfig.EnableNewReader {
 		var resp gcsx.ReadResponse
-		resp, err = fh.ReadWithReadManager(ctx, op.Dst, op.Offset, fs.sequentialReadSizeMb)
+		req := &gcsx.ReadRequest{
+			Buffer: op.Dst,
+			Offset: op.Offset,
+		}
+		resp, err = fh.ReadWithReadManager(ctx, req, fs.sequentialReadSizeMb)
 		op.BytesRead = resp.Size
 		op.Data = resp.Data
 		op.Callback = resp.Callback

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -134,7 +134,10 @@ func (t *fileCacheReaderTest) TestNewFileCacheReader() {
 func (t *fileCacheReaderTest) Test_ReadAt_NilFileCacheHandlerThrowFallBackError() {
 	reader := NewFileCacheReader(t.object, t.mockBucket, nil, true, nil)
 
-	readResponse, err := reader.ReadAt(t.ctx, make([]byte, 10), 0)
+	readResponse, err := reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, 10),
+		Offset: 0,
+	})
 
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -144,7 +147,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_FileSizeIsGreaterThanCacheSize() {
 	t.object.Size = cacheMaxSize + 5
 	t.mockBucket.On("Name").Return("test-bucket")
 
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -153,7 +159,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_FileSizeIsGreaterThanCacheSize() {
 func (t *fileCacheReaderTest) Test_ReadAt_OffsetGreaterThanFileSizeWillReturnEOF() {
 	offset := t.object.Size + 10
 
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, 10), int64(offset))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, 10),
+		Offset: int64(offset),
+	})
 
 	assert.True(t.T(), errors.Is(err, io.EOF), "expected %v error got %v", io.EOF, err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -221,7 +230,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialRangeRead() {
 	require.Less(t.T(), end, int(t.object.Size))
 	buf := make([]byte, end-start)
 
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start),
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent[start:end], buf[:readResponse.Size])
@@ -234,14 +246,20 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	end := 10
 	t.mockBucket.On("Name").Return("test-bucket")
 	buf := make([]byte, end-start)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start),
+	})
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
 	job := t.jobManager.CreateJobIfNotExists(t.object, t.mockBucket)
 	jobStatus := job.GetStatus()
 	assert.True(t.T(), jobStatus.Name == downloader.NotStarted)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, int64(start))
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start),
+	})
 
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -260,7 +278,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCa
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, end-start)
 
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start),
+	})
 
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -282,7 +303,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	require.Less(t.T(), end1, int(t.object.Size))
 	// First call from offset 0 - sequential read
 	buf := make([]byte, end1-start1)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start1))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start1),
+	})
 	// Served from file cache
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent[start1:end1], buf[:readResponse.Size])
@@ -290,7 +314,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	end2 := start2 + util.MiB
 	buf2 := make([]byte, end2-start2)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf2,
+		Offset: int64(start2),
+	})
 
 	// Assuming a download with a start offset of start2 is in progress, a fallback to another reader will be required.
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
@@ -313,7 +340,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	require.Less(t.T(), end1, int(t.object.Size))
 	// First call from offset 0 - sequential read
 	buf := make([]byte, end1-start1)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, int64(start1))
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: int64(start1),
+	})
 	// Served from file cache
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent[start1:end1], buf[:readResponse.Size])
@@ -321,7 +351,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	end2 := start2 + util.MiB
 	buf2 := make([]byte, end2-start2)
 	// Assuming a download with a start offset of start2 is in progress, a fallback to another reader will be required.
-	readResponse, err = t.reader.ReadAt(t.ctx, buf2, int64(start2))
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf2,
+		Offset: int64(start2),
+	})
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
 	// Assuming start3 offset is downloaded
@@ -329,7 +362,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffset
 	end3 := start3 + util.MiB
 	buf3 := make([]byte, end3-start3)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf3, int64(start3))
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf3,
+		Offset: int64(start3),
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent[start3:end3], buf3)
@@ -343,7 +379,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
@@ -354,7 +393,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
 	err = t.reader.fileCacheHandler.InvalidateCache(t.object.Name, t.mockBucket.Name())
 	assert.NoError(t.T(), err)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 
 	// As job is invalidated Need to get served from GCS reader
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
@@ -370,7 +412,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf)
 	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
@@ -382,7 +427,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	// Invalidate the cache to simulate cache miss
 	err = t.reader.fileCacheHandler.InvalidateCache(t.object.Name, t.mockBucket.Name())
 	assert.NoError(t.T(), err)
-	readResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
 	assert.Nil(t.T(), t.reader.fileCacheHandle)
@@ -390,7 +438,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	t.mockNewReaderWithHandleCallForTestBucket(t.object.Size, rd2)
 	clear(buf)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
@@ -405,19 +456,28 @@ func (t *fileCacheReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInv
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
 	err = t.reader.fileCacheHandle.Close()
 	assert.NoError(t.T(), err)
-	readResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
 	assert.Nil(t.T(), t.reader.fileCacheHandle)
 	clear(buf)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 
 	// Reading from file cache with new file cache handle.
 	assert.NoError(t.T(), err)
@@ -433,7 +493,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
@@ -445,7 +508,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
 	err = os.Remove(filePath)
 	assert.NoError(t.T(), err)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 
 	assert.True(t.T(), errors.Is(err, util.ErrFileNotPresentInCache))
 	assert.Zero(t.T(), readResponse.Size)
@@ -458,7 +524,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
@@ -470,7 +539,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleO
 
 	// Read via cache only, as we have old fileHandle open and linux
 	// doesn't delete the file until the fileHandle count for the file is zero.
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
@@ -488,7 +560,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	// - Should result in a FallbackToAnotherReader error.
 	// - No data should be returned.
 	// - The job should be marked as failed (if jobManager is functioning correctly).
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 	assert.True(t.T(), errors.Is(err, FallbackToAnotherReader), "expected %v error got %v", FallbackToAnotherReader, err)
 	assert.Zero(t.T(), readResponse.Size)
 	job := t.jobManager.GetJob(t.object.Name, t.mockBucket.Name())
@@ -497,14 +572,20 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 	t.mockNewReaderWithHandleCallForTestBucket(t.object.Size, rc)
 	buf := make([]byte, t.object.Size)
 	// Second ReadAt call: The file cache should be populated as a result of this successful read.
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
 	clear(buf)
 
 	// Third ReadAt call: Should be served directly from the file cache.
-	readResponse, err = t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
@@ -515,14 +596,20 @@ func (t *fileCacheReaderTest) Test_ReadAt_FailedJobNextReadCreatesNewJobAndCache
 func (t *fileCacheReaderTest) Test_ReadAt_NegativeOffsetShouldThrowError() {
 	t.mockBucket.On("Name").Return("test-bucket")
 
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, 10), -1)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, 10),
+		Offset: -1,
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_OffsetBeyondObjectSizeShouldThrowEOFError() {
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, 10), int64(t.object.Size)+1)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, 10),
+		Offset: int64(t.object.Size) + 1,
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -544,7 +631,10 @@ func (t *fileCacheReaderTest) fullyReadOriginalSizeOfUnfinalizedObject(origObjec
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(t.unfinalized_object.Size, rd)
 	t.mockBucket.On("BucketType").Return(t.bucketType)
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, origObjectSize), 0)
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, origObjectSize),
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(origObjectSize), readResponse.Size)
 }
@@ -574,7 +664,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondC
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, objectSizeIncrease), cachedObjectSize)
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, objectSizeIncrease),
+		Offset: cachedObjectSize,
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -595,7 +688,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondO
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, 1), int64(newObjectSize))
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, 1),
+		Offset: int64(newObjectSize),
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -617,7 +713,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, cachedObjectSize+1), cachedObjectSize/2)
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, cachedObjectSize+1),
+		Offset: cachedObjectSize / 2,
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -639,7 +738,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, newObjectSize), cachedObjectSize/2)
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, newObjectSize),
+		Offset: cachedObjectSize / 2,
+	})
 
 	assert.Error(t.T(), err)
 	assert.Zero(t.T(), readResponse.Size)
@@ -653,7 +755,10 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 
 	cachedObjectSize := int64(origObjectSize)
-	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, make([]byte, cachedObjectSize+1), cachedObjectSize/2)
+	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, cachedObjectSize+1),
+		Offset: cachedObjectSize / 2,
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(cachedObjectSize-cachedObjectSize/2), readResponse.Size)
@@ -666,11 +771,17 @@ func (t *fileCacheReaderTest) Test_ReadAt_FinalizedObjectReadFromOffsetBelowCach
 	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 	t.mockNewReaderWithHandleCallForTestBucket(t.object.Size, rd)
 	t.mockBucket.On("BucketType").Return(t.bucketType)
-	readResponse, err := t.reader.ReadAt(t.ctx, make([]byte, t.object.Size), 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size),
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(t.object.Size), readResponse.Size)
 
-	readResponse, err = t.reader.ReadAt(t.ctx, make([]byte, t.object.Size+1), int64(t.object.Size)/2)
+	readResponse, err = t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: make([]byte, t.object.Size+1),
+		Offset: int64(t.object.Size) / 2,
+	})
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(t.object.Size-t.object.Size/2), readResponse.Size)
@@ -684,7 +795,10 @@ func (t *fileCacheReaderTest) Test_Destroy_NonNilCacheHandle() {
 	t.mockBucket.On("Name").Return("test-bucket")
 	t.mockBucket.On("BucketType").Return(t.bucketType)
 	buf := make([]byte, t.object.Size)
-	readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+	readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+		Buffer: buf,
+		Offset: 0,
+	})
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), testContent, buf[:readResponse.Size])
 	assert.NotNil(t.T(), t.reader.fileCacheHandle)
@@ -721,7 +835,10 @@ func (t *fileCacheReaderTest) Test_Concurrent_ReadAt() {
 		go func() {
 			defer wg.Done()
 			buf := make([]byte, t.object.Size)
-			readResponse, err := t.reader.ReadAt(t.ctx, buf, 0)
+			readResponse, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+				Buffer: buf,
+				Offset: 0,
+			})
 
 			// Assert
 			assert.NoError(t.T(), err)
@@ -766,7 +883,10 @@ func (t *fileCacheReaderTest) Test_Concurrent_ReadAt_And_Destroy() {
 			// This read should not cause a panic, even if Destroy() nils out the handle
 			// in the middle of the operation.
 			buf := make([]byte, t.object.Size)
-			_, err := t.reader.ReadAt(t.ctx, buf, 0)
+			_, err := t.reader.ReadAt(t.ctx, &ReadRequest{
+				Buffer: buf,
+				Offset: 0,
+			})
 
 			// Assert: The read might fail with a fallback error or succeed if it completes before Destroy.
 			// The key is that it doesn't panic.

--- a/internal/gcsx/mock_reader.go
+++ b/internal/gcsx/mock_reader.go
@@ -24,8 +24,8 @@ type MockReader struct {
 	mock.Mock
 }
 
-func (m *MockReader) ReadAt(ctx context.Context, p []byte, offset int64) (ReadResponse, error) {
-	args := m.Called(ctx, p, offset)
+func (m *MockReader) ReadAt(ctx context.Context, req *ReadRequest) (ReadResponse, error) {
+	args := m.Called(ctx, req)
 	return args.Get(0).(ReadResponse), args.Error(1)
 }
 

--- a/internal/gcsx/read_manager/mock_read_manager.go
+++ b/internal/gcsx/read_manager/mock_read_manager.go
@@ -27,8 +27,8 @@ type MockReadManager struct {
 	mock.Mock
 }
 
-func (m *MockReadManager) ReadAt(ctx context.Context, dst []byte, offset int64) (gcsx.ReadResponse, error) {
-	args := m.Called(ctx, dst, offset)
+func (m *MockReadManager) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcsx.ReadResponse, error) {
+	args := m.Called(ctx, req)
 	return args.Get(0).(gcsx.ReadResponse), args.Error(1)
 }
 

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -132,20 +132,20 @@ func (rr *ReadManager) CheckInvariants() {
 // ReadAt attempts to read data from the provided offset, using the configured readers.
 // It prioritizes readers in the order they are defined (file cache first, then GCS).
 // If a reader returns a FallbackToAnotherReader error, it tries the next reader.
-func (rr *ReadManager) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.ReadResponse, error) {
+func (rr *ReadManager) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcsx.ReadResponse, error) {
 	var readResponse gcsx.ReadResponse
-	if offset >= int64(rr.object.Size) {
+	if req.Offset >= int64(rr.object.Size) {
 		return readResponse, io.EOF
 	}
 
 	// empty read
-	if len(p) == 0 {
+	if len(req.Buffer) == 0 {
 		return readResponse, nil
 	}
 
 	var err error
 	for _, r := range rr.readers {
-		readResponse, err = r.ReadAt(ctx, p, offset)
+		readResponse, err = r.ReadAt(ctx, req)
 		if err == nil {
 			return readResponse, nil
 		}

--- a/internal/gcsx/read_manager/visual_read_manager.go
+++ b/internal/gcsx/read_manager/visual_read_manager.go
@@ -65,13 +65,13 @@ func NewVisualReadManager(wrapped gcsx.ReadManager, ioRenderer *workloadinsight.
 }
 
 // ReadAt records the read I/O range and delegates the read to the wrapped ReadManager.
-func (vrm *VisualReadManager) ReadAt(ctx context.Context, p []byte, offset int64) (gcsx.ReadResponse, error) {
+func (vrm *VisualReadManager) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcsx.ReadResponse, error) {
 	// Capture the range in the visualizer
-	if len(p) > 0 {
-		vrm.acceptRange(uint64(offset), uint64(offset)+uint64(len(p)))
+	if len(req.Buffer) > 0 {
+		vrm.acceptRange(uint64(req.Offset), uint64(req.Offset)+uint64(len(req.Buffer)))
 	}
 	// Delegate to the wrapped ReadManager
-	return vrm.wrapped.ReadAt(ctx, p, offset)
+	return vrm.wrapped.ReadAt(ctx, req)
 }
 
 // Destroy outputs the read I/O visualization and destroys the wrapped ReadManager.

--- a/internal/gcsx/read_manager/visual_read_manager_test.go
+++ b/internal/gcsx/read_manager/visual_read_manager_test.go
@@ -188,12 +188,15 @@ func TestVisualReadManager_MergeRanges(t *testing.T) {
 func TestVisualReadManager_ReadAt(t *testing.T) {
 	mockReadManager := &MockReadManager{}
 	mockReadManager.On("Object").Return(&gcs.MinObject{Name: "test-object", Size: 100}).Maybe()
-	mockReadManager.On("ReadAt", mock.Anything, mock.Anything, mock.Anything).Return(gcsx.ReadResponse{}, nil).Once()
+	mockReadManager.On("ReadAt", mock.Anything, mock.AnythingOfType("*gcsx.ReadRequest")).Return(gcsx.ReadResponse{}, nil).Once()
 	ioRenderer, err := workloadinsight.NewRenderer()
 	require.NoError(t, err, "Failed to create IORenderer")
 	vrm := NewVisualReadManager(mockReadManager, ioRenderer, cfg.WorkloadInsightConfig{})
 
-	_, err = vrm.ReadAt(context.Background(), make([]byte, 20), 10)
+	_, err = vrm.ReadAt(context.Background(), &gcsx.ReadRequest{
+		Buffer: make([]byte, 20),
+		Offset: 10,
+	})
 	require.NoError(t, err, "ReadAt should not return an error")
 
 	expectedRange := workloadinsight.Range{Start: 10, End: 30}

--- a/internal/gcsx/reader.go
+++ b/internal/gcsx/reader.go
@@ -26,6 +26,18 @@ import (
 // to an alternative reader.
 var FallbackToAnotherReader = errors.New("fallback to another reader is required")
 
+// ReadRequest encapsulates the parameters for a read operation.
+type ReadRequest struct {
+	// Buffer is provided by jacobsa/fuse and should be filled with data from the object.
+	Buffer []byte
+
+	// Offset specifies the starting position in the object from where data should be read.
+	Offset int64
+
+	// ReadInfo contains metadata about the read pattern.
+	ReadInfo
+}
+
 // GCSReaderRequest represents the request parameters needed to read a data from a GCS object.
 type GCSReaderRequest struct {
 	// Buffer is provided by jacobsa/fuse and should be filled with data from the object.
@@ -69,7 +81,7 @@ type Reader interface {
 	// ReadResponse. To indicate that the operation should be handled by an
 	// alternative reader, return the error FallbackToAnotherReader.
 	// If an error occurs, the size in ReadResponse will be zero.
-	ReadAt(ctx context.Context, p []byte, offset int64) (ReadResponse, error)
+	ReadAt(ctx context.Context, req *ReadRequest) (ReadResponse, error)
 
 	// Destroy is called to release any resources held by the reader.
 	Destroy()


### PR DESCRIPTION
### Description
This PR refactors the `Reader` interface, changing the `ReadAt` method to accept a `gcsx.ReadRequest` struct. This change is a prerequisite for integrating the `ReadTypeClassifier` with the `ReadManager`, as it enables passing `ReadInfo` to the underlying readers.

The new `ReadRequest` struct encapsulates the read `buffer`, `offset`, and `ReadInfo`, which will enable more flexible and extensible read operations. In the future, this will also allow for passing additional details, such as a separate prefetch window, in individual read requests to the readers.

### Link to the issue in case of a bug fix.
b/462587679

### Testing details
1. Manual - Done
2. Unit tests - Updated
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
