### PR TITLE
test(integration): hardcode cache-dir for readonly and read_large_files packages

### DIFF
--- a/tools/integration_tests/read_large_files/read_large_files_test.go
+++ b/tools/integration_tests/read_large_files/read_large_files_test.go
@@ -17,7 +17,6 @@ package read_large_files
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -58,10 +57,10 @@ func TestMain(m *testing.M) {
 		cfg.ReadLargeFiles[0].Configs[0].Flags = []string{
 			"--implicit-dirs",
 			"--implicit-dirs --client-protocol=grpc",
-			fmt.Sprintf("--implicit-dirs=true --file-cache-max-size-mb=700 --file-cache-cache-file-for-range-read=true --cache-dir=%s/cache-dir-read-large-files-%s", os.TempDir(), setup.GenerateRandomString(4)),
-			fmt.Sprintf("--implicit-dirs=true --file-cache-max-size-mb=700 --file-cache-cache-file-for-range-read=true --client-protocol=grpc --cache-dir=%s/cache-dir-read-large-files-%s", os.TempDir(), setup.GenerateRandomString(4)),
-			fmt.Sprintf("--implicit-dirs=true --file-cache-max-size-mb=-1 --file-cache-cache-file-for-range-read=false --cache-dir=%s/cache-dir-read-large-files-%s", os.TempDir(), setup.GenerateRandomString(4)),
-			fmt.Sprintf("--implicit-dirs=true --file-cache-max-size-mb=-1 --file-cache-cache-file-for-range-read=false --client-protocol=grpc --cache-dir=%s/cache-dir-read-large-files-%s", os.TempDir(), setup.GenerateRandomString(4)),
+			"--implicit-dirs=true --file-cache-max-size-mb=700 --file-cache-cache-file-for-range-read=true --cache-dir=/gcsfuse-tmp/read_large_files",
+			"--implicit-dirs=true --file-cache-max-size-mb=700 --file-cache-cache-file-for-range-read=true --client-protocol=grpc --cache-dir=/gcsfuse-tmp/read_large_files",
+			"--implicit-dirs=true --file-cache-max-size-mb=-1 --file-cache-cache-file-for-range-read=false --cache-dir=/gcsfuse-tmp/read_large_files",
+			"--implicit-dirs=true --file-cache-max-size-mb=-1 --file-cache-cache-file-for-range-read=false --client-protocol=grpc --cache-dir=/gcsfuse-tmp/read_large_files",
 		}
 		cfg.ReadLargeFiles[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ReadLargeFiles[0].Configs[1].Flags = []string{
@@ -88,12 +87,11 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadLargeFiles[0].GKEMountedDirectory, m))
 	}
 
-	// Run tests for testBucket.
-	// 4. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.ReadLargeFiles[0], bucketType, "")
-	flags = setup.AddCacheDirToFlags(flags, "read-large-files")
-
 	setup.SetUpTestDirForTestBucket(&cfg.ReadLargeFiles[0])
+	setup.OverrideFilePathsInFlagSet(&cfg.ReadLargeFiles[0], setup.TestDir())
+
+	// 4. Build the flag sets dynamically from the modified config.
+	flags := setup.BuildFlagSets(cfg.ReadLargeFiles[0], bucketType, "")
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ReadLargeFiles[0], flags, m)
 

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -112,12 +112,11 @@ func TestMain(m *testing.M) {
 		cfg.ReadOnly[0].TestBucket = setup.TestBucket()
 		cfg.ReadOnly[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ReadOnly[0].Configs = make([]test_suite.ConfigItem, 1)
-		cacheDirPath := path.Join(os.TempDir(), "cache-dir-readonly-"+setup.GenerateRandomString(4))
 		cfg.ReadOnly[0].Configs[0].Flags = []string{
 			"--o=ro --implicit-dirs=true",
 			"--file-mode=544 --dir-mode=544 --implicit-dirs=true",
 			"--client-protocol=grpc --o=ro --implicit-dirs=true",
-			fmt.Sprintf("--o=ro --implicit-dirs=true --cache-dir=%s --file-cache-max-size-mb=3", cacheDirPath),
+			"--o=ro --implicit-dirs=true --cache-dir=/gcsfuse-tmp/readonly --file-cache-max-size-mb=3",
 		}
 		cfg.ReadOnly[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
@@ -143,10 +142,11 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.ReadOnly[0].GKEMountedDirectory, m))
 	}
 
