### PR TITLE
test(file cache parallel reads): Enabling parallel reads from file cache

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -55,7 +55,7 @@ func (s *concurrentReadTest) SetupTest() {
 
 func (s *concurrentReadTest) TearDownTest() {
 	setup.UnmountGCSFuse(setup.MntDir())
-	operations.RemoveDir(cacheDirPath)
+	setup.CleanUpDir(cacheDirPath)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -273,7 +273,11 @@ func TestConcurrentRead(t *testing.T) {
 		return
 	}
 
-	cacheDirPath = fmt.Sprintf("/tmp/gcsfuse-file-cache-concurrent-read-%s", setup.GenerateRandomString(5))
+	var err error
+	cacheDirPath, err = os.MkdirTemp("", fmt.Sprintf("gcsfuse-file-cache-concurrent-read-%s", setup.GenerateRandomString(5)))
+	require.NoError(t, err)
+	defer operations.RemoveDir(cacheDirPath)
+
 	cacheDirFlag := fmt.Sprintf("--cache-dir=%s", cacheDirPath)
 	// Define flag sets specific for concurrent read tests
 	flagsSet := [][]string{


### PR DESCRIPTION
1. Enabled concurrent read tests for file cache as well
2. Updated the test name for one of the e2e tests

### Description

### Link to the issue in case of a bug fix.
b/465027261

### Testing details
1. Manual - NA
3. Unit tests - NA
4. Integration tests - Done

### Any backward incompatible change? If so, please explain.
