### PR TITLE
chore: Remove duplication in optimizedFlagNames

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,9 +159,6 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 			isSet := &pflagAsIsValueSet{fs: cmd.PersistentFlags()}
 			optimizedFlags := mountInfo.config.ApplyOptimizations(isSet)
 			optimizedFlagNames := slices.Collect(maps.Keys(optimizedFlags))
-			for k := range optimizedFlags {
-				optimizedFlagNames = append(optimizedFlagNames, k)
-			}
 			if err := cfg.Rationalize(v, mountInfo.config, optimizedFlagNames); err != nil {
 				return fmt.Errorf("error rationalizing config: %w", err)
 			}


### PR DESCRIPTION
### Description
This pull request focuses on a minor code cleanup by eliminating a redundant operation within the `cmd/root.go` file. The change removes an unnecessary loop that duplicated the collection of optimized flag names, thereby improving code efficiency and readability without altering the application's behavior or introducing any breaking changes.

#### Highlights

* **Code Optimization**: Removed a redundant loop that was inefficiently populating the `optimizedFlagNames` slice. The `slices.Collect(maps.Keys(optimizedFlags))` function already handles this, making the subsequent loop unnecessary.
* **Technical Debt Reduction**: Addressed an inefficiency introduced in a previous pull request (#3965) that did not affect functionality but was identified as superfluous during a later review (#4189).

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Tested mount and optimization locally
2. Unit tests - NA
3. Integration tests - Ran through presubmit ([log](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/8824b601-eea9-425a-97b2-edbf071876ba))

### Any backward incompatible change? If so, please explain.
