### PR TITLE
feat(kernel-settings): make max-read-ahead-kb flag public

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1158,10 +1158,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("max-read-ahead-kb", "", 0, "Sets max kernel-read-ahead for the mount in KiB. 0 means system default. Requires sudo permission to set this value, otherwise the value will be ignored and system default will be used.")
 
-	if err := flagSet.MarkHidden("max-read-ahead-kb"); err != nil {
-		return err
-	}
-
 	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. A value of 0 indicates no limit.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -477,7 +477,6 @@ params:
       Requires sudo permission to set this value, otherwise the value will be ignored
       and system default will be used.
     default: "0"
-    hide-flag: true
     optimizations:
       bucket-type-optimization:
         - bucket-type: "zonal"
@@ -1198,7 +1197,6 @@ params:
     type: "bool"
     usage: "Enables streaming uploads during write file operation."
     default: true
-    hide-flag: false
 
   - config-path: "write.finalize-file-for-rapid"
     flag-name: "finalize-file-for-rapid"
@@ -1215,7 +1213,6 @@ params:
       The value should be >= 0 or -1 (for infinite blocks).
       A value of 0 disables streaming writes.
     default: 4
-    hide-flag: false
     optimizations:
       machine-based-optimization:
         - group: "high-performance"


### PR DESCRIPTION
### Description
Same as title.

### Link to the issue in case of a bug fix.
b/476875199

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
