### PR TITLE
feat(tests): add package-level retry mechanism

### DIFF
--- a/tools/cd_scripts/improved_e2e_test.sh
+++ b/tools/cd_scripts/improved_e2e_test.sh
@@ -170,5 +170,8 @@ ARGS+=("--output-dir=$OUTPUT_DIR")
 # Run all packages except cloud profiler during release testing.
 ARGS+=("--run-package=!cloud_profiler")
 
+# Set --max-flake-retries to 3 for release tests.
+ARGS+=("--max-flake-retries=3")
+
 # Run the main e2e script
 bash ./tools/integration_tests/improved_run_e2e_tests.sh "${ARGS[@]}"

--- a/tools/cd_scripts/improved_e2e_test.sh
+++ b/tools/cd_scripts/improved_e2e_test.sh
@@ -170,8 +170,8 @@ ARGS+=("--output-dir=$OUTPUT_DIR")
 # Run all packages except cloud profiler during release testing.
 ARGS+=("--run-package=!cloud_profiler")
 
-# Set --max-flake-retries to 3 for release tests.
-ARGS+=("--max-flake-retries=3")
+# Set --max-flake-retries to 2 for release tests.
+ARGS+=("--max-flake-retries=2")
 
 # Run the main e2e script
 bash ./tools/integration_tests/improved_run_e2e_tests.sh "${ARGS[@]}"

--- a/tools/cd_scripts/improved_e2e_test.sh
+++ b/tools/cd_scripts/improved_e2e_test.sh
@@ -170,8 +170,8 @@ ARGS+=("--output-dir=$OUTPUT_DIR")
 # Run all packages except cloud profiler during release testing.
 ARGS+=("--run-package=!cloud_profiler")
 
-# Set --max-flake-retries to 2 for release tests.
-ARGS+=("--max-flake-retries=2")
+# Set --flake-attempts to 3 for release tests.
+ARGS+=("--flake-attempts=3")
 
 # Run the main e2e script
 bash ./tools/integration_tests/improved_run_e2e_tests.sh "${ARGS[@]}"

--- a/tools/integration_tests/create_package_runtime_table.sh
+++ b/tools/integration_tests/create_package_runtime_table.sh
@@ -30,7 +30,9 @@
 #
 # EXAMPLE FILE CONTENT:
 #     pkg1 bucket-standard 0 0 120
+#     pkg2 bucket-premium 1 0 60
 #     pkg2 bucket-premium 0 60 180
+#     pkg3 bucket-standard 1 0 120
 #     pkg3 bucket-standard 1 120 240
 # ==============================================================================
 
@@ -53,6 +55,7 @@ trap 'rm -rf "$VENV_DIR"' EXIT
 PYTHON_SCRIPT_FILE="$VENV_DIR/visualize.py"
 cat << 'EOF' > "$PYTHON_SCRIPT_FILE"
 import sys, os
+from collections import defaultdict
 
 # Column indices for the input file data
 IDX_PKG_NAME = 0
@@ -70,13 +73,12 @@ MIN_LEN_RUNTIME_BAR_HEADER = 31
 
 # Estimated padding for table columns
 PADDING_TIME_COL = 8
-PADDING_STATUS_COL = 10
+PADDING_STATUS_COL = 25
 PADDING_BORDERS = 20
 
 WIDTH_FALLBACK = 80
 SECONDS_PER_MINUTE = 60
 
-# Verify command line arguments
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} <FILE_PATH>")
     sys.exit(1)
@@ -86,40 +88,78 @@ if not os.path.isfile(path):
     print(f"Error: File '{path}' not found.")
     sys.exit(1)
 
-# Read input file, filter out empty lines, and sort alphabetically
 with open(path) as f:
-    lines = sorted([l.split() for l in f if l.strip()])
+    lines = [l.split() for l in f if l.strip()]
 
-# Use the 'rich' library to generate a pretty table visualization
+# Group by package and bucket
+groups = defaultdict(list)
+for p in lines:
+    if len(p) >= MIN_REQUIRED_FIELDS:
+        groups[(p[IDX_PKG_NAME], p[IDX_BUCKET_TYPE])].append(p)
+
+# Sort groups by package name and bucket type
+sorted_keys = sorted(groups.keys())
+
 try:
     from rich.console import Console
     from rich.table import Table
     import shutil
 
     # Calculate optimal table width based on content
