### PR TITLE
fix(simple_reader): set kernel-fuse-settings for enable-kernel-reader

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -621,8 +621,8 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 		}
 		markSuccessfulMount()
 
-		// Apply kernel settings only when kernel reader is enabled and file-cache is disabled and not a dynamic mount.
-		if !isDynamicMount(bucketName) && newConfig.FileSystem.EnableKernelReader && !cfg.IsFileCacheEnabled(newConfig) {
+		// Apply kernel settings only when kernel reader is enabled and not a dynamic mount.
+		if newConfig.FileSystem.EnableKernelReader && (!isDynamicMount(bucketName)) {
 			if newConfig.FileSystem.MaxReadAheadKb > 0 {
 				setMaxReadAhead(mountPoint, int(newConfig.FileSystem.MaxReadAheadKb))
 			}


### PR DESCRIPTION
### Description
- set kernel-fuse-settings for enable-kernel-reader, irrespective of file-cache is on or off.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
