### PR TITLE
ci(cd_e2e): fixing minor test failure in run_light_test mode

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -576,10 +576,16 @@ function run_e2e_tests_for_emulator_and_log() {
 declare -A exit_status
 if [[ "$RUN_LIGHT_TEST" == "true" ]]; then
     light_test_dir_non_parallel=("monitoring")
-    light_test_dir_parallel=("")
+    light_test_dir_parallel=()
 
     run_e2e_tests "flat"  light_test_dir_parallel light_test_dir_non_parallel false
     exit_status["flat"]=$?
+
+    run_e2e_tests "hns"  light_test_dir_parallel light_test_dir_non_parallel false
+    exit_status["hns"]=$?
+
+    run_e2e_tests "zonal"  light_test_dir_parallel light_test_dir_non_parallel true
+    exit_status["zonal"]=$?
 elif [[ "$RUN_READ_CACHE_TESTS_ONLY" == "true" ]]; then
     read_cache_test_dir_parallel=() # Empty for read cache tests only
     read_cache_test_dir_non_parallel=("read_cache")


### PR DESCRIPTION
### Description
- Earlier parallel package list started taking empty string, which leads to failure. Not able to catch exit code in the last manual testing, focused on the successful run_light_test mode.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
