### PR TITLE
revert(grpc-metrics): "Enable metrics using cloud-exporter"

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -145,15 +145,16 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 	clientOpts = append(clientOpts, option.WithGRPCConnectionPool(clientConfig.GrpcConnPoolSize))
 	clientOpts = append(clientOpts, option.WithUserAgent(clientConfig.UserAgent))
 
-	if clientConfig.EnableGrpcMetrics && clientConfig.IsGKE {
+	if clientConfig.EnableGrpcMetrics {
 		// Pass the OpenTelemetry MeterProvider to the Go storage client,
 		// using the new WithMeterProvider client option.
+		// TODO - Gracefully handle gRPC metrics outside of GKE.
 		mp := otel.GetMeterProvider()
 		if sdkmp, ok := mp.(*sdkmetric.MeterProvider); ok {
 			// pass in if sdkmp is of type *sdkmetric.MeterProvider (not a No-op)
 			clientOpts = append(clientOpts, experimental.WithMeterProvider(sdkmp))
 		}
-	} else if !clientConfig.EnableGrpcMetrics {
+	} else {
 		clientOpts = append(clientOpts, storage.WithDisabledClientMetrics())
 	}
 


### PR DESCRIPTION
### Description
This reverts commit 3c1d24052c733504444a177971d45f802ec0d32e since it caused integration tests to fail.

### Link to the issue in case of a bug fix.
b/471097206, b/471538162

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
