### PR TITLE
fix(kokoro script): Rename script to be used for distributed benchmarking.

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -28,7 +28,7 @@ TOOLS_DIR="${KOKORO_ARTIFACTS_DIR}/github/gcsfuse-tools"
 PERF_BENCHMARKS_FAILED=0
 if [ -d "$TOOLS_DIR" ]; then
     echo "Running Distributed Micro-Benchmark from gcsfuse-tools..."
-    "$TOOLS_DIR/distributed-micro-benchmark/kokoro_run.sh" --commit "$commitId"
+    "$TOOLS_DIR/distributed-micro-benchmark/kokoro_run.sh" --commit "$commitId" || PERF_BENCHMARKS_FAILED=1
     
 else
     echo "ERROR: gcsfuse-tools directory not found!"


### PR DESCRIPTION
### Description
Renamed this file recently in gcsfuse-tools repo as a PR review. Need this change to avoid failure of script not being found.

### Link to the issue in case of a bug fix.
b/485096293
