### PR TITLE
feat(tracing): Add write flow traces

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -15,6 +15,7 @@
 package bufferedwrites
 
 import (
+"context"
 	"errors"
 	"fmt"
 	"math"
@@ -33,16 +34,16 @@ import (
 type BufferedWriteHandler interface {
 	// Write writes the given data to the buffer. It writes to an existing buffer if
 	// the capacity is available otherwise writes to a new buffer.
-	Write(data []byte, offset int64) (err error)
+	Write(ctx context.Context, data []byte, offset int64) (err error)
 
 	// Sync uploads all the pending buffers to GCS.
 	// Sync returns
 	// 1. un-finalized object created on GCS for zonal buckets.
 	// 2. nil object for non-zonal buckets.
-	Sync() (*gcs.MinObject, error)
+	Sync(ctx context.Context) (*gcs.MinObject, error)
 
 	// Flush finalizes the upload.
-	Flush() (*gcs.MinObject, error)
+	Flush(ctx context.Context) (*gcs.MinObject, error)
 
 	// SetMtime stores the mtime with the bufferedWriteHandler.
 	SetMtime(mtime time.Time)
@@ -134,7 +135,7 @@ func NewBWHandler(req *CreateBWHandlerRequest) (bwh BufferedWriteHandler, err er
 	return
 }
 
-func (wh *bufferedWriteHandlerImpl) Write(data []byte, offset int64) (err error) {
+func (wh *bufferedWriteHandlerImpl) Write(ctx context.Context, data []byte, offset int64) (err error) {
 	// Fail early if the uploadHandler has already failed.
 	err = wh.uploadHandler.UploadError()
 	if err != nil {
@@ -148,16 +149,16 @@ func (wh *bufferedWriteHandlerImpl) Write(data []byte, offset int64) (err error)
 
 	if offset == wh.truncatedSize {
 		// Check and update if any data filling has to be done.
-		err = wh.writeDataForTruncatedSize()
+		err = wh.writeDataForTruncatedSize(ctx)
 		if err != nil {
 			return
 		}
 	}
 
-	return wh.appendBuffer(data)
+	return wh.appendBuffer(ctx, data)
 }
 
-func (wh *bufferedWriteHandlerImpl) appendBuffer(data []byte) (err error) {
+func (wh *bufferedWriteHandlerImpl) appendBuffer(ctx context.Context, data []byte) (err error) {
 	dataWritten := 0
 	for dataWritten < len(data) {
 		if wh.current == nil {
@@ -190,7 +191,7 @@ func (wh *bufferedWriteHandlerImpl) appendBuffer(data []byte) (err error) {
 	return
 }
 
-func (wh *bufferedWriteHandlerImpl) Sync() (o *gcs.MinObject, err error) {
+func (wh *bufferedWriteHandlerImpl) Sync(ctx context.Context) (o *gcs.MinObject, err error) {
 	// Upload current block (for both regional and zonal buckets).
 	if wh.current != nil && wh.current.Size() != 0 {
 		err = wh.uploadHandler.Upload(wh.current)
@@ -228,7 +229,7 @@ func (wh *bufferedWriteHandlerImpl) Sync() (o *gcs.MinObject, err error) {
 }
 
 // Flush finalizes the upload.
-func (wh *bufferedWriteHandlerImpl) Flush() (*gcs.MinObject, error) {
+func (wh *bufferedWriteHandlerImpl) Flush(ctx context.Context) (*gcs.MinObject, error) {
 	// Fail early if upload already failed.
 	err := wh.uploadHandler.UploadError()
 	if err != nil {
@@ -236,7 +237,7 @@ func (wh *bufferedWriteHandlerImpl) Flush() (*gcs.MinObject, error) {
 	}
 
 	// In case it is a truncated file, upload empty blocks as required.
-	err = wh.writeDataForTruncatedSize()
+	err = wh.writeDataForTruncatedSize(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (wh *bufferedWriteHandlerImpl) Destroy() error {
 	return wh.blockPool.ClearFreeBlockChannel(true)
 }
 
-func (wh *bufferedWriteHandlerImpl) writeDataForTruncatedSize() error {
+func (wh *bufferedWriteHandlerImpl) writeDataForTruncatedSize(ctx context.Context) error {
 	// If totalSize is greater than truncatedSize, that means user has
 	// written more data than they actually truncated in the beginning.
 	if wh.totalSize >= wh.truncatedSize {
@@ -301,7 +302,7 @@ func (wh *bufferedWriteHandlerImpl) writeDataForTruncatedSize() error {
 	chunkSize := 1024 * 1024
 	for i := 0; i < int(diff); i += chunkSize {
 		size := math.Min(float64(chunkSize), float64(int(diff)-i))
-		err := wh.appendBuffer(make([]byte, int(size)))
+		err := wh.appendBuffer(ctx, make([]byte, int(size)))
 		if err != nil {
 			return err
 		}

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -15,7 +15,7 @@
 package bufferedwrites
 
 import (
-"context"
+	"context"
 	"errors"
 	"fmt"
 	"math"

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -179,7 +179,7 @@ func (wh *bufferedWriteHandlerImpl) appendBuffer(ctx context.Context, data []byt
 		dataWritten += bytesToCopy
 
 		if wh.current.Size() == wh.blockPool.BlockSize() {
-			err := wh.uploadHandler.Upload(wh.current)
+			err := wh.uploadHandler.Upload(ctx, wh.current)
 			if err != nil {
 				return err
 			}
@@ -194,7 +194,7 @@ func (wh *bufferedWriteHandlerImpl) appendBuffer(ctx context.Context, data []byt
 func (wh *bufferedWriteHandlerImpl) Sync(ctx context.Context) (o *gcs.MinObject, err error) {
 	// Upload current block (for both regional and zonal buckets).
 	if wh.current != nil && wh.current.Size() != 0 {
-		err = wh.uploadHandler.Upload(wh.current)
+		err = wh.uploadHandler.Upload(ctx, wh.current)
 		if err != nil {
 			return nil, err
 		}
@@ -207,7 +207,7 @@ func (wh *bufferedWriteHandlerImpl) Sync(ctx context.Context) (o *gcs.MinObject,
 	// other operations like read.
 	// This functionality is exclusively supported on zonal buckets.
 	if wh.uploadHandler.bucket.BucketType().Zonal {
-		o, err = wh.uploadHandler.FlushPendingWrites()
+		o, err = wh.uploadHandler.FlushPendingWrites(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -243,14 +243,14 @@ func (wh *bufferedWriteHandlerImpl) Flush(ctx context.Context) (*gcs.MinObject, 
 	}
 
 	if wh.current != nil {
-		err := wh.uploadHandler.Upload(wh.current)
+		err := wh.uploadHandler.Upload(ctx, wh.current)
 		if err != nil {
 			return nil, err
 		}
 		wh.current = nil
 	}
 
-	obj, err := wh.uploadHandler.Finalize()
+	obj, err := wh.uploadHandler.Finalize(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("BufferedWriteHandler.Flush(): %w", err)
 	}

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -98,6 +99,7 @@ type CreateBWHandlerRequest struct {
 	GlobalMaxBlocksSem       *semaphore.Weighted
 	ChunkRetryDeadlineSecs   int64
 	ChunkTransferTimeoutSecs int64
+	TraceHandle              tracing.TraceHandle
 }
 
 // NewBWHandler creates the bufferedWriteHandler struct.
@@ -123,6 +125,7 @@ func NewBWHandler(req *CreateBWHandlerRequest) (bwh BufferedWriteHandler, err er
 			BlockSize:                req.BlockSize,
 			ChunkRetryDeadlineSecs:   req.ChunkRetryDeadlineSecs,
 			ChunkTransferTimeoutSecs: req.ChunkTransferTimeoutSecs,
+			TraceHandle:              req.TraceHandle,
 		}),
 		totalSize:     size,
 		mtime:         time.Now(),

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -81,7 +81,7 @@ func (testSuite *BufferedWriteTest) TestSetMTime() {
 }
 
 func (testSuite *BufferedWriteTest) TestWrite() {
-	err := testSuite.bwh.Write([]byte("hi"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -91,7 +91,7 @@ func (testSuite *BufferedWriteTest) TestWrite() {
 }
 
 func (testSuite *BufferedWriteTest) TestWriteWithEmptyBuffer() {
-	err := testSuite.bwh.Write([]byte{}, 0)
+	err := testSuite.bwh.Write(context.Background(), []byte{}, 0)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -104,7 +104,7 @@ func (testSuite *BufferedWriteTest) TestWriteEqualToBlockSize() {
 	size := 1024
 	data := strings.Repeat("A", size)
 
-	err := testSuite.bwh.Write([]byte(data), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte(data), 0)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -117,7 +117,7 @@ func (testSuite *BufferedWriteTest) TestWriteDataSizeGreaterThanBlockSize() {
 	size := 2000
 	data := strings.Repeat("A", size)
 
-	err := testSuite.bwh.Write([]byte(data), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte(data), 0)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -127,11 +127,11 @@ func (testSuite *BufferedWriteTest) TestWriteDataSizeGreaterThanBlockSize() {
 }
 
 func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsGreaterThanExpected() {
-	err := testSuite.bwh.Write([]byte("hi"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
 
 	// Next offset should be 2, but we are calling with 5.
-	err = testSuite.bwh.Write([]byte("hello"), 5)
+	err = testSuite.bwh.Write(context.Background(), []byte("hello"), 5)
 
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
@@ -142,11 +142,11 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsGreaterThanExpected
 }
 
 func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsLessThanExpected() {
-	err := testSuite.bwh.Write([]byte("hello"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 
 	// Next offset should be 5, but we are calling with 2.
-	err = testSuite.bwh.Write([]byte("abcdefgh"), 2)
+	err = testSuite.bwh.Write(context.Background(), []byte("abcdefgh"), 2)
 
 	require.NotNil(testSuite.T(), err)
 	require.Equal(testSuite.T(), err, ErrOutOfOrderWrite)
@@ -157,10 +157,10 @@ func (testSuite *BufferedWriteTest) TestWriteWhenNextOffsetIsLessThanExpected() 
 }
 
 func (testSuite *BufferedWriteTest) TestMultipleWrites() {
-	err := testSuite.bwh.Write([]byte("hello"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 
-	err = testSuite.bwh.Write([]byte("abcdefgh"), 5)
+	err = testSuite.bwh.Write(context.Background(), []byte("abcdefgh"), 5)
 	require.Nil(testSuite.T(), err)
 
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -170,7 +170,7 @@ func (testSuite *BufferedWriteTest) TestMultipleWrites() {
 }
 
 func (testSuite *BufferedWriteTest) TestWriteWithSignalUploadFailureInBetween() {
-	err := testSuite.bwh.Write([]byte("hello"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
@@ -180,7 +180,7 @@ func (testSuite *BufferedWriteTest) TestWriteWithSignalUploadFailureInBetween() 
 	// Set an error to simulate failure in uploader.
 	bwhImpl.uploadHandler.uploadError.Store(&errUploadFailure)
 
-	err = testSuite.bwh.Write([]byte("hello"), 5)
+	err = testSuite.bwh.Write(context.Background(), []byte("hello"), 5)
 	require.Error(testSuite.T(), err)
 	assert.Equal(testSuite.T(), err, errUploadFailure)
 }
@@ -193,7 +193,7 @@ func (testSuite *BufferedWriteTest) TestWriteAtTruncatedOffset() {
 	require.Equal(testSuite.T(), int64(2), bwhImpl.truncatedSize)
 
 	// Write at offset = truncatedSize
-	err = testSuite.bwh.Write([]byte("hello"), 2)
+	err = testSuite.bwh.Write(context.Background(), []byte("hello"), 2)
 
 	require.Nil(testSuite.T(), err)
 	fileInfo := testSuite.bwh.WriteFileInfo()
@@ -202,7 +202,7 @@ func (testSuite *BufferedWriteTest) TestWriteAtTruncatedOffset() {
 }
 
 func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
-	err := testSuite.bwh.Write([]byte("hello"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hello"), 0)
 	require.Nil(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Equal(testSuite.T(), int64(5), bwhImpl.totalSize)
@@ -213,7 +213,7 @@ func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
 	require.Equal(testSuite.T(), int64(20), testSuite.bwh.WriteFileInfo().TotalSize)
 
 	// Write at offset=bwh.totalSize
-	err = testSuite.bwh.Write([]byte("abcde"), 5)
+	err = testSuite.bwh.Write(context.Background(), []byte("abcde"), 5)
 
 	require.Nil(testSuite.T(), err)
 	assert.Equal(testSuite.T(), int64(10), bwhImpl.totalSize)
@@ -221,10 +221,10 @@ func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
-	err := testSuite.bwh.Write([]byte("hi"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
 
-	obj, err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush(context.Background())
 
 	require.NoError(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
@@ -240,7 +240,7 @@ func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	require.Nil(testSuite.T(), bwhImpl.current)
 
-	obj, err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush(context.Background())
 
 	assert.NoError(testSuite.T(), err)
 	// Validate empty object created.
@@ -249,14 +249,14 @@ func (testSuite *BufferedWriteTest) TestFlushWithNilCurrentBlock() {
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithSignalUploadFailureDuringWrite() {
-	err := testSuite.bwh.Write([]byte("hi"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 
 	// Set an error to simulate failure in uploader.
 	bwhImpl.uploadHandler.uploadError.Store(&errUploadFailure)
 
-	obj, err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush(context.Background())
 	require.Error(testSuite.T(), err)
 	assert.Equal(testSuite.T(), err, errUploadFailure)
 	assert.Nil(testSuite.T(), obj)
@@ -272,12 +272,12 @@ func (testSuite *BufferedWriteTest) TestFlushWithMultiBlockWritesAndSignalUpload
 	bwhImpl.uploadHandler.uploadError.Store(&errUploadFailure)
 	// Write 5 more blocks.
 	for i := range 5 {
-		err := testSuite.bwh.Write(buffer, int64(blockSize*(i+5)))
+		err := testSuite.bwh.Write(context.Background(), buffer, int64(blockSize*(i+5)))
 		require.Error(testSuite.T(), err)
 		assert.Equal(testSuite.T(), errUploadFailure, err)
 	}
 
-	obj, err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush(context.Background())
 
 	require.Error(testSuite.T(), err)
 	assert.Equal(testSuite.T(), err, errUploadFailure)
@@ -289,12 +289,12 @@ func (testSuite *BufferedWriteTest) TestSync5InProgressBlocks() {
 	assert.NoError(testSuite.T(), err)
 	// Write 5 blocks.
 	for i := range 5 {
-		err = testSuite.bwh.Write(buffer, int64(blockSize*i))
+		err = testSuite.bwh.Write(context.Background(), buffer, int64(blockSize*i))
 		require.Nil(testSuite.T(), err)
 	}
 
 	// Wait for 5 blocks to upload successfully.
-	o, err := testSuite.bwh.Sync()
+	o, err := testSuite.bwh.Sync(context.Background())
 
 	assert.NoError(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
@@ -336,11 +336,11 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			testSuite.setupTestWithBucketType(tc.bucketType)
 			buffer, err := operations.GenerateRandomData(int64(blockSize * tc.numBlocks))
 			assert.NoError(testSuite.T(), err)
-			err = testSuite.bwh.Write(buffer, 0)
+			err = testSuite.bwh.Write(context.Background(), buffer, 0)
 			require.Nil(testSuite.T(), err)
 
 			// Wait for blocks to upload successfully.
-			o, err := testSuite.bwh.Sync()
+			o, err := testSuite.bwh.Sync(context.Background())
 
 			require.NoError(testSuite.T(), err)
 			bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
@@ -372,14 +372,14 @@ func (testSuite *BufferedWriteTest) TestSyncBlocksWithError() {
 	assert.NoError(testSuite.T(), err)
 	// Write 5 blocks.
 	for i := range 5 {
-		err = testSuite.bwh.Write(buffer, int64(blockSize*i))
+		err = testSuite.bwh.Write(context.Background(), buffer, int64(blockSize*i))
 		require.Nil(testSuite.T(), err)
 	}
 	// Set an error to simulate failure in uploader.
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.uploadHandler.uploadError.Store(&errUploadFailure)
 
-	o, err := testSuite.bwh.Sync()
+	o, err := testSuite.bwh.Sync(context.Background())
 
 	assert.Error(testSuite.T(), err)
 	assert.Equal(testSuite.T(), errUploadFailure, err)
@@ -391,19 +391,19 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonZeroTruncatedLengthForEmptyO
 	require.Nil(testSuite.T(), bwhImpl.current)
 	bwhImpl.truncatedSize = 10
 
-	_, err := testSuite.bwh.Flush()
+	_, err := testSuite.bwh.Flush(context.Background())
 
 	assert.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjectSize() {
-	err := testSuite.bwh.Write([]byte("hi"), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
 	bwhImpl.truncatedSize = 10
 
-	_, err = testSuite.bwh.Flush()
+	_, err = testSuite.bwh.Flush(context.Background())
 
 	assert.NoError(testSuite.T(), err)
 	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
@@ -451,7 +451,7 @@ func (testSuite *BufferedWriteTest) TestWriteFileInfoWithTruncatedLengthGreaterT
 func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 	// Try to write 4 blocks of data.
 	contents := strings.Repeat("A", blockSize*4)
-	err := testSuite.bwh.Write([]byte(contents), 0)
+	err := testSuite.bwh.Write(context.Background(), []byte(contents), 0)
 	require.Nil(testSuite.T(), err)
 
 	err = testSuite.bwh.Destroy()
@@ -479,7 +479,7 @@ func (testSuite *BufferedWriteTest) TestUnlinkAfterWrite() {
 	assert.NoError(testSuite.T(), err)
 	// Write 5 blocks.
 	for i := range 5 {
-		err = testSuite.bwh.Write(buffer, int64(blockSize*i))
+		err = testSuite.bwh.Write(context.Background(), buffer, int64(blockSize*i))
 		require.Nil(testSuite.T(), err)
 	}
 	cancelCalled := false
@@ -500,7 +500,7 @@ func (testSuite *BufferedWriteTest) TestReFlushAfterUploadFails() {
 	testSuite.TestFlushWithMultiBlockWritesAndSignalUploadFailureInBetween()
 
 	// Re-flush.
-	obj, err := testSuite.bwh.Flush()
+	obj, err := testSuite.bwh.Flush(context.Background())
 
 	require.Error(testSuite.T(), err)
 	assert.Nil(testSuite.T(), obj)

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,7 @@ func (testSuite *BufferedWriteTest) setupTestWithBucketType(bucketType gcs.Bucke
 		GlobalMaxBlocksSem:       testSuite.globalSemaphore,
 		ChunkRetryDeadlineSecs:   chunkRetryDeadlineSecs,
 		ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
+		TraceHandle:              tracing.NewNoopTracer(),
 	})
 	require.Nil(testSuite.T(), err)
 	testSuite.bwh = bwh

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -105,7 +105,9 @@ func (uh *UploadHandler) Upload(block block.Block) error {
 	}
 	// Start the uploader goroutine but only once.
 	uh.startUploader.Do(func() {
+		_, span := uh.traceHandle.StartSpan(context.Background(), tracing.UploadAsync)
 		go uh.uploader()
+		uh.traceHandle.EndSpan(span)
 	})
 	uh.uploadCh <- block
 	return nil
@@ -157,7 +159,9 @@ func (uh *UploadHandler) uploader() {
 // If there is an error during upload, it returns after storing the error in uploadError.
 func (uh *UploadHandler) uploadBlock(b block.Block) {
 	_, span := uh.traceHandle.StartSpan(context.Background(), tracing.StreamingUploadBlock)
+	var written int64
 	defer func() {
+		uh.traceHandle.SetUploadAttributes(span, written, uh.objectName)
 		uh.traceHandle.EndSpan(span)
 	}()
 	if b == nil {
@@ -177,7 +181,8 @@ func (uh *UploadHandler) uploadBlock(b block.Block) {
 		return
 	}
 
-	_, err := io.Copy(uh.writer, b)
+	var err error
+	written, err = io.Copy(uh.writer, b)
 	if errors.Is(err, context.Canceled) {
 		// Context canceled error indicates that the file was deleted from the
 		// same mount. In this case, we suppress the error to match local
@@ -198,6 +203,8 @@ func (uh *UploadHandler) Finalize() (obj *gcs.MinObject, err error) {
 	defer func() {
 		if err != nil {
 			uh.traceHandle.RecordError(span, err)
+		} else if obj != nil {
+			uh.traceHandle.SetUploadAttributes(span, int64(obj.Size), uh.objectName)
 		}
 		uh.traceHandle.EndSpan(span)
 	}()
@@ -237,6 +244,8 @@ func (uh *UploadHandler) FlushPendingWrites() (o *gcs.MinObject, err error) {
 	defer func() {
 		if err != nil {
 			uh.traceHandle.RecordError(span, err)
+		} else if o != nil {
+			uh.traceHandle.SetUploadAttributes(span, int64(o.Size), uh.objectName)
 		}
 		uh.traceHandle.EndSpan(span)
 	}()

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -139,7 +139,8 @@ func (uh *UploadHandler) UploadError() (err error) {
 
 // uploader is the single-threaded goroutine that uploads blocks.
 func (uh *UploadHandler) uploader(ctx context.Context) {
-	_, span := uh.traceHandle.StartSpan(context.Background(), tracing.StreamingUploader)
+	_, _, finishSpan := uh.traceHandle.Trace(context.Background(), tracing.StreamingUploader, nil)
+	defer finishSpan()
 	for currBlock := range uh.uploadCh {
 		uh.uploadBlock(ctx, currBlock)
 
@@ -148,7 +149,6 @@ func (uh *UploadHandler) uploader(ctx context.Context) {
 		uh.blockPool.Release(currBlock)
 		uh.wg.Done()
 	}
-	uh.traceHandle.EndSpan(span)
 }
 
 // uploadBlock uploads the block content to GCS writer.
@@ -157,15 +157,12 @@ func (uh *UploadHandler) uploader(ctx context.Context) {
 // If there is already an error in uploadError, it returns without doing anything.
 // If there is an error during upload, it returns after storing the error in uploadError.
 func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
-	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadBlock)
 	var written int64
 	var err error
+	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadBlock, &err)
 	defer func() {
 		uh.traceHandle.SetUploadAttributes(span, written, uh.objectName)
-		if err != nil {
-			uh.traceHandle.RecordError(span, err)
-		}
-		uh.traceHandle.EndSpan(span)
+		finishSpan()
 	}()
 	if b == nil {
 		logger.Warnf("uploadBlock: received nil block for object %s", uh.objectName)
@@ -201,14 +198,12 @@ func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 // Finalize finalizes the upload.
 func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err error) {
 	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
-	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFinalize)
+	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadFinalize, &err)
 	defer func() {
-		if err != nil {
-			uh.traceHandle.RecordError(span, err)
-		} else if obj != nil {
+		if err == nil && obj != nil {
 			uh.traceHandle.SetUploadAttributes(span, int64(obj.Size), uh.objectName)
 		}
-		uh.traceHandle.EndSpan(span)
+		finishSpan()
 	}()
 	uh.wg.Wait()
 	close(uh.uploadCh)
@@ -241,14 +236,12 @@ func (uh *UploadHandler) ensureWriter(ctx context.Context) error {
 
 // FlushPendingWrites uploads any data in the write buffer.
 func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObject, err error) {
-	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFlush)
+	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadFlush, &err)
 	defer func() {
-		if err != nil {
-			uh.traceHandle.RecordError(span, err)
-		} else if o != nil {
+		if err == nil && o != nil {
 			uh.traceHandle.SetUploadAttributes(span, int64(o.Size), uh.objectName)
 		}
-		uh.traceHandle.EndSpan(span)
+		finishSpan()
 	}()
 	uh.wg.Wait()
 

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -210,14 +210,14 @@ func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err 
 	}
 
 	obj, err = uh.bucket.FinalizeUpload(ctx, uh.writer)
-	if obj != nil {
-		bytes = int64(obj.Size)
-	}
 	if err != nil {
 		// FinalizeUpload already returns GCSerror so no need to convert again.
 		uh.uploadError.Store(&err)
 		logger.Errorf("FinalizeUpload failed for object %s: %v", uh.objectName, err)
 		return nil, err
+	}
+	if obj != nil {
+		bytes = int64(obj.Size)
 	}
 	return obj, nil
 }
@@ -246,14 +246,14 @@ func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObje
 	}
 
 	o, err = uh.bucket.FlushPendingWrites(ctx, uh.writer)
-	if o != nil {
-		bytes = int64(o.Size)
-	}
 	if err != nil {
 		// FlushUpload already returns GCS error so no need to convert again.
 		uh.uploadError.Store(&err)
 		logger.Errorf("FlushUpload failed for object %s: %v", uh.objectName, err)
 		return nil, err
+	}
+	if o != nil {
+		bytes = int64(o.Size)
 	}
 	return o, nil
 }

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -106,7 +106,7 @@ func (uh *UploadHandler) Upload(ctx context.Context, block block.Block) error {
 	// Start the uploader goroutine but only once.
 	uh.startUploader.Do(func() {
 		_, span := uh.traceHandle.StartSpan(context.Background(), tracing.UploadAsync)
-		go uh.uploader()
+		go uh.uploader(ctx)
 		uh.traceHandle.EndSpan(span)
 	})
 	uh.uploadCh <- block
@@ -140,9 +140,9 @@ func (uh *UploadHandler) UploadError() (err error) {
 }
 
 // uploader is the single-threaded goroutine that uploads blocks.
-func (uh *UploadHandler) uploader() {
+func (uh *UploadHandler) uploader(ctx context.Context) {
 	for currBlock := range uh.uploadCh {
-		uh.uploadBlock(currBlock)
+		uh.uploadBlock(ctx, currBlock)
 
 		// Put back the uploaded block to the pool for re-use,
 		// irrespective of whether the upload was successful or not.
@@ -156,8 +156,8 @@ func (uh *UploadHandler) uploader() {
 // If the block is nil, it logs a warning and returns.
 // If there is already an error in uploadError, it returns without doing anything.
 // If there is an error during upload, it returns after storing the error in uploadError.
-func (uh *UploadHandler) uploadBlock(b block.Block) {
-	_, span := uh.traceHandle.StartSpan(context.Background(), tracing.StreamingUploadBlock)
+func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
+	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadBlock)
 	var written int64
 	defer func() {
 		uh.traceHandle.SetUploadAttributes(span, written, uh.objectName)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -96,10 +96,10 @@ func newUploadHandler(req *CreateUploadHandlerRequest) *UploadHandler {
 }
 
 // Upload adds a block to the upload queue.
-func (uh *UploadHandler) Upload(block block.Block) error {
+func (uh *UploadHandler) Upload(ctx context.Context, block block.Block) error {
 	uh.wg.Add(1)
 
-	err := uh.ensureWriter()
+	err := uh.ensureWriter(ctx)
 	if err != nil {
 		return fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
@@ -114,12 +114,11 @@ func (uh *UploadHandler) Upload(block block.Block) error {
 }
 
 // createObjectWriter creates a GCS object writer.
-func (uh *UploadHandler) createObjectWriter() (err error) {
+func (uh *UploadHandler) createObjectWriter(ctx context.Context) (err error) {
 	req := gcs.NewCreateObjectRequest(uh.obj, uh.objectName, nil, uh.chunkRetryDeadline, uh.chunkTransferTimeout)
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
-	var ctx context.Context
-	ctx, uh.cancelFunc = context.WithCancel(context.Background())
+	ctx, uh.cancelFunc = context.WithCancel(uh.traceHandle.PropagateTraceContext(context.Background(), ctx))
 	if uh.bucket.BucketType().Zonal && (uh.obj != nil && uh.obj.Finalized.IsZero()) {
 		chunkWriterReq := gcs.CreateObjectChunkWriterRequest{
 			CreateObjectRequest: *req,
@@ -197,8 +196,8 @@ func (uh *UploadHandler) uploadBlock(b block.Block) {
 }
 
 // Finalize finalizes the upload.
-func (uh *UploadHandler) Finalize() (obj *gcs.MinObject, err error) {
-	ctx := context.Background()
+func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err error) {
+	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
 	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFinalize)
 	defer func() {
 		if err != nil {
@@ -213,7 +212,7 @@ func (uh *UploadHandler) Finalize() (obj *gcs.MinObject, err error) {
 
 	// Writer may not have been created for empty file creation flow or for very
 	// small writes of size less than 1 block.
-	err = uh.ensureWriter()
+	err = uh.ensureWriter(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
@@ -228,9 +227,9 @@ func (uh *UploadHandler) Finalize() (obj *gcs.MinObject, err error) {
 	return obj, nil
 }
 
-func (uh *UploadHandler) ensureWriter() error {
+func (uh *UploadHandler) ensureWriter(ctx context.Context) error {
 	if uh.writer == nil {
-		if err := uh.createObjectWriter(); err != nil {
+		if err := uh.createObjectWriter(ctx); err != nil {
 			return fmt.Errorf("createObjectWriter failed for object %s: %w", uh.objectName, err)
 		}
 	}
@@ -238,8 +237,8 @@ func (uh *UploadHandler) ensureWriter() error {
 }
 
 // FlushPendingWrites uploads any data in the write buffer.
-func (uh *UploadHandler) FlushPendingWrites() (o *gcs.MinObject, err error) {
-	ctx := context.Background()
+func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObject, err error) {
+	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
 	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFlush)
 	defer func() {
 		if err != nil {
@@ -253,7 +252,7 @@ func (uh *UploadHandler) FlushPendingWrites() (o *gcs.MinObject, err error) {
 
 	// Writer may not have been created for empty file creation flow or for very
 	// small writes of size less than 1 block.
-	err = uh.ensureWriter()
+	err = uh.ensureWriter(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -156,8 +156,7 @@ func (uh *UploadHandler) uploader() {
 // If there is already an error in uploadError, it returns without doing anything.
 // If there is an error during upload, it returns after storing the error in uploadError.
 func (uh *UploadHandler) uploadBlock(b block.Block) {
-	ctx := context.Background()
-	ctx, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadBlock)
+	_, span := uh.traceHandle.StartSpan(context.Background(), tracing.StreamingUploadBlock)
 	defer func() {
 		uh.traceHandle.EndSpan(span)
 	}()

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -139,7 +139,7 @@ func (uh *UploadHandler) UploadError() (err error) {
 
 // uploader is the single-threaded goroutine that uploads blocks.
 func (uh *UploadHandler) uploader(ctx context.Context) {
-	_, _, finishSpan := uh.traceHandle.Trace(context.Background(), tracing.StreamingUploader, nil)
+	_, finishSpan := uh.traceHandle.TraceUpload(context.Background(), tracing.StreamingUploader, "", nil, nil)
 	defer finishSpan()
 	for currBlock := range uh.uploadCh {
 		uh.uploadBlock(ctx, currBlock)
@@ -159,11 +159,9 @@ func (uh *UploadHandler) uploader(ctx context.Context) {
 func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 	var written int64
 	var err error
-	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadBlock, &err)
-	defer func() {
-		uh.traceHandle.SetUploadAttributes(span, written, uh.objectName)
-		finishSpan()
-	}()
+	_, finishSpan := uh.traceHandle.TraceUpload(ctx, tracing.StreamingUploadBlock, uh.objectName, &written, &err)
+	defer finishSpan()
+
 	if b == nil {
 		logger.Warnf("uploadBlock: received nil block for object %s", uh.objectName)
 		return
@@ -198,13 +196,9 @@ func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 // Finalize finalizes the upload.
 func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err error) {
 	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
-	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadFinalize, &err)
-	defer func() {
-		if err == nil && obj != nil {
-			uh.traceHandle.SetUploadAttributes(span, int64(obj.Size), uh.objectName)
-		}
-		finishSpan()
-	}()
+	bytes := int64(obj.Size)
+	_, finishSpan := uh.traceHandle.TraceUpload(ctx, tracing.StreamingUploadFinalize, uh.objectName, &bytes, &err)
+	defer finishSpan()
 	uh.wg.Wait()
 	close(uh.uploadCh)
 
@@ -236,13 +230,9 @@ func (uh *UploadHandler) ensureWriter(ctx context.Context) error {
 
 // FlushPendingWrites uploads any data in the write buffer.
 func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObject, err error) {
-	_, span, finishSpan := uh.traceHandle.Trace(ctx, tracing.StreamingUploadFlush, &err)
-	defer func() {
-		if err == nil && o != nil {
-			uh.traceHandle.SetUploadAttributes(span, int64(o.Size), uh.objectName)
-		}
-		finishSpan()
-	}()
+	bytes := int64(o.Size)
+	_, finishSpan := uh.traceHandle.TraceUpload(ctx, tracing.StreamingUploadFlush, uh.objectName, &bytes, &err)
+	defer finishSpan()
 	uh.wg.Wait()
 
 	// Writer may not have been created for empty file creation flow or for very

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -89,9 +89,6 @@ func newUploadHandler(req *CreateUploadHandlerRequest) *UploadHandler {
 		chunkTransferTimeout: req.ChunkTransferTimeoutSecs,
 		traceHandle:          req.TraceHandle,
 	}
-	if uh.traceHandle == nil {
-		uh.traceHandle = tracing.NewNoopTracer()
-	}
 	return uh
 }
 

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -196,7 +196,7 @@ func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 // Finalize finalizes the upload.
 func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err error) {
 	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
-	bytes := int64(obj.Size)
+	bytes := int64(0)
 	_, finishSpan := uh.traceHandle.TraceUpload(ctx, tracing.StreamingUploadFinalize, uh.objectName, &bytes, &err)
 	defer finishSpan()
 	uh.wg.Wait()
@@ -210,6 +210,9 @@ func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err 
 	}
 
 	obj, err = uh.bucket.FinalizeUpload(ctx, uh.writer)
+	if obj != nil {
+		bytes = int64(obj.Size)
+	}
 	if err != nil {
 		// FinalizeUpload already returns GCSerror so no need to convert again.
 		uh.uploadError.Store(&err)
@@ -230,7 +233,7 @@ func (uh *UploadHandler) ensureWriter(ctx context.Context) error {
 
 // FlushPendingWrites uploads any data in the write buffer.
 func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObject, err error) {
-	bytes := int64(o.Size)
+	bytes := int64(0)
 	_, finishSpan := uh.traceHandle.TraceUpload(ctx, tracing.StreamingUploadFlush, uh.objectName, &bytes, &err)
 	defer finishSpan()
 	uh.wg.Wait()
@@ -243,6 +246,9 @@ func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObje
 	}
 
 	o, err = uh.bucket.FlushPendingWrites(ctx, uh.writer)
+	if o != nil {
+		bytes = int64(o.Size)
+	}
 	if err != nil {
 		// FlushUpload already returns GCS error so no need to convert again.
 		uh.uploadError.Store(&err)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -105,9 +105,7 @@ func (uh *UploadHandler) Upload(ctx context.Context, block block.Block) error {
 	}
 	// Start the uploader goroutine but only once.
 	uh.startUploader.Do(func() {
-		_, span := uh.traceHandle.StartSpan(context.Background(), tracing.UploadAsync)
 		go uh.uploader(ctx)
-		uh.traceHandle.EndSpan(span)
 	})
 	uh.uploadCh <- block
 	return nil
@@ -141,6 +139,7 @@ func (uh *UploadHandler) UploadError() (err error) {
 
 // uploader is the single-threaded goroutine that uploads blocks.
 func (uh *UploadHandler) uploader(ctx context.Context) {
+	_, span := uh.traceHandle.StartSpan(context.Background(), tracing.StreamingUploader)
 	for currBlock := range uh.uploadCh {
 		uh.uploadBlock(ctx, currBlock)
 
@@ -149,6 +148,7 @@ func (uh *UploadHandler) uploader(ctx context.Context) {
 		uh.blockPool.Release(currBlock)
 		uh.wg.Done()
 	}
+	uh.traceHandle.EndSpan(span)
 }
 
 // uploadBlock uploads the block content to GCS writer.
@@ -159,8 +159,12 @@ func (uh *UploadHandler) uploader(ctx context.Context) {
 func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadBlock)
 	var written int64
+	var err error
 	defer func() {
 		uh.traceHandle.SetUploadAttributes(span, written, uh.objectName)
+		if err != nil {
+			uh.traceHandle.RecordError(span, err)
+		}
 		uh.traceHandle.EndSpan(span)
 	}()
 	if b == nil {
@@ -180,7 +184,6 @@ func (uh *UploadHandler) uploadBlock(ctx context.Context, b block.Block) {
 		return
 	}
 
-	var err error
 	written, err = io.Copy(uh.writer, b)
 	if errors.Is(err, context.Canceled) {
 		// Context canceled error indicates that the file was deleted from the
@@ -217,7 +220,7 @@ func (uh *UploadHandler) Finalize(ctx context.Context) (obj *gcs.MinObject, err 
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
 
-	obj, err = uh.bucket.FinalizeUpload(context.Background(), uh.writer)
+	obj, err = uh.bucket.FinalizeUpload(ctx, uh.writer)
 	if err != nil {
 		// FinalizeUpload already returns GCSerror so no need to convert again.
 		uh.uploadError.Store(&err)
@@ -238,7 +241,6 @@ func (uh *UploadHandler) ensureWriter(ctx context.Context) error {
 
 // FlushPendingWrites uploads any data in the write buffer.
 func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObject, err error) {
-	ctx = uh.traceHandle.PropagateTraceContext(context.Background(), ctx)
 	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFlush)
 	defer func() {
 		if err != nil {
@@ -257,7 +259,7 @@ func (uh *UploadHandler) FlushPendingWrites(ctx context.Context) (o *gcs.MinObje
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
 
-	o, err = uh.bucket.FlushPendingWrites(context.Background(), uh.writer)
+	o, err = uh.bucket.FlushPendingWrites(ctx, uh.writer)
 	if err != nil {
 		// FlushUpload already returns GCS error so no need to convert again.
 		uh.uploadError.Store(&err)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 )
 
 // UploadHandler is responsible for synchronized uploads of the filled blocks
@@ -58,6 +59,8 @@ type UploadHandler struct {
 	chunkRetryDeadline   int64
 	chunkTransferTimeout int64
 	blockSize            int64
+
+	traceHandle tracing.TraceHandle
 }
 
 type CreateUploadHandlerRequest struct {
@@ -69,6 +72,7 @@ type CreateUploadHandlerRequest struct {
 	BlockSize                int64
 	ChunkRetryDeadlineSecs   int64
 	ChunkTransferTimeoutSecs int64
+	TraceHandle              tracing.TraceHandle
 }
 
 // newUploadHandler creates the UploadHandler struct.
@@ -83,6 +87,10 @@ func newUploadHandler(req *CreateUploadHandlerRequest) *UploadHandler {
 		blockSize:            req.BlockSize,
 		chunkRetryDeadline:   req.ChunkRetryDeadlineSecs,
 		chunkTransferTimeout: req.ChunkTransferTimeoutSecs,
+		traceHandle:          req.TraceHandle,
+	}
+	if uh.traceHandle == nil {
+		uh.traceHandle = tracing.NewNoopTracer()
 	}
 	return uh
 }
@@ -148,6 +156,11 @@ func (uh *UploadHandler) uploader() {
 // If there is already an error in uploadError, it returns without doing anything.
 // If there is an error during upload, it returns after storing the error in uploadError.
 func (uh *UploadHandler) uploadBlock(b block.Block) {
+	ctx := context.Background()
+	ctx, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadBlock)
+	defer func() {
+		uh.traceHandle.EndSpan(span)
+	}()
 	if b == nil {
 		logger.Warnf("uploadBlock: received nil block for object %s", uh.objectName)
 		return
@@ -180,18 +193,26 @@ func (uh *UploadHandler) uploadBlock(b block.Block) {
 }
 
 // Finalize finalizes the upload.
-func (uh *UploadHandler) Finalize() (*gcs.MinObject, error) {
+func (uh *UploadHandler) Finalize() (obj *gcs.MinObject, err error) {
+	ctx := context.Background()
+	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFinalize)
+	defer func() {
+		if err != nil {
+			uh.traceHandle.RecordError(span, err)
+		}
+		uh.traceHandle.EndSpan(span)
+	}()
 	uh.wg.Wait()
 	close(uh.uploadCh)
 
 	// Writer may not have been created for empty file creation flow or for very
 	// small writes of size less than 1 block.
-	err := uh.ensureWriter()
+	err = uh.ensureWriter()
 	if err != nil {
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
 
-	obj, err := uh.bucket.FinalizeUpload(context.Background(), uh.writer)
+	obj, err = uh.bucket.FinalizeUpload(context.Background(), uh.writer)
 	if err != nil {
 		// FinalizeUpload already returns GCSerror so no need to convert again.
 		uh.uploadError.Store(&err)
@@ -211,17 +232,25 @@ func (uh *UploadHandler) ensureWriter() error {
 }
 
 // FlushPendingWrites uploads any data in the write buffer.
-func (uh *UploadHandler) FlushPendingWrites() (*gcs.MinObject, error) {
+func (uh *UploadHandler) FlushPendingWrites() (o *gcs.MinObject, err error) {
+	ctx := context.Background()
+	_, span := uh.traceHandle.StartSpan(ctx, tracing.StreamingUploadFlush)
+	defer func() {
+		if err != nil {
+			uh.traceHandle.RecordError(span, err)
+		}
+		uh.traceHandle.EndSpan(span)
+	}()
 	uh.wg.Wait()
 
 	// Writer may not have been created for empty file creation flow or for very
 	// small writes of size less than 1 block.
-	err := uh.ensureWriter()
+	err = uh.ensureWriter()
 	if err != nil {
 		return nil, fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
 
-	o, err := uh.bucket.FlushPendingWrites(context.Background(), uh.writer)
+	o, err = uh.bucket.FlushPendingWrites(context.Background(), uh.writer)
 	if err != nil {
 		// FlushUpload already returns GCS error so no need to convert again.
 		uh.uploadError.Store(&err)

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,7 @@ func (t *UploadHandlerTest) SetupTest() {
 		BlockSize:                blockSize,
 		ChunkRetryDeadlineSecs:   chunkRetryDeadlineSecs,
 		ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
+		TraceHandle:              tracing.NewNoopTracer(),
 	})
 }
 
@@ -87,6 +89,7 @@ func (t *UploadHandlerTest) createUploadHandlerWithObjectOfGivenSize(size uint64
 		BlockSize:                blockSize,
 		ChunkRetryDeadlineSecs:   chunkRetryDeadlineSecs,
 		ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
+		TraceHandle:              tracing.NewNoopTracer(),
 	})
 }
 

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -15,6 +15,7 @@
 package bufferedwrites
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -94,7 +95,7 @@ func (t *UploadHandlerTest) TestCreateObjectWriter_CreateAppendableObjectWriterC
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{Zonal: true})
 	t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
 
-	_ = t.uh.createObjectWriter()
+	_ = t.uh.createObjectWriter(context.Background())
 
 	t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
 }
@@ -104,7 +105,7 @@ func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalled
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
 
-	_ = t.uh.createObjectWriter()
+	_ = t.uh.createObjectWriter(context.Background())
 
 	t.mockBucket.AssertCalled(t.T(), "CreateObjectChunkWriter", mock.Anything, mock.Anything)
 }
@@ -113,7 +114,7 @@ func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalled
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
 
-	_ = t.uh.createObjectWriter()
+	_ = t.uh.createObjectWriter(context.Background())
 
 	t.mockBucket.AssertCalled(t.T(), "CreateObjectChunkWriter", mock.Anything, mock.Anything)
 }
@@ -124,7 +125,7 @@ func (t *UploadHandlerTest) TestEnsureWriter_CreateAppendableWriterIsSuccessful(
 	writer := &storagemock.Writer{}
 	t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 
-	err := t.uh.createObjectWriter()
+	err := t.uh.createObjectWriter(context.Background())
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.uh.writer)
@@ -135,7 +136,7 @@ func (t *UploadHandlerTest) TestEnsureWriter_CreateAppendableWriterReturnsError(
 	expectedErr := fmt.Errorf("createAppendableObjectWriter failed")
 	t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	err := t.uh.ensureWriter()
+	err := t.uh.ensureWriter(context.Background())
 
 	assert.NotNil(t.T(), err)
 	assert.Nil(t.T(), t.uh.writer)
@@ -147,7 +148,7 @@ func (t *UploadHandlerTest) TestEnsureWriter_CreateObjectChunkWriterIsSuccessful
 	writer := &storagemock.Writer{}
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 
-	err := t.uh.ensureWriter()
+	err := t.uh.ensureWriter(context.Background())
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.uh.writer)
@@ -158,7 +159,7 @@ func (t *UploadHandlerTest) TestEnsureWriter_CreateObjectChunkWriterReturnsError
 	expectedErr := fmt.Errorf("createObjectChunkWriter failed")
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-	err := t.uh.ensureWriter()
+	err := t.uh.ensureWriter(context.Background())
 
 	assert.NotNil(t.T(), err)
 	assert.Nil(t.T(), t.uh.writer)
@@ -175,12 +176,12 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 	// Upload the blocks.
 	blocks := t.createBlocks(5)
 	for _, b := range blocks {
-		err := t.uh.Upload(b)
+		err := t.uh.Upload(context.Background(), b)
 		require.NoError(t.T(), err)
 	}
 
 	// Finalize.
-	obj, err := t.uh.Finalize()
+	obj, err := t.uh.Finalize(context.Background())
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), obj)
 	assert.Equal(t.T(), mockObj, obj)
@@ -204,7 +205,7 @@ func (t *UploadHandlerTest) TestUploadWhenCreateObjectWriterFails() {
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("taco"))
 
 	// Upload the block.
-	err = t.uh.Upload(b)
+	err = t.uh.Upload(context.Background(), b)
 
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "createObjectWriter")
@@ -217,7 +218,7 @@ func (t *UploadHandlerTest) TestFinalizeWithWriterAlreadyPresent() {
 	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 	t.uh.writer = writer
 
-	obj, err := t.uh.Finalize()
+	obj, err := t.uh.Finalize(context.Background())
 
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), obj)
@@ -232,7 +233,7 @@ func (t *UploadHandlerTest) TestFinalizeWithNoWriter() {
 	mockObj := &gcs.MinObject{}
 	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
 
-	obj, err := t.uh.Finalize()
+	obj, err := t.uh.Finalize(context.Background())
 
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), obj)
@@ -244,7 +245,7 @@ func (t *UploadHandlerTest) TestFinalizeWithNoWriterWhenCreateObjectWriterFails(
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("taco"))
 	assert.Nil(t.T(), t.uh.writer)
 
-	obj, err := t.uh.Finalize()
+	obj, err := t.uh.Finalize(context.Background())
 
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "taco")
@@ -260,7 +261,7 @@ func (t *UploadHandlerTest) TestFinalizeWhenFinalizeUploadFails() {
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	t.mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, fmt.Errorf("taco"))
 
-	obj, err := t.uh.Finalize()
+	obj, err := t.uh.Finalize(context.Background())
 
 	require.Error(t.T(), err)
 	assert.Nil(t.T(), obj)
@@ -274,7 +275,7 @@ func (t *UploadHandlerTest) TestFlushWithWriterAlreadyPresent() {
 	t.mockBucket.On("FlushPendingWrites", mock.Anything, writer).Return(mockObject, nil)
 	t.uh.writer = writer
 
-	o, err := t.uh.FlushPendingWrites()
+	o, err := t.uh.FlushPendingWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), mockObject, o)
@@ -288,7 +289,7 @@ func (t *UploadHandlerTest) TestFlushWithNoWriter() {
 	mockObject := &gcs.MinObject{Size: 10}
 	t.mockBucket.On("FlushPendingWrites", mock.Anything, writer).Return(mockObject, nil)
 
-	o, err := t.uh.FlushPendingWrites()
+	o, err := t.uh.FlushPendingWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), mockObject, o)
@@ -299,7 +300,7 @@ func (t *UploadHandlerTest) TestFlushWithNoWriterWhenCreateObjectWriterFails() {
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("taco"))
 	assert.Nil(t.T(), t.uh.writer)
 
-	o, err := t.uh.FlushPendingWrites()
+	o, err := t.uh.FlushPendingWrites(context.Background())
 
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "taco")
@@ -315,7 +316,7 @@ func (t *UploadHandlerTest) TestFlushWhenFlushPendingWritesFails() {
 	var minObj *gcs.MinObject = nil
 	t.mockBucket.On("FlushPendingWrites", mock.Anything, writer).Return(minObj, fmt.Errorf("taco"))
 
-	o, err := t.uh.FlushPendingWrites()
+	o, err := t.uh.FlushPendingWrites(context.Background())
 
 	require.Error(t.T(), err)
 	assert.Nil(t.T(), nil, o)
@@ -337,7 +338,7 @@ func (t *UploadHandlerTest) TestUploadSingleBlockThrowsErrorInCopy() {
 	writer.On("Write", mock.Anything).Return(0, fmt.Errorf("taco")).Once()
 
 	// Upload the block.
-	err = t.uh.Upload(b)
+	err = t.uh.Upload(context.Background(), b)
 
 	require.NoError(t.T(), err)
 	// Expect an error on upload due to error while copying content to GCS writer.
@@ -365,7 +366,7 @@ func (t *UploadHandlerTest) TestUploadMultipleBlocksThrowsErrorInCopy() {
 
 	// Upload the blocks.
 	for _, b := range blocks {
-		err := t.uh.Upload(b)
+		err := t.uh.Upload(context.Background(), b)
 		require.NoError(t.T(), err)
 	}
 
@@ -429,7 +430,7 @@ func (t *UploadHandlerTest) TestMultipleBlockAwaitBlocksUpload() {
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
 	// Upload the blocks.
 	for _, b := range t.createBlocks(5) {
-		err := t.uh.Upload(b)
+		err := t.uh.Upload(context.Background(), b)
 		require.NoError(t.T(), err)
 	}
 
@@ -484,7 +485,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 	b, err := t.blockPool.Get()
 	require.NoError(t.T(), err)
 	// Upload the block.
-	err = t.uh.Upload(b)
+	err = t.uh.Upload(context.Background(), b)
 	require.NoError(t.T(), err)
 }
 
@@ -511,7 +512,7 @@ func (t *UploadHandlerTest) TestCreateObjectChunkWriterIsCalledWithCorrectReques
 	b, err := t.blockPool.Get()
 	require.NoError(t.T(), err)
 	// Upload the block.
-	err = t.uh.Upload(b)
+	err = t.uh.Upload(context.Background(), b)
 	require.NoError(t.T(), err)
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1024,7 +1024,8 @@ func (fs *fileSystem) mintInode(ic inode.Core, parInodeCtx context.Context) (in 
 			ic.Local,
 			fs.newConfig,
 			fs.globalMaxWriteBlocksSem,
-			fs.mrdCache)
+			fs.mrdCache,
+			fs.traceHandle)
 	}
 
 	// Place it in our map of IDs to inodes.

--- a/internal/fs/grpc_metrics_test.go
+++ b/internal/fs/grpc_metrics_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/timeutil"
@@ -333,6 +334,7 @@ func createTestFileSystemWithGrpcMetrics(ctx context.Context, t *testing.T, para
 			},
 		},
 		MetricHandle:  mh,
+		TraceHandle:   tracing.NewNoopTracer(),
 		CacheClock:    &timeutil.SimulatedClock{},
 		BucketName:    bucketName,
 		BucketManager: bm,

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -163,6 +163,7 @@ func createFileInode(
 		config,
 		semaphore.NewWeighted(100),
 		nil,
+		tracing.NewNoopTracer(),
 	)
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -33,6 +33,7 @@ import (
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -266,7 +267,8 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		true, //localFile
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
-		nil) // mrdCache
+		nil,
+		tracing.NewNoopTracer()) // mrdCache
 	return
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -707,13 +707,16 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 // Helper function to serve write for file using buffered writes handler.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (bool, error) {
+func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (_ bool, err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
 	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
 	defer func() {
+		if err != nil {
+			f.traceHandle.RecordError(span, err)
+		}
 		f.traceHandle.EndSpan(span)
 	}()
-	err := f.bwh.Write(ctx, data, offset)
+	err = f.bwh.Write(ctx, data, offset)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		return false, &gcsfuse_errors.FileClobberedError{
@@ -727,13 +730,11 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
-			f.traceHandle.RecordError(span, err)
 			return false, fmt.Errorf("could not finalize what has been written so far: %w", err)
 		}
 		return true, f.writeUsingTempFile(ctx, data, offset)
 	}
 	if err != nil {
-		f.traceHandle.RecordError(span, err)
 		return false, fmt.Errorf("write to buffered write handler failed: %w", err)
 	}
 	return false, nil

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -156,9 +156,6 @@ func NewFileInode(
 	mrdCache *lru.Cache,
 	traceHandle tracing.TraceHandle) (f *FileInode) {
 	// Set up the basic struct.
-	if traceHandle == nil {
-		traceHandle = tracing.NewNoopTracer()
-	}
 	var minObj gcs.MinObject
 	if m != nil {
 		minObj = *m

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -739,12 +739,12 @@ func (f *FileInode) flushUsingBufferedWriteHandler(ctx context.Context) error {
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		return &gcsfuse_errors.FileClobberedError{
-			Err:        fmt.Errorf("f.bwh.Flush(ctx): %w", err),
+			Err:        fmt.Errorf("f.bwh.Flush(): %w", err),
 			ObjectName: f.src.Name,
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("f.bwh.Flush(ctx): %w", err)
+		return fmt.Errorf("f.bwh.Flush(): %w", err)
 	}
 	// If we finalized the object, we need to update our state.
 	f.updateInodeStateAfterFlush(obj)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -683,6 +683,7 @@ func (f *FileInode) Write(
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset int64) (err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStaged)
+	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)
@@ -945,6 +946,12 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
+	st, err := f.content.Stat()
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+
+	f.traceHandle.SetUploadAttributes(span, st.Size, f.src.Name)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -682,14 +682,9 @@ func (f *FileInode) Write(
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset int64) (err error) {
-	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStaged)
+	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.WriteFileStaged, &err)
+	defer finishSpan()
 	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
-	defer func() {
-		if err != nil {
-			f.traceHandle.RecordError(span, err)
-		}
-		f.traceHandle.EndSpan(span)
-	}()
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)
 	if err != nil {
@@ -708,14 +703,9 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (_ bool, err error) {
-	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
+	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.WriteFileStreaming, &err)
 	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
-	defer func() {
-		if err != nil {
-			f.traceHandle.RecordError(span, err)
-		}
-		f.traceHandle.EndSpan(span)
-	}()
+	defer finishSpan()
 	err = f.bwh.Write(ctx, data, offset)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
@@ -961,14 +951,9 @@ func (f *FileInode) getTempContentSizeForSpan() int64 {
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
-	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
+	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.SyncFileStaged, &err)
 	f.traceHandle.SetUploadAttributes(span, f.getTempContentSizeForSpan(), f.src.Name)
-	defer func() {
-		if err != nil {
-			f.traceHandle.RecordError(span, err)
-		}
-		f.traceHandle.EndSpan(span)
-	}()
+	defer finishSpan()
 	var latestGcsObj *gcs.Object
 	if !f.local {
 		latestGcsObj, err = f.fetchLatestGcsObject(ctx)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -711,7 +711,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	defer func() {
 		f.traceHandle.EndSpan(span)
 	}()
-	err := f.bwh.Write(data, offset)
+	err := f.bwh.Write(ctx, data, offset)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		return false, &gcsfuse_errors.FileClobberedError{
@@ -723,7 +723,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
 		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
 		// Finalize the object.
-		err = f.flushUsingBufferedWriteHandler()
+		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
 			f.traceHandle.RecordError(span, err)
 			return false, fmt.Errorf("could not finalize what has been written so far: %w", err)
@@ -741,17 +741,17 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 // new object.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) flushUsingBufferedWriteHandler() error {
-	obj, err := f.bwh.Flush()
+func (f *FileInode) flushUsingBufferedWriteHandler(ctx context.Context) error {
+	obj, err := f.bwh.Flush(ctx)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		return &gcsfuse_errors.FileClobberedError{
-			Err:        fmt.Errorf("f.bwh.Flush(): %w", err),
+			Err:        fmt.Errorf("f.bwh.Flush(ctx): %w", err),
 			ObjectName: f.src.Name,
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("f.bwh.Flush(): %w", err)
+		return fmt.Errorf("f.bwh.Flush(ctx): %w", err)
 	}
 	// If we finalized the object, we need to update our state.
 	f.updateInodeStateAfterFlush(obj)
@@ -762,21 +762,21 @@ func (f *FileInode) flushUsingBufferedWriteHandler() error {
 // It is a no-op when bwh is nil.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) SyncPendingBufferedWrites() (gcsSynced bool, err error) {
+func (f *FileInode) SyncPendingBufferedWrites(ctx context.Context) (gcsSynced bool, err error) {
 	if f.bwh == nil {
 		return
 	}
-	minObj, err := f.bwh.Sync()
+	minObj, err := f.bwh.Sync(ctx)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
 		err = &gcsfuse_errors.FileClobberedError{
-			Err:        fmt.Errorf("f.bwh.Sync(): %w", err),
+			Err:        fmt.Errorf("f.bwh.Sync(ctx): %w", err),
 			ObjectName: f.src.Name,
 		}
 		return
 	}
 	if err != nil {
-		err = fmt.Errorf("f.bwh.Sync(): %w", err)
+		err = fmt.Errorf("f.bwh.Sync(ctx): %w", err)
 		return
 	}
 	// We return gcsSynced as true when we get minObject from Sync() for Zonal Buckets.
@@ -925,7 +925,7 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 	}
 
 	if f.bwh != nil {
-		gcsSynced, err = f.SyncPendingBufferedWrites()
+		gcsSynced, err = f.SyncPendingBufferedWrites(ctx)
 		if err != nil {
 			err = fmt.Errorf("could not sync what has been written so far: %w", err)
 		}
@@ -1000,7 +1000,7 @@ func (f *FileInode) Flush(ctx context.Context) (err error) {
 	// Flush using the appropriate method based on whether we're using a
 	// buffered write handler.
 	if f.bwh != nil {
-		return f.flushUsingBufferedWriteHandler()
+		return f.flushUsingBufferedWriteHandler(ctx)
 	}
 	return f.syncUsingContent(ctx)
 }
@@ -1059,7 +1059,7 @@ func (f *FileInode) truncateUsingBufferedWriteHandler(ctx context.Context, size 
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
 		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
 		// Finalize the object.
-		err = f.flushUsingBufferedWriteHandler()
+		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
 			return false, fmt.Errorf("could not finalize what has been written so far: %w", err)
 		}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -949,7 +949,7 @@ func (f *FileInode) getTempContentSizeForSpan() int64 {
 
 	st, err := f.content.Stat()
 	if err != nil {
-		logger.Errorf("stat: %v", err)
+		logger.Errorf("failed getting content size for staged sync file span: %v", err)
 		return -1
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -962,7 +962,6 @@ func (f *FileInode) getTempContentSizeForSpan() int64 {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
-
 	f.traceHandle.SetUploadAttributes(span, f.getTempContentSizeForSpan(), f.src.Name)
 	defer func() {
 		if err != nil {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -33,6 +33,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -127,6 +128,7 @@ type FileInode struct {
 
 	// mrdInstance manages the MultiRangeDownloader instances for this inode.
 	mrdInstance *gcsx.MrdInstance
+	traceHandle tracing.TraceHandle
 }
 
 var _ Inode = &FileInode{}
@@ -151,8 +153,12 @@ func NewFileInode(
 	localFile bool,
 	cfg *cfg.Config,
 	globalMaxBlocksSem *semaphore.Weighted,
-	mrdCache *lru.Cache) (f *FileInode) {
+	mrdCache *lru.Cache,
+	traceHandle tracing.TraceHandle) (f *FileInode) {
 	// Set up the basic struct.
+	if traceHandle == nil {
+		traceHandle = tracing.NewNoopTracer()
+	}
 	var minObj gcs.MinObject
 	if m != nil {
 		minObj = *m
@@ -170,6 +176,7 @@ func NewFileInode(
 		unlinked:                false,
 		config:                  cfg,
 		globalMaxWriteBlocksSem: globalMaxBlocksSem,
+		traceHandle:             traceHandle,
 	}
 
 	if f.bucket.BucketType().Zonal {
@@ -675,6 +682,13 @@ func (f *FileInode) Write(
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset int64) (err error) {
+	_, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStaged)
+	defer func() {
+		if err != nil {
+			f.traceHandle.RecordError(span, err)
+		}
+		f.traceHandle.EndSpan(span)
+	}()
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)
 	if err != nil {
@@ -693,6 +707,10 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (bool, error) {
+	_, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
+	defer func() {
+		f.traceHandle.EndSpan(span)
+	}()
 	err := f.bwh.Write(data, offset)
 	var preconditionErr *gcs.PreconditionError
 	if errors.As(err, &preconditionErr) {
@@ -707,11 +725,13 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler()
 		if err != nil {
+			f.traceHandle.RecordError(span, err)
 			return false, fmt.Errorf("could not finalize what has been written so far: %w", err)
 		}
 		return true, f.writeUsingTempFile(ctx, data, offset)
 	}
 	if err != nil {
+		f.traceHandle.RecordError(span, err)
 		return false, fmt.Errorf("write to buffered write handler failed: %w", err)
 	}
 	return false, nil
@@ -922,7 +942,14 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 // object, syncs the content and updates the inode state.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) syncUsingContent(ctx context.Context) error {
+func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
+	_, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
+	defer func() {
+		if err != nil {
+			f.traceHandle.RecordError(span, err)
+		}
+		f.traceHandle.EndSpan(span)
+	}()
 	var latestGcsObj *gcs.Object
 	if !f.local {
 		var err error
@@ -1147,6 +1174,7 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 			GlobalMaxBlocksSem:       f.globalMaxWriteBlocksSem,
 			ChunkRetryDeadlineSecs:   f.config.GcsRetries.ChunkRetryDeadlineSecs,
 			ChunkTransferTimeoutSecs: f.config.GcsRetries.ChunkTransferTimeoutSecs,
+			TraceHandle:              f.traceHandle,
 		})
 		if errors.Is(err, block.CantAllocateAnyBlockError) {
 			logger.Warnf("File %s will use legacy staged writes because concurrent streaming write "+

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -947,12 +947,12 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
-	st, err := f.content.Stat()
 	if err != nil {
 		return fmt.Errorf("stat: %w", err)
 	}
 
-	f.traceHandle.SetUploadAttributes(span, st.Size, f.src.Name)
+	// -1 represents full content size being uploaded
+	f.traceHandle.SetUploadAttributes(span, -1, f.src.Name)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -962,9 +962,6 @@ func (f *FileInode) getTempContentSizeForSpan() int64 {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
-	if err != nil {
-		return fmt.Errorf("stat: %w", err)
-	}
 
 	f.traceHandle.SetUploadAttributes(span, f.getTempContentSizeForSpan(), f.src.Name)
 	defer func() {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -941,6 +941,21 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 	return true, nil
 }
 
+// get the temp content size when tracing is enabled to set the BYTES_UPLOADED attribute
+func (f *FileInode) getTempContentSizeForSpan() int64 {
+	if !cfg.IsTracingEnabled(f.config) {
+		return -1
+	}
+
+	st, err := f.content.Stat()
+	if err != nil {
+		logger.Errorf("stat: %v", err)
+		return -1
+	}
+
+	return st.Size
+}
+
 // syncUsingContent syncs the inode content to GCS. It fetches the latest GCS
 // object, syncs the content and updates the inode state.
 //
@@ -951,8 +966,7 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 		return fmt.Errorf("stat: %w", err)
 	}
 
-	// -1 represents full content size being uploaded
-	f.traceHandle.SetUploadAttributes(span, -1, f.src.Name)
+	f.traceHandle.SetUploadAttributes(span, f.getTempContentSizeForSpan(), f.src.Name)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -682,9 +682,9 @@ func (f *FileInode) Write(
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset int64) (err error) {
-	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.WriteFileStaged, &err)
+	bytes := int64(len(data))
+	ctx, finishSpan := f.traceHandle.TraceUpload(ctx, tracing.WriteFileStaged, f.src.Name, &bytes, &err)
 	defer finishSpan()
-	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
 	// Make sure f.content != nil.
 	err = f.ensureContent(ctx)
 	if err != nil {
@@ -703,8 +703,8 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (_ bool, err error) {
-	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.WriteFileStreaming, &err)
-	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
+	bytes := int64(len(data))
+	ctx, finishSpan := f.traceHandle.TraceUpload(ctx, tracing.WriteFileStreaming, f.src.Name, &bytes, &err)
 	defer finishSpan()
 	err = f.bwh.Write(ctx, data, offset)
 	var preconditionErr *gcs.PreconditionError
@@ -951,8 +951,8 @@ func (f *FileInode) getTempContentSizeForSpan() int64 {
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
-	ctx, span, finishSpan := f.traceHandle.Trace(ctx, tracing.SyncFileStaged, &err)
-	f.traceHandle.SetUploadAttributes(span, f.getTempContentSizeForSpan(), f.src.Name)
+	bytes := f.getTempContentSizeForSpan()
+	ctx, finishSpan := f.traceHandle.TraceUpload(ctx, tracing.SyncFileStaged, f.src.Name, &bytes, &err)
 	defer finishSpan()
 	var latestGcsObj *gcs.Object
 	if !f.local {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -682,7 +682,7 @@ func (f *FileInode) Write(
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset int64) (err error) {
-	_, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStaged)
+	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStaged)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)
@@ -707,7 +707,7 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (bool, error) {
-	_, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
+	ctx, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
 	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
 	defer func() {
 		f.traceHandle.EndSpan(span)
@@ -944,7 +944,7 @@ func (f *FileInode) Sync(ctx context.Context) (gcsSynced bool, err error) {
 //
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
-	_, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
+	ctx, span := f.traceHandle.StartSpan(ctx, tracing.SyncFileStaged)
 	defer func() {
 		if err != nil {
 			f.traceHandle.RecordError(span, err)
@@ -953,7 +953,6 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	}()
 	var latestGcsObj *gcs.Object
 	if !f.local {
-		var err error
 		latestGcsObj, err = f.fetchLatestGcsObject(ctx)
 		if err != nil {
 			return err

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -708,6 +708,7 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (bool, error) {
 	_, span := f.traceHandle.StartSpan(ctx, tracing.WriteFileStreaming)
+	f.traceHandle.SetUploadAttributes(span, int64(len(data)), f.src.Name)
 	defer func() {
 		f.traceHandle.EndSpan(span)
 	}()

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -29,6 +29,7 @@ import (
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -117,7 +118,8 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		isLocal,
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
-		nil)
+		nil,
+		tracing.NewNoopTracer())
 
 	// Create empty file for local inode created above.
 	err := t.in.CreateEmptyTempFile(t.ctx)
@@ -153,7 +155,8 @@ func (t *FileMockBucketTest) createGCSBackedFileInode(backingObj *gcs.MinObject)
 		false, // localFile
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
-		nil)
+		nil,
+		tracing.NewNoopTracer())
 	f.Lock()
 	return f
 }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -179,7 +179,7 @@ func (t *FileStreamingWritesCommon) TestIsUsingBWH() {
 
 func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnZeroSizeRecreatesBwhOnInitAgain() {
 	t.createBufferedWriteHandler()
-	err := t.in.flushUsingBufferedWriteHandler()
+	err := t.in.flushUsingBufferedWriteHandler(context.Background())
 	require.NoError(t.T(), err)
 	assert.Nil(t.T(), t.in.bwh)
 
@@ -195,7 +195,7 @@ func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnNonZeroS
 	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, WriteMode)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
-	err = t.in.flushUsingBufferedWriteHandler()
+	err = t.in.flushUsingBufferedWriteHandler(context.Background())
 	require.NoError(t.T(), err)
 	assert.Nil(t.T(), t.in.bwh)
 
@@ -240,7 +240,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 	assert.NoError(t.T(), err)
 	require.False(t.T(), gcsSynced)
 
-	gcsSynced, err = t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.True(t.T(), gcsSynced)
@@ -257,7 +257,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	gcsSynced, err = t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.True(t.T(), gcsSynced)
@@ -291,7 +291,7 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
-	gcsSynced, err = t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -306,7 +306,7 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
 
-	gcsSynced, err = t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -814,14 +814,14 @@ type FakeBufferedWriteHandler struct {
 	FlushFunc func() (*gcs.MinObject, error)
 }
 
-func (t *FakeBufferedWriteHandler) Write(data []byte, offset int64) error {
+func (t *FakeBufferedWriteHandler) Write(ctx context.Context, data []byte, offset int64) error {
 	if t.WriteFunc != nil {
 		return t.WriteFunc(data, offset)
 	}
 	return nil
 }
 
-func (t *FakeBufferedWriteHandler) Flush() (*gcs.MinObject, error) {
+func (t *FakeBufferedWriteHandler) Flush(ctx context.Context) (*gcs.MinObject, error) {
 	if t.FlushFunc != nil {
 		return t.FlushFunc()
 	}
@@ -835,7 +835,7 @@ func (t *FakeBufferedWriteHandler) WriteFileInfo() bufferedwrites.WriteFileInfo 
 	}
 }
 
-func (t *FakeBufferedWriteHandler) Sync() (*gcs.MinObject, error) { return nil, nil }
+func (t *FakeBufferedWriteHandler) Sync(ctx context.Context) (*gcs.MinObject, error) { return nil, nil }
 func (t *FakeBufferedWriteHandler) SetMtime(_ time.Time)          {}
 func (t *FakeBufferedWriteHandler) Truncate(_ int64) error        { return nil }
 func (t *FakeBufferedWriteHandler) Destroy() error                { return nil }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -152,7 +153,8 @@ func (t *FileStreamingWritesCommon) createInode(fileType string) {
 		isLocal,
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
-		nil)
+		nil,
+		tracing.NewNoopTracer())
 
 	// Set buffered write config for created inode.
 	t.in.config = &cfg.Config{Write: cfg.WriteConfig{

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -836,10 +836,10 @@ func (t *FakeBufferedWriteHandler) WriteFileInfo() bufferedwrites.WriteFileInfo 
 }
 
 func (t *FakeBufferedWriteHandler) Sync(ctx context.Context) (*gcs.MinObject, error) { return nil, nil }
-func (t *FakeBufferedWriteHandler) SetMtime(_ time.Time)          {}
-func (t *FakeBufferedWriteHandler) Truncate(_ int64) error        { return nil }
-func (t *FakeBufferedWriteHandler) Destroy() error                { return nil }
-func (t *FakeBufferedWriteHandler) Unlink()                       {}
+func (t *FakeBufferedWriteHandler) SetMtime(_ time.Time)                             {}
+func (t *FakeBufferedWriteHandler) Truncate(_ int64) error                           { return nil }
+func (t *FakeBufferedWriteHandler) Destroy() error                                   { return nil }
+func (t *FakeBufferedWriteHandler) Unlink()                                          {}
 
 func (t *FakeBufferedWriteHandler) SetTotalSize() {}
 

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -165,7 +166,8 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 		local,
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
-		nil)
+		nil,
+		tracing.NewNoopTracer())
 
 	t.in.Lock()
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -330,7 +330,7 @@ func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreaming
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
-	gcsSynced, err = t.in.SyncPendingBufferedWrites()
+	gcsSynced, err = t.in.SyncPendingBufferedWrites(context.Background())
 
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)

--- a/internal/fs/tracing_test.go
+++ b/internal/fs/tracing_test.go
@@ -899,10 +899,14 @@ func (s *TracingTestSuite) TestTraceWriteFile() {
 			require.NoError(t, err)
 
 			ss := s.globalExporter.GetSpans()
-			require.Len(t, ss, len(tt.spans))
-			for i, spanName := range tt.spans {
-				assert.Equal(t, spanName, ss[i].Name)
-				assert.Equal(t, trace.SpanKindServer, ss[i].SpanKind)
+			require.GreaterOrEqual(t, len(ss), len(tt.spans))
+			spanNamesInSS := make(map[string]trace.SpanKind)
+			for _, s := range ss {
+				spanNamesInSS[s.Name] = s.SpanKind
+			}
+			for _, spanName := range tt.spans {
+				assert.Contains(t, spanNamesInSS, spanName, "span %s not found", spanName)
+				assert.Equal(t, spanNamesInSS[spanName], trace.SpanKindServer)
 			}
 		})
 	}

--- a/internal/fs/tracing_test.go
+++ b/internal/fs/tracing_test.go
@@ -906,7 +906,7 @@ func (s *TracingTestSuite) TestTraceWriteFile() {
 			}
 			for _, spanName := range tt.spans {
 				assert.Contains(t, spanNamesInSS, spanName, "span %s not found", spanName)
-				assert.Equal(t, spanNamesInSS[spanName], trace.SpanKindServer)
+				assert.Equal(t, trace.SpanKindServer, spanNamesInSS[spanName])
 			}
 		})
 	}

--- a/tracing/benchmark_test.go
+++ b/tracing/benchmark_test.go
@@ -68,23 +68,45 @@ func BenchmarkTrace(b *testing.B) {
 			th.EndSpan(span)
 		})
 
-		b.Run(fmt.Sprintf("BenchmarkTraceWithError_%s", prefix), func(b *testing.B) {
+		b.Run(fmt.Sprintf("BenchmarkTraceUploadWithErrorNoBytes_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
 			err := fmt.Errorf("TestError")
+			bytes := int64(0)
 
 			for b.Loop() {
-				_, _, done := th.Trace(ctx, "TestSpanName", &err)
-				done()
+				_, finishSpan := th.TraceUpload(ctx, "TestSpanName", "A/B/C/test_file.text", &bytes, &err)
+				finishSpan()
 			}
 		})
 
-		b.Run(fmt.Sprintf("BenchmarkTraceWithoutError_%s", prefix), func(b *testing.B) {
+		b.Run(fmt.Sprintf("BenchmarkTraceUploadWithErrorWithBytes_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
 			err := fmt.Errorf("TestError")
+			bytes := int64(33554432)
 
 			for b.Loop() {
-				_, _, done := th.Trace(ctx, "TestSpanName", &err)
-				done()
+				_, finishSpan := th.TraceUpload(ctx, "TestSpanName", "A/B/C/test_file.text", &bytes, &err)
+				finishSpan()
+			}
+		})
+
+		b.Run(fmt.Sprintf("BenchmarkTraceUploadWithoutErrorNoBytes_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+			bytes := int64(0)
+
+			for b.Loop() {
+				_, finishSpan := th.TraceUpload(ctx, "TestSpanName", "A/B/C/test_file.text", &bytes, nil)
+				finishSpan()
+			}
+		})
+
+		b.Run(fmt.Sprintf("BenchmarkTraceUploadWithoutErrorWithBytes_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+			bytes := int64(33554432)
+
+			for b.Loop() {
+				_, finishSpan := th.TraceUpload(ctx, "TestSpanName", "A/B/C/test_file.text", &bytes, nil)
+				finishSpan()
 			}
 		})
 

--- a/tracing/benchmark_test.go
+++ b/tracing/benchmark_test.go
@@ -68,6 +68,26 @@ func BenchmarkTrace(b *testing.B) {
 			th.EndSpan(span)
 		})
 
+		b.Run(fmt.Sprintf("BenchmarkTraceWithError_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+			err := fmt.Errorf("TestError")
+
+			for b.Loop() {
+				_, _, done := th.Trace(ctx, "TestSpanName", &err)
+				done()
+			}
+		})
+
+		b.Run(fmt.Sprintf("BenchmarkTraceWithoutError_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+			err := fmt.Errorf("TestError")
+
+			for b.Loop() {
+				_, _, done := th.Trace(ctx, "TestSpanName", &err)
+				done()
+			}
+		})
+
 		b.Run(fmt.Sprintf("BenchmarkSetCacheReadAttributes_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
 

--- a/tracing/benchmark_test.go
+++ b/tracing/benchmark_test.go
@@ -78,6 +78,16 @@ func BenchmarkTrace(b *testing.B) {
 			th.EndSpan(span)
 		})
 
+		b.Run(fmt.Sprintf("BenchmarkSetUploadAttributes_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+
+			_, span := th.StartSpan(ctx, "TestSpanName")
+			for b.Loop() {
+				th.SetUploadAttributes(span, 100, "A/B/C/test_file.text")
+			}
+			th.EndSpan(span)
+		})
+
 		b.Run(fmt.Sprintf("BenchmarkPropagateTraceContext_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
 

--- a/tracing/noop_tracer.go
+++ b/tracing/noop_tracer.go
@@ -37,6 +37,8 @@ func (*noopTracer) RecordError(span trace.Span, err error) {}
 
 func (o *noopTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int) {}
 
+func (o *noopTracer) SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string) {}
+
 // Return the new context as it is as this is a no-op implementation
 func (*noopTracer) PropagateTraceContext(newCtx context.Context, _ context.Context) context.Context {
 	return newCtx

--- a/tracing/noop_tracer.go
+++ b/tracing/noop_tracer.go
@@ -21,6 +21,10 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
+var (
+	emptyFinisher = func() {}
+)
+
 type noopTracer struct{}
 
 func (*noopTracer) StartSpan(ctx context.Context, traceName string) (context.Context, trace.Span) {
@@ -32,6 +36,10 @@ func (*noopTracer) StartServerSpan(ctx context.Context, traceName string) (conte
 }
 
 func (*noopTracer) EndSpan(span trace.Span) {}
+
+func (*noopTracer) Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func()) {
+	return ctx, noop.Span{}, emptyFinisher
+}
 
 func (*noopTracer) RecordError(span trace.Span, err error) {}
 

--- a/tracing/noop_tracer.go
+++ b/tracing/noop_tracer.go
@@ -37,15 +37,15 @@ func (*noopTracer) StartServerSpan(ctx context.Context, traceName string) (conte
 
 func (*noopTracer) EndSpan(span trace.Span) {}
 
-func (*noopTracer) Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func()) {
-	return ctx, noop.Span{}, emptyFinisher
-}
-
 func (*noopTracer) RecordError(span trace.Span, err error) {}
 
 func (o *noopTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int) {}
 
 func (o *noopTracer) SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string) {}
+
+func (*noopTracer) TraceUpload(ctx context.Context, name string, objName string, bytes *int64, err *error) (context.Context, func()) {
+	return ctx, emptyFinisher
+}
 
 // Return the new context as it is as this is a no-op implementation
 func (*noopTracer) PropagateTraceContext(newCtx context.Context, _ context.Context) context.Context {

--- a/tracing/otel_tracer.go
+++ b/tracing/otel_tracer.go
@@ -30,9 +30,11 @@ type otelTracer struct {
 }
 
 var (
-	bytesReadKey = attribute.Key(BYTES_READ)
-	cacheHit     = attribute.Bool(IS_CACHE_HIT, true)
-	cacheMiss    = attribute.Bool(IS_CACHE_HIT, false)
+	bytesReadKey     = attribute.Key(BYTES_READ)
+	bytesUploadedKey = attribute.Key(BYTES_UPLOADED)
+	objectNameKey    = attribute.Key(OBJECT_NAME)
+	cacheHit         = attribute.Bool(IS_CACHE_HIT, true)
+	cacheMiss        = attribute.Bool(IS_CACHE_HIT, false)
 )
 
 func (o *otelTracer) StartSpan(ctx context.Context, traceName string) (context.Context, trace.Span) {
@@ -62,6 +64,15 @@ func (o *otelTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, by
 	} else {
 		attrSet[1] = cacheMiss
 	}
+	span.SetAttributes(attrSet...)
+}
+
+func (o *otelTracer) SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string) {
+	attrSetPtr := o.slicePool.Get().(*[]attribute.KeyValue)
+	attrSet := *attrSetPtr
+	defer o.slicePool.Put(attrSetPtr)
+	attrSet[0] = bytesUploadedKey.Int64(bytesUploaded)
+	attrSet[1] = objectNameKey.String(objectName)
 	span.SetAttributes(attrSet...)
 }
 

--- a/tracing/otel_tracer.go
+++ b/tracing/otel_tracer.go
@@ -54,6 +54,18 @@ func (o *otelTracer) RecordError(span trace.Span, err error) {
 	span.SetStatus(codes.Error, err.Error())
 }
 
+// Trace starts a span and returns a finisher function.
+// Use it like: ctx, span, done := th.Trace(ctx, name, &err); defer done()
+func (o *otelTracer) Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func()) {
+	ctx, span := o.StartSpan(ctx, name)
+	return ctx, span, func() {
+		if err != nil && *err != nil {
+			o.RecordError(span, *err)
+		}
+		o.EndSpan(span)
+	}
+}
+
 func (o *otelTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int) {
 	attrSetPtr := o.slicePool.Get().(*[]attribute.KeyValue)
 	attrSet := *attrSetPtr

--- a/tracing/otel_tracer.go
+++ b/tracing/otel_tracer.go
@@ -54,18 +54,6 @@ func (o *otelTracer) RecordError(span trace.Span, err error) {
 	span.SetStatus(codes.Error, err.Error())
 }
 
-// Trace starts a span and returns a finisher function.
-// Use it like: ctx, span, done := th.Trace(ctx, name, &err); defer done()
-func (o *otelTracer) Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func()) {
-	ctx, span := o.StartSpan(ctx, name)
-	return ctx, span, func() {
-		if err != nil && *err != nil {
-			o.RecordError(span, *err)
-		}
-		o.EndSpan(span)
-	}
-}
-
 func (o *otelTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int) {
 	attrSetPtr := o.slicePool.Get().(*[]attribute.KeyValue)
 	attrSet := *attrSetPtr
@@ -86,6 +74,20 @@ func (o *otelTracer) SetUploadAttributes(span trace.Span, bytesUploaded int64, o
 	attrSet[0] = bytesUploadedKey.Int64(bytesUploaded)
 	attrSet[1] = objectNameKey.String(objectName)
 	span.SetAttributes(attrSet...)
+}
+
+func (o *otelTracer) TraceUpload(ctx context.Context, name string, objName string, bytes *int64, err *error) (context.Context, func()) {
+	ctx, span := o.StartSpan(ctx, name)
+
+	return ctx, func() {
+		if bytes != nil {
+			o.SetUploadAttributes(span, *bytes, objName)
+		}
+		if err != nil && *err != nil {
+			o.RecordError(span, *err)
+		}
+		o.EndSpan(span)
+	}
 }
 
 func (o *otelTracer) PropagateTraceContext(newCtx context.Context, oldCtx context.Context) context.Context {

--- a/tracing/span_attributes.go
+++ b/tracing/span_attributes.go
@@ -15,6 +15,8 @@
 package tracing
 
 const (
-	IS_CACHE_HIT = "cache.hit" // Indicates if the response was served from cache or not.
-	BYTES_READ   = "read.size" // Indicates the number of bytes read from the given reader
+	IS_CACHE_HIT   = "cache.hit"          // Indicates if the response was served from cache or not.
+	BYTES_READ     = "read.size"          // Indicates the number of bytes read from the given reader
+	BYTES_UPLOADED = "upload.size"        // Indicates the number of bytes uploaded
+	OBJECT_NAME    = "upload.object_name" // Indicates the object name uploaded
 )

--- a/tracing/span_attributes.go
+++ b/tracing/span_attributes.go
@@ -15,8 +15,8 @@
 package tracing
 
 const (
-	IS_CACHE_HIT   = "cache.hit"          // Indicates if the response was served from cache or not.
-	BYTES_READ     = "read.size"          // Indicates the number of bytes read from the given reader
-	BYTES_UPLOADED = "upload.size"        // Indicates the number of bytes uploaded
-	OBJECT_NAME    = "upload.object_name" // Indicates the object name uploaded
+	IS_CACHE_HIT   = "cache.hit"         // Indicates if the response was served from cache or not.
+	BYTES_READ     = "read.size"         // Indicates the number of bytes read from the given reader
+	BYTES_UPLOADED = "write.chunk.size"  // Indicates the number of bytes uploaded
+	OBJECT_NAME    = "write.object_name" // Indicates the object name uploaded
 )

--- a/tracing/span_names.go
+++ b/tracing/span_names.go
@@ -131,6 +131,6 @@ const (
 	StreamingUploadFinalize = "streaming.upload.finalize"
 	// StreamingUploadFlush traces the flushing of pending streaming writes.
 	StreamingUploadFlush = "streaming.upload.flush"
-	// Tracks the go routine and async upload of the write blocks received
-	UploadAsync = "upload.async"
+	// Tracks the complete go routine that trigger the async upload of the write blocks received
+	StreamingUploader = "write.streaming.uploader"
 )

--- a/tracing/span_names.go
+++ b/tracing/span_names.go
@@ -114,4 +114,21 @@ const (
 	Fallocate = "fs.fallocate"
 	// SyncFS flushes all buffered data for the entire filesystem to disk.
 	SyncFS = "fs.sync_fs"
+
+	// --- Write Flow traces ---
+
+	// WriteFileStaged traces a write operation using the legacy staged writes.
+	WriteFileStaged = "write.staged"
+	// WriteFileStreaming traces a write operation using the buffered writes handler.
+	WriteFileStreaming = "write.streaming"
+	// SyncFileStaged traces the synchronization of the staged temp file to GCS.
+	SyncFileStaged = "sync.staged"
+	// SyncFileStreaming traces the synchronization of buffered writes to GCS.
+	SyncFileStreaming = "sync.streaming"
+	// StreamingUploadBlock traces the upload of a single streaming block to GCS.
+	StreamingUploadBlock = "streaming.upload.block"
+	// StreamingUploadFinalize traces the finalization of the streaming upload.
+	StreamingUploadFinalize = "streaming.upload.finalize"
+	// StreamingUploadFlush traces the flushing of pending streaming writes.
+	StreamingUploadFlush = "streaming.upload.flush"
 )

--- a/tracing/span_names.go
+++ b/tracing/span_names.go
@@ -131,4 +131,6 @@ const (
 	StreamingUploadFinalize = "streaming.upload.finalize"
 	// StreamingUploadFlush traces the flushing of pending streaming writes.
 	StreamingUploadFlush = "streaming.upload.flush"
+	// Tracks the go routine and async upload of the write blocks received
+	UploadAsync = "upload.async"
 )

--- a/tracing/span_names.go
+++ b/tracing/span_names.go
@@ -119,18 +119,18 @@ const (
 
 	// WriteFileStaged traces a write operation using the legacy staged writes.
 	WriteFileStaged = "write.staged"
+	// SyncFileStaged traces the synchronization of the staged temp file to GCS.
+	SyncFileStaged = "write.staged.sync"
 	// WriteFileStreaming traces a write operation using the buffered writes handler.
 	WriteFileStreaming = "write.streaming"
-	// SyncFileStaged traces the synchronization of the staged temp file to GCS.
-	SyncFileStaged = "sync.staged"
 	// SyncFileStreaming traces the synchronization of buffered writes to GCS.
-	SyncFileStreaming = "sync.streaming"
+	SyncFileStreaming = "write.streaming.sync"
 	// StreamingUploadBlock traces the upload of a single streaming block to GCS.
-	StreamingUploadBlock = "streaming.upload.block"
+	StreamingUploadBlock = "write.streaming.upload.block"
 	// StreamingUploadFinalize traces the finalization of the streaming upload.
-	StreamingUploadFinalize = "streaming.upload.finalize"
+	StreamingUploadFinalize = "write.streaming.upload.finalize"
 	// StreamingUploadFlush traces the flushing of pending streaming writes.
-	StreamingUploadFlush = "streaming.upload.flush"
+	StreamingUploadFlush = "write.streaming.upload.flush"
 	// Tracks the complete go routine that trigger the async upload of the write blocks received
 	StreamingUploader = "write.streaming.uploader"
 )

--- a/tracing/trace_handle.go
+++ b/tracing/trace_handle.go
@@ -36,6 +36,10 @@ type TraceHandle interface {
 	// Record an error on the span for export in case of failure
 	RecordError(span trace.Span, err error)
 
+	// Trace starts a span and returns a finisher function.
+	// Use it like: ctx, span, end_span := th.Trace(ctx, name, &err); defer end_span()
+	Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func())
+
 	// A handle interface method to set attributes for file cache read
 	// attribute creation and generic interface using variadic operator is a costly affair both from memory allocation and CPU time perspectives - (3.883 ns/op	       0 B/op	       0 allocs/op) vs (90.21 ns/op	     128 B/op	       1 allocs/op)
 	// This method is specifically created so that the caller doesn't have to create the attributes themselves.

--- a/tracing/trace_handle.go
+++ b/tracing/trace_handle.go
@@ -36,10 +36,6 @@ type TraceHandle interface {
 	// Record an error on the span for export in case of failure
 	RecordError(span trace.Span, err error)
 
-	// Trace starts a span and returns a finisher function.
-	// Use it like: ctx, span, end_span := th.Trace(ctx, name, &err); defer end_span()
-	Trace(ctx context.Context, name string, err *error) (context.Context, trace.Span, func())
-
 	// A handle interface method to set attributes for file cache read
 	// attribute creation and generic interface using variadic operator is a costly affair both from memory allocation and CPU time perspectives - (3.883 ns/op	       0 B/op	       0 allocs/op) vs (90.21 ns/op	     128 B/op	       1 allocs/op)
 	// This method is specifically created so that the caller doesn't have to create the attributes themselves.
@@ -49,6 +45,9 @@ type TraceHandle interface {
 
 	// A handle interface method to set attributes for upload
 	SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string)
+
+	// TraceUpload starts a span and returns a finisher function that can set upload attributes, record error and end span
+	TraceUpload(ctx context.Context, name string, objName string, bytes *int64, err *error) (context.Context, func())
 
 	// A handle interface method to retain relevant span data in new context from the older context
 	PropagateTraceContext(newCtx context.Context, oldCtx context.Context) context.Context

--- a/tracing/trace_handle.go
+++ b/tracing/trace_handle.go
@@ -43,6 +43,9 @@ type TraceHandle interface {
 	// This allows skipping the attribute creation entirely in case of noop tracer which is selected when tracing is disabled.
 	SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int)
 
+	// A handle interface method to set attributes for upload
+	SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string)
+
 	// A handle interface method to retain relevant span data in new context from the older context
 	PropagateTraceContext(newCtx context.Context, oldCtx context.Context) context.Context
 }


### PR DESCRIPTION
### Description
Adding traces in write flows to help quicker debugging.
Traces added are as below.

| Trace Name | Identifier | Description |
| :--- | :--- | :--- |
| **Write File Staged** | `write.staged` | Traces a write operation using the legacy staged writes. |
| **Write File Streaming** | `write.streaming` | Traces a write operation using the buffered writes handler. |
| **Sync File Staged** | `write.staged.sync` | Traces the synchronization of the staged temp file to GCS. |
| **Sync File Streaming** | `write.streaming.sync` | Traces the synchronization of buffered writes to GCS. |
| **Streaming Upload Block** | `write.streaming.upload.block` | Traces the upload of a single streaming block to GCS. |
| **Streaming Upload Finalize** | `write.streaming.upload.finalize` | Traces the finalization of the streaming upload. |
| **Streaming Upload Flush** | `write.streaming.upload.flush` | Traces the flushing of pending streaming writes. |
| **Streaming Uploader** | `write.streaming.uploader` | Traces the go routine uploading blocks to GCS when received |

Perf results run on the PR:

<img width="660" height="296" alt="Screenshot 2026-04-10 at 6 45 39 PM" src="https://github.com/user-attachments/assets/01d648c3-2bd0-415b-82f5-768d023830f2" />

There is no degradation on the performance of writes seen.

Attaching golang benchmark test results for the traceHandle interface. Added a method Trace to the handle for better code reuse.

goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/tracing
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
BenchmarkTrace/BenchmarkStartSpan_Otel-64         	 6412791	       188.3 ns/op	     240 B/op	       3 allocs/op
BenchmarkTrace/BenchmarkStartServerSpan_Otel-64   	 5128497	       234.1 ns/op	     272 B/op	       5 allocs/op
BenchmarkTrace/BenchmarkRecordError_Otel-64       	265906203	         4.510 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithErrorNoBytes_Otel-64         	 4450281	       269.1 ns/op	     305 B/op	       4 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithErrorWithBytes_Otel-64       	 4457209	       267.2 ns/op	     305 B/op	       4 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithoutErrorNoBytes_Otel-64      	 4598284	       260.4 ns/op	     305 B/op	       4 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithoutErrorWithBytes_Otel-64    	 4535978	       262.5 ns/op	     305 B/op	       4 allocs/op
BenchmarkTrace/BenchmarkSetCacheReadAttributes_Otel-64              	56318166	        21.30 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkSetUploadAttributes_Otel-64                 	40176628	        29.71 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkPropagateTraceContext_Otel-64               	25519111	        45.39 ns/op	      48 B/op	       1 allocs/op
BenchmarkTrace/BenchmarkStartSpan_Noop-64                           	504248462	         2.380 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkStartServerSpan_Noop-64                     	448551762	         2.675 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkRecordError_Noop-64                         	644497599	         1.861 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithErrorNoBytes_Noop-64         	447284846	         2.682 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithErrorWithBytes_Noop-64       	504384649	         2.386 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithoutErrorNoBytes_Noop-64      	446925662	         2.684 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkTraceUploadWithoutErrorWithBytes_Noop-64    	504111261	         2.379 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkSetCacheReadAttributes_Noop-64              	745226696	         1.572 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkSetUploadAttributes_Noop-64                 	799512030	         1.501 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrace/BenchmarkPropagateTraceContext_Noop-64               	534620713	         2.233 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/googlecloudplatform/gcsfuse/v3/tracing	23.932s

We check no-op is very performant to ensure tracing when disabled has minimal if not no impact to the performance.

### Link to the issue in case of a bug fix.
b/454482833

### Testing details
1. Manual 

Triggered a single file upload with sequential writes for a new file and observed the following trace(Note: GCS writer doesn't take in context, so we only see one single clear trace). Along with the object name and the upload size details.

<img width="1601" height="837" alt="Screenshot 2026-04-10 at 5 08 20 PM" src="https://github.com/user-attachments/assets/6713524e-8666-4b80-b37e-3e6a26f609b1" />


Triggered a single file upload with staged writes, below shows WriteFile making a read call to download the complete object from GCS 

<img width="1612" height="826" alt="Screenshot 2026-04-09 at 4 17 43 PM" src="https://github.com/user-attachments/assets/4e7b74f7-330a-47b6-9f08-5ef208aefaf8" />

Flush fs op shows the file content being uploaded to GCS from the tempFile.

<img width="1593" height="837" alt="Screenshot 2026-04-10 at 5 02 23 PM" src="https://github.com/user-attachments/assets/c7196ea1-a325-4d40-a2cb-6f058c1ccb55" />


2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A