### PR TITLE
ci(build): Add make targets for running integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build-csi:
 	@echo "Starting build for version: $(STAGINGVERSION)"
 	@echo "--------------------------------------"
 	# Actual build commands would go here...
-	GO_VERSION=$(shell cat .go-version); gcloud builds submit --config csi_driver_build.yml --substitutions=_GOLANG_VERSION=${GO_VERSION} --project=$(PROJECT) --substitutions=_CSI_VERSION=$(CSI_VERSION),_GCSFUSE_VERSION=$(GCSFUSE_VERSION),_BUILD_ARM=$(BUILD_ARM),_STAGINGVERSION=$(STAGINGVERSION)
+	gcloud builds submit --config csi_driver_build.yml --project=$(PROJECT) --substitutions=_GOLANG_VERSION=$(GOLANG_VERSION),_CSI_VERSION=$(CSI_VERSION),_GCSFUSE_VERSION=$(GCSFUSE_VERSION),_BUILD_ARM=$(BUILD_ARM),_STAGINGVERSION=$(STAGINGVERSION)
 
 e2e-test:
 	ZONE=$$(curl -H "Metadata-Flavor: Google" metadata.google.internal/computeMetadata/v1/instance/zone | awk -F'/' '{print $$NF}'); \


### PR DESCRIPTION
### Description
Add `make` targets for running integration tests. This allows one to execute `make e2e-test` to run integration tests


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
