### PR TITLE
feat(dir-metadata-prefetch): Log max results and start offset in list log for better debugability

### DIFF
--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -257,7 +257,7 @@ func (b *debugBucket) StatObject(
 func (b *debugBucket) ListObjects(
 	ctx context.Context,
 	req *gcs.ListObjectsRequest) (listing *gcs.Listing, err error) {
-	id, desc, start := b.startRequest("ListObjects(%q, StartOffset='%s', MaxResults=%d)", req.Prefix, req.StartOffset, req.MaxResults)
+	id, desc, start := b.startRequest("ListObjects(Prefix=%q, StartOffset=%q, MaxResults=%d)", req.Prefix, req.StartOffset, req.MaxResults)
 	defer b.finishRequest(id, desc, start, &err)
 
 	listing, err = b.wrapped.ListObjects(ctx, req)


### PR DESCRIPTION
### Description
This pull request enhances the debug logging for ListObjects calls by including `StartOffset` and `MaxResults`.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
4. Manual testing:
Log:
```
{"timestamp":{"seconds":1769073136,"nanos":225971852},"severity":"TRACE","message":"gcs: Req              0x1: <- ListObjects(Prefix=\"\", StartOffset=\"\", MaxResults=5000)","mount-id":"redacted-29032a7b"}
{"timestamp":{"seconds":1769073136,"nanos":589028967},"severity":"TRACE","message":"gcs: Req              0x1: -> ListObjects(Prefix=\"\", StartOffset=\"\", MaxResults=5000) (363.084706ms): OK","mount-id":"redacted-29032a7b"}
```
### Any backward incompatible change? If so, please explain.
