### PR TITLE
fix(dns-cache): Fix "udp: write operation not permitted" error on RHEL machines.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jacobsa/syncutil v0.0.0-20180201203307-228ac8e5a6c3
 	github.com/jacobsa/timeutil v0.0.0-20170205232429-577e5acbbcf6
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
-	github.com/ncruces/go-dns v1.2.7
+	github.com/ncruces/go-dns v1.3.0
 	github.com/pkg/xattr v0.4.10
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/minio/minio-go/v7 v7.0.86 h1:DcgQ0AUjLJzRH6y/HrxiZ8CXarA70PAIufXHodP4
 github.com/minio/minio-go/v7 v7.0.86/go.mod h1:VbfO4hYwUu3Of9WqGLBZ8vl3Hxnxo4ngxK4hzQDf4x4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/ncruces/go-dns v1.2.7 h1:NMA7vFqXUl+nBhGFlleLyo2ni3Lqv3v+qFWZidzRemI=
-github.com/ncruces/go-dns v1.2.7/go.mod h1:SqmhVMBd8Wr7hsu3q6yTt6/Jno/xLMrbse/JLOMBo1Y=
+github.com/ncruces/go-dns v1.3.0 h1:5+dlEuNjCHeWU6jEdpXppVu6fgGkbRLH+FEBMt/biRM=
+github.com/ncruces/go-dns v1.3.0/go.mod h1:8RZXGOalSIFiyUyE74TEkw0B+u8qL6AOzTQkncXgfzE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/xattr v0.4.10 h1:Qe0mtiNFHQZ296vRgUjRCoPHPqH7VdTOrZx3g0T+pGA=


### PR DESCRIPTION
### Description
Upgrade go-dns to v1.3.0 that has the fix for "udp: write operation not permitted" error.

Basically, it brings in this change: https://github.com/ncruces/go-dns/pull/17

### Perf
| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW | RandWrite BW |
|--------|------------|--------------|------------|-------------|--------------|
| Master |  0.25MiB   | 567.64MiB/s  | 1.16MiB/s  |  83.95MiB/s |   1.2MiB/s   |
|   PR   |  0.25MiB   | 607.12MiB/s  | 1.26MiB/s  |  81.7MiB/s  |  1.16MiB/s   |
|        |            |              |            |             |              |
|        |            |              |            |             |              |
| Master | 48.828MiB  | 4768.09MiB/s | 79.85MiB/s | 1366.0MiB/s |  76.49MiB/s  |
|   PR   | 48.828MiB  | 4768.31MiB/s | 77.9MiB/s  | 1628.5MiB/s |  77.4MiB/s   |
|        |            |              |            |             |              |
|        |            |              |            |             |              |
| Master | 976.562MiB | 4799.55MiB/s | 37.96MiB/s | 816.22MiB/s |  38.96MiB/s  |
|   PR   | 976.562MiB | 4793.43MiB/s | 38.65MiB/s | 1030.8MiB/s |  38.07MiB/s  |

### Link to the issue in case of a bug fix.
b/464895026

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
