### PR TITLE
feat(consistent symlink): Enable flag for updated symlink handling flow by default 

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -413,11 +413,11 @@ type Config struct {
 
 	EnableNewReader bool `yaml:"enable-new-reader"`
 
+	EnableStandardSymlinks bool `yaml:"enable-standard-symlinks"`
+
 	EnableTypeCacheDeprecation bool `yaml:"enable-type-cache-deprecation"`
 
 	EnableUnsupportedPathSupport bool `yaml:"enable-unsupported-path-support"`
-
-	ExperimentalEnableStandardSymlinks bool `yaml:"experimental-enable-standard-symlinks"`
 
 	FileCache FileCacheConfig `yaml:"file-cache"`
 
@@ -960,6 +960,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.BoolP("enable-standard-symlinks", "", true, "Enables the creation and reading of symbolic links using the standard GCS representation. When enabled, new symlinks created via GCSFuse mount ensure compatibility with other GCS clients like Storage Transfer Service (STS).")
+
+	if err := flagSet.MarkHidden("enable-standard-symlinks"); err != nil {
+		return err
+	}
+
 	flagSet.BoolP("enable-streaming-writes", "", true, "Enables streaming uploads during write file operation.")
 
 	flagSet.BoolP("enable-type-cache-deprecation", "", true, "Enables support to deprecate type cache.")
@@ -995,12 +1001,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("experimental-enable-readdirplus", "", false, "Enables ReadDirPlus capability")
 
 	if err := flagSet.MarkHidden("experimental-enable-readdirplus"); err != nil {
-		return err
-	}
-
-	flagSet.BoolP("experimental-enable-standard-symlinks", "", false, "Enables the creation and reading of symbolic links using the standard GCS representation. When enabled, new symlinks created via GCSFuse mount ensure compatibility with other GCS clients like Storage Transfer Service (STS).")
-
-	if err := flagSet.MarkHidden("experimental-enable-standard-symlinks"); err != nil {
 		return err
 	}
 
@@ -1569,6 +1569,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	if err := v.BindPFlag("enable-standard-symlinks", flagSet.Lookup("enable-standard-symlinks")); err != nil {
+		return err
+	}
+
 	if err := v.BindPFlag("write.enable-streaming-writes", flagSet.Lookup("enable-streaming-writes")); err != nil {
 		return err
 	}
@@ -1594,10 +1598,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.experimental-enable-readdirplus", flagSet.Lookup("experimental-enable-readdirplus")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("experimental-enable-standard-symlinks", flagSet.Lookup("experimental-enable-standard-symlinks")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -231,6 +231,16 @@ params:
     default: true
     hide-flag: true
 
+  - config-path: "enable-standard-symlinks"
+    flag-name: "enable-standard-symlinks"
+    type: "bool"
+    usage: >-
+      Enables the creation and reading of symbolic links using the standard GCS representation.
+      When enabled, new symlinks created via GCSFuse mount ensure compatibility with other
+      GCS clients like Storage Transfer Service (STS).
+    default: true
+    hide-flag: true
+
   - config-path: "enable-type-cache-deprecation"
     flag-name: "enable-type-cache-deprecation"
     type: "bool"
@@ -246,16 +256,6 @@ params:
       When set, GCSFuse will ignore these objects during listing and copying operations. 
       For rename and delete operations, the flag allows the action to proceed for all specified objects, including those with unsupported names.
     default: true
-    hide-flag: true
-
-  - config-path: "experimental-enable-standard-symlinks"
-    flag-name: "experimental-enable-standard-symlinks"
-    type: "bool"
-    usage: >-
-      Enables the creation and reading of symbolic links using the standard GCS representation.
-      When enabled, new symlinks created via GCSFuse mount ensure compatibility with other
-      GCS clients like Storage Transfer Service (STS).
-    default: false
     hide-flag: true
 
   - config-path: "file-cache.cache-file-for-range-read"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1586,12 +1586,12 @@ func TestArgsParsing_EnableStandardSymlinks(t *testing.T) {
 		{
 			name:                           "default",
 			args:                           []string{"gcsfuse", "abc", "pqr"},
-			expectedEnableStandardSymlinks: false,
+			expectedEnableStandardSymlinks: true,
 		},
 		{
 			name:                           "normal",
-			args:                           []string{"gcsfuse", "--experimental-enable-standard-symlinks=true", "abc", "pqr"},
-			expectedEnableStandardSymlinks: true,
+			args:                           []string{"gcsfuse", "--enable-standard-symlinks=false", "abc", "pqr"},
+			expectedEnableStandardSymlinks: false,
 		},
 	}
 
@@ -1599,7 +1599,7 @@ func TestArgsParsing_EnableStandardSymlinks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotEnableStandardSymlinks bool
 			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
-				gotEnableStandardSymlinks = mountInfo.config.ExperimentalEnableStandardSymlinks
+				gotEnableStandardSymlinks = mountInfo.config.EnableStandardSymlinks
 				return nil
 			})
 			require.Nil(t, err)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -347,7 +347,7 @@ func NewDirInode(
 		name:                                   name,
 		attrs:                                  attrs,
 		isHNSEnabled:                           cfg.EnableHns,
-		isStandardSymlinkRepresentationEnabled: cfg.ExperimentalEnableStandardSymlinks,
+		isStandardSymlinkRepresentationEnabled: cfg.EnableStandardSymlinks,
 		isUnsupportedPathSupportEnabled:        cfg.EnableUnsupportedPathSupport,
 		isEnableTypeCacheDeprecation:           cfg.EnableTypeCacheDeprecation,
 		unlinked:                               false,

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1573,12 +1573,12 @@ func (t *DirTest) TestCreateChildSymlink_StandardSymlinkEnabled() {
 	// Re-create inode with standard symlinks enabled.
 	t.in.Unlock()
 	config := &cfg.Config{
-		List:                               cfg.ListConfig{EnableEmptyManagedFolders: true},
-		MetadataCache:                      cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
-		EnableHns:                          false,
-		EnableUnsupportedPathSupport:       true,
-		EnableTypeCacheDeprecation:         isTypeCacheDeprecationEnabled,
-		ExperimentalEnableStandardSymlinks: true,
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: true},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   isTypeCacheDeprecationEnabled,
+		EnableStandardSymlinks:       true,
 	}
 	parInodeCtx := context.Background()
 	t.in = NewDirInode(

--- a/tools/integration_tests/symlink_handling/symlink_handling_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_handling_test.go
@@ -58,12 +58,12 @@ func TestMain(m *testing.M) {
 		cfg.SymlinkHandling[0].Configs = make([]test_suite.ConfigItem, 2)
 
 		// 1. TestStandardSymlinksTestSuite
-		cfg.SymlinkHandling[0].Configs[0].Flags = []string{"--experimental-enable-standard-symlinks=true"}
+		cfg.SymlinkHandling[0].Configs[0].Flags = []string{"--enable-standard-symlinks=true"}
 		cfg.SymlinkHandling[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.SymlinkHandling[0].Configs[0].Run = "TestStandardSymlinksTestSuite"
 
 		// 2. TestLegacySymlinksTestSuite
-		cfg.SymlinkHandling[0].Configs[1].Flags = []string{"--experimental-enable-standard-symlinks=false"}
+		cfg.SymlinkHandling[0].Configs[1].Flags = []string{"--enable-standard-symlinks=false"}
 		cfg.SymlinkHandling[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.SymlinkHandling[0].Configs[1].Run = "TestLegacySymlinksTestSuite"
 	}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -983,7 +983,7 @@ symlink_handling:
     configs:
       - run: TestStandardSymlinksTestSuite
         flags:
-          - "--experimental-enable-standard-symlinks=true"
+          - "--enable-standard-symlinks=true"
         compatible:
           flat: true
           hns: true
@@ -991,7 +991,7 @@ symlink_handling:
         run_on_gke: true
       - run: TestLegacySymlinksTestSuite
         flags:
-          - "--experimental-enable-standard-symlinks=false"
+          - "--enable-standard-symlinks=false"
         compatible:
           flat: true
           hns: true


### PR DESCRIPTION
### Description
Ahead of GCSFuse v3.9.0 release, enable the updated flow of handling symlinks by default on. The changes will  improve interoperability between GCSFuse and other GCS clients with respect to symbolic links. Details at: [go/sts-consistent-symlink-handling-in-gcsfuse](http://goto.google.com/sts-consistent-symlink-handling-in-gcsfuse)

Performance impact documented at: [go/perf-testing-for-updated-symlink-handling-in-gcsfuse](http://goto.google.com/perf-testing-for-updated-symlink-handling-in-gcsfuse)
### Link to the issue in case of a bug fix.
[b/498600492
](b/498600492)
### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated.

### Any backward incompatible change? If so, please explain.
No, changes will be backward compatible. 