### PR TITLE
docs(troubleshooting): for fuse: writeMessage: no such file or directory error

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,7 +270,7 @@ This occurs when the gcsfuse package corresponding to OS version returned by `ls
 
 ### fuse: writeMessage: no such file or directory error
 
-This error indicates that the GCSFuse process attempted to write a response (such as an "OK" status for a pending I/O request) back to the kernel, but the underlying communication channel—the FUSE file descriptor—was already closed.
+This error indicates that the GCSFuse process attempted to write a response (such as an "OK" status for a pending I/O request) back to the kernel, but the underlying communication channel— the FUSE file descriptor— was already closed.
 
 The primary cause is typically a concurrent or premature `unmount` syscall that tears down the mount point while active I/O is still being finalized. When the mount is unmounted, the kernel closes the FUSE device file descriptor, causing subsequent attempts by GCSFuse to send responses back to the kernel to fail with "no such file or directory".
 


### PR DESCRIPTION
### Description
Added a new section to the troubleshooting.md document detailing the fuse: writeMessage: no such file or directory error, explaining its cause and providing a fix.

### Link to the issue in case of a bug fix.
b/490186467

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
