### PR TITLE
chore: [cache-dir-size-fix] Part 2: Add configuration flags and parsing for file cache size fix

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -489,9 +489,15 @@ type FileCacheConfig struct {
 
 	ExcludeRegex string `yaml:"exclude-regex"`
 
+	ExperimentalDeleteEmptyDirs bool `yaml:"experimental-delete-empty-dirs"`
+
 	ExperimentalEnableChunkCache bool `yaml:"experimental-enable-chunk-cache"`
 
+	ExperimentalEnableSizeCalculationFix bool `yaml:"experimental-enable-size-calculation-fix"`
+
 	ExperimentalParallelDownloadsDefaultOn bool `yaml:"experimental-parallel-downloads-default-on"`
+
+	ExperimentalSizeCalculationFrequencySecs int64 `yaml:"experimental-size-calculation-frequency-secs"`
 
 	IncludeRegex string `yaml:"include-regex"`
 
@@ -993,6 +999,16 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("experimental-enable-standard-symlinks"); err != nil {
 		return err
 	}
+
+	flagSet.BoolP("experimental-file-cache-delete-empty-dirs", "", true, "Whether or not to delete empty directories inside cache-dir during periodic disk-size scan of file-cache cache-dir. It should be set only when file-cache-size-scan-enable is true.")
+
+	if err := flagSet.MarkHidden("experimental-file-cache-delete-empty-dirs"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("experimental-file-cache-enable-size-calculation-fix", "", false, "Whether or not to scan disk sizes of file-cache cache-dir.")
+
+	flagSet.IntP("experimental-file-cache-size-calculation-frequency-secs", "", 10, "The duration in seconds after which the size of the file-cache cache-dir is calculated again. It should be set only when file-cache-size-scan-enable is true.")
 
 	flagSet.IntP("experimental-grpc-conn-pool-size", "", 1, "The number of gRPC channel in grpc client.")
 
@@ -1578,6 +1594,18 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("experimental-enable-standard-symlinks", flagSet.Lookup("experimental-enable-standard-symlinks")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.experimental-delete-empty-dirs", flagSet.Lookup("experimental-file-cache-delete-empty-dirs")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.experimental-enable-size-calculation-fix", flagSet.Lookup("experimental-file-cache-enable-size-calculation-fix")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-cache.experimental-size-calculation-frequency-secs", flagSet.Lookup("experimental-file-cache-size-calculation-frequency-secs")); err != nil {
 		return err
 	}
 

--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -26,6 +26,11 @@ const (
 	// setting. This is more than sufficient to saturate the 200 Gbps network bandwidth
 	// on a single VM. Revise the numbers if you plan to support higher bandwidth VMs.
 	maxBackgroundLimit = 192
+
+	// DefaultFileCacheSizeScanFrequencySecs is default period in seconds
+	// after which the scanning and empty-dir deletion of the cache-dir
+	// should be repeated.
+	DefaultFileCacheSizeScanFrequencySecs = 10
 )
 
 func DefaultMaxBackground() int {

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -307,6 +307,13 @@ params:
     usage: "Exclude file paths (in the format bucket_name/object_key) specified by this regex from file caching."
     default: ""
 
+  - config-path: "file-cache.experimental-delete-empty-dirs"
+    flag-name: "experimental-file-cache-delete-empty-dirs"
+    type: "bool"
+    usage: "Whether or not to delete empty directories inside cache-dir during periodic disk-size scan of file-cache cache-dir. It should be set only when file-cache-size-scan-enable is true."
+    default: true
+    hide-flag: true
+
   - config-path: "file-cache.experimental-enable-chunk-cache"
     flag-name: "file-cache-experimental-enable-chunk-cache"
     type: "bool"
@@ -314,12 +321,26 @@ params:
     default: false
     hide-flag: true
 
+  - config-path: "file-cache.experimental-enable-size-calculation-fix"
+    flag-name: "experimental-file-cache-enable-size-calculation-fix"
+    type: "bool"
+    usage: "Whether or not to scan disk sizes of file-cache cache-dir."
+    default: false
+    hide-flag: false
+
   - config-path: "file-cache.experimental-parallel-downloads-default-on"
     flag-name: "file-cache-experimental-parallel-downloads-default-on"
     type: "bool"
     usage: "Enable parallel downloads by default on experimental basis."
     default: true
     hide-flag: true
+
+  - config-path: "file-cache.experimental-size-calculation-frequency-secs"
+    flag-name: "experimental-file-cache-size-calculation-frequency-secs"
+    type: "int"
+    usage: "The duration in seconds after which the size of the file-cache cache-dir is calculated again. It should be set only when file-cache-size-scan-enable is true."
+    default: "10" # 10 seconds
+    hide-flag: false
 
   - config-path: "file-cache.include-regex"
     flag-name: "file-cache-include-regex"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -115,6 +115,12 @@ func resolveCloudMetricsUploadIntervalSecs(m *MetricsConfig) {
 	}
 }
 
+func resolveSizeScanEnableValue(c *Config) {
+	if c.FileCache.MaxSizeMb == -1 || !IsFileCacheEnabled(c) {
+		c.FileCache.ExperimentalEnableSizeCalculationFix = false
+	}
+}
+
 func resolveParallelDownloadsValue(v *viper.Viper, fc *FileCacheConfig, c *Config) {
 	// Parallel downloads should be default ON when file cache is enabled, in case
 	// it is explicitly set by the user, use that value.
@@ -184,6 +190,7 @@ func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	resolveMetadataCacheConfig(v, &c.MetadataCache, optimizedFlags)
 	resolveStatCacheMaxSizeMB(v, &c.MetadataCache, optimizedFlags)
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
+	resolveSizeScanEnableValue(c)
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
 	resolveFileCacheAndBufferedReadConflict(v, c)
 	resolveGCSRetriesConfig(&c.GcsRetries)

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -901,3 +901,53 @@ func TestRationalize_MetadataCacheConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestRationalize_SizeScanEnableValue(t *testing.T) {
+	testCases := []struct {
+		name                                      string
+		config                                    *Config
+		expectedFileCacheEnableSizeCalculationFiz bool
+	}{
+		{
+			name: "max_size_mb_is_-1_size_scan_enable_is_true",
+			config: &Config{
+				CacheDir: ResolvedPath("/tmp/cache"),
+				FileCache: FileCacheConfig{
+					MaxSizeMb:                            -1,
+					ExperimentalEnableSizeCalculationFix: true,
+				},
+			},
+			expectedFileCacheEnableSizeCalculationFiz: false,
+		},
+		{
+			name: "max_size_mb_is_10_size_scan_enable_is_true",
+			config: &Config{
+				CacheDir: ResolvedPath("/tmp/cache"),
+				FileCache: FileCacheConfig{
+					MaxSizeMb:                            10,
+					ExperimentalEnableSizeCalculationFix: true,
+				},
+			},
+			expectedFileCacheEnableSizeCalculationFiz: true,
+		},
+		{
+			name: "max_size_mb_is_10_cache_dir_empty_size_scan_enable_is_true",
+			config: &Config{
+				CacheDir: ResolvedPath(""),
+				FileCache: FileCacheConfig{
+					MaxSizeMb:                            10,
+					ExperimentalEnableSizeCalculationFix: true,
+				},
+			},
+			expectedFileCacheEnableSizeCalculationFiz: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolveSizeScanEnableValue(tc.config)
+
+			assert.Equal(t, tc.expectedFileCacheEnableSizeCalculationFiz, tc.config.FileCache.ExperimentalEnableSizeCalculationFix)
+		})
+	}
+}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -92,6 +92,16 @@ func isValidFileCacheConfig(config *FileCacheConfig) error {
 		return fmt.Errorf("invalid regex value %q provided for include-regex", config.IncludeRegex)
 	}
 
+	if config.ExperimentalEnableSizeCalculationFix {
+		if config.ExperimentalSizeCalculationFrequencySecs <= 0 {
+			return errors.New("the value of experimental-file-cache-size-calculation-frequency-secs must be greater than 0 when experimental-file-cache-enable-size-calculation-fix is enabled")
+		}
+	} else {
+		if config.ExperimentalSizeCalculationFrequencySecs != DefaultFileCacheSizeScanFrequencySecs {
+			return errors.New("experimental-file-cache-size-calculation-frequency-secs must be 0 or must not be set when experimental-file-cache-enable-size-caclulation-fix is false")
+		}
+	}
+
 	return nil
 }
 

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -1255,3 +1255,67 @@ func TestValidateProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFileCacheConfig_SizeCalculationFixConfig(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name    string
+		config  FileCacheConfig
+		wantErr bool
+	}{
+		{
+			name: "Enable=False,_Frequency!=default_->_Error",
+			config: FileCacheConfig{
+				ExperimentalEnableSizeCalculationFix:     false,
+				ExperimentalDeleteEmptyDirs:              true,
+				ExperimentalSizeCalculationFrequencySecs: 20,
+				// Valid defaults
+				CacheFileForRangeRead:    false,
+				DownloadChunkSizeMb:      50,
+				EnableCrc:                false,
+				EnableParallelDownloads:  false,
+				MaxParallelDownloads:     4,
+				MaxSizeMb:                10,
+				ParallelDownloadsPerFile: 16,
+				WriteBufferSize:          4 * 1024 * 1024,
+				EnableODirect:            true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Enable=True,_Delete=True_->_Valid",
+			config: FileCacheConfig{
+				ExperimentalEnableSizeCalculationFix:     true,
+				ExperimentalDeleteEmptyDirs:              true,
+				ExperimentalSizeCalculationFrequencySecs: 10,
+				// Valid defaults
+				CacheFileForRangeRead:    false,
+				DownloadChunkSizeMb:      50,
+				EnableCrc:                false,
+				EnableParallelDownloads:  false,
+				MaxParallelDownloads:     4,
+				MaxSizeMb:                -1,
+				ParallelDownloadsPerFile: 16,
+				WriteBufferSize:          4 * 1024 * 1024,
+				EnableODirect:            true,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := validConfig(t)
+			c.FileCache = tc.config
+
+			err := ValidateConfig(viper.New(), &c)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -54,17 +54,20 @@ func getConfigObjectWithConfigFile(t *testing.T, configFilePath string) (*cfg.Co
 func defaultFileCacheConfig(t *testing.T) cfg.FileCacheConfig {
 	t.Helper()
 	return cfg.FileCacheConfig{
-		CacheFileForRangeRead:                  false,
-		DownloadChunkSizeMb:                    200,
-		EnableCrc:                              false,
-		EnableParallelDownloads:                false,
-		ExperimentalParallelDownloadsDefaultOn: true,
-		MaxParallelDownloads:                   int64(max(16, 2*runtime.NumCPU())),
-		MaxSizeMb:                              -1,
-		ParallelDownloadsPerFile:               16,
-		SharedCacheChunkSizeMb:                 8,
-		WriteBufferSize:                        4 * 1024 * 1024,
-		EnableODirect:                          false,
+		CacheFileForRangeRead:                    false,
+		DownloadChunkSizeMb:                      200,
+		EnableCrc:                                false,
+		EnableParallelDownloads:                  false,
+		ExperimentalParallelDownloadsDefaultOn:   true,
+		MaxParallelDownloads:                     int64(max(16, 2*runtime.NumCPU())),
+		MaxSizeMb:                                -1,
+		ParallelDownloadsPerFile:                 16,
+		SharedCacheChunkSizeMb:                   8,
+		WriteBufferSize:                          4 * 1024 * 1024,
+		EnableODirect:                            false,
+		ExperimentalEnableSizeCalculationFix:     false,
+		ExperimentalDeleteEmptyDirs:              true,
+		ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
 	}
 }
 
@@ -416,28 +419,31 @@ func TestValidateConfigFile_FileCacheConfigSuccessful(t *testing.T) {
 		expectedConfig *cfg.Config
 	}{
 		{
-			name:       "Empty config file [default values].",
+			name:       "Empty_config_file_default_values.",
 			configFile: "testdata/empty_file.yaml",
 			expectedConfig: &cfg.Config{
 				FileCache: defaultFileCacheConfig(t),
 			},
 		},
 		{
-			name:       "Valid config file.",
+			name:       "Valid_config_file.",
 			configFile: "testdata/valid_config.yaml",
 			expectedConfig: &cfg.Config{
 				FileCache: cfg.FileCacheConfig{
-					CacheFileForRangeRead:                  true,
-					DownloadChunkSizeMb:                    300,
-					EnableCrc:                              true,
-					EnableParallelDownloads:                false,
-					MaxParallelDownloads:                   200,
-					MaxSizeMb:                              40,
-					ParallelDownloadsPerFile:               10,
-					SharedCacheChunkSizeMb:                 8,
-					WriteBufferSize:                        8192,
-					EnableODirect:                          true,
-					ExperimentalParallelDownloadsDefaultOn: true,
+					CacheFileForRangeRead:                    true,
+					DownloadChunkSizeMb:                      300,
+					EnableCrc:                                true,
+					EnableParallelDownloads:                  false,
+					MaxParallelDownloads:                     200,
+					MaxSizeMb:                                40,
+					ParallelDownloadsPerFile:                 10,
+					SharedCacheChunkSizeMb:                   8,
+					WriteBufferSize:                          8192,
+					EnableODirect:                            true,
+					ExperimentalParallelDownloadsDefaultOn:   true,
+					ExperimentalEnableSizeCalculationFix:     true,
+					ExperimentalDeleteEmptyDirs:              false,
+					ExperimentalSizeCalculationFrequencySecs: 20,
 				},
 			},
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -570,45 +570,51 @@ func TestArgsParsing_FileCacheFlags(t *testing.T) {
 		expectedConfig *cfg.Config
 	}{
 		{
-			name: "Test file cache flags.",
+			name: "Test_file_cache_flags",
 			args: []string{"gcsfuse", "--file-cache-cache-file-for-range-read", "--file-cache-download-chunk-size-mb=20", "--file-cache-enable-crc", "--cache-dir=/some/valid/dir", "--file-cache-exclude-regex=.*", "--file-cache-include-regex=.*", "--file-cache-enable-parallel-downloads", "--file-cache-max-parallel-downloads=40", "--file-cache-max-size-mb=100", "--file-cache-parallel-downloads-per-file=2", "--file-cache-enable-o-direct=false", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				CacheDir: "/some/valid/dir",
 				FileCache: cfg.FileCacheConfig{
-					CacheFileForRangeRead:                  true,
-					DownloadChunkSizeMb:                    20,
-					EnableCrc:                              true,
-					EnableParallelDownloads:                true,
-					ExcludeRegex:                           ".*",
-					IncludeRegex:                           ".*",
-					ExperimentalParallelDownloadsDefaultOn: true,
-					MaxParallelDownloads:                   40,
-					MaxSizeMb:                              100,
-					ParallelDownloadsPerFile:               2,
-					SharedCacheChunkSizeMb:                 8,
-					WriteBufferSize:                        4 * 1024 * 1024,
-					EnableODirect:                          false,
+					CacheFileForRangeRead:                    true,
+					DownloadChunkSizeMb:                      20,
+					EnableCrc:                                true,
+					EnableParallelDownloads:                  true,
+					ExcludeRegex:                             ".*",
+					IncludeRegex:                             ".*",
+					ExperimentalParallelDownloadsDefaultOn:   true,
+					MaxParallelDownloads:                     40,
+					MaxSizeMb:                                100,
+					ParallelDownloadsPerFile:                 2,
+					SharedCacheChunkSizeMb:                   8,
+					ExperimentalEnableSizeCalculationFix:     false,
+					ExperimentalDeleteEmptyDirs:              true,
+					ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					WriteBufferSize:                          4 * 1024 * 1024,
+					EnableODirect:                            false,
 				},
 			},
 		},
 		{
-			name: "Test default file cache flags.",
+			name: "Test_default_file_cache_flags",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				FileCache: cfg.FileCacheConfig{
-					CacheFileForRangeRead:                  false,
-					DownloadChunkSizeMb:                    200,
-					EnableCrc:                              false,
-					EnableParallelDownloads:                false,
-					ExcludeRegex:                           "",
-					IncludeRegex:                           "",
-					ExperimentalParallelDownloadsDefaultOn: true,
-					MaxParallelDownloads:                   int64(max(16, 2*runtime.NumCPU())),
-					MaxSizeMb:                              -1,
-					ParallelDownloadsPerFile:               16,
-					SharedCacheChunkSizeMb:                 8,
-					WriteBufferSize:                        4 * 1024 * 1024,
-					EnableODirect:                          false,
+					CacheFileForRangeRead:                    false,
+					DownloadChunkSizeMb:                      200,
+					EnableCrc:                                false,
+					EnableParallelDownloads:                  false,
+					ExcludeRegex:                             "",
+					IncludeRegex:                             "",
+					ExperimentalParallelDownloadsDefaultOn:   true,
+					MaxParallelDownloads:                     int64(max(16, 2*runtime.NumCPU())),
+					MaxSizeMb:                                -1,
+					ParallelDownloadsPerFile:                 16,
+					SharedCacheChunkSizeMb:                   8,
+					ExperimentalEnableSizeCalculationFix:     false,
+					ExperimentalDeleteEmptyDirs:              true,
+					ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					WriteBufferSize:                          4 * 1024 * 1024,
+					EnableODirect:                            false,
 				},
 			},
 		},
@@ -2845,6 +2851,129 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, capturedMountInfo)
 			tc.validate(t, capturedMountInfo)
+		})
+	}
+}
+
+func TestArgsParsing_FileCacheSizeScanFlags(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 []string
+		expectedConfig       *cfg.Config
+		expectedErrorMessage string
+	}{
+		{
+			name: "Test_size_scan_flags_explicitly_enabled_but_max-size_is_-1",
+			args: []string{"gcsfuse", "--cache-dir=/tmp", "--experimental-file-cache-enable-size-calculation-fix", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					// Even though size scan is explicitly enabled via flags,
+					// it should be resolved to false because MaxSizeMb is -1 (default).
+					ExperimentalEnableSizeCalculationFix: false,
+					MaxSizeMb:                            -1,
+				},
+			},
+		},
+		{
+			name: "Test_size_scan_flags_explicitly_enabled_with_default_frequency_and_files",
+			args: []string{"gcsfuse", "--cache-dir=/tmp", "--file-cache-max-size-mb=10", "--experimental-file-cache-enable-size-calculation-fix", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					// Size scan is explicitly enabled and max-size is set > -1,
+					// so it should remain enabled.
+					ExperimentalEnableSizeCalculationFix:     true,
+					ExperimentalDeleteEmptyDirs:              true,
+					ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					MaxSizeMb:                                10,
+				},
+			},
+		},
+		{
+			name: "Test_size_scan_flags_explicitly_enabled_with_deletes_disabled",
+			args: []string{"gcsfuse", "--cache-dir=/tmp", "--file-cache-max-size-mb=10", "--experimental-file-cache-enable-size-calculation-fix", "--experimental-file-cache-delete-empty-dirs=false", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					ExperimentalEnableSizeCalculationFix:     true,
+					ExperimentalDeleteEmptyDirs:              false,
+					ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					MaxSizeMb:                                10,
+				},
+			},
+		},
+		{
+			name:                 "Test_size_scan_flags_explicitly_enabled_with_frequency_0",
+			args:                 []string{"gcsfuse", "--cache-dir=/tmp", "--file-cache-max-size-mb=10", "--experimental-file-cache-enable-size-calculation-fix", "--experimental-file-cache-size-calculation-frequency-secs=0", "abc", "pqr"},
+			expectedErrorMessage: "invalid config: error parsing file cache config: the value of experimental-file-cache-size-calculation-frequency-secs must be greater than 0 when experimental-file-cache-enable-size-calculation-fix is enabled",
+		},
+		{
+			name: "Test_size_scan_flags_explicitly_enabled_with_frequency_30",
+			args: []string{"gcsfuse", "--cache-dir=/tmp", "--file-cache-max-size-mb=10", "--experimental-file-cache-enable-size-calculation-fix", "--experimental-file-cache-size-calculation-frequency-secs=30", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					ExperimentalEnableSizeCalculationFix:     true,
+					ExperimentalDeleteEmptyDirs:              true,
+					ExperimentalSizeCalculationFrequencySecs: 30,
+					MaxSizeMb:                                10,
+				},
+			},
+		},
+		{
+			name: "Test_size_scan_flags_default_max-size_is_greater_than_-1",
+			args: []string{"gcsfuse", "--cache-dir=/tmp", "--file-cache-max-size-mb=100", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					// Default is false, and MaxSizeMb > -1 shouldn't automatically enable it.
+					ExperimentalEnableSizeCalculationFix: false,
+					MaxSizeMb:                            100,
+				},
+			},
+		},
+		{
+			name: "Test_size_scan_flags_default",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					ExperimentalEnableSizeCalculationFix: false,
+					//ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					MaxSizeMb: -1,
+				},
+			},
+		},
+		{
+			name: "Test_size_scan_flags_explicitly_enabled_but_cache_dir_missing",
+			args: []string{"gcsfuse", "--file-cache-max-size-mb=10", "--experimental-file-cache-enable-size-calculation-fix", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileCache: cfg.FileCacheConfig{
+					ExperimentalEnableSizeCalculationFix: false,
+					//ExperimentalSizeCalculationFrequencySecs: cfg.DefaultFileCacheSizeScanFrequencySecs,
+					MaxSizeMb: 10,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
+				gotConfig = mountInfo.config
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			if tc.expectedErrorMessage != "" {
+				require.ErrorContains(t, err, tc.expectedErrorMessage)
+			} else if assert.NoError(t, err) {
+				assert.Equal(t, tc.expectedConfig.FileCache.MaxSizeMb, gotConfig.FileCache.MaxSizeMb)
+				assert.Equal(t, tc.expectedConfig.FileCache.ExperimentalEnableSizeCalculationFix, gotConfig.FileCache.ExperimentalEnableSizeCalculationFix)
+				if tc.expectedConfig.FileCache.ExperimentalEnableSizeCalculationFix {
+					assert.Equal(t, tc.expectedConfig.FileCache.ExperimentalDeleteEmptyDirs, gotConfig.FileCache.ExperimentalDeleteEmptyDirs)
+					assert.Equal(t, tc.expectedConfig.FileCache.ExperimentalSizeCalculationFrequencySecs, gotConfig.FileCache.ExperimentalSizeCalculationFrequencySecs)
+				}
+			}
 		})
 	}
 }

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -25,6 +25,10 @@ file-cache:
   parallel-downloads-per-file: 10
   write-buffer-size: 8192
   enable-o-direct: true
+  experimental-enable-size-calculation-fix: true
+  experimental-delete-empty-dirs: false
+  experimental-size-calculation-frequency-secs: 20
+cache-dir: "/tmp"
 gcs-auth:
   anonymous-access: true
   key-file: "~/key.file"


### PR DESCRIPTION
### Description
- Dependent on #4414 
- Adds new gcsfuse parameters for testing
- Dependency for #4416 

### Link to the issue in case of a bug fix.
[b/477828938](http://b/477828938)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
