### PR TITLE
test: Randomize test directory names in negative stat cache tests

### DIFF
--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -28,13 +28,14 @@ import (
 )
 
 type disabledNegativeStatCacheTest struct {
-	flags []string
+	flags   []string
+	testDir string
 	suite.Suite
 }
 
 func (s *disabledNegativeStatCacheTest) SetupTest() {
-	testDir := testDirName + setup.GenerateRandomString(5)
-	mountGCSFuseAndSetupTestDir(s.flags, testDir)
+	s.testDir = testDirName + setup.GenerateRandomString(5)
+	mountGCSFuseAndSetupTestDir(s.flags, s.testDir)
 }
 
 func (s *disabledNegativeStatCacheTest) TearDownTest() {
@@ -60,8 +61,7 @@ func (s *disabledNegativeStatCacheTest) TestNegativeStatCacheDisabled() {
 	assert.ErrorContains(s.T(), err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	testDir := path.Base(testEnv.testDirPath)
-	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDir, "explicit_dir/file1.txt", "some-content", s.T())
+	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, s.testDir, "explicit_dir/file1.txt", "some-content", s.T())
 
 	// File should be returned, as call will be served from GCS and gcsfuse should not return from cache
 	f, err := os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -29,13 +29,14 @@ import (
 )
 
 type finiteNegativeStatCacheTest struct {
-	flags []string
+	flags   []string
+	testDir string
 	suite.Suite
 }
 
 func (s *finiteNegativeStatCacheTest) SetupTest() {
-	testDir := testDirName + setup.GenerateRandomString(5)
-	mountGCSFuseAndSetupTestDir(s.flags, testDir)
+	s.testDir = testDirName + setup.GenerateRandomString(5)
+	mountGCSFuseAndSetupTestDir(s.flags, s.testDir)
 }
 
 func (s *finiteNegativeStatCacheTest) TearDownTest() {
@@ -61,8 +62,7 @@ func (s *finiteNegativeStatCacheTest) TestFiniteNegativeStatCache() {
 	assert.ErrorContains(s.T(), err, "explicit_dir/file1.txt: no such file or directory")
 
 	// Adding the object with same name
-	testDir := path.Base(testEnv.testDirPath)
-	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDir, path.Join("explicit_dir", "file1.txt"), "some-content", s.T())
+	client.CreateObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, s.testDir, path.Join("explicit_dir", "file1.txt"), "some-content", s.T())
 
 	// Error should be returned again, as call will not be served from GCS due to finite gcsfuse stat cache
 	_, err = os.OpenFile(targetFile, os.O_RDONLY, os.FileMode(0600))


### PR DESCRIPTION
Use random directory names for negative stat cache tests. This prevents collisions 

- when running tests in parallel or concurrently on the same bucket.
- When the cleanup doesn't happen properly

---
*PR created automatically by Jules for task [10178962003327661698](https://jules.google.com/task/10178962003327661698) started by @vadlakondaswetha*