### PR TITLE
ci: Fix CD pipeline for centos machines by upgrading python version to 3.11

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -34,7 +34,7 @@ echo "Upgrade gcloud version"
 wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
 sudo tar xzf gcloud.tar.gz && sudo cp -r google-cloud-sdk /usr/local && sudo rm -r google-cloud-sdk
 
-# Conditionally install python3.11 and run gcloud installer with it for RHEL 8 and Rocky 8
+# Conditionally install python3.11 and run gcloud installer with it for all variants of RHEL, Rocky and CENTOS.
 INSTALL_COMMAND="sudo /usr/local/google-cloud-sdk/install.sh --quiet"
 if [ -f /etc/os-release ]; then
     . /etc/os-release


### PR DESCRIPTION
### Description
- Upgrading python version 3.11 for centos as well just as earlier it had been done for `rhel` and `rocky` linux OS.
- The check `$ID == 'centos'` is based on the following shell command
   ```sh
   [starterscriptuser@release-test-centos-stream-9 gargnitin_google_com]$ cat /etc/os-release | grep -w 'ID='
   ID="centos"
   ```

### Link to the issue in case of a bug fix.
[b/478091145](http://b/478091145)

### Testing details
1. Manual - Tested manually by using script https://github.com/GoogleCloudPlatform/gcsfuse-tools/blob/main/manual_cd_testing/run_cd_script.sh with this branch.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
