### PR TITLE
feat(gRPC-metrics): enable gRPC metrics via Go-SDK inbuilt metrics-exporter in GCE

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -145,16 +145,15 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 	clientOpts = append(clientOpts, option.WithGRPCConnectionPool(clientConfig.GrpcConnPoolSize))
 	clientOpts = append(clientOpts, option.WithUserAgent(clientConfig.UserAgent))
 
-	if clientConfig.EnableGrpcMetrics {
+	if clientConfig.EnableGrpcMetrics && clientConfig.IsGKE {
 		// Pass the OpenTelemetry MeterProvider to the Go storage client,
 		// using the new WithMeterProvider client option.
-		// TODO - Gracefully handle gRPC metrics outside of GKE.
 		mp := otel.GetMeterProvider()
 		if sdkmp, ok := mp.(*sdkmetric.MeterProvider); ok {
 			// pass in if sdkmp is of type *sdkmetric.MeterProvider (not a No-op)
 			clientOpts = append(clientOpts, experimental.WithMeterProvider(sdkmp))
 		}
-	} else {
+	} else if !clientConfig.EnableGrpcMetrics {
 		clientOpts = append(clientOpts, storage.WithDisabledClientMetrics())
 	}
 


### PR DESCRIPTION
### Description
Currently, the grpc-metrics use the existing GCSFuse exporters when enable-grpc-metrics is true. However, in GCE environment, we'd like grpc-metrics to be exported via the Go SDK inbuilt exporter as opposed to using the GCSFuse exporter. This is required to ensure that these metrics get categorized correctly and remain free to the end-users.

### Link to the issue in case of a bug fix.
b/471097206

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No