### PR TITLE
fix(integration_tests): add nil check in write_test

### DIFF
--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -69,6 +69,10 @@ func validateObjectAttributes(attr1, attr2 *storage.ObjectAttrs, t *testing.T) {
 	const sizeBeforeOperation = int64(len(tempFileContent))
 	const sizeAfterOperation = sizeBeforeOperation + int64(len(appendContent))
 	storageClass := "STANDARD"
+	if attr1 == nil || attr2 == nil {
+		t.Fatalf("attr1 or attr2 is nil. attr1: %v, attr2: %v", attr1, attr2)
+	}
+
 	if setup.IsZonalBucketRun() {
 		storageClass = "RAPID"
 	}


### PR DESCRIPTION
### Description

This PR fixes a potential nil pointer dereference in the `validateObjectAttributes` function in the `write_test.go` integration test. The function did not check if the `attr1` or `attr2` arguments were nil before accessing their fields, which could lead to a panic.

This change adds a nil check at the beginning of the function and provides a descriptive error message if either of the attributes is nil.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/468986239

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.

No.
