### PR TITLE
feat(tailing reads):  E2E tests for updating inode with latest size

### DIFF
--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -855,3 +855,14 @@ func CreateFileOnDiskAndCopyToMntDir(t *testing.T, filePathInLocalDisk string, f
 		t.Errorf("Error in copying file:%v", err)
 	}
 }
+
+// StatFileOrFatal stats the given file path and returns the syscall.Stat_t struct.
+// It fails the test if os.Stat or the type assertion fails.
+func StatFileOrFatal(filePath string, t *testing.T) *syscall.Stat_t {
+	t.Helper()
+	fi, err := os.Stat(filePath)
+	require.NoError(t, err)
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	return stat
+}


### PR DESCRIPTION
### Description
This PR includes E2E tests for https://github.com/GoogleCloudPlatform/gcsfuse/pull/4162

The new tests verify two key scenarios:

- The inode ID is preserved when an object is appended to remotely (size increases, but generation does not change) .
- A new inode ID is created when an object is overwritten remotely (generation changes)

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Updated and automated.

### Any backward incompatible change? If so, please explain.
