### PR TITLE
test(monitoring package): align log file paths with test suite names for monitoring integration tests

### DIFF
--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -38,7 +38,7 @@ type timeoutEnabledSuite struct {
 }
 
 func (s *timeoutEnabledSuite) SetupSuite() {
-	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
+	setup.SetUpLogFilePath(s.flags, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -38,7 +38,7 @@ type timeoutDisabledSuite struct {
 }
 
 func (s *timeoutDisabledSuite) SetupSuite() {
-	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
+	setup.SetUpLogFilePath(s.flags, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/log_rotation/log_rotation_test.go
+++ b/tools/integration_tests/log_rotation/log_rotation_test.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -100,7 +99,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// 6. Override GKE specific paths with GCSFuse paths if running in GCE environment.
-	overrideFilePathsInFlagSet(cfg, setup.TestDir())
+	setup.OverrideFilePathsInFlagSet(cfg, setup.TestDir())
 
 	flags := setup.BuildFlagSets(*cfg, bucketType, "")
 	setupLogFilePath(testDirName)
@@ -110,13 +109,4 @@ func TestMain(m *testing.M) {
 	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
-}
-
-func overrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
-	for _, flags := range t.Configs {
-		for i := range flags.Flags {
-			// Iterate over the indices of the flags slice
-			flags.Flags[i] = strings.ReplaceAll(flags.Flags[i], "/gcsfuse-tmp", path.Join(GCSFuseTempDirPath, "gcsfuse-tmp"))
-		}
-	}
 }

--- a/tools/integration_tests/monitoring/setup_test.go
+++ b/tools/integration_tests/monitoring/setup_test.go
@@ -177,28 +177,28 @@ func TestMain(m *testing.M) {
 		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
 
 		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 7)
-		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[0].Flags = []string{"--prometheus-port=9190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/TestPromOTELSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[0].Run = "TestPromOTELSuite"
-		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/monitoring_hns.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[1].Flags = []string{"--prometheus-port=10190 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/PromOTELSuite --log-file=/gcsfuse-tmp/TestPromOTELSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[1].Run = "TestPromOTELSuite"
 
-		testEnv.cfg.Configs[2].Flags = []string{"--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[2].Flags = []string{"--prometheus-port=9191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[2].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[2].Run = "TestPromBufferedReadSuite"
-		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/prom_buffered_read_hns.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[3].Flags = []string{"--prometheus-port=10191 --enable-buffered-read --read-block-size-mb=4 --read-random-seek-threshold=2 --read-global-max-blocks=5 --read-min-blocks-per-handle=2 --read-start-blocks-per-handle=2 --log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[3].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[3].Run = "TestPromBufferedReadSuite"
 
-		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[4].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=9192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[4].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
 		testEnv.cfg.Configs[4].Run = "TestPromGrpcMetricsSuite"
-		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log --enable-kernel-reader=false"}
+		testEnv.cfg.Configs[5].Flags = []string{"--client-protocol=grpc --experimental-enable-grpc-metrics=true --prometheus-port=10192 --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite --log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log --enable-kernel-reader=false"}
 		testEnv.cfg.Configs[5].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
 		testEnv.cfg.Configs[5].Run = "TestPromGrpcMetricsSuite"
 
-		testEnv.cfg.Configs[6].Flags = []string{"--prometheus-port=9193 --log-file=/gcsfuse-tmp/prom_kernel_reader.log"}
+		testEnv.cfg.Configs[6].Flags = []string{"--prometheus-port=9193 --log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"}
 		testEnv.cfg.Configs[6].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
 		testEnv.cfg.Configs[6].Run = "TestPromKernelReaderSuite"
 	}

--- a/tools/integration_tests/monitoring/setup_test.go
+++ b/tools/integration_tests/monitoring/setup_test.go
@@ -64,7 +64,7 @@ type PromTestBase struct {
 }
 
 func (p *PromTestBase) SetupSuite() {
-	setup.SetUpLogFilePath(p.suiteName, gkeTempDir, "", testEnv.cfg)
+	setup.SetUpLogFilePath(p.flags, gkeTempDir, "", testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(p.flags, testEnv.ctx, testEnv.storageClient)
 }
 

--- a/tools/integration_tests/readdirplus/readdirplus_with_dentry_cache_test.go
+++ b/tools/integration_tests/readdirplus/readdirplus_with_dentry_cache_test.go
@@ -53,7 +53,7 @@ func (s *ReaddirplusWithDentryCacheTest) TearDownSuite() {
 }
 
 func (s *ReaddirplusWithDentryCacheTest) SetupSuite() {
-	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
+	setup.SetUpLogFilePath(s.flags, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/readdirplus/readdirplus_without_dentry_cache_test.go
+++ b/tools/integration_tests/readdirplus/readdirplus_without_dentry_cache_test.go
@@ -53,7 +53,7 @@ func (s *ReaddirplusWithoutDentryCacheTest) TearDownSuite() {
 }
 
 func (s *ReaddirplusWithoutDentryCacheTest) SetupSuite() {
-	setup.SetUpLogFilePath(s.baseTestName, GKETempDir, OldGKElogFilePath, testEnv.cfg)
+	setup.SetUpLogFilePath(s.flags, GKETempDir, OldGKElogFilePath, testEnv.cfg)
 	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
 }
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -921,7 +921,7 @@ monitoring:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/monitoring.log,--enable-kernel-reader=false"
+        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -929,7 +929,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/monitoring_hns.log,--enable-kernel-reader=false"
+        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -937,7 +937,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=9191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/prom_buffered_read.log,--enable-kernel-reader=false"
+        - "--prometheus-port=9191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -945,7 +945,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/prom_buffered_read_hns.log,--enable-kernel-reader=false"
+        - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -953,7 +953,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/prom_grpc_metrics.log,--enable-kernel-reader=false"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -961,7 +961,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: true
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/prom_grpc_metrics_hns.log,--enable-kernel-reader=false"
+        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -969,7 +969,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: true
       - flags:
-        - "--prometheus-port=9193 --log-file=/gcsfuse-tmp/prom_kernel_reader.log"
+        - "--prometheus-port=9193 --log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
         compatible:
           flat: false
           hns: false

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -856,15 +856,15 @@ func ParseLogFileFromFlags(flags []string) string {
 
 func SetUpLogFilePath(flags []string, GKETempDir string, OldGKElogFilePath string, cfg *test_suite.TestConfig) {
 	var logFilePath string
-	parsedFileName := ParseLogFileFromFlags(flags)
+	parsedLogFileName := ParseLogFileFromFlags(flags)
 	if cfg.GKEMountedDirectory != "" { // GKE path
-		logFilePath = path.Join(GKETempDir, parsedFileName) + ".log"
+		logFilePath = path.Join(GKETempDir, parsedLogFileName) + ".log"
 		if ConfigFile() == "" {
 			// TODO: clean this up when GKE test migration completes.
 			logFilePath = OldGKElogFilePath
 		}
 	} else {
-		logFilePath = path.Join(TestDir(), GKETempDir, parsedFileName) + ".log"
+		logFilePath = path.Join(TestDir(), GKETempDir, parsedLogFileName) + ".log"
 	}
 	cfg.LogFile = logFilePath
 	SetLogFile(logFilePath)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -841,16 +841,30 @@ func OverrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath str
 	}
 }
 
-func SetUpLogFilePath(testName string, GKETempDir string, OldGKElogFilePath string, cfg *test_suite.TestConfig) {
+func ParseLogFileFromFlags(flags []string) string {
+	for _, flagStr := range flags {
+		parts := strings.Fields(flagStr)
+		for _, part := range parts {
+			if strings.HasPrefix(part, "--log-file=") {
+				// Get just the filename from the path
+				return path.Base(strings.TrimPrefix(part, "--log-file="))
+			}
+		}
+	}
+	return ""
+}
+
+func SetUpLogFilePath(flags []string, GKETempDir string, OldGKElogFilePath string, cfg *test_suite.TestConfig) {
 	var logFilePath string
+	parsedFileName := ParseLogFileFromFlags(flags)
 	if cfg.GKEMountedDirectory != "" { // GKE path
-		logFilePath = path.Join(GKETempDir, testName) + ".log"
+		logFilePath = path.Join(GKETempDir, parsedFileName) + ".log"
 		if ConfigFile() == "" {
 			// TODO: clean this up when GKE test migration completes.
 			logFilePath = OldGKElogFilePath
 		}
 	} else {
-		logFilePath = path.Join(TestDir(), GKETempDir, testName) + ".log"
+		logFilePath = path.Join(TestDir(), GKETempDir, parsedFileName) + ".log"
 	}
 	cfg.LogFile = logFilePath
 	SetLogFile(logFilePath)


### PR DESCRIPTION
### Description
When running the monitoring integration tests (such as `TestPromGrpcMetricsSuite`, `TestPromOTELSuite`, etc.) using the flags from `test_config.yaml`, the tests fail with log file missing errors:
`{"timestamp":{"seconds":1773961819,"nanos":1102831},"severity":"INFO","message":"Error reading log file: open /gcsfuse-tmp/TestPromGrpcMetricsSuite.log: no such file or directory"}`

For monitoring tests, the YAML explicitly specifies log files in the flags parameter (e.g., `--log-file=/gcsfuse-tmp/prom_grpc_metrics.log`). 

However, when running the tests on GKE, the monitoring testsuite explicitly calls `setup.SetUpLogFilePath(p.suiteName, gkeTempDir, "", testEnv.cfg)`. This function ignores the explicitly configured flag and completely overrides the expected log file to match the `testName`. As a result, the logs are recorded at `/gcsfuse-tmp/prom_grpc_metrics.log` but the testsuite looks for `/gcsfuse-tmp/TestPromGrpcMetricsSuite.log`.

* **Updating setup.SetUpLogFilePath:** It now accepts the flags slice and uses a new ParseLogFileFromFlags helper to extract the intended log filename. This ensures the GKE log path alignment respects the --log-file flag if provided.

* **Standardizing Log Paths:** Updates test_config.yaml and monitoring test configurations to use log filenames that align with the test suite names (e.g., /gcsfuse-tmp/TestPromOTELSuite.log) for better identifiability.


### Link to the issue in case of a bug fix.
[b/494350392](https://b.corp.google.com/issues/494350392)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran the 4 affected packages tests(with, without the test_config.yaml file, mounted dir tests) and verified they are now passing with the updated log paths. https://paste.googleplex.com/5160574443978752 

### Any backward incompatible change? If so, please explain.
No
