### PR TITLE
test(tracing): Add benchmark tests to the repository for reference

### DIFF
--- a/tracing/benchmark_test.go
+++ b/tracing/benchmark_test.go
@@ -58,11 +58,14 @@ func BenchmarkTrace(b *testing.B) {
 
 		b.Run(fmt.Sprintf("BenchmarkRecordError_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
+			err := fmt.Errorf("TestError")
+			_, span := th.StartSpan(ctx, "TestSpanName")
 
 			for b.Loop() {
-				_, span := th.StartServerSpan(ctx, "TestSpanName")
-				th.EndSpan(span)
+				th.RecordError(span, err)
 			}
+
+			th.EndSpan(span)
 		})
 
 		b.Run(fmt.Sprintf("BenchmarkSetCacheReadAttributes_%s", prefix), func(b *testing.B) {


### PR DESCRIPTION
### Description
Add benchmark tests to the repository for reference.

Ran benchmarks and below is the output.

goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/tracing
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
BenchmarkTrace/BenchmarkStartSpan_Otel-64         	 6454726	       183.4 ns/op	     240 B/op	       3 allocs/op
BenchmarkTrace/BenchmarkStartServerSpan_Otel-64   	 5038105	       238.5 ns/op	     272 B/op	       5 allocs/op
BenchmarkTrace/BenchmarkRecordError_Otel-64       	250574862	         4.787 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkSetCacheReadAttributes_Otel-64         	56006740	        21.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkPropagateTraceContext_Otel-64          	26608670	        45.93 ns/op	      48 B/op	       1 allocs/op
BenchmarkTrace/BenchmarkStartSpan_Noop-64                      	500905828	         2.392 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkStartServerSpan_Noop-64                	445954076	         2.687 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkRecordError_Noop-64                    	662981062	         1.818 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkSetCacheReadAttributes_Noop-64         	786007035	         1.524 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkPropagateTraceContext_Noop-64          	535797530	         2.230 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/googlecloudplatform/gcsfuse/v3/tracing	12.012s

### Link to the issue in case of a bug fix.
b/490302363

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

Added benchmark tests for reference. Ran them locally and pasted the result in the description with machine details as well.

### Any backward incompatible change? If so, please explain.
N/A