### PR TITLE
test(ci): Update runner version to Ubuntu 22.04 for flake detector

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   flake-detector:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
Adding same change done for CI in #4551 

### Link to the issue in case of a bug fix.
b/496763741

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NONE