### PR TITLE
fix:read cache tests for HNS buckets in GKE environment

### DIFF
--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -97,7 +97,11 @@ func setupLogFileAndCacheDir(testName string) {
 		if setup.ConfigFile() == "" {
 			// TODO: clean this up when GKE test migration completes.
 			logFilePath = "/tmp/gcsfuse_read_cache_test_logs/log.json"
-			testEnv.cacheDirPath = "/tmp/cache-dir-read-cache-hns-false"
+			if testEnv.bucketType == setup.FlatBucket {
+				testEnv.cacheDirPath = "/tmp/cache-dir-read-cache-hns-false"
+			} else {
+				testEnv.cacheDirPath = "/tmp/cache-dir-read-cache-hns-true"
+			}
 		}
 	}
 	testEnv.cfg.LogFile = logFilePath


### PR DESCRIPTION
### Description

Read cache tests in GKE environment were broken for HNS buckets due to wrong bucket name. The fix was verified for v3.5.x release, merging the change to master.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/463626752#comment2

### Testing details
1. Manual - tested in GKE env for v3.5 release.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA