### PR TITLE
Force IsGKEEnvironment to true for gRPC metrics testing

### DIFF
--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -17,7 +17,6 @@ package cfg
 import (
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
 )
 
@@ -75,7 +74,7 @@ func IsMetricsEnabled(c *MetricsConfig) bool {
 
 // IsGKEEnvironment returns true for /dev/fd/N mountpoints.
 func IsGKEEnvironment(mountPoint string) bool {
-	return strings.HasPrefix(mountPoint, "/dev/fd/")
+	return true
 }
 
 // GetBucketType converts BucketType boolean flags to a BucketType enum.

--- a/cfg/config_util_test.go
+++ b/cfg/config_util_test.go
@@ -219,7 +219,7 @@ func TestIsGKEEnvironment(t *testing.T) {
 		mountPoint string
 		expected   bool
 	}{
-		{"non-GKE", "/usr/local/mount-folder", false},
+		{"non-GKE", "/usr/local/mount-folder", true},
 		{"GKE mountpoint", "/dev/fd/", true},
 		{"GKE /dev/fd/N", "/dev/fd/8", true},
 	}


### PR DESCRIPTION
- Modified `IsGKEEnvironment` in `cfg/config_util.go` to always return `true`.
- Updated `TestIsGKEEnvironment` in `cfg/config_util_test.go` to expect `true` for all test cases.
- Removed unused `strings` import in `cfg/config_util.go`.


---
*PR created automatically by Jules for task [12244165480734560535](https://jules.google.com/task/12244165480734560535) started by @alleaditya*