### PR TITLE
fix: Fix periodic e2e test run timeouts by cleaning only buckets created in current run

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -328,9 +328,9 @@ create_bucket() {
   done
   echo "$bucket_name"
   # Append to created buckets list file for cleanup
-  acquire_lock "$LOG_LOCK_FILE"
+  acquire_lock "$BUCKET_CREATION_LOCK_FILE"
   echo "$bucket_name" >> "$CREATED_BUCKETS_LIST_FILE"
-  release_lock "$LOG_LOCK_FILE"
+  release_lock "$BUCKET_CREATION_LOCK_FILE"
   rm -rf "$bucket_cmd_log"
   return 0
 }
@@ -381,11 +381,11 @@ cleanup_created_buckets() {
         done
 
         batch_count=$((batch_count + 1))
-        log_info "Deleting bucket batch $batch_count: $batch_names_str"
+        log_info "Deleting bucket batch: $batch_count ..."
 
         # Delete batch
         if ! gcloud storage rm -r "${batch_uris[@]}" --no-user-output-enabled --verbosity=error; then
-            log_error "Failed to delete batch $batch_count. Continuing cleanup..."
+            log_error "Failed to delete one or more buckets in batch: $batch_count. These buckets would be cleaned up by the periodic cleanup job."
             # We continue here to try deleting other batches if one fails
         fi
 


### PR DESCRIPTION
### Description
- Instead of deleting old/expired buckets, delete only the gcs buckets created in this test run.
- Deletes a bunch of buckets at a time, rather than the extreme of deleting one bucket at a time, or deleting all buckets at once.
- Sample log
  ```sh
  [INFO] 2026-02-03 08:29:17: Found 66 buckets created during run to cleanup.
  [INFO] 2026-02-03 08:29:17: Deleting bucket batch 1: gcsfuse-e2e-managed_folders-flat-1770104907190838617, gcsfuse-e2e-operations-flat-1770104907191139451, gcsfuse-e2e-read_large_files-flat-1770104907191240499, gcsfuse-e2e-concurrent_operations-flat-1770104907191467315, gcsfuse-e2e-list_large_dir-flat-1770104907191523236, gcsfuse-e2e-write_large_files-flat-1770104907191952636, gcsfuse-e2e-mount_timeout-flat-1770104907191742968, gcsfuse-e2e-implicit_dir-flat-1770104907192169383, gcsfuse-e2e-managed_folders-hns-1770104907192300825, gcsfuse-e2e-interrupt-flat-1770104907192385283
  [INFO] 2026-02-03 08:30:23: Deleting bucket batch 2: gcsfuse-e2e-operations-hns-1770104907192480526, gcsfuse-e2e-local_file-flat-1770104907192522939, gcsfuse-e2e-read_large_files-hns-1770104907192734406, gcsfuse-e2e-concurrent_operations-hns-1770104907192986563, gcsfuse-e2e-list_large_dir-hns-1770104907193044548, gcsfuse-e2e-mount_timeout-hns-1770104907193378979, gcsfuse-e2e-write_large_files-hns-1770104907193597686, gcsfuse-e2e-implicit_dir-hns-1770104907193742332, gcsfuse-e2e-interrupt-hns-1770104907193900837, gcsfuse-e2e-local_file-hns-1770104907194077333
  [INFO] 2026-02-03 08:35:34: Deleting bucket batch 3: gcsfuse-e2e-readonly-flat-1770105051345429883, gcsfuse-e2e-readonly-hns-1770105142525334737, gcsfuse-e2e-readonly_creds-flat-1770105168677167258, gcsfuse-e2e-rename_dir_limit-flat-1770105207806126357, gcsfuse-e2e-kernel_list_cache-flat-1770105241486802257, gcsfuse-e2e-streaming_writes-flat-1770105262277881641, gcsfuse-e2e-readonly_creds-hns-1770105265000981842, gcsfuse-e2e-rename_dir_limit-hns-1770105291612414648, gcsfuse-e2e-kernel_list_cache-hns-1770105300987709823, gcsfuse-e2e-benchmarking-flat-1770105302476933014
  [INFO] 2026-02-03 08:35:39: Deleting bucket batch 4: gcsfuse-e2e-explicit_dir-flat-1770105305957382600, gcsfuse-e2e-gzip-flat-1770105308749188436, gcsfuse-e2e-streaming_writes-hns-1770105312057998408, gcsfuse-e2e-log_rotation-flat-1770105313597006217, gcsfuse-e2e-monitoring-flat-1770105317067628633, gcsfuse-e2e-benchmarking-hns-1770105328226127101, gcsfuse-e2e-mounting-flat-1770105336029087223, gcsfuse-e2e-unsupported_path-flat-1770105337408400022, gcsfuse-e2e-negative_stat_cache-flat-1770105354675159705, gcsfuse-e2e-stale_handle-flat-1770105354852225688
  [INFO] 2026-02-03 08:35:42: Deleting bucket batch 5: gcsfuse-e2e-explicit_dir-hns-1770105359930086994, gcsfuse-e2e-gzip-hns-1770105375361980605, gcsfuse-e2e-log_rotation-hns-1770105376120762911, gcsfuse-e2e-release_version-flat-1770105389362025206, gcsfuse-e2e-monitoring-hns-1770105395572788633, gcsfuse-e2e-readdirplus-flat-1770105395628027905, gcsfuse-e2e-dentry_cache-flat-1770105399890771033, gcsfuse-e2e-mounting-hns-1770105402840025330, gcsfuse-e2e-unsupported_path-hns-1770105409163901298, gcsfuse-e2e-buffered_read-flat-1770105409476531328
  [INFO] 2026-02-03 08:35:45: Deleting bucket batch 6: gcsfuse-e2e-flag_optimizations-flat-1770105417386548964, gcsfuse-e2e-negative_stat_cache-hns-1770105418767725286, gcsfuse-e2e-stale_handle-hns-1770105426676147879, gcsfuse-e2e-read_cache-flat-1770105434145385365, gcsfuse-e2e-inactive_stream_timeout-flat-1770105452756224383, gcsfuse-e2e-cloud_profiler-flat-1770105475253833201, gcsfuse-e2e-requester_pays_bucket-flat-1770105475733663856, gcsfuse-e2e-release_version-hns-1770105477296567903, gcsfuse-e2e-readdirplus-hns-1770105478166344021, gcsfuse-e2e-dentry_cache-hns-1770105489342942007
  [INFO] 2026-02-03 08:35:50: Deleting bucket batch 7: gcsfuse-e2e-buffered_read-hns-1770105498374229532, gcsfuse-e2e-flag_optimizations-hns-1770105502833814159, gcsfuse-e2e-read_cache-hns-1770105517097254751, gcsfuse-e2e-inactive_stream_timeout-hns-1770105526432881803, gcsfuse-e2e-cloud_profiler-hns-1770105544654921192, gcsfuse-e2e-requester_pays_bucket-hns-1770105546426318443
  [INFO] 2026-02-03 08:35:53: Bucket cleanup complete.
```
- I have setup a separate periodic job to delete the buckets failed to delete here and the preexisting old/stale e2e test buckets.


### Link to the issue in case of a bug fix.
[b/480793095](http://b/480793095)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - [passed](http://fusion2/ci/kokoro/prod%3Agcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/9fb9cd61-49ba-411e-81c1-80706f88d615)

### Any backward incompatible change? If so, please explain.
