### PR TITLE
test(ci): enable read_cache tests for zonal buckets

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -313,7 +313,7 @@ TEST_PACKAGES_COMMON=(
   "operations"
   "read_large_files"
   "concurrent_operations"
-  # "read_cache"
+  "read_cache"
   "list_large_dir"
   "mount_timeout"
   "write_large_files"
@@ -344,7 +344,7 @@ TEST_PACKAGES_COMMON=(
 )
 
 # Test packages for regional buckets.
-TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "read_cache" "inactive_stream_timeout" "cloud_profiler" "requester_pays_bucket")
+TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "inactive_stream_timeout" "cloud_profiler" "requester_pays_bucket")
 # Test packages for zonal buckets.
 TEST_PACKAGES_FOR_ZB=("${TEST_PACKAGES_COMMON[@]}" "rapid_appends" "unfinalized_object")
 # Test packages for TPC buckets.


### PR DESCRIPTION
### Description
This PR enables the `read_cache` test suite for zonal buckets in CI e2e tests.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/495290301

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
