### PR TITLE
fix: ensure that retries are set as per user config after DP connectivity check

### DIFF
--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -160,6 +160,12 @@ func resolveMonitoringConfig(m *MonitoringConfig) {
 	}
 }
 
+func resolveGCSRetriesConfig(c *GcsRetriesConfig) {
+	if c.MaxRetryAttempts == 0 {
+		c.MaxRetryAttempts = math.MaxInt
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	var err error
@@ -180,6 +186,7 @@ func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	resolveCloudMetricsUploadIntervalSecs(&c.Metrics)
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
 	resolveFileCacheAndBufferedReadConflict(v, c)
+	resolveGCSRetriesConfig(&c.GcsRetries)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -64,6 +64,42 @@ func TestRationalizeCustomEndpointSuccessful(t *testing.T) {
 	}
 }
 
+func TestRationalize_GcsRetriesConfig(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		config                   *Config
+		expectedMaxRetryAttempts int
+	}{
+		{
+			name: "max-retry-attempts is 0",
+			config: &Config{
+				GcsRetries: GcsRetriesConfig{
+					MaxRetryAttempts: 0,
+				},
+			},
+			expectedMaxRetryAttempts: math.MaxInt,
+		},
+		{
+			name: "max-retry-attempts is not 0",
+			config: &Config{
+				GcsRetries: GcsRetriesConfig{
+					MaxRetryAttempts: 10,
+				},
+			},
+			expectedMaxRetryAttempts: 10,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Rationalize(viper.New(), tc.config, []string{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedMaxRetryAttempts, int(tc.config.GcsRetries.MaxRetryAttempts))
+		})
+	}
+}
+
 func TestRationalize_ReadConfig(t *testing.T) {
 	testCases := []struct {
 		name                    string

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"runtime"
@@ -835,7 +836,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   120,
 					ChunkTransferTimeoutSecs: 10,
-					MaxRetryAttempts:         0,
+					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
@@ -856,7 +857,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   180,
 					ChunkTransferTimeoutSecs: 20,
-					MaxRetryAttempts:         0,
+					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2080,7 +2080,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   120,
 					ChunkTransferTimeoutSecs: 30,
-					MaxRetryAttempts:         0,
+					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
@@ -2101,7 +2101,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   360,
 					ChunkTransferTimeoutSecs: 10,
-					MaxRetryAttempts:         0,
+					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -190,16 +190,13 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 		Multiplier: clientConfig.RetryMultiplier,
 	}),
 		storage.WithPolicy(storage.RetryAlways),
+		storage.WithMaxAttempts(clientConfig.MaxRetryAttempts),
+		storage.WithMaxRetryDuration(0),
 		storage.WithErrorFunc(func(err error) bool {
 			return storageutil.ShouldRetryWithMonitoring(ctx, err, clientConfig.MetricHandle)
 		})}
 
 	sc.SetRetry(retryOpts...)
-
-	// The default MaxRetryAttempts value is 0 indicates no limit.
-	if clientConfig.MaxRetryAttempts != 0 {
-		sc.SetRetry(storage.WithMaxAttempts(clientConfig.MaxRetryAttempts))
-	}
 }
 
 // setDPDetectionRetryConfig applies a lenient retry configuration for DirectPath detection phase.


### PR DESCRIPTION
### Description
This PR fixes a bug where retry configurations used during the DirectPath detection phase (e.g., MaxAttempts, MaxRetryDuration) were persisting into the production lifecycle of the storage client.

The Issue in the GCS Go SDK, calling sc.SetRetry(opts...) updates the client's internal retry configuration. However, if a subsequent call to SetRetry does not include a specific option (like WithMaxAttempts), the client retains the value from the previous configuration because it merges the new configs into the previous configs instead of re-setting it completely.

In our flow:
- setDPDetectionRetryConfig sets MaxAttempts to 5 and max duration to 1m0s.
- verifyDirectPathConnectivity succeeds.
- setRetryConfig is called to apply production settings.
- If the production config has MaxRetryAttempts set to 0 (default/no limit), the code skips calling storage.WithMaxAttempts, as well as max retry duration is not set.

Result: The client incorrectly keeps the limit of 5 and retry duration of 1m0s from the DP detection phase.

This was verified via logs showing the maxAttempts remaining at 5 and duration remaining at 1m0s even after the production config was supposedly applied. This has been fixed by overriding these configs to appropriate values.

### Link to the issue in case of a bug fix.
b/492050201

### Testing details
1. Manual - manually verified by adding a log in SDK layer that retries are being set to infinite (int max).
Before changes:
```
{"timestamp":{"seconds":1773400434,"nanos":303110770},"severity":"TRACE","message":"Success in fetching cred.UniverseDomain"}
max-retry-duration=0s, max-retry-attempts=nil
{"timestamp":{"seconds":1773400434,"nanos":303582850},"severity":"INFO","message":"Verifying DirectPath connectivity for bucket with stat call"}
max-retry-duration=1m0s, max-retry-attempts=5
{"timestamp":{"seconds":1773400434,"nanos":437365401},"severity":"INFO","message":"DirectPath verification successful for bucket applying production retry config"}
max-retry-duration=1m0s, max-retry-attempts=5
{"timestamp":{"seconds":1773400434,"nanos":437466784},"severity":"INFO","message":"Checking for DirectPath connectivity for bucket}
{"timestamp":{"seconds":1773400434,"nanos":498745697},"severity":"WARNING","message":"Direct path connectivity unavailable for bucket reason: storage: direct connectivity not detected"}
{"timestamp":{"seconds":1773400434,"nanos":500199747},"severity":"INFO","message":"Mounting file system}
```
After Changes:
```
{"timestamp":{"seconds":1773400434,"nanos":303110770},"severity":"TRACE","message":"Success in fetching cred.UniverseDomain"}
max-retry-duratin=0s, max-retry-attempts=9223372036854775807
{"timestamp":{"seconds":1773400434,"nanos":303582850},"severity":"INFO","message":"Verifying DirectPath connectivity for bucket with stat call"}
max-retry-duration=1m0s, max-retry-attempts=5
{"timestamp":{"seconds":1773400434,"nanos":437365401},"severity":"INFO","message":"DirectPath verification successful for bucket applying production retry config"}
max-retry-duratin=0s, max-retry-attempts=9223372036854775807
{"timestamp":{"seconds":1773400434,"nanos":437466784},"severity":"INFO","message":"Checking for DirectPath connectivity for bucket}
{"timestamp":{"seconds":1773400434,"nanos":498745697},"severity":"WARNING","message":"Direct path connectivity unavailable for bucket reason: storage: direct connectivity not detected"}
{"timestamp":{"seconds":1773400434,"nanos":500199747},"severity":"INFO","message":"Mounting file system}
```

2. Unit tests - added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA