### PR TITLE
chore: update test config to skip unfinalized object package for non-zonal bucket

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -535,16 +535,16 @@ unfinalized_object:
       - flags:
         - "--metadata-cache-ttl-secs=-1"
         compatible:
-          flat: true
-          hns: true
+          flat: false
+          hns: false
           zonal: true
         run: TestUnfinalizedObjectReadTest
         run_on_gke: true
       - flags:
         - "--metadata-cache-ttl-secs=0"
         compatible:
-          flat: true
-          hns: true
+          flat: false
+          hns: false
           zonal: true
         run: TestUnfinalizedObjectOperationTest
         run_on_gke: true


### PR DESCRIPTION
### Description
Unfinalized object test package is strictly specific for zonal buckets, so not compatible with HNS/Flat bucket.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
