### PR TITLE
fix(test): prevent panic in read cache validation when chunks are empty

### DIFF
--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -92,6 +92,10 @@ func validate(expected *Expected, logEntry *read_logs.StructuredReadLogEntry, is
 		t.Errorf("chunks read don't match! Expected: %d, Got from logs: %d",
 			chunkCount, len(logEntry.Chunks))
 	}
+	// If no chunks are found in logs, we can't validate further.
+	if len(logEntry.Chunks) == 0 {
+		return
+	}
 	if logEntry.Chunks[len(logEntry.Chunks)-1].StartTimeSeconds > expected.EndTimeStampSeconds {
 		t.Errorf("end time in logs more than actual end time.")
 	}


### PR DESCRIPTION
### Description
The validation logic in `tools/integration_tests/read_cache/helpers_test.go` was attempting to access the last element of the `logEntry.Chunks` slice using `logEntry.Chunks[len(logEntry.Chunks)-1]` without first verifying if the slice contained any elements. This caused a panic when the slice was empty.

This change adds a guard clause to return early if no chunks are found in the logs, preventing the index out-of-bounds error and allowing the test to fail gracefully or proceed correctly.

### Link to the issue in case of a bug fix.
b/477184829

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
