### PR TITLE
refactor(kokoro perf tests): increase timeout to 6hrs from default 3hrs

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -24,5 +24,6 @@ action {
   }
 }
 
+# Increase timeout to 6 hours
+timeout_mins: 360
 build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh"
-


### PR DESCRIPTION
### Description
Because of a recent addition of fio configs in our Kokoro perf tests, the perf test was timing out.

`ERROR: Aborting VM command due to timeout of 10800 seconds`

The default value is taken as 3 hours. 
I am setting this timeout as 6 hours in this PR

### Link to the issue in case of a bug fix.
b/487460676

### Testing - via Kokoro