### PR TITLE
fix(e2e script): Fix e2e script for rhel8 machine python installation.

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -268,7 +268,7 @@ else
     # Set CLOUDSDK_PYTHON to python3 for gcloud commands to work.
 
     if [[ -f /etc/os-release ]]; then
-        # Extract VERSION_ID using double quotes only
+        # Extract VERSION_ID from /etc/os-release
         V_ID=$(awk -F= "/^VERSION_ID=/{print \$2}" /etc/os-release | tr -d "\"")
 
         # Check if the version starts with 8


### PR DESCRIPTION
### Description
export python3.11 for rhel-8 machines in startupscript.

### Link to the issue in case of a bug fix.
[b/480779912](https://b.corp.google.com/issues/480779912)

### Testing details
1. Manual - Validated through running e2e tests on rhel-8 and rhel-10 machines.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
