### PR TITLE
ci: Update npm install command to fix version in PR reminder workflow

### DIFF
--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -25,7 +25,8 @@ jobs:
           node-version: '20'
 
       - name: Install Dependencies
-        run: npm install @actions/github @actions/core
+        # Pin to latest version supporting commonJS syntax used in reminder.js
+        run: npm install @actions/github@5.1.1 @actions/core 
 
       - name: Run Reminder Script
         run: node .github/scripts/reminder.js


### PR DESCRIPTION
### Description
Pin dependency to latest version supporting commonJS syntax used in the reminder.js.

### Fixes error
<img width="1792" height="774" alt="image" src="https://github.com/user-attachments/assets/de880dc8-640c-4741-9ac8-48616cf9651f" />


### Testing details
1. Manual - Tested
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
