### PR TITLE
fix: network unreachable error

### DIFF
--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -57,12 +57,12 @@ func ShouldRetryForTest(err error) (b bool) {
 		return
 	}
 
-	if err != nil && strings.Contains(err.Error(), networkUnreachableError) {
+	// Convert err.Error() to lowercase to make the check case-insensitive
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), networkUnreachableError) {
 		b = true
 		log.Printf("Retrying for 'network is unreachable' error: %v", err)
 		return
 	}
-
 	return
 }
 


### PR DESCRIPTION
### Description
We encountered connect: network is unreachable errors during storage client calls within our end-to-end (e2e) tests. This client is initialized directly within the test suite to validate GCSFuse results against GCS results.

Created separate ShouldRetry function for test only so that core logic won't get change. 

### Link to the issue in case of a bug fix.
[b/470721588](https://b.corp.google.com/issues/470721588)

### Testing details
1. Manual - Tested through louhi flow ([b/470721588#comment4](https://b.corp.google.com/issues/470721588#comment4))
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
