### PR TITLE
chore: update log and test messages after removal of IsValueSet interface

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2697,7 +2697,7 @@ func TestArgParsing_ConfigFileOverridesFlagOptimizations(t *testing.T) {
 			args: []string{"--machine-type=a3-highgpu-8g"},
 			validate: func(t *testing.T, mi *mountInfo) {
 				assert.Equal(t, int64(123), mi.config.Write.GlobalMaxBlocks, "Should respect config file value 123, not optimize to 1600")
-				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "isUserSet should be true for write.global-max-blocks")
+				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "ViperConfig.IsSet should be true for write.global-max-blocks")
 				assert.True(t, mi.config.ImplicitDirs, "Should optimize implicit-dirs to true based on machine-type")
 				assert.False(t, mi.viperConfig.IsSet("implicit-dirs"))
 			},
@@ -2709,7 +2709,7 @@ func TestArgParsing_ConfigFileOverridesFlagOptimizations(t *testing.T) {
 			args: []string{"--profile=" + cfg.ProfileAIMLTraining},
 			validate: func(t *testing.T, mi *mountInfo) {
 				assert.False(t, mi.config.ImplicitDirs, "Should respect config file value false, not optimize to true")
-				assert.True(t, mi.viperConfig.IsSet("implicit-dirs"), "isUserSet should be true for implicit-dirs")
+				assert.True(t, mi.viperConfig.IsSet("implicit-dirs"), "ViperConfig.IsSet should be true for implicit-dirs")
 				assert.Equal(t, int64(testMaxSupportedTTLInSeconds), mi.config.MetadataCache.TtlSecs, "Should optimize metadata-cache.ttl-secs to -1 based on profile")
 				assert.False(t, mi.viperConfig.IsSet("metadata-cache.ttl-secs"))
 			},
@@ -2722,7 +2722,7 @@ write:
   global-max-blocks: 123`,
 			validate: func(t *testing.T, mi *mountInfo) {
 				assert.Equal(t, int64(123), mi.config.Write.GlobalMaxBlocks, "Should respect config file value 123, not optimize to 1600")
-				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "isUserSet should be true for write.global-max-blocks")
+				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "ViperConfig.IsSet should be true for write.global-max-blocks")
 				assert.True(t, mi.config.ImplicitDirs, "Should optimize implicit-dirs to true based on machine-type")
 				assert.False(t, mi.viperConfig.IsSet("implicit-dirs"))
 			},
@@ -2762,7 +2762,7 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 			args: []string{"--machine-type=a3-highgpu-8g", "--write-global-max-blocks=123"},
 			validate: func(t *testing.T, mi *mountInfo) {
 				assert.Equal(t, int64(123), mi.config.Write.GlobalMaxBlocks, "Should respect CLI value 123, not optimize to 1600")
-				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "isUserSet should be true for write.global-max-blocks")
+				assert.True(t, mi.viperConfig.IsSet("write.global-max-blocks"), "ViperConfig.IsSet should be true for write.global-max-blocks")
 				assert.True(t, mi.config.ImplicitDirs, "Should optimize implicit-dirs to true based on machine-type")
 				assert.False(t, mi.viperConfig.IsSet("implicit-dirs"))
 			},
@@ -2772,7 +2772,7 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 			args: []string{"--profile=" + cfg.ProfileAIMLTraining, "--implicit-dirs=false"},
 			validate: func(t *testing.T, mi *mountInfo) {
 				assert.False(t, mi.config.ImplicitDirs, "Should respect CLI value false, not optimize to true")
-				assert.True(t, mi.viperConfig.IsSet("implicit-dirs"), "isUserSet should be true for implicit-dirs")
+				assert.True(t, mi.viperConfig.IsSet("implicit-dirs"), "ViperConfig.IsSet should be true for implicit-dirs")
 				assert.Equal(t, int64(testMaxSupportedTTLInSeconds), mi.config.MetadataCache.TtlSecs, "Should optimize metadata-cache.ttl-secs to -1 based on profile")
 				assert.False(t, mi.viperConfig.IsSet("metadata-cache.ttl-secs"))
 			},

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -277,7 +277,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 				}
 			}
 		} else {
-			logger.Warnf("Cannot apply bucket-type optimizations as IsUserSet is nil")
+			logger.Warnf("Cannot apply bucket-type optimizations as ViperConfig is nil")
 		}
 		// Write post mount kernel settings for Zonal Buckets when kernel reader is enabled in GKE environments for
 		// non dynamic mounts before user space mounting in GCSFuse. Mounting in GKE is already done at this point but


### PR DESCRIPTION
### Description
This PR cleans up remaining textual references to `IsUserSet` and `isUserSet` in log messages and test assertions. These references were left over after the `IsValueSet` interface was removed and replaced with `*viper.Viper` in a previous refactor (PR #4291)

### Link to the issue in case of a bug fix.
b/491383839

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
