### PR TITLE
fix(tests): optimize file operations and fix handle closure in integration tests

### DIFF
--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -106,18 +106,9 @@ func CopyFileAllowOverwrite(srcFileName, newFileName string) (err error) {
 }
 
 func ReadFile(filePath string) (content []byte, err error) {
-	file, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, FilePermission_0600)
+	content, err = os.ReadFile(filePath)
 	if err != nil {
-		err = fmt.Errorf("error in the opening the file %v", err)
-		return
-	}
-
-	// Closing file at the end.
-	defer CloseFile(file)
-
-	content, err = os.ReadFile(file.Name())
-	if err != nil {
-		err = fmt.Errorf("ReadAll: %v", err)
+		err = fmt.Errorf("ReadFile: %v", err)
 		return
 	}
 	return
@@ -292,15 +283,13 @@ func ReadChunkFromFile(filePath string, chunkSize int64, offset int64, flag int)
 		log.Printf("Error in opening file: %v", err)
 		return
 	}
+	defer CloseFile(file)
 
-	f, err := os.Stat(filePath)
+	f, err := file.Stat()
 	if err != nil {
 		log.Printf("Error in stating file: %v", err)
 		return
 	}
-
-	// Closing the file at the end.
-	defer CloseFile(file)
 
 	var numberOfBytes int
 


### PR DESCRIPTION
### Description
This PR improves the reliability and efficiency of file operations within the integration test utilities by addressing file handle leaks and redundant operations.

**Changes:**

- **ReadFile:** Simplified the function by replacing manual `os.OpenFile` and `defer CloseFile` logic with a direct call to `os.ReadFile(filePath)`. This removes the redundant opening of the file handle that was not being utilized for the read operation.
- **ReadChunkFromFile:** Moved the `defer CloseFile(file)` statement to immediately after the file is opened. This ensures the file handle is properly closed even if subsequent operations, such as `Stat`, fail and cause an early return.

### Link to the issue in case of a bug fix.
b/482941062

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
