### PR TITLE
test(cloud profiler package): Improve cloud profiler test package and optimize pagination for profile lookup

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -386,6 +386,8 @@ type CloudProfilerConfig struct {
 	Label string `yaml:"label"`
 
 	Mutex bool `yaml:"mutex"`
+
+	ServiceName string `yaml:"service-name"`
 }
 
 type Config struct {
@@ -799,6 +801,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("cloud-profiler-mutex", "", false, "Enables mutex cloud-profiler. This only works when --enable-cloud-profiler is set to true.")
 
 	if err := flagSet.MarkHidden("cloud-profiler-mutex"); err != nil {
+		return err
+	}
+
+	flagSet.StringP("cloud-profiler-service-name", "", "gcsfuse", "The service name for cloud-profiler. This only works when --enable-cloud-profiler is set to true.")
+
+	if err := flagSet.MarkHidden("cloud-profiler-service-name"); err != nil {
 		return err
 	}
 
@@ -1442,6 +1450,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("cloud-profiler.mutex", flagSet.Lookup("cloud-profiler-mutex")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("cloud-profiler.service-name", flagSet.Lookup("cloud-profiler-service-name")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -125,6 +125,13 @@ params:
     default: false
     hide-flag: true
 
+  - config-path: "cloud-profiler.service-name"
+    flag-name: "cloud-profiler-service-name"
+    type: "string"
+    usage: "The service name for cloud-profiler. This only works when --enable-cloud-profiler is set to true."
+    default: "gcsfuse"
+    hide-flag: true
+
   - config-path: "debug.exit-on-invariant-violation"
     flag-name: "debug_invariants"
     type: "bool"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2182,6 +2182,7 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 				AllocatedHeap: true,  // Default for --cloud-profiler-allocated-heap
 				Heap:          true,  // Default for --cloud-profiler-heap
 				Goroutines:    false, // Default for --cloud-profiler-goroutines
+				ServiceName:   "gcsfuse",
 			},
 		},
 		{
@@ -2195,6 +2196,7 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 				AllocatedHeap: true,
 				Heap:          true,
 				Goroutines:    false,
+				ServiceName:   "gcsfuse",
 			},
 		},
 		{
@@ -2208,6 +2210,7 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 				AllocatedHeap: true,
 				Heap:          true,
 				Goroutines:    true,
+				ServiceName:   "gcsfuse",
 			},
 		},
 		{
@@ -2221,6 +2224,7 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 				AllocatedHeap: false,
 				Heap:          false,
 				Goroutines:    false,
+				ServiceName:   "gcsfuse",
 			},
 		},
 		{
@@ -2234,6 +2238,21 @@ func TestArgsParsing_ProfilerFlags(t *testing.T) {
 				AllocatedHeap: true,  // Default for its flag
 				Heap:          true,  // Default for its flag
 				Goroutines:    false, // Default for its flag
+				ServiceName:   "gcsfuse",
+			},
+		},
+		{
+			name: "Profiler enabled, custom service name set",
+			args: []string{"gcsfuse", "--enable-cloud-profiler", "--cloud-profiler-service-name=custom_service", "bucket", "mountpoint"},
+			expectedConfig: cfg.CloudProfilerConfig{
+				Enabled:       true,
+				Label:         "gcsfuse-0.0.0",
+				Mutex:         false,
+				Cpu:           true,
+				AllocatedHeap: true,
+				Heap:          true,
+				Goroutines:    false,
+				ServiceName:   "custom_service",
 			},
 		},
 	}

