### PR TITLE
test: update local_modifications_test.go to use stretchr/testify

### DIFF
--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -37,9 +38,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/jacobsa/fuse/fusetesting"
-	. "github.com/jacobsa/oglematchers"
-	. "github.com/jacobsa/ogletest"
-	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 // The radius we use for "expect mtime is within"-style assertions. We can't
@@ -171,24 +172,25 @@ func interestingLegalNames() (names []string) {
 
 type OpenTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&OpenTest{})
+func TestOpenTest(t *testing.T) {
+	suite.Run(t, new(OpenTest))
 }
 
 func (t *OpenTest) NonExistent_CreateFlagNotSet() {
 	var err error
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0700)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("no such file")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "no such file")
 
 	// No object should have been created.
 	_, err = storageutil.ReadObject(ctx, bucket, "foo")
 
 	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
+	assert.True(t.T(), errors.As(err, &notFoundErr))
 }
 
 func (t *OpenTest) NonExistent_CreateFlagSet() {
@@ -200,36 +202,36 @@ func (t *OpenTest) NonExistent_CreateFlagSet() {
 		os.O_RDWR|os.O_CREATE,
 		0700)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write some contents.
 	_, err = t.f1.Write([]byte("012"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Read some contents with Seek and Read.
 	_, err = t.f1.Seek(1, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	buf := make([]byte, 2)
 	_, err = io.ReadFull(t.f1, buf)
 
-	AssertEq(nil, err)
-	ExpectEq("12", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "12", string(buf))
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// The object should now be present in the bucket.
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("012", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "012", string(contents))
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("012", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "012", string(fileContents))
 }
 
 func (t *OpenTest) ExistingFile() {
@@ -237,49 +239,47 @@ func (t *OpenTest) ExistingFile() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the start of the file using File.Write.
 	_, err = t.f1.Write([]byte("012"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Read some contents with Seek and Read.
 	_, err = t.f1.Seek(2, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	buf := make([]byte, 4)
 	_, err = io.ReadFull(t.f1, buf)
 
-	AssertEq(nil, err)
-	ExpectEq("2obu", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "2obu", string(buf))
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("012oburritoenchilada", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "012oburritoenchilada", string(fileContents))
 }
 
 func (t *OpenTest) ExistingFile_Truncate() {
 	var err error
 
 	// Create a file.
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte("blahblahblah"),
 			os.FileMode(0644)))
@@ -290,34 +290,34 @@ func (t *OpenTest) ExistingFile_Truncate() {
 		os.O_RDWR|os.O_TRUNC,
 		0)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The file should be empty.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(0, fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 0, fi.Size())
 
 	// Write to the start of the file using File.Write.
 	_, err = t.f1.Write([]byte("012"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Read the contents.
 	_, err = t.f1.Seek(0, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	contentsSlice, err := io.ReadAll(t.f1)
-	AssertEq(nil, err)
-	ExpectEq("012", string(contentsSlice))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "012", string(contentsSlice))
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("012", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "012", string(fileContents))
 }
 
 func (t *OpenTest) AlreadyOpenedFile() {
@@ -327,34 +327,34 @@ func (t *OpenTest) AlreadyOpenedFile() {
 
 	// Create and open a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write some data into it.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Open another handle for reading and writing.
 	t.f2, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The contents written through the first handle should be available to the
 	// second handle..
 	n, err = t.f2.Read(buf[:2])
-	AssertEq(nil, err)
-	AssertEq(2, n)
-	ExpectEq("ta", string(buf[:n]))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, n)
+	assert.Equal(t.T(), "ta", string(buf[:n]))
 
 	// Write some contents with the second handle, which should now be at offset
 	// 2.
 	n, err = t.f2.Write([]byte("nk"))
-	AssertEq(nil, err)
-	AssertEq(2, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, n)
 
 	// Check the overall contents now.
 	contents, err := os.ReadFile(t.f2.Name())
-	AssertEq(nil, err)
-	ExpectEq("tank", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "tank", string(contents))
 }
 
 func (t *OpenTest) LegalNames() {
@@ -366,30 +366,30 @@ func (t *OpenTest) LegalNames() {
 	// We should be able to create each name.
 	for _, n := range names {
 		err = os.WriteFile(path.Join(mntDir, n), []byte(n), 0400)
-		AssertEq(nil, err, "Name: %q", n)
+		require.Equal(t.T(), nil, err, "Name: %q", n)
 	}
 
 	// A listing should contain them all.
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	AssertEq(len(names), len(entries))
+	require.Equal(t.T(), len(names), len(entries))
 	for i, n := range names {
-		ExpectEq(n, entries[i].Name(), "Name: %q", n)
-		ExpectEq(len(n), entries[i].Size(), "Name: %q", n)
+		assert.Equal(t.T(), n, entries[i].Name(), "Name: %q", n)
+		assert.Equal(t.T(), len(n), entries[i].Size(), "Name: %q", n)
 	}
 
 	// We should be able to read them all.
 	for _, n := range names {
 		contents, err := os.ReadFile(path.Join(mntDir, n))
-		AssertEq(nil, err, "Name: %q", n)
-		ExpectEq(n, string(contents), "Name: %q", n)
+		require.Equal(t.T(), nil, err, "Name: %q", n)
+		assert.Equal(t.T(), n, string(contents), "Name: %q", n)
 	}
 
 	// And delete each.
 	for _, n := range names {
 		err = os.Remove(path.Join(mntDir, n))
-		AssertEq(nil, err, "Name: %q", n)
+		require.Equal(t.T(), nil, err, "Name: %q", n)
 	}
 }
 
@@ -412,7 +412,7 @@ func (t *OpenTest) IllegalNames() {
 	// We should not be able to create any of these names.
 	for _, tc := range testCases {
 		err = os.WriteFile(path.Join(mntDir, tc.name), []byte{}, 0400)
-		ExpectThat(err, Error(HasSubstr(tc.err)), "Name: %q", tc.name)
+		assert.ErrorContains(t.T(), err, tc.err, "Name: %q", tc.name)
 	}
 }
 
@@ -422,10 +422,11 @@ func (t *OpenTest) IllegalNames() {
 
 type MknodTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&MknodTest{})
+func TestMknodTest(t *testing.T) {
+	suite.Run(t, new(MknodTest))
 }
 
 func (t *MknodTest) File() {
@@ -439,20 +440,20 @@ func (t *MknodTest) File() {
 
 	// Create
 	err = syscall.Mknod(p, syscall.S_IFREG|0600, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq(path.Base(p), fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(filePerms, fi.Mode())
+	assert.Equal(t.T(), path.Base(p), fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
 
 	// Read
 	contents, err := os.ReadFile(p)
-	AssertEq(nil, err)
-	ExpectEq("", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "", string(contents))
 }
 
 func (t *MknodTest) Directory() {
@@ -467,7 +468,7 @@ func (t *MknodTest) Directory() {
 	// Quoth `man 2 mknod`: "Under Linux, this call cannot be used to create
 	// directories."
 	err = syscall.Mknod(p, syscall.S_IFDIR|0700, 0)
-	ExpectEq(syscall.EPERM, err)
+	assert.Equal(t.T(), syscall.EPERM, err)
 }
 
 func (t *MknodTest) AlreadyExists() {
@@ -481,16 +482,16 @@ func (t *MknodTest) AlreadyExists() {
 
 	// Create (first)
 	err = os.WriteFile(p, []byte("taco"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create (second)
 	err = syscall.Mknod(p, syscall.S_IFREG|0600, 0)
-	ExpectEq(syscall.EEXIST, err)
+	assert.Equal(t.T(), syscall.EEXIST, err)
 
 	// Read
 	contents, err := os.ReadFile(p)
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 }
 
 func (t *MknodTest) NonExistentParent() {
@@ -503,7 +504,7 @@ func (t *MknodTest) NonExistentParent() {
 	p := path.Join(mntDir, "foo/bar")
 
 	err = syscall.Mknod(p, syscall.S_IFREG|0600, 0)
-	ExpectEq(syscall.ENOENT, err)
+	assert.Equal(t.T(), syscall.ENOENT, err)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -512,10 +513,11 @@ func (t *MknodTest) NonExistentParent() {
 
 type ModesTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&ModesTest{})
+func TestModesTest(t *testing.T) {
+	suite.Run(t, new(ModesTest))
 }
 
 func (t *ModesTest) ReadOnlyMode() {
@@ -523,28 +525,27 @@ func (t *ModesTest) ReadOnlyMode() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDONLY, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Read its contents.
 	fileContents, err := io.ReadAll(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(contents, string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), contents, string(fileContents))
 
 	// Attempt to write.
 	n, err := t.f1.Write([]byte("taco"))
 
-	AssertEq(0, n)
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("bad file descriptor")))
+	require.Equal(t.T(), 0, n)
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "bad file descriptor")
 }
 
 func (t *ModesTest) WriteOnlyMode() {
@@ -552,52 +553,51 @@ func (t *ModesTest) WriteOnlyMode() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_WRONLY, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Reading should fail.
 	_, err = io.ReadAll(t.f1)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("bad file descriptor")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "bad file descriptor")
 
 	// Write to the start of the file using File.Write.
 	_, err = t.f1.Write([]byte("000"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the middle of the file using File.WriteAt.
 	_, err = t.f1.WriteAt([]byte("111"), 4)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek and write past the end of the file.
 	_, err = t.f1.Seek(int64(len(contents)), 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	_, err = t.f1.Write([]byte("222"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Check the size now.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(len(contents)+len("222"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len(contents)+len("222"), fi.Size())
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("000o111ritoenchilada222", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "000o111ritoenchilada222", string(fileContents))
 }
 
 func (t *ModesTest) ReadWriteMode() {
@@ -605,63 +605,62 @@ func (t *ModesTest) ReadWriteMode() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the start of the file using File.Write.
 	_, err = t.f1.Write([]byte("000"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the middle of the file using File.WriteAt.
 	_, err = t.f1.WriteAt([]byte("111"), 4)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek and write past the end of the file.
 	_, err = t.f1.Seek(int64(len(contents)), 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	_, err = t.f1.Write([]byte("222"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Check the size now.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(len(contents)+len("222"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len(contents)+len("222"), fi.Size())
 
 	// Read some contents with Seek and Read.
 	_, err = t.f1.Seek(4, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	buf := make([]byte, 4)
 	_, err = io.ReadFull(t.f1, buf)
 
-	AssertEq(nil, err)
-	ExpectEq("111r", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "111r", string(buf))
 
 	// Read the full contents with ReadAt.
 	buf = make([]byte, len(contents)+len("222"))
 	_, err = t.f1.ReadAt(buf, 0)
 
-	AssertEq(nil, err)
-	ExpectEq("000o111ritoenchilada222", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "000o111ritoenchilada222", string(buf))
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("000o111ritoenchilada222", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "000o111ritoenchilada222", string(fileContents))
 }
 
 func (t *ModesTest) FuzzyReadWriteMode() {
@@ -669,64 +668,63 @@ func (t *ModesTest) FuzzyReadWriteMode() {
 
 	// Create a file.
 	const contents = "baz\u1100\u1161"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Read back its contents.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
-	ExpectEq("baz\u1100\u1161", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "baz\u1100\u1161", string(fileContents))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the start of the file using File.Write.
 	_, err = t.f1.Write([]byte("타코世界"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek and write immediately after the previous string.
 	_, err = t.f1.Seek(int64(len("타코世界")), 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	_, err = t.f1.Write([]byte("\u0041\u030a"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Check the size now.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(len("타코世界")+len("\u0041\u030a"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len("타코世界")+len("\u0041\u030a"), fi.Size())
 
 	// Read some contents with Seek and Read.
 	_, err = t.f1.Seek(0, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	buf := make([]byte, 3)
 	_, err = io.ReadFull(t.f1, buf)
 
-	AssertEq(nil, err)
-	ExpectEq("타", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "타", string(buf))
 
 	// Read the full contents with ReadAt.
 	buf = make([]byte, len("타코世界")+len("\u0041\u030a"))
 	_, err = t.f1.ReadAt(buf, 0)
 
-	AssertEq(nil, err)
-	ExpectEq("타코世界\u0041\u030a", string(buf))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "타코世界\u0041\u030a", string(buf))
 
 	// Close the file.
-	AssertEq(nil, t.f1.Close())
+	require.Equal(t.T(), nil, t.f1.Close())
 	t.f1 = nil
 
 	// Read back its contents.
 	fileContents, err = os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("타코世界\u0041\u030a", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "타코世界\u0041\u030a", string(fileContents))
 }
 
 func (t *ModesTest) AppendMode_SeekAndWrite() {
@@ -734,47 +732,46 @@ func (t *ModesTest) AppendMode_SeekAndWrite() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR|os.O_APPEND, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write using File.Write. This should go to the end of the file regardless
 	// of whether we Seek somewhere else first.
 	_, err = t.f1.Seek(1, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	_, err = t.f1.Write([]byte("222"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The seek position should have been updated.
 	off, err := getFileOffset(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(len(contents)+len("222"), off)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len(contents)+len("222"), off)
 
 	// Check the size now.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(len(contents)+len("222"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len(contents)+len("222"), fi.Size())
 
 	// Read the full contents with ReadAt.
 	buf := make([]byte, 1024)
 	n, err := t.f1.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
-	ExpectEq(contents+"222", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), contents+"222", string(buf[:n]))
 
 	// Read the full contents with another file handle.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq(contents+"222", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), contents+"222", string(fileContents))
 }
 
 func (t *ModesTest) AppendMode_WriteAt() {
@@ -782,47 +779,46 @@ func (t *ModesTest) AppendMode_WriteAt() {
 
 	// Create a file.
 	const contents = "tacoburritoenchilada"
-	AssertEq(
-		nil,
-		os.WriteFile(
+	require.Equal(t.T(),
+		nil, os.WriteFile(
 			path.Join(mntDir, "foo"),
 			[]byte(contents),
 			os.FileMode(0644)))
 
 	// Open the file.
 	t.f1, err = os.OpenFile(path.Join(mntDir, "foo"), os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek somewhere in the file.
 	_, err = t.f1.Seek(1, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write to the middle of the file using File.WriteAt.
 	_, err = t.f1.WriteAt([]byte("111"), 4)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The seek position should have been unaffected.
 	off, err := getFileOffset(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(1, off)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 1, off)
 
 	// Check the size now.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(len(contents), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len(contents), fi.Size())
 
 	// Read the full contents with ReadAt.
 	buf := make([]byte, 1024)
 	n, err := t.f1.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
-	ExpectEq("taco111ritoenchilada", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), "taco111ritoenchilada", string(buf[:n]))
 
 	// Read the full contents with another file handle.
 	fileContents, err := os.ReadFile(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("taco111ritoenchilada", string(fileContents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco111ritoenchilada", string(fileContents))
 }
 
 func (t *ModesTest) AppendMode_WriteAt_PastEOF() {
@@ -834,28 +830,28 @@ func (t *ModesTest) AppendMode_WriteAt_PastEOF() {
 		os.O_RDWR|os.O_CREATE,
 		0600)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write three bytes.
 	n, err := t.f1.Write([]byte("111"))
-	AssertEq(nil, err)
-	AssertEq(3, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 3, n)
 
 	// Write at offset six.
 	n, err = t.f1.WriteAt([]byte("222"), 6)
-	AssertEq(nil, err)
-	AssertEq(3, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 3, n)
 
 	// The seek position should have been unaffected.
 	off, err := getFileOffset(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(3, off)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 3, off)
 
 	// Read the full contents of the file.
 	contents, err := os.ReadFile(t.f1.Name())
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("111\x00\x00\x00222", string(contents))
+	assert.Equal(t.T(), "111\x00\x00\x00222", string(contents))
 }
 
 func (t *ModesTest) ReadFromWriteOnlyFile() {
@@ -867,13 +863,13 @@ func (t *ModesTest) ReadFromWriteOnlyFile() {
 		os.O_WRONLY|os.O_CREATE,
 		0700)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to read from it.
 	_, err = t.f1.Read(make([]byte, 1024))
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("bad file descriptor")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "bad file descriptor")
 }
 
 func (t *ModesTest) WriteToReadOnlyFile() {
@@ -885,13 +881,13 @@ func (t *ModesTest) WriteToReadOnlyFile() {
 		os.O_RDONLY|os.O_CREATE,
 		0700)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to write t it.
 	_, err = t.f1.Write([]byte("taco"))
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("bad file descriptor")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "bad file descriptor")
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -900,10 +896,11 @@ func (t *ModesTest) WriteToReadOnlyFile() {
 
 type DirectoryTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&DirectoryTest{})
+func TestDirectoryTest(t *testing.T) {
+	suite.Run(t, new(DirectoryTest))
 }
 
 func (t *DirectoryTest) Mkdir_OneLevel() {
@@ -915,35 +912,35 @@ func (t *DirectoryTest) Mkdir_OneLevel() {
 
 	// Create a directory within the root.
 	err = os.Mkdir(dirName, 0754)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat the directory.
 	fi, err = os.Stat(dirName)
 
-	AssertEq(nil, err)
-	ExpectEq("dir", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 
 	// Read the directory.
 	entries, err = fusetesting.ReadDirPicky(dirName)
 
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 
 	// Read the root.
 	entries, err = fusetesting.ReadDirPicky(mntDir)
 
-	AssertEq(nil, err)
-	AssertEq(1, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(entries))
 
 	fi = entries[0]
-	ExpectEq("dir", fi.Name())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
 }
 
 func (t *DirectoryTest) Mkdir_TwoLevels() {
@@ -953,39 +950,39 @@ func (t *DirectoryTest) Mkdir_TwoLevels() {
 
 	// Create a directory within the root.
 	err = os.Mkdir(path.Join(mntDir, "parent"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a child of that directory.
 	err = os.Mkdir(path.Join(mntDir, "parent/dir"), 0754)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat the directory.
 	fi, err = os.Stat(path.Join(mntDir, "parent/dir"))
 
-	AssertEq(nil, err)
-	ExpectEq("dir", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 
 	// Read the directory.
 	entries, err = fusetesting.ReadDirPicky(path.Join(mntDir, "parent/dir"))
 
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 
 	// Read the parent.
 	entries, err = fusetesting.ReadDirPicky(path.Join(mntDir, "parent"))
 
-	AssertEq(nil, err)
-	AssertEq(1, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(entries))
 
 	fi = entries[0]
-	ExpectEq("dir", fi.Name())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
 }
 
 func (t *DirectoryTest) Mkdir_AlreadyExists() {
@@ -994,13 +991,13 @@ func (t *DirectoryTest) Mkdir_AlreadyExists() {
 
 	// Create the directory once.
 	err = os.Mkdir(dirName, 0754)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to create it again.
 	err = os.Mkdir(dirName, 0754)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("exists")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "exists")
 }
 
 func (t *DirectoryTest) Mkdir_IntermediateIsFile() {
@@ -1009,14 +1006,14 @@ func (t *DirectoryTest) Mkdir_IntermediateIsFile() {
 	// Create a file.
 	fileName := path.Join(mntDir, "foo")
 	err = os.WriteFile(fileName, []byte{}, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to create a directory within the file.
 	dirName := path.Join(fileName, "dir")
 	err = os.Mkdir(dirName, 0754)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("not a directory")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "not a directory")
 }
 
 func (t *DirectoryTest) Mkdir_IntermediateIsNonExistent() {
@@ -1026,21 +1023,21 @@ func (t *DirectoryTest) Mkdir_IntermediateIsNonExistent() {
 	dirName := path.Join(mntDir, "foo/dir")
 	err = os.Mkdir(dirName, 0754)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("no such file or directory")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "no such file or directory")
 }
 
 func (t *DirectoryTest) Stat_Root() {
 	fi, err := os.Stat(mntDir)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq(path.Base(mntDir), fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), path.Base(mntDir), fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *DirectoryTest) Stat_FirstLevelDirectory() {
@@ -1048,19 +1045,19 @@ func (t *DirectoryTest) Stat_FirstLevelDirectory() {
 
 	// Create a sub-directory.
 	err = os.Mkdir(path.Join(mntDir, "dir"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := os.Stat(path.Join(mntDir, "dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("dir", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *DirectoryTest) Stat_SecondLevelDirectory() {
@@ -1068,19 +1065,19 @@ func (t *DirectoryTest) Stat_SecondLevelDirectory() {
 
 	// Create two levels of directories.
 	err = os.MkdirAll(path.Join(mntDir, "parent/dir"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := os.Stat(path.Join(mntDir, "parent/dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("dir", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *DirectoryTest) ReadDir_Root() {
@@ -1090,36 +1087,36 @@ func (t *DirectoryTest) ReadDir_Root() {
 	// Create a file and a directory.
 	createTime := mtimeClock.Now()
 	err = os.WriteFile(path.Join(mntDir, "bar"), []byte("taco"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = os.Mkdir(path.Join(mntDir, "foo"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// ReadDir
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
-	AssertEq(2, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, len(entries))
 
 	// bar
 	fi = entries[0]
-	ExpectEq("bar", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
-	ExpectThat(fi, fusetesting.MtimeIsWithin(createTime, timeSlop))
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "bar", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
+	assert.WithinDuration(t.T(), createTime, fi.ModTime(), timeSlop)
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 
 	// foo
 	fi = entries[1]
-	ExpectEq("foo", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *DirectoryTest) ReadDir_SubDirectory() {
@@ -1129,41 +1126,41 @@ func (t *DirectoryTest) ReadDir_SubDirectory() {
 	// Create a directory.
 	parent := path.Join(mntDir, "parent")
 	err = os.Mkdir(parent, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a file and a directory within it.
 	createTime := mtimeClock.Now()
 	err = os.WriteFile(path.Join(parent, "bar"), []byte("taco"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = os.Mkdir(path.Join(parent, "foo"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// ReadDir
 	entries, err := fusetesting.ReadDirPicky(parent)
-	AssertEq(nil, err)
-	AssertEq(2, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, len(entries))
 
 	// bar
 	fi = entries[0]
-	ExpectEq("bar", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
-	ExpectThat(fi, fusetesting.MtimeIsWithin(createTime, timeSlop))
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "bar", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
+	assert.WithinDuration(t.T(), createTime, fi.ModTime(), timeSlop)
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 
 	// foo
 	fi = entries[1]
-	ExpectEq("foo", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(dirPerms|os.ModeDir, fi.Mode())
-	ExpectTrue(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), dirPerms|os.ModeDir, fi.Mode())
+	assert.True(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *DirectoryTest) Rmdir_NotEmpty() {
@@ -1171,20 +1168,20 @@ func (t *DirectoryTest) Rmdir_NotEmpty() {
 
 	// Create two levels of directories.
 	err = os.MkdirAll(path.Join(mntDir, "foo/bar"), 0754)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to remove the parent.
 	err = os.Remove(path.Join(mntDir, "foo"))
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("not empty")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "not empty")
 
 	// The parent should still be there.
 	fi, err := os.Lstat(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectEq("foo", fi.Name())
-	ExpectTrue(fi.IsDir())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.True(t.T(), fi.IsDir())
 }
 
 func (t *DirectoryTest) Rmdir_Empty() {
@@ -1193,27 +1190,27 @@ func (t *DirectoryTest) Rmdir_Empty() {
 
 	// Create two levels of directories.
 	err = os.MkdirAll(path.Join(mntDir, "foo/bar"), 0754)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Remove the leaf.
 	err = os.Remove(path.Join(mntDir, "foo/bar"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// There should be nothing left in the parent.
 	entries, err = fusetesting.ReadDirPicky(path.Join(mntDir, "foo"))
 
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 
 	// Remove the parent.
 	err = os.Remove(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Now the root directory should be empty, too.
 	entries, err = fusetesting.ReadDirPicky(mntDir)
 
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 }
 
 func (t *DirectoryTest) Rmdir_OpenedForReading() {
@@ -1221,38 +1218,38 @@ func (t *DirectoryTest) Rmdir_OpenedForReading() {
 
 	// Create a directory.
 	err = os.Mkdir(path.Join(mntDir, "dir"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Open the directory for reading.
 	t.f1, err = os.Open(path.Join(mntDir, "dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Remove the directory.
 	err = os.Remove(path.Join(mntDir, "dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a new directory, with the same name even, and add some contents
 	// within it.
 	err = os.MkdirAll(path.Join(mntDir, "dir/foo"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = os.MkdirAll(path.Join(mntDir, "dir/bar"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = os.MkdirAll(path.Join(mntDir, "dir/baz"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// We should still be able to stat the open file handle.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq("dir", fi.Name())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "dir", fi.Name())
 
 	// Attempt to read from the directory. Unfortunately we can't implement the
 	// guarantee that no new entries are returned, but nothing crazy should
 	// happen.
 	_, err = t.f1.Readdirnames(0)
 	if err != nil {
-		ExpectThat(err, Error(HasSubstr("no such file")))
+		assert.ErrorContains(t.T(), err, "no such file")
 	}
 }
 
@@ -1261,25 +1258,25 @@ func (t *DirectoryTest) Rmdir_ThenRecreateWithSameName() {
 
 	// Create a directory.
 	err = os.Mkdir(path.Join(mntDir, "dir"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Unlink the directory.
 	err = os.Remove(path.Join(mntDir, "dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Re-create the directory with the same name. Nothing crazy should happen.
 	// In the past, this used to crash (cf.
 	// https://github.com/GoogleCloudPlatform/gcsfuse/issues/8).
 	err = os.Mkdir(path.Join(mntDir, "dir"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Statting should reveal nothing surprising.
 	fi, err := os.Stat(path.Join(mntDir, "dir"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("dir", fi.Name())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectTrue(fi.IsDir())
+	assert.Equal(t.T(), "dir", fi.Name())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.True(t.T(), fi.IsDir())
 }
 
 func (t *DirectoryTest) CreateHardLink() {
@@ -1287,7 +1284,7 @@ func (t *DirectoryTest) CreateHardLink() {
 
 	// Write a file.
 	err = os.WriteFile(path.Join(mntDir, "foo"), []byte(""), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to hard link it. We don't support doing so.
 	err = os.Link(
@@ -1297,8 +1294,8 @@ func (t *DirectoryTest) CreateHardLink() {
 	// Kernel behavior changed with: https://github.com/torvalds/linux/commit/8344213571b2ac8caf013cfd3b37bc3467c3a893
 	// Older kernels return ENOSYS (function not implemented)
 	// Newer kernels (6.x+) return EPERM (operation not permitted)
-	AssertNe(nil, err)
-	ExpectTrue(errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EPERM), "Expected ENOSYS or EPERM, got: %v", err)
+	require.NotEqual(t.T(), nil, err)
+	assert.True(t.T(), errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EPERM), "Expected ENOSYS or EPERM, got: %v", err)
 }
 
 func (t *DirectoryTest) Chmod() {
@@ -1307,13 +1304,13 @@ func (t *DirectoryTest) Chmod() {
 	// Create a directory.
 	p := path.Join(mntDir, "foo")
 	err = os.Mkdir(p, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to chmod it. Chmod should succeed even though we don't do anything
 	// useful. The OS X Finder otherwise complains to the user when copying in a
 	// file.
 	err = os.Chmod(p, 0777)
-	ExpectEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 }
 
 func (t *DirectoryTest) Chtimes() {
@@ -1322,12 +1319,12 @@ func (t *DirectoryTest) Chtimes() {
 	// Create a directory.
 	p := path.Join(mntDir, "foo")
 	err = os.Mkdir(p, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Chtimes should succeed even though we don't do anything useful. The OS X
 	// Finder otherwise complains to the user when copying in a directory.
 	err = os.Chtimes(p, time.Now(), time.Now())
-	ExpectEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 }
 
 func (t *DirectoryTest) AtimeCtimeAndMtime() {
@@ -1337,19 +1334,19 @@ func (t *DirectoryTest) AtimeCtimeAndMtime() {
 	p := path.Join(mntDir, "foo")
 	createTime := mtimeClock.Now()
 	err = os.Mkdir(p, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// We require only that the times be "reasonable".
 	atime, ctime, mtime := fusetesting.GetTimes(fi)
 	const delta = 5 * time.Hour
 
-	ExpectThat(atime, timeutil.TimeNear(createTime, delta))
-	ExpectThat(ctime, timeutil.TimeNear(createTime, delta))
-	ExpectThat(mtime, timeutil.TimeNear(createTime, delta))
+	assert.WithinDuration(t.T(), createTime, atime, delta)
+	assert.WithinDuration(t.T(), createTime, ctime, delta)
+	assert.WithinDuration(t.T(), createTime, mtime, delta)
 }
 
 func (t *DirectoryTest) RootAtimeCtimeAndMtime() {
@@ -1358,15 +1355,15 @@ func (t *DirectoryTest) RootAtimeCtimeAndMtime() {
 
 	// Stat the root directory.
 	fi, err := os.Stat(mntDir)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// We require only that the times be "reasonable".
 	atime, ctime, mtime := fusetesting.GetTimes(fi)
 	const delta = 5 * time.Hour
 
-	ExpectThat(atime, timeutil.TimeNear(mountTime, delta))
-	ExpectThat(ctime, timeutil.TimeNear(mountTime, delta))
-	ExpectThat(mtime, timeutil.TimeNear(mountTime, delta))
+	assert.WithinDuration(t.T(), mountTime, atime, delta)
+	assert.WithinDuration(t.T(), mountTime, ctime, delta)
+	assert.WithinDuration(t.T(), mountTime, mtime, delta)
 }
 
 func (t *DirectoryTest) ContentTypes() {
@@ -1381,16 +1378,16 @@ func (t *DirectoryTest) ContentTypes() {
 
 		// Create the directory.
 		err := os.Mkdir(p, 0700)
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 
 		// There should be no content type set in GCS.
 		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{
 			Name:                           name,
 			ForceFetchFromGcs:              true,
 			ReturnExtendedObjectAttributes: true})
-		AssertEq(nil, err)
-		AssertNe(nil, e)
-		ExpectEq("", e.ContentType, "name: %q", name)
+		require.Equal(t.T(), nil, err)
+		require.NotEqual(t.T(), nil, e)
+		assert.Equal(t.T(), "", e.ContentType, "name: %q", name)
 	}
 }
 
@@ -1400,10 +1397,11 @@ func (t *DirectoryTest) ContentTypes() {
 
 type FileTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&FileTest{})
+func TestFileTest(t *testing.T) {
+	suite.Run(t, new(FileTest))
 }
 
 func (t *FileTest) WriteOverlapsEndOfFile() {
@@ -1412,21 +1410,21 @@ func (t *FileTest) WriteOverlapsEndOfFile() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Make it 4 bytes long.
 	err = t.f1.Truncate(4)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write the range [2, 6).
 	n, err = t.f1.WriteAt([]byte("taco"), 2)
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Read the full contents of the file.
 	contents, err := io.ReadAll(t.f1)
-	AssertEq(nil, err)
-	ExpectEq("\x00\x00taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "\x00\x00taco", string(contents))
 }
 
 func (t *FileTest) WriteStartsAtEndOfFile() {
@@ -1435,21 +1433,21 @@ func (t *FileTest) WriteStartsAtEndOfFile() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Make it 2 bytes long.
 	err = t.f1.Truncate(2)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write the range [2, 6).
 	n, err = t.f1.WriteAt([]byte("taco"), 2)
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Read the full contents of the file.
 	contents, err := io.ReadAll(t.f1)
-	AssertEq(nil, err)
-	ExpectEq("\x00\x00taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "\x00\x00taco", string(contents))
 }
 
 func (t *FileTest) WriteStartsPastEndOfFile() {
@@ -1458,17 +1456,17 @@ func (t *FileTest) WriteStartsPastEndOfFile() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write the range [2, 6).
 	n, err = t.f1.WriteAt([]byte("taco"), 2)
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Read the full contents of the file.
 	contents, err := io.ReadAll(t.f1)
-	AssertEq(nil, err)
-	ExpectEq("\x00\x00taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "\x00\x00taco", string(contents))
 }
 
 func (t *FileTest) WriteAtDoesntChangeOffset_NotAppendMode() {
@@ -1477,25 +1475,25 @@ func (t *FileTest) WriteAtDoesntChangeOffset_NotAppendMode() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Make it 16 bytes long.
 	err = t.f1.Truncate(16)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek to offset 4.
 	_, err = t.f1.Seek(4, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write the range [10, 14).
 	n, err = t.f1.WriteAt([]byte("taco"), 2)
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// We should still be at offset 4.
 	offset, err := getFileOffset(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(4, offset)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 4, offset)
 }
 
 func (t *FileTest) WriteAtDoesntChangeOffset_AppendMode() {
@@ -1508,113 +1506,113 @@ func (t *FileTest) WriteAtDoesntChangeOffset_AppendMode() {
 		os.O_RDWR|os.O_CREATE,
 		0600)
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Make it 16 bytes long.
 	err = t.f1.Truncate(16)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Seek to offset 4.
 	_, err = t.f1.Seek(4, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write the range [10, 14).
 	n, err = t.f1.WriteAt([]byte("taco"), 2)
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// We should still be at offset 4.
 	offset, err := getFileOffset(t.f1)
-	AssertEq(nil, err)
-	ExpectEq(4, offset)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 4, offset)
 }
 
-func validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAttributes,
+func (t *FileTest) validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAttributes,
 	minObject1, minObject2 *gcs.MinObject) {
-	AssertNe(nil, extendedAttr1)
-	AssertNe(nil, extendedAttr2)
-	AssertNe(nil, minObject1)
-	AssertNe(nil, minObject2)
+	require.NotEqual(t.T(), nil, extendedAttr1)
+	require.NotEqual(t.T(), nil, extendedAttr2)
+	require.NotEqual(t.T(), nil, minObject1)
+	require.NotEqual(t.T(), nil, minObject2)
 	// Validate Min Object.
-	ExpectEq(minObject1.Name, minObject2.Name)
-	ExpectEq(0, minObject1.Size)
-	ExpectEq(FileContentsSize, minObject2.Size)
-	ExpectNe(minObject1.Generation, minObject2.Generation)
-	ExpectTrue(minObject1.Updated.Before(minObject2.Updated))
+	assert.Equal(t.T(), minObject1.Name, minObject2.Name)
+	assert.Equal(t.T(), 0, minObject1.Size)
+	assert.Equal(t.T(), FileContentsSize, minObject2.Size)
+	assert.NotEqual(t.T(), minObject1.Generation, minObject2.Generation)
+	assert.True(t.T(), minObject1.Updated.Before(minObject2.Updated))
 	attr1MTime, _ := time.Parse(time.RFC3339Nano, minObject1.Metadata[gcs.MtimeMetadataKey])
 	attr2MTime, _ := time.Parse(time.RFC3339Nano, minObject2.Metadata[gcs.MtimeMetadataKey])
-	ExpectTrue(attr1MTime.Before(attr2MTime))
-	ExpectEq(minObject1.ContentEncoding, minObject2.ContentEncoding)
-	ExpectNe(nil, minObject1.CRC32C)
-	ExpectNe(nil, minObject2.CRC32C)
+	assert.True(t.T(), attr1MTime.Before(attr2MTime))
+	assert.Equal(t.T(), minObject1.ContentEncoding, minObject2.ContentEncoding)
+	assert.NotEqual(t.T(), nil, minObject1.CRC32C)
+	assert.NotEqual(t.T(), nil, minObject2.CRC32C)
 
 	// Validate Extended Object Attributes.
-	ExpectEq(extendedAttr1.ContentType, extendedAttr2.ContentType)
-	ExpectEq(extendedAttr1.ContentLanguage, extendedAttr2.ContentLanguage)
-	ExpectEq(extendedAttr1.CacheControl, extendedAttr2.CacheControl)
-	ExpectEq(extendedAttr1.Owner, extendedAttr2.Owner)
-	ExpectEq(extendedAttr1.MediaLink, extendedAttr2.MediaLink)
-	ExpectEq(extendedAttr1.StorageClass, extendedAttr2.StorageClass)
-	ExpectTrue(reflect.DeepEqual(extendedAttr1.Deleted, time.Time{}))
-	ExpectTrue(reflect.DeepEqual(extendedAttr2.Deleted, time.Time{}))
-	ExpectEq(extendedAttr1.ComponentCount+1, extendedAttr2.ComponentCount)
-	ExpectEq(extendedAttr1.EventBasedHold, extendedAttr2.EventBasedHold)
-	ExpectEq(extendedAttr1.Acl, extendedAttr2.Acl)
-	ExpectEq(nil, extendedAttr1.Acl)
+	assert.Equal(t.T(), extendedAttr1.ContentType, extendedAttr2.ContentType)
+	assert.Equal(t.T(), extendedAttr1.ContentLanguage, extendedAttr2.ContentLanguage)
+	assert.Equal(t.T(), extendedAttr1.CacheControl, extendedAttr2.CacheControl)
+	assert.Equal(t.T(), extendedAttr1.Owner, extendedAttr2.Owner)
+	assert.Equal(t.T(), extendedAttr1.MediaLink, extendedAttr2.MediaLink)
+	assert.Equal(t.T(), extendedAttr1.StorageClass, extendedAttr2.StorageClass)
+	assert.True(t.T(), reflect.DeepEqual(extendedAttr1.Deleted, time.Time{}))
+	assert.True(t.T(), reflect.DeepEqual(extendedAttr2.Deleted, time.Time{}))
+	assert.Equal(t.T(), extendedAttr1.ComponentCount+1, extendedAttr2.ComponentCount)
+	assert.Equal(t.T(), extendedAttr1.EventBasedHold, extendedAttr2.EventBasedHold)
+	assert.Equal(t.T(), extendedAttr1.Acl, extendedAttr2.Acl)
+	assert.Equal(t.T(), nil, extendedAttr1.Acl)
 }
 
-func createFile(filePath string) {
+func (t *FileTest) createFile(filePath string) {
 	f, err := os.Create(filePath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	err = f.Close()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 }
 
 func (t *FileTest) AppendFileOperation_ShouldNotChangeObjectAttributes() {
 	// Create file.
 	fileName := "foo"
-	createFile(path.Join(mntDir, fileName))
+	t.createFile(path.Join(mntDir, fileName))
 	// Fetch object attributes before file append.
 	minObject1, extendedAttr1, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: fileName, ForceFetchFromGcs: true, ReturnExtendedObjectAttributes: true})
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	time.Sleep(timeSlop + timeSlop/2)
 
 	// Append to the file.
 	err = operations.WriteFileInAppendMode(path.Join(mntDir, fileName), FileContents)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Fetch object attributes after file append.
 	minObject2, extendedAttr2, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: fileName, ForceFetchFromGcs: true, ReturnExtendedObjectAttributes: true})
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	// Validate object attributes are as expected.
 	// TODO: Validate on Finalized attribute once the default behavior on GCSFuse
 	// side is to never finalize object.
-	validateObjectAttributes(extendedAttr1, extendedAttr2, minObject1, minObject2)
+	t.validateObjectAttributes(extendedAttr1, extendedAttr2, minObject1, minObject2)
 }
 
 func (t *FileTest) WriteAtFileOperation_ShouldNotChangeObjectAttributes() {
 	// Create file.
 	fileName := "foo"
-	createFile(path.Join(mntDir, fileName))
+	t.createFile(path.Join(mntDir, fileName))
 	// Fetch object attributes before file append.
 	minObject1, extendedAttr1, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: fileName, ForceFetchFromGcs: true, ReturnExtendedObjectAttributes: true})
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	time.Sleep(timeSlop + timeSlop/2)
 
 	// Over-write the file.
 	fh, err := os.OpenFile(path.Join(mntDir, fileName), os.O_RDWR, operations.FilePermission_0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	_, err = fh.WriteAt([]byte(FileContents), 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	err = fh.Close()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	minObject2, extendedAttr2, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: fileName, ForceFetchFromGcs: true, ReturnExtendedObjectAttributes: true})
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Validate object attributes are as expected.
 	// TODO: Validate on Finalized attribute once the default behavior on GCSFuse
 	// side is to never finalize object.
-	validateObjectAttributes(extendedAttr1, extendedAttr2, minObject1, minObject2)
+	t.validateObjectAttributes(extendedAttr1, extendedAttr2, minObject1, minObject2)
 }
 
 func (t *FileTest) ReadsPastEndOfFile() {
@@ -1624,30 +1622,30 @@ func (t *FileTest) ReadsPastEndOfFile() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Give it some contents.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Read a range overlapping EOF.
 	n, err = t.f1.ReadAt(buf[:4], 2)
-	AssertEq(io.EOF, err)
-	ExpectEq(2, n)
-	ExpectEq("co", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), 2, n)
+	assert.Equal(t.T(), "co", string(buf[:n]))
 
 	// Read a range starting at EOF.
 	n, err = t.f1.ReadAt(buf[:4], 4)
-	AssertEq(io.EOF, err)
-	ExpectEq(0, n)
-	ExpectEq("", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), 0, n)
+	assert.Equal(t.T(), "", string(buf[:n]))
 
 	// Read a range starting past EOF.
 	n, err = t.f1.ReadAt(buf[:4], 100)
-	AssertEq(io.EOF, err)
-	ExpectEq(0, n)
-	ExpectEq("", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), 0, n)
+	assert.Equal(t.T(), "", string(buf[:n]))
 }
 
 func (t *FileTest) Truncate_Smaller() {
@@ -1656,25 +1654,25 @@ func (t *FileTest) Truncate_Smaller() {
 
 	// Create a file.
 	err = os.WriteFile(fileName, []byte("taco"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Open it for modification.
 	t.f1, err = os.OpenFile(fileName, os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Truncate it.
 	err = t.f1.Truncate(2)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(2, fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 2, fi.Size())
 
 	// Read the contents.
 	contents, err := os.ReadFile(fileName)
-	AssertEq(nil, err)
-	ExpectEq("ta", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "ta", string(contents))
 }
 
 func (t *FileTest) Truncate_SameSize() {
@@ -1683,25 +1681,25 @@ func (t *FileTest) Truncate_SameSize() {
 
 	// Create a file.
 	err = os.WriteFile(fileName, []byte("taco"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Open it for modification.
 	t.f1, err = os.OpenFile(fileName, os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Truncate it.
 	err = t.f1.Truncate(4)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(4, fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 4, fi.Size())
 
 	// Read the contents.
 	contents, err := os.ReadFile(fileName)
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 }
 
 func (t *FileTest) Truncate_Larger() {
@@ -1710,25 +1708,25 @@ func (t *FileTest) Truncate_Larger() {
 
 	// Create a file.
 	err = os.WriteFile(fileName, []byte("taco"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Open it for modification.
 	t.f1, err = os.OpenFile(fileName, os.O_RDWR, 0)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Truncate it.
 	err = t.f1.Truncate(6)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
-	ExpectEq(6, fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 6, fi.Size())
 
 	// Read the contents.
 	contents, err := os.ReadFile(fileName)
-	AssertEq(nil, err)
-	ExpectEq("taco\x00\x00", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco\x00\x00", string(contents))
 }
 
 func (t *FileTest) Seek() {
@@ -1738,26 +1736,26 @@ func (t *FileTest) Seek() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Give it some contents.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Seek and overwrite.
 	off, err := t.f1.Seek(1, 0)
-	AssertEq(nil, err)
-	AssertEq(1, off)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, off)
 
 	n, err = t.f1.Write([]byte("xx"))
-	AssertEq(nil, err)
-	AssertEq(2, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, n)
 
 	// Read full the contents of the file.
 	n, err = t.f1.ReadAt(buf, 0)
-	AssertEq(io.EOF, err)
-	ExpectEq("txxo", string(buf[:n]))
+	require.Equal(t.T(), io.EOF, err)
+	assert.Equal(t.T(), "txxo", string(buf[:n]))
 }
 
 func (t *FileTest) Stat() {
@@ -1766,30 +1764,30 @@ func (t *FileTest) Stat() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Give it some contents.
 	time.Sleep(timeSlop + timeSlop/2)
 	writeTime := mtimeClock.Now()
 
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	time.Sleep(timeSlop + timeSlop/2)
 
 	// Stat it.
 	fi, err := t.f1.Stat()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("foo", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
-	ExpectThat(fi, fusetesting.MtimeIsWithin(writeTime, timeSlop))
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
+	assert.WithinDuration(t.T(), writeTime, fi.ModTime(), timeSlop)
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *FileTest) StatUnopenedFile() {
@@ -1800,22 +1798,22 @@ func (t *FileTest) StatUnopenedFile() {
 	createTime := mtimeClock.Now()
 
 	err = os.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	time.Sleep(timeSlop + timeSlop/2)
 
 	// Stat it.
 	fi, err := os.Stat(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("foo", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
-	ExpectThat(fi, fusetesting.MtimeIsWithin(createTime, timeSlop))
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
+	assert.WithinDuration(t.T(), createTime, fi.ModTime(), timeSlop)
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *FileTest) LstatUnopenedFile() {
@@ -1826,22 +1824,22 @@ func (t *FileTest) LstatUnopenedFile() {
 	createTime := mtimeClock.Now()
 
 	err = os.WriteFile(path.Join(mntDir, "foo"), []byte("taco"), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	time.Sleep(timeSlop + timeSlop/2)
 
 	// Lstat it.
 	fi, err := os.Lstat(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("foo", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
-	ExpectThat(fi, fusetesting.MtimeIsWithin(createTime, timeSlop))
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
-	ExpectEq(currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
+	assert.WithinDuration(t.T(), createTime, fi.ModTime(), timeSlop)
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), currentUid(), fi.Sys().(*syscall.Stat_t).Uid)
+	assert.Equal(t.T(), currentGid(), fi.Sys().(*syscall.Stat_t).Gid)
 }
 
 func (t *FileTest) UnlinkFile_Exists() {
@@ -1850,29 +1848,29 @@ func (t *FileTest) UnlinkFile_Exists() {
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
 	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Unlink it.
 	err = os.Remove(fileName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Statting it should fail.
 	_, err = os.Stat(fileName)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("no such file")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "no such file")
 
 	// Nothing should be in the directory.
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 }
 
 func (t *FileTest) UnlinkFile_NonExistent() {
 	err := os.Remove(path.Join(mntDir, "foo"))
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("no such file")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "no such file")
 }
 
 func (t *FileTest) UnlinkFile_StillOpen() {
@@ -1882,43 +1880,43 @@ func (t *FileTest) UnlinkFile_StillOpen() {
 
 	// Create and open a file.
 	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer f.Close()
 
 	// Write some data into it.
 	n, err := f.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Unlink it.
 	err = os.Remove(fileName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The directory should no longer contain it.
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 
 	// We should be able to stat the file. It should still show as having
 	// contents, but with no links.
 	fi, err := f.Stat()
 
-	AssertEq(nil, err)
-	ExpectEq(4, fi.Size())
-	ExpectEq(0, fi.Sys().(*syscall.Stat_t).Nlink)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), 4, fi.Size())
+	assert.Equal(t.T(), 0, fi.Sys().(*syscall.Stat_t).Nlink)
 
 	// The contents should still be available.
 	buf := make([]byte, 1024)
 	n, err = f.ReadAt(buf, 0)
 
-	AssertEq(io.EOF, err)
-	AssertEq(4, n)
-	ExpectEq("taco", string(buf[:4]))
+	require.Equal(t.T(), io.EOF, err)
+	require.Equal(t.T(), 4, n)
+	assert.Equal(t.T(), "taco", string(buf[:4]))
 
 	// Writing should still work, too.
 	n, err = f.Write([]byte("burrito"))
-	AssertEq(nil, err)
-	AssertEq(len("burrito"), n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), len("burrito"), n)
 }
 
 func (t *FileTest) UnlinkFile_NoLongerInBucket() {
@@ -1927,22 +1925,22 @@ func (t *FileTest) UnlinkFile_NoLongerInBucket() {
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
 	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Delete it from the bucket through the back door.
-	AssertEq(
+	require.Equal(t.T(),
 		nil,
 		bucket.DeleteObject(
 			ctx,
 			&gcs.DeleteObjectRequest{Name: "foo"}))
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to unlink it.
 	err = os.Remove(fileName)
 
-	AssertNe(nil, err)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	require.NotEqual(t.T(), nil, err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 }
 
 func (t *FileTest) UnlinkFile_FromSubDirectory() {
@@ -1951,27 +1949,27 @@ func (t *FileTest) UnlinkFile_FromSubDirectory() {
 	// Create a sub-directory.
 	dirName := path.Join(mntDir, "dir")
 	err = os.Mkdir(dirName, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Write a file to that directory.
 	fileName := path.Join(dirName, "foo")
 	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Unlink it.
 	err = os.Remove(fileName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Statting it should fail.
 	_, err = os.Stat(fileName)
 
-	AssertNe(nil, err)
-	ExpectThat(err, Error(HasSubstr("no such file")))
+	require.NotEqual(t.T(), nil, err)
+	assert.ErrorContains(t.T(), err, "no such file")
 
 	// Nothing should be in the directory.
 	entries, err := fusetesting.ReadDirPicky(dirName)
-	AssertEq(nil, err)
-	ExpectThat(entries, ElementsAre())
+	require.Equal(t.T(), nil, err)
+	assert.Empty(t.T(), entries)
 }
 
 func (t *FileTest) UnlinkFile_ThenRecreateWithSameName() {
@@ -1980,24 +1978,24 @@ func (t *FileTest) UnlinkFile_ThenRecreateWithSameName() {
 	// Write a file.
 	fileName := path.Join(mntDir, "foo")
 	err = os.WriteFile(fileName, []byte("Hello, world!"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Unlink it.
 	err = os.Remove(fileName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Re-create a file with the same name.
 	err = os.WriteFile(fileName, []byte("taco"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Statting should result in a record for the new contents.
 	fi, err := os.Stat(fileName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("foo", fi.Name())
-	ExpectEq(len("taco"), fi.Size())
-	ExpectFalse(fi.IsDir())
-	ExpectEq(1, fi.Sys().(*syscall.Stat_t).Nlink)
+	assert.Equal(t.T(), "foo", fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
+	assert.False(t.T(), fi.IsDir())
+	assert.Equal(t.T(), 1, fi.Sys().(*syscall.Stat_t).Nlink)
 }
 
 func (t *FileTest) Chmod() {
@@ -2006,13 +2004,13 @@ func (t *FileTest) Chmod() {
 	// Write a file.
 	p := path.Join(mntDir, "foo")
 	err = os.WriteFile(p, []byte(""), 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to chmod it. Chmod should succeed even though we don't do anything
 	// useful. The OS X Finder otherwise complains to the user when copying in a
 	// file.
 	err = os.Chmod(p, 0777)
-	ExpectEq(nil, err)
+	assert.Equal(t.T(), nil, err)
 }
 
 func (t *FileTest) Chtimes_InactiveFile() {
@@ -2021,17 +2019,17 @@ func (t *FileTest) Chtimes_InactiveFile() {
 	// Create a file.
 	p := path.Join(mntDir, "foo")
 	err = os.WriteFile(p, []byte{}, 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Change its mtime.
 	newMtime := time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local)
 	err = os.Chtimes(p, time.Now(), newMtime)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it and confirm that it worked.
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 }
 
 func (t *FileTest) Chtimes_OpenFile_Clean() {
@@ -2040,35 +2038,35 @@ func (t *FileTest) Chtimes_OpenFile_Clean() {
 	// Create a file.
 	p := path.Join(mntDir, "foo")
 	err = os.WriteFile(p, []byte{}, 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Open it for reading.
 	f, err := os.Open(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer f.Close()
 
 	// Change its mtime.
 	newMtime := time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local)
 	err = os.Chtimes(p, time.Now(), newMtime)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it by path.
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 
 	// Stat it by fd.
 	fi, err = f.Stat()
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 
 	// Close the file, then stat it by path again.
 	err = f.Close()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	fi, err = os.Stat(p)
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 }
 
 func (t *FileTest) Chtimes_OpenFile_Dirty() {
@@ -2077,35 +2075,35 @@ func (t *FileTest) Chtimes_OpenFile_Dirty() {
 	// Create a file.
 	p := path.Join(mntDir, "foo")
 	f, err := os.Create(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer f.Close()
 
 	// Dirty the file.
 	_, err = f.Write([]byte("taco"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Change its mtime.
 	newMtime := time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local)
 	err = os.Chtimes(p, time.Now(), newMtime)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it by path.
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 
 	// Stat it by fd.
 	fi, err = f.Stat()
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 
 	// Close the file, then stat it by path again.
 	err = f.Close()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	fi, err = os.Stat(p)
-	AssertEq(nil, err)
-	ExpectThat(fi.ModTime(), timeutil.TimeEq(newMtime))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), newMtime, fi.ModTime())
 }
 
 func (t *FileTest) Sync_Dirty() {
@@ -2114,22 +2112,22 @@ func (t *FileTest) Sync_Dirty() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Give it some contents.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Sync it.
 	err = t.f1.Sync()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The contents should now be in the bucket, even though we haven't closed
 	// the file.
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 }
 
 func (t *FileTest) Sync_NotDirty() {
@@ -2137,10 +2135,10 @@ func (t *FileTest) Sync_NotDirty() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	// Sync the file.
 	err = t.f1.Sync()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The above should have created a generation for the object. Grab a record
 	// for it.
@@ -2148,18 +2146,18 @@ func (t *FileTest) Sync_NotDirty() {
 		Name: "foo",
 	}
 	m1, _, err := bucket.StatObject(ctx, statReq)
-	AssertEq(nil, err)
-	AssertNe(nil, m1)
+	require.Equal(t.T(), nil, err)
+	require.NotEqual(t.T(), nil, m1)
 
 	// Sync the file again.
 	err = t.f1.Sync()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// A new generation need not have been written.
 	m2, _, err := bucket.StatObject(ctx, statReq)
-	AssertEq(nil, err)
-	AssertNe(nil, m2)
-	ExpectEq(m1.Generation, m2.Generation)
+	require.Equal(t.T(), nil, err)
+	require.NotEqual(t.T(), nil, m2)
+	assert.Equal(t.T(), m1.Generation, m2.Generation)
 }
 
 func (t *FileTest) Sync_Clobbered() {
@@ -2168,12 +2166,12 @@ func (t *FileTest) Sync_Clobbered() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Dirty the file by giving it some contents.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Replace the underlying object with a new generation.
 	_, err = storageutil.CreateObject(
@@ -2182,7 +2180,7 @@ func (t *FileTest) Sync_Clobbered() {
 		"foo",
 		[]byte("foobar"))
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to sync the file. This may result in an error if the OS has
 	// decided to hold back the writes from above until now (in which case the
@@ -2190,12 +2188,12 @@ func (t *FileTest) Sync_Clobbered() {
 	// Either way, this should not result in a new generation being created.
 	err = t.f1.Sync()
 	if err != nil {
-		ExpectThat(err, Error(HasSubstr("input/output error")))
+		assert.ErrorContains(t.T(), err, "input/output error")
 	}
 
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("foobar", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "foobar", string(contents))
 }
 
 func (t *FileTest) Close_Dirty() {
@@ -2204,22 +2202,22 @@ func (t *FileTest) Close_Dirty() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Give it some contents.
 	n, err = t.f1.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Close it.
 	err = t.f1.Close()
 	t.f1 = nil
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The contents should now be in the bucket.
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 }
 
 func (t *FileTest) Close_NotDirty() {
@@ -2227,19 +2225,19 @@ func (t *FileTest) Close_NotDirty() {
 
 	// Create a file.
 	t.f1, err = os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Close the file.
 	err = t.f1.Close()
 	t.f1 = nil
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Verify if the object is created in GCS.
 	statReq := &gcs.StatObjectRequest{
 		Name: "foo",
 	}
 	_, _, err = bucket.StatObject(ctx, statReq)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 }
 
 func (t *FileTest) Close_Clobbered() {
@@ -2248,13 +2246,13 @@ func (t *FileTest) Close_Clobbered() {
 
 	// Create a file.
 	f, err := os.Create(path.Join(mntDir, "foo"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer f.Close()
 
 	// Dirty the file by giving it some contents.
 	n, err = f.Write([]byte("taco"))
-	AssertEq(nil, err)
-	AssertEq(4, n)
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 4, n)
 
 	// Replace the underlying object with a new generation.
 	_, err = storageutil.CreateObject(
@@ -2263,7 +2261,7 @@ func (t *FileTest) Close_Clobbered() {
 		"foo",
 		[]byte("foobar"))
 
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Close the file. This may result in a "generation not found" error when
 	// faulting in the object's contents on Linux where close may cause cached
@@ -2272,8 +2270,8 @@ func (t *FileTest) Close_Clobbered() {
 	f.Close()
 
 	contents, err := storageutil.ReadObject(ctx, bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("foobar", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "foobar", string(contents))
 }
 
 func (t *FileTest) AtimeAndCtime() {
@@ -2283,22 +2281,22 @@ func (t *FileTest) AtimeAndCtime() {
 	p := path.Join(mntDir, "foo")
 	createTime := mtimeClock.Now()
 	f, err := os.Create(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	_, err = f.Write([]byte("test contents"))
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	err = f.Close()
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Stat it.
 	fi, err := os.Stat(p)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// We require only that atime and ctime be "reasonable".
 	atime, ctime, _ := fusetesting.GetTimes(fi)
 	const delta = 5 * time.Hour
 
-	ExpectThat(atime, timeutil.TimeNear(createTime, delta))
-	ExpectThat(ctime, timeutil.TimeNear(createTime, delta))
+	assert.WithinDuration(t.T(), createTime, atime, delta)
+	assert.WithinDuration(t.T(), createTime, ctime, delta)
 }
 
 func (t *FileTest) ContentTypes() {
@@ -2313,31 +2311,31 @@ func (t *FileTest) ContentTypes() {
 
 		// Create a file.
 		f, err := os.Create(p)
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 		err = f.Close()
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 
 		// Modify the file and cause a new generation to be written out.
 		f1, err := os.OpenFile(p, os.O_WRONLY, 0)
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 		defer func() {
 			err := f1.Close()
-			AssertEq(nil, err)
+			require.Equal(t.T(), nil, err)
 		}()
 		_, err = f1.Write([]byte("taco"))
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 
 		err = f1.Sync()
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 
 		// The GCS content type should still be correct.
 		_, e, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{
 			Name:                           name,
 			ForceFetchFromGcs:              true,
 			ReturnExtendedObjectAttributes: true})
-		AssertEq(nil, err)
-		AssertNe(nil, e)
-		ExpectEq(expected, e.ContentType, "name: %q", name)
+		require.Equal(t.T(), nil, err)
+		require.NotEqual(t.T(), nil, e)
+		assert.Equal(t.T(), expected, e.ContentType, "name: %q", name)
 	}
 
 	for name, expected := range testCases {
@@ -2351,10 +2349,11 @@ func (t *FileTest) ContentTypes() {
 
 type SymlinkTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&SymlinkTest{})
+func TestSymlinkTest(t *testing.T) {
+	suite.Run(t, new(SymlinkTest))
 }
 
 func (t *SymlinkTest) CreateLink() {
@@ -2366,51 +2365,51 @@ func (t *SymlinkTest) CreateLink() {
 	const contents = "taco"
 
 	err = os.WriteFile(fileName, []byte(contents), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a symlink to it.
 	symlinkName := path.Join(mntDir, "bar")
 	err = os.Symlink("foo", symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Check the object in the bucket.
 	m, _, err := bucket.StatObject(ctx, &gcs.StatObjectRequest{Name: "bar"})
 
-	AssertEq(nil, err)
-	AssertNe(nil, m)
-	ExpectEq(0, m.Size)
-	ExpectEq("foo", m.Metadata["gcsfuse_symlink_target"])
+	require.Equal(t.T(), nil, err)
+	require.NotEqual(t.T(), nil, m)
+	assert.Equal(t.T(), 0, m.Size)
+	assert.Equal(t.T(), "foo", m.Metadata["gcsfuse_symlink_target"])
 
 	// Read the link.
 	target, err := os.Readlink(symlinkName)
-	AssertEq(nil, err)
-	ExpectEq("foo", target)
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "foo", target)
 
 	// Stat the link.
 	fi, err = os.Lstat(symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("bar", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
+	assert.Equal(t.T(), "bar", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), filePerms|os.ModeSymlink, fi.Mode())
 
 	// Read the parent directory.
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
-	AssertEq(2, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 2, len(entries))
 
 	fi = entries[0]
-	ExpectEq("bar", fi.Name())
-	ExpectEq(0, fi.Size())
-	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
+	assert.Equal(t.T(), "bar", fi.Name())
+	assert.Equal(t.T(), 0, fi.Size())
+	assert.Equal(t.T(), filePerms|os.ModeSymlink, fi.Mode())
 
 	// Stat the target via the link.
 	fi, err = os.Stat(symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
-	ExpectEq("bar", fi.Name())
-	ExpectEq(len(contents), fi.Size())
-	ExpectEq(filePerms, fi.Mode())
+	assert.Equal(t.T(), "bar", fi.Name())
+	assert.Equal(t.T(), len(contents), fi.Size())
+	assert.Equal(t.T(), filePerms, fi.Mode())
 }
 
 func (t *SymlinkTest) CreateLink_Exists() {
@@ -2419,16 +2418,16 @@ func (t *SymlinkTest) CreateLink_Exists() {
 	// Create a file and a directory.
 	fileName := path.Join(mntDir, "foo")
 	err = os.WriteFile(fileName, []byte{}, 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	dirName := path.Join(mntDir, "bar")
 	err = os.Mkdir(dirName, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create an existing symlink.
 	symlinkName := path.Join(mntDir, "baz")
 	err = os.Symlink("blah", symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Symlinking on top of any of them should fail.
 	names := []string{
@@ -2439,7 +2438,7 @@ func (t *SymlinkTest) CreateLink_Exists() {
 
 	for _, n := range names {
 		err = os.Symlink("blah", n)
-		ExpectThat(err, Error(HasSubstr("exists")))
+		assert.ErrorContains(t.T(), err, "exists")
 	}
 }
 
@@ -2449,16 +2448,16 @@ func (t *SymlinkTest) RemoveLink() {
 	// Create the link.
 	symlinkName := path.Join(mntDir, "foo")
 	err = os.Symlink("blah", symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Remove it.
 	err = os.Remove(symlinkName)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// It should be gone from the bucket.
 	_, err = storageutil.ReadObject(ctx, bucket, "foo")
 	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
+	assert.True(t.T(), errors.As(err, &notFoundErr))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2467,10 +2466,11 @@ func (t *SymlinkTest) RemoveLink() {
 
 type RenameTest struct {
 	fsTest
+	suite.Suite
 }
 
-func init() {
-	RegisterTestSuite(&RenameTest{})
+func TestRenameTest(t *testing.T) {
+	suite.Run(t, new(RenameTest))
 }
 
 func (t *RenameTest) DirectoryNamingConflicts() {
@@ -2478,24 +2478,24 @@ func (t *RenameTest) DirectoryNamingConflicts() {
 
 	oldPath := path.Join(mntDir, "foo")
 	err = os.Mkdir(oldPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	conflictingPath := path.Join(mntDir, "bar")
 	err = os.Mkdir(conflictingPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	conflictingFile := path.Join(conflictingPath, "placeholder.txt")
 	err = os.WriteFile(conflictingFile, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = syscall.Rename(oldPath, conflictingPath)
-	ExpectThat(err, Error(HasSubstr("directory not empty")))
+	assert.ErrorContains(t.T(), err, "directory not empty")
 
 	err = os.Remove(conflictingFile)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = syscall.Rename(oldPath, conflictingPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 }
 
 func (t *RenameTest) DirectoryContainingFiles() {
@@ -2504,27 +2504,27 @@ func (t *RenameTest) DirectoryContainingFiles() {
 	// Create a directory.
 	oldPath := path.Join(mntDir, "foo")
 	err = os.Mkdir(oldPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	for i := range int(RenameDirLimit) {
 		file := fmt.Sprintf("%s/%d.txt", oldPath, i)
 		err = os.WriteFile(file, []byte("taco"), 0400)
-		AssertEq(nil, err)
+		require.Equal(t.T(), nil, err)
 	}
 
 	// Attempt to rename it.
 	newPath := path.Join(mntDir, "bar")
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// File count exceeds the limit.
 	file := fmt.Sprintf("%s/%d.txt", newPath, RenameDirLimit)
 	err = os.WriteFile(file, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to rename it.
 	err = os.Rename(newPath, oldPath)
-	ExpectThat(err, Error(HasSubstr("too many open files")))
+	assert.ErrorContains(t.T(), err, "too many open files")
 }
 
 func (t *RenameTest) DirectoryContainingDirectories() {
@@ -2533,35 +2533,35 @@ func (t *RenameTest) DirectoryContainingDirectories() {
 	// Create a directory.
 	oldPath := path.Join(mntDir, "foo")
 	err = os.Mkdir(oldPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a subdirectory.
 	subPath := path.Join(oldPath, "baz")
 	err = os.Mkdir(subPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create a subsubdirectory.
 	subSubPath := path.Join(subPath, "qux")
 	err = os.Mkdir(subSubPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Create files.
 	filePath1 := path.Join(subPath, "file1")
 	err = os.WriteFile(filePath1, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	filePath2 := path.Join(subSubPath, "file2")
 	err = os.WriteFile(filePath2, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Rename the directory.
 	newPath := path.Join(mntDir, "bar")
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	files, err := os.ReadDir(newPath)
-	AssertEq(nil, err)
-	AssertEq(1, len(files))
-	ExpectEq("baz", files[0].Name())
-	ExpectTrue(files[0].IsDir())
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(files))
+	assert.Equal(t.T(), "baz", files[0].Name())
+	assert.True(t.T(), files[0].IsDir())
 }
 
 func (t *RenameTest) EmptyDirectory() {
@@ -2570,19 +2570,19 @@ func (t *RenameTest) EmptyDirectory() {
 	// Create a directory.
 	oldPath := path.Join(mntDir, "foo")
 	err = os.Mkdir(oldPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Rename it.
 	newPath := path.Join(mntDir, "bar")
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	_, err = os.Stat(oldPath)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 
 	file, err := os.Stat(newPath)
-	AssertEq(nil, err)
-	ExpectTrue(file.IsDir())
+	require.Equal(t.T(), nil, err)
+	assert.True(t.T(), file.IsDir())
 }
 
 func (t *RenameTest) WithinDir() {
@@ -2592,44 +2592,44 @@ func (t *RenameTest) WithinDir() {
 	parentPath := path.Join(mntDir, "parent")
 
 	err = os.Mkdir(parentPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// And a file within it.
 	oldPath := path.Join(parentPath, "foo")
 
 	err = os.WriteFile(oldPath, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Rename it.
 	newPath := path.Join(parentPath, "bar")
 
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The old name shouldn't work.
 	_, err = os.Stat(oldPath)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 
 	_, err = os.ReadFile(oldPath)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 
 	// The new name should.
 	fi, err := os.Stat(newPath)
-	AssertEq(nil, err)
-	ExpectEq(len("taco"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len("taco"), fi.Size())
 
 	contents, err := os.ReadFile(newPath)
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 
 	// There should only be the new entry in the directory.
 	entries, err := fusetesting.ReadDirPicky(parentPath)
-	AssertEq(nil, err)
-	AssertEq(1, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(entries))
 	fi = entries[0]
 
-	ExpectEq(path.Base(newPath), fi.Name())
-	ExpectEq(len("taco"), fi.Size())
+	assert.Equal(t.T(), path.Base(newPath), fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
 }
 
 func (t *RenameTest) AcrossDirs() {
@@ -2640,52 +2640,52 @@ func (t *RenameTest) AcrossDirs() {
 	newParentPath := path.Join(mntDir, "new")
 
 	err = os.Mkdir(oldParentPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	err = os.Mkdir(newParentPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// And a file within the first.
 	oldPath := path.Join(oldParentPath, "foo")
 
 	err = os.WriteFile(oldPath, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Rename it.
 	newPath := path.Join(newParentPath, "bar")
 
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// The old name shouldn't work.
 	_, err = os.Stat(oldPath)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 
 	_, err = os.ReadFile(oldPath)
-	ExpectTrue(os.IsNotExist(err), "err: %v", err)
+	assert.True(t.T(), os.IsNotExist(err), "err: %v", err)
 
 	// The new name should.
 	fi, err := os.Stat(newPath)
-	AssertEq(nil, err)
-	ExpectEq(len("taco"), fi.Size())
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), len("taco"), fi.Size())
 
 	contents, err := os.ReadFile(newPath)
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 
 	// Check the old parent.
 	entries, err := fusetesting.ReadDirPicky(oldParentPath)
-	AssertEq(nil, err)
-	AssertEq(0, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 0, len(entries))
 
 	// And the new one.
 	entries, err = fusetesting.ReadDirPicky(newParentPath)
-	AssertEq(nil, err)
-	AssertEq(1, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(entries))
 	fi = entries[0]
 
-	ExpectEq(path.Base(newPath), fi.Name())
-	ExpectEq(len("taco"), fi.Size())
+	assert.Equal(t.T(), path.Base(newPath), fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
 }
 
 func (t *RenameTest) OutOfFileSystem() {
@@ -2695,15 +2695,15 @@ func (t *RenameTest) OutOfFileSystem() {
 	oldPath := path.Join(mntDir, "foo")
 
 	err = os.WriteFile(oldPath, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Attempt to move it out of the file system.
 	tempDir, err := os.MkdirTemp("", "memfs_test")
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer os.RemoveAll(tempDir)
 
 	err = os.Rename(oldPath, path.Join(tempDir, "bar"))
-	ExpectThat(err, Error(HasSubstr("cross-device")))
+	assert.ErrorContains(t.T(), err, "cross-device")
 }
 
 func (t *RenameTest) IntoFileSystem() {
@@ -2711,7 +2711,7 @@ func (t *RenameTest) IntoFileSystem() {
 
 	// Create a file outside of our file system.
 	f, err := os.CreateTemp("", "memfs_test")
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 	defer f.Close()
 
 	oldPath := f.Name()
@@ -2719,7 +2719,7 @@ func (t *RenameTest) IntoFileSystem() {
 
 	// Attempt to move it into the file system.
 	err = os.Rename(oldPath, path.Join(mntDir, "bar"))
-	ExpectThat(err, Error(HasSubstr("cross-device")))
+	assert.ErrorContains(t.T(), err, "cross-device")
 }
 
 func (t *RenameTest) OverExistingFile() {
@@ -2728,29 +2728,29 @@ func (t *RenameTest) OverExistingFile() {
 	// Create two files.
 	oldPath := path.Join(mntDir, "foo")
 	err = os.WriteFile(oldPath, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	newPath := path.Join(mntDir, "bar")
 	err = os.WriteFile(newPath, []byte("burrito"), 0600)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Rename one over the other.
 	err = os.Rename(oldPath, newPath)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Check the file contents.
 	contents, err := os.ReadFile(newPath)
-	AssertEq(nil, err)
-	ExpectEq("taco", string(contents))
+	require.Equal(t.T(), nil, err)
+	assert.Equal(t.T(), "taco", string(contents))
 
 	// And the parent listing.
 	entries, err := fusetesting.ReadDirPicky(mntDir)
-	AssertEq(nil, err)
-	AssertEq(1, len(entries))
+	require.Equal(t.T(), nil, err)
+	require.Equal(t.T(), 1, len(entries))
 	fi := entries[0]
 
-	ExpectEq(path.Base(newPath), fi.Name())
-	ExpectEq(len("taco"), fi.Size())
+	assert.Equal(t.T(), path.Base(newPath), fi.Name())
+	assert.Equal(t.T(), len("taco"), fi.Size())
 }
 
 func (t *RenameTest) OverExisting_WrongType() {
@@ -2759,23 +2759,23 @@ func (t *RenameTest) OverExisting_WrongType() {
 	// Create a file and a directory.
 	filePath := path.Join(mntDir, "foo")
 	err = os.WriteFile(filePath, []byte("taco"), 0400)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	dirPath := path.Join(mntDir, "bar")
 	err = os.Mkdir(dirPath, 0700)
-	AssertEq(nil, err)
+	require.Equal(t.T(), nil, err)
 
 	// Renaming one over the other shouldn't work.
 	err = os.Rename(filePath, dirPath)
-	ExpectThat(err, Error(MatchesRegexp("file exists|is a directory")))
+	assert.Regexp(t.T(), "file exists|is a directory", err.Error())
 
 	err = os.Rename(dirPath, filePath)
-	ExpectThat(err, Error(HasSubstr("not a directory")))
+	assert.ErrorContains(t.T(), err, "not a directory")
 }
 
 func (t *RenameTest) NonExistentFile() {
 	var err error
 
 	err = os.Rename(path.Join(mntDir, "foo"), path.Join(mntDir, "bar"))
-	ExpectThat(err, Error(HasSubstr("no such file")))
+	assert.ErrorContains(t.T(), err, "no such file")
 }


### PR DESCRIPTION
### Description
test: update local_modifications_test.go to use stretchr/testify

### Link to the issue in case of a bug fix.
b/490437726

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No