### PR TITLE
fix: add read cache required flags for GKE env in GCSFuse tests

### DIFF
--- a/tools/integration_tests/flag_optimizations/setup_test.go
+++ b/tools/integration_tests/flag_optimizations/setup_test.go
@@ -149,15 +149,15 @@ func TestMain(m *testing.M) {
 		cfg.FlagOptimizations[0].Configs[8].Run = "TestKernelReader_DefaultAndPrecedence"
 		cfg.FlagOptimizations[0].Configs[8].Flags = []string{
 			"--implicit-dirs --log-severity=trace",
-			"--implicit-dirs --log-severity=trace --cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_FileCache",
+			"--implicit-dirs --log-severity=trace --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_FileCache",
 			"--implicit-dirs --log-severity=trace --enable-buffered-read=true",
-			"--implicit-dirs --log-severity=trace --enable-buffered-read=true --cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both",
+			"--implicit-dirs --log-severity=trace --enable-buffered-read=true --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both",
 		}
 		cfg.FlagOptimizations[0].Configs[8].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
 		cfg.FlagOptimizations[0].Configs[8].RunOnGKE = false
 
 		cfg.FlagOptimizations[0].Configs[9].Run = "TestFileCache_KernelReaderDisabled"
-		cfg.FlagOptimizations[0].Configs[9].Flags = []string{"--implicit-dirs --log-severity=trace --enable-kernel-reader=false --cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled"}
+		cfg.FlagOptimizations[0].Configs[9].Flags = []string{"--implicit-dirs --log-severity=trace --enable-kernel-reader=false --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled"}
 		cfg.FlagOptimizations[0].Configs[9].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
 		cfg.FlagOptimizations[0].Configs[9].RunOnGKE = false
 

--- a/tools/integration_tests/monitoring/setup_test.go
+++ b/tools/integration_tests/monitoring/setup_test.go
@@ -177,10 +177,10 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
 
 		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 7)
-		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
-		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
 
@@ -191,10 +191,10 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
 
-		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
-		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
 

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -298,8 +298,8 @@ func TestMain(m *testing.M) {
 		cfg.ReadCache[0].Configs[15].Run = "TestRemountTest"
 
 		cfg.ReadCache[0].Configs[16].Flags = []string{
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex= --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex= --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
 			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
 			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
 		}
@@ -307,13 +307,13 @@ func TestMain(m *testing.M) {
 		cfg.ReadCache[0].Configs[16].Run = "TestCacheFileForIncludeRegexTest"
 
 		cfg.ReadCache[0].Configs[17].Flags = []string{
-			"--file-cache-experimental-enable-chunk-cache=true --file-cache-download-chunk-size-mb=10 --cache-dir=/gcsfuse-tmp/TestChunkCacheTest --log-file=/gcsfuse-tmp/TestChunkCacheTest.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-experimental-enable-chunk-cache=true --file-cache-download-chunk-size-mb=10 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestChunkCacheTest --log-file=/gcsfuse-tmp/TestChunkCacheTest.log --log-severity=TRACE --enable-kernel-reader=false",
 		}
 		cfg.ReadCache[0].Configs[17].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ReadCache[0].Configs[17].Run = "TestChunkCacheTest"
 
 		cfg.ReadCache[0].Configs[18].Flags = []string{
-			"--file-cache-experimental-enable-chunk-cache=false --cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest --log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-experimental-enable-chunk-cache=false --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest --log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log --log-severity=TRACE --enable-kernel-reader=false",
 		}
 		cfg.ReadCache[0].Configs[18].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ReadCache[0].Configs[18].Run = "TestChunkCacheDisabledTest"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -424,8 +424,8 @@ read_cache:
         run: TestRemountTest
         run_on_gke: false
       - flags:
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
           - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
@@ -435,7 +435,7 @@ read_cache:
         run: TestCacheFileForIncludeRegexTest
         run_on_gke: true
       - flags:
-          - "--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--cache-dir=/gcsfuse-tmp/TestChunkCacheTest,--log-file=/gcsfuse-tmp/TestChunkCacheTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheTest,--log-file=/gcsfuse-tmp/TestChunkCacheTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
@@ -443,7 +443,7 @@ read_cache:
         run: TestChunkCacheTest
         run_on_gke: true
       - flags:
-          - "--file-cache-experimental-enable-chunk-cache=false,--cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest,--log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--file-cache-experimental-enable-chunk-cache=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest,--log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
@@ -750,9 +750,9 @@ flag_optimizations:
         # Tests that kernel reader is used by default and takes precedence over buffered reader and file cache.
         flags:
           - "--implicit-dirs,--log-severity=trace"
-          - "--implicit-dirs,--log-severity=trace,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_FileCache"
+          - "--implicit-dirs,--log-severity=trace,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_FileCache"
           - "--implicit-dirs,--log-severity=trace,--enable-buffered-read=true"
-          - "--implicit-dirs,--log-severity=trace,--enable-buffered-read=true,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both"
+          - "--implicit-dirs,--log-severity=trace,--enable-buffered-read=true,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both"
         compatible:
           flat: false
           hns: false
@@ -761,7 +761,7 @@ flag_optimizations:
       - run: TestFileCache_KernelReaderDisabled
         # Tests that file cache is used when kernel reader is explicitly disabled.
         flags:
-          - "--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled"
+          - "--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled"
         compatible:
           flat: false
           hns: false
@@ -921,7 +921,7 @@ monitoring:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--log-file=/gcsfuse-tmp/monitoring.log,--enable-kernel-reader=false"
+        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/monitoring.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -929,7 +929,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--log-file=/gcsfuse-tmp/monitoring_hns.log,--enable-kernel-reader=false"
+        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/monitoring_hns.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -953,7 +953,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--log-file=/gcsfuse-tmp/prom_grpc_metrics.log,--enable-kernel-reader=false"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/prom_grpc_metrics.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -961,7 +961,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log,--enable-kernel-reader=false"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true


### PR DESCRIPTION
### Description
- Test Configuration Updates: Added the `--file-cache-max-size-mb=-1` flag to various GCSFuse test configurations across `flag_optimizations`, `monitoring`, and `read_cache` test suites to ensure proper read cache behavior in GKE environment where file cache is enabled only when cache size is specified.
- Flag Refinement: Removed the `--file-cache-exclude-regex=` flag from specific `read_cache` test configurations where it was redundant because of using the default value.

### Link to the issue in case of a bug fix.
b/494120672

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
