### PR TITLE
test(symlink handling): remove secondary flagset from symlink_handling test package

### DIFF
--- a/tools/integration_tests/symlink_handling/symlink_handling_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_handling_test.go
@@ -86,7 +86,6 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		// If using config, GKEMountedDirectorySecondary should be set.
 		testEnv.cfg.GCSFuseMountedDirectory = testEnv.cfg.GKEMountedDirectory
 		os.Exit(m.Run())
 	}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -979,7 +979,6 @@ monitoring:
 
 symlink_handling:
   - mounted_directory: "${MOUNTED_DIR}"
-    mounted_directory_secondary: "${MOUNTED_DIR_SECONDARY}"
     test_bucket: "${BUCKET_NAME}"
     configs:
       - run: TestStandardSymlinksTestSuite


### PR DESCRIPTION
### Description
`symlink_handling` is a single mount only test package, hence, secondary flagset is redundant, Cleanup for the same.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No
