### PR TITLE
fix(test): Fix Flaky Tracing Tests  (-count failures)

### DIFF
--- a/tracing/otel_tracer.go
+++ b/tracing/otel_tracer.go
@@ -17,18 +17,21 @@ package tracing
 import (
 	"context"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
-type otelTracer struct{}
+type otelTracer struct {
+	tracer trace.Tracer
+}
 
 func (o *otelTracer) StartSpan(ctx context.Context, traceName string) (context.Context, trace.Span) {
-	return GCSFuseTracer().Start(ctx, traceName)
+	return o.tracer.Start(ctx, traceName)
 }
 
 func (o *otelTracer) StartServerSpan(ctx context.Context, traceName string) (context.Context, trace.Span) {
-	return GCSFuseTracer().Start(ctx, traceName, trace.WithSpanKind(trace.SpanKindServer))
+	return o.tracer.Start(ctx, traceName, trace.WithSpanKind(trace.SpanKindServer))
 }
 
 func (o *otelTracer) EndSpan(span trace.Span) {
@@ -41,6 +44,7 @@ func (o *otelTracer) RecordError(span trace.Span, err error) {
 }
 
 func NewOTELTracer() TraceHandle {
-	var o otelTracer
-	return &o
+	return &otelTracer{
+		tracer: otel.Tracer(name),
+	}
 }

--- a/tracing/util.go
+++ b/tracing/util.go
@@ -17,17 +17,10 @@ package tracing
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
 const name = "cloud.google.com/gcsfuse"
-
-var tracer = otel.Tracer(name)
-
-func GCSFuseTracer() trace.Tracer {
-	return tracer
-}
 
 // When tracing is enabled ensure span & trace context from oldCtx is passed on to newCtx
 func MaybePropagateTraceContext(newCtx context.Context, oldCtx context.Context, isTracingEnabled bool) context.Context {


### PR DESCRIPTION
### Description
The Issue Tests passed on the first run but failed on subsequent runs (-count > 1) with 0 spans detected. This was caused by stale global state: the tracer was captured once at startup and became "orphaned" when the test suite moved to the next iteration, sending spans to a dead provider.

The Fix:

Changed GCSFuseTracer() to fetch the tracer from the current global provider instead of a one-time package variable and move it to OtelTracer traceHandle struct.

### Link to the issue in case of a bug fix.
b/475710717
b/476297291

### Testing details
1. Manual - Yes
 Ran the below command where tests were run 5 times, multiple times to check they are passing.
 
 /usr/local/go/bin/go test -v   -fullpath   -timeout 30s -count 5  -run "^TestTracingTestSuite$"   github.com/googlecloudplatform
/gcsfuse/v3/internal/fs   -testify.m "^(TestTraceLookupInode)$"

Also verified that the tracing is working fine by exporting the traces to google cloud trace exporter.


2. Unit tests - existing tests need to pass.

3. Integration tests - tests need to pass.

### Any backward incompatible change? If so, please explain.
NA