### PR TITLE
ci(build-csi): Make the bucket-names for csi builds small

### DIFF
--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -63,6 +63,7 @@ steps:
   args:
   - '-c'
   - |
+    set -e
     BUILD_ID_VAL="${BUILD_ID}"
     BUCKET_NAME="gs://${PROJECT_ID}-csi-$${BUILD_ID_VAL:0:8}"
     gcloud storage buckets create $$BUCKET_NAME
@@ -76,6 +77,7 @@ steps:
   args:
   - '-c'
   - |
+    set -e
     BUCKET_NAME=$$(cat /workspace/bucket_name)
     gcloud storage cp -r /workspace/gcsfuse-artifacts/* $$BUCKET_NAME/
 
@@ -124,6 +126,8 @@ steps:
   - |
     BUCKET_NAME=$$(cat /workspace/bucket_name)
     gcloud storage rm --recursive $$BUCKET_NAME
+    rm /workspace/bucket_name
+
 
 options:
   # Using a more powerful machine is recommended for multi-platform builds.


### PR DESCRIPTION
### Description

* If the project-id is long enough, then when the BUILD_ID is appended to create the bucket name, the total bucket length can become too long. This can result in the bucket creationg failing. Fix this by reducing the bucket names to use only a few characters of the build id.
* Don't fail the build if bucket-cleanup fails. 
* Fail the build-step if bucket-creation fails. Currently, even though the build fails eventually due to the bucket being absent, the step that creates the bucket doesn't fail.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
