### PR TITLE
feat(kernel-settings): Do nothing when kernel config is applied with empty parameter list.

### DIFF
--- a/internal/kernelparams/kernelparams.go
+++ b/internal/kernelparams/kernelparams.go
@@ -231,6 +231,9 @@ func (m *KernelParamsManager) SetCongestionWindowThreshold(threshold int) {
 func (m *KernelParamsManager) ApplyGKE(kernelParamsFile string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if len(m.Parameters) == 0 {
+		return
+	}
 	kernelConfigJson, err := json.Marshal(m.KernelParamsConfig)
 	if err != nil {
 		logger.Warnf("Failed to marshal kernel parameters config: %v", err)
@@ -248,6 +251,9 @@ func (m *KernelParamsManager) ApplyGKE(kernelParamsFile string) {
 func (m *KernelParamsManager) ApplyNonGKE(mountPoint string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if len(m.Parameters) == 0 {
+		return
+	}
 	kernelConfigJson, err := json.Marshal(m.KernelParamsConfig)
 	if err != nil {
 		logger.Warnf("Failed to marshal kernel parameters config: %v", err)

--- a/internal/kernelparams/kernelparams_test.go
+++ b/internal/kernelparams/kernelparams_test.go
@@ -205,6 +205,17 @@ func TestApplyGKE(t *testing.T) {
 	assert.Equal(t, "1024", actualCfg.Parameters[0].Value)
 }
 
+func TestApplyGKE_EmptyParams(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "kernel_params.json")
+	cfg := NewKernelParamsManager()
+
+	cfg.ApplyGKE(filePath)
+
+	_, err := os.Stat(filePath)
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestWriteValue_DirectWriteSuccess(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Skipping test on non-linux OS")


### PR DESCRIPTION
### Description
Same as above. Without this change it would just print redundant logs.

### Link to the issue in case of a bug fix.
b/475441040

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
