### PR TITLE
refactor: concurrent operations test package migration [GKE-GCSFuse Test migration]

### DIFF
--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -15,6 +15,7 @@
 package concurrent_operations
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -22,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
@@ -49,27 +51,29 @@ const (
 // the degree of parallelism. By default it uses GOMAXPROCS.
 // Ref: https://stackoverflow.com/questions/24375966/does-go-test-run-unit-tests-concurrently
 type concurrentListingTest struct {
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	baseTestName  string
 	suite.Suite
 }
 
-func (s *concurrentListingTest) SetupTest() {
-	testDirPath = setup.SetupTestDirectory(testDirName)
+func (s *concurrentListingTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
-
-func (s *concurrentListingTest) TearDownTest() {}
 
 // createDirectoryStructureForTestCase creates initial directory structure in the
 // given testCaseDir.
 // bucket
 //
-//	  explicitDir/
-//		explicitDir/file1.txt
-//		explicitDir/file2.txt
+//	explicitDir/
+//	explicitDir/file1.txt
+//	explicitDir/file2.txt
 func createDirectoryStructureForTestCase(t *testing.T, testCaseDir string) {
-	operations.CreateDirectory(path.Join(testDirPath, testCaseDir), t)
+	operations.CreateDirectory(path.Join(testEnv.testDirPath, testCaseDir), t)
 
 	// Create explicitDir structure
-	explicitDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	explicitDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	operations.CreateDirectory(explicitDir, t)
 	operations.CreateFileOfSize(5, path.Join(explicitDir, "file1.txt"), t)
 	operations.CreateFileOfSize(10, path.Join(explicitDir, "file2.txt"), t)
@@ -85,7 +89,7 @@ func (s *concurrentListingTest) Test_OpenDirAndLookUp() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_OpenDirAndLookUp"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	// Fails if the operation takes more than timeout.
@@ -132,7 +136,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndLookUp() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_Parallel_ReadDirAndLookUp"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 200 * time.Second
@@ -182,7 +186,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentReadDir() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_MultipleConcurrentReadDir"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	goroutineCount := 10 // Number of concurrent goroutines
 	wg.Add(goroutineCount)
@@ -227,7 +231,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileOperations() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_Parallel_ReadDirAndFileOperations"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 400 * time.Second // Adjust timeout as needed
@@ -293,7 +297,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndDirOperations() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_Parallel_ReadDirAndDirOperations"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 200 * time.Second
@@ -356,7 +360,7 @@ func (s *concurrentListingTest) Test_Parallel_ReadDirAndFileEdit() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_Parallel_ListDirAndFileEdit"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 400 * time.Second
@@ -418,7 +422,7 @@ func (s *concurrentListingTest) Test_MultipleConcurrentOperations() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_MultipleConcurrentOperations"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(5)
 	timeout := 400 * time.Second
@@ -523,7 +527,7 @@ func (s *concurrentListingTest) Test_ListWithMoveFile() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_ListWithMoveFile"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 400 * time.Second // Adjust timeout as needed
@@ -548,14 +552,14 @@ func (s *concurrentListingTest) Test_ListWithMoveFile() {
 		for range iterationsForHeavyOperations { // Adjust iteration count if needed
 			fileName := setup.GenerateRandomString(5) + "move_file.txt"
 			// Create file
-			err := os.WriteFile(path.Join(testDirPath, fileName), []byte("Hello, world!"), setup.FilePermission_0600)
+			err := os.WriteFile(path.Join(testEnv.testDirPath, fileName), []byte("Hello, world!"), setup.FilePermission_0600)
 			require.NoError(s.T(), err)
 
 			// Move File in the target directory
-			err = operations.Move(path.Join(testDirPath, fileName), path.Join(targetDir, fileName))
+			err = operations.Move(path.Join(testEnv.testDirPath, fileName), path.Join(targetDir, fileName))
 			require.NoError(s.T(), err)
 			// Move File out of the target directory
-			err = operations.Move(path.Join(targetDir, fileName), path.Join(testDirPath, fileName))
+			err = operations.Move(path.Join(targetDir, fileName), path.Join(testEnv.testDirPath, fileName))
 			require.NoError(s.T(), err)
 		}
 	}()
@@ -581,7 +585,7 @@ func (s *concurrentListingTest) Test_ListWithMoveDir() {
 	s.T().Parallel() // Mark the test parallelizable.
 	testCaseDir := "Test_ListWithMoveDir"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 400 * time.Second // Adjust timeout as needed
@@ -606,14 +610,14 @@ func (s *concurrentListingTest) Test_ListWithMoveDir() {
 		for range iterationsForHeavyOperations { // Adjust iteration count if needed
 			dirName := setup.GenerateRandomString(5) + "move_dir"
 			// Create Dir
-			err := os.Mkdir(path.Join(testDirPath, dirName), setup.DirPermission_0755)
+			err := os.Mkdir(path.Join(testEnv.testDirPath, dirName), setup.DirPermission_0755)
 			require.NoError(s.T(), err)
 
 			// Move Dir in the target dir
-			err = operations.Move(path.Join(testDirPath, dirName), path.Join(targetDir, dirName))
+			err = operations.Move(path.Join(testEnv.testDirPath, dirName), path.Join(targetDir, dirName))
 			require.NoError(s.T(), err)
 			// Move Dir out of the target dir
-			err = operations.Move(path.Join(targetDir, dirName), path.Join(testDirPath, dirName))
+			err = operations.Move(path.Join(targetDir, dirName), path.Join(testEnv.testDirPath, dirName))
 			require.NoError(s.T(), err)
 		}
 	}()
@@ -639,7 +643,7 @@ func (s *concurrentListingTest) Test_StatWithNewFileWrite() {
 	s.T().Parallel()
 	testCaseDir := "Test_StatWithNewFileWrite"
 	createDirectoryStructureForTestCase(s.T(), testCaseDir)
-	targetDir := path.Join(testDirPath, testCaseDir, "explicitDir")
+	targetDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
 	var wg sync.WaitGroup
 	wg.Add(2)
 	timeout := 400 * time.Second // Adjust timeout as needed
@@ -686,30 +690,38 @@ func (s *concurrentListingTest) Test_StatWithNewFileWrite() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestConcurrentListing(t *testing.T) {
-	ts := &concurrentListingTest{}
-
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		ts := &concurrentListingTest{
+			ctx:           context.Background(),
+			storageClient: testEnv.storageClient,
+			baseTestName:  t.Name(),
+		}
 		suite.Run(t, ts)
 		return
 	}
 
-	flagsSet := [][]string{
-		{"--kernel-list-cache-ttl-secs=0", "--enable-metadata-prefetch"}, {"--kernel-list-cache-ttl-secs=-1"},
-	}
-
-	if !testing.Short() {
-		setup.AppendFlagsToAllFlagsInTheFlagsSet(&flagsSet, "", "--client-protocol=grpc")
-	}
-
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
-		mountGCSFuseAndSetupTestDir(flags, testDirName, t)
+		ts := &concurrentListingTest{
+			ctx:           context.Background(),
+			storageClient: testEnv.storageClient,
+			baseTestName:  t.Name(),
+			flags:         flags,
+		}
+
+		// Mount logic must remain OUTSIDE of the test methods so the mount stays alive
+		setup.SetUpLogFilePath(flags, GKETempDir, "", testEnv.cfg)
+		mountGCSFuseAndSetupTestDir(flags, ts.ctx, ts.storageClient)
+
 		// Parallel subtest execution is suspended until its calling test function has
 		// returned. Hence invoking RunTest inside another test, otherwise unmount will
 		// happen before the subtest execution starts.
 		t.Run(fmt.Sprintf("Flags_%v", flags), func(t *testing.T) {
 			suite.Run(t, ts)
 		})
-		setup.UnmountGCSFuse(setup.MntDir())
+
+		// Safely unmount AFTER the wrapper t.Run completes (which waits for all parallel subtests)
+		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 	}
 }

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -697,7 +697,12 @@ func TestConcurrentListing(t *testing.T) {
 			storageClient: testEnv.storageClient,
 			baseTestName:  t.Name(),
 		}
-		suite.Run(t, ts)
+		setup.SetUpLogFilePath(nil, GKETempDir, "", testEnv.cfg)
+		mountGCSFuseAndSetupTestDir(nil, ts.ctx, ts.storageClient)
+		t.Run("MountedDirectory", func(t *testing.T) {
+			suite.Run(t, ts)
+		})
+		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 		return
 	}
 

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -70,7 +70,7 @@ func (s *concurrentListingTest) TearDownTest() {
 //	explicitDir/file1.txt
 //	explicitDir/file2.txt
 func createDirectoryStructureForTestCase(t *testing.T, testCaseDir string) {
-	operations.CreateDirectory(path.Join(testEnv.testDirPath, testCaseDir), t)
+	setup.SetupTestDirectory(path.Join(testDirName, testCaseDir))
 
 	// Create explicitDir structure
 	explicitDir := path.Join(testEnv.testDirPath, testCaseDir, "explicitDir")
@@ -698,7 +698,9 @@ func TestConcurrentListing(t *testing.T) {
 			baseTestName:  t.Name(),
 		}
 		setup.SetUpLogFilePath(nil, GKETempDir, "", testEnv.cfg)
-		mountGCSFuseAndSetupTestDir(nil, ts.ctx, ts.storageClient)
+		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, nil, mountFunc)
+		setup.SetMntDir(mountDir)
+		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)
 		t.Run("MountedDirectory", func(t *testing.T) {
 			suite.Run(t, ts)
 		})
@@ -717,7 +719,9 @@ func TestConcurrentListing(t *testing.T) {
 
 		// Mount logic must remain OUTSIDE of the test methods so the mount stays alive
 		setup.SetUpLogFilePath(flags, GKETempDir, "", testEnv.cfg)
-		mountGCSFuseAndSetupTestDir(flags, ts.ctx, ts.storageClient)
+		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+		setup.SetMntDir(mountDir)
+		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)
 
 		// Parallel subtest execution is suspended until its calling test function has
 		// returned. Hence invoking RunTest inside another test, otherwise unmount will

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -697,7 +697,7 @@ func TestConcurrentListing(t *testing.T) {
 			storageClient: testEnv.storageClient,
 			baseTestName:  t.Name(),
 		}
-		setup.SetUpLogFilePath(nil, GKETempDir, "", testEnv.cfg)
+		setup.SetUpLogFilePath(s.T().Name(), nil, GKETempDir, "", testEnv.cfg)
 		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, nil, mountFunc)
 		setup.SetMntDir(mountDir)
 		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)
@@ -718,7 +718,7 @@ func TestConcurrentListing(t *testing.T) {
 		}
 
 		// Mount logic must remain OUTSIDE of the test methods so the mount stays alive
-		setup.SetUpLogFilePath(flags, GKETempDir, "", testEnv.cfg)
+		setup.SetUpLogFilePath(s.T().Name(), flags, GKETempDir, "", testEnv.cfg)
 		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
 		setup.SetMntDir(mountDir)
 		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)

