### PR TITLE
revert(kernel settings): Keep max-read-ahead-kb flag hidden in GCSFuse

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1158,6 +1158,10 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("max-read-ahead-kb", "", 0, "Sets max kernel-read-ahead for the mount in KiB. 0 means system default. Requires sudo permission to set this value, otherwise the value will be ignored and system default will be used.")
 
+	if err := flagSet.MarkHidden("max-read-ahead-kb"); err != nil {
+		return err
+	}
+
 	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. A value of 0 indicates no limit.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -477,6 +477,7 @@ params:
       Requires sudo permission to set this value, otherwise the value will be ignored
       and system default will be used.
     default: "0"
+    hide-flag: true
     optimizations:
       bucket-type-optimization:
         - bucket-type: "zonal"


### PR DESCRIPTION
### Description
Same as above.

### Link to the issue in case of a bug fix.
b/476875199

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
