### PR TITLE
fix: Mark the enable-grpc-metrics flag as experimental.

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -585,7 +585,7 @@ type MetricsConfig struct {
 
 	CloudMetricsExportIntervalSecs int64 `yaml:"cloud-metrics-export-interval-secs"`
 
-	EnableGrpcMetrics bool `yaml:"enable-grpc-metrics"`
+	ExperimentalEnableGrpcMetrics bool `yaml:"experimental-enable-grpc-metrics"`
 
 	PrometheusPort int64 `yaml:"prometheus-port"`
 
@@ -828,8 +828,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-grpc-metrics", "", false, "Enables support for gRPC metrics")
-
 	flagSet.BoolP("enable-hns", "", true, "Enables support for HNS buckets")
 
 	if err := flagSet.MarkHidden("enable-hns"); err != nil {
@@ -875,6 +873,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")
 
 	if err := flagSet.MarkHidden("experimental-enable-dentry-cache"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("experimental-enable-grpc-metrics", "", false, "Enables support for gRPC metrics")
+
+	if err := flagSet.MarkHidden("experimental-enable-grpc-metrics"); err != nil {
 		return err
 	}
 
@@ -1359,10 +1363,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("metrics.enable-grpc-metrics", flagSet.Lookup("enable-grpc-metrics")); err != nil {
-		return err
-	}
-
 	if err := v.BindPFlag("enable-hns", flagSet.Lookup("enable-hns")); err != nil {
 		return err
 	}
@@ -1400,6 +1400,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.experimental-enable-dentry-cache", flagSet.Lookup("experimental-enable-dentry-cache")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metrics.experimental-enable-grpc-metrics", flagSet.Lookup("experimental-enable-grpc-metrics")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -920,11 +920,12 @@ params:
     usage: "Specifies the interval at which the metrics are uploaded to cloud monitoring"
     default: 0
 
-  - config-path: "metrics.enable-grpc-metrics"
-    flag-name: "enable-grpc-metrics"
+  - config-path: "metrics.experimental-enable-grpc-metrics"
+    flag-name: "experimental-enable-grpc-metrics"
     type: "bool"
     usage: "Enables support for gRPC metrics"
     default: false
+    hide-flag: true
 
   - config-path: "metrics.prometheus-port"
     flag-name: "prometheus-port"

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -166,7 +166,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		TracingEnabled:             cfg.IsTracingEnabled(newConfig),
 		EnableHTTPDNSCache:         newConfig.GcsConnection.EnableHttpDnsCache,
 		LocalSocketAddress:         newConfig.GcsConnection.ExperimentalLocalSocketAddress,
-		EnableGrpcMetrics:          newConfig.Metrics.EnableGrpcMetrics,
+		EnableGrpcMetrics:          newConfig.Metrics.ExperimentalEnableGrpcMetrics,
 		IsGKE:                      isGKE,
 	}
 	logger.Infof("UserAgent = %s\n", storageClientConfig.UserAgent)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1644,11 +1644,11 @@ func TestArgsParsing_MetricsFlags(t *testing.T) {
 		},
 		{
 			name: "enable_grpc_metrics_non_default",
-			args: []string{"gcsfuse", "--enable-grpc-metrics=false", "abc", "pqr"},
+			args: []string{"gcsfuse", "--experimental-enable-grpc-metrics=false", "abc", "pqr"},
 			expected: &cfg.MetricsConfig{
-				Workers:           3,
-				BufferSize:        256,
-				EnableGrpcMetrics: false,
+				Workers:                       3,
+				BufferSize:                    256,
+				ExperimentalEnableGrpcMetrics: false,
 			},
 		},
 	}

--- a/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
+++ b/tools/integration_tests/monitoring/prom_w_grpc_metrics_test.go
@@ -58,7 +58,7 @@ func (testSuite *PromGrpcMetricsTest) mount(bucketName string) error {
 	testSuite.T().Cleanup(func() { _ = os.RemoveAll(cacheDir) })
 
 	// Specify client protocol to "grpc" for gRPC metrics to be emitted and captured.
-	flags := []string{"--client-protocol=grpc", "--enable-grpc-metrics=true", fmt.Sprintf("--prometheus-port=%d", prometheusPort), "--cache-dir", cacheDir}
+	flags := []string{"--client-protocol=grpc", "--experimental-enable-grpc-metrics=true", fmt.Sprintf("--prometheus-port=%d", prometheusPort), "--cache-dir", cacheDir}
 	return testSuite.mountGcsfuse(bucketName, flags)
 }
 


### PR DESCRIPTION
### Description
This flag could be deleted in upcoming releases. Hence marking it as experimental.

### Link to the issue in case of a bug fix.
b/471097206

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - Yes
 
### Any backward incompatible change? If so, please explain.
No, this flag was not present in previous releases.