--- a/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_listing_test.go
@@ -697,7 +697,7 @@ func TestConcurrentListing(t *testing.T) {
 			storageClient: testEnv.storageClient,
 			baseTestName:  t.Name(),
 		}
-		setup.SetUpLogFilePath(s.T().Name(), nil, GKETempDir, "", testEnv.cfg)
+		setup.SetUpLogFilePath(t.Name(), nil, GKETempDir, "", testEnv.cfg)
 		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, nil, mountFunc)
 		setup.SetMntDir(mountDir)
 		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)
@@ -718,7 +718,7 @@ func TestConcurrentListing(t *testing.T) {
 		}
 
 		// Mount logic must remain OUTSIDE of the test methods so the mount stays alive
-		setup.SetUpLogFilePath(s.T().Name(), flags, GKETempDir, "", testEnv.cfg)
+		setup.SetUpLogFilePath(t.Name(), flags, GKETempDir, "", testEnv.cfg)
 		setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
 		setup.SetMntDir(mountDir)
 		testEnv.testDirPath = path.Join(setup.MntDir(), testDirName)

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -16,7 +16,9 @@ package concurrent_operations
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"path"
@@ -25,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -33,29 +36,29 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	testDirNameForRead = "concurrent_read_test"
-)
-
-var testDirPathForRead string
-var cacheDirPath string
-
 ////////////////////////////////////////////////////////////////////////
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
 type concurrentReadTest struct {
-	flags []string
+	flags         []string
+	storageClient *storage.Client
+	ctx           context.Context
+	baseTestName  string
 	suite.Suite
 }
 
