### PR TITLE
ci: group dependabot PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,8 @@ updates:
   - dependency-type: "direct"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
   groups:
-    # Group all Go updates together
+    # Group all Go updates together in a single PR.
     go-dependencies:
       patterns:
         - "*"
@@ -21,7 +20,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
   groups:
     python-dependencies:
       patterns:


### PR DESCRIPTION
### Description
Group dependabot PRs together so perf tests and e2e tests can be run together.

### Link to the issue in case of a bug fix.
b/472231233

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
