### PR TITLE
perf(metrics): track gcs/read_bytes_count in MrdSimpleReader

### DIFF
--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -587,6 +587,7 @@ func TestReadFile_MrdSimpleReaderMetrics(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(1))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/request_count", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), int64(1))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "gcs/request_latencies", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), uint64(1))
 }


### PR DESCRIPTION
### Description
This PR updates the `MrdSimpleReader` to correctly capture and report the `gcs/read_bytes_count` metric.

The logic has also been refactored to use a defer block for metric collection. This ensures that the total bytes read, including those from potential retries after short reads, are accurately recorded before the function returns

### Link to the issue in case of a bug fix.
b/479074389

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
