### PR TITLE
fix(cd script): upgrade python version for rhel 9

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -40,9 +40,9 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     if [[ ($ID == "rhel" || $ID == "rocky" || $ID == "centos") ]]; then
         
-        # Check if we are on version 8 to install 3.11
-        if [[ $VERSION_ID =~ ^8 ]]; then
-            echo "Detected version 8. Installing Python 3.11..."
+        # Check if we are on version 8 or 9 to install 3.11
+         if [[ $VERSION_ID =~ ^[89] ]]; then
+            echo "Detected version 8/9. Installing Python 3.11..."
             sudo yum install -y python311
             PYTHON_BIN="/usr/bin/python3.11"
         else
@@ -271,8 +271,8 @@ else
         # Extract VERSION_ID from /etc/os-release
         V_ID=$(awk -F= "/^VERSION_ID=/{print \$2}" /etc/os-release | tr -d "\"")
 
-        # Check if the version starts with 8
-        if [[ "$V_ID" == 8* ]]; then
+        # Check if the version starts with 8 or 9
+        if [[ "$V_ID" =~ ^[89] ]]; then
             export CLOUDSDK_PYTHON="/usr/bin/python3.11"
         else
             export CLOUDSDK_PYTHON="/usr/bin/python3"


### PR DESCRIPTION
### Description

Modified the e2e_test.sh script to include RHEL 9 in the conditions for installing Python 3.11, ensuring that systems running RHEL 9 will correctly install the required Python version. Without these changes, the tests are failing on release pipeline.

### Link to the issue in case of a bug fix.
b/489994943

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA
4. CD tests - ran on pipeline

### Any backward incompatible change? If so, please explain.
