### PR TITLE
test(fix creds): Use temporary file for creds ensuring no corruption during package runs.

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -202,6 +202,11 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 
 	// Fetch credentials and apply permission on bucket.
 	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials(ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			t.Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
 	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
 
 	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=5", "--stat-cache-ttl=0"}

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -45,7 +45,6 @@ var (
 	bucket           string
 	testDir          string
 	serviceAccount   string
-	localKeyFilePath string
 )
 
 // The permission granted by roles at project, bucket, and managed folder
@@ -201,6 +200,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	setup.RunTestsOnlyForStaticMount(mountDir, t)
 
 	// Fetch credentials and apply permission on bucket.
+	var localKeyFilePath string
 	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials(ctx)
 	defer func() {
 		if err := os.Remove(localKeyFilePath); err != nil {

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -42,9 +42,9 @@ const (
 )
 
 var (
-	bucket           string
-	testDir          string
-	serviceAccount   string
+	bucket         string
+	testDir        string
+	serviceAccount string
 )
 
 // The permission granted by roles at project, bucket, and managed folder

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -139,6 +139,11 @@ func TestManagedFolders_FolderViewPermission(t *testing.T) {
 
 	// Fetch credentials and apply permission on bucket.
 	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			t.Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
 	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 	defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
 

--- a/tools/integration_tests/mount_timeout/mount_access_test.go
+++ b/tools/integration_tests/mount_timeout/mount_access_test.go
@@ -82,6 +82,11 @@ func (testSuite *MountAccessTest) mountWithKeyFile(bucketName, keyFile string) (
 
 func (testSuite *MountAccessTest) TestMountingWithMinimalAccessSucceeds() {
 	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(gCtx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			testSuite.T().Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
 	creds_tests.ApplyCustomRoleToServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, setup.TestBucket())
 	defer creds_tests.RevokeCustomRoleFromServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, setup.TestBucket())
 

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -19,10 +19,8 @@ package creds_tests
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"os"
-	"path"
 	"slices"
 	"strings"
 	"testing"
@@ -70,8 +68,6 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 	// Service account id format is name@project-id.iam.gserviceaccount.com
 	serviceAccount = NameOfServiceAccount + "@" + id + ".iam.gserviceaccount.com"
 
-	localKeyFilePath = path.Join(os.Getenv("HOME"), "creds.json")
-
 	// Download credentials
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
@@ -87,11 +83,12 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 	}
 
 	// Create and write creds to local file.
-	file, err := os.Create(localKeyFilePath)
+	file, err := os.CreateTemp("", "creds-*.json")
 	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while creating credentials file %v", err))
+		setup.LogAndExit(fmt.Sprintf("Error while creating temp credentials file %v", err))
 	}
-	_, err = io.Writer.Write(file, creds.Payload.Data)
+	localKeyFilePath = file.Name()
+	_, err = file.Write(creds.Payload.Data)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
 	}
@@ -155,6 +152,11 @@ func RevokeCustomRoleFromServiceAccountOnBucket(ctx context.Context, storageClie
 
 func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
 	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
 	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 


### PR DESCRIPTION
### Description
Earlier creds file was generated at a hardcoded file path. So two test packages running together would use the same filepath resulting in corruption if one test is reading and other is writing. This change fixes it by removing that constraint and also cleaning up the file after test runs.

### Error
```
{"timestamp":{"seconds":1774941558,"nanos":345334488},"severity":"INFO","message":"Building GCSFuse from source in the dir: /tmp/gcsfuse_readwrite_test_1260618432 ..."}
{"timestamp":{"seconds":1774941558,"nanos":345392728},"severity":"INFO","message":"Building build_gcsfuse at /tmp/gcsfuse_integration_tests3366748157/build_gcsfuse"}
{"timestamp":{"seconds":1774941562,"nanos":905365158},"severity":"INFO","message":"Building gcsfuse into /tmp/gcsfuse_readwrite_test_1260618432"}
{"timestamp":{"seconds":1774941618,"nanos":35159606},"severity":"INFO","message":"Running static mounting tests..."}
=== RUN   TestManagedFolders_FolderAdminPermission
{"timestamp":{"seconds":1774941618,"nanos":35288596},"severity":"INFO","message":"Running credentials tests..."}
{"timestamp":{"seconds":1774941620,"nanos":591778812},"severity":"INFO","message":"/tmp/gcsfuse_readwrite_test_1260618432/bin/gcsfuse --config-file=/tmp/gcsfuse_readwrite_test_1260618432/config_hns.yaml --key-file=/usr/local/google/home/mohitkyadav/creds.json --stat-cache-ttl=0 --log-severity=trace --log-file=/tmp/gcsfuse_readwrite_test_1260618432/gcsfuse.log mohitkyadav-hns-usw4a /tmp/gcsfuse_readwrite_test_1260618432/mnt"}
{"timestamp":{"seconds":1774941620,"nanos":591816822},"severity":"INFO","message":"Error:  Flag --stat-cache-ttl has been deprecated, This flag has been deprecated (starting v2.0) in favor of metadata-cache-ttl-secs.\n{\"timestamp\":{\"seconds\":1774941620,\"nanos\":572208132},\"severity\":\"INFO\",\"message\":\"Start gcsfuse/0.0.0 (Go version go1.26.1) for app \\\"\\\" using mount point: /tmp/gcsfuse_readwrite_test_1260618432/mnt\\n\",\"mount-id\":\"mohitkyadav-hns-usw4a-be1b2690\"}\n{\"timestamp\":{\"seconds\":1774941620,\"nanos\":572239872},\"severity\":\"WARNING\",\"message\":\"Deprecated flag stat-cache-ttl and/or type-cache-ttl used! Please switch to config parameter 'metadata-cache: ttl-secs' .\",\"mount-id\":\"mohitkyadav-hns-usw4a-be1b2690\"}\nError: daemonize.Run: readFromProcess: sub-process: Error while mounting gcsfuse: mountWithArgs: failed to create storage handle using createStorageHandle: error in getting clientOpts for gRPC client: failed to get client auth options and token: while fetching credentials: failed to detect credentials: unexpected end of JSON input\n{\"timestamp\":{\"seconds\":1774941620,\"nanos\":591414332},\"severity\":\"INFO\",\"message\":\"Error occurred during command execution on gcsfuse/0.0.0 (Go version go1.26.1): daemonize.Run: readFromProcess: sub-process: Error while mounting gcsfuse: mountWithArgs: failed to create storage handle using createStorageHandle: error in getting clientOpts for gRPC client: failed to get client auth options and token: while fetching credentials: failed to detect credentials: unexpected end of JSON input\",\"mount-id\":\"mohitkyadav-hns-usw4a-be1b2690\"}\n"}
{"timestamp":{"seconds":1774941620,"nanos":591863722},"severity":"INFO","message":"Failed to mount GCSFuse: cannot mount gcsfuse: exit status 1"}
{"timestamp":{"seconds":1774941620,"nanos":591915372},"severity":"INFO","message":"goroutine 100 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup.LogAndExit({0x31cd0e692480?, 0x1b?})\n\t/usr/local/google/home/mohitkyadav/checkpoint-fix/gcsfuse/tools/integration_tests/util/setup/setup.go:446 +0x7b\ngithub.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup.MountGCSFuseWithGivenMountFunc({0x31cd0e9141e0?, 0x18650e1?, 0x31cd0eba8240?}, 0x31cd0eea80f0?)\n\t/usr/local/google/home/mohitkyadav/checkpoint-fix/gcsfuse/tools/integration_tests/util/setup/setup.go:665 +0x6a\ngithub.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/managed_folders.TestManagedFolders_FolderAdminPermission(0x31cd0e762b48)\n\t/usr/local/google/home/mohitkyadav/checkpoint-fix/gcsfuse/tools/integration_tests/managed_folders/admin_permissions_test.go:224 +0x4c5\ntesting.tRunner(0x31cd0e762b48, 0x19117b0)\n\t/usr/local/go/src/testing/testing.go:2036 +0xea\ncreated by testing.(*T).Run in goroutine 1\n\t/usr/local/go/src/testing/testing.go:2101 +0x4c5"}
FAIL	github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/managed_folders	62.320s
FAIL

```

### Link to the issue in case of a bug fix.
b/496799288

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Part of presubmit.

### Any backward incompatible change? If so, please explain.
