### PR TITLE
fix(tests): Make test directory names unique to avoid 429 errors

### DIFF
--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -212,8 +212,9 @@ func testdataCreateExplicitDir(t *testing.T, ctx context.Context, storageClient 
 func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs bool) string {
 	t.Helper()
 
-	testDirPathOnBucket := path.Join(setup.TestBucket(), t.Name())
-	testDirPath := path.Join(setup.MntDir(), t.Name())
+	testDirSuffix := setup.GenerateRandomString(4)
+	testDirPathOnBucket := path.Join(setup.TestBucket(), t.Name()+testDirSuffix)
+	testDirPath := path.Join(setup.MntDir(), t.Name()+testDirSuffix)
 
 	err := os.MkdirAll(testDirPath, 0755)
 	if err != nil {

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -213,10 +213,9 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 	t.Helper()
 
 	testDirSuffix := setup.GenerateRandomString(4)
-    testDir :=  t.Name()+testDirSuffix
+	testDir := t.Name() + testDirSuffix
 	testDirPathOnBucket := path.Join(setup.TestBucket(), testDir)
 	testDirPath := path.Join(setup.MntDir(), testDir)
-	testDirPath := path.Join(setup.MntDir(), t.Name()+testDirSuffix)
 
 	err := os.MkdirAll(testDirPath, 0755)
 	if err != nil {

--- a/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
+++ b/tools/integration_tests/list_large_dir/list_dir_with_twelve_thousand_files_test.go
@@ -213,7 +213,9 @@ func prepareTestDirectory(t *testing.T, withExplicitDirs bool, withImplicitDirs 
 	t.Helper()
 
 	testDirSuffix := setup.GenerateRandomString(4)
-	testDirPathOnBucket := path.Join(setup.TestBucket(), t.Name()+testDirSuffix)
+    testDir :=  t.Name()+testDirSuffix
+	testDirPathOnBucket := path.Join(setup.TestBucket(), testDir)
+	testDirPath := path.Join(setup.MntDir(), testDir)
 	testDirPath := path.Join(setup.MntDir(), t.Name()+testDirSuffix)
 
 	err := os.MkdirAll(testDirPath, 0755)

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -36,7 +36,7 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if err != nil {
 		t.Errorf("os.Stat error: %s, %v", objName, err)
 	}
-	statObjName := path.Join(setup.MntDir(), DirForOperationTests, oStat.Name())
+	statObjName := path.Join(path.Dir(objName), oStat.Name())
 	if objName != statObjName {
 		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
 	}

--- a/tools/integration_tests/operations/list_dir_test.go
+++ b/tools/integration_tests/operations/list_dir_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func createDirectoryStructureForTest(t *testing.T) {
-	testDir := setup.SetupTestDirectory(DirForOperationTests)
-
+func createDirectoryStructureForTest(testDir string, t *testing.T) {
 	// Directory structure
 	// testBucket/dirForOperationTests/directoryForListTest                                                                            -- Dir
 	// testBucket/dirForOperationTests/directoryForListTest/fileInDirectoryForListTest1		                                      -- File
@@ -66,7 +64,7 @@ func TestListDirectoryRecursively(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	// Create directory structure for testing.
-	createDirectoryStructureForTest(t)
+	createDirectoryStructureForTest(testDir, t)
 
 	// Recursively walk into directory and test.
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -137,7 +137,7 @@ func TestWriteAtEndOfFile(t *testing.T) {
 
 	setup.CompareFileContents(t, fileName, "line 1\nline 2\nline 3\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 }
 
 func TestWriteAtStartOfFile(t *testing.T) {
@@ -153,7 +153,7 @@ func TestWriteAtStartOfFile(t *testing.T) {
 
 	setup.CompareFileContents(t, fileName, "line 4\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 }
 
 func TestWriteAtRandom(t *testing.T) {
@@ -177,7 +177,7 @@ func TestWriteAtRandom(t *testing.T) {
 
 	setup.CompareFileContents(t, fileName, "line 1\nline 5\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 }
 
 func TestCreateFile(t *testing.T) {
@@ -193,7 +193,7 @@ func TestCreateFile(t *testing.T) {
 
 	setup.CompareFileContents(t, fileName, "line 1\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 }
 
 func TestAppendFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
@@ -202,13 +202,13 @@ func TestAppendFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 	fileName := path.Join(testDir, tempFileName)
 
 	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 	// Append to the file.
 	err := operations.WriteFileInAppendMode(fileName, appendContent)
 	if err != nil {
 		t.Errorf("Could not append to file: %v", err)
 	}
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 
 	// Validate object attributes are as expected.
 	validateObjectAttributes(attr1, attr2, t)
@@ -220,7 +220,7 @@ func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 	fileName := path.Join(testDir, tempFileName)
 
 	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 	// Over-write the file.
 	fh, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
 	}
 	operations.WriteAt(tempFileContent+appendContent, 0, fh, t)
 	operations.CloseFileShouldNotThrowError(t, fh)
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(path.Base(testDir), tempFileName), t)
 
 	// Validate object attributes are as expected.
 	validateObjectAttributes(attr1, attr2, t)

--- a/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
+++ b/tools/integration_tests/streaming_writes/common_streaming_writes_suite_test.go
@@ -30,6 +30,7 @@ type StreamingWritesSuite struct {
 	// filePath of the above file in the mounted directory.
 	filePath string
 	data     string
+	dirName  string
 	test_suite.TestifySuite
 }
 

--- a/tools/integration_tests/streaming_writes/empty_gcs_file_test.go
+++ b/tools/integration_tests/streaming_writes/empty_gcs_file_test.go
@@ -38,10 +38,11 @@ func (t *streamingWritesEmptyGCSFileTestSuite) SetupSubTest() {
 }
 
 func (t *streamingWritesEmptyGCSFileTestSuite) createEmptyGCSFile() {
+	t.dirName = path.Base(testEnv.testDirPath)
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	// Create an empty file on GCS.
-	CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "", t.T())
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "", t.T())
+	CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, "", t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, "", t.T())
 	t.filePath = path.Join(testEnv.testDirPath, t.fileName)
 	t.f1 = operations.OpenFileWithODirect(t.T(), t.filePath)
 }

--- a/tools/integration_tests/streaming_writes/local_file_test.go
+++ b/tools/integration_tests/streaming_writes/local_file_test.go
@@ -38,6 +38,7 @@ func (t *streamingWritesLocalFileTestSuite) SetupSubTest() {
 }
 
 func (t *streamingWritesLocalFileTestSuite) createLocalFile() {
+	t.dirName = path.Base(testEnv.testDirPath)
 	t.fileName = FileName1 + setup.GenerateRandomString(5)
 	t.filePath = path.Join(testEnv.testDirPath, t.fileName)
 	// Create a local file with O_DIRECT.

--- a/tools/integration_tests/streaming_writes/read_file_test.go
+++ b/tools/integration_tests/streaming_writes/read_file_test.go
@@ -33,7 +33,7 @@ func (t *StreamingWritesSuite) TestReadFileAfterSync() {
 	t.validateReadCall(t.f1, t.data)
 
 	// Close the file and validate that the file is created on GCS.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, t.data, t.T())
 }
 
 func (t *StreamingWritesSuite) TestReadBeforeFileIsFlushed() {
@@ -44,7 +44,7 @@ func (t *StreamingWritesSuite) TestReadBeforeFileIsFlushed() {
 	t.validateReadCall(t.f1, t.data)
 
 	// Validate if correct content is uploaded to GCS after read error.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, t.data, t.T())
 }
 
 func (t *StreamingWritesSuite) TestReadBeforeSyncThenWriteAgainAndRead() {
@@ -56,13 +56,13 @@ func (t *StreamingWritesSuite) TestReadBeforeSyncThenWriteAgainAndRead() {
 	operations.WriteAt(t.data, int64(len(t.data)), t.f1, t.T())
 	t.validateReadCall(t.f1, t.data+t.data)
 	// Validate if correct content is uploaded to GCS after read.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, t.data+t.data, t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, t.data+t.data, t.T())
 }
 
 func (t *StreamingWritesSuite) TestReadAfterFlush() {
 	// Write data to file and flush.
 	operations.WriteAt(t.data, 0, t.f1, t.T())
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, t.data, t.T())
 
 	// Perform read and validate the contents.
 	var err error

--- a/tools/integration_tests/streaming_writes/rename_file_test.go
+++ b/tools/integration_tests/streaming_writes/rename_file_test.go
@@ -36,10 +36,10 @@ func (t *StreamingWritesSuite) TestRenameBeforeFileIsFlushed() {
 	// Validate that move didn't throw any error.
 	require.NoError(t.T(), err)
 	// Verify the new object contents.
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, newFile, t.data+t.data, t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, newFile, t.data+t.data, t.T())
 	require.NoError(t.T(), t.f1.Close())
 	// Check if old object is deleted.
-	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, t.T())
+	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, t.T())
 }
 
 func (t *StreamingWritesSuite) TestSyncAfterRenameSucceeds() {
@@ -57,8 +57,8 @@ func (t *StreamingWritesSuite) TestSyncAfterRenameSucceeds() {
 	// Verify that sync succeeds after rename.
 	require.NoError(t.T(), err)
 	// Verify the new object contents.
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, newFile, string(t.data), t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, newFile, string(t.data), t.T())
 	require.NoError(t.T(), t.f1.Close())
 	// Check if old object is deleted.
-	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, t.T())
+	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, t.T())
 }

--- a/tools/integration_tests/streaming_writes/setup_test.go
+++ b/tools/integration_tests/streaming_writes/setup_test.go
@@ -35,6 +35,7 @@ type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
 	testDirPath   string
+	dirName       string
 	cfg           test_suite.TestConfig
 }
 
@@ -81,6 +82,7 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
 	flagsSet := setup.BuildFlagSets(testEnv.cfg, bucketType, "")
+	testEnv.dirName = testDirName
 	setup.SetUpTestDirForTestBucket(&testEnv.cfg)
 
 	successCode := static_mounting.RunTestsWithConfigFile(&testEnv.cfg, flagsSet, m)

--- a/tools/integration_tests/streaming_writes/symlink_file_test.go
+++ b/tools/integration_tests/streaming_writes/symlink_file_test.go
@@ -39,7 +39,7 @@ func (t *StreamingWritesSuite) TestCreateSymlinkForLocalFileAndReadFromSymlink()
 	t.validateReadCall(symlink_fh, t.data)
 
 	// Close the file and validate that the file is created on GCS.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, t.data, t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, t.data, t.T())
 }
 
 func (t *StreamingWritesSuite) TestReadingFromSymlinkForDeletedLocalFile() {
@@ -59,7 +59,7 @@ func (t *StreamingWritesSuite) TestReadingFromSymlinkForDeletedLocalFile() {
 	// Remove filePath and then close the fileHandle to avoid syncing to GCS.
 	operations.RemoveFile(t.filePath)
 	operations.CloseFileShouldNotThrowError(t.T(), t.f1)
-	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, t.T())
+	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, t.T())
 	// Reading symlink should fail.
 	_, err = os.Stat(symlink)
 	assert.Error(t.T(), err)

--- a/tools/integration_tests/streaming_writes/truncate_file_test.go
+++ b/tools/integration_tests/streaming_writes/truncate_file_test.go
@@ -33,7 +33,7 @@ func (t *StreamingWritesSuite) TestTruncate() {
 	// Verify that GCSFuse is returning correct file size before the file is uploaded.
 	operations.VerifyStatFile(t.filePath, int64(truncateSize), FilePerms, t.T())
 	// Close the file and validate that the file is created on GCS.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, string(data[:]), t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, string(data[:]), t.T())
 }
 
 func (t *StreamingWritesSuite) TestTruncateNegative() {
@@ -85,7 +85,7 @@ func (t *StreamingWritesSuite) TestWriteAfterTruncate() {
 			data[tc.offset] = newData[0]
 			data[tc.offset+1] = newData[1]
 			// Close the file and validate that the file is created on GCS.
-			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, string(data[:]), t.T())
+			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, string(data[:]), t.T())
 		})
 	}
 
@@ -123,7 +123,7 @@ func (t *StreamingWritesSuite) TestWriteAndTruncate() {
 			require.NoError(t.T(), err)
 			operations.VerifyStatFile(t.filePath, tc.truncateSize, FilePerms, t.T())
 			// Close the file and validate that the file is created on GCS.
-			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, tc.finalContent, t.T())
+			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, tc.finalContent, t.T())
 		})
 	}
 }
@@ -167,7 +167,7 @@ func (t *StreamingWritesSuite) TestWriteTruncateWrite() {
 
 			operations.VerifyStatFile(t.filePath, int64(len(tc.finalContent)), FilePerms, t.T())
 			// Close the file and validate that the file is created on GCS.
-			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, tc.finalContent, t.T())
+			CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, tc.finalContent, t.T())
 		})
 	}
 }
