### PR TITLE
fix(build): Excluding DEBIAN folder while building rpm package

### DIFF
--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -109,7 +109,6 @@ WORKDIR ${GCSFUSE_PKG}
 # Build the package
 RUN dpkg-deb --build ${GCSFUSE_BIN}
 RUN mv ${GCSFUSE_BIN}.deb .
-RUN rm -rf ${GCSFUSE_BIN}/DEBIAN
 RUN fpm \
     -s dir \
     -t rpm \
@@ -117,6 +116,7 @@ RUN fpm \
     -C ${GCSFUSE_BIN} \
     -v ${GCSFUSE_VERSION} \
     -d fuse \
+    --exclude DEBIAN \
     --rpm-digest sha256 \
     --license Apache-2.0 \
     --vendor "" \


### PR DESCRIPTION
### Description
Excluding DEBIAN folder while building rpm package to ensure it's not packaged in the RPM binary.

### Link to the issue in case of a bug fix.
b/463363713
https://github.com/GoogleCloudPlatform/gcsfuse/issues/4066

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
