### PR TITLE
fix: changing python 311 to python3

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -34,14 +34,14 @@ echo "Upgrade gcloud version"
 wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz -q
 sudo tar xzf gcloud.tar.gz && sudo cp -r google-cloud-sdk /usr/local && sudo rm -r google-cloud-sdk
 
-# Conditionally install python3.11 and run gcloud installer with it for all variants of RHEL, Rocky and CENTOS.
+# Conditionally install python3 and run gcloud installer with it for all variants of RHEL, Rocky and CENTOS.
 INSTALL_COMMAND="sudo /usr/local/google-cloud-sdk/install.sh --quiet"
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     if [[ ($ID == "rhel" || $ID == "rocky" || $ID == "centos") ]]; then
-        sudo yum install -y python311
-        export CLOUDSDK_PYTHON=/usr/bin/python3.11
-        INSTALL_COMMAND="sudo env CLOUDSDK_PYTHON=/usr/bin/python3.11 /usr/local/google-cloud-sdk/install.sh --quiet"
+        sudo yum install -y python3
+        export CLOUDSDK_PYTHON=/usr/bin/python3
+        INSTALL_COMMAND="sudo env CLOUDSDK_PYTHON=/usr/bin/python3 /usr/local/google-cloud-sdk/install.sh --quiet"
     fi
 fi
 $INSTALL_COMMAND
@@ -254,8 +254,8 @@ then
     sudo apt install -y build-essential
 else
     # For rhel and centos
-    # Set CLOUDSDK_PYTHON to python3.11 for gcloud commands to work.
-    export CLOUDSDK_PYTHON=/usr/bin/python3.11
+    # Set CLOUDSDK_PYTHON to python3 for gcloud commands to work.
+    export CLOUDSDK_PYTHON=/usr/bin/python3
 
     # uname can be aarch or x86_64
     uname=$(uname -m)


### PR DESCRIPTION
### Description
This PR generalizes the Python installation logic within the tools/cd_scripts/e2e_test.sh script to improve compatibility across different versions of RHEL, Rocky, and CentOS.

Previously, the script was hardcoded to install and use python3.11. This caused issues on newer operating system images where Python 3.11 might not be available in the default repositories, or where Python 3.12 is the preferred default. By switching to the generic python3 package, the script dynamically adapts to the default Python 3 version provided by the underlying OS.

### Link to the issue in case of a bug fix.
[b/480779912](https://buganizer.corp.google.com/issues/480779912)

### Testing details
1. Manual - Tested for centOS-9(python version 3.11 compatible) and centOS-10(python version 3.12 compatible)
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
