### PR TITLE
refactor(kokoro perf tests): increase timeout to 9hrs

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -24,6 +24,6 @@ action {
   }
 }
 
-# Increase timeout to 6 hours
-timeout_mins: 360
+# Increase timeout to 9 hours
+timeout_mins: 540
 build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh"


### PR DESCRIPTION
### Description
Because of a recent addition of fio configs in our Kokoro perf tests, the perf test was timing out.

`ERROR: Aborting VM command due to timeout of 21600 seconds`
 
I am setting this timeout as 9 hours in this PR(current value is set as 6hrs). I still need to add Zonal tests to the perf tests

### Link to the issue in case of a bug fix.
b/487460676

### Testing - via Kokoro