### PR TITLE
test(ci): Use ubuntu 22.04 to run composite tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   linux-tests:
     needs: filter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
### Description
Use ubuntu 22.04 to run composite tests. A newer ubuntu version 24.04 causes a unit test failure due to expectation mismatch. This PR unblocks devs until a proper fix is made to the test and this PR can be reverted.

### Link to the issue in case of a bug fix.
b/496763741

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
