### PR TITLE
feat(dir-metadata-prefetch): create readObjectsUnlocked function + refactoring of existing code

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -734,15 +734,6 @@ func (d *dirInode) listObjectsAndBuildCores(
 	}
 
 	cores = make(map[Name]*Core)
-	if !d.IsTypeCacheDeprecated() {
-		defer func() {
-			now := d.cacheClock.Now()
-			for fullName, c := range cores {
-				d.cache.Insert(now, path.Base(fullName.LocalName()), c.Type())
-			}
-		}()
-	}
-
 	for _, o := range listing.MinObjects {
 		if storageutil.IsUnsupportedPath(o.Name) {
 			unsupportedPaths = append(unsupportedPaths, o.Name)
@@ -835,6 +826,9 @@ func (d *dirInode) listObjectsAndBuildCores(
 }
 
 func (d *dirInode) insertToCache(cores map[Name]*Core) {
+	if d.IsTypeCacheDeprecated() {
+		return
+	}
 	now := d.cacheClock.Now()
 	for fullName, c := range cores {
 		d.cache.Insert(now, path.Base(fullName.LocalName()), c.Type())

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1566,7 +1566,7 @@ func (t *DirTest) TestDeleteChildFile_Succeeds_TypeCacheEvicted() {
 	// Check the bucket.
 	_, err = storageutil.ReadObject(t.ctx, t.bucket, objName)
 	var notFoundErr *gcs.NotFoundError
-	assert.ErrorAs(t.T(), notFoundErr, err)
+	assert.ErrorAs(t.T(), err, &notFoundErr)
 	// Check that the type cache has been updated.
 	assert.Equal(t.T(), metadata.UnknownType, t.getTypeFromCache(name))
 }
@@ -1842,7 +1842,7 @@ func (t *DirTest) TestEraseFromTypeCache() {
 	require.EqualValues(t.T(), 0, tp)
 }
 
-func (t *DirTest) TestTestDeleteObjects() {
+func (t *DirTest) TestDeleteObjects() {
 	// Arrange
 	parentDirGcsName := t.in.Name().GcsObjectName() // e.g., "foo/bar/"
 	d := t.in.(*dirInode)


### PR DESCRIPTION
### Description
This PR refactors the directory reading logic by introducing a new `readObjectsUnlocked` function to perform GCS I/O without holding the directory lock. This will allow for for more concurrent operations by minimizing lock contention during potentially long-running List calls which will become more frequent as we `add dir-metadata-prefetch` feature. 

It also migrates the test suite from ogletest to the more standard testify/suite, which improves maintainability.

### Link to the issue in case of a bug fix.
b/473411326

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA