### PR TITLE
fix(GKE GCSFuse test migration): only dir tests for read cache test package

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -441,29 +441,6 @@ func SetUpTestDirForTestBucket(cfg *test_suite.TestConfig) {
 	SetLogFile(cfg.LogFile)
 }
 
-func SetUpLogDirForTestDirTests(logDirName string) (logDir string) {
-	logDir = path.Join(TestDir(), logDirName)
-	err := os.Mkdir(logDir, DirPermission_0755)
-	if err != nil {
-		log.Printf("os.Mkdir %s: %v\n", logDir, err)
-		os.Exit(1)
-	}
-	return
-}
-
-func ValidateLogDirForMountedDirTests(logDirName string) (logDir string) {
-	if *mountedDirectory == "" {
-		return ""
-	}
-	logDir = path.Join(os.TempDir(), logDirName)
-	_, err := os.Stat(logDir)
-	if err != nil {
-		log.Printf("validateLogDirForMountedDirTests %s: %v\n", logDir, err)
-		os.Exit(1)
-	}
-	return
-}
-
 func LogAndExit(s string) {
 	log.Print(s)
 	log.Print(string(debug.Stack()))
@@ -644,9 +621,11 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 }
 
 func SetGlobalVars(cfg *test_suite.TestConfig) {
+	// TODO: clean global variables after test migration to config file completes.
 	testBucket = &cfg.TestBucket
 	logFile = cfg.LogFile
 	mntDir = cfg.GKEMountedDirectory
+	onlyDirMounted = cfg.OnlyDir
 }
 
 // Explicitly set the enable-hns config flag to true when running tests on the HNS bucket.

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -17,7 +17,6 @@ package test_suite
 import (
 	"log"
 	"os"
-	"path"
 
 	"gopkg.in/yaml.v3"
 )
@@ -85,47 +84,6 @@ type Config struct {
 	UnsupportedPath       []TestConfig `yaml:"unsupported_path"`
 }
 
-func processTestConfigs(configs []TestConfig) {
-	for i := range configs {
-		if configs[i].OnlyDir != "" && configs[i].GKEMountedDirectory != "" {
-			// Add onlyDir infront of bucket_name incase of mounted dir
-			configs[i].TestBucket = path.Join(configs[i].TestBucket, configs[i].OnlyDir)
-		}
-	}
-}
-
-func (c *Config) postProcessConfig() {
-	processTestConfigs(c.ImplicitDir)
-	processTestConfigs(c.ExplicitDir)
-	processTestConfigs(c.ListLargeDir)
-	processTestConfigs(c.WriteLargeFiles)
-	processTestConfigs(c.Operations)
-	processTestConfigs(c.ReadLargeFiles)
-	processTestConfigs(c.ReadOnly)
-	processTestConfigs(c.ReadCache)
-	processTestConfigs(c.RenameDirLimit)
-	processTestConfigs(c.Gzip)
-	processTestConfigs(c.LocalFile)
-	processTestConfigs(c.LogRotation)
-	processTestConfigs(c.ManagedFolders)
-	processTestConfigs(c.ConcurrentOperations)
-	processTestConfigs(c.Benchmarking)
-	processTestConfigs(c.StaleHandle)
-	processTestConfigs(c.StreamingWrites)
-	processTestConfigs(c.InactiveStreamTimeout)
-	processTestConfigs(c.CloudProfiler)
-	processTestConfigs(c.KernelListCache)
-	processTestConfigs(c.ReadDirPlus)
-	processTestConfigs(c.DentryCache)
-	processTestConfigs(c.ReadGCSAlgo)
-	processTestConfigs(c.Interrupt)
-	processTestConfigs(c.UnfinalizedObject)
-	processTestConfigs(c.RapidAppends)
-	processTestConfigs(c.MountTimeout)
-	processTestConfigs(c.Monitoring)
-	processTestConfigs(c.FlagOptimizations)
-}
-
 // ReadConfigFile returns a Config struct from the YAML file.
 func ReadConfigFile(configFilePath string) Config {
 	var cfg Config
@@ -140,6 +98,5 @@ func ReadConfigFile(configFilePath string) Config {
 		}
 	}
 
-	cfg.postProcessConfig()
 	return cfg
 }


### PR DESCRIPTION
### Description
`only-dir` mount tests for the read cache test package were failing in the GKE environment. This was due to incorrect extraction of the test bucket and directory at various points in the tests. The issue arose because we had not previously run only directory mount tests for the read cache package in the GKE environment. 

Setting a global variable to get `only-dir` mounted resolved the problem, also aligning with standard GCSFuse tests. 

Future work:
Going forward, after the test migration is complete, we will clean up the logic for extracting "only dir" from test bucket names and remove the global variables.

### Link to the issue in case of a bug fix.
b/487007686

### Testing details
1. Manual - Manually ran local_file and read_cache test package with only dir and mounted directory set.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
