### PR TITLE
feat(kernel-settings): Write kernel config only for zonal buckets in GKE env when kernel reader is enabled

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -530,15 +530,12 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 		}
 		markSuccessfulMount()
 
-		// Apply post mount kernel settings in non-GKE environments for non dynamic mounts.
-		if !isDynamicMount(bucketName) && !cfg.IsGKEEnvironment(mountPoint) {
+		// Apply post mount kernel settings in non-GKE environments for non dynamic mounts when kernel reader is enabled.
+		if !isDynamicMount(bucketName) && !cfg.IsGKEEnvironment(mountPoint) && newConfig.FileSystem.EnableKernelReader {
 			kernelparams := kernelparams.NewKernelParamsManager()
 			kernelparams.SetReadAheadKb(int(newConfig.FileSystem.MaxReadAheadKb))
-			// Set max-background and congestion window when async read is enabled via kernel reader.
-			if newConfig.FileSystem.EnableKernelReader {
-				kernelparams.SetCongestionWindowThreshold(int(newConfig.FileSystem.CongestionThreshold))
-				kernelparams.SetMaxBackgroundRequests(int(newConfig.FileSystem.MaxBackground))
-			}
+			kernelparams.SetCongestionWindowThreshold(int(newConfig.FileSystem.CongestionThreshold))
+			kernelparams.SetMaxBackgroundRequests(int(newConfig.FileSystem.MaxBackground))
 			kernelparams.ApplyNonGKE(mountPoint)
 		}
 	}


### PR DESCRIPTION
### Description
Same as title. This change is as per revised plan of using continuous enforcement of kernel params.

### Link to the issue in case of a bug fix.
b/478858189

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
