### PR TITLE
test(inactive-stream-timeout): de-flake inactive stream reader ensuring expectation is validated eventually. 

### DIFF
--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -15,9 +15,9 @@
 package inactive_stream_timeout
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -73,14 +73,6 @@ func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageCli
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, kTestDirName)
 }
 
-func loadLogLines(reader io.Reader) ([]string, error) {
-	content, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	return strings.Split(string(content), "\n"), nil
-}
-
 // doesNotHaveInactiveReaderClosedLogLineInLogFile checks if the "Closing reader for object ... due to inactivity"
 // log message is absent for the given objectName, b/w the [startTime, endTime] interval.
 // It sleeps for 5 seconds before checking to allow logs to be flushed.
@@ -106,12 +98,17 @@ func hasInactiveReaderClosedLogLineInLogFile(t *testing.T, objectName, logFile s
 	}
 	defer file.Close()
 
-	logLines, err := loadLogLines(file)
-	if err != nil {
-		return "", fmt.Errorf("failed to read log file: %w", err)
-	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
 
-	for _, line := range logLines {
+		// Pre-filter: skip lines that do not contain the core parts of the expected message.
+		// We cannot use `expectedMsgSubstring` directly for the pre-filter because the double
+		// quotes around the object name will be escaped as `\"` in the raw JSON string.
+		if !strings.Contains(line, "Closing reader for object") || !strings.Contains(line, objectName) {
+			continue
+		}
+
 		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line)
 		if err == nil && logEntry != nil {
 			if (logEntry.Timestamp.After(startTime) || logEntry.Timestamp.Equal(startTime)) &&
@@ -121,6 +118,10 @@ func hasInactiveReaderClosedLogLineInLogFile(t *testing.T, objectName, logFile s
 				}
 			}
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read log file: %w", err)
 	}
 
 	return "", fmt.Errorf("expected log message substring %q not found between %s and %s", expectedMsgSubstring, startTime, endTime)