-func (s *concurrentReadTest) SetupTest() {
-	mountGCSFuseAndSetupTestDir(s.flags, testDirNameForRead, s.T())
+func (s *concurrentReadTest) SetupSuite() {
+	setup.SetUpLogFilePath(s.flags, GKETempDir, "", testEnv.cfg)
+	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
+}
+
+func (s *concurrentReadTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 }
 
 func (s *concurrentReadTest) TearDownTest() {
-	setup.UnmountGCSFuse(setup.MntDir())
-	setup.CleanUpDir(cacheDirPath)
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -75,7 +78,7 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 		randomReads     = 5                       // Number of random readers
 	)
 	// Create a 100MiB test file
-	testFilePath := path.Join(testDirPathForRead, "large_test_file.bin")
+	testFilePath := path.Join(testEnv.testDirPath, "large_test_file.bin")
 	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
 	var wg sync.WaitGroup
 	timeout := 300 * time.Second // 5 minutes timeout for 100MiB operations
@@ -91,8 +94,8 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 			content, err := operations.ReadFileSequentially(file, chunkSize)
 			require.NoError(s.T(), err, "Sequential reader %d: read failed.", readerID)
 			require.Equal(s.T(), fileSize, len(content), "Sequential reader %d: expected to read entire file", readerID)
-			obj := storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testDirPathForRead), "large_test_file.bin"))
-			attrs, err := obj.Attrs(ctx)
+			obj := s.storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testEnv.testDirPath), "large_test_file.bin"))
+			attrs, err := obj.Attrs(s.ctx)
 			require.NoError(s.T(), err, "obj.Attrs")
 			localCRC32C, err := operations.CalculateCRC32(bytes.NewReader(content))
 			require.NoError(s.T(), err, "Sequential reader %d: failed to calculate local CRC32C", readerID)
@@ -112,7 +115,7 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 				// Use operations.ReadChunkFromFile for reading chunks
 				chunk, err := operations.ReadChunkFromFile(testFilePath, chunkSize, randomOffset, os.O_RDONLY)
 				require.NoError(s.T(), err, "Random reader %d: ReadChunkFromFile failed at offset %d", readerID, randomOffset)
-				client.ValidateObjectChunkFromGCS(ctx, storageClient, path.Base(testDirPathForRead), "large_test_file.bin", randomOffset, int64(len(chunk)), string(chunk), s.T())
+				client.ValidateObjectChunkFromGCS(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), "large_test_file.bin", randomOffset, int64(len(chunk)), string(chunk), s.T())
 			}
 		}(i)
 	}
@@ -138,12 +141,12 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 // with each reader handling a distinct segment of the file for comprehensive coverage.
 func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 	const (
-		fileSize    = 100 * operations.OneMiB // 100 MiB file
-		numReaders  = 5                       // Number of concurrent readers
-		segmentSize = fileSize / numReaders   // Each reader reads 20 MiB segment
+		fileSize    = 100 * operations.OneMiB       // 100 MiB file
+		numReaders  = 5                             // Number of concurrent readers
+		segmentSize = fileSize / numReaders         // Each reader reads 20 MiB segment
 	)
 	// Create a 100MiB test file
-	testFilePath := path.Join(testDirPathForRead, "segment_test_file.bin")
+	testFilePath := path.Join(testEnv.testDirPath, "segment_test_file.bin")
 	operations.CreateFileOfSize(fileSize, testFilePath, s.T())
 	// Open shared file handle that will be used by all goroutines
 	sharedFile, err := os.Open(testFilePath)
@@ -200,8 +203,8 @@ func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 		// Validate checksum of reconstructed content
 		reconstructedChecksum, err := operations.CalculateCRC32(bytes.NewReader(fullContent.Bytes()))
 		require.NoError(s.T(), err, "Failed to calculate reconstructed checksum")
-		obj := storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testDirPathForRead), "segment_test_file.bin"))
-		attrs, err := obj.Attrs(ctx)
+		obj := s.storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testEnv.testDirPath), "segment_test_file.bin"))
+		attrs, err := obj.Attrs(s.ctx)
 		require.NoError(s.T(), err, "obj.Attrs")
 		assert.Equal(s.T(), attrs.CRC32C, reconstructedChecksum, "CRC32C mismatch. GCS: %d, Local: %d", attrs.CRC32C, reconstructedChecksum)
 	case <-time.After(timeout):
@@ -213,9 +216,9 @@ func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 // It creates 10 goroutines, each writing a 32 MiB file and then reading it sequentially.
 func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 	const (
-		fileSize      = 32 * operations.OneMiB  // 32 MiB file
-		numGoRoutines = 10                      // Number of concurrent readers
-		chunkSize     = 128 * operations.OneKiB // 128 KiB chunks for reads
+		fileSize      = 32 * operations.OneMiB    // 32 MiB file
+		numGoRoutines = 10                        // Number of concurrent readers
+		chunkSize     = 128 * operations.OneKiB   // 128 KiB chunks for reads
 	)
 	var wg sync.WaitGroup
 	wg.Add(numGoRoutines)
@@ -226,7 +229,7 @@ func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 			defer wg.Done()
 
 			fileName := fmt.Sprintf("test_%d.bin", workerId)
