### PR TITLE
fix(ci): update install_test.sh to support Python 3.10+ and missing dependencies

### DIFF
--- a/tools/cd_scripts/install_test.sh
+++ b/tools/cd_scripts/install_test.sh
@@ -24,7 +24,11 @@ if [ -f /etc/debian_version ]; then
   sudo apt-get install -y python3.11 wget tar
 elif [ -f /etc/redhat-release ] || [ -f /etc/os-release ]; then
   # Use dnf for RHEL/Rocky/CentOS; falls back to yum if dnf is missing
-  sudo command -v dnf >/dev/null 2>&1 && sudo dnf install -y python3.11 wget tar || sudo yum install -y python3.11 wget tar
+  if command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y python3.11 wget tar
+  else
+    sudo yum install -y python3.11 wget tar
+  fi
 fi
 
 # Ensure gcloud uses the newly installed Python 3.11


### PR DESCRIPTION
### Description
This PR fixes the `install_test.sh` script to resolve failures encountered during release validation on RHEL 9 and Rocky Linux 9 arm64 instances.

The primary issues addressed are:
1. **Python Version Incompatibility**: Modern `gcloud` versions require Python 3.10+, but EL9 distributions default to Python 3.9, causing `gcloud storage` commands to crash. We now install `python3.11` and set `CLOUDSDK_PYTHON` accordingly.
2. **Missing Dependencies**: Minimal cloud images for EL9 often lack `wget` and `tar`, which are required for manual SDK installation. These are now explicitly installed.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/494081608

### Testing details
1. Manual - Tested on `Debian`,`Ubuntu`,`Rhel`,`Centos` and `Rocky Linux`
2. Unit tests - NA
4. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA