### PR TITLE
feat(wire-log): plumb through wire log

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -621,6 +621,8 @@ type LoggingConfig struct {
 	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
 
 	Severity LogSeverity `yaml:"severity"`
+
+	WireLog ResolvedPath `yaml:"wire-log"`
 }
 
 type MetadataCacheConfig struct {
@@ -1333,6 +1335,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.StringP("wire-log", "", "", "The file name of the wire log. When specified, GCSFuse will serialize each FUSE operation as a JSON object and append it to this file.")
+
+	if err := flagSet.MarkHidden("wire-log"); err != nil {
+		return err
+	}
+
 	flagSet.IntP("workload-insight-forward-merge-threshold-mb", "", 0, "The threshold in MB for merging forward sequential reads for workload insights visualization.Reads within this threshold will be merged into a single read operation. Applicable only when --visualize-workload-insight is enabled.")
 
 	if err := flagSet.MarkHidden("workload-insight-forward-merge-threshold-mb"); err != nil {
@@ -1909,6 +1917,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("workload-insight.visualize", flagSet.Lookup("visualize-workload-insight")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.wire-log", flagSet.Lookup("wire-log")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -839,6 +839,14 @@ params:
     usage: "Specifies the logging severity expressed as one of [trace, debug, info, warning, error, off]"
     default: "info"
 
+  - config-path: "logging.wire-log"
+    flag-name: "wire-log"
+    type: "resolvedPath"
+    usage: >-
+      The file name of the wire log. When specified, GCSFuse will serialize
+      each FUSE operation as a JSON object and append it to this file.
+    hide-flag: true
+
   - config-path: "machine-type"
     flag-name: "machine-type"
     type: "string"

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -190,6 +190,15 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		EnableAsyncReads: newConfig.FileSystem.EnableKernelReader,
 	}
 
+	if newConfig.Logging.WireLog != "" {
+		wireLog, err := os.Create(string(newConfig.Logging.WireLog))
+		if err == nil {
+			mountCfg.WireLogger = wireLog
+		} else {
+			logger.Errorf("Unable to create wire log: %v", err)
+		}
+	}
+
 	// GCSFuse to Jacobsa Fuse Log Level mapping:
 	// OFF           OFF
 	// ERROR         ERROR


### PR DESCRIPTION
### Description

This adds a new flag, `-wire-log=<path>`, that enables the wire log that was recently added to jacobsa/fuse. When enabled, this will serialize every FUSE operation as a JSON object and append it to the specified file.

The wire log is useful when analyzing workload patterns.

### Testing details

The wirelog feature has unit tests in jacobsa/fuse. This merely plumbs through the flag. I have run this manually adding `-wire-log wirelog.json` and verified that the wire log is correctly generated.

### Any backward incompatible change? If so, please explain.

None