### PR TITLE
feat(dir-metadata-prefetch): add logic to limit prefetch workers

### DIFF
--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -175,7 +175,7 @@ func isValidMetadataCache(v isSet, c *MetadataCacheConfig) error {
 	}
 
 	if c.MetadataPrefetchEntriesLimit < -1 {
-		return fmt.Errorf("invalid value of metadata-cache.experimental-metadata-prefetch-limit: %d; should be >=0 or -1 (for infinite)", c.MetadataPrefetchEntriesLimit)
+		return fmt.Errorf("invalid value of metadata-cache.metadata-prefetch-entries-limit: %d; should be >=0 or -1 (for infinite)", c.MetadataPrefetchEntriesLimit)
 	}
 
 	return nil

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -22,6 +22,7 @@ import (
 
 	cfg2 "github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -90,6 +91,7 @@ func (t *DirHandleTest) resetDirHandle() {
 		&t.bucket,
 		&t.clock,
 		&t.clock,
+		semaphore.NewWeighted(10),
 		cfg)
 
 	t.dh = NewDirHandle(

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -109,6 +109,7 @@ func createDirInode(
 		bucket,
 		clock,
 		clock,
+		semaphore.NewWeighted(10),
 		config,
 	)
 }

--- a/internal/fs/inode/dir_prefetcher_test.go
+++ b/internal/fs/inode/dir_prefetcher_test.go
@@ -17,6 +17,7 @@ package inode
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/semaphore"
 )
 
 type DirPrefetchTest struct {
@@ -39,6 +41,7 @@ type DirPrefetchTest struct {
 	fake   gcs.Bucket
 	clock  timeutil.SimulatedClock
 	in     *dirInode
+	config *cfg.Config
 	suite.Suite
 }
 
@@ -49,7 +52,7 @@ func (t *DirPrefetchTest) setup(enablePrefetch bool, ttl time.Duration) (d *dirI
 	t.fake = fake.NewFakeBucket(&t.clock, "some_bucket", gcs.BucketType{})
 	t.bucket = gcsx.NewSyncerBucket(1, 10, ".gcsfuse_tmp/", t.fake)
 
-	config := &cfg.Config{
+	t.config = &cfg.Config{
 		MetadataCache: cfg.MetadataCacheConfig{
 			EnableMetadataPrefetch:       enablePrefetch,
 			TypeCacheMaxSizeMb:           400,
@@ -68,7 +71,8 @@ func (t *DirPrefetchTest) setup(enablePrefetch bool, ttl time.Duration) (d *dirI
 		&t.bucket,
 		&t.clock,
 		&t.clock,
-		config,
+		semaphore.NewWeighted(10),
+		t.config,
 	)
 	return in.(*dirInode)
 }
@@ -242,4 +246,75 @@ func (t *DirPrefetchTest) TestPrefetch_HandlesMultiplePages() {
 	// Check the first item that SHOULD NOT be cached (5500).
 	assert.Equal(t.T(), metadata.UnknownType, t.in.cache.Get(t.clock.Now(), "file5500"),
 		"Should have stopped prefetching after 5500 items")
+}
+
+// mockListFunc returns a function that blocks until the provided channel is closed.
+// This allows us to simulate long-running GCS calls to test concurrency limits.
+func blockingListFunc(blockChan chan struct{}) func(context.Context, string, string, int) (map[Name]*Core, []string, string, error) {
+	return func(ctx context.Context, tok string, start string, limit int) (map[Name]*Core, []string, string, error) {
+		<-blockChan
+		return make(map[Name]*Core), nil, "", nil
+	}
+}
+
+func (t *DirPrefetchTest) TestMetadataPrefetcher_ConcurrencyLimit() {
+	// Setup: Semaphore with a limit of 2 workers.
+	limit := int64(2)
+	sem := semaphore.NewWeighted(limit)
+	blockChan := make(chan struct{})
+	p1 := NewMetadataPrefetcher(t.config, sem, blockingListFunc(blockChan))
+	p2 := NewMetadataPrefetcher(t.config, sem, blockingListFunc(blockChan))
+	p3 := NewMetadataPrefetcher(t.config, sem, blockingListFunc(blockChan))
+	// 1. Run two prefetches to fill up the limit.
+	p1.Run("dir1/obj1")
+	p2.Run("dir2/obj2")
+	// 2. Wait until the semaphore is fully occupied.
+	time.Sleep(10 * time.Millisecond)
+	assert.False(t.T(), sem.TryAcquire(1), "Expected semaphore to be full")
+
+	// 3. Trigger a third prefetch.
+	// Because TryAcquire(1) is used in Run(), it should skip immediately if full.
+	p3.Run("dir3/obj3")
+
+	// 4. Release the blocked workers.
+	close(blockChan)
+	// 5. Use Eventually to wait until all permits are released.
+	t.Eventually(func() bool {
+		// Attempt to acquire the full weight. If successful, workers have finished.
+		if sem.TryAcquire(limit) {
+			sem.Release(limit)
+			return true
+		}
+		return false
+	}, 50*time.Millisecond, 5*time.Millisecond, "Expected all workers to release permits")
+}
+
+func (t *DirPrefetchTest) TestMetadataPrefetcher_RespectsMaxParallelPrefetchesConfig() {
+	// User configures max 1 parallel prefetch.
+	sem := semaphore.NewWeighted(1)
+	blockChan := make(chan struct{})
+	// Track how many times listFunc was actually entered.
+	var callCount int
+	var mu sync.Mutex
+	listFunc := func(ctx context.Context, tok string, start string, limit int) (map[Name]*Core, []string, string, error) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		<-blockChan
+		return nil, nil, "", nil
+	}
+	p := NewMetadataPrefetcher(t.config, sem, listFunc)
+
+	// Trigger multiple runs on the same prefetcher (simulating different objects in same dir)
+	// and different prefetchers.
+	p.Run("a/1")
+	p.Run("a/2") // Will be skipped by atomic state check anyway
+	p2 := NewMetadataPrefetcher(t.config, sem, listFunc)
+	p2.Run("b/1") // Should be skipped by semaphore check
+
+	time.Sleep(10 * time.Millisecond)
+	mu.Lock()
+	assert.Equal(t.T(), 1, callCount, "Expected only 1 concurrent call based on semaphore")
+	mu.Unlock()
+	close(blockChan)
 }

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -129,6 +129,7 @@ func (t *DirTest) resetInodeWithTypeCacheConfigs(implicitDirs, enableNonexistent
 		&t.bucket,
 		&t.clock,
 		&t.clock,
+		semaphore.NewWeighted(10),
 		config,
 	)
 
@@ -171,6 +172,7 @@ func (t *DirTest) createDirInodeWithTypeCacheDeprecationFlag(dirInodeName string
 		&t.bucket,
 		&t.clock,
 		&t.clock,
+		semaphore.NewWeighted(10),
 		config,
 	)
 }

--- a/internal/fs/inode/explicit_dir.go
+++ b/internal/fs/inode/explicit_dir.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/timeutil"
+	"golang.org/x/sync/semaphore"
 )
 
 // An inode representing a directory backed by an object in GCS with a specific
@@ -44,6 +45,7 @@ func NewExplicitDirInode(
 	bucket *gcsx.SyncerBucket,
 	mtimeClock timeutil.Clock,
 	cacheClock timeutil.Clock,
+	prefetchSem *semaphore.Weighted,
 	cfg *cfg.Config) (d ExplicitDirInode) {
 	wrapped := NewDirInode(
 		id,
@@ -55,6 +57,7 @@ func NewExplicitDirInode(
 		bucket,
 		mtimeClock,
 		cacheClock,
+		prefetchSem,
 		cfg)
 
 	dirInode := &explicitDirInode{

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sync/semaphore"
 
 	"golang.org/x/net/context"
 
@@ -113,6 +114,7 @@ func (t *hnsDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonex
 		&t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
+		semaphore.NewWeighted(10),
 		config,
 	)
 
@@ -152,6 +154,7 @@ func (t *hnsDirTest) createDirInode(dirInodeName string) DirInode {
 		&t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
+		semaphore.NewWeighted(10),
 		config,
 	)
 }
@@ -775,6 +778,7 @@ func (t *NonHNSDirTest) TestDeleteChildDir_TypeCacheDeprecated() {
 				&t.bucket,
 				&t.fixedTime,
 				&t.fixedTime,
+				semaphore.NewWeighted(10),
 				config,
 			)
 			dirName := path.Join(dirInodeName, tc.name) + "/"


### PR DESCRIPTION
### Description
This PR introduces a global concurrency limit for directory metadata prefetching to prevent system overload and avoid queuing stale background work.

A global semaphore (globalMetadataPrefetchSem) is added to the fileSystem struct, initialized with the configured MetadataPrefetchMaxWorkers limit. This semaphore is passed down to the MetadataPrefetcher.

In MetadataPrefetcher.Run, the logic now attempts to acquire a permit from this semaphore using TryAcquire(1). If the semaphore is full, the prefetch operation is skipped immediately rather than blocking, ensuring that we don't accumulate a backlog of prefetch tasks that might become stale.

### Link to the issue in case of a bug fix.
b/473412191

### Testing details
1. Manual - NA
2. Unit tests - added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA