### PR TITLE
feat(simple_reader): changing the default value for max-background

### DIFF
--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -23,9 +23,9 @@ import (
 
 const (
 	// maxBackgroundLimit configures the upper limit for max-background kernel fuse
-	// setting. This is more than sufficient to saturated the 200 Gbps network bandwidth
+	// setting. This is more than sufficient to saturate the 200 Gbps network bandwidth
 	// on a single VM. Revise the numbers if you plan to support higher bandwidth VMs.
-	maxBackgroundLimit = 256
+	maxBackgroundLimit = 192
 )
 
 func DefaultMaxBackground() int {

--- a/cfg/config_util_test.go
+++ b/cfg/config_util_test.go
@@ -28,7 +28,7 @@ func Test_DefaultMaxBackground(t *testing.T) {
 
 func Test_DefaultCongestionThreshold(t *testing.T) {
 	assert.GreaterOrEqual(t, DefaultCongestionThreshold(), 9)
-	assert.LessOrEqual(t, DefaultCongestionThreshold(), (3*maxBackgroundLimit)/4)
+	assert.LessOrEqual(t, DefaultCongestionThreshold(), 144) // 75% of maxBackgroundLimit
 }
 
 func Test_DefaultMaxParallelDownloads(t *testing.T) {


### PR DESCRIPTION
### Description
- Current default value of max-background was leading to high gcsfuse cpu usage and a way more than required to saturate the 200Gbps read throughput.
- Capping the default value based on the max supported nic value, kept the value slightly more than to saturate the network. With this we are kind of getting almost same performance with less gcsfuse cpu utilization.
- CSV file: https://github.com/GoogleCloudPlatform/gcsfuse-tools/blob/d_princer_micro_benchmarking/distributed-micro-benchmarking/final_reports/tune_kernel_settings/final_comparison.csv
-  Comparison Graph (the blue one is the proposed one):
<img width="2984" height="10754" alt="image" src="https://github.com/user-attachments/assets/7bb9005b-2a98-43a0-a24e-9ff134441459" />



### Link to the issue in case of a bug fix.
b/475124487

### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
