### PR TITLE
ci(orbax-benchmark): Disable machine-specific overrides

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
@@ -63,4 +63,4 @@ spec:
       driver: gcsfuse.csi.storage.gke.io
       volumeAttributes:
         bucketName: "$bucket_name"
-        mountOptions: "read_ahead_kb=1024"
+        mountOptions: "read_ahead_kb=1024,disable-autoconfig"


### PR DESCRIPTION
### Description
We don't want to enable machine-specific overrides that might taint the performance results of the Orbax benchmark.
### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
