### PR TITLE
feat(logging): InfoLogger in mount config

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -203,5 +203,8 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 	if newConfig.Logging.Severity.Rank() <= cfg.TraceLogSeverity.Rank() {
 		mountCfg.DebugLogger = logger.NewLegacyLogger(logger.LevelTrace, "fuse_debug: ", fsName)
 	}
+	if newConfig.Logging.Severity.Rank() <= cfg.InfoLogSeverity.Rank() {
+		mountCfg.InfoLogger = logger.NewLegacyLogger(logger.LevelInfo, "fuse_debug: ", fsName)
+	}
 	return mountCfg
 }

--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
 )
+
+replace github.com/jacobsa/fuse => ../fuse


### PR DESCRIPTION
### Description
Add InfoLogger in fuse mount config. Can be merged only after https://github.com/jacobsa/fuse/pull/190 is in.

### Link to the issue in case of a bug fix.
b/491758985

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A