-			filePath := path.Join(testDirPathForRead, fileName)
+			filePath := path.Join(testEnv.testDirPath, fileName)
 			f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, setup.FilePermission_0600) //nolint:staticcheck
 			require.NoError(s.T(), err)
 			randomData, err := operations.GenerateRandomData(fileSize)
@@ -241,8 +244,8 @@ func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 			content, err := operations.ReadFileSequentially(file, chunkSize)
 			require.NoError(s.T(), err, "Sequential reader %d: read failed.", workerId)
 			require.Equal(s.T(), fileSize, len(content), "Sequential reader %d: expected to read entire file", workerId)
-			obj := storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testDirPathForRead), fileName))
-			attrs, err := obj.Attrs(ctx)
+			obj := s.storageClient.Bucket(setup.TestBucket()).Object(path.Join(path.Base(testEnv.testDirPath), fileName))
+			attrs, err := obj.Attrs(s.ctx)
 			require.NoError(s.T(), err, "obj.Attrs")
 			localCRC32C, err := operations.CalculateCRC32(bytes.NewReader(content))
 			require.NoError(s.T(), err, "Sequential reader %d: failed to calculate local CRC32C", workerId)
@@ -269,34 +272,21 @@ func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestConcurrentRead(t *testing.T) {
-	ts := &concurrentReadTest{}
+	ts := &concurrentReadTest{
+		ctx:           context.Background(),
+		storageClient: testEnv.storageClient,
+		baseTestName:  t.Name(),
+	}
 
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
-	var err error
-	cacheDirPath, err = os.MkdirTemp("", fmt.Sprintf("gcsfuse-file-cache-concurrent-read-%s", setup.GenerateRandomString(5)))
-	require.NoError(t, err)
-	defer operations.RemoveDir(cacheDirPath)
-
-	cacheDirFlag := fmt.Sprintf("--cache-dir=%s", cacheDirPath)
-	// Define flag sets specific for concurrent read tests
-	flagsSet := [][]string{
-		{}, // For default read path.
-		{"--file-cache-cache-file-for-range-read=true", "--file-cache-enable-parallel-downloads=true", cacheDirFlag, "--enable-kernel-reader=false"}, // For file cache path
-		{"--enable-buffered-read", "--enable-kernel-reader=false", "--enable-metadata-prefetch"},                                                     // For Buffered read enabled.
-	}
-	if setup.IsZonalBucketRun() {
-		// Zonal buckets enable the kernel reader by default. Disable it to verify the GCSReader flow.
-		flagsSet = append(flagsSet, []string{"--enable-kernel-reader=false"})
-	}
-
-	// Run tests with each flag set
-	for _, flags := range flagsSet {
-		ts.flags = flags
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running concurrent read tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
 	}
 }

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -146,9 +146,9 @@ func (s *concurrentReadTest) Test_ConcurrentSequentialAndRandomReads() {
 // with each reader handling a distinct segment of the file for comprehensive coverage.
 func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 	const (
-		fileSize    = 100 * operations.OneMiB       // 100 MiB file
-		numReaders  = 5                             // Number of concurrent readers
-		segmentSize = fileSize / numReaders         // Each reader reads 20 MiB segment
+		fileSize    = 100 * operations.OneMiB // 100 MiB file
+		numReaders  = 5                       // Number of concurrent readers
+		segmentSize = fileSize / numReaders   // Each reader reads 20 MiB segment
 	)
 	// Create a 100MiB test file
 	testFilePath := path.Join(testEnv.testDirPath, "segment_test_file.bin")
@@ -221,9 +221,9 @@ func (s *concurrentReadTest) Test_ConcurrentSegmentReadsSharedHandle() {
 // It creates 10 goroutines, each writing a 32 MiB file and then reading it sequentially.
 func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 	const (
-		fileSize      = 32 * operations.OneMiB    // 32 MiB file
-		numGoRoutines = 10                        // Number of concurrent readers
-		chunkSize     = 128 * operations.OneKiB   // 128 KiB chunks for reads
+		fileSize      = 32 * operations.OneMiB  // 32 MiB file
+		numGoRoutines = 10                      // Number of concurrent readers
+		chunkSize     = 128 * operations.OneKiB // 128 KiB chunks for reads
 	)
 	var wg sync.WaitGroup
 	wg.Add(numGoRoutines)

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -50,7 +50,12 @@ type concurrentReadTest struct {
 
 func (s *concurrentReadTest) SetupSuite() {
 	setup.SetUpLogFilePath(s.flags, GKETempDir, "", testEnv.cfg)
-	mountGCSFuseAndSetupTestDir(s.flags, s.ctx, s.storageClient)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(mountDir)
+}
+
+func (s *concurrentReadTest) SetupTest() {
+	testEnv.testDirPath = setup.SetupTestDirectory(testDirName)
 }
 
 func (s *concurrentReadTest) TearDownSuite() {

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"path"

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -277,21 +277,29 @@ func (s *concurrentReadTest) Test_MultiThreadedWritePlusRead() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestConcurrentRead(t *testing.T) {
-	ts := &concurrentReadTest{
-		ctx:           context.Background(),
-		storageClient: testEnv.storageClient,
-		baseTestName:  t.Name(),
-	}
-
 	// Run tests for mounted directory if the flag is set.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		suite.Run(t, ts)
+		ts := &concurrentReadTest{
+			ctx:           context.Background(),
+			storageClient: testEnv.storageClient,
+			baseTestName:  t.Name(),
+		}
+		t.Run("MountedDirectory", func(t *testing.T) {
+			suite.Run(t, ts)
+		})
 		return
 	}
 
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
-	for _, ts.flags = range flagsSet {
-		log.Printf("Running concurrent read tests with flags: %s", ts.flags)
-		suite.Run(t, ts)
+	for _, flags := range flagsSet {
+		ts := &concurrentReadTest{
+			ctx:           context.Background(),
+			storageClient: testEnv.storageClient,
+			baseTestName:  t.Name(),
+			flags:         flags,
+		}
+		t.Run(fmt.Sprintf("Flags_%v", flags), func(t *testing.T) {
+			suite.Run(t, ts)
+		})
 	}
 }

--- a/tools/integration_tests/concurrent_operations/concurrent_read_test.go
+++ b/tools/integration_tests/concurrent_operations/concurrent_read_test.go
@@ -48,7 +48,7 @@ type concurrentReadTest struct {
 }
 
 func (s *concurrentReadTest) SetupSuite() {
-	setup.SetUpLogFilePath(s.flags, GKETempDir, "", testEnv.cfg)
+	setup.SetUpLogFilePath(s.T().Name(), s.flags, GKETempDir, "", testEnv.cfg)
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
 	setup.SetMntDir(mountDir)
 }

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,75 +29,94 @@ import (
 )
 
 const (
-	testDirName    = "ConcurrentOperationsTest"
+	testDirName       = "TestConcurrentOperations"
+	GKETempDir        = "/gcsfuse-tmp"
 	onlyDirMounted = "OnlyDirConcurrentOperationsTest"
 )
 
 var (
-	storageClient *storage.Client
-	ctx           context.Context
-	testDirPath   string
-
+	testEnv   env
+	mountFunc func(*test_suite.TestConfig, []string) error
+	mountDir  string
 	// root directory is the directory to be unmounted.
 	rootDir string
 )
 
-////////////////////////////////////////////////////////////////////////
-// Helper functions
-////////////////////////////////////////////////////////////////////////
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
 
-func mountGCSFuseAndSetupTestDir(flags []string, testDirName string, t *testing.T) {
-	// When tests are running in GKE environment, use the mounted directory provided as test flag.
-	if setup.MountedDirectory() != "" {
-		testDirPathForRead = setup.MountedDirectory()
-	} else {
-		config := &test_suite.TestConfig{
-			TestBucket:              setup.TestBucket(),
-			GCSFuseMountedDirectory: setup.MntDir(),
-			GKEMountedDirectory:     setup.MountedDirectory(),
-			LogFile:                 setup.LogFile(),
-		}
-		if err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags); err != nil {
-			t.Fatalf("Failed to mount GCS FUSE: %v", err)
-			return
-		}
-		testDirPathForRead = setup.MntDir()
-	}
-	setup.SetMntDir(testDirPathForRead)
-	testDirPath := setup.SetupTestDirectory(testDirName)
-	testDirPathForRead = testDirPath
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
+	setup.SetMntDir(mountDir)
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.ConcurrentOperations) == 0 {
+		log.Println("No configuration found for concurrent operations tests in config. Using flags instead.")
+		// Populate the config manually with the migrated pattern and requested flags.
+		cfg.ConcurrentOperations = make([]test_suite.TestConfig, 1)
+		cfg.ConcurrentOperations[0].TestBucket = setup.TestBucket()
+		cfg.ConcurrentOperations[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.ConcurrentOperations[0].LogFile = setup.LogFile()
+		cfg.ConcurrentOperations[0].Configs = make([]test_suite.ConfigItem, 2)
 
-	// Create common storage client to be used in test.
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
-	defer func() {
-		err := closeStorageClient()
-		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
+		cfg.ConcurrentOperations[0].Configs[0].Flags = []string{
+			"",
+			"--file-cache-cache-file-for-range-read=true --file-cache-enable-parallel-downloads=true --enable-kernel-reader=false --cache-dir=/gcsfuse-tmp/read_large_files",
+			"--enable-buffered-read --enable-kernel-reader=false --enable-metadata-prefetch",
 		}
-	}()
+		cfg.ConcurrentOperations[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ConcurrentOperations[0].Configs[0].Run = "TestConcurrentRead"
 
-	// If Mounted Directory flag is set, run tests for mounted directory.
-	setup.RunTestsForMountedDirectoryFlag(m)
-	// Else run tests for testBucket.
-	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+				cfg.ConcurrentOperations[0].Configs[1].Flags = []string{
+			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch",
+			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc",
+			"--kernel-list-cache-ttl-secs=-1",
+			"--kernel-list-cache-ttl-secs=-1 --client-protocol=grpc",
+		}
+		cfg.ConcurrentOperations[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ConcurrentOperations[0].Configs[1].Run = "TestConcurrentListing"
+	}
 
-	// Save root directory variables.
-	rootDir = setup.MntDir()
+	testEnv.ctx = context.Background()
+	testEnv.cfg = &cfg.ConcurrentOperations[0]
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
+
+	// 2. Create storage client before running tests.
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Printf("Error creating storage client: %v\n", err)
+		os.Exit(1)
+	}
+	defer testEnv.storageClient.Close()
+
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory.
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir = testEnv.cfg.GKEMountedDirectory
+		os.Exit(setup.RunTestsForMountedDirectory(mountDir, m))
+	}
+
+	// Run tests for testBucket.
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+
+	// Save mount and root directory variables.
+	mountDir, rootDir = setup.MntDir(), setup.MntDir()
 
 	log.Println("Running static mounting tests...")
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
 
-	// If test failed, save the gcsfuse log files for debugging.
-	setup.SaveLogFileInCaseOfFailure(successCode)
-
 	// Clean up test directory created.
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -50,12 +50,6 @@ type env struct {
 	bucketType    string
 }
 
-func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
-	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	setup.SetMntDir(mountDir)
-	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 	// 1. Load and parse the common configuration.
@@ -111,7 +105,7 @@ func TestMain(m *testing.M) {
 	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 	
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -91,13 +91,14 @@ func TestMain(m *testing.M) {
 	testEnv.cfg = &cfg.ConcurrentOperations[0]
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
-	// 2. Create common storage client to be used in test.
-	var err error
-	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
-	if err != nil {
-		log.Fatalf("client.CreateStorageClient: %v", err)
-	}
-	defer testEnv.storageClient.Close()
+	// 2. Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
+	defer func() {
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
+		}
+	}()
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	testDirName       = "TestConcurrentOperations"
-	GKETempDir        = "/gcsfuse-tmp"
+	testDirName    = "TestConcurrentOperations"
+	GKETempDir     = "/gcsfuse-tmp"
 	onlyDirMounted = "OnlyDirConcurrentOperationsTest"
 )
 
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 		cfg.ConcurrentOperations[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ConcurrentOperations[0].Configs[0].Run = "TestConcurrentRead"
 
-				cfg.ConcurrentOperations[0].Configs[1].Flags = []string{
+		cfg.ConcurrentOperations[0].Configs[1].Flags = []string{
 			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch",
 			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc",
 			"--kernel-list-cache-ttl-secs=-1",
@@ -103,7 +103,7 @@ func TestMain(m *testing.M) {
 	// Run tests for testBucket.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
-	
+
 	// Save mount and root directory variables.
 	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -108,7 +108,8 @@ func TestMain(m *testing.M) {
 
 	// Run tests for testBucket.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
+	
 	// Save mount and root directory variables.
 	mountDir, rootDir = setup.MntDir(), setup.MntDir()
 

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -91,12 +91,11 @@ func TestMain(m *testing.M) {
 	testEnv.cfg = &cfg.ConcurrentOperations[0]
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
-	// 2. Create storage client before running tests.
+	// 2. Create common storage client to be used in test.
 	var err error
 	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
 	if err != nil {
-		log.Printf("Error creating storage client: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("client.CreateStorageClient: %v", err)
 	}
 	defer testEnv.storageClient.Close()
 

--- a/tools/integration_tests/concurrent_operations/setup_test.go
+++ b/tools/integration_tests/concurrent_operations/setup_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 		cfg.ConcurrentOperations[0].TestBucket = setup.TestBucket()
 		cfg.ConcurrentOperations[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.ConcurrentOperations[0].LogFile = setup.LogFile()
-		cfg.ConcurrentOperations[0].Configs = make([]test_suite.ConfigItem, 2)
+		cfg.ConcurrentOperations[0].Configs = make([]test_suite.ConfigItem, 3)
 
 		cfg.ConcurrentOperations[0].Configs[0].Flags = []string{
 			"",
@@ -71,14 +71,18 @@ func TestMain(m *testing.M) {
 		cfg.ConcurrentOperations[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ConcurrentOperations[0].Configs[0].Run = "TestConcurrentRead"
 
-		cfg.ConcurrentOperations[0].Configs[1].Flags = []string{
+		cfg.ConcurrentOperations[0].Configs[1].Flags = []string{"--enable-kernel-reader=false"}
+		cfg.ConcurrentOperations[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
+		cfg.ConcurrentOperations[0].Configs[1].Run = "TestConcurrentRead"
+
+		cfg.ConcurrentOperations[0].Configs[2].Flags = []string{
 			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch",
 			"--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc",
 			"--kernel-list-cache-ttl-secs=-1",
 			"--kernel-list-cache-ttl-secs=-1 --client-protocol=grpc",
 		}
-		cfg.ConcurrentOperations[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ConcurrentOperations[0].Configs[1].Run = "TestConcurrentListing"
+		cfg.ConcurrentOperations[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ConcurrentOperations[0].Configs[2].Run = "TestConcurrentListing"
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1148,7 +1148,7 @@ concurrent_operations:
    configs:
      - flags:
        - ""
-       - "--file-cache-cache-file-for-range-read=true --file-cache-enable-parallel-downloads=true --enable-kernel-reader=false"
+       - "--file-cache-cache-file-for-range-read=true --file-cache-enable-parallel-downloads=true --enable-kernel-reader=false --cache-dir=/gcsfuse-tmp/read_large_files"
        - "--enable-buffered-read --enable-kernel-reader=false --enable-metadata-prefetch"
        compatible:
          flat: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1157,6 +1157,14 @@ concurrent_operations:
        run: TestConcurrentRead
        run_on_gke: true
      - flags:
+       - "--enable-kernel-reader=false"
+       compatible:
+         flat: false
+         hns: false
+         zonal: true
+       run: TestConcurrentRead
+       run_on_gke: true
+     - flags:
        - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch"
        - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc"
        - "--kernel-list-cache-ttl-secs=-1"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1141,3 +1141,29 @@ managed_folders:
           hns: true
           zonal: true
         run_on_gke: false
+
+concurrent_operations:
+ - mounted_directory: "${MOUNTED_DIR}"
+   test_bucket: "${BUCKET_NAME}"
+   configs:
+     - flags:
+       - ""
+       - "--file-cache-cache-file-for-range-read=true --file-cache-enable-parallel-downloads=true --enable-kernel-reader=false"
+       - "--enable-buffered-read --enable-kernel-reader=false --enable-metadata-prefetch"
+       compatible:
+         flat: true
+         hns: true
+         zonal: true
+       run: TestConcurrentRead
+       run_on_gke: true
+     - flags:
+       - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch"
+       - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc"
+       - "--kernel-list-cache-ttl-secs=-1"
+       - "--kernel-list-cache-ttl-secs=-1 --client-protocol=grpc"
+       compatible:
+         flat: true
+         hns: true
+         zonal: true
+       run: TestConcurrentListing
+       run_on_gke: true


### PR DESCRIPTION
### Description
This PR includes changes to migrate concurrent operations test package to use common config file. This common config will be used by both GCSFuse binary and GCSFuse CSI driver tests.

#### Changes include:

refactoring to use config file by test methods.
changes are made in a backward compatible way so tests can run with both config file and flags. This will be cleaned up in future PRs after the migration is complete.
Migration of concurrent package so it can use config file.

### Link to the issue in case of a bug fix.
[b/445952164](https://buganizer.corp.google.com/issues/445952164)

### Testing details
1. Manual - Manually tested with config file for both cases when mounted directory is set and not set. Also validated that the tests work without config file.
2. Unit tests - NA
3. Integration tests - via KOKORO

https://paste.googleplex.com/5379649958969344

### Any backward incompatible change? If so, please explain.
