### PR TITLE
feat(dir-metadata-prefetch): make metadata prefetch flags public

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -929,10 +929,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-metadata-prefetch", "", false, "Enables background prefetching of object metadata when a directory is first opened.  This reduces latency for subsequent file lookups by pre-filling the metadata cache.")
 
-	if err := flagSet.MarkHidden("enable-metadata-prefetch"); err != nil {
-		return err
-	}
-
 	flagSet.BoolP("enable-new-reader", "", true, "Enables support for new reader implementation.")
 
 	if err := flagSet.MarkHidden("enable-new-reader"); err != nil {
@@ -1181,15 +1177,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("metadata-prefetch-entries-limit", "", 5000, "The maximum number of metadata entries (files and directories) to prefetch  into the cache upon a prefetch trigger. Since a single GCS List call is capped at 5000 results, values higher than 5000 will trigger multiple sequential GCS  List calls per directory.\n")
 
-	if err := flagSet.MarkHidden("metadata-prefetch-entries-limit"); err != nil {
-		return err
-	}
-
 	flagSet.IntP("metadata-prefetch-max-workers", "", 10, "The maximum number of concurrent goroutines (workers) allowed to perform  metadata prefetching across all directories.\n")
-
-	if err := flagSet.MarkHidden("metadata-prefetch-max-workers"); err != nil {
-		return err
-	}
 
 	flagSet.IntP("metrics-buffer-size", "", 256, "The maximum number of histogram metric updates in the queue.")
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -899,7 +899,7 @@ params:
       This reduces latency for subsequent file lookups by pre-filling the metadata cache.
     default: false
     deprecated: false
-    hide-flag: true
+    hide-flag: false
 
   - config-path: "metadata-cache.enable-nonexistent-type-cache"
     flag-name: "enable-nonexistent-type-cache"
@@ -936,7 +936,7 @@ params:
       List calls per directory.
     default: "5000"
     deprecated: false
-    hide-flag: true
+    hide-flag: false
 
   - config-path: "metadata-cache.metadata-prefetch-max-workers"
     flag-name: "metadata-prefetch-max-workers"
@@ -946,7 +946,7 @@ params:
       metadata prefetching across all directories.
     default: "10"
     deprecated: false
-    hide-flag: true
+    hide-flag: false
 
   - config-path: "metadata-cache.negative-ttl-secs"
     flag-name: "metadata-cache-negative-ttl-secs"


### PR DESCRIPTION
### Description
Exposing previously hidden command-line flags and configuration parameters related to directory metadata prefetching.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA