### PR TITLE
feat(kernel-settings): [DO NOT MERGE] Conditionally set the max-read-ahead-kb for regional buckets with GCSFuse profiles

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -58,6 +58,12 @@ import (
 	"github.com/jacobsa/timeutil"
 )
 
+const (
+	profileAimlServing        = "aiml-serving"
+	profileAimlCheckpointing  = "aiml-checkpointing"
+	regionalBucketReadAheadKb = 1024
+)
+
 type ServerConfig struct {
 	// A clock used for cache expiration. It is *not* used for inode times, for
 	// which we use the wall clock.
@@ -271,9 +277,9 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 			})
 			// TODO(b/477149142): Remove this once regional bucket type based optimisations are in-place.
 			if !serverCfg.IsUserSet.IsSet("file-system.max-read-ahead-kb") && !bucketType.Zonal {
-				if serverCfg.NewConfig.Profile == "aiml-serving" || serverCfg.NewConfig.Profile == "aiml-checkpointing" {
+				if serverCfg.NewConfig.Profile == profileAimlServing || serverCfg.NewConfig.Profile == profileAimlCheckpointing {
 					optimizedFlags["file-system.max-read-ahead-kb"] = cfg.OptimizationResult{
-						FinalValue:         1024,
+						FinalValue:         regionalBucketReadAheadKb,
 						OptimizationReason: fmt.Sprintf("bucket-type %q", bucketTypeEnum),
 						Optimized:          true,
 					}


### PR DESCRIPTION
### Description
Conditionally set max-read-ahead-kb when regional bucket is used with GCSFuse profile serving or checkpointing.

Fix: Log only bucket type optimisations in bucket type optimisation log.

### Link to the issue in case of a bug fix.
b/477148347

### Test Scenarios:
Regional Bucket:
+ Profile and + Read ahead Kb:
https://paste.googleplex.com/6527469635108864
https://paste.googleplex.com/6091809057013760
https://paste.googleplex.com/6723829332312064
+ Profile and - Read ahead Kb:
https://paste.googleplex.com/6121303436296192
https://paste.googleplex.com/6093360647503872
https://paste.googleplex.com/5970623635521536
- Profile and - Read ahead kb:
https://paste.googleplex.com/6684253389717504
- Profile and + Read ahead kb:
https://paste.googleplex.com/4796070607585280

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
