### PR TITLE
chore(CD script): changes to script to persist gcsfuse logs and using custom bucket when provided

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -313,8 +313,7 @@ fi
 git checkout ${COMMIT_HASH} |& tee -a ${LOG_FILE}
 if [[ "${BUCKET_NAME_TO_USE}" != "gcsfuse-release-packages" ]]; then
     echo "Installing GCSFuse from source..."
-    VERSION_TAG=$(sed -n 1p ~/details.txt)
-    GOOS=linux GOARCH=${architecture} go run tools/build_gcsfuse/main.go . . "${VERSION_TAG}"
+    GOOS=linux GOARCH=${architecture} go run tools/build_gcsfuse/main.go . . "${VERSION}"
     sudo cp bin/* /usr/bin/
     sudo cp sbin/* /usr/sbin/
 fi
@@ -597,7 +596,7 @@ function log_based_on_exit_status() {
     gcloud storage cp $logfile gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
     done
 
-    gcloud storage cp -R "$KOKORO_ARTIFACTS_DIR" gs://${BUCKET_NAME_TO_USE}/v$({VERSION}/
+    gcloud storage cp -R "$KOKORO_ARTIFACTS_DIR" gs://${BUCKET_NAME_TO_USE}/v${VERSION}/
 }
 
 # Function to run emulator-based E2E tests and log results.
@@ -609,7 +608,7 @@ function run_e2e_tests_for_emulator_and_log() {
         echo "Test failures detected in emulator based tests." &>> ~/logs-emulator.txt
     else
         touch success-emulator.txt
-        gcloud storage cp success-emulator.txt gs://${BUCKET_NAME_TO_USE}/v{VERSION})/${VM_INSTANCE_NAME}/
+        gcloud storage cp success-emulator.txt gs://${BUCKET_NAME_TO_USE}/v{VERSION}/${VM_INSTANCE_NAME}/
     fi
     gcloud storage cp ~/logs-emulator.txt gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
 }


### PR DESCRIPTION
### Description

This pull request introduces support for custom GCS buckets and improving log persistence. 
1. The changes allow the script to fetch and utilize a user-defined GCS bucket for managing release packages and test artifacts, providing flexibility for running the script concurrently by different users for testing without interfering with the CD pipeline. 
2. Furthermore, it ensures that GCSFuse logs are consistently captured and uploaded to the specified GCS bucket, streamlining the debugging process for test failures.

Highlights
- Custom GCS Bucket Support: The CD script now dynamically determines the GCS bucket to use for release packages and test artifacts. It fetches a "custom_bucket" from VM metadata, if available, and falls back to the default "gcsfuse-release-packages" bucket otherwise.
- Dynamic GCSFuse Installation: When a custom GCS bucket is specified, the script will now build and install GCSFuse directly from source. This allows the script to be run manually without any dependency on the release pipeline.
- Persistent GCSFuse Logs: A "KOKORO_ARTIFACTS_DIR" has been introduced and configured to store GCSFuse logs. The contents of this directory are now uploaded to the designated GCS bucket, ensuring that detailed logs are persisted for easier debugging and analysis of test runs.

### Link to the issue in case of a bug fix.
b/468970197, b/463954850

### Testing details
1. Manual - Manually ran the script to validate that it is working
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA