### PR TITLE
fix: Add stall timeout for direct path connectivity

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -52,8 +52,8 @@ const (
 	dynamicReadReqIncreaseRateEnv   = "DYNAMIC_READ_REQ_INCREASE_RATE"
 	dynamicReadReqInitialTimeoutEnv = "DYNAMIC_READ_REQ_INITIAL_TIMEOUT"
 
-	zonalLocationType             = "zone"
-stallTimeoutForDirectPath = 60 * time.Second
+	zonalLocationType         = "zone"
+	stallTimeoutForDirectPath = 60 * time.Second
 )
 
 type StorageHandle interface {
@@ -87,7 +87,7 @@ type gRPCDirectPathDetector struct {
 // from the environment where the client is running. A `nil` error represents Direct Connectivity was
 // detected.
 func (pd *gRPCDirectPathDetector) isDirectPathPossible(ctx context.Context, bucketName string) error {
-newCtx, cancel := context.WithTimeout(ctx, stallTimeoutForDirectPath)
+	newCtx, cancel := context.WithTimeout(ctx, stallTimeoutForDirectPath)
 	defer cancel()
 
 	// The storage library will see the timeout in 'newCtx' and abort the request if it takes too long.


### PR DESCRIPTION
### Description
Addressed an issue where Direct Path connectivity calls would occasionally hang indefinitely, leading to a poor user experience. A 60-second context timeout has been implemented to cancel these stuck requests, allowing the mount operation to successfully fail over to the cloud path.

### Link to the issue in case of a bug fix.
[b/475733879](https://buganizer.corp.google.com/issues/475733879)

### Testing details
1. Manual - tested with small ttl(60ns) and verified that it is giving context deadline exceeded error.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
