### PR TITLE
chore(improved_run_e2e_tests): add bash upgrade in improved_run_e2e_tests.sh and remove from other places

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -23,8 +23,6 @@ if [[ $# -gt 0 ]]; then
 fi
 
 readonly BUCKET_LOCATION="us-central1"
-readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
-readonly INSTALL_BASH_VERSION="5.3" # Using 5.3 for installation as bash 5.1 has an installation bug.
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
@@ -36,25 +34,9 @@ commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 # To execute tests for a specific commitId, ensure you've checked out from that commitId first.
 git checkout $commitId
 
-# Check and install required bash version for e2e script.
-BASH_EXECUTABLE="bash"
-REQUIRED_BASH_MAJOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f1)
-REQUIRED_BASH_MINOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f2)
-
-echo "Current Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
-echo "Required Bash version for e2e script: ${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}"
-
-if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
-    echo "Current Bash version is older than the required version. Installing Bash ${INSTALL_BASH_VERSION}..."
-    ./perfmetrics/scripts/install_bash.sh "$INSTALL_BASH_VERSION"
-    BASH_EXECUTABLE="/usr/local/bin/bash"
-else
-    echo "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) meets or exceeds the required version (${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}). Skipping Bash installation."
-fi
-
 if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then
     echo "Running zonal e2e tests on installed package...."
-    "${BASH_EXECUTABLE}" ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package --zonal
+    bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package --zonal
 else
     if [[ -n "${RUN_TESTS_WITH_ZONAL_BUCKET-}" ]]; then
         echo "Warning: RUN_TESTS_WITH_ZONAL_BUCKET is set to '${RUN_TESTS_WITH_ZONAL_BUCKET}', which is not 'true'. Running regional tests."
@@ -62,5 +44,5 @@ else
         echo "RUN_TESTS_WITH_ZONAL_BUCKET is not set. Running regional tests by default."
     fi
     echo "Running regional e2e tests on installed package...."
-    "${BASH_EXECUTABLE}" ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package
+    bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package
 fi

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -25,26 +25,8 @@ fi
 # TPC project id
 readonly PROJECT_ID="tpczero-system:gcsfuse-test-project"
 readonly BUCKET_LOCATION="u-us-prp1"
-readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
-readonly INSTALL_BASH_VERSION="5.3" # Using 5.3 for installation as bash 5.1 has an installation bug.
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
-
-# Check and install required bash version for e2e script.
-BASH_EXECUTABLE="bash"
-REQUIRED_BASH_MAJOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f1)
-REQUIRED_BASH_MINOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f2)
-
-echo "Current Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
-echo "Required Bash version for e2e script: ${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}"
-
-if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
-    echo "Current Bash version is older than the required version. Installing Bash ${INSTALL_BASH_VERSION}..."
-    ./perfmetrics/scripts/install_bash.sh "$INSTALL_BASH_VERSION"
-    BASH_EXECUTABLE="/usr/local/bin/bash"
-else
-    echo "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) meets or exceeds the required version (${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}). Skipping Bash installation."
-fi
 
 # Install latest gcloud.
 ./perfmetrics/scripts/install_latest_gcloud.sh
@@ -71,7 +53,7 @@ gcloud auth activate-service-account --key-file=/tmp/sa.key.json
 gcloud config set project $PROJECT_ID
 
 set +e
-${BASH_EXECUTABLE} ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --test-installed-package --skip-non-essential-tests --test-on-tpc-endpoint
+bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --test-installed-package --skip-non-essential-tests --test-on-tpc-endpoint
 exit_code=$?
 set -e
 

--- a/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
+++ b/perfmetrics/scripts/presubmit_test/pr_perf_test/build.sh
@@ -23,8 +23,6 @@ readonly EXECUTE_CHECKPOINT_TEST_LABEL="execute-checkpoint-test"
 readonly EXECUTE_ORBAX_BENCHMARK_LABEL="execute-orbax-benchmark"
 readonly EXECUTE_MACHINE_TYPE_TEST_LABEL="execute-machine-type-test"
 readonly BUCKET_LOCATION=us-west4
-readonly REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT="5.1"
-readonly INSTALL_BASH_VERSION="5.3" # Using 5.3 for installation as bash 5.1 has an installation bug.
 
 curl https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER >> pr.json
 perfTest=$(grep "$EXECUTE_PERF_TEST_LABEL" pr.json)
@@ -128,22 +126,6 @@ then
  python3 ./perfmetrics/scripts/presubmit/print_results.py
 fi
 
