### PR TITLE
refactor(gcsreader): Optimize prefetching for regional buckets by recalculating read type

### DIFF
--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -278,7 +278,7 @@ func (t *gcsReaderTest) Test_ExistingReader_WrongOffset() {
 			content := "abcde"
 			rc := &fake.FakeReader{ReadCloser: getReadCloser([]byte(content))}
 			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(rc, nil).Times(1)
-			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(3)
+			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{}).Times(2)
 			requestSize := 6
 			buf := make([]byte, requestSize)
 
@@ -414,7 +414,7 @@ func (t *gcsReaderTest) Test_ReadAt_WithAndWithoutReadConfig() {
 				ReadHandle:     nil, // No existing read handle
 			}
 			t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, expectedReadObjectRequest).Return(rc, nil).Once()
-			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false}).Times(3)
+			t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false}).Times(2)
 			buf := make([]byte, readLength)
 
 			objectData := t.readAt(t.ctx, &gcsx.ReadRequest{

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -272,7 +272,7 @@ func (t *readManagerTest) Test_ReadAt_ReaderFailsWithTimeout() {
 	r := iotest.OneByteReader(iotest.TimeoutReader(strings.NewReader("xxx")))
 	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(rc, nil).Once()
-	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(3)
+	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(2)
 
 	_, err := t.readAt(make([]byte, 3), 0)
 
@@ -283,7 +283,7 @@ func (t *readManagerTest) Test_ReadAt_ReaderFailsWithTimeout() {
 
 func (t *readManagerTest) Test_ReadAt_FileClobbered() {
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).Return(nil, &gcs.NotFoundError{})
-	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(3)
+	t.mockBucket.On("BucketType", mock.Anything).Return(t.bucketType).Times(2)
 	t.mockBucket.On("Name").Return("test-bucket")
 
 	_, err := t.readAt(make([]byte, 3), 1)


### PR DESCRIPTION
### Description
This PR removes the zonal bucket check for recalculating the read type. The read type is now recalculated if the expected offset has changed for both zonal and regional buckets. This is important for regional buckets to adjust the prefetching window when the read pattern changes, and for zonal buckets, it allows switching to MRD for high-performance random reads

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/465375267

### Testing details
1. Manual - Done
2. Unit tests - Updated
3. Integration tests - Automated

### Performance Test: Sequential Read

The following table shows the results of a sequential read performance for a regional bucket in `us-west4` test on a 10GiB file, averaged over 3 runs. The test compares the `master` branch with the changes in this PR.

| Branch | Throughput (MiB/s) |
| :--- | :--- |
| `master` | 243.33 |
| `remove-zonal-check` | 304.67 |

**Conclusion:** No regression. 


### Any backward incompatible change? If so, please explain.
