### PR TITLE
test(kokoro build.sh): run distributed micro-benchmarks from build.sh

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -25,15 +25,14 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 
 TOOLS_DIR="${KOKORO_ARTIFACTS_DIR}/github/gcsfuse-tools"
-
+PERF_BENCHMARKS_FAILED=0
 if [ -d "$TOOLS_DIR" ]; then
     echo "Running Distributed Micro-Benchmark from gcsfuse-tools..."
-    chmod +x "$TOOLS_DIR/distributed-micro-benchmark/run.sh"
     "$TOOLS_DIR/distributed-micro-benchmark/run.sh" --commit "$commitId"
     
 else
     echo "ERROR: gcsfuse-tools directory not found!"
-    exit 1
+    PERF_BENCHMARKS_FAILED=1
 fi
 
 echo "Building and installing gcsfuse"
@@ -101,7 +100,10 @@ run_ls_benchmark "$GCSFUSE_LS_FLAGS" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
 cd "./hns_rename_folders_metrics"
 ./run_rename_benchmark.sh $UPLOAD_FLAGS
 
-
+if [ $PERF_BENCHMARKS_FAILED -ne 0 ]; then
+  echo "Distributed benchmarks have failed."
+  exit 1
+fi
 # TODO: Testing for hns bucket with client protocol set to grpc. To be done when
 #  includeFolderAsPrefixes is supported in grpc.
 # TODO: Testing for hns bucket with client protocol set to grpc with grpc-conn-pool-size


### PR DESCRIPTION
### Description
This change modifies `perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh` to check for and run the distributed micro-benchmarks from the gcsfuse-tools directory on the Kokoro VM. 

This ensures that the new distributed tests can run without disrupting the existing performance test suite

### Link to the issue in case of a bug fix.
b/485096293

### Testing details
1. Kokoro: Integration tests rely on the corresponding configuration change being active in the build environment 
[Kokoro Test Link](https://fusion2.corp.google.com/ci/kokoro/qa:codelab%2Ftulsishah%2Fgcp_ubuntu%2Fmaster%2Fsubjobs%2Famd64_master/activity/888f1806-97b8-4980-a43d-1ac2f052ec5f/log)
