### PR TITLE
feat(Unsupported dir path): Adding e2e test in cd script

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -318,6 +318,7 @@ TEST_DIR_PARALLEL=(
   # Disabled because of b/451462914.
   #"requester_pays_bucket"
   "flag_optimizations"
+  "unsupported_path"
 )
 
 # These tests never become parallel as they are changing bucket permissions.
@@ -357,6 +358,7 @@ TEST_DIR_PARALLEL_ZONAL=(
   streaming_writes
   unfinalized_object
   write_large_files
+  "unsupported_path"
 )
 
 # For Zonal Buckets :  These tests never become parallel as they are changing bucket permissions.


### PR DESCRIPTION
### Description
Adding e2e test package in cd script

### Link to the issue in case of a bug fix.
[b/464393427](https://b.corp.google.com/issues/464393427)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