-	// Run tests for testBucket
-	// 4. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.ReadOnly[0], bucketType, "")
 	setup.SetUpTestDirForTestBucket(&cfg.ReadOnly[0])
+	setup.OverrideFilePathsInFlagSet(&cfg.ReadOnly[0], setup.TestDir())
+
+	// 4. Build the flag sets dynamically from the modified config.
+	flags := setup.BuildFlagSets(cfg.ReadOnly[0], bucketType, "")
 
 	// 5. Run tests.
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.ReadOnly[0], flags, m)

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -117,10 +117,10 @@ read_large_files:
       - flags:
           - "--implicit-dirs"
           - "--implicit-dirs,--client-protocol=grpc"
-          - "--implicit-dirs,--file-cache-max-size-mb=700,--file-cache-cache-file-for-range-read,--cache-dir=${CACHE_DIR_PATH}"
-          - "--implicit-dirs,--file-cache-max-size-mb=700,--file-cache-cache-file-for-range-read,--client-protocol=grpc,--cache-dir=${CACHE_DIR_PATH}"
-          - "--implicit-dirs,--file-cache-max-size-mb=-1,--cache-dir=${CACHE_DIR_PATH}"
-          - "--implicit-dirs,--file-cache-max-size-mb=-1,--client-protocol=grpc,--cache-dir=${CACHE_DIR_PATH}"
+          - "--implicit-dirs,--file-cache-max-size-mb=700,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/read_large_files"
+          - "--implicit-dirs,--file-cache-max-size-mb=700,--file-cache-cache-file-for-range-read,--client-protocol=grpc,--cache-dir=/gcsfuse-tmp/read_large_files"
+          - "--implicit-dirs,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/read_large_files"
+          - "--implicit-dirs,--file-cache-max-size-mb=-1,--client-protocol=grpc,--cache-dir=/gcsfuse-tmp/read_large_files"
         compatible:
           flat: true
           hns: true
@@ -142,7 +142,7 @@ readonly:
           - "--o=ro,--implicit-dirs"
           - "--file-mode=544,--dir-mode=544,--implicit-dirs"
           - "--client-protocol=grpc,--o=ro,--implicit-dirs"
-          - "--o=ro,--implicit-dirs,--cache-dir=${CACHE_DIR_PATH},--file-cache-max-size-mb=3"
+          - "--o=ro,--implicit-dirs,--cache-dir=/gcsfuse-tmp/readonly,--file-cache-max-size-mb=3"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -576,7 +576,6 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	return FlatBucket, nil
 }
 
-
 // BuildFlagSets dynamically builds a list of flag sets based on bucket compatibility.
 // bucketType should be "flat", "hns", or "zonal".
 // The run parameter filters flag sets based on the 'Run' field in the test

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -576,17 +576,6 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	return FlatBucket, nil
 }
 
-// AddCacheDirToFlags iterates over a set of flag slices and updates any empty "--cache-dir" flags.
-func AddCacheDirToFlags(flagSets [][]string, testname string) [][]string {
-	for i := range flagSets {
-		for j := range flagSets[i] {
-			if flagSets[i][j] == "--cache-dir=" {
-				flagSets[i][j] = fmt.Sprintf("--cache-dir=%s/cache-dir-%s-%s", os.TempDir(), testname, GenerateRandomString(4))
-			}
-		}
-	}
-	return flagSets
-}
 
 // BuildFlagSets dynamically builds a list of flag sets based on bucket compatibility.
 // bucketType should be "flat", "hns", or "zonal".


### PR DESCRIPTION
### Description
Currently, the integration test cases for the `readonly` and `read_large_files` packages pass the `cache-dir` flag using an environment variable (`cache-dir=${CACHE_DIR_PATH}`). This deviates from the pattern established in the majority of other test cases, where the `cache-dir` is explicitly hardcoded (e.g., `/gcsfuse-tmp/<testName>`). 

This PR updates these test configurations to use a hardcoded path for `cache-dir` instead of relying on the `${CACHE_DIR_PATH}` environment variable, ensuring consistency across the entire integration testing suite.

### Link to the issue in case of a bug fix.
Fixes http://b/494320769

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Verified that the `readonly` and `read_large_files` integration tests execute and pass successfully with the newly hardcoded cache directory paths.

### Any backward incompatible change? If so, please explain.
No
