### PR TITLE
test(symlink handling): Fix symlink_handling test package to handle and run using config driven approach

### DIFF
--- a/tools/integration_tests/symlink_handling/symlink_handling_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_handling_test.go
@@ -70,6 +70,7 @@ func TestMain(m *testing.M) {
 
 	testEnv.ctx = context.Background()
 	testEnv.cfg = &cfg.SymlinkHandling[0]
+	setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
 	// 2. Create storage client before running tests.
 	var err error

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -51,7 +51,7 @@ func (s *BaseSymlinkSuite) SetupTest() {
 	} else {
 		s.mntDir = testEnv.cfg.GCSFuseMountedDirectory
 		setup.SetMntDir(s.mntDir)
-		err := static_mounting.MountGcsfuseWithStaticMounting(s.flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(testEnv.cfg, s.flags)
 		s.Require().NoError(err)
 		s.testDirPath = setup.SetupTestDirectory(TestDirName)
 	}


### PR DESCRIPTION
### Description
This PR addresses an issue in the `symlink_handling` package where the TestBucket global variable was not being populated during integration test execution. This lack of initialization caused failures specifically when using the configuration-driven approach , as the variable was not explicitly passed.

Additionally, this change replaces the deprecated `MountGcsfuseWithStaticMounting` method with the recommended `MountGcsfuseWithStaticMountingWithConfigFile` to ensure compatibility .

### Link to the issue in case of a bug fix.
No.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.