### PR TITLE
feat(async_read): adding hidden config to enable async_read

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -449,6 +449,8 @@ type FileCacheConfig struct {
 }
 
 type FileSystemConfig struct {
+	AsyncRead bool `yaml:"async-read"`
+
 	CongestionThreshold int64 `yaml:"congestion-threshold"`
 
 	DirMode Octal `yaml:"dir-mode"`
@@ -661,6 +663,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("anonymous-access", "", false, "This flag disables authentication.")
 
 	flagSet.StringP("app-name", "", "", "The application name of this mount.")
+
+	flagSet.BoolP("async-read", "", false, "When set to true, kernel read-ahead requests will be issued in parallel to GCSFuse. This happens when a file is being read sequentially and read-ahead is set to higher value.")
+
+	if err := flagSet.MarkHidden("async-read"); err != nil {
+		return err
+	}
 
 	flagSet.StringP("billing-project", "", "", "Project to use for billing when accessing a bucket enabled with \"Requester Pays\".")
 
@@ -1220,6 +1228,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("app-name", flagSet.Lookup("app-name")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.async-read", flagSet.Lookup("async-read")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -315,6 +315,16 @@ params:
     default: "4194304" # 4MiB
     hide-flag: true
 
+  - config-path: "file-system.async-read"
+    flag-name: "async-read"
+    type: "bool"
+    usage: >-
+      When set to true, kernel read-ahead requests will be issued in parallel
+      to GCSFuse. This happens when a file is being read sequentially and read-ahead
+      is set to higher value.
+    default: "false"
+    hide-flag: true
+
   - config-path: "file-system.congestion-threshold"
     flag-name: "congestion-threshold"
     type: "int"

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -176,6 +176,7 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		// Enables ReadDirPlus, allowing the kernel to retrieve directory entries and their
 		// attributes in a single operation.
 		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
+		EnableAsyncReads:  newConfig.FileSystem.AsyncRead,
 	}
 
 	// GCSFuse to Jacobsa Fuse Log Level mapping:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1240,6 +1240,40 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "Test file system async-read flag enabled.",
+			args: []string{"gcsfuse", "--async-read", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					DirMode:             0755,
+					FileMode:            0644,
+					FuseOptions:         []string{},
+					Gid:                 -1,
+					IgnoreInterrupts:    true,
+					ExperimentalODirect: false,
+					PreconditionErrors:  true,
+					Uid:                 -1,
+					AsyncRead:           true,
+				},
+			},
+		},
+		{
+			name: "Test file system async-read flag disabled.",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					DirMode:             0755,
+					FileMode:            0644,
+					FuseOptions:         []string{},
+					Gid:                 -1,
+					IgnoreInterrupts:    true,
+					ExperimentalODirect: false,
+					PreconditionErrors:  true,
+					Uid:                 -1,
+					AsyncRead:           false,
+				},
+			},
+		},
+		{
 			name: "cli_flag_overrides_config_file",
 			args: []string{"gcsfuse", "--config-file", createTempConfigFile(t, "machine-type: config-file-type"), "--machine-type=cli-type", "abc", "pqr"},
 			expectedConfig: &cfg.Config{


### PR DESCRIPTION
### Description
- Adding hidden config to enable async read.
- Works with higher `max-read-ahead-kb` > 1 MB and when application performs sequential read. As then only kernel async read-ahead comes into the picture.

### Link to the issue in case of a bug fix.
b/469191453

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