-# Check and install required bash version for e2e script.
-BASH_EXECUTABLE="bash"
-REQUIRED_BASH_MAJOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f1)
-REQUIRED_BASH_MINOR=$(echo "$REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT" | cut -d'.' -f2)
-
-echo "Current Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
-echo "Required Bash version for e2e script: ${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}"
-
-if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
-    echo "Current Bash version is older than the required version. Installing Bash ${INSTALL_BASH_VERSION}..."
-    ./perfmetrics/scripts/install_bash.sh "$INSTALL_BASH_VERSION"
-    BASH_EXECUTABLE="/usr/local/bin/bash"
-else
-    echo "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) meets or exceeds the required version (${REQUIRED_BASH_VERSION_FOR_E2E_SCRIPT}). Skipping Bash installation."
-fi
-
 # Execute integration tests on zonal bucket(s).
 if test -n "${integrationTestsOnZBStr}" ;
 then
@@ -151,7 +133,7 @@ then
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   echo "Running e2e tests on zonal bucket(s) ..."
-  ${BASH_EXECUTABLE} ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --zonal --track-resource-usage
+  bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --zonal --track-resource-usage
 fi
 
 # Execute integration tests on non-zonal bucket(s).
@@ -161,7 +143,7 @@ then
   git checkout pr/$KOKORO_GITHUB_PULL_REQUEST_NUMBER
 
   echo "Running e2e tests on non-zonal bucket(s) ..."
-  ${BASH_EXECUTABLE} ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --track-resource-usage
+  bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location=$BUCKET_LOCATION --presubmit --track-resource-usage
 fi
 
 # Execute package build tests.

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -44,10 +44,26 @@ log_error() {
 # Confirm bash version before continuing script.
 REQUIRED_BASH_MAJOR=5
 REQUIRED_BASH_MINOR=1
+
 if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
-    log_error "This script requires Bash version: ${REQUIRED_BASH_MAJOR}.${REQUIRED_BASH_MINOR} or higher."
-    log_error "You are currently using Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+  log_info "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) is older than required (${REQUIRED_BASH_MAJOR}.${REQUIRED_BASH_MINOR})."
+  log_info "Installing Bash 5.3..."
+  
+  # Dynamically find the repo root so we can locate the install script safely
+  SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+  REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
+  
+  # Run the installation script
+  "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "5.3"
+  if [[ ! -x "/usr/local/bin/bash" ]]; then
+    log_error "Failed to locate the newly installed bash at /usr/local/bin/bash"
     exit 1
+  fi
+
+  log_info "Re-executing the e2e script using the newly installed Bash 5.3..."
+  # The 'exec' command completely replaces the current old-bash process 
+  # with the new bash process, passing along the script name ($0) and all arguments ($@).
+  exec /usr/local/bin/bash "$0" "$@"
 fi
 log_info "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -41,7 +41,7 @@ log_error() {
   echo "[ERROR] $(date +"%Y-%m-%d %H:%M:%S"): $1"
 }
 
