### PR TITLE
fix(ci): adding emulator test too as part of light run test

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -586,6 +586,9 @@ if [[ "$RUN_LIGHT_TEST" == "true" ]]; then
 
     run_e2e_tests "zonal"  light_test_dir_parallel light_test_dir_non_parallel true
     exit_status["zonal"]=$?
+
+    # Run emulator tests and log their results.
+    run_e2e_tests_for_emulator_and_log
 elif [[ "$RUN_READ_CACHE_TESTS_ONLY" == "true" ]]; then
     read_cache_test_dir_parallel=() # Empty for read cache tests only
     read_cache_test_dir_non_parallel=("read_cache")


### PR DESCRIPTION
### Description
- Louhi checks for all the success.txt, hence adding emulator test too. This should be fine as emulator test doesn't take much time.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
