### PR TITLE
fix: fix managed folder tests

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -307,6 +307,7 @@ go version |& tee -a ${LOG_FILE}
 
 # Install latest gcloud.
 bash ./perfmetrics/scripts/install_latest_gcloud.sh
+export PATH=/usr/local/google-cloud-sdk/bin:$PATH
 
 # Installation of crcmod is working through pip only on rhel and centos.
 # For debian and ubuntu, we are installing through sudo apt.


### PR DESCRIPTION
### Description
1. When we run bash install_latest_gcloud.sh, it runs in a sub-shell. Any path changes made inside that script are lost the moment it finishes.
2. If that script replaces the google-cloud-sdk folder, the shell sometimes loses the hash/reference to the gcloud binary. Re-exporting the path "refreshes" the shell's lookup table.

### Link to the issue in case of a bug fix.
[b/477146969](http://b/477146969)

### Testing details
1. Manual - Validated through louhi(Without this fix it is constantly failing)
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
