### PR TITLE
refactor(e2e_test): Upload logs using a trap

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -177,6 +177,13 @@ sudo -u starterscriptuser bash -c '
 # Exit immediately if a command exits with a non-zero status.
 set -e
 # Print commands and their arguments as they are executed.
+
+function cleanup() {
+    echo "Performing cleanup..."
+    #Log results based on the collected exit statuses.
+    log_based_on_exit_status exit_status
+}
+trap cleanup EXIT
 set -x
 # GCSFuse test suite uses this environment variable to save failure logs at the specified location.
 export KOKORO_ARTIFACTS_DIR=/home/starterscriptuser/failure_logs
@@ -670,7 +677,4 @@ else
     fi
 
 fi
-#Log results based on the collected exit statuses.
-log_based_on_exit_status exit_status
-
 '


### PR DESCRIPTION
### Description
This PR refactors CD script to ensure that logs are always uploaded, even if the script fails. This is achieved by using a `trap` to call the `log_based_on_exit_status` function when the script exits.

Previously, the log upload was called at the end of the script, which meant that if the script exited prematurely due to an error, the logs would not be uploaded.

### Link to the issue in case of a bug fix.
b/470272958

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
