### PR TITLE
refactor: monitoring test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/monitoring/buffered_read_prom_test.go
+++ b/tools/integration_tests/monitoring/buffered_read_prom_test.go
@@ -1,10 +1,10 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,7 @@ package monitoring
 import (
 	"io"
 	"log"
-	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -30,32 +28,6 @@ import (
 
 type PromBufferedReadTest struct {
 	PromTestBase
-	flags          []string
-	prometheusPort int
-}
-
-func (p *PromBufferedReadTest) SetupSuite() {
-	setup.SetUpLogFilePath("TestPromBufferedReadSuite", gkeTempDir, "", testEnv.cfg)
-	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
-}
-
-func (p *PromBufferedReadTest) TearDownSuite() {
-	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
-}
-
-func (p *PromBufferedReadTest) SetupTest() {
-	// Create a new directory for each test.
-	testName := strings.ReplaceAll(p.T().Name(), "/", "_")
-	gcsDir := path.Join(testDirName, testName)
-	testEnv.testDirPath = path.Join(mountDir, gcsDir)
-	operations.CreateDirectory(testEnv.testDirPath, p.T())
-	// Create a file with content "world".
-	err := os.WriteFile(path.Join(testEnv.testDirPath, "hello.txt"), []byte("world"), 0644)
-	require.NoError(p.T(), err)
-}
-
-func (p *PromBufferedReadTest) TearDownTest() {
-	setup.SaveGCSFuseLogFileInCaseOfFailure(p.T())
 }
 
 func (p *PromBufferedReadTest) TestBufferedReadMetrics() {
@@ -120,6 +92,7 @@ func (p *PromBufferedReadTest) TestInsufficientMemoryFallback() {
 func TestPromBufferedReadSuite(t *testing.T) {
 	t.SkipNow()
 	ts := &PromBufferedReadTest{}
+	ts.suiteName = "TestPromBufferedReadSuite"
 	flagSets := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagSets {
 		ts.flags = flags

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -99,11 +99,11 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"}
 		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
-		
-		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log",}
-		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"}
+		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
-		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log",}
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"}
 		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
 	}

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,216 +15,19 @@
 package monitoring
 
 import (
-	"context"
-	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"path"
-	"strconv"
-	"strings"
 	"testing"
 
-	"cloud.google.com/go/storage"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/pkg/xattr"
-	promclient "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	testDirName = "monitoring"
-	gkeTempDir  = "/gcsfuse-tmp"
-)
-
-type env struct {
-	storageClient *storage.Client
-	ctx           context.Context
-	testDirPath   string
-	cfg           *test_suite.TestConfig
-	bucketType    string
-}
-
-var (
-	testEnv   env
-	mountFunc func(*test_suite.TestConfig, []string) error
-	mountDir  string
-	rootDir   string
-)
-
-// PromTestBase preserves the base struct as requested.
-type PromTestBase struct {
-	suite.Suite
-}
-
-func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
-	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory != "" {
-		setup.SetMntDir(testEnv.cfg.GKEMountedDirectory)
-	}
-	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
-}
-
-func TestMain(m *testing.M) {
-	setup.ParseSetUpFlags()
-
-	configFile := test_suite.ReadConfigFile(setup.ConfigFile())
-	if len(configFile.Monitoring) == 0 {
-		log.Println("No configuration found for monitoring tests in config. Using default flags.")
-		configFile.Monitoring = make([]test_suite.TestConfig, 1)
-		testEnv.cfg = &configFile.Monitoring[0]
-		testEnv.cfg.TestBucket = setup.TestBucket()
-		testEnv.cfg.LogFile = setup.LogFile()
-		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
-
-		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 6)
-		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log"}
-		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
-		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
-		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log"}
-		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
-		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
-
-		testEnv.cfg.Configs[2].Flags = []string{"--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log"}
-		testEnv.cfg.Configs[2].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
-		testEnv.cfg.Configs[2].Run = "TestPromBufferedReadSuite"
-		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"}
-		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
-		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
-
-		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"}
-		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
-		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
-		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"}
-		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
-		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
-	}
-	testEnv.cfg = &configFile.Monitoring[0]
-	testEnv.ctx = context.Background()
-	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
-
-	var err error
-	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
-	if err != nil {
-		log.Fatalf("client.CreateStorageClient: %v", err)
-	}
-	defer testEnv.storageClient.Close()
-
-	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
-		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
-	}
-
-	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
-
-	log.Println("Running static mounting tests...")
-	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
-	successCode := m.Run()
-
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
-	os.Exit(successCode)
-}
-
 type PromTest struct {
 	PromTestBase
-	flags          []string
-	prometheusPort int
-}
-
-func (p *PromTest) SetupSuite() {
-	setup.SetUpLogFilePath("TestPromOTELSuite", gkeTempDir, "", testEnv.cfg)
-	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
-}
-
-func (p *PromTest) TearDownSuite() {
-	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
-}
-
-func (p *PromTest) SetupTest() {
-	// Create a new directory for each test.
-	testName := strings.ReplaceAll(p.T().Name(), "/", "_")
-	gcsDir := path.Join(testDirName, testName)
-	testEnv.testDirPath = path.Join(mountDir, gcsDir)
-	operations.CreateDirectory(testEnv.testDirPath, p.T())
-	client.SetupFileInTestDirectory(testEnv.ctx, testEnv.storageClient, gcsDir, "hello.txt", 10, p.T())
-}
-
-func (p *PromTest) TearDownTest() {
-	setup.SaveGCSFuseLogFileInCaseOfFailure(p.T())
-}
-
-func parsePromFormat(t *testing.T, prometheusPort int) (map[string]*promclient.MetricFamily, error) {
-	t.Helper()
-
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
-	require.NoError(t, err)
-	parser := expfmt.NewTextParser(model.UTF8Validation)
-	return parser.TextToMetricFamilies(resp.Body)
-}
-
-// assertNonZeroCountMetric asserts that the specified count metric is present and is positive in the Prometheus export
-func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
-	t.Helper()
-	mf, err := parsePromFormat(t, prometheusPort)
-	require.NoError(t, err)
-	for k, v := range mf {
-		if k != metricName || *v.Type != promclient.MetricType_COUNTER {
-			continue
-		}
-		for _, m := range v.Metric {
-			if *m.Counter.Value <= 0 {
-				continue
-			}
-			if labelName == "" {
-				return
-			}
-			for _, l := range m.GetLabel() {
-				if *l.Name == labelName && *l.Value == labelValue {
-					return
-				}
-			}
-		}
-	}
-	assert.Fail(t, fmt.Sprintf("Didn't find the metric with name: %s, labelName: %s and labelValue: %s",
-		metricName, labelName, labelValue))
-}
-
-// assertNonZeroHistogramMetric asserts that the specified histogram metric is present and is positive for at least one of the buckets in the Prometheus export.
-func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
-	t.Helper()
-	mf, err := parsePromFormat(t, prometheusPort)
-	require.NoError(t, err)
-
-	for k, v := range mf {
-		if k != metricName || *v.Type != promclient.MetricType_HISTOGRAM {
-			continue
-		}
-		for _, m := range v.Metric {
-			for _, bkt := range m.GetHistogram().Bucket {
-				if bkt.CumulativeCount == nil || *bkt.CumulativeCount == 0 {
-					continue
-				}
-				if labelName == "" {
-					return
-				}
-				for _, l := range m.GetLabel() {
-					if *l.Name == labelName && *l.Value == labelValue {
-						return
-					}
-				}
-			}
-		}
-	}
 }
 
 func (p *PromTest) TestStatMetrics() {
@@ -284,22 +87,9 @@ func (p *PromTest) TestReadMetrics() {
 	assertNonZeroHistogramMetric(p.T(), "gcs_request_latencies", "gcs_method", "NewReader", prometheusPort)
 }
 
-func parsePortFromFlags(flags []string) int {
-	for _, flagStr := range flags {
-		parts := strings.Split(flagStr, " ")
-		for _, part := range parts {
-			if strings.HasPrefix(part, "--prometheus-port=") {
-				portStr := strings.TrimPrefix(part, "--prometheus-port=")
-				port, _ := strconv.Atoi(portStr)
-				return port
-			}
-		}
-	}
-	return 0
-}
-
 func TestPromOTELSuite(t *testing.T) {
 	ts := &PromTest{}
+	ts.suiteName = "TestPromOTELSuite"
 	flagSets := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagSets {
 		ts.flags = flags

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -17,17 +17,20 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/pkg/xattr"
 	promclient "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -38,110 +41,126 @@ import (
 )
 
 const (
-	testHNSBucket  = "gcsfuse_monitoring_test_bucket"
-	testFlatBucket = "gcsfuse_monitoring_test_bucket_flat"
+	testDirName = "monitoring"
+	gkeTempDir  = "/gcsfuse-tmp"
 )
+
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
 
 var (
-	portNonHNSRun = 9190
-	portHNSRun    = 10190
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
+	mountDir  string
+	rootDir   string
 )
 
-var prometheusPort int
-
-func setPrometheusPort(t *testing.T) {
-	if isHNSTestRun(t) {
-		prometheusPort = portHNSRun
-		portHNSRun++
-		return
-	}
-	prometheusPort = portNonHNSRun
-	portNonHNSRun++
-}
-
-func getBucket(t *testing.T) string {
-	if isHNSTestRun(t) {
-		return testHNSBucket
-	}
-	return testFlatBucket
-}
-
-func isPortOpen(port int) bool {
-	c := exec.Command("lsof", "-t", fmt.Sprintf("-i:%d", port))
-	output, _ := c.CombinedOutput()
-	return len(output) == 0
-}
-
+// PromTestBase preserves the base struct as requested.
 type PromTestBase struct {
 	suite.Suite
-	gcsfusePath string
-	mountPoint  string
 }
 
-func (testSuite *PromTestBase) mountGcsfuse(bucketName string, flags []string) error {
-	testSuite.T().Helper()
-	if portAvailable := isPortOpen(prometheusPort); !portAvailable {
-		require.Failf(testSuite.T(), "prometheus port is not available.", "port: %d", int64(prometheusPort))
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+	if testEnv.cfg.GKEMountedDirectory != "" {
+		setup.SetMntDir(testEnv.cfg.GKEMountedDirectory)
 	}
-	args := append(flags, bucketName, testSuite.mountPoint)
-
-	if err := mounting.MountGcsfuse(testSuite.gcsfusePath, args); err != nil {
-		return err
-	}
-	return nil
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
-func (testSuite *PromTestBase) SetupSuite() {
-	setup.IgnoreTestIfIntegrationTestFlagIsNotSet(testSuite.T())
-	_, err := setup.SetUpTestDir()
-	require.NoError(testSuite.T(), err, "error while building GCSFuse")
-}
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
 
-func (testSuite *PromTestBase) TearDownTest() {
-	if err := util.Unmount(testSuite.mountPoint); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: unmount failed: %v\n", err)
+	configFile := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(configFile.Monitoring) == 0 {
+		log.Println("No configuration found for monitoring tests in config. Using default flags.")
+		configFile.Monitoring = make([]test_suite.TestConfig, 1)
+		testEnv.cfg = &configFile.Monitoring[0]
+		testEnv.cfg.TestBucket = setup.TestBucket()
+		testEnv.cfg.LogFile = setup.LogFile()
+		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
+
+		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 5)
+		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring.log"}
+		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
+		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring_hns.log"}
+		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
+
+		testEnv.cfg.Configs[2].Flags = []string{"--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log"}
+		testEnv.cfg.Configs[2].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		testEnv.cfg.Configs[2].Run = "TestPromBufferedReadSuite"
+		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"}
+		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
+		
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log",}
+		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
 	}
-	require.True(testSuite.T(), isPortOpen(prometheusPort))
+	testEnv.cfg = &configFile.Monitoring[0]
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
-	err := os.Remove(testSuite.mountPoint)
-	assert.NoError(testSuite.T(), err)
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Fatalf("client.CreateStorageClient: %v", err)
+	}
+	defer testEnv.storageClient.Close()
+
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir = testEnv.cfg.GKEMountedDirectory
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+	}
+
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
+	successCode := m.Run()
+
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	os.Exit(successCode)
 }
 
 type PromTest struct {
 	PromTestBase
+	flags          []string
+	prometheusPort int
 }
 
-// isHNSTestRun returns true if the bucket is an HNS bucket.
-func isHNSTestRun(t *testing.T) bool {
-	storageClient, err := client.CreateStorageClient(context.Background())
-	require.NoError(t, err, "error while creating storage client")
-	defer storageClient.Close()
-	return setup.ResolveIsHierarchicalBucket(context.Background(), setup.TestBucket(), storageClient)
+func (p *PromTest) SetupSuite() {
+	setup.SetUpLogFilePath("TestPromOTELSuite", gkeTempDir, "", testEnv.cfg)
+	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
 }
 
-func (testSuite *PromTest) SetupTest() {
-	var err error
-	testSuite.gcsfusePath = setup.BinFile()
-	testSuite.mountPoint, err = os.MkdirTemp("", "gcsfuse_monitoring_tests")
-	require.NoError(testSuite.T(), err)
-	setPrometheusPort(testSuite.T())
-
-	setup.SetLogFile(fmt.Sprintf("%s%s.txt", "/tmp/gcsfuse_monitoring_test_", strings.ReplaceAll(testSuite.T().Name(), "/", "_")))
-	err = testSuite.mount(getBucket(testSuite.T()))
-	require.NoError(testSuite.T(), err)
+func (p *PromTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 }
 
-func (testSuite *PromTest) mount(bucketName string) error {
-	testSuite.T().Helper()
-	cacheDir, err := os.MkdirTemp("", "gcsfuse-cache")
-	require.NoError(testSuite.T(), err)
-	testSuite.T().Cleanup(func() { _ = os.RemoveAll(cacheDir) })
-
-	flags := []string{fmt.Sprintf("--prometheus-port=%d", prometheusPort), "--cache-dir", cacheDir}
-	return testSuite.mountGcsfuse(bucketName, flags)
+func (p *PromTest) SetupTest() {
+	// Create a new directory for each test.
+	testName := strings.ReplaceAll(p.T().Name(), "/", "_")
+	gcsDir := path.Join(testDirName, testName)
+	testEnv.testDirPath = path.Join(mountDir, gcsDir)
+	operations.CreateDirectory(testEnv.testDirPath, p.T())
+	client.SetupFileInTestDirectory(testEnv.ctx, testEnv.storageClient, gcsDir, "hello.txt", 10, p.T())
 }
 
-func parsePromFormat(t *testing.T) (map[string]*promclient.MetricFamily, error) {
+func (p *PromTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(p.T())
+}
+
+func parsePromFormat(t *testing.T, prometheusPort int) (map[string]*promclient.MetricFamily, error) {
 	t.Helper()
 
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
@@ -151,9 +170,9 @@ func parsePromFormat(t *testing.T) (map[string]*promclient.MetricFamily, error) 
 }
 
 // assertNonZeroCountMetric asserts that the specified count metric is present and is positive in the Prometheus export
-func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue string) {
+func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
 	t.Helper()
-	mf, err := parsePromFormat(t)
+	mf, err := parsePromFormat(t, prometheusPort)
 	require.NoError(t, err)
 	for k, v := range mf {
 		if k != metricName || *v.Type != promclient.MetricType_COUNTER {
@@ -178,9 +197,9 @@ func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue st
 }
 
 // assertNonZeroHistogramMetric asserts that the specified histogram metric is present and is positive for at least one of the buckets in the Prometheus export.
-func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValue string) {
+func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
 	t.Helper()
-	mf, err := parsePromFormat(t)
+	mf, err := parsePromFormat(t, prometheusPort)
 	require.NoError(t, err)
 
 	for k, v := range mf {
@@ -205,64 +224,84 @@ func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValu
 	}
 }
 
-func (testSuite *PromTest) TestStatMetrics() {
-	_, err := os.Stat(path.Join(testSuite.mountPoint, "hello/hello.txt"))
+func (p *PromTest) TestStatMetrics() {
+	prometheusPort := p.prometheusPort
+	_, err := os.Stat(path.Join(testEnv.testDirPath, "hello.txt"))
 
-	require.NoError(testSuite.T(), err)
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "LookUpInode")
-	assertNonZeroHistogramMetric(testSuite.T(), "fs_ops_latency", "fs_op", "LookUpInode")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_request_count", "gcs_method", "StatObject")
-	assertNonZeroHistogramMetric(testSuite.T(), "gcs_request_latencies", "gcs_method", "StatObject")
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "LookUpInode")
-	assertNonZeroHistogramMetric(testSuite.T(), "fs_ops_latency", "fs_op", "LookUpInode")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_request_count", "gcs_method", "StatObject")
-	assertNonZeroHistogramMetric(testSuite.T(), "gcs_request_latencies", "gcs_method", "StatObject")
+	require.NoError(p.T(), err)
+	assertNonZeroCountMetric(p.T(), "fs_ops_count", "fs_op", "LookUpInode", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "fs_ops_latency", "fs_op", "LookUpInode", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_request_count", "gcs_method", "StatObject", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "gcs_request_latencies", "gcs_method", "StatObject", prometheusPort)
 }
 
-func (testSuite *PromTest) TestFsOpsErrorMetrics() {
-	_, err := os.Stat(path.Join(testSuite.mountPoint, "non_existent_path.txt"))
-	require.Error(testSuite.T(), err)
+func (p *PromTest) TestFsOpsErrorMetrics() {
+	prometheusPort := p.prometheusPort
+	_, err := os.Stat(path.Join(testEnv.testDirPath, "non_existent_path.txt"))
+	require.Error(p.T(), err)
 
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_error_count", "fs_op", "LookUpInode")
-	assertNonZeroHistogramMetric(testSuite.T(), "fs_ops_latency", "fs_op", "LookUpInode")
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_error_count", "fs_op", "LookUpInode")
-	assertNonZeroHistogramMetric(testSuite.T(), "fs_ops_latency", "fs_op", "LookUpInode")
+	assertNonZeroCountMetric(p.T(), "fs_ops_error_count", "fs_op", "LookUpInode", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "fs_ops_latency", "fs_op", "LookUpInode", prometheusPort)
 }
 
-func (testSuite *PromTest) TestListMetrics() {
-	_, err := os.ReadDir(path.Join(testSuite.mountPoint, "hello"))
+func (p *PromTest) TestListMetrics() {
+	prometheusPort := p.prometheusPort
+	_, err := os.ReadDir(testEnv.testDirPath)
 
-	require.NoError(testSuite.T(), err)
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "ReadDir")
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "OpenDir")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_request_count", "gcs_method", "ListObjects")
-	assertNonZeroHistogramMetric(testSuite.T(), "gcs_request_latencies", "gcs_method", "ListObjects")
+	require.NoError(p.T(), err)
+	assertNonZeroCountMetric(p.T(), "fs_ops_count", "fs_op", "ReadDir", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "fs_ops_count", "fs_op", "OpenDir", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_request_count", "gcs_method", "ListObjects", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "gcs_request_latencies", "gcs_method", "ListObjects", prometheusPort)
 }
 
-func (testSuite *PromTest) TestSetXAttrMetrics() {
-	err := xattr.Set(path.Join(testSuite.mountPoint, "hello/hello.txt"), "alpha", []byte("beta"))
+func (p *PromTest) TestSetXAttrMetrics() {
+	prometheusPort := p.prometheusPort
+	err := xattr.Set(path.Join(testEnv.testDirPath, "hello.txt"), "alpha", []byte("beta"))
 
-	require.Error(testSuite.T(), err)
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_error_count", "fs_op", "Others")
+	require.Error(p.T(), err)
+	assertNonZeroCountMetric(p.T(), "fs_ops_error_count", "fs_op", "Others", prometheusPort)
 }
 
-func (testSuite *PromTest) TestReadMetrics() {
-	_, err := os.ReadFile(path.Join(testSuite.mountPoint, "hello/hello.txt"))
+func (p *PromTest) TestReadMetrics() {
+	prometheusPort := p.prometheusPort
+	_, err := os.ReadFile(path.Join(testEnv.testDirPath, "hello.txt"))
 
-	require.NoError(testSuite.T(), err)
-	assertNonZeroCountMetric(testSuite.T(), "file_cache_read_bytes_count", "read_type", "Sequential")
-	assertNonZeroCountMetric(testSuite.T(), "file_cache_read_count", "cache_hit", "false")
-	assertNonZeroCountMetric(testSuite.T(), "file_cache_read_count", "read_type", "Sequential")
-	assertNonZeroHistogramMetric(testSuite.T(), "file_cache_read_latencies", "cache_hit", "false")
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "OpenFile")
-	assertNonZeroCountMetric(testSuite.T(), "fs_ops_count", "fs_op", "ReadFile")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_request_count", "gcs_method", "NewReader")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_reader_count", "io_method", "opened")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_reader_count", "io_method", "closed")
-	assertNonZeroCountMetric(testSuite.T(), "gcs_download_bytes_count", "", "")
-	assertNonZeroHistogramMetric(testSuite.T(), "gcs_request_latencies", "gcs_method", "NewReader")
+	require.NoError(p.T(), err)
+	assertNonZeroCountMetric(p.T(), "file_cache_read_bytes_count", "read_type", "Sequential", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "file_cache_read_count", "cache_hit", "false", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "file_cache_read_count", "read_type", "Sequential", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "file_cache_read_latencies", "cache_hit", "false", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "fs_ops_count", "fs_op", "OpenFile", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "fs_ops_count", "fs_op", "ReadFile", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_request_count", "gcs_method", "NewReader", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_reader_count", "io_method", "opened", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_reader_count", "io_method", "closed", prometheusPort)
+	assertNonZeroCountMetric(p.T(), "gcs_download_bytes_count", "", "", prometheusPort)
+	assertNonZeroHistogramMetric(p.T(), "gcs_request_latencies", "gcs_method", "NewReader", prometheusPort)
+}
+
+func parsePortFromFlags(flags []string) int {
+	for _, flagStr := range flags {
+		parts := strings.Split(flagStr, " ")
+		for _, part := range parts {
+			if strings.HasPrefix(part, "--prometheus-port=") {
+				portStr := strings.TrimPrefix(part, "--prometheus-port=")
+				port, _ := strconv.Atoi(portStr)
+				return port
+			}
+		}
+	}
+	return 0
 }
 
 func TestPromOTELSuite(t *testing.T) {
-	suite.Run(t, new(PromTest))
+	ts := &PromTest{}
+	flagSets := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagSets {
+		ts.flags = flags
+		ts.prometheusPort = parsePortFromFlags(flags)
+		log.Printf("Running monitoring tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -86,10 +86,10 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
 
 		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 6)
-		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring.log"}
+		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log"}
 		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
-		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring_hns.log"}
+		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log"}
 		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
 
@@ -100,10 +100,10 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
 
-		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"}
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"}
 		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
-		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"}
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"}
 		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
 	}

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.LogFile = setup.LogFile()
 		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
 
-		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 5)
+		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 6)
 		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring.log"}
 		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
@@ -103,6 +103,9 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log",}
 		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log",}
+		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
 	}
 	testEnv.cfg = &configFile.Monitoring[0]
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
+++ b/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,8 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -31,30 +28,6 @@ import (
 // PromGrpcMetricsTest is the test suite for gRPC metrics.
 type PromGrpcMetricsTest struct {
 	PromTestBase
-	flags          []string
-	prometheusPort int
-}
-
-func (p *PromGrpcMetricsTest) SetupSuite() {
-	setup.SetUpLogFilePath("TestPromGrpcMetricsSuite", gkeTempDir, "", testEnv.cfg)
-	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
-}
-
-func (p *PromGrpcMetricsTest) TearDownSuite() {
-	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
-}
-
-func (p *PromGrpcMetricsTest) SetupTest() {
-	// Create a new directory for each test.
-	testName := strings.ReplaceAll(p.T().Name(), "/", "_")
-	gcsDir := path.Join(testDirName, testName)
-	testEnv.testDirPath = path.Join(mountDir, gcsDir)
-	operations.CreateDirectory(testEnv.testDirPath, p.T())
-	client.SetupFileInTestDirectory(testEnv.ctx, testEnv.storageClient, gcsDir, "hello.txt", 10, p.T())
-}
-
-func (p *PromGrpcMetricsTest) TearDownTest() {
-	setup.SaveGCSFuseLogFileInCaseOfFailure(p.T())
 }
 
 func (p *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
@@ -76,6 +49,7 @@ func (p *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
 
 func TestPromGrpcMetricsSuite(t *testing.T) {
 	ts := &PromGrpcMetricsTest{}
+	ts.suiteName = "TestPromGrpcMetricsSuite"
 	if testEnv.cfg.GKEMountedDirectory == "" {
 		// Skip the test if the testing environment is GCE VM.
 		t.SkipNow()

--- a/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
+++ b/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
@@ -62,8 +62,12 @@ func (p *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
 	require.NoError(p.T(), err)
 
 	// Assert that gRPC metrics are present.
+	if(testEnv.bucketType=="zonal") {
+		assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/BidiReadObject", p.prometheusPort)
+	} else {
+		assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/ReadObject", p.prometheusPort)
+	}
 	assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "", "", p.prometheusPort)
-	assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/ReadObject", p.prometheusPort)
 	assertNonZeroHistogramMetric(p.T(), "grpc_client_attempt_duration_seconds", "", "", p.prometheusPort)
 	assertNonZeroHistogramMetric(p.T(), "grpc_client_call_duration_seconds", "", "", p.prometheusPort)
 	assertNonZeroHistogramMetric(p.T(), "grpc_client_attempt_rcvd_total_compressed_message_size_bytes", "", "", p.prometheusPort)

--- a/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
+++ b/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
@@ -62,7 +62,7 @@ func (p *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
 	require.NoError(p.T(), err)
 
 	// Assert that gRPC metrics are present.
-	if(testEnv.bucketType=="zonal") {
+	if testEnv.bucketType == "zonal" {
 		assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/BidiReadObject", p.prometheusPort)
 	} else {
 		assertNonZeroCountMetric(p.T(), "grpc_client_attempt_started", "grpc_method", "google.storage.v2.Storage/ReadObject", p.prometheusPort)
@@ -76,6 +76,10 @@ func (p *PromGrpcMetricsTest) TestStorageClientGrpcMetrics() {
 
 func TestPromGrpcMetricsSuite(t *testing.T) {
 	ts := &PromGrpcMetricsTest{}
+	if testEnv.cfg.GKEMountedDirectory == "" {
+		// Skip the test if the testing environment is GCE VM.
+		t.SkipNow()
+	}
 	flagSets := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagSets {
 		ts.flags = flags

--- a/tools/integration_tests/monitoring/setup_test.go
+++ b/tools/integration_tests/monitoring/setup_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	promclient "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testDirName = "monitoring"
+	gkeTempDir  = "/gcsfuse-tmp"
+)
+
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
+
+var (
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
+)
+
+// PromTestBase preserves the base struct and common methods.
+type PromTestBase struct {
+	suite.Suite
+	flags          []string
+	prometheusPort int
+	suiteName      string
+}
+
+func (p *PromTestBase) SetupSuite() {
+	setup.SetUpLogFilePath(p.suiteName, gkeTempDir, "", testEnv.cfg)
+	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
+}
+
+func (p *PromTestBase) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (p *PromTestBase) SetupTest() {
+	testName := strings.ReplaceAll(p.T().Name(), "/", "_")
+	gcsDir := path.Join(testDirName, testName)
+	// Use the setup helper to prepare the test directory.
+	testEnv.testDirPath = client.SetupTestDirectory(testEnv.ctx, testEnv.storageClient, gcsDir)
+	// Setup a standard hello.txt file for metrics collection.
+	client.SetupFileInTestDirectory(testEnv.ctx, testEnv.storageClient, gcsDir, "hello.txt", 10, p.T())
+}
+
+func (p *PromTestBase) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(p.T())
+}
+
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+	if testEnv.cfg.GKEMountedDirectory != "" {
+		setup.SetMntDir(testEnv.cfg.GKEMountedDirectory)
+	}
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+}
+
+func parsePortFromFlags(flags []string) int {
+	for _, flagStr := range flags {
+		parts := strings.Split(flagStr, " ")
+		for _, part := range parts {
+			if strings.HasPrefix(part, "--prometheus-port=") {
+				portStr := strings.TrimPrefix(part, "--prometheus-port=")
+				port, _ := strconv.Atoi(portStr)
+				return port
+			}
+		}
+	}
+	return 0
+}
+
+func parsePromFormat(t *testing.T, prometheusPort int) (map[string]*promclient.MetricFamily, error) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", prometheusPort))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	return parser.TextToMetricFamilies(resp.Body)
+}
+
+func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
+	t.Helper()
+	mf, err := parsePromFormat(t, prometheusPort)
+	require.NoError(t, err)
+	for k, v := range mf {
+		if k != metricName || *v.Type != promclient.MetricType_COUNTER {
+			continue
+		}
+		for _, m := range v.Metric {
+			if labelName != "" {
+				for _, l := range m.Label {
+					if *l.Name == labelName && *l.Value == labelValue && *m.Counter.Value > 0 {
+						return
+					}
+				}
+			} else if *m.Counter.Value > 0 {
+				return
+			}
+		}
+	}
+	require.Fail(t, fmt.Sprintf("Metric %s with label %s=%s not found or zero", metricName, labelName, labelValue))
+}
+
+func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
+	t.Helper()
+	mf, err := parsePromFormat(t, prometheusPort)
+	require.NoError(t, err)
+	for k, v := range mf {
+		if k != metricName || *v.Type != promclient.MetricType_HISTOGRAM {
+			continue
+		}
+		for _, m := range v.Metric {
+			if labelName != "" {
+				for _, l := range m.Label {
+					if *l.Name == labelName && *l.Value == labelValue && *m.Histogram.SampleCount > 0 {
+						return
+					}
+				}
+			} else if *m.Histogram.SampleCount > 0 {
+				return
+			}
+		}
+	}
+	require.Fail(t, fmt.Sprintf("Metric %s with label %s=%s not found or zero", metricName, labelName, labelValue))
+}
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	configFile := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(configFile.Monitoring) == 0 {
+		log.Println("No configuration found for monitoring tests in config. Using default flags.")
+		configFile.Monitoring = make([]test_suite.TestConfig, 1)
+		testEnv.cfg = &configFile.Monitoring[0]
+		testEnv.cfg.TestBucket = setup.TestBucket()
+		testEnv.cfg.LogFile = setup.LogFile()
+		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
+
+		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 6)
+		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log"}
+		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
+		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log"}
+		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
+
+		testEnv.cfg.Configs[2].Flags = []string{"--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log"}
+		testEnv.cfg.Configs[2].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		testEnv.cfg.Configs[2].Run = "TestPromBufferedReadSuite"
+		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"}
+		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
+
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"}
+		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"}
+		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
+	}
+	testEnv.cfg = &configFile.Monitoring[0]
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
+
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Fatalf("client.CreateStorageClient: %v", err)
+	}
+	defer testEnv.storageClient.Close()
+
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+	}
+
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
+
+	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
+	successCode := m.Run()
+
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -845,6 +845,14 @@ monitoring:
         - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
         compatible:
           flat: true
+          hns: false
+          zonal: false
+        run: "TestPromGrpcMetricsSuite"
+        run_on_gke: true
+      - flags:
+        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"
+        compatible:
+          flat: false
           hns: true
           zonal: true
         run: "TestPromGrpcMetricsSuite"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -810,7 +810,7 @@ monitoring:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log"
+        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--log-file=/gcsfuse-tmp/monitoring.log"
         compatible:
           flat: true
           hns: false
@@ -818,7 +818,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log"
+        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--log-file=/gcsfuse-tmp/monitoring_hns.log"
         compatible:
           flat: false
           hns: true
@@ -826,7 +826,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log"
+        - "--prometheus-port=9191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/prom_buffered_read.log"
         compatible:
           flat: true
           hns: false
@@ -834,7 +834,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"
+        - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"
         compatible:
           flat: false
           hns: true
@@ -842,7 +842,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics=true,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
         compatible:
           flat: true
           hns: false
@@ -850,7 +850,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics=true,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"
         compatible:
           flat: false
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -810,7 +810,7 @@ monitoring:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--prometheus-port=9190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring.log"
+        - "--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log"
         compatible:
           flat: true
           hns: false
@@ -818,7 +818,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring_hns.log"
+        - "--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log"
         compatible:
           flat: false
           hns: true
@@ -842,7 +842,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
+        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
         compatible:
           flat: true
           hns: false
@@ -850,7 +850,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"
+        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log"
         compatible:
           flat: false
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -804,3 +804,48 @@ rapid_appends:
           hns: false
           zonal: true
         run_on_gke: true
+
+monitoring:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+        - "--prometheus-port=9190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring.log"
+        compatible:
+          flat: true
+          hns: false
+          zonal: false
+        run: "TestPromOTELSuite"
+        run_on_gke: true
+      - flags:
+        - "--prometheus-port=10190 --cache-dir=/tmp/gcsfuse-cache --log-file=/gcsfuse-tmp/monitoring_hns.log"
+        compatible:
+          flat: false
+          hns: true
+          zonal: true
+        run: "TestPromOTELSuite"
+        run_on_gke: true
+      - flags:
+        - "--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log"
+        compatible:
+          flat: true
+          hns: false
+          zonal: false
+        run: "TestPromBufferedReadSuite"
+        run_on_gke: true
+      - flags:
+        - "--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log"
+        compatible:
+          flat: false
+          hns: true
+          zonal: true
+        run: "TestPromBufferedReadSuite"
+        run_on_gke: true
+      - flags:
+        - "--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --log-file=/gcsfuse-tmp/prom_grpc_metrics.log"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: "TestPromGrpcMetricsSuite"
+        run_on_gke: true


### PR DESCRIPTION
### Description
This PR includes changes to migrate monitoring test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse csi driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of monitoring package so it can use config file.

### Link to the issue in case of a bug fix.
[b/467269173](https://buganizer.corp.google.com/issues/467269173)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