@@ -180,10 +180,10 @@ func (t *StreamingWritesSuite) TestTruncateDownAndDeleteFile() {
 	err := t.f1.Truncate(3)
 	require.NoError(t.T(), err)
 	operations.VerifyStatFile(t.filePath, 3, FilePerms, t.T())
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "foobar", t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, "foobar", t.T())
 
 	err = os.Remove(t.filePath)
 
 	require.NoError(t.T(), err)
-	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, t.T())
+	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, t.T())
 }

--- a/tools/integration_tests/streaming_writes/write_file_test.go
+++ b/tools/integration_tests/streaming_writes/write_file_test.go
@@ -30,8 +30,8 @@ func (t *StreamingWritesSuite) TestOutOfOrderWriteSyncsFileToGcs() {
 	// Perform out of order write.
 	operations.WriteAt("foo", 3, t.f1, t.T())
 
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "foobar", t.T())
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, testDirName, t.fileName, "foofoo", t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, "foobar", t.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, t.f1, t.dirName, t.fileName, "foofoo", t.T())
 }
 
 func (t *StreamingWritesSuite) TestOutOfOrderWriteSyncsFileToGcsAndDeletingFileDeletesFileFromGcs() {
@@ -40,10 +40,10 @@ func (t *StreamingWritesSuite) TestOutOfOrderWriteSyncsFileToGcsAndDeletingFileD
 	operations.VerifyStatFile(t.filePath, int64(len("foobar")), FilePerms, t.T())
 	// Perform out of order write.
 	operations.WriteAt("foo", 3, t.f1, t.T())
-	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "foobar", t.T())
+	ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, "foobar", t.T())
 
 	err := os.Remove(t.filePath)
 
 	require.NoError(t.T(), err)
