### PR TITLE
feat(tracing): Add a global text map propagator for GCSFuse tracing

### DIFF
--- a/internal/monitor/traceexporter.go
+++ b/internal/monitor/traceexporter.go
@@ -23,9 +23,18 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func initPropagators() {
+	props := propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	)
+	otel.SetTextMapPropagator(props)
+}
 
 // SetupTracing bootstraps the OpenTelemetry tracing pipeline.
 func SetupTracing(ctx context.Context, c *cfg.Config, mountID string) common.ShutdownFn {
@@ -36,6 +45,7 @@ func SetupTracing(ctx context.Context, c *cfg.Config, mountID string) common.Shu
 	}
 	if tp != nil {
 		otel.SetTracerProvider(tp)
+		initPropagators()
 		return shutdown
 	}
 


### PR DESCRIPTION
### Description
It is recommended to add a global TextMapPropagator for tracing to pass the trace context across service boundaries.

### Link to the issue in case of a bug fix.
b/469952719

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A