### PR TITLE
refactor(metrics): Remove reader attribute from gcs/read_bytes_count

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -303,7 +303,7 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcs
 	defer func() {
 		dur := time.Since(start)
 		p.metricHandle.BufferedReadReadLatency(ctx, dur)
-		p.metricHandle.GcsReadBytesCount(int64(bytesRead), metrics.ReaderBufferedAttr)
+		p.metricHandle.GcsReadBytesCount(int64(bytesRead))
 		if err == nil || errors.Is(err, io.EOF) {
 			logger.Tracef("%.13v -> ReadAt(): Ok(%v)", reqID, dur)
 		}

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -196,7 +196,7 @@ func TestReadFile_BufferedReadMetrics(t *testing.T) {
 
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeBufferedAttr))), int64(len(content)))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(attribute.String("reader", string(metrics.ReaderBufferedAttr))), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "buffered_read/read_latency", attribute.NewSet(), uint64(1))
 }
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -240,7 +240,7 @@ type monitoringReadCloser struct {
 
 func (mrc *monitoringReadCloser) Read(p []byte) (n int, err error) {
 	n, err = mrc.wrapped.Read(p)
-	mrc.metricHandle.GcsReadBytesCount(int64(n), metrics.ReaderOthersAttr)
+	mrc.metricHandle.GcsReadBytesCount(int64(n))
 	return
 }
 

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -118,14 +118,6 @@ const (
 	ReadTypeUnknownAttr    ReadType = "Unknown"
 )
 
-// Reader is a custom type for the reader attribute.
-type Reader string
-
-const (
-	ReaderBufferedAttr Reader = "Buffered"
-	ReaderOthersAttr   Reader = "Others"
-)
-
 // Reason is a custom type for the reason attribute.
 type Reason string
 
@@ -182,7 +174,7 @@ type MetricHandle interface {
 	GcsDownloadBytesCount(inc int64, readType ReadType)
 
 	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
-	GcsReadBytesCount(inc int64, reader Reader)
+	GcsReadBytesCount(inc int64)
 
 	// GcsReadCount - Specifies the number of gcs reads made along with type - Sequential/Random
 	GcsReadCount(inc int64, readType ReadType)

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -167,12 +167,6 @@
   description: "The cumulative number of bytes read from GCS objects."
   unit: "By"
   type: "int_counter"
-  attributes:
-  - attribute-name: reader
-    attribute-type: string
-    values: &reader_types_list
-    - "Buffered"
-    - "Others"
 
 - metric-name: "gcs/read_count"
   description: "Specifies the number of gcs reads made along with type - Sequential/Random"

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -41,7 +41,7 @@ func (*noopMetrics) FsOpsLatency(ctx context.Context, latency time.Duration, fsO
 
 func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsReadBytesCount(inc int64, reader Reader) {}
+func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}
 

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4658,72 +4658,28 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 }
 
 func TestGcsReadBytesCount(t *testing.T) {
-	tests := []struct {
-		name     string
-		f        func(m *otelMetrics)
-		expected map[attribute.Set]int64
-	}{
-		{
-			name: "reader_Buffered",
-			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Buffered")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reader", "Buffered")): 5,
-			},
-		},
-		{
-			name: "reader_Others",
-			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Others")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reader", "Others")): 5,
-			},
-		}, {
-			name: "multiple_attributes_summed",
-			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Buffered")
-				m.GcsReadBytesCount(2, "Others")
-				m.GcsReadBytesCount(3, "Buffered")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reader", "Buffered")): 8,
-				attribute.NewSet(attribute.String("reader", "Others")): 2,
-			},
-		},
-		{
-			name: "negative_increment",
-			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(-5, "Buffered")
-				m.GcsReadBytesCount(2, "Buffered")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reader", "Buffered")): 2},
-		},
-	}
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			encoder := attribute.DefaultEncoder()
-			m, rd := setupOTel(ctx, t)
+	m.GcsReadBytesCount(1024)
+	m.GcsReadBytesCount(2048)
+	waitForMetricsProcessing()
 
-			tc.f(m)
-			waitForMetricsProcessing()
+	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok := metrics["gcs/read_bytes_count"]
+	require.True(t, ok, "gcs/read_bytes_count metric not found")
+	s := attribute.NewSet()
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
 
-			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-			metric, ok := metrics["gcs/read_bytes_count"]
-			if len(tc.expected) == 0 {
-				assert.False(t, ok, "gcs/read_bytes_count metric should not be found")
-				return
-			}
-			require.True(t, ok, "gcs/read_bytes_count metric not found")
-			expectedMap := make(map[string]int64)
-			for k, v := range tc.expected {
-				expectedMap[k.Encoded(encoder)] = v
-			}
-			assert.Equal(t, expectedMap, metric)
-		})
-	}
+	// Test negative increment
+	m.GcsReadBytesCount(-100)
+	waitForMetricsProcessing()
+
+	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok = metrics["gcs/read_bytes_count"]
+	require.True(t, ok, "gcs/read_bytes_count metric not found after negative increment")
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
 }
 
 func TestGcsReadCount(t *testing.T) {

--- a/tools/integration_tests/monitoring/buffered_read_prom_test.go
+++ b/tools/integration_tests/monitoring/buffered_read_prom_test.go
@@ -62,7 +62,7 @@ func (testSuite *PromBufferedReadTest) TestBufferedReadMetrics() {
 	_, err := operations.ReadFile(path.Join(testSuite.mountPoint, "hello/hello.txt"))
 
 	require.NoError(testSuite.T(), err)
-	assertNonZeroCountMetric(testSuite.T(), "gcs_read_bytes_count", "reader", "Buffered")
+	assertNonZeroCountMetric(testSuite.T(), "gcs_read_bytes_count", "", "")
 	assertNonZeroCountMetric(testSuite.T(), "gcs_download_bytes_count", "read_type", "Buffered")
 	assertNonZeroHistogramMetric(testSuite.T(), "buffered_read/read_latency", "", "")
 }


### PR DESCRIPTION
### Description
This PR removes the `reader` attribute from the `gcs/read_bytes_count metric`.

The addition of the reader attribute, with possible values "Buffered" and "Others," triples the cardinality of the metric. This increases the cardinality from 3312 to 9936, which exceeds the recommended limit of 5,000 unique streams per target.

Removing this attribute will bring the metric's cardinality back within the recommended limits, preventing potential issues with metric collection and querying.

More detailed analysis in the document: https://docs.google.com/document/d/11hRZvXwmLIzyD72WOnb91YDMKHMH7zBj_uP8qidemQU/edit?usp=sharing&resourcekey=0-MqUOcxn5wDAd8nsNTMx5AQ

### Link to the issue in case of a bug fix.
https://b.corp.google.com/467884761

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