-# Confirm bash version before continuing script.
+# Check or install bash version before continuing script.
 REQUIRED_BASH_MAJOR=5
 REQUIRED_BASH_MINOR=1
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -44,18 +44,17 @@ log_error() {
 # Check or install bash version before continuing script.
 REQUIRED_BASH_MAJOR=5
 REQUIRED_BASH_MINOR=1
+BASH_TO_INSTALL_VERSION="5.3"
+NEW_BASH_PATH="/usr/local/bin/bash"
 
 if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
   log_info "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) is older than required (${REQUIRED_BASH_MAJOR}.${REQUIRED_BASH_MINOR})."
-  local BASH_TO_INSTALL_VERSION="5.3"
-  local NEW_BASH_PATH="/usr/local/bin/bash"
-
   log_info "Installing Bash ${BASH_TO_INSTALL_VERSION}..."
-  
+
   # Dynamically find the repo root so we can locate the install script safely
   SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
   REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
-  
+
   # Run the installation script
   "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "${BASH_TO_INSTALL_VERSION}"
   if [[ ! -x "${NEW_BASH_PATH}" ]]; then

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -42,30 +42,30 @@ log_error() {
 }
 
 # Check or install bash version before continuing script.
-REQUIRED_BASH_MAJOR=5
-REQUIRED_BASH_MINOR=1
-BASH_TO_INSTALL_VERSION="5.3"
-NEW_BASH_PATH="/usr/local/bin/bash"
+readonly REQUIRED_BASH_MAJOR=5
+readonly REQUIRED_BASH_MINOR=1
+readonly BASH_INSTALL_VERSION="5.3"
+readonly BASH_INSTALLATION_PATH="/usr/local/bin/bash" # Using 5.3 for installation as bash 5.1 has an installation bug.
 
 if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
   log_info "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) is older than required (${REQUIRED_BASH_MAJOR}.${REQUIRED_BASH_MINOR})."
-  log_info "Installing Bash ${BASH_TO_INSTALL_VERSION}..."
+  log_info "Installing Bash ${BASH_INSTALL_VERSION}..."
 
   # Dynamically find the repo root so we can locate the install script safely
   SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
   REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
 
   # Run the installation script
-  "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "${BASH_TO_INSTALL_VERSION}"
-  if [[ ! -x "${NEW_BASH_PATH}" ]]; then
-    log_error "Failed to locate the newly installed bash at ${NEW_BASH_PATH}"
+  "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "${BASH_INSTALL_VERSION}"
+  if [[ ! -x "${BASH_INSTALLATION_PATH}" ]]; then
+    log_error "Failed to locate the newly installed bash at ${BASH_INSTALLATION_PATH}"
     exit 1
   fi
 
-  log_info "Re-executing the e2e script using the newly installed Bash ${BASH_TO_INSTALL_VERSION}..."
+  log_info "Re-executing the e2e script using the newly installed Bash ${BASH_INSTALL_VERSION}..."
   # The 'exec' command completely replaces the current old-bash process 
   # with the new bash process, passing along the script name ($0) and all arguments ($@).
-  exec "${NEW_BASH_PATH}" "$0" "$@"
+  exec "${BASH_INSTALLATION_PATH}" "$0" "$@"
 fi
 log_info "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -47,23 +47,26 @@ REQUIRED_BASH_MINOR=1
 
 if (( BASH_VERSINFO[0] < REQUIRED_BASH_MAJOR || ( BASH_VERSINFO[0] == REQUIRED_BASH_MAJOR && BASH_VERSINFO[1] < REQUIRED_BASH_MINOR ) )); then
   log_info "Current Bash version (${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}) is older than required (${REQUIRED_BASH_MAJOR}.${REQUIRED_BASH_MINOR})."
-  log_info "Installing Bash 5.3..."
+  local BASH_TO_INSTALL_VERSION="5.3"
+  local NEW_BASH_PATH="/usr/local/bin/bash"
+
+  log_info "Installing Bash ${BASH_TO_INSTALL_VERSION}..."
   
   # Dynamically find the repo root so we can locate the install script safely
   SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
   REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
   
   # Run the installation script
-  "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "5.3"
-  if [[ ! -x "/usr/local/bin/bash" ]]; then
-    log_error "Failed to locate the newly installed bash at /usr/local/bin/bash"
+  "${REPO_ROOT}/perfmetrics/scripts/install_bash.sh" "${BASH_TO_INSTALL_VERSION}"
+  if [[ ! -x "${NEW_BASH_PATH}" ]]; then
+    log_error "Failed to locate the newly installed bash at ${NEW_BASH_PATH}"
     exit 1
   fi
 
-  log_info "Re-executing the e2e script using the newly installed Bash 5.3..."
+  log_info "Re-executing the e2e script using the newly installed Bash ${BASH_TO_INSTALL_VERSION}..."
   # The 'exec' command completely replaces the current old-bash process 
   # with the new bash process, passing along the script name ($0) and all arguments ($@).
-  exec /usr/local/bin/bash "$0" "$@"
+  exec "${NEW_BASH_PATH}" "$0" "$@"
 fi
 log_info "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
 


### PR DESCRIPTION
### Description
**Upgrade bash version dynamically in `improved_run_e2e_tests.sh`**

Previously, the script would simply fail and `exit 1` if the system's Bash version was older than the required 5.1. This PR introduces a self-re-execution mechanism that automatically installs Bash 5.3 and re-launches the script using the newly installed interpreter. This eliminates manual intervention and prevents failures on older environments.

### Link to the issue in case of a bug fix.
Fixes [b/493130285](https://b.corp.google.com/issues/493130285)

### Testing details
1. **Manual:** Verified the Bash upgrade logic by explicitly running the script with an older Bash version (5.0). Logs confirming the successful installation of Bash 5.3 and the subsequent re-execution of the script have been added to the bug. More details on the bug.

### Any backward incompatible change? If so, please explain.
No.
