### PR TITLE
refactor(optimize.go): remove unused function setFlagValue in optimize flow

### DIFF
--- a/cfg/optimize.go
+++ b/cfg/optimize.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -153,70 +152,6 @@ func convertToCamelCase(input string) string {
 	}
 
 	return strings.Join(parts, "")
-}
-
-// setFlagValue uses reflection to set the value of a flag in ServerConfig.
-func setFlagValue(cfg *Config, flag string, override flagOverride, isSet isValueSet) error {
-	// Split the flag name into parts to traverse nested structs.
-	parts := strings.Split(flag, ".")
-	if len(parts) == 0 {
-		return fmt.Errorf("invalid flag name: %s", flag)
-	}
-
-	// Start with the Config.
-	v := reflect.ValueOf(cfg).Elem()
-	var field reflect.Value
-	// Traverse nested structs.
-	for _, part := range parts {
-		field = v.FieldByName(convertToCamelCase(part))
-		if !field.IsValid() {
-			return fmt.Errorf("invalid flag name: %s", flag)
-		}
-		v = field
-	}
-
-	// Check if the field exists.
-	if !field.IsValid() {
-		return fmt.Errorf("invalid flag name: %s", flag)
-	}
-
-	// Check if the field is settable.
-	if !field.CanSet() {
-		return fmt.Errorf("cannot set flag: %s", flag)
-	}
-
-	// Construct the full flag name for IsSet check.
-	fullFlagName := strings.ToLower(flag)
-
-	// Only override if the user hasn't set it.
-	if !isSet.IsSet(fullFlagName) {
-		// Set the value based on the field type.
-
-		switch field.Kind() {
-		case reflect.Bool:
-			boolValue, ok := override.newValue.(bool)
-			if !ok {
-				return fmt.Errorf("invalid boolean value for flag %s: %v", flag, override.newValue)
-			}
-			field.SetBool(boolValue)
-		case reflect.Int, reflect.Int64:
-			intValue, ok := override.newValue.(int)
-			if !ok {
-				return fmt.Errorf("invalid integer value for flag %s: %v", flag, override.newValue)
-			}
-			field.SetInt(int64(intValue))
-		case reflect.String:
-			stringValue, ok := override.newValue.(string)
-			if !ok {
-				return fmt.Errorf("invalid string value for flag %s: %v", flag, override.newValue)
-			}
-			field.SetString(stringValue)
-		default:
-			return fmt.Errorf("unsupported flag type for flag %s", flag)
-		}
-	}
-
-	return nil
 }
 
 func isFlagPresent(flags []string, flag string) bool {

--- a/cfg/optimize_test.go
+++ b/cfg/optimize_test.go
@@ -355,45 +355,6 @@ func TestApplyOptimizations_NoError(t *testing.T) {
 	assert.NotEmpty(t, optimizedFlags)
 }
 
-func TestSetFlagValue_Bool(t *testing.T) {
-	cfg := &Config{}
-	isSet := &mockIsValueSet{setFlags: map[string]bool{}}
-
-	err := setFlagValue(cfg, "implicit-dirs", flagOverride{newValue: true}, isSet)
-
-	require.NoError(t, err)
-	assert.True(t, cfg.ImplicitDirs)
-}
-
-func TestSetFlagValue_String(t *testing.T) {
-	cfg := &Config{}
-	isSet := &mockIsValueSet{setFlags: map[string]bool{}}
-
-	err := setFlagValue(cfg, "app-name", flagOverride{newValue: "optimal_gcsfuse"}, isSet)
-
-	require.NoError(t, err)
-	assert.Equal(t, "optimal_gcsfuse", cfg.AppName)
-}
-
-func TestSetFlagValue_Int(t *testing.T) {
-	cfg := &Config{}
-	isSet := &mockIsValueSet{setFlags: map[string]bool{}}
-
-	err := setFlagValue(cfg, "metadata-cache.stat-cache-max-size-mb", flagOverride{newValue: 1024}, isSet)
-
-	require.NoError(t, err)
-	assert.EqualValues(t, 1024, cfg.MetadataCache.StatCacheMaxSizeMb)
-}
-
-func TestSetFlagValue_InvalidFlagName(t *testing.T) {
-	cfg := &Config{}
-	isSet := &mockIsValueSet{setFlags: map[string]bool{}}
-
-	err := setFlagValue(cfg, "invalid-flag", flagOverride{newValue: true}, isSet)
-
-	assert.Error(t, err)
-}
-
 func TestApplyOptimizations_Success(t *testing.T) {
 	resetMetadataEndpoints(t)
 	// Create a test server that returns a matching machine type.


### PR DESCRIPTION
### Description
- Removing unused function setFlagValue in the optimize.go

### Link to the issue in case of a bug fix.
b/472177719

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