-    valid_lines = [p for p in lines if len(p) >= MIN_REQUIRED_FIELDS]
-    if valid_lines:
-        max_pkg = max(MIN_LEN_PKG_NAME_HEADER, max(len(p[IDX_PKG_NAME]) for p in valid_lines))
-        max_type = max(MIN_LEN_BUCKET_TYPE_HEADER, max(len(p[IDX_BUCKET_TYPE]) for p in valid_lines))
-        max_rt = max(MIN_LEN_RUNTIME_BAR_HEADER, max(int(p[IDX_START_TIME]) // SECONDS_PER_MINUTE + (int(p[IDX_END_TIME]) - int(p[IDX_START_TIME]) + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE for p in valid_lines))
+    if groups:
+        max_pkg = max(MIN_LEN_PKG_NAME_HEADER, max(len(k[0]) for k in groups.keys()))
+        max_type = max(MIN_LEN_BUCKET_TYPE_HEADER, max(len(k[1]) for k in groups.keys()))
+        
+        # For runtime bar, we need to find the max total time
+        max_total_time = 0
+        for key, items in groups.items():
+            total_run = 0
+            total_wait = 0
+            for p in items:
+                start, end = int(p[IDX_START_TIME]), int(p[IDX_END_TIME])
+                total_wait += start // SECONDS_PER_MINUTE
+                total_run += (end - start + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE
+            max_total_time = max(max_total_time, total_wait + total_run)
+            
+        max_rt = max(MIN_LEN_RUNTIME_BAR_HEADER, max_total_time)
         table_width = max_pkg + max_type + PADDING_TIME_COL + PADDING_STATUS_COL + max_rt + PADDING_BORDERS
     else:
         table_width = WIDTH_FALLBACK
-    # Initialize Console and Table with appropriate width and styling
+
     term_width = shutil.get_terminal_size().columns
     console = Console(width=max(term_width, table_width))
     table = Table(title="e2e Test Packages Runtime", show_header=True, header_style="bold magenta")
     for col, kwargs in [("Package Name", {"style": "cyan"}), ("Bucket Type", {"style": "blue"}), 
-                        ("Time", {"justify": "right"}), ("Runtime (░=1m wait, ▓=1m run)", {}),
+                        ("Time", {"justify": "right"}), ("Runtime (░=total wait, ▓=total run)", {}),
                         ("Status", {"justify": "center"})]: table.add_column(col, **kwargs)
 
-    # Populate table rows
-    for p in lines:
-        if len(p) >= MIN_REQUIRED_FIELDS:
-            code, start, end = int(p[IDX_EXIT_CODE]), int(p[IDX_START_TIME]), int(p[IDX_END_TIME])
-            wait, run = start // SECONDS_PER_MINUTE, (end - start + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE
-            status = "[green]✅ PASSED[/]" if code == 0 else "[red]❌ FAILED[/]"
-            table.add_row(p[IDX_PKG_NAME], p[IDX_BUCKET_TYPE], f"{run}m", f"[dim]{'░'*wait}[/][cyan]{'▓'*run}[/]", status)
+    for key in sorted_keys:
+        items = groups[key]
+        pkg_name, bucket_type = key
+        
+        attempts = len(items)
+        succeeded = any(int(p[IDX_EXIT_CODE]) == 0 for p in items)
+        
+        total_wait = 0
+        total_run = 0
+        for p in items:
+            start, end = int(p[IDX_START_TIME]), int(p[IDX_END_TIME])
+            total_wait += start // SECONDS_PER_MINUTE
+            total_run += (end - start + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE
+            
+        if succeeded:
+            if attempts > 1:
+                status = f"[yellow]✅ FLAKY (Attempt {attempts})[/]"
+            else:
+                status = "[green]✅ PASSED[/]"
+        else:
+            if attempts > 1:
+                status = f"[red]❌ FAILED (Attempt {attempts})[/]"
+            else:
+                status = "[red]❌ FAILED[/]"
+                
+        table.add_row(pkg_name, bucket_type, f"{total_run}m", f"[dim]{'░'*total_wait}[/][cyan]{'▓'*total_run}[/]", status)
+        
     console.print(table)
     
 except ImportError:

--- a/tools/integration_tests/create_package_runtime_table.sh
+++ b/tools/integration_tests/create_package_runtime_table.sh
@@ -29,11 +29,11 @@
 #     <package_name> <bucket_type> <exit_code> <start_time_seconds> <end_time_seconds>
 #
 # EXAMPLE FILE CONTENT:
-#     pkg1 bucket-standard 0 0 120
-#     pkg2 bucket-premium 1 0 60
-#     pkg2 bucket-premium 0 60 180
-#     pkg3 bucket-standard 1 0 120
-#     pkg3 bucket-standard 1 120 240
+#     operations hns 0 0 120
+#     operations hns 1 0 60
+#     local_file hns 0 60 180
+#     local_file flat 1 0 120
+#     streaming_writes flat 1 120 240
 # ==============================================================================
 
 if [ "$#" -ne 1 ]; then
@@ -72,7 +72,7 @@ MIN_LEN_BUCKET_TYPE_HEADER = 11
 MIN_LEN_RUNTIME_BAR_HEADER = 31
 
 # Estimated padding for table columns
-PADDING_TIME_COL = 8
+PADDING_TIME_COL = 16
 PADDING_STATUS_COL = 25
 PADDING_BORDERS = 20
 
@@ -131,7 +131,7 @@ try:
     table = Table(title="e2e Test Packages Runtime", show_header=True, header_style="bold magenta")
     for col, kwargs in [("Package Name", {"style": "cyan"}), ("Bucket Type", {"style": "blue"}), 
                         ("Time", {"justify": "right"}), ("Runtime (░=total wait, ▓=total run)", {}),
-                        ("Status", {"justify": "center"})]: table.add_column(col, **kwargs)
+                        ("Status", {"justify": "left"})]: table.add_column(col, **kwargs)
 
     for key in sorted_keys:
         items = groups[key]
@@ -140,25 +140,47 @@ try:
         attempts = len(items)
         succeeded = any(int(p[IDX_EXIT_CODE]) == 0 for p in items)
         
-        total_wait = 0
+        icon_str = ""
+        for p in items:
+            if int(p[IDX_EXIT_CODE]) == 0:
+                icon_str += "✅"
+            else:
+                icon_str += "❌"
+
+        bar_str = ""
+        last_end = 0
         total_run = 0
+        segments = []
+        run_times = []
+        # Sort items by start time to ensure correct timeline
+        items.sort(key=lambda x: int(x[IDX_START_TIME]))
         for p in items:
             start, end = int(p[IDX_START_TIME]), int(p[IDX_END_TIME])
-            total_wait += start // SECONDS_PER_MINUTE
-            total_run += (end - start + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE
+            wait = max(0, (start - last_end) // SECONDS_PER_MINUTE)
+            run = max(1, (end - start + SECONDS_PER_MINUTE) // SECONDS_PER_MINUTE)
+            
+            seg = ""
+            if wait > 0:
+                seg += '░' * wait
+            seg += '▓' * run
+            segments.append(seg)
+            
+            run_times.append(f"{run}m")
+            last_end = end
+            total_run += run
+            
+        bar_str = '|'.join(segments)
+        time_str = ', '.join(run_times)
             
         if succeeded:
             if attempts > 1:
-                status = f"[yellow]✅ FLAKY (Attempt {attempts})[/]"
+                status = f"[yellow]FLAKED {icon_str}[/]"
             else:
-                status = "[green]✅ PASSED[/]"
+                status = "[green]PASSED ✅[/]"
         else:
-            if attempts > 1:
-                status = f"[red]❌ FAILED (Attempt {attempts})[/]"
-            else:
-                status = "[red]❌ FAILED[/]"
+            status = f"[red]FAILED {icon_str}[/]"
                 
-        table.add_row(pkg_name, bucket_type, f"{total_run}m", f"[dim]{'░'*total_wait}[/][cyan]{'▓'*total_run}[/]", status)
+        table.add_row(pkg_name, bucket_type, time_str, bar_str, status)
         
     console.print(table)
     

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -36,7 +36,7 @@ usage() {
   echo "                                                 Example: 'cloud_profiler|operations' to run only cloud_profiler and operations test packages."
   echo "                                                 Example: '!cloud_profiler|operations' to run all test packages except cloud_profiler and operations."
   echo "    --skip-emulator                              Skip running emulator tests. (Default: false)"
-  echo "    --max-flake-retries           <number>       Number of times to retry a package if it fails. (Default: 0)"
+  echo "    --flake-attempts              <number>       Number of attempts to run a package if it fails. (Default: 1)"
   echo "    --help                                       Display this help and exit."
   exit "$1"
 }
@@ -136,11 +136,11 @@ TRACK_RESOURCE_USAGE=false
 PACKAGE_LEVEL_PARALLELISM=10 # Controls how many test packages are run in parallel for hns, flat or zonal buckets.
 RUN_PACKAGE_REGEX=""
 SKIP_EMULATOR=false
-MAX_FLAKE_RETRIES=0
+FLAKE_ATTEMPTS=1
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,max-flake-retries:
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -212,8 +212,8 @@ while (( $# >= 1 )); do
             SKIP_EMULATOR=true
             shift
             ;;
-        --max-flake-retries)
-            MAX_FLAKE_RETRIES="$2"
+        --flake-attempts)
+            FLAKE_ATTEMPTS="$2"
             shift 2
             ;;
         --help)
@@ -272,7 +272,7 @@ fi
 validate_option_value "--bucket-location" "$BUCKET_LOCATION"
 validate_option_value "--project-id" "$PROJECT_ID"
 validate_option_value "--package-level-parallelism" "$PACKAGE_LEVEL_PARALLELISM"
-validate_option_value "--max-flake-retries" "$MAX_FLAKE_RETRIES"
+validate_option_value "--flake-attempts" "$FLAKE_ATTEMPTS"
 
 # Validate test install package from path
 if ${TEST_INSTALLED_PACKAGE} && [[ -n "$INSTALL_PACKAGE_FROM_PATH" ]]; then 
@@ -631,7 +631,7 @@ run_package_parallel() {
     log_error_locked "run_package_parallel() called with incorrect number of arguments."
     return 1
   fi
-  local parallelism="$1" bucket_type="$2" max_retries="$3"
+  local parallelism="$1" bucket_type="$2" flake_attempts="$3"
   shift 3
 
   local -a package_list=("$@")
@@ -655,7 +655,7 @@ run_package_parallel() {
       [[ "${package_status["$pkg"]}" -eq 0 ]] && continue
       
       # Skip if max retries exceeded
-      [[ "${package_attempt["$pkg"]}" -gt "$max_retries" ]] && continue
+      [[ "${package_attempt["$pkg"]}" -gt "$flake_attempts" ]] && continue
       
       # Skip if already running
       [[ " ${package_name_by_pid[@]} " =~ " $pkg " ]] && continue
@@ -757,7 +757,7 @@ test_package() {
 
   if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
     exit_code=1
-    if [[ "$attempt_number" -le "$MAX_FLAKE_RETRIES" ]]; then
+    if [[ "$attempt_number" -lt "$FLAKE_ATTEMPTS" ]]; then
       log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). Will retry."
     else
       log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). No more retries."
@@ -771,7 +771,7 @@ test_package() {
   # Add the package stats to the file.
   echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
   # Generate Kokoro artifacts(log) files only on terminal attempt.
-  if [[ "$exit_code" -eq 0 || "$attempt_number" -gt "$MAX_FLAKE_RETRIES" ]]; then
+  if [[ "$exit_code" -eq 0 || "$attempt_number" -ge "$FLAKE_ATTEMPTS" ]]; then
     generate_test_log_artifacts "$test_package_log_file" "$package_name" "$bucket_type"
   fi
   # Call the helper to organize logs and cleanup the original file
@@ -935,7 +935,7 @@ run_test_group() {
   local group_exit_code=0
   log_info_locked "Started running e2e tests for ${group_name} group (bucket type: ${bucket_type})."
 
-  run_package_parallel "$PACKAGE_LEVEL_PARALLELISM" "$bucket_type" "$MAX_FLAKE_RETRIES" "${test_packages[@]}"
+  run_package_parallel "$PACKAGE_LEVEL_PARALLELISM" "$bucket_type" "$FLAKE_ATTEMPTS" "${test_packages[@]}"
   group_exit_code=$?
 
   if [ "$group_exit_code" -ne 0 ]; then
@@ -961,7 +961,7 @@ run_e2e_tests_for_emulator() {
 
     if ! ./tools/integration_tests/emulator_tests/emulator_tests.sh "$TEST_INSTALLED_PACKAGE" "$BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR" > "$emulator_test_log" 2>&1; then
       exit_code=1
-      if [[ "$attempt" -le "$MAX_FLAKE_RETRIES" ]]; then
+      if [[ "$attempt" -lt "$FLAKE_ATTEMPTS" ]]; then
         log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt). Will retry."
       else
         log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt). No more retries."
@@ -977,7 +977,7 @@ run_e2e_tests_for_emulator() {
     local end=$SECONDS
     echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
 
-    if [[ "$exit_code" -eq 0 || "$attempt" -gt "$MAX_FLAKE_RETRIES" ]]; then
+    if [[ "$exit_code" -eq 0 || "$attempt" -ge "$FLAKE_ATTEMPTS" ]]; then
       break
     fi
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -423,7 +423,7 @@ acquire_lock() {
     exit 1
   fi
   local lock_file="$1"
-  local timeout_seconds=600 # 10 minutes
+  local timeout_seconds=5400 # 90 minutes
   local lock_fd
   exec {lock_fd}>"$lock_file" || {
     log_error "Could not open lock file $lock_file."

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -28,6 +28,7 @@ usage() {
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
   echo "    --zonal                                      Run tests with zonal bucket in --bucket-location region."
   echo "                                                 The placement for Zonal buckets by deafault is Zone A of --bucket-location. (Default: false)"
+  echo "    --max-flake-retries           <count>        Number of times to retry a failed test. (Default: 1)"
   echo "    --no-build-binary-in-script                  To disable building gcsfuse binary in script. (Default: false)"
   echo "    --package-level-parallelism   <parallelism>  To adjust the number of packages to execute in parallel. (Default: 10)"
   echo "    --track-resource-usage                       To track resource(cpu/mem/disk) usage during e2e run. (Default: false)"
@@ -131,6 +132,7 @@ RUN_TEST_ON_TPC_ENDPOINT=false
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 RUN_TESTS_WITH_ZONAL_BUCKET=false
 BUILD_BINARY_IN_SCRIPT=true
+MAX_FLAKE_RETRIES=1
 TRACK_RESOURCE_USAGE=false
 PACKAGE_LEVEL_PARALLELISM=10 # Controls how many test packages are run in parallel for hns, flat or zonal buckets.
 RUN_PACKAGE_REGEX=""
@@ -138,7 +140,7 @@ SKIP_EMULATOR=false
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,max-flake-retries:,track-resource-usage,output-dir:,help,run-package:,skip-emulator
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -193,6 +195,10 @@ while (( $# >= 1 )); do
         --zonal)
             RUN_TESTS_WITH_ZONAL_BUCKET=true
             shift
+            ;;
+        --max-flake-retries)
+            MAX_FLAKE_RETRIES="$2"
+            shift 2
             ;;
         --track-resource-usage)
             TRACK_RESOURCE_USAGE=true
@@ -272,6 +278,7 @@ if ${TEST_INSTALLED_PACKAGE} && [[ -n "$INSTALL_PACKAGE_FROM_PATH" ]]; then
   log_error "Option --test-installed-package and --install-package-from-path are mutually exclusive. Please set only one"
   usage 1
 fi
+validate_option_value "--max-flake-retries" "$MAX_FLAKE_RETRIES"
 
 # Zonal Bucket location validation.
 if ${RUN_TESTS_WITH_ZONAL_BUCKET}; then
@@ -717,29 +724,58 @@ test_package() {
     go_test_cmd_parts+=("--gcsfuse_prebuilt_dir=${BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR}")
   fi
 
-  local go_test_cmd test_package_log_file start=$SECONDS exit_code=0 
+  local go_test_cmd start exit_code=0 end
   # Use printf %q to quote each argument safely for eval
   # This ensures spaces and special characters within arguments are handled correctly.
   go_test_cmd=$(printf "%q " "${go_test_cmd_parts[@]}")
-  test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}.txt")
-  # Run the package test command and capture log output with runtime stats.
-  log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name]"
 
-  if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
-    exit_code=1
-    log_info "Failed test package [$package_name] for bucket type [$bucket_type]"
-  else
-    log_info "Passed test package [$package_name] for bucket type [$bucket_type]"
-  fi
+  local attempt=0
+  while : ; do
+    start=$SECONDS
+    local current_log_file
+    if [ "$attempt" -eq 0 ]; then
+      current_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}.txt")
+    else
+      current_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}/retry_attempt_${attempt}.txt")
+    fi
+    
+    log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt $((attempt + 1)))"
 
-  local end=$SECONDS
+    if ! eval "$go_test_cmd" > "$current_log_file" 2>&1; then
+      exit_code=1
+      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt $((attempt + 1)))"
+    else
+      exit_code=0
+      log_info "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt $((attempt + 1)))"
+    fi
+    end=$SECONDS
 
-  # Add the package stats to the file.
-  echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
-  # Generate Kokoro artifacts(log) files.
-  generate_test_log_artifacts "$test_package_log_file" "$package_name" "$bucket_type"
-  # Call the helper to organize logs and cleanup the original file
-  organize_test_logfile "$exit_code" "$test_package_log_file" "$package_name" "$bucket_type"
+    # Add the package stats to the file after EVERY attempt.
+    echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+
+    # Organize log file
+    local base_filename="$package_name"
+    if [ "$attempt" -gt 0 ]; then
+      base_filename="${package_name}_attempt_${attempt}"
+    fi
+    
+    # Generate artifacts for Kokoro if this is the last attempt
+    if [[ "$exit_code" -eq 0 ]] || [ "$attempt" -eq "$MAX_FLAKE_RETRIES" ]; then
+      generate_test_log_artifacts "$current_log_file" "$package_name" "$bucket_type"
+    fi
+
+    organize_test_logfile "$exit_code" "$current_log_file" "$base_filename" "$bucket_type"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    if [ "$attempt" -gt "$MAX_FLAKE_RETRIES" ]; then
+      break
+    fi
+  done
+
   return "$exit_code"
 }
 

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -28,7 +28,6 @@ usage() {
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
   echo "    --zonal                                      Run tests with zonal bucket in --bucket-location region."
   echo "                                                 The placement for Zonal buckets by deafault is Zone A of --bucket-location. (Default: false)"
-  echo "    --max-flake-retries           <count>        Number of times to retry a failed test. (Default: 1)"
   echo "    --no-build-binary-in-script                  To disable building gcsfuse binary in script. (Default: false)"
   echo "    --package-level-parallelism   <parallelism>  To adjust the number of packages to execute in parallel. (Default: 10)"
   echo "    --track-resource-usage                       To track resource(cpu/mem/disk) usage during e2e run. (Default: false)"
@@ -37,6 +36,7 @@ usage() {
   echo "                                                 Example: 'cloud_profiler|operations' to run only cloud_profiler and operations test packages."
   echo "                                                 Example: '!cloud_profiler|operations' to run all test packages except cloud_profiler and operations."
   echo "    --skip-emulator                              Skip running emulator tests. (Default: false)"
+  echo "    --max-flake-retries           <number>       Number of times to retry a package if it fails. (Default: 0)"
   echo "    --help                                       Display this help and exit."
   exit "$1"
 }
@@ -132,15 +132,15 @@ RUN_TEST_ON_TPC_ENDPOINT=false
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 RUN_TESTS_WITH_ZONAL_BUCKET=false
 BUILD_BINARY_IN_SCRIPT=true
-MAX_FLAKE_RETRIES=1
 TRACK_RESOURCE_USAGE=false
 PACKAGE_LEVEL_PARALLELISM=10 # Controls how many test packages are run in parallel for hns, flat or zonal buckets.
 RUN_PACKAGE_REGEX=""
 SKIP_EMULATOR=false
+MAX_FLAKE_RETRIES=0
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,max-flake-retries:,track-resource-usage,output-dir:,help,run-package:,skip-emulator
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,max-flake-retries:
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -196,10 +196,6 @@ while (( $# >= 1 )); do
             RUN_TESTS_WITH_ZONAL_BUCKET=true
             shift
             ;;
-        --max-flake-retries)
-            MAX_FLAKE_RETRIES="$2"
-            shift 2
-            ;;
         --track-resource-usage)
             TRACK_RESOURCE_USAGE=true
             shift
@@ -215,6 +211,10 @@ while (( $# >= 1 )); do
         --skip-emulator)
             SKIP_EMULATOR=true
             shift
+            ;;
+        --max-flake-retries)
+            MAX_FLAKE_RETRIES="$2"
+            shift 2
             ;;
         --help)
             usage 0
@@ -272,13 +272,13 @@ fi
 validate_option_value "--bucket-location" "$BUCKET_LOCATION"
 validate_option_value "--project-id" "$PROJECT_ID"
 validate_option_value "--package-level-parallelism" "$PACKAGE_LEVEL_PARALLELISM"
+validate_option_value "--max-flake-retries" "$MAX_FLAKE_RETRIES"
 
 # Validate test install package from path
 if ${TEST_INSTALLED_PACKAGE} && [[ -n "$INSTALL_PACKAGE_FROM_PATH" ]]; then 
   log_error "Option --test-installed-package and --install-package-from-path are mutually exclusive. Please set only one"
   usage 1
 fi
-validate_option_value "--max-flake-retries" "$MAX_FLAKE_RETRIES"
 
 # Zonal Bucket location validation.
 if ${RUN_TESTS_WITH_ZONAL_BUCKET}; then
@@ -382,21 +382,6 @@ filter_array() {
   mapfile -t arr < <(printf '%s\n' "${arr[@]}" | grep $invert -E "$regex")
 }
 
-# expand_package_list: Expands an array of packages to include retry attempts.
-# Args: $1 = name of the array variable, $2 = max retries.
-expand_package_list() {
-  local -n arr=$1
-  local max_retries=$2
-  local -a expanded=()
-
-  for attempt in $(seq 1 $max_retries); do
-    for pkg in "${arr[@]}"; do
-      expanded+=("$pkg $attempt")
-    done
-  done
-  arr=("${expanded[@]}")
-}
-
 # Test packages for regional buckets.
 TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "inactive_stream_timeout" "cloud_profiler" "requester_pays_bucket")
 # Test packages for zonal buckets.
@@ -410,11 +395,6 @@ if [[ -n "$RUN_PACKAGE_REGEX" ]]; then
   filter_array TEST_PACKAGES_FOR_ZB "$RUN_PACKAGE_REGEX"
 fi
 
-expand_package_list TEST_PACKAGES_FOR_RB "$MAX_FLAKE_RETRIES"
-expand_package_list TEST_PACKAGES_FOR_ZB "$MAX_FLAKE_RETRIES"
-expand_package_list TEST_PACKAGES_FOR_TPC "$MAX_FLAKE_RETRIES"
-
-
 # acquire_lock: Acquires exclusive lock or exits script on failure.
 # Args: $1 = path to lock file.
 acquire_lock() {
@@ -423,52 +403,48 @@ acquire_lock() {
     exit 1
   fi
   local lock_file="$1"
-  local timeout_seconds=5400 # 90 minutes
-  local lock_fd
-  exec {lock_fd}>"$lock_file" || {
+  local timeout_seconds=600 # 10 minutes
+  exec 200>"$lock_file" || {
     log_error "Could not open lock file $lock_file."
     exit 1
   }
   # Attempt to acquire the lock with a timeout
-  if ! flock -x -w "$timeout_seconds" "$lock_fd"; then
+  if ! flock -x -w "$timeout_seconds" 200; then
     log_error "Failed to acquire lock on $lock_file within $timeout_seconds seconds."
     # Close the file descriptor if the lock was not acquired
-    exec {lock_fd}>&-
+    exec 200>&-
     exit 1
   fi
-  LAST_LOCK_FD="$lock_fd"
   return 0
 }
 
 # release_lock: Releases lock or exits script on failure.
-# Args: $1 = lock file descriptor
+# Args: $1 = path to lock file
 release_lock() {
-  local lock_fd="$1"
-  if [[ -z "$lock_fd" ]]; then
-    log_error "release_lock: Lock file descriptor is required."
+  if [[ -z "$1" ]]; then
+    log_error "release_lock: Lock file path is required."
     exit 1
   fi
-  exec {lock_fd}>&- || {
-    log_error "Failed to close lock file descriptor $lock_fd."
+  local lock_file="$1"
+  [[ -e "/proc/self/fd/200" || -L "/proc/self/fd/200" ]] && exec 200>&- || {
+    log_error "Lock file descriptor (FD 200) not open for $lock_file. Possible previous error or double release."
     exit 1
-  }
+  } # FD not open or close failed
   return 0
 }
 
 # logs info to stdout exclusively. used in background commands to ensure logs aren't interleaved.
 log_info_locked() {
   acquire_lock "$LOG_LOCK_FILE"
-  local fd="$LAST_LOCK_FD"
   log_info "$1"
-  release_lock "$fd"
+  release_lock "$LOG_LOCK_FILE"
 }
 
 # logs error to stdout exclusively. Used in background commands to ensure logs aren't interleaved.
 log_error_locked() {
   acquire_lock "$LOG_LOCK_FILE"
-  local fd="$LAST_LOCK_FD"
   log_error "$1"
-  release_lock "$fd"
+  release_lock "$LOG_LOCK_FILE"
 }
 
 # Helper method to organize the test log file based on exit code and bucket type.
@@ -531,11 +507,10 @@ create_bucket() {
       return 1
     fi
     acquire_lock "$BUCKET_CREATION_LOCK_FILE"
-    local fd="$LAST_LOCK_FD"
     eval "$bucket_cmd" > "$bucket_cmd_log" 2>&1
     local status=$?
     sleep "$DELAY_BETWEEN_BUCKET_CREATION" # have 6 seconds gap between creating buckets.
-    release_lock "$fd"
+    release_lock "$BUCKET_CREATION_LOCK_FILE"
     if [ $status -eq 0 ]; then
       break
     fi
@@ -543,9 +518,8 @@ create_bucket() {
   echo "$bucket_name"
   # Append to created buckets list file for cleanup
   acquire_lock "$BUCKET_CREATION_LOCK_FILE"
-  local fd="$LAST_LOCK_FD"
   echo "$bucket_name" >> "$CREATED_BUCKETS_LIST_FILE"
-  release_lock "$fd"
+  release_lock "$BUCKET_CREATION_LOCK_FILE"
   rm -rf "$bucket_cmd_log"
   return 0
 }
@@ -640,132 +614,112 @@ clean_up() {
   cleanup_created_buckets
 }
 
-# Helper method to process any of the background process and
-# returns exit status of waited pid.
-process_any_pid() {
-  local -n cmds_by_pid_ref="$1"
-  local waited_pid
-  local pid_status # To store the exit status of the waited pid
-
-  wait -n -p waited_pid # waited_pid gets the PID, $? gets the status
-  pid_status=$?
-
-  unset "cmds_by_pid_ref[$waited_pid]"
-  if [[ "$pid_status" -ne 0 ]]; then
+# run_package_parallel: Executes test packages in parallel.
+#   The function returns a non-zero exit status if any of the packages fail all attempts.
+#
+# Usage: run_package_parallel "parallelism" "bucket_type" "max_retries" "package1" "package2" ...
+#   First argument is extent of parallelism for this command.
+#   Second argument is the bucket type ("flat", "hns", "zonal").
+#   Third argument is the maximum number of retries for failed commands.
+#   Rest of the arguments are package names to run.
+#
+# Example:
+#   run_package_parallel 2 "flat" 2 "managed_folders" "operations" "read_large_files"
+# This command will run at max 2 packages in parallel, with up to 2 retries on failure.
+run_package_parallel() {
+  if [[ $# -lt 3 ]]; then
+    log_error_locked "run_package_parallel() called with incorrect number of arguments."
     return 1
   fi
+  local parallelism="$1" bucket_type="$2" max_retries="$3"
+  shift 3
+
+  local -a package_list=("$@")
+  local -A package_status=()
+  local -A package_attempt=()
+
+  for pkg in "${package_list[@]}"; do
+    package_status["$pkg"]=1
+    package_attempt["$pkg"]=1
+  done
+
+  local -A package_name_by_pid=()
+
+  while :; do
+    # Launch packages up to parallelism limit
+    for pkg in "${package_list[@]}"; do
+      # Skip if we hit parallelism limit
+      [[ ${#package_name_by_pid[@]} -ge $parallelism ]] && continue
+      
+      # Skip if package already succeeded
+      [[ "${package_status["$pkg"]}" -eq 0 ]] && continue
+      
+      # Skip if max retries exceeded
+      [[ "${package_attempt["$pkg"]}" -gt "$max_retries" ]] && continue
+      
+      # Skip if already running
+      [[ " ${package_name_by_pid[@]} " =~ " $pkg " ]] && continue
+      
+      create_bucket_and_run_package "${bucket_type}" "$pkg" "${package_attempt["$pkg"]}" &
+      local pid=$!
+      package_name_by_pid["$pid"]="$pkg"
+    done
+
+    # Break if no commands are running
+    [[ ${#package_name_by_pid[@]} -eq 0 ]] && break
+
+    # Wait for any background process to finish
+    local waited_pid
+    wait -n -p waited_pid
+    local exit_status=$?
+    
+    local pkg="${package_name_by_pid[$waited_pid]}"
+    unset "package_name_by_pid[$waited_pid]"
+    
+    package_status["$pkg"]=$exit_status
+
+    if [[ "$exit_status" -ne 0 ]]; then
+      package_attempt["$pkg"]=$((package_attempt[$pkg] + 1))
+    fi
+  done
+
+  # Return non-zero if any package failed all attempts
+  for s in "${package_status[@]}"; do
+    if [[ "$s" -ne 0 ]]; then
+      return 1
+    fi
+  done
+  
   return 0
 }
 
-# run_parallel: Executes commands in parallel based on a template and substitutes.
-#   The function returns a non-zero exit status if any of the parallel commands fail.
-#
-# Usage: run_parallel "parallelism" "command_template_with_@" "substitute1" "substitute2" ...
-#   First argument is extent of parallelism for this command.
-#   Second argument is the command template with single @.
-#   Rest of the arguments are values that would be substituted in the command template.
-#
-# Example:
-#   run_parallel 2 "echo 'Processing @' && sleep 1" "itemA" "itemB" "itemC"
-# This command will run at max 2 commands in parallel.
-run_parallel() {
-  if [[ $# -lt 2 ]]; then
-    log_error_locked "run_parallel() called with incorrect number of arguments."
-    return 1
-  fi
-  local parallelism="$1"
-  shift
-  local cmd_template="$1"
-  shift
-  local -A cmds_by_pid=()
-  local overall_exit_code=0 parallel_cmd pid
-  # Launch parallel commands in the background based on parallelism.
-  for arg in "$@"; do
-    parallel_cmd="${cmd_template//@/$arg}"
-    eval "$parallel_cmd" &
-    pid=$!
-    cmds_by_pid["$pid"]="$parallel_cmd"
-    if [[ ${#cmds_by_pid[@]} -eq $parallelism ]]; then
-      process_any_pid "cmds_by_pid"
-      overall_exit_code=$((overall_exit_code || $? ))
-    fi
-  done
-  # Process any remaining PIDs
-  while [[ ${#cmds_by_pid[@]} -gt 0 ]]; do
-      process_any_pid "cmds_by_pid"
-      overall_exit_code=$((overall_exit_code || $? ))
-  done
-  return $overall_exit_code
-}
-
 # Helper method that creates a bucket and then runs the test package.
-create_bucket_and_run_test() {
-  if [[ $# -ne 2 ]]; then
-    log_error_locked "create_bucket_and_run_test() called with incorrect number of arguments."
+create_bucket_and_run_package() {
+  if [[ $# -ne 3 ]]; then
+    log_error_locked "create_bucket_and_run_package() called with incorrect number of arguments."
     return 1
   fi
-  local pkg_arg="$1"
-  local bucket_type="$2"
+  local bucket_type="$1"
+  local package_name="$2"
+  local attempt_number="$3"
 
-  # Extract base package name and attempt
-  local package_name="$pkg_arg"
-  local attempt=1
-  if [[ "$pkg_arg" =~ (.*)[[:space:]]([0-9]+) ]]; then
-    package_name="${BASH_REMATCH[1]}"
-    attempt="${BASH_REMATCH[2]}"
-  fi
-
-  # Check if already successful (fast path without lock)
-  if [ -f "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success" ]; then
-    log_info_locked "Package [$package_name] already succeeded for bucket type [$bucket_type]. Skipping $pkg_arg."
-    return 0
-  fi
-
-  # Create a lock file for this package
-  local pkg_lock_file="${OUTPUT_DIR}/locks/${package_name}.lock"
-  mkdir -p "$(dirname "$pkg_lock_file")"
-
-  # Acquire lock for the package
-  acquire_lock "$pkg_lock_file"
-  local fd="$LAST_LOCK_FD"
-
-  # Check again after acquiring lock
-  if [ -f "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success" ]; then
-    log_info_locked "Package [$package_name] already succeeded for bucket type [$bucket_type] (checked after lock). Skipping $pkg_arg."
-    release_lock "$fd"
-    return 0
-  fi
-
-  local exit_code=0
-  local bucket_name
   if ! bucket_name=$(create_bucket "$package_name" "$bucket_type"); then
     log_error_locked "Failed to create bucket of type ${bucket_type} for package ${package_name}. Bucket creation output: ${bucket_name}"
-    exit_code=1
-  else
-    test_package "$package_name" "$bucket_name" "$bucket_type" "$attempt"
-    exit_code=$?
+    return 1
   fi
-
-  # If successful, mark it in status file
-  if [ $exit_code -eq 0 ]; then
-    mkdir -p "${OUTPUT_DIR}/status"
-    touch "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success"
-  fi
-
-  release_lock "$fd"
-  return $exit_code
+  test_package "$package_name" "$bucket_name" "$bucket_type" "$attempt_number"
 }
 
-# Helper method to executes e2e test package.
+# Helper method to execute an E2E test package.
 test_package() {
-  if [[ $# -lt 3 || $# -gt 4 ]]; then
+  if [[ $# -ne 4 ]]; then
     log_error_locked "test_package() called with incorrect number of arguments."
     return 1
   fi
   local package_name="$1"
   local bucket_name="$2"
   local bucket_type="$3"
-  local attempt="${4:-1}"
+  local attempt_number="$4"
 
   # Build go package test command.
   local go_test_cmd_parts=("GODEBUG=asyncpreemptoff=1" "go" "test" "-v" "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m" "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}")
@@ -793,29 +747,35 @@ test_package() {
     go_test_cmd_parts+=("--gcsfuse_prebuilt_dir=${BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR}")
   fi
 
-  local go_test_cmd start exit_code=0 end
+  local go_test_cmd test_package_log_file start=$SECONDS exit_code=0 
+  # Use printf %q to quote each argument safely for eval
+  # This ensures spaces and special characters within arguments are handled correctly.
   go_test_cmd=$(printf "%q " "${go_test_cmd_parts[@]}")
-
-  start=$SECONDS
-  test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_${attempt}.txt")
-
-  log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] as [${package_name}_${attempt}]"
+  test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_attempt_${attempt_number}.txt")
+  # Run the package test command and capture log output with runtime stats.
+  log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt: $attempt_number)"
 
   if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
     exit_code=1
-    log_info "Failed test package [$package_name] for bucket type [$bucket_type] as [${package_name}_${attempt}]"
+    if [[ "$attempt_number" -le "$MAX_FLAKE_RETRIES" ]]; then
+      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). Will retry."
+    else
+      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). No more retries."
+    fi
   else
-    exit_code=0
-    log_info "Passed test package [$package_name] for bucket type [$bucket_type] as [${package_name}_${attempt}]"
+    log_info "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number)"
   fi
-  end=$SECONDS
 
- # Add the package stats to the file.
+  local end=$SECONDS
+
+  # Add the package stats to the file.
   echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
-  # Generate Kokoro artifacts(log) files.
-  generate_test_log_artifacts "$test_package_log_file" "$package_name" "$bucket_type"
+  # Generate Kokoro artifacts(log) files only on terminal attempt.
+  if [[ "$exit_code" -eq 0 || "$attempt_number" -gt "$MAX_FLAKE_RETRIES" ]]; then
+    generate_test_log_artifacts "$test_package_log_file" "$package_name" "$bucket_type"
+  fi
   # Call the helper to organize logs and cleanup the original file
-  organize_test_logfile "$exit_code" "$test_package_log_file" "$package_name" "$bucket_type"
+  organize_test_logfile "$exit_code" "$test_package_log_file" "${package_name}_attempt_${attempt_number}" "$bucket_type"
   return "$exit_code"
 }
 
@@ -975,7 +935,7 @@ run_test_group() {
   local group_exit_code=0
   log_info_locked "Started running e2e tests for ${group_name} group (bucket type: ${bucket_type})."
 
-  run_parallel "$PACKAGE_LEVEL_PARALLELISM" "create_bucket_and_run_test '@' ${bucket_type}" "${test_packages[@]}"
+  run_package_parallel "$PACKAGE_LEVEL_PARALLELISM" "$bucket_type" "$MAX_FLAKE_RETRIES" "${test_packages[@]}"
   group_exit_code=$?
 
   if [ "$group_exit_code" -ne 0 ]; then
@@ -989,24 +949,40 @@ run_test_group() {
 run_e2e_tests_for_emulator() {
   local package_name="emulator_tests"
   local bucket_type="emulator"
-  local start=$SECONDS
-
-  log_info_locked "Started running e2e tests for emulator."
-  local emulator_test_log
-  emulator_test_log=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}.txt")
 
   local exit_code=0
-  if ! ./tools/integration_tests/emulator_tests/emulator_tests.sh "$TEST_INSTALLED_PACKAGE" "$BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR" > "$emulator_test_log" 2>&1; then
-    log_error_locked "Failed e2e tests for emulator."
-    exit_code=1
-  else
-    log_info_locked "Passed e2e tests for emulator."
-  fi
-  local end=$SECONDS
-  echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+  local attempt=1
 
-  # Call the helper to organize logs and cleanup the original file
-  organize_test_logfile "$exit_code" "$emulator_test_log" "$package_name" "$bucket_type" 
+  while :; do
+    local start=$SECONDS
+    emulator_test_log=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_attempt_${attempt}.txt")
+
+    log_info_locked "Started running test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt)"
+
+    if ! ./tools/integration_tests/emulator_tests/emulator_tests.sh "$TEST_INSTALLED_PACKAGE" "$BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR" > "$emulator_test_log" 2>&1; then
+      exit_code=1
+      if [[ "$attempt" -le "$MAX_FLAKE_RETRIES" ]]; then
+        log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt). Will retry."
+      else
+        log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt). No more retries."
+      fi
+    else
+      log_info_locked "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt)"
+      exit_code=0
+    fi
+
+    # Call the helper to organize logs and cleanup the original file
+    organize_test_logfile "$exit_code" "$emulator_test_log" "${package_name}_attempt_${attempt}" "$bucket_type"
+
+    local end=$SECONDS
+    echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+
+    if [[ "$exit_code" -eq 0 || "$attempt" -gt "$MAX_FLAKE_RETRIES" ]]; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+  done
 
   return "$exit_code"
 }

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -382,6 +382,21 @@ filter_array() {
   mapfile -t arr < <(printf '%s\n' "${arr[@]}" | grep $invert -E "$regex")
 }
 
+# expand_package_list: Expands an array of packages to include retry attempts.
+# Args: $1 = name of the array variable, $2 = max retries.
+expand_package_list() {
+  local -n arr=$1
+  local max_retries=$2
+  local -a expanded=()
+
+  for attempt in $(seq 1 $max_retries); do
+    for pkg in "${arr[@]}"; do
+      expanded+=("$pkg $attempt")
+    done
+  done
+  arr=("${expanded[@]}")
+}
+
 # Test packages for regional buckets.
 TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "inactive_stream_timeout" "cloud_profiler" "requester_pays_bucket")
 # Test packages for zonal buckets.
@@ -394,6 +409,11 @@ if [[ -n "$RUN_PACKAGE_REGEX" ]]; then
   filter_array TEST_PACKAGES_FOR_RB "$RUN_PACKAGE_REGEX"
   filter_array TEST_PACKAGES_FOR_ZB "$RUN_PACKAGE_REGEX"
 fi
+
+expand_package_list TEST_PACKAGES_FOR_RB "$MAX_FLAKE_RETRIES"
+expand_package_list TEST_PACKAGES_FOR_ZB "$MAX_FLAKE_RETRIES"
+expand_package_list TEST_PACKAGES_FOR_TPC "$MAX_FLAKE_RETRIES"
+
 
 # acquire_lock: Acquires exclusive lock or exits script on failure.
 # Args: $1 = path to lock file.
@@ -678,25 +698,67 @@ create_bucket_and_run_test() {
     log_error_locked "create_bucket_and_run_test() called with incorrect number of arguments."
     return 1
   fi
-  local package_name="$1"
+  local pkg_arg="$1"
   local bucket_type="$2"
 
+  # Extract base package name and attempt
+  local package_name="$pkg_arg"
+  local attempt=1
+  if [[ "$pkg_arg" =~ (.*)[[:space:]]([0-9]+) ]]; then
+    package_name="${BASH_REMATCH[1]}"
+    attempt="${BASH_REMATCH[2]}"
+  fi
+
+  # Check if already successful (fast path without lock)
+  if [ -f "${OUTPUT_DIR}/status/${package_name}.success" ]; then
+    log_info_locked "Package [$package_name] already succeeded. Skipping $pkg_arg."
+    return 0
+  fi
+
+  # Create a lock file for this package
+  local pkg_lock_file="${OUTPUT_DIR}/locks/${package_name}.lock"
+  mkdir -p "$(dirname "$pkg_lock_file")"
+
+  # Acquire lock for the package
+  acquire_lock "$pkg_lock_file"
+
+  # Check again after acquiring lock
+  if [ -f "${OUTPUT_DIR}/status/${package_name}.success" ]; then
+    log_info_locked "Package [$package_name] already succeeded (checked after lock). Skipping $pkg_arg."
+    release_lock "$pkg_lock_file"
+    return 0
+  fi
+
+  local exit_code=0
+  local bucket_name
   if ! bucket_name=$(create_bucket "$package_name" "$bucket_type"); then
     log_error_locked "Failed to create bucket of type ${bucket_type} for package ${package_name}. Bucket creation output: ${bucket_name}"
-    return 1
+    exit_code=1
+  else
+    test_package "$package_name" "$bucket_name" "$bucket_type" "$attempt"
+    exit_code=$?
   fi
-  test_package "$package_name" "$bucket_name" "$bucket_type"
+
+  # If successful, mark it in status file
+  if [ $exit_code -eq 0 ]; then
+    mkdir -p "${OUTPUT_DIR}/status"
+    touch "${OUTPUT_DIR}/status/${package_name}.success"
+  fi
+
+  release_lock "$pkg_lock_file"
+  return $exit_code
 }
 
 # Helper method to executes e2e test package.
 test_package() {
-  if [[ $# -ne 3 ]]; then
+  if [[ $# -lt 3 || $# -gt 4 ]]; then
     log_error_locked "test_package() called with incorrect number of arguments."
     return 1
   fi
   local package_name="$1"
   local bucket_name="$2"
   local bucket_type="$3"
+  local attempt="${4:-1}"
 
   # Build go package test command.
   local go_test_cmd_parts=("GODEBUG=asyncpreemptoff=1" "go" "test" "-v" "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m" "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}")
@@ -725,57 +787,28 @@ test_package() {
   fi
 
   local go_test_cmd start exit_code=0 end
-  # Use printf %q to quote each argument safely for eval
-  # This ensures spaces and special characters within arguments are handled correctly.
   go_test_cmd=$(printf "%q " "${go_test_cmd_parts[@]}")
 
-  local attempt=0
-  while : ; do
-    start=$SECONDS
-    local current_log_file
-    if [ "$attempt" -eq 0 ]; then
-      current_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}.txt")
-    else
-      current_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}/retry_attempt_${attempt}.txt")
-    fi
-    
-    log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt $((attempt + 1)))"
+  start=$SECONDS
+  test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_${attempt}.txt")
 
-    if ! eval "$go_test_cmd" > "$current_log_file" 2>&1; then
-      exit_code=1
-      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt $((attempt + 1)))"
-    else
-      exit_code=0
-      log_info "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt $((attempt + 1)))"
-    fi
-    end=$SECONDS
+  log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] as [${package_name}_${attempt}]"
 
-    # Add the package stats to the file after EVERY attempt.
-    echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+  if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
+    exit_code=1
+    log_info "Failed test package [$package_name] for bucket type [$bucket_type] as [${package_name}_${attempt}]"
+  else
+    exit_code=0
+    log_info "Passed test package [$package_name] for bucket type [$bucket_type] as [${package_name}_${attempt}]"
+  fi
+  end=$SECONDS
 
-    # Organize log file
-    local base_filename="$package_name"
-    if [ "$attempt" -gt 0 ]; then
-      base_filename="${package_name}_attempt_${attempt}"
-    fi
-    
-    # Generate artifacts for Kokoro if this is the last attempt
-    if [[ "$exit_code" -eq 0 ]] || [ "$attempt" -eq "$MAX_FLAKE_RETRIES" ]; then
-      generate_test_log_artifacts "$current_log_file" "$package_name" "$bucket_type"
-    fi
-
-    organize_test_logfile "$exit_code" "$current_log_file" "$base_filename" "$bucket_type"
-
-    if [[ "$exit_code" -eq 0 ]]; then
-      break
-    fi
-
-    attempt=$((attempt + 1))
-    if [ "$attempt" -gt "$MAX_FLAKE_RETRIES" ]; then
-      break
-    fi
-  done
-
+ # Add the package stats to the file.
+  echo "${package_name} ${bucket_type} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+  # Generate Kokoro artifacts(log) files.
+  generate_test_log_artifacts "$test_package_log_file" "$package_name" "$bucket_type"
+  # Call the helper to organize logs and cleanup the original file
+  organize_test_logfile "$exit_code" "$test_package_log_file" "$package_name" "$bucket_type"
   return "$exit_code"
 }
 
@@ -935,7 +968,7 @@ run_test_group() {
   local group_exit_code=0
   log_info_locked "Started running e2e tests for ${group_name} group (bucket type: ${bucket_type})."
 
-  run_parallel "$PACKAGE_LEVEL_PARALLELISM" "create_bucket_and_run_test @ ${bucket_type}" "${test_packages[@]}"
+  run_parallel "$PACKAGE_LEVEL_PARALLELISM" "create_bucket_and_run_test '@' ${bucket_type}" "${test_packages[@]}"
   group_exit_code=$?
 
   if [ "$group_exit_code" -ne 0 ]; then

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -424,47 +424,51 @@ acquire_lock() {
   fi
   local lock_file="$1"
   local timeout_seconds=600 # 10 minutes
-  exec 200>"$lock_file" || {
+  local lock_fd
+  exec {lock_fd}>"$lock_file" || {
     log_error "Could not open lock file $lock_file."
     exit 1
   }
   # Attempt to acquire the lock with a timeout
-  if ! flock -x -w "$timeout_seconds" 200; then
+  if ! flock -x -w "$timeout_seconds" "$lock_fd"; then
     log_error "Failed to acquire lock on $lock_file within $timeout_seconds seconds."
     # Close the file descriptor if the lock was not acquired
-    exec 200>&-
+    exec {lock_fd}>&-
     exit 1
   fi
+  LAST_LOCK_FD="$lock_fd"
   return 0
 }
 
 # release_lock: Releases lock or exits script on failure.
-# Args: $1 = path to lock file
+# Args: $1 = lock file descriptor
 release_lock() {
-  if [[ -z "$1" ]]; then
-    log_error "release_lock: Lock file path is required."
+  local lock_fd="$1"
+  if [[ -z "$lock_fd" ]]; then
+    log_error "release_lock: Lock file descriptor is required."
     exit 1
   fi
-  local lock_file="$1"
-  [[ -e "/proc/self/fd/200" || -L "/proc/self/fd/200" ]] && exec 200>&- || {
-    log_error "Lock file descriptor (FD 200) not open for $lock_file. Possible previous error or double release."
+  exec {lock_fd}>&- || {
+    log_error "Failed to close lock file descriptor $lock_fd."
     exit 1
-  } # FD not open or close failed
+  }
   return 0
 }
 
 # logs info to stdout exclusively. used in background commands to ensure logs aren't interleaved.
 log_info_locked() {
   acquire_lock "$LOG_LOCK_FILE"
+  local fd="$LAST_LOCK_FD"
   log_info "$1"
-  release_lock "$LOG_LOCK_FILE"
+  release_lock "$fd"
 }
 
 # logs error to stdout exclusively. Used in background commands to ensure logs aren't interleaved.
 log_error_locked() {
   acquire_lock "$LOG_LOCK_FILE"
+  local fd="$LAST_LOCK_FD"
   log_error "$1"
-  release_lock "$LOG_LOCK_FILE"
+  release_lock "$fd"
 }
 
 # Helper method to organize the test log file based on exit code and bucket type.
@@ -527,10 +531,11 @@ create_bucket() {
       return 1
     fi
     acquire_lock "$BUCKET_CREATION_LOCK_FILE"
+    local fd="$LAST_LOCK_FD"
     eval "$bucket_cmd" > "$bucket_cmd_log" 2>&1
     local status=$?
     sleep "$DELAY_BETWEEN_BUCKET_CREATION" # have 6 seconds gap between creating buckets.
-    release_lock "$BUCKET_CREATION_LOCK_FILE"
+    release_lock "$fd"
     if [ $status -eq 0 ]; then
       break
     fi
@@ -538,8 +543,9 @@ create_bucket() {
   echo "$bucket_name"
   # Append to created buckets list file for cleanup
   acquire_lock "$BUCKET_CREATION_LOCK_FILE"
+  local fd="$LAST_LOCK_FD"
   echo "$bucket_name" >> "$CREATED_BUCKETS_LIST_FILE"
-  release_lock "$BUCKET_CREATION_LOCK_FILE"
+  release_lock "$fd"
   rm -rf "$bucket_cmd_log"
   return 0
 }
@@ -710,8 +716,8 @@ create_bucket_and_run_test() {
   fi
 
   # Check if already successful (fast path without lock)
-  if [ -f "${OUTPUT_DIR}/status/${package_name}.success" ]; then
-    log_info_locked "Package [$package_name] already succeeded. Skipping $pkg_arg."
+  if [ -f "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success" ]; then
+    log_info_locked "Package [$package_name] already succeeded for bucket type [$bucket_type]. Skipping $pkg_arg."
     return 0
   fi
 
@@ -721,11 +727,12 @@ create_bucket_and_run_test() {
 
   # Acquire lock for the package
   acquire_lock "$pkg_lock_file"
+  local fd="$LAST_LOCK_FD"
 
   # Check again after acquiring lock
-  if [ -f "${OUTPUT_DIR}/status/${package_name}.success" ]; then
-    log_info_locked "Package [$package_name] already succeeded (checked after lock). Skipping $pkg_arg."
-    release_lock "$pkg_lock_file"
+  if [ -f "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success" ]; then
+    log_info_locked "Package [$package_name] already succeeded for bucket type [$bucket_type] (checked after lock). Skipping $pkg_arg."
+    release_lock "$fd"
     return 0
   fi
 
@@ -742,10 +749,10 @@ create_bucket_and_run_test() {
   # If successful, mark it in status file
   if [ $exit_code -eq 0 ]; then
     mkdir -p "${OUTPUT_DIR}/status"
-    touch "${OUTPUT_DIR}/status/${package_name}.success"
+    touch "${OUTPUT_DIR}/status/${package_name}_${bucket_type}.success"
   fi
 
-  release_lock "$pkg_lock_file"
+  release_lock "$fd"
   return $exit_code
 }
 


### PR DESCRIPTION
### Description
This PR introduces a robust retry mechanism to reduce flakiness in integration tests.

Key changes include:

1. **Package-Level Retries for E2E Tests**:
    * Modified `tools/integration_tests/improved_run_e2e_tests.sh` to support retrying entire test packages when they fail.
    * Added a new flag `--flake-attempts` to control the total number of attempts to run a package if it fails (defaults to 1).
    * Updated `tools/cd_scripts/improved_e2e_test.sh` to set `--flake-attempts=3` for release tests.
    * Test log files now include the attempt number in their filenames (e.g., `[package_name]_attempt_[number].txt`) so that logs from prior attempts are preserved.

2. **Enhanced Test Reporting**:
    * Updated `tools/integration_tests/create_package_runtime_table.sh` to track and correctly report these retry attempts.
    * Test packages that pass after a retry can now be accurately reflected in the final summary table.

### Link to the issue
[b/496104155](https://b.corp.google.com/issues/496104155)

### Testing details
1. **Manual**: Verified that running with `--flake-attempts` correctly triggers retries on failure and logs attempts in the summary table.

### **With the retries:**  (used a failure simulator)
<img width="707" height="372" alt="image" src="https://github.com/user-attachments/assets/37b4ff75-8bf2-44cd-a655-e650cbf19f71" />

### **Without the retries:**
<img width="655" height="263" alt="image" src="https://github.com/user-attachments/assets/2c731af0-9e88-4162-8c48-4860d507cef4" />



### Any backward incompatible change?
No.