### PR TITLE
fix(cve-2025-61729): Upgrade Golang to 1.24.11 (master)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Mount the gcsfuse to /mnt/gcs:
 #  > docker run --privileged --device /fuse -v /mnt/gcs:/gcs:rw,rshared gcsfuse
 
-FROM golang:1.24.10-alpine AS builder
+FROM golang:1.24.11-alpine AS builder
 
 RUN apk add git
 

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 substitutions:
-  _GOLANG_VERSION: '1.24'
+  _GOLANG_VERSION: '1.24.11'
   _GCSFUSE_VERSION: 'v4'
   _CSI_VERSION: 'main'
   _BUILD_ARM: 'false'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googlecloudplatform/gcsfuse/v3
 
-go 1.24.10
+go 1.24.11
 
 require (
 	cloud.google.com/go/auth v0.16.5

--- a/perfmetrics/scripts/install_go.sh
+++ b/perfmetrics/scripts/install_go.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 if [[ $# -ne 1 ]]; then
     echo "This script requires exactly one argument."
     echo "Usage: $0 <go-version>"
-    echo "Example: $0 1.24.10"
+    echo "Example: $0 1.24.11"
     exit 1
 fi
 

--- a/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
+++ b/perfmetrics/scripts/ml_tests/checkpoint/Jax/run_checkpoints.sh
@@ -23,9 +23,9 @@ sudo apt-get update
 echo "Installing git"
 sudo apt-get install git
 # Install Golang.
-#wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-amd64.tar.gz -q
+#wget -O go_tar.tar.gz https://go.dev/dl/go1.24.11.linux-amd64.tar.gz -q
 architecture=$(dpkg --print-architecture)
-wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${architecture}.tar.gz -q
+wget -O go_tar.tar.gz https://go.dev/dl/go1.24.11.linux-${architecture}.tar.gz -q
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -21,7 +21,7 @@ readonly EXECUTE_INTEGRATION_TEST_LABEL_ON_ZB="execute-integration-tests-on-zb"
 readonly EXECUTE_PACKAGE_BUILD_TEST_LABEL="execute-package-build-tests"
 readonly EXECUTE_CHECKPOINT_TEST_LABEL="execute-checkpoint-test"
 readonly BUCKET_LOCATION=us-west4
-readonly GO_VERSION="1.24.10"
+readonly GO_VERSION="1.24.11"
 readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
 readonly INSTALL_BASH_VERSION="5.3" # Using 5.3 for installation as bash 5.1 has an installation bug.
 

--- a/perfmetrics/scripts/read_cache/setup.sh
+++ b/perfmetrics/scripts/read_cache/setup.sh
@@ -64,7 +64,7 @@ sed -i 's/define \+FIO_IO_U_PLAT_GROUP_NR \+\([0-9]\+\)/define FIO_IO_U_PLAT_GRO
 cd -
 
 # Install and validate go.
-version=1.24.10
+version=1.24.11
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 sudo rm -rf /usr/local/go
 tar -xzf go_tar.tar.gz && sudo mv go /usr/local

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -261,7 +261,7 @@ else
 fi
 
 # install go
-wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${architecture}.tar.gz
+wget -O go_tar.tar.gz https://go.dev/dl/go1.24.11.linux-${architecture}.tar.gz
 sudo tar -C /usr/local -xzf go_tar.tar.gz
 export PATH=${PATH}:/usr/local/go/bin
 #Write gcsfuse and go version to log file

--- a/tools/containerize_gcsfuse_docker/Dockerfile
+++ b/tools/containerize_gcsfuse_docker/Dockerfile
@@ -34,7 +34,7 @@ ARG OS_VERSION
 ARG OS_NAME
 
 # Image with gcsfuse installed and its package (.deb)
-FROM golang:1.24.10 as gcsfuse-package
+FROM golang:1.24.11 as gcsfuse-package
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential rpm fuse && gem install --no-document bundler
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -52,7 +52,7 @@ fi
 log_info "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 
 # Constants
-readonly GO_VERSION="1.24.10"
+readonly GO_VERSION="1.24.11"
 readonly DEFAULT_PROJECT_ID="gcs-fuse-test-ml"
 readonly TPCZERO_PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly TPC_BUCKET_LOCATION="u-us-prp1"

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -258,7 +258,7 @@ function upgrade_gcloud_version() {
 
 function install_packages() {
   # Install required go version.
-  ./perfmetrics/scripts/install_go.sh "1.24.10"
+  ./perfmetrics/scripts/install_go.sh "1.24.11"
   export PATH="/usr/local/go/bin:$PATH"
   
   sudo apt-get update

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -52,7 +52,7 @@ RUN if [ "${ARCHITECTURE}" != "amd64" ] && [ "${ARCHITECTURE}" != "arm64" ]; the
     exit 1; \
     fi
 
-RUN wget -O go_tar.tar.gz https://go.dev/dl/go1.24.10.linux-${ARCHITECTURE}.tar.gz -q
+RUN wget -O go_tar.tar.gz https://go.dev/dl/go1.24.11.linux-${ARCHITECTURE}.tar.gz -q
 RUN rm -rf /usr/local/go
 RUN tar -C /usr/local -xzf go_tar.tar.gz
 RUN PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
### Description
Upgrade Golang to 1.24.11

### Link to the issue in case of a bug fix.
b/462792349, b/460451405

### Perf
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 627.52MiB/s  | 1.22MiB/s  |  87.46MiB/s  |  1.24MiB/s   |
|   PR   |  0.25MiB   | 613.92MiB/s  | 1.11MiB/s  |  87.39MiB/s  |  1.27MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 4340.48MiB/s | 80.88MiB/s | 1690.29MiB/s |  83.63MiB/s  |
|   PR   | 48.828MiB  | 4348.75MiB/s | 81.56MiB/s | 1625.93MiB/s |  82.68MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 4319.67MiB/s | 36.91MiB/s | 906.82MiB/s  |  39.36MiB/s  |
|   PR   | 976.562MiB | 4361.81MiB/s | 37.88MiB/s | 1333.12MiB/s |  38.75MiB/s  |

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
