### PR TITLE
test(rapid appends): fix typo

### DIFF
--- a/tools/integration_tests/rapid_appends/suites_test.go
+++ b/tools/integration_tests/rapid_appends/suites_test.go
@@ -132,7 +132,7 @@ func (t *BaseSuite) unmountAndCleanupMount(m mountPoint, name string) {
 	err := os.RemoveAll(m.rootDir)
 	require.NoError(t.T(), err, "Failed to clean up %v mount root directory", name)
 	// Cleaning up the intermediate generated test files.
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, m.testDirPath)
+	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 }
 
 func (t *BaseSuite) createUnfinalizedObject() {


### PR DESCRIPTION
### Description
This is causing empty bucket name and the package is failing on master after the code for extracting bucket is using stricter checks as per #4009.

<img width="1266" height="74" alt="image" src="https://github.com/user-attachments/assets/4131b997-ce65-48ff-8b28-fcc5bde2e0d1" />


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
