### PR TITLE
chore: Add A4X Max to high-performance machine type

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -191,6 +191,7 @@ var machineTypeToGroupMap = map[string]string{
 	"a4-highgpu-8g-nolssd":  "high-performance",
 	"a4x-highgpu-4g":        "high-performance",
 	"a4x-highgpu-4g-nolssd": "high-performance",
+	"a4x-maxgpu-4g-metal":   "high-performance",
 	"ct5l-hightpu-8t":       "high-performance",
 	"ct5lp-hightpu-8t":      "high-performance",
 	"ct5p-hightpu-4t":       "high-performance",

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -46,6 +46,7 @@ machine-type-groups:
     - "a4-highgpu-8g-nolssd"
     - "a4x-highgpu-4g"
     - "a4x-highgpu-4g-nolssd"
+    - "a4x-maxgpu-4g-metal"
     - "ct5l-hightpu-8t"
     - "ct5lp-hightpu-8t"
     - "ct5p-hightpu-4t"


### PR DESCRIPTION
### Description
A4X Max is a high-performance machine. It has ~960GB of host-memory and has a better NIC compared to A4X. 

### Link to the issue in case of a bug fix.
b/491279024

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No