-	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, t.T())
+	ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, t.dirName, t.fileName, t.T())
 }

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -147,7 +147,7 @@ func SetupFileInTestDirectory(ctx context.Context, storageClient *storage.Client
 }
 
 func SetupTestDirectory(ctx context.Context, storageClient *storage.Client, testDirName string) string {
-	testDirPath := path.Join(setup.MntDir(), testDirName)
+	testDirPath := path.Join(setup.MntDir(), testDirName+setup.GenerateRandomString(4))
 	err := DeleteAllObjectsWithPrefix(ctx, storageClient, path.Join(setup.OnlyDirMounted(), testDirName))
 	if err != nil {
 		log.Printf("Failed to clean up test directory: %v", err)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -489,7 +489,7 @@ func CleanUpDir(directoryPath string) {
 // cleaning up any content present. It takes a testDirName which can include
 // slashes to create nested directories (e.g., "a/b/c").
 func SetupTestDirectory(testDirName string) string {
-	testDirPath := path.Join(MntDir(), testDirName)
+	testDirPath := path.Join(MntDir(), testDirName+GenerateRandomString(4))
 	err := os.MkdirAll(testDirPath, DirPermission_0755)
 	if err != nil && !strings.Contains(err.Error(), "file exists") {
 		log.Printf("Error while setting up directory %s for testing: %v", testDirPath, err)
@@ -501,7 +501,7 @@ func SetupTestDirectory(testDirName string) string {
 // SetupTestDirectoryRecursive recursively creates a testDirectory in the mounted directory and cleans up
 // any content present in it.
 func SetupTestDirectoryRecursive(testDirName string) string {
-	testDirPath := path.Join(MntDir(), testDirName)
+	testDirPath := path.Join(MntDir(), testDirName+GenerateRandomString(4))
 	err := os.MkdirAll(testDirPath, DirPermission_0755)
 	if err != nil && !strings.Contains(err.Error(), "file exists") {
 		log.Printf("Error while setting up directory %s for testing: %v", testDirPath, err)


### PR DESCRIPTION
**Description:**

We were observing `googleapi: Error 429: rateLimitExceeded` errors in our integration tests. This was caused by multiple tests in the same suite using the same directory names, leading to a high rate of object mutation operations (create, update, and delete) on the same GCS objects.

**Error Message:**
```
googleapi: Error 429: The object release-test-rhel-9-arm64-parallel/FlagOptimizationsTests/ exceeded the rate limit for object mutation operations (create, update, and delete). Please reduce your request rate. See https://cloud.google.com/storage/docs/gcs429., rateLimitExceeded
```

This PR fixes the issue by making the test directory names unique. A random suffix is now appended while creating test directories . This ensures that each test run operates on a unique set of GCS objects, thus avoiding the rate limit.

### Link to the issue in case of a bug fix.
b/470281785

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
