### PR TITLE
feat(simple_reader): rationzlize kernel-reader-flag based on file-cache

### DIFF
--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -152,6 +152,13 @@ func resolveLoggingConfig(config *Config) {
 	}
 }
 
+func disableKernelReaderFlagBasedOnFileCache(c *Config) {
+	if IsFileCacheEnabled(c) {
+		log.Print("Warning: kernel-reader cannot be enabled when file-cache is enabled. Disabling kernel-reader.")
+		c.FileSystem.EnableKernelReader = false
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	var err error
@@ -171,6 +178,7 @@ func Rationalize(v isSet, c *Config, optimizedFlags []string) error {
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
 	resolveFileCacheAndBufferedReadConflict(v, c)
+	disableKernelReaderFlagBasedOnFileCache(c)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -753,3 +753,42 @@ func TestResolveLoggingConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestDisableKernelReaderBasedOnFileCache(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		config                   *Config
+		expectedEnableKernelRead bool
+	}{
+		{
+			name: "file_cache_enabled",
+			config: &Config{
+				CacheDir: ResolvedPath("/some-path"),
+				FileCache: FileCacheConfig{
+					MaxSizeMb: 500,
+				},
+				FileSystem: FileSystemConfig{
+					EnableKernelReader: true,
+				},
+			},
+			expectedEnableKernelRead: false,
+		},
+		{
+			name: "file_cache_disabled",
+			config: &Config{
+				FileSystem: FileSystemConfig{
+					EnableKernelReader: true,
+				},
+			},
+			expectedEnableKernelRead: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			disableKernelReaderFlagBasedOnFileCache(tc.config)
+
+			assert.Equal(t, tc.expectedEnableKernelRead, tc.config.FileSystem.EnableKernelReader)
+		})
+	}
+}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -621,8 +621,10 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 		}
 		markSuccessfulMount()
 
-		// Apply kernel settings only when kernel reader is enabled and file-cache is disabled and not a dynamic mount.
-		if !isDynamicMount(bucketName) && newConfig.FileSystem.EnableKernelReader && !cfg.IsFileCacheEnabled(newConfig) {
+		// Apply kernel settings only when kernel reader is enabled and not a dynamic mount.
+		// Note: enableKernelReader is disabled automatically when file-cache is enabled, as
+		// part of cfg.Rationalize.
+		if !isDynamicMount(bucketName) && newConfig.FileSystem.EnableKernelReader {
 			if newConfig.FileSystem.MaxReadAheadKb > 0 {
 				setMaxReadAhead(mountPoint, int(newConfig.FileSystem.MaxReadAheadKb))
 			}


### PR DESCRIPTION
### Description
Instead of adding file-cache checks at every place: (a) while setting fuse_system settings (b) while enabling async read, we should rationalize the newly added `enable-kernel-reader` flag. After that no need to add file-cache check anywhere.

**Thinking Ahead:** - Later if we want to set enable-kernel-reader as true with file-cache on regional bucket. We can modify the rationalize condition to when bucket-type is regional.  In that case, bucket-type information will be required in the rationalize which is true for other cases too.

### Link to the issue in case of a bug fix.
b/472923739

### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
