### PR TITLE
ci(orbax-benchmark): Don't enable LRO

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
@@ -19,9 +19,6 @@ spec:
       args:
       - |
         echo always > /sys/kernel/mm/transparent_hugepage/enabled
-        apt update -y
-        apt-get install -y ethtool
-        ethtool -K eth0 lro on
       volumeMounts:
       - name: sys-mm
         mountPath: /sys/kernel/mm

--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/run_benchmark.py
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/run_benchmark.py
@@ -92,7 +92,7 @@ async def check_prerequisites():
         stdout=asyncio.subprocess.PIPE
     )
     gpg_process = await asyncio.create_subprocess_exec(
-        "sudo", "gpg", "--dearmor", "-o", "/usr/share/keyrings/cloud.google.gpg",
+        "sudo", "gpg", "--yes", "--dearmor", "-o", "/usr/share/keyrings/cloud.google.gpg",
         stdin=asyncio.subprocess.PIPE
     )
     await gpg_process.communicate(input=await curl_process.stdout.read())


### PR DESCRIPTION
### Description
* LRO works only with host-network and doesn't improve the performance by much. So, it's fine to be removed.
* This prevents the need for a human input if the public key file is already present.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
