### PR TITLE
feat(consistent symlink): add complete set of integration tests for symlinks-  read and other symlink operations

### DIFF
--- a/tools/integration_tests/symlink_handling/symlink_operations_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_operations_test.go
@@ -18,8 +18,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -28,42 +26,33 @@ import (
 
 // TestCreateSymlink tests the creation of symlinks.
 func (s *BaseSymlinkSuite) TestCreateSymlink() {
-	target := s.createTempFile()
-	linkName := setup.GenerateRandomString(5)
-
 	// Create the symlink
-	_ = s.createSymlink(linkName, target)
+	_ = s.createSymlink(s.linkName, s.targetPath)
 
 	// Validate the underlying GCS Object
-	s.validateBackingGCSObjectForSymlink(linkName, target, s.isStandardSymlink)
+	s.validateBackingGCSObjectForSymlink(s.linkName, s.targetPath, s.isStandardSymlink)
 }
 
 // TestReadSymlinkTest tests reading a symlink's target.
 func (s *BaseSymlinkSuite) TestReadSymlinkTest() {
-	linkName := setup.GenerateRandomString(5)
-	target := "target_file_path"
-	s.createGCSSymlinkObject(linkName, target)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
 
 	result, err := os.Readlink(linkPath)
 
 	s.Require().NoError(err)
-	s.Assert().Equal(target, result)
+	s.Assert().Equal(s.targetPath, result)
 }
 
 // TestReadFileViaSymlink tests reading a file through a symlink.
 func (s *BaseSymlinkSuite) TestReadFileViaSymlink() {
-	prefix := setup.GenerateRandomString(5)
 	const content = "hello world"
-	targetName := prefix + "target.txt"
-	linkName := prefix + "link"
 	// Create a target file with content.
-	targetPath := path.Join(s.testDirPath, targetName)
-	err := os.WriteFile(targetPath, []byte(content), 0644)
+	err := os.WriteFile(s.targetPath, []byte(content), 0644)
 	s.Require().NoError(err)
 	// Create a symlink to the target file.
-	s.createGCSSymlinkObject(linkName, targetName)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
 
 	// Read file via symlink.
 	readContent, err := os.ReadFile(linkPath)
@@ -75,45 +64,37 @@ func (s *BaseSymlinkSuite) TestReadFileViaSymlink() {
 
 // TestWriteFileViaSymlink tests writing to a file through a symlink.
 func (s *BaseSymlinkSuite) TestWriteFileViaSymlink() {
-	prefix := setup.GenerateRandomString(5)
 	const content = "new content"
-	targetName := prefix + "target.txt"
-	linkName := prefix + "link"
 	// Create an empty target file.
-	targetPath := path.Join(s.testDirPath, targetName)
-	f, err := os.Create(targetPath)
+	f, err := os.Create(s.targetPath)
 	s.Require().NoError(err)
 	s.Require().NoError(f.Close())
 	// Create a symlink to the target file.
-	s.createGCSSymlinkObject(linkName, targetName)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
 
 	// Write to file via symlink.
 	err = os.WriteFile(linkPath, []byte(content), 0644)
 	s.Require().NoError(err)
 
 	// Verify content of the original file.
-	readContent, err := os.ReadFile(targetPath)
+	readContent, err := os.ReadFile(s.targetPath)
 	s.Require().NoError(err)
 	s.Assert().Equal(content, string(readContent))
 }
 
 // TestListDirViaSymlink tests listing a directory through a symlink.
 func (s *BaseSymlinkSuite) TestListDirViaSymlink() {
-	prefix := setup.GenerateRandomString(5)
-	targetDirName := prefix + "target_dir"
-	linkName := prefix + "link"
 	fileName := "file_in_dir.txt"
 	// Create a target directory with a file.
-	targetDirPath := path.Join(s.testDirPath, targetDirName)
-	err := os.Mkdir(targetDirPath, 0755)
+	err := os.Mkdir(s.targetPath, 0755)
 	s.Require().NoError(err)
-	filePath := path.Join(targetDirPath, fileName)
-	err = os.WriteFile(filePath, []byte(""), 0644)
+	filePath := path.Join(s.targetPath, fileName)
+	err = os.WriteFile(filePath, []byte("content"), 0644)
 	s.Require().NoError(err)
 	// Create a symlink to the target directory.
-	s.createGCSSymlinkObject(linkName, targetDirName)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
 
 	// List directory via symlink.
 	entries, err := os.ReadDir(linkPath)
@@ -126,17 +107,14 @@ func (s *BaseSymlinkSuite) TestListDirViaSymlink() {
 
 // TestRenameSymlink tests renaming a symlink.
 func (s *BaseSymlinkSuite) TestRenameSymlink() {
-	prefix := setup.GenerateRandomString(5)
-	targetName := prefix + "target.txt"
-	linkName := prefix + "link"
-	newLinkName := prefix + "new_link"
+	newLinkName := s.linkName + "_renamed"
 	// Create a target file.
-	targetPath := path.Join(s.testDirPath, targetName)
-	err := os.WriteFile(targetPath, []byte("content"), 0644)
+	err := os.WriteFile(s.targetPath, []byte("content"), 0644)
 	s.Require().NoError(err)
 	// Create a symlink to the target file.
-	s.createGCSSymlinkObject(linkName, targetName)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
+
 	newLinkPath := path.Join(s.testDirPath, newLinkName)
 
 	// Rename the symlink.
@@ -150,27 +128,23 @@ func (s *BaseSymlinkSuite) TestRenameSymlink() {
 	fi, err := os.Lstat(newLinkPath)
 	s.Require().NoError(err)
 	s.Assert().True(fi.Mode()&os.ModeSymlink != 0)
-	readTarget, err := os.Readlink(newLinkPath)
+	readTargetName, err := os.Readlink(newLinkPath)
 	s.Require().NoError(err)
-	s.Assert().Equal(targetName, readTarget)
+	s.Assert().Equal(s.targetPath, readTargetName)
 	// Verify target file is untouched.
-	_, err = os.Stat(targetPath)
+	_, err = os.Stat(s.targetPath)
 	s.Assert().NoError(err)
 }
 
 // TestCopySymlink tests copying a symlink without dereferencing.
 func (s *BaseSymlinkSuite) TestCopySymlink() {
-	prefix := setup.GenerateRandomString(5)
-	targetName := prefix + "target.txt"
-	linkName := prefix + "link"
-	newLinkName := prefix + "new_link"
+	newLinkName := s.linkName + "_copied"
 	// Create a target file.
-	targetPath := path.Join(s.testDirPath, targetName)
-	err := os.WriteFile(targetPath, []byte("content"), 0644)
+	err := os.WriteFile(s.targetPath, []byte("content"), 0644)
 	s.Require().NoError(err)
 	// Create a symlink to the target file.
-	s.createGCSSymlinkObject(linkName, targetName)
-	linkPath := path.Join(s.testDirPath, linkName)
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
 	newLinkPath := path.Join(s.testDirPath, newLinkName)
 
 	// Copy the symlink using cp -P to ensure no dereferencing.
@@ -185,10 +159,10 @@ func (s *BaseSymlinkSuite) TestCopySymlink() {
 	fi, err := os.Lstat(newLinkPath)
 	s.Require().NoError(err)
 	s.Assert().True(fi.Mode()&os.ModeSymlink != 0)
-	readTarget, err := os.Readlink(newLinkPath)
+	readTargetName, err := os.Readlink(newLinkPath)
 	s.Require().NoError(err)
-	s.Assert().Equal(targetName, readTarget)
+	s.Assert().Equal(s.targetPath, readTargetName)
 	// Verify target file is untouched.
-	_, err = os.Stat(targetPath)
+	_, err = os.Stat(s.targetPath)
 	s.Assert().NoError(err)
 }

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -35,6 +35,10 @@ type BaseSymlinkSuite struct {
 	mntDir            string
 	testDirPath       string
 	isStandardSymlink bool
+	// linkName is the name of the symlink (relative to testDirPath).
+	linkName string
+	// targetPath is the absolute path of the target file/dir .
+	targetPath string
 }
 
 // StandardSymlinksTestSuite groups all test related to symlinks following standard representation.
@@ -58,6 +62,9 @@ func (s *BaseSymlinkSuite) SetupTest() {
 		s.Require().NoError(err)
 		s.testDirPath = setup.SetupTestDirectory(TestDirName)
 	}
+	// Initialize common variables for symlink tests, ensuring they are unique for each test method.
+	s.linkName = setup.GenerateRandomString(5) + "_link"
+	s.targetPath = path.Join(s.testDirPath, setup.GenerateRandomString(5))
 }
 
 func (s *BaseSymlinkSuite) TearDownTest() {


### PR DESCRIPTION
### Description
This PR introduces a comprehensive suite of integration tests to validate the Consistent Symlink Handling feature in GCSFuse . These tests ensure that GCSFuse can correctly interpret and manage symbolic links in two distinct formats:

- Standard GCS Representation: STS-compatible symlinks where the target path is stored as object content and the metadata `goog-reserved-file-is-symlink: true` is present .
- Legacy GCSFuse Representation: Backward compatibility for symlinks using the `gcsfuse_symlink_target` custom metadata .

The new test suite covers various filesystem operations through symlinks, including:

- Reading and creating symlinks in both standard and legacy formats .
- Reading and writing to files through symlinks .
- Listing directories via symlink targets .
- Renaming and copying symlinks without dereferencing (cp -P) .
- Validation of the backing GCS object structure (metadata and content) for both representations .

### Link to the issue in case of a bug fix.
[b/489058517](b/489058517)
[b/489268223](b/489268223)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated.

### Any backward incompatible change? If so, please explain.
No.