--- a/internal/profiler/cloud_profiler.go
+++ b/internal/profiler/cloud_profiler.go
@@ -36,7 +36,7 @@ func setupCloudProfiler(mpc *cfg.CloudProfilerConfig, startFunc startFunctionTyp
 	}
 
 	pConfig := cloudprofiler.Config{
-		Service:              "gcsfuse",
+		Service:              mpc.ServiceName,
 		ServiceVersion:       mpc.Label,
 		MutexProfiling:       mpc.Mutex,
 		NoCPUProfiling:       !mpc.Cpu,
@@ -50,6 +50,6 @@ func setupCloudProfiler(mpc *cfg.CloudProfilerConfig, startFunc startFunctionTyp
 		return err
 	}
 
-	logger.Info("Cloud Profiler started successfully.")
+	logger.Infof("Cloud Profiler started successfully with Service Name: %s for version: %s", mpc.ServiceName, mpc.Label)
 	return nil
 }

--- a/internal/profiler/cloud_profiler_test.go
+++ b/internal/profiler/cloud_profiler_test.go
@@ -57,6 +57,7 @@ func TestSetupCloudProfiler_EnabledSuccess(t *testing.T) {
 		AllocatedHeap: false,
 		Heap:          true,
 		Goroutines:    false,
+		ServiceName:   "gcsfuse",
 	}
 
 	err := setupCloudProfiler(cloudProfilerConfig, profilerStart)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -36,10 +36,10 @@ import (
 )
 
 const (
-	testDirName           = "CloudProfilerTest"
-	testSuffix            = "cloud-profiler-test"
-	retryFrequency        = 30 * time.Second
-	retryDuration         = 10 * time.Minute
+	testDirName    = "CloudProfilerTest"
+	testSuffix     = "cloud-profiler-test"
+	retryFrequency = 30 * time.Second
+	retryDuration  = 10 * time.Minute
 )
 
 var (

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -94,6 +95,9 @@ func TestMain(m *testing.M) {
 		testServiceNameFlag := fmt.Sprintf(" --cloud-profiler-service-name=%s", testServiceName)
 		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testVersionFlag + testServiceNameFlag
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+	} else if cfg.CloudProfiler[0].GKEMountedDirectory == "" {
+		cfg.CloudProfiler[0].Configs[0].Flags[0] = strings.ReplaceAll(cfg.CloudProfiler[0].Configs[0].Flags[0], "--cloud-profiler-label=", fmt.Sprintf("--cloud-profiler-label=%s", testVersionName))
+		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + fmt.Sprintf(" --cloud-profiler-service-name=%s", testServiceName)
 	}
 
 	ctx = context.Background()

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -88,7 +88,7 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.CloudProfiler[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.CloudProfiler[0].Configs[0].Flags = []string{
-			"--log-severity=TRACE --enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap",
+			"--enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap",
 		}
 		testVersionFlag := fmt.Sprintf(" --cloud-profiler-label=%s", testVersionName)
 		testServiceNameFlag := fmt.Sprintf(" --cloud-profiler-service-name=%s", testServiceName)

--- a/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
+++ b/tools/integration_tests/cloud_profiler/cloud_profiler_test.go
@@ -21,13 +21,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path"
-	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/google/uuid"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
@@ -36,15 +36,37 @@ import (
 )
 
 const (
-	testDirName     = "CloudProfilerTest"
-	testServiceName = "gcsfuse"
+	testDirName           = "CloudProfilerTest"
+	testSuffix            = "cloud-profiler-test"
+	retryFrequency        = 30 * time.Second
+	retryDuration         = 10 * time.Minute
 )
 
 var (
-	storageClient      *storage.Client
-	testServiceVersion string
-	ctx                context.Context
+	storageClient   *storage.Client
+	testVersionName string
+	testServiceName string
+	ctx             context.Context
 )
+
+// The alphabet defines the sort order: 0 is smallest, z is largest.
+const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+const fixedLength = 13 // math.MaxInt64 in base 36 fits in 13 characters.
+
+// getDecreasingString generates a string that decreases lexicographically as time increases, making newer items appear earlier in sorted results.
+func getDecreasingString() string {
+	// Calculate the decreasing value
+	val := uint64(math.MaxInt64 - time.Now().UnixNano())
+
+	// Map the value to our 36-character alphabet
+	res := make([]byte, fixedLength)
+	for i := fixedLength - 1; i >= 0; i-- {
+		res[i] = alphabet[val%36]
+		val /= 36
+	}
+
+	return string(res)
+}
 
 ////////////////////////////////////////////////////////////////////////
 // TestMain
@@ -52,7 +74,9 @@ var (
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-
+	prefix := getDecreasingString()
+	testServiceName = fmt.Sprintf("%s-%s", prefix, testSuffix)
+	testVersionName = fmt.Sprintf("%s-%s", prefix, testSuffix)
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.CloudProfiler) == 0 {
@@ -64,10 +88,11 @@ func TestMain(m *testing.M) {
 		cfg.CloudProfiler[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.CloudProfiler[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.CloudProfiler[0].Configs[0].Flags = []string{
-			"--enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap",
+			"--log-severity=TRACE --enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap",
 		}
-		testServiceVersionFlag := fmt.Sprintf(" --cloud-profiler-label=%s", testServiceVersion)
-		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testServiceVersionFlag
+		testVersionFlag := fmt.Sprintf(" --cloud-profiler-label=%s", testVersionName)
+		testServiceNameFlag := fmt.Sprintf(" --cloud-profiler-service-name=%s", testServiceName)
+		cfg.CloudProfiler[0].Configs[0].Flags[0] = cfg.CloudProfiler[0].Configs[0].Flags[0] + testVersionFlag + testServiceNameFlag
 		cfg.CloudProfiler[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
@@ -86,16 +111,15 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if cfg.CloudProfiler[0].GKEMountedDirectory != "" {
-		testServiceVersion = setup.ExtractServiceVersionFromFlags(cfg.CloudProfiler[0].Configs[0].Flags)
+		testVersionName = setup.ExtractServiceVersionFromFlags(cfg.CloudProfiler[0].Configs[0].Flags)
+		testServiceName = setup.CloudProfilerServiceNameFromFlags(cfg.CloudProfiler[0].Configs[0].Flags)
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.CloudProfiler[0].GKEMountedDirectory, m))
 	}
 
-	testServiceVersion = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
-	logger.Infof("Enabling cloud profiler with version tag: %s", testServiceVersion)
+	logger.Infof("Enabling cloud profiler with Service Name: %s and version: %s", testServiceName, testVersionName)
 
 	// Run tests for testBucket
 	// 4. Build the flag sets dynamically from the config.
-	cfg.CloudProfiler[0].Configs[0].Flags[0] = strings.ReplaceAll(cfg.CloudProfiler[0].Configs[0].Flags[0], "--cloud-profiler-label=", fmt.Sprintf("--cloud-profiler-label=%s", testServiceVersion))
 	flags := setup.BuildFlagSets(cfg.CloudProfiler[0], bucketType, "")
 
 	setup.SetUpTestDirForTestBucket(&cfg.CloudProfiler[0])

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -132,11 +132,11 @@ func (s *CloudProfilerSuite) TestValidateProfilerWithActualService() {
 		t.Fatalf("Failed to create Cloud Profiler API client: %v", err)
 	}
 	t.Logf("Waiting for cloud profile to eventually appear for service [%s] and version [%s]", testServiceName, testVersionName)
-	operations.RetryUntil(apiCtx, t, retryFrequency, retryDuration, func() (bool, error) {
+	operations.RetryUntil(apiCtx, t, retryFrequency, retryDuration, func(ctx context.Context) (bool, error) {
 		if err := s.writeSingleRandomFile(); err != nil {
 			t.Logf("Failed to write load file: %v. So profile generation may be affected...", err)
 		}
-		return checkIfProfileExistForServiceAndVersion(apiCtx, t, profilerAPIClient, projectID)
+		return checkIfProfileExistForServiceAndVersion(ctx, t, profilerAPIClient, projectID)
 	})
 }
 

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -48,11 +48,14 @@ func (s *CloudProfilerSuite) writeSingleRandomFile() error {
 	if err != nil {
 		return fmt.Errorf("failed to create load file: %v", err)
 	}
-	defer f.Close()
-
 	if _, err = f.Write(data); err != nil {
 		return fmt.Errorf("failed to write to load file %s: %v", fileName, err)
 	}
+
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("failed to close load file %s: %v", fileName, err)
+	}
+
 	t.Logf("Successfully wrote 100MB to %s", fileName)
 	return nil
 }

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -132,11 +132,11 @@ func (s *CloudProfilerSuite) TestValidateProfilerWithActualService() {
 		t.Fatalf("Failed to create Cloud Profiler API client: %v", err)
 	}
 	t.Logf("Waiting for cloud profile to eventually appear for service [%s] and version [%s]", testServiceName, testVersionName)
-	operations.RetryUntil(apiCtx, t, retryFrequency, retryDuration, func(ctx context.Context) (bool, error) {
+	operations.RetryUntil(apiCtx, t, retryFrequency, retryDuration, func() (bool, error) {
 		if err := s.writeSingleRandomFile(); err != nil {
 			t.Logf("Failed to write load file: %v. So profile generation may be affected...", err)
 		}
-		return checkIfProfileExistForServiceAndVersion(ctx, t, profilerAPIClient, projectID)
+		return checkIfProfileExistForServiceAndVersion(apiCtx, t, profilerAPIClient, projectID)
 	})
 }
 

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -57,7 +57,6 @@ func (s *CloudProfilerSuite) writeSingleRandomFile() error {
 	return nil
 }
 
-
 func getGCPProjectID(t *testing.T) string {
 	fetchProjectCtx, fetchProjectCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer fetchProjectCancel()

--- a/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
+++ b/tools/integration_tests/cloud_profiler/with_gcp_profiler_service_test.go
@@ -16,16 +16,47 @@ package cloud_profiler_test
 
 import (
 	"context"
-	"errors"
+	"crypto/rand"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"cloud.google.com/go/compute/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	gcpProfiler "google.golang.org/api/cloudprofiler/v2"
 	"google.golang.org/api/option"
 )
+
+type CloudProfilerSuite struct {
+	suite.Suite
+}
+
+func (s *CloudProfilerSuite) writeSingleRandomFile() error {
+	t := s.T()
+	data := make([]byte, 100*1024*1024)
+	if _, err := rand.Read(data); err != nil {
+		return fmt.Errorf("failed to generate random data: %v", err)
+	}
+
+	fileName := filepath.Join(setup.MntDir(), fmt.Sprintf("load_file_%d.bin", time.Now().UnixNano()))
+	f, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("failed to create load file: %v", err)
+	}
+	defer f.Close()
+
+	if _, err = f.Write(data); err != nil {
+		return fmt.Errorf("failed to write to load file %s: %v", fileName, err)
+	}
+	t.Logf("Successfully wrote 100MB to %s", fileName)
+	return nil
+}
+
 
 func getGCPProjectID(t *testing.T) string {
 	fetchProjectCtx, fetchProjectCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -50,15 +81,15 @@ func checkIfProfileExistForServiceAndVersion(
 	t *testing.T, // Pass testing.T for logging within the helper
 	profilerAPIClient *gcpProfiler.Service,
 	projectID string,
-) bool {
+) (bool, error) {
 
-	t.Logf("Querying profiles for service [%s] version [%s]", testServiceName, testServiceVersion)
+	t.Logf("Querying profiles for service [%s] with version [%s]", testServiceName, testVersionName)
 
-	listCtx, listCancel := context.WithTimeout(ctx, 10*time.Minute)
+	listCtx, listCancel := context.WithCancel(ctx)
 	defer listCancel()
 
 	pagesFetched := 0
-	completedErr := errors.New("completed")
+	profileFound := false
 	listCall := profilerAPIClient.Projects.Profiles.List(fmt.Sprintf("projects/%s", projectID))
 	err := listCall.Pages(listCtx, func(resp *gcpProfiler.ListProfilesResponse) error {
 		pagesFetched++
@@ -67,33 +98,27 @@ func checkIfProfileExistForServiceAndVersion(
 			if p.Deployment == nil || p.Deployment.Labels == nil {
 				continue
 			}
-
+			// Since results are sorted on page listing, seeing a greater name means our profile is not yet available.
+			if p.Deployment.Target > testServiceName {
+				return fmt.Errorf("Didn't find matching profile after fetching %d pages, profile not yet available.", pagesFetched)
+			}
 			// Return if matching profile found.
-			if p.Deployment.Target == testServiceName && p.Deployment.Labels["version"] == testServiceVersion {
-				t.Logf("Found matching profile: Type=%s, ID=%s", p.ProfileType, p.Deployment.Labels["version"])
-				return completedErr
+			if p.Deployment.Target == testServiceName && p.Deployment.Labels["version"] == testVersionName {
+				t.Logf("Found matching profile: Type=%s, ServiceName=%s, Version=%s", p.ProfileType, p.Deployment.Target, p.Deployment.Labels["version"])
+				profileFound = true
+				return fmt.Errorf("Returning error on success to break pagination early")
 			}
 		}
-		return nil // Continue to the next page
+		return nil
 	})
-	if err != nil && err != completedErr {
-		t.Logf("while listing: %v", err)
-		return false
+	if profileFound {
+		return true, nil
 	}
-
-	if pagesFetched == 0 {
-		t.Logf("No profiles found")
-		return false
-	}
-
-	return true
+	return false, err
 }
 
-func TestValidateProfilerWithActualService(t *testing.T) {
-	// GCSFuse process will be started as part of mount.
-	// Allow some time to export the profile data to GCP profiler service.
-	time.Sleep(2*time.Minute + 30*time.Second)
-
+func (s *CloudProfilerSuite) TestValidateProfilerWithActualService() {
+	t := s.T()
 	// 1. Fetch GCP projectID.
 	// 2. Create a profiler service api client.
 	// 3. Make list call to the profiler service api client and fetch the profiles.
@@ -104,7 +129,15 @@ func TestValidateProfilerWithActualService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Cloud Profiler API client: %v", err)
 	}
-	if !checkIfProfileExistForServiceAndVersion(apiCtx, t, profilerAPIClient, projectID) {
-		t.Errorf("No valid profile found for service [%s] and version [%s]", testServiceName, testServiceVersion)
-	}
+	t.Logf("Waiting for cloud profile to eventually appear for service [%s] and version [%s]", testServiceName, testVersionName)
+	operations.RetryUntil(apiCtx, t, retryFrequency, retryDuration, func() (bool, error) {
+		if err := s.writeSingleRandomFile(); err != nil {
+			t.Logf("Failed to write load file: %v. So profile generation may be affected...", err)
+		}
+		return checkIfProfileExistForServiceAndVersion(apiCtx, t, profilerAPIClient, projectID)
+	})
+}
+
+func TestCloudProfilerSuite(t *testing.T) {
+	suite.Run(t, new(CloudProfilerSuite))
 }

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -102,7 +102,7 @@ func RetryUntil[T any](
 	tb testing.TB,
 	retryFrequency time.Duration,
 	retryDeadline time.Duration,
-	operation func(ctx context.Context) (T, error),
+	operation func() (T, error),
 ) T {
 	tb.Helper()
 
@@ -121,7 +121,7 @@ func RetryUntil[T any](
 	var lastErr error // Save last error for fatal log
 
 	for {
-		result, err := operation(ctx)
+		result, err := operation()
 		if err == nil {
 			// It can be helpful to know if an operation was flaky
 			// but eventually succeeded during verbose test runs.

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -102,7 +102,7 @@ func RetryUntil[T any](
 	tb testing.TB,
 	retryFrequency time.Duration,
 	retryDeadline time.Duration,
-	operation func() (T, error),
+	operation func(ctx context.Context) (T, error),
 ) T {
 	tb.Helper()
 
@@ -121,7 +121,7 @@ func RetryUntil[T any](
 	var lastErr error // Save last error for fatal log
 
 	for {
-		result, err := operation()
+		result, err := operation(ctx)
 		if err == nil {
 			// It can be helpful to know if an operation was flaky
 			// but eventually succeeded during verbose test runs.

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -816,6 +816,22 @@ func ExtractServiceVersionFromFlags(flags []string) string {
 	return ""
 }
 
+// CloudProfilerServiceNameFromFlags parses the cloud-profiler-service-name from a slice of flag strings.
+func CloudProfilerServiceNameFromFlags(flags []string) string {
+	// Regex to find --cloud-profiler-service-name=some_value or --cloud-profiler-service-name some_value
+	re := regexp.MustCompile(`--cloud-profiler-service-name[=\s]([^\s]+)`)
+	for _, flagSet := range flags {
+		matches := re.FindStringSubmatch(flagSet)
+		// matches[0] is the full match, e.g., "--cloud-profiler-service-name=v1"
+		// matches[1] is the first capturing group, e.g., "v1"
+		if len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	// If not provided then return default value for profiler service name.
+	return "gcsfuse"
+}
+
 func OverrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
 	for _, flags := range t.Configs {
 		for i := range flags.Flags {


### PR DESCRIPTION
### Description
Implements a robust retry mechanism for Cloud Profiler integration tests, ensures profile generation by writing load data, and optimizes the profile lookup pagination.

* CloudProfilerServiceNameFromFlags: Added a helper to parse the --cloud-profiler-service-name flag from test configurations.
* Active Load Generation: Added writeSingleRandomFile to write a 100MB random file during retries, ensuring the GCSFuse process triggers profile data exportation.
* Pagination Optimization: Updated checkIfProfileExistForServiceAndVersion to break pagination early if it encounters a service name greater than our target (because results are sorted), preventing unnecessary API calls.
* Flake Reduction with Retries: Refactored TestValidateProfilerWithActualService to use operations.RetryUntil instead of a static 2.5-minute sleep, allowing the test to pass as soon as the profile appears.
* Testify Suite Migration: Converted the test to use testify/suite for better test management.

### Why not use "gcsfuse" service name
If we were to use gcsfuse service name then even if we generated version name lexicographically smaller. It's always possible that someone runs a gcsfuse with a version  which is lower than all versions generated by test causing a humongous pagination to pass through those profiles unnecessary and would result in timeout and package failure. Using custom service name which are lexicographically smaller to each other is less likely a problem as long as people do not generate huge number of profiles with non-default service names which would be rare as this flag has a default value while the label doesn't. 

### Test Runs:
Package is able to complete successfully in 2 mins.
```
  GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0  /usr/local/go/bin/go  test ./tools/integration_tests/cloud_profiler/... -count=1 -v --integrationTest --testInstalledPackage=false --testbucket=mohitkyadav-usw4-hns --timeout 60m
{"timestamp":{"seconds":1774583074,"nanos":947299180},"severity":"INFO","message":"No configuration found for cloud profiler tests in config. Using flags instead."}
{"timestamp":{"seconds":1774583075,"nanos":358634720},"severity":"INFO","message":"Enabling cloud profiler with Service Name: 1klbrbcv3zm2z-cloud-profiler-test and version: 1klbrbcv3zm2z-cloud-profiler-test"}
{"timestamp":{"seconds":1774583075,"nanos":358714604},"severity":"INFO","message":"Building GCSFuse from source in the dir: /tmp/gcsfuse_readwrite_test_1446376621 ..."}
{"timestamp":{"seconds":1774583075,"nanos":358737198},"severity":"INFO","message":"Building build_gcsfuse at /tmp/gcsfuse_integration_tests1635877258/build_gcsfuse"}
{"timestamp":{"seconds":1774583078,"nanos":293140507},"severity":"INFO","message":"Building gcsfuse into /tmp/gcsfuse_readwrite_test_1446376621"}
{"timestamp":{"seconds":1774583092,"nanos":355165070},"severity":"INFO","message":"Running static mounting tests..."}
{"timestamp":{"seconds":1774583092,"nanos":355190514},"severity":"INFO","message":"GCSFuse Log File for test: /tmp/gcsfuse_readwrite_test_1446376621/gcsfuse.log"}
{"timestamp":{"seconds":1774583092,"nanos":532378875},"severity":"INFO","message":"Running static mounting tests with flags: [--log-severity=TRACE --enable-cloud-profiler --cloud-profiler-cpu --cloud-profiler-heap --cloud-profiler-goroutines --cloud-profiler-mutex --cloud-profiler-allocated-heap --cloud-profiler-label=1klbrbcv3zm2z-cloud-profiler-test --cloud-profiler-service-name=1klbrbcv3zm2z-cloud-profiler-test]"}
=== RUN   TestCloudProfilerSuite
=== RUN   TestCloudProfilerSuite/TestValidateProfilerWithActualService
    with_gcp_profiler_service_test.go:134: Waiting for cloud profile to eventually appear for service [1klbrbcv3zm2z-cloud-profiler-test] and version [1klbrbcv3zm2z-cloud-profiler-test]
    with_gcp_profiler_service_test.go:59: Successfully wrote 100MB to /tmp/gcsfuse_readwrite_test_1446376621/mnt/load_file_1774583092773084242.bin
    with_gcp_profiler_service_test.go:88: Querying profiles for service [1klbrbcv3zm2z-cloud-profiler-test] with version [1klbrbcv3zm2z-cloud-profiler-test]
    with_gcp_profiler_service_test.go:98: Processing page 1 of profiles, number of profiles in page: 1000
    with_gcp_profiler_service_test.go:135: Attempt 1 failed with error: Didn't find matching profile after fetching 1 pages, profile not yet available.. Retrying in 30s...
    with_gcp_profiler_service_test.go:59: Successfully wrote 100MB to /tmp/gcsfuse_readwrite_test_1446376621/mnt/load_file_1774583122780644456.bin
    with_gcp_profiler_service_test.go:88: Querying profiles for service [1klbrbcv3zm2z-cloud-profiler-test] with version [1klbrbcv3zm2z-cloud-profiler-test]
    with_gcp_profiler_service_test.go:98: Processing page 1 of profiles, number of profiles in page: 1000
    with_gcp_profiler_service_test.go:135: Attempt 2 failed with error: Didn't find matching profile after fetching 1 pages, profile not yet available.. Retrying in 30s...
    with_gcp_profiler_service_test.go:59: Successfully wrote 100MB to /tmp/gcsfuse_readwrite_test_1446376621/mnt/load_file_1774583152779596925.bin
    with_gcp_profiler_service_test.go:88: Querying profiles for service [1klbrbcv3zm2z-cloud-profiler-test] with version [1klbrbcv3zm2z-cloud-profiler-test]
    with_gcp_profiler_service_test.go:98: Processing page 1 of profiles, number of profiles in page: 1000
    with_gcp_profiler_service_test.go:109: Found matching profile: Type=CPU, ServiceName=1klbrbcv3zm2z-cloud-profiler-test, Version=1klbrbcv3zm2z-cloud-profiler-test
    with_gcp_profiler_service_test.go:135: Operation succeeded on attempt 3
--- PASS: TestCloudProfilerSuite (79.75s)
    --- PASS: TestCloudProfilerSuite/TestValidateProfilerWithActualService (79.75s)
PASS
ok      github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/cloud_profiler        97.487s
```

### Link to the issue in case of a bug fix.
b/496749793

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Part of pre-submit.

### Any backward incompatible change? If so, please explain.
None
