### PR TITLE
ci(orbax-benchmark): Use release-channel=rapid and leverage host-network support in GKE

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/pod.yaml.template
@@ -64,3 +64,4 @@ spec:
       volumeAttributes:
         bucketName: "$bucket_name"
         mountOptions: "read_ahead_kb=1024,disable-autoconfig"
+        hostNetworkPodKSA: "true"

--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/run_benchmark.py
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/run_benchmark.py
@@ -277,7 +277,7 @@ async def setup_gke_cluster(project_id, zone, cluster_name, network_name, subnet
             await create_node_pool_async(project_id, zone, cluster_name, node_pool_name, machine_type, reservation_name)
     else:
         await create_network(project_id, network_name, subnet_name, region, DEFAULT_MTU)
-        cmd = ["gcloud", "container", "clusters", "create", cluster_name, f"--project={project_id}", f"--zone={zone}", f"--network={network_name}", f"--subnetwork={subnet_name}", f"--workload-pool={project_id}.svc.id.goog", "--addons=GcsFuseCsiDriver", "--num-nodes=1"]
+        cmd = ["gcloud", "container", "clusters", "create", cluster_name, "--release-channel=rapid", f"--project={project_id}", f"--zone={zone}", f"--network={network_name}", f"--subnetwork={subnet_name}", f"--workload-pool={project_id}.svc.id.goog", "--addons=GcsFuseCsiDriver", "--num-nodes=1"]
         await run_command_async(cmd)
         await create_node_pool_async(project_id, zone, cluster_name, node_pool_name, machine_type, reservation_name)
 


### PR DESCRIPTION
### Description
Use release-channel=rapid to use latest GKE.
Leverage host-network support in GKE

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
