### PR TITLE
test: Temporarily disable failing managed_folders test

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -354,7 +354,8 @@ TEST_DIR_PARALLEL=(
 # These tests never become parallel as they are changing bucket permissions.
 TEST_DIR_NON_PARALLEL=(
   "readonly"
-  "managed_folders"
+  # TODO(b/469933367): Enable after fixing permission error due to race condition.
+  # "managed_folders"
   "readonly_creds"
   "list_large_dir"
 )
@@ -393,7 +394,8 @@ TEST_DIR_PARALLEL_ZONAL=(
 
 # For Zonal Buckets :  These tests never become parallel as they are changing bucket permissions.
 TEST_DIR_NON_PARALLEL_ZONAL=(
-  "managed_folders"
+  # TODO(b/469933367): Enable after fixing permission error due to race condition.
+  # "managed_folders"
   "readonly"
   "readonly_creds"
   "list_large_dir"


### PR DESCRIPTION
### Description
This PR temporarily disables the `managed_folders` tests in `tools/cd_scripts/e2e_test.sh` to resolve ongoing release failures.

The `TestManagedFolders_FolderAdminPermission` test suite is consistently failing with a `gcloud` authentication error when trying to set IAM policies on managed folders. By commenting out the "managed_folders" test, we can ensure the stability of the release pipeline while the underlying permission issues are being addressed.

### Link to the issue in case of a bug fix.
https://buganizer.corp.google.com/issues/469933367

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
