### PR TITLE
fix: Fix in check_prerequisites in gke-tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/common/utils.py
+++ b/perfmetrics/scripts/continuous_test/gke/common/utils.py
@@ -81,7 +81,7 @@ async def check_prerequisites():
       stdout=asyncio.subprocess.PIPE,
   )
   gpg_process = await asyncio.create_subprocess_exec(
-      "sudo gpg --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg",
+      "sudo", "gpg", "--yes", "--dearmor", "-o", "/usr/share/keyrings/cloud.google.gpg",
       stdin=asyncio.subprocess.PIPE,
   )
   await gpg_process.communicate(input=await curl_process.stdout.read())
@@ -89,8 +89,7 @@ async def check_prerequisites():
   # Pipe echo output to tee
   echo_process = await asyncio.create_subprocess_exec(
       "echo",
-      "deb [signed-by=/usr/share/keyrings/cloud.google.gpg]"
-      "https://packages.cloud.google.com/apt cloud-sdk main",
+      "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main",
       stdout=asyncio.subprocess.PIPE,
   )
   tee_process = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
### Description
- Fixes couple of bugs introduced in function check_prerequisites at https://github.com/GoogleCloudPlatform/gcsfuse/blob/6a479bc1b166c4dec13548f4ff979cfd5f48a194/perfmetrics/scripts/continuous_test/gke/common/utils.py#L66, introduced in #4180.

This fixes the new bug showing up in [this run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgke%2Fperiodic%2Fgke_orbax_benchmark%2Fcontinuous/activity/dafe807d-da82-4d67-ad28-82ce89fc8938/log).

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Tested the fix manually. Also verified it by adding a new presubmit label `execute-orbax-benchmark`, implementing it in PR #4256 and running it in as part of [presubmit run](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/0d8abcbb-cff7-4222-b2ee-0df8cd01511d/log) .
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
