### PR TITLE
feat: Making MRD Reader compatible to integrate with REadmanager

### DIFF
--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -162,13 +162,13 @@ func (gr *GCSReader) read(ctx context.Context, readReq *gcsx.GCSReaderRequest) (
 			// Calculate the end offset based on previous read requests.
 			// It will be used if a new range reader needs to be created.
 			readReq.EndOffset = gr.getEndOffset(readReq.Offset)
-			readResp, err = gr.rangeReader.ReadAt(ctx, readReq)
+			readResp, err = gr.rangeReader.Read(ctx, readReq)
 			return readResp.Size, err
 		}
 		gr.mu.Unlock()
 	}
 
-	readResp, err = gr.mrr.ReadAt(ctx, readReq)
+	readResp, err = gr.mrr.Read(ctx, readReq)
 	return readResp.Size, err
 }
 

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -111,7 +111,7 @@ func (rr *RangeReader) closeReader() {
 	}
 }
 
-func (rr *RangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (gcsx.ReadResponse, error) {
+func (rr *RangeReader) Read(ctx context.Context, req *gcsx.GCSReaderRequest) (gcsx.ReadResponse, error) {
 	var (
 		readResponse gcsx.ReadResponse
 		err          error

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -101,7 +101,7 @@ func (t *rangeReaderTest) readAt(dst []byte, offset int64) (gcsx.ReadResponse, e
 	}
 	t.rangeReader.checkInvariants()
 	defer t.rangeReader.checkInvariants()
-	return t.rangeReader.ReadAt(t.ctx, req)
+	return t.rangeReader.Read(t.ctx, req)
 }
 
 func (t *rangeReaderTest) mockNewReaderWithHandleCallForTestBucket(start uint64, limit uint64, rd gcs.StorageReader) {
@@ -443,7 +443,7 @@ func (t *rangeReaderTest) Test_ReadAt_PropagatesCancellation() {
 	readReturned := make(chan struct{})
 
 	go func() {
-		_, _ = t.rangeReader.ReadAt(ctx, &gcsx.GCSReaderRequest{
+		_, _ = t.rangeReader.Read(ctx, &gcsx.GCSReaderRequest{
 			Buffer:    make([]byte, 2),
 			Offset:    0,
 			EndOffset: 2,
@@ -493,7 +493,7 @@ func (t *rangeReaderTest) Test_ReadAt_DoesntPropagateCancellationAfterReturning(
 	buf := make([]byte, bufSize)
 
 	// Successfully read two bytes using a context whose cancellation we control.
-	readResponse, err := t.rangeReader.ReadAt(ctx, &gcsx.GCSReaderRequest{
+	readResponse, err := t.rangeReader.Read(ctx, &gcsx.GCSReaderRequest{
 		Buffer:    buf,
 		Offset:    0,
 		ReadInfo:  &gcsx.ReadInfo{},
@@ -662,7 +662,7 @@ func (t *rangeReaderTest) Test_ReadAt_ForceCreateReader() {
 		EndOffset: offset + size,
 		ReadInfo:  &gcsx.ReadInfo{},
 	}
-	resp1, err := t.rangeReader.ReadAt(t.ctx, req1)
+	resp1, err := t.rangeReader.Read(t.ctx, req1)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(readSize), resp1.Size)
@@ -684,7 +684,7 @@ func (t *rangeReaderTest) Test_ReadAt_ForceCreateReader() {
 		ForceCreateReader: true,
 		ReadInfo:          &gcsx.ReadInfo{},
 	}
-	resp2, err := t.rangeReader.ReadAt(t.ctx, req2)
+	resp2, err := t.rangeReader.Read(t.ctx, req2)
 
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), int(readsize2), resp2.Size)

--- a/internal/gcsx/reader.go
+++ b/internal/gcsx/reader.go
@@ -113,5 +113,5 @@ type GCSReader interface {
 	// ReadAt reads data into the `Buffer` field of the provided `GCSReaderRequest`,
 	// starting from the specified offset and ending at the specified end offset.
 	// It returns a `ReadResponse` indicating the number of bytes successfully read and any error encountered.
-	ReadAt(ctx context.Context, req *GCSReaderRequest) (ReadResponse, error)
+	Read(ctx context.Context, req *GCSReaderRequest) (ReadResponse, error)
 }


### PR DESCRIPTION
Renamed ReadAt() to Read method in GCSReader interface. This is to make mrd_reader.go compatible with both GCSReader and Reader interfaces.
Added ReadAt() method in mrd_reader.go. This helps in integrating mrdReader with read_manager.go directly.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - done
2. Unit tests - done
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
