### PR TITLE
fix(metrics): Remove ReadHandle attribute from the gcs/reader_count metric.

### DIFF
--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -254,7 +254,5 @@ func (mrc *monitoringReadCloser) Close() (err error) {
 }
 
 func (mrc *monitoringReadCloser) ReadHandle() (rh storagev2.ReadHandle) {
-	rh = mrc.wrapped.ReadHandle()
-	recordReader(mrc.metricHandle, metrics.IoMethodReadHandleAttr)
-	return
+	return mrc.wrapped.ReadHandle()
 }

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -102,9 +102,8 @@ const (
 type IoMethod string
 
 const (
-	IoMethodReadHandleAttr IoMethod = "ReadHandle"
-	IoMethodClosedAttr     IoMethod = "closed"
-	IoMethodOpenedAttr     IoMethod = "opened"
+	IoMethodClosedAttr IoMethod = "closed"
+	IoMethodOpenedAttr IoMethod = "opened"
 )
 
 // ReadType is a custom type for the read_type attribute.

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -185,7 +185,6 @@
     values:
     - "closed"
     - "opened"
-    - "ReadHandle"
 
 - metric-name: "gcs/request_count"
   description: "The cumulative number of GCS requests processed along with the GCS method."

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -507,7 +507,6 @@ var (
 	gcsReadCountReadTypeRandomAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsReadCountReadTypeSequentialAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
 	gcsReadCountReadTypeUnknownAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsReaderCountIoMethodReadHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "ReadHandle")))
 	gcsReaderCountIoMethodClosedAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "closed")))
 	gcsReaderCountIoMethodOpenedAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "opened")))
 	gcsRequestCountGcsMethodComposeObjectsAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
@@ -1012,7 +1011,6 @@ type otelMetrics struct {
 	gcsReadCountReadTypeRandomAtomic                                                   *atomic.Int64
 	gcsReadCountReadTypeSequentialAtomic                                               *atomic.Int64
 	gcsReadCountReadTypeUnknownAtomic                                                  *atomic.Int64
-	gcsReaderCountIoMethodReadHandleAtomic                                             *atomic.Int64
 	gcsReaderCountIoMethodClosedAtomic                                                 *atomic.Int64
 	gcsReaderCountIoMethodOpenedAtomic                                                 *atomic.Int64
 	gcsRequestCountGcsMethodComposeObjectsAtomic                                       *atomic.Int64
@@ -2243,8 +2241,6 @@ func (o *otelMetrics) GcsReaderCount(
 		return
 	}
 	switch ioMethod {
-	case IoMethodReadHandleAttr:
-		o.gcsReaderCountIoMethodReadHandleAtomic.Add(inc)
 	case IoMethodClosedAttr:
 		o.gcsReaderCountIoMethodClosedAtomic.Add(inc)
 	case IoMethodOpenedAttr:
@@ -2868,8 +2864,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsReadCountReadTypeSequentialAtomic,
 		gcsReadCountReadTypeUnknownAtomic atomic.Int64
 
-	var gcsReaderCountIoMethodReadHandleAtomic,
-		gcsReaderCountIoMethodClosedAtomic,
+	var gcsReaderCountIoMethodClosedAtomic,
 		gcsReaderCountIoMethodOpenedAtomic atomic.Int64
 
 	var gcsRequestCountGcsMethodComposeObjectsAtomic,
@@ -3423,7 +3418,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &gcsReaderCountIoMethodReadHandleAtomic, gcsReaderCountIoMethodReadHandleAttrSet)
 			conditionallyObserve(obsrv, &gcsReaderCountIoMethodClosedAtomic, gcsReaderCountIoMethodClosedAttrSet)
 			conditionallyObserve(obsrv, &gcsReaderCountIoMethodOpenedAtomic, gcsReaderCountIoMethodOpenedAttrSet)
 			return nil
@@ -3945,7 +3939,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsReadCountReadTypeRandomAtomic:                           &gcsReadCountReadTypeRandomAtomic,
 		gcsReadCountReadTypeSequentialAtomic:                       &gcsReadCountReadTypeSequentialAtomic,
 		gcsReadCountReadTypeUnknownAtomic:                          &gcsReadCountReadTypeUnknownAtomic,
-		gcsReaderCountIoMethodReadHandleAtomic:                     &gcsReaderCountIoMethodReadHandleAtomic,
 		gcsReaderCountIoMethodClosedAtomic:                         &gcsReaderCountIoMethodClosedAtomic,
 		gcsReaderCountIoMethodOpenedAtomic:                         &gcsReaderCountIoMethodOpenedAtomic,
 		gcsRequestCountGcsMethodComposeObjectsAtomic:               &gcsRequestCountGcsMethodComposeObjectsAtomic,

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4776,15 +4776,6 @@ func TestGcsReaderCount(t *testing.T) {
 		expected map[attribute.Set]int64
 	}{
 		{
-			name: "io_method_ReadHandle",
-			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "ReadHandle")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("io_method", "ReadHandle")): 5,
-			},
-		},
-		{
 			name: "io_method_closed",
 			f: func(m *otelMetrics) {
 				m.GcsReaderCount(5, "closed")
@@ -4804,21 +4795,21 @@ func TestGcsReaderCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(5, "ReadHandle")
-				m.GcsReaderCount(2, "closed")
-				m.GcsReaderCount(3, "ReadHandle")
+				m.GcsReaderCount(5, "closed")
+				m.GcsReaderCount(2, "opened")
+				m.GcsReaderCount(3, "closed")
 			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "ReadHandle")): 8,
-				attribute.NewSet(attribute.String("io_method", "closed")): 2,
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "closed")): 8,
+				attribute.NewSet(attribute.String("io_method", "opened")): 2,
 			},
 		},
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsReaderCount(-5, "ReadHandle")
-				m.GcsReaderCount(2, "ReadHandle")
+				m.GcsReaderCount(-5, "closed")
+				m.GcsReaderCount(2, "closed")
 			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "ReadHandle")): 2},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("io_method", "closed")): 2},
 		},
 	}
 


### PR DESCRIPTION
### Description
gcs/reader_count tracks the number of open and closed readers. ReadHandle label doesn't make sense there.

### Link to the issue in case of a bug fix.
b/447561660

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
yes, a metric label is being deleted.
