### PR TITLE
refactor: propagate config to dir inode

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -335,16 +335,12 @@ func makeRootForBucket(
 			Mtime: fs.mtimeClock.Now(),
 		},
 		fs.implicitDirs,
-		fs.newConfig.List.EnableEmptyManagedFolders,
 		fs.enableNonexistentTypeCache,
 		fs.dirTypeCacheTTL,
 		&syncerBucket,
 		fs.mtimeClock,
 		fs.cacheClock,
-		fs.newConfig.MetadataCache.TypeCacheMaxSizeMb,
-		fs.newConfig.EnableHns,
-		fs.newConfig.EnableUnsupportedPathSupport,
-		fs.newConfig.EnableTypeCacheDeprecation,
+		fs.newConfig,
 	)
 }
 
@@ -819,16 +815,12 @@ func (fs *fileSystem) createExplicitDirInode(inodeID fuseops.InodeID, ic inode.C
 			Mtime: fs.mtimeClock.Now(),
 		},
 		fs.implicitDirs,
-		fs.newConfig.List.EnableEmptyManagedFolders,
 		fs.enableNonexistentTypeCache,
 		fs.dirTypeCacheTTL,
 		ic.Bucket,
 		fs.mtimeClock,
 		fs.cacheClock,
-		fs.newConfig.MetadataCache.TypeCacheMaxSizeMb,
-		fs.newConfig.EnableHns,
-		fs.newConfig.EnableUnsupportedPathSupport,
-		fs.newConfig.EnableTypeCacheDeprecation)
+		fs.newConfig)
 
 	return in
 }
@@ -864,16 +856,12 @@ func (fs *fileSystem) mintInode(ic inode.Core) (in inode.Inode) {
 				Mtime: fs.mtimeClock.Now(),
 			},
 			fs.implicitDirs,
-			fs.newConfig.List.EnableEmptyManagedFolders,
 			fs.enableNonexistentTypeCache,
 			fs.dirTypeCacheTTL,
 			ic.Bucket,
 			fs.mtimeClock,
 			fs.cacheClock,
-			fs.newConfig.MetadataCache.TypeCacheMaxSizeMb,
-			fs.newConfig.EnableHns,
-			fs.newConfig.EnableUnsupportedPathSupport,
-			fs.newConfig.EnableTypeCacheDeprecation,
+			fs.newConfig,
 		)
 
 	case inode.IsSymlink(ic.MinObject):

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	cfg2 "github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
@@ -68,6 +69,13 @@ func (t *DirHandleTest) TearDown() {}
 // Helpers
 // //////////////////////////////////////////////////////////////////////
 func (t *DirHandleTest) resetDirHandle() {
+	cfg := &cfg2.Config{
+		List:                         cfg2.ListConfig{EnableEmptyManagedFolders: true},
+		MetadataCache:                cfg2.MetadataCacheConfig{TypeCacheMaxSizeMb: 0},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+	}
 	dirInode := inode.NewDirInode(
 		17,
 		inode.NewDirName(inode.NewRootName(""), "testDir"),
@@ -77,16 +85,12 @@ func (t *DirHandleTest) resetDirHandle() {
 			Mode: 0712,
 		},
 		false, // implicitDirs,
-		true,  // enableManagedFoldersListing
 		false, // enableNonExistentTypeCache
 		0,     // typeCacheTTL
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		0,
-		false,
-		true,
-		isTypeCacheDeprecationEnabled)
+		cfg)
 
 	t.dh = NewDirHandle(
 		dirInode,

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -85,6 +85,14 @@ func (t *fileTest) TearDownTest() {
 func createDirInode(
 	bucket *gcsx.SyncerBucket,
 	clock *timeutil.SimulatedClock) inode.DirInode {
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: false},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+	}
+
 	return inode.NewDirInode(
 		1,
 		inode.NewDirName(inode.NewRootName(""), testDirName),
@@ -94,16 +102,12 @@ func createDirInode(
 			Mode: 0712,
 		},
 		false,
-		false,
 		true,
 		0,
 		bucket,
 		clock,
 		clock,
-		4,
-		false,
-		true,
-		isTypeCacheDeprecationEnabled,
+		config,
 	)
 }
 

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
@@ -276,16 +277,12 @@ func NewDirInode(
 	name Name,
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
-	includeFoldersAsPrefixes bool,
 	enableNonexistentTypeCache bool,
 	typeCacheTTL time.Duration,
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
-	typeCacheMaxSizeMB int64,
-	isHNSEnabled bool,
-	isUnsupportedPathSupportEnabled bool,
-	isEnableTypeCacheDeprecation bool,
+	cfg *cfg.Config,
 ) (d DirInode) {
 
 	if !name.IsDir() {
@@ -298,18 +295,18 @@ func NewDirInode(
 		cacheClock:                      cacheClock,
 		id:                              id,
 		implicitDirs:                    implicitDirs,
-		includeFoldersAsPrefixes:        includeFoldersAsPrefixes,
+		includeFoldersAsPrefixes:        cfg.List.EnableEmptyManagedFolders,
 		enableNonexistentTypeCache:      enableNonexistentTypeCache,
 		name:                            name,
 		attrs:                           attrs,
-		isHNSEnabled:                    isHNSEnabled,
-		isUnsupportedPathSupportEnabled: isUnsupportedPathSupportEnabled,
-		isEnableTypeCacheDeprecation:    isEnableTypeCacheDeprecation,
+		isHNSEnabled:                    cfg.EnableHns,
+		isUnsupportedPathSupportEnabled: cfg.EnableUnsupportedPathSupport,
+		isEnableTypeCacheDeprecation:    cfg.EnableTypeCacheDeprecation,
 		unlinked:                        false,
 	}
 	var cache metadata.TypeCache
-	if !isEnableTypeCacheDeprecation {
-		cache = metadata.NewTypeCache(typeCacheMaxSizeMB, typeCacheTTL)
+	if !cfg.EnableTypeCacheDeprecation {
+		cache = metadata.NewTypeCache(cfg.MetadataCache.TypeCacheMaxSizeMb, typeCacheTTL)
 		typed.cache = cache
 	}
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -108,6 +108,14 @@ func (t *DirTest) resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistent
 		t.in.Unlock()
 	}
 
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: enableManagedFoldersListing},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: typeCacheMaxSizeMB},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+	}
+
 	t.in = NewDirInode(
 		dirInodeID,
 		NewDirName(NewRootName(""), dirInodeName),
@@ -117,16 +125,12 @@ func (t *DirTest) resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistent
 			Mode: dirMode,
 		},
 		implicitDirs,