--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -44,6 +43,8 @@ const (
 	kDefaultInactiveReadTimeoutInSeconds = 1                // A short timeout for testing
 	GKETempDir                           = "/gcsfuse-tmp"
 	OldGKElogFilePath                    = "/tmp/inactive_stream_timeout_logs/log.json"
+	retryFrequency                       = 1 * time.Second
+	retryDuration                        = 30 * time.Second
 )
 
 type env struct {
@@ -80,44 +81,49 @@ func loadLogLines(reader io.Reader) ([]string, error) {
 	return strings.Split(string(content), "\n"), nil
 }
 
-// validateInactiveReaderClosedLog checks if the "Closing reader for object ... due to inactivity"
-// log message is present (or absent) for the given objectName, b/w the [startTime, endTime] interval.
-// Also expects based on the shouldBePresent value.
-func validateInactiveReaderClosedLog(t *testing.T, logFile, objectName string, shouldBePresent bool, startTime, endTime time.Time) {
+// doesNotHaveInactiveReaderClosedLogLineInLogFile checks if the "Closing reader for object ... due to inactivity"
+// log message is absent for the given objectName, b/w the [startTime, endTime] interval.
+// It sleeps for 5 seconds before checking to allow logs to be flushed.
+func doesNotHaveInactiveReaderClosedLogLineInLogFile(t *testing.T, objectName, logFile string, startTime, endTime time.Time) {
 	t.Helper()
-	// Be specific about the object name in the expected message.
+	time.Sleep(5 * time.Second)
+
+	_, err := hasInactiveReaderClosedLogLineInLogFile(t, objectName, logFile, startTime, endTime)
+	if err == nil {
+		t.Fatalf("Unexpected 'Inactive Reader Closed' log message found in log file %s for object %s", logFile, objectName)
+	}
+}
+
+// hasInactiveReaderClosedLogInLogFile checks if the "Closing reader for object ... due to inactivity"
+// log message is present for the given objectName, b/w the [startTime, endTime] interval.
+func hasInactiveReaderClosedLogLineInLogFile(t *testing.T, objectName, logFile string, startTime, endTime time.Time) (string, error) {
+	t.Helper()
 	expectedMsgSubstring := fmt.Sprintf("Closing reader for object %q due to inactivity.", objectName)
 
 	file, err := os.Open(logFile)
-	require.NoError(t, err, "Failed to open log file")
+	if err != nil {
+		return "", fmt.Errorf("failed to open log file: %w", err)
+	}
 	defer file.Close()
 
 	logLines, err := loadLogLines(file)
-	require.NoError(t, err, "Failed to read log file")
+	if err != nil {
+		return "", fmt.Errorf("failed to read log file: %w", err)
+	}
 
-	found := false
 	for _, line := range logLines {
-		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line) // Assuming read_logs can parse general log lines too or a more generic parser is available.
-		// If parsing fails, it might be a non-JSON line or a different structured log.
-		// For this specific message, we expect it to be in the "Message" field of a structured log.
-
+		logEntry, err := read_logs.ParseJsonLogLineIntoLogEntryStruct(line)
 		if err == nil && logEntry != nil {
-			// Check if the log entry's timestamp is within the expected window.
 			if (logEntry.Timestamp.After(startTime) || logEntry.Timestamp.Equal(startTime)) &&
 				(logEntry.Timestamp.Before(endTime) || logEntry.Timestamp.Equal(endTime)) {
 				if strings.Contains(logEntry.Message, expectedMsgSubstring) {
-					found = true
-					break
+					return line, nil
 				}
 			}
 		}
 	}
 
-	if shouldBePresent {
-		require.True(t, found, "Expected log message substring '%s' not found between %v and %v", expectedMsgSubstring, startTime, endTime)
-	} else {
-		require.False(t, found, "Unexpected log message substring '%s' found between %v and %v", expectedMsgSubstring, startTime, endTime)
-	}
+	return "", fmt.Errorf("expected log message substring %q not found between %s and %s", expectedMsgSubstring, startTime, endTime)
 }
 
 func TestMain(m *testing.M) {

--- a/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/with_timeout_test.go
@@ -76,10 +76,12 @@ func (s *timeoutEnabledSuite) TestReaderCloses() {
 	time.Sleep(2*timeoutDuration + 1*time.Second) // Add buffer
 	endTimeWait := time.Now()
 
-	// 4. "Closing reader" log should be present.
-	validateInactiveReaderClosedLog(s.T(), testEnv.cfg.LogFile, path.Join(kTestDirName, fileName), true, endTimeRead, endTimeWait)
+	s.T().Log("Waiting for 'Closing reader' log message...")
+	operations.RetryUntil(testEnv.ctx, s.T(), retryFrequency, retryDuration, func() (string, error) {
+		return hasInactiveReaderClosedLogLineInLogFile(s.T(), path.Join(kTestDirName, fileName), testEnv.cfg.LogFile, endTimeRead, endTimeWait)
+	})
 
-	// 5. Further reads should work as it is, yeah it will create a new reader.
+	// 4. Further reads should work as it is, yeah it will create a new reader.
 	_, err = fileHandle.ReadAt(buff, 8)
 	require.NoError(s.T(), err)
 }
@@ -111,7 +113,7 @@ func (s *timeoutEnabledSuite) TestReaderStaysOpenWithinTimeout() {
 
 	// 4. Check log: "Closing reader for object..." should NOT be present for this object
 	// between the first read's end and the second read's start.
-	validateInactiveReaderClosedLog(s.T(), testEnv.cfg.LogFile, path.Join(kTestDirName, fileName), false, endTimeRead1, startTimeRead2)
+	doesNotHaveInactiveReaderClosedLogLineInLogFile(s.T(), path.Join(kTestDirName, fileName), testEnv.cfg.LogFile, endTimeRead1, startTimeRead2)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/without_timeout_test.go
@@ -77,7 +77,7 @@ func (s *timeoutDisabledSuite) TestNoReaderCloser() {
 	endTimeWait := time.Now()
 
 	// 4. Shouldn't be any `Close reader logs...`.
-	validateInactiveReaderClosedLog(s.T(), testEnv.cfg.LogFile, path.Join(kTestDirName, fileName), false, endTimeRead, endTimeWait)
+	doesNotHaveInactiveReaderClosedLogLineInLogFile(s.T(), path.Join(kTestDirName, fileName), testEnv.cfg.LogFile, endTimeRead, endTimeWait)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
On some machines or environments, log entries (specifically the "Closing reader for object... due to inactivity" message) may experience a slight delay before being written to the log file. This delay causes the `inactive_stream_timeout` integration tests to occasionally fail because the expected log lines aren't immediately present upon the first check.

This PR replaces `validateInactiveReaderClosedLog` with explicit log checking functions (`hasInactiveReaderClosedLogLineInLogFile` and `doesNotHaveInactiveReaderClosedLogLineInLogFile`) and integrates the `operations.RetryUntil` mechanism. It will now poll for the expected log entry for up to 30 seconds (checking every 1 second), improving the robustness of the log validation and preventing flaky test failures.

### Link to the issue in case of a bug fix.
Fixes [b/498811132](https://buganizer.corp.google.com/issue/498811132)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - `tools/integration_tests/inactive_stream_timeout`

### Any backward incompatible change? If so, please explain.
No
