### PR TITLE
fix(louhi e2e tests): fix python installation for older Oses

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -39,9 +39,20 @@ INSTALL_COMMAND="sudo /usr/local/google-cloud-sdk/install.sh --quiet"
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     if [[ ($ID == "rhel" || $ID == "rocky" || $ID == "centos") ]]; then
-        sudo yum install -y python3
-        export CLOUDSDK_PYTHON=/usr/bin/python3
-        INSTALL_COMMAND="sudo env CLOUDSDK_PYTHON=/usr/bin/python3 /usr/local/google-cloud-sdk/install.sh --quiet"
+        
+        # Check if we are on version 8 to install 3.11
+        if [[ $VERSION_ID =~ ^8 ]]; then
+            echo "Detected version 8. Installing Python 3.11..."
+            sudo yum install -y python311
+            PYTHON_BIN="/usr/bin/python3.11"
+        else
+            # Default behavior for other versions
+            sudo yum install -y python3
+            PYTHON_BIN="/usr/bin/python3"
+        fi
+
+        export CLOUDSDK_PYTHON=$PYTHON_BIN
+        INSTALL_COMMAND="sudo env CLOUDSDK_PYTHON=$PYTHON_BIN /usr/local/google-cloud-sdk/install.sh --quiet"
     fi
 fi
 $INSTALL_COMMAND


### PR DESCRIPTION
### Description
This pull request modifies the E2E test script to explicitly handle Python installation on RHEL/ROCKY 8 variants.

On RHEL/ROCKY 8, the default python3 package can sometimes point to versions (like 3.6) that are no longer compatible with the latest Google Cloud SDK installation requirements. This change introduces logic to detect version 8 of the OS and specifically install python311. For other versions, it falls back to the default python3 package.

It also ensures that the CLOUDSDK_PYTHON environment variable and the gcloud INSTALL_COMMAND are updated to use the correct Python binary discovered during the installation process

### Link to the issue in case of a bug fix.
[b/480779912](https://b.corp.google.com/issues/480779912)

### Testing details
1. Manual - Tested manually on Rhel-8 and Rhel-9
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