-		enableManagedFoldersListing,
 		enableNonexistentTypeCache,
 		typeCacheTTL,
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		typeCacheMaxSizeMB,
-		false,
-		true,
-		isTypeCacheDeprecationEnabled,
+		config,
 	)
 
 	d := t.in.(*dirInode)
@@ -146,6 +150,14 @@ func (t *DirTest) createDirInode(dirInodeName string) DirInode {
 }
 
 func (t *DirTest) createDirInodeWithTypeCacheDeprecationFlag(dirInodeName string, isTypeCacheDeprecated bool) DirInode {
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: false},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecated,
+	}
+
 	return NewDirInode(
 		5,
 		NewDirName(NewRootName(""), dirInodeName),
@@ -155,16 +167,12 @@ func (t *DirTest) createDirInodeWithTypeCacheDeprecationFlag(dirInodeName string
 			Mode: dirMode,
 		},
 		false,
-		false,
 		true,
 		typeCacheTTL,
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		4,
-		false,
-		true,
-		isTypeCacheDeprecated,
+		config,
 	)
 }
 

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -17,6 +17,7 @@ package inode
 import (
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/jacobsa/fuse/fuseops"
@@ -38,31 +39,23 @@ func NewExplicitDirInode(
 	m *gcs.MinObject,
 	attrs fuseops.InodeAttributes,
 	implicitDirs bool,
-	includeFoldersAsPrefixes bool,
 	enableNonexistentTypeCache bool,
 	typeCacheTTL time.Duration,
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
-	typeCacheMaxSizeMB int64,
-	enableHNS bool,
-	enableUnsupportedPathSupport bool,
-	enableTypeCacheDeprecation bool) (d ExplicitDirInode) {
+	cfg *cfg.Config) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
 		name,
 		attrs,
 		implicitDirs,
-		includeFoldersAsPrefixes,
 		enableNonexistentTypeCache,
 		typeCacheTTL,
 		bucket,
 		mtimeClock,
 		cacheClock,
-		typeCacheMaxSizeMB,
-		enableHNS,
-		enableUnsupportedPathSupport,
-		enableTypeCacheDeprecation)
+		cfg)
 
 	dirInode := &explicitDirInode{
 		dirInode: wrapped.(*dirInode),

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
@@ -90,6 +91,14 @@ func (t *hnsDirTest) resetDirInode(implicitDirs, enableNonexistentTypeCache, ena
 func (t *hnsDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonexistentTypeCache, enableManagedFoldersListing bool, typeCacheMaxSizeMB int64, typeCacheTTL time.Duration) {
 	t.fixedTime.SetTime(time.Date(2024, 7, 22, 2, 15, 0, 0, time.Local))
 
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: enableManagedFoldersListing},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: typeCacheMaxSizeMB},
+		EnableHns:                    true,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+	}
+
 	t.in = NewDirInode(
 		dirInodeID,
 		NewDirName(NewRootName(""), dirInodeName),
@@ -99,16 +108,12 @@ func (t *hnsDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonex
 			Mode: dirMode,
 		},
 		implicitDirs,
-		enableManagedFoldersListing,
 		enableNonexistentTypeCache,
 		typeCacheTTL,
 		&t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
-		typeCacheMaxSizeMB,
-		true,
-		true,
-		isTypeCacheDeprecationEnabled,
+		config,
 	)
 
 	d := t.in.(*dirInode)
@@ -125,6 +130,14 @@ func (t *hnsDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonex
 }
 
 func (t *hnsDirTest) createDirInode(dirInodeName string) DirInode {
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: false},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+	}
+
 	return NewDirInode(
 		5,
 		NewDirName(NewRootName(""), dirInodeName),
@@ -134,16 +147,12 @@ func (t *hnsDirTest) createDirInode(dirInodeName string) DirInode {
 			Mode: dirMode,
 		},
 		false,
-		false,
 		true,
 		typeCacheTTL,
 		&t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
-		4,
-		false,
-		true,
-		isTypeCacheDeprecationEnabled,
+		config,
 	)
 }
 


### PR DESCRIPTION
### Description
Instead of passing individual config parameters, pass reference of config file to dir inode. 

### Link to the issue in case of a bug fix.
b/473411326

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA 