### PR TITLE
refactor(read_cache): Deflake read_cache integration tests using unique directories and retry logic

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_exclude_regex_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_exclude_regex_test.go
@@ -52,7 +52,7 @@ func (s *cacheFileForExcludeRegexTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *cacheFileForExcludeRegexTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/cache_file_for_include_regex_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_include_regex_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -51,7 +52,7 @@ func (s *cacheFileForIncludeRegexTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *cacheFileForIncludeRegexTest) TearDownTest() {
@@ -81,7 +82,7 @@ func (s *cacheFileForIncludeRegexTest) TestCacheFileForIncludeRegexForIncludedFi
 
 func (s *cacheFileForIncludeRegexTest) TestCacheFileForIncludeRegexForNonIncludedFile() {
 	testFileName := "non-matching-regex" + setup.GenerateRandomString(testFileNameSuffixLength)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, testFileName, fileSize, s.T())
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), testFileName, fileSize, s.T())
 
 	// Read the file and validate that it is not cached.
 	expectedOutcome1 := readFileAndGetExpectedOutcome(testEnv.testDirPath, testFileName, true, 0, s.T())
@@ -96,7 +97,7 @@ func (s *cacheFileForIncludeRegexTest) TestCacheFileForIncludeRegexForNonInclude
 func (s *cacheFileForIncludeRegexTest) TestCacheFileForIncludeRegexForIncludedAndExcludeNoOverlap() {
 	includedFileName := setupFileInTestDir(s.ctx, s.storageClient, fileSize, s.T())
 	excludedFileName := "non-matching-regex" + setup.GenerateRandomString(testFileNameSuffixLength)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, excludedFileName, fileSize, s.T())
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), excludedFileName, fileSize, s.T())
 
 	// Read the included file and validate that it is cached.
 	expectedOutcome1 := readFileAndGetExpectedOutcome(testEnv.testDirPath, includedFileName, true, 0, s.T())

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_false_test.go
@@ -59,7 +59,7 @@ func (s *cacheFileForRangeReadFalseTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *cacheFileForRangeReadFalseTest) TearDownTest() {
@@ -79,7 +79,7 @@ func readFileBetweenOffset(t *testing.T, file *os.File, startOffset, endOffSet i
 	expected := &Expected{
 		StartTimeStampSeconds: time.Now().Unix(),
 		BucketName:            setup.TestBucket(),
-		ObjectName:            path.Join(testDirName, path.Base(file.Name())),
+		ObjectName:            path.Join(path.Base(testEnv.testDirPath), path.Base(file.Name())),
 	}
 	if setup.DynamicBucketMounted() != "" {
 		expected.BucketName = setup.DynamicBucketMounted()

--- a/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_range_read_true_test.go
@@ -56,7 +56,7 @@ func (s *cacheFileForRangeReadTrueTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *cacheFileForRangeReadTrueTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/chunk_cache_disabled_test.go
+++ b/tools/integration_tests/read_cache/chunk_cache_disabled_test.go
@@ -50,7 +50,7 @@ func (s *chunkCacheDisabledTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *chunkCacheDisabledTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/chunk_cache_eviction_test.go
+++ b/tools/integration_tests/read_cache/chunk_cache_eviction_test.go
@@ -50,7 +50,7 @@ func (s *chunkCacheEvictionTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *chunkCacheEvictionTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/chunk_cache_test.go
+++ b/tools/integration_tests/read_cache/chunk_cache_test.go
@@ -58,7 +58,7 @@ func (s *chunkCacheTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *chunkCacheTest) TearDownTest() {
@@ -135,7 +135,7 @@ func (s *chunkCacheTest) TestReadSpanningTwoBlocks() {
 	content, err := operations.ReadChunkFromFile(path.Join(testEnv.testDirPath, testFileName), 1*util.MiB, 19.5*util.MiB, os.O_RDONLY|syscall.O_DIRECT)
 
 	require.NoError(s.T(), err)
-	client.ValidateObjectChunkFromGCS(s.ctx, s.storageClient, testDirName, testFileName, 19.5*util.MiB, 1*util.MiB, string(content), s.T())
+	client.ValidateObjectChunkFromGCS(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), testFileName, 19.5*util.MiB, 1*util.MiB, string(content), s.T())
 	jobLogs := read_logs.GetJobLogsSortedByTimestamp(testEnv.cfg.LogFile, s.T())
 	require.NotEmpty(s.T(), jobLogs)
 	expectedDownloads := []data.ObjectRange{
@@ -178,7 +178,7 @@ func (s *chunkCacheTest) TestReadOfDeletedfile() {
 	// Read first chunk to ensure cache file is created and populated.
 	readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, 0, s.T())
 	// Delete the file from GCS to trigger a failure during the next download attempt.
-	_, objectName := setup.GetBucketAndObjectBasedOnTypeOfMount(path.Join(testDirName, testFileName))
+	_, objectName := setup.GetBucketAndObjectBasedOnTypeOfMount(path.Join(path.Base(testEnv.testDirPath), testFileName))
 	err := client.DeleteObjectOnGCS(s.ctx, s.storageClient, objectName)
 	require.NoError(s.T(), err)
 

--- a/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/disabled_cache_ttl_test.go
@@ -52,7 +52,7 @@ func (s *disabledCacheTTLTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *disabledCacheTTLTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -50,7 +50,7 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, readFullFile bo
 	expected := &Expected{
 		StartTimeStampSeconds: time.Now().Unix(),
 		BucketName:            setup.TestBucket(),
-		ObjectName:            path.Join(testDirName, fileName),
+		ObjectName:            path.Join(path.Base(testEnv.testDirPath), fileName),
 	}
 	if setup.DynamicBucketMounted() != "" {
 		expected.BucketName = setup.DynamicBucketMounted()
@@ -115,7 +115,7 @@ func getCachedFilePath(fileName string) string {
 	if setup.DynamicBucketMounted() != "" {
 		bucketName = setup.DynamicBucketMounted()
 	}
-	return path.Join(testEnv.cacheDirPath, cacheSubDirectoryName, bucketName, testDirName, fileName)
+	return path.Join(testEnv.cacheDirPath, cacheSubDirectoryName, bucketName, path.Base(testEnv.testDirPath), fileName)
 }
 
 func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testing.T) {
@@ -145,7 +145,7 @@ func validateFileSizeInCacheDirectory(fileName string, filesize int64, t *testin
 func validateFileInCacheDirectory(fileName string, filesize int64, ctx context.Context, storageClient *storage.Client, t *testing.T) {
 	validateFileSizeInCacheDirectory(fileName, filesize, t)
 
-	gcsCRC, err := client.GetCRCFromGCS(path.Join(testDirName, fileName), ctx, storageClient)
+	gcsCRC, err := client.GetCRCFromGCS(path.Join(path.Base(testEnv.testDirPath), fileName), ctx, storageClient)
 	require.NoError(t, err)
 	maxRetries := 20
 	retryDelay := 500 * time.Millisecond
@@ -200,7 +200,7 @@ func readFileAndValidateCacheWithGCS(ctx context.Context, storageClient *storage
 	if err != nil {
 		t.Errorf("CalculateCRC32 Failed: %v", err)
 	}
-	gcsCRC, err := client.GetCRCFromGCS(path.Join(testDirName, filename), ctx, storageClient)
+	gcsCRC, err := client.GetCRCFromGCS(path.Join(path.Base(testEnv.testDirPath), filename), ctx, storageClient)
 	if err != nil || gcsCRC != gotCRC32Value {
 		t.Errorf("Content served CRC mismatch: %v", err)
 	}
@@ -219,7 +219,7 @@ func readChunkAndValidateObjectContentsFromGCS(ctx context.Context, storageClien
 	// Read file via gcsfuse mount.
 	expectedOutcome = readFileAndGetExpectedOutcome(testEnv.testDirPath, filename, false, offset, t)
 	// Validate content read via gcsfuse with gcs.
-	client.ValidateObjectChunkFromGCS(ctx, storageClient, testDirName, filename, offset, chunkSizeToRead,
+	client.ValidateObjectChunkFromGCS(ctx, storageClient, path.Base(testEnv.testDirPath), filename, offset, chunkSizeToRead,
 		expectedOutcome.content, t)
 
 	return expectedOutcome
@@ -232,15 +232,15 @@ func readFileAndValidateFileIsNotCached(ctx context.Context, storageClient *stor
 	validateFileIsNotCached(fileName, t)
 	// validate the content read matches the content on GCS.
 	if readFullFile {
-		client.ValidateObjectContentsFromGCS(ctx, storageClient, testDirName, fileName, expectedOutcome.content, t)
+		client.ValidateObjectContentsFromGCS(ctx, storageClient, path.Base(testEnv.testDirPath), fileName, expectedOutcome.content, t)
 	} else {
-		client.ValidateObjectChunkFromGCS(ctx, storageClient, testDirName, fileName, offset, chunkSizeToRead, expectedOutcome.content, t)
+		client.ValidateObjectChunkFromGCS(ctx, storageClient, path.Base(testEnv.testDirPath), fileName, offset, chunkSizeToRead, expectedOutcome.content, t)
 	}
 	return expectedOutcome
 }
 
 func modifyFile(ctx context.Context, storageClient *storage.Client, testFileName string, t *testing.T) {
-	objectName := path.Join(testDirName, testFileName)
+	objectName := path.Join(path.Base(testEnv.testDirPath), testFileName)
 	smallContent, err := operations.GenerateRandomData(smallContentSize)
 	if err != nil {
 		t.Errorf("Could not generate random data to modify file: %v", err)
@@ -263,7 +263,7 @@ func validateCacheSizeWithinLimit(cacheCapacity int64, t *testing.T) {
 
 func setupFileInTestDir(ctx context.Context, storageClient *storage.Client, fileSize int64, t *testing.T) (fileName string) {
 	testFileName := testFileName + setup.GenerateRandomString(testFileNameSuffixLength)
-	client.SetupFileInTestDirectory(ctx, storageClient, testDirName, testFileName, fileSize, t)
+	client.SetupFileInTestDirectory(ctx, storageClient, path.Base(testEnv.testDirPath), testFileName, fileSize, t)
 
 	return testFileName
 }
@@ -321,7 +321,7 @@ func validateContent(t *testing.T, fileName string, start, end int64) {
 	require.NoError(t, err)
 
 	// Read from GCS
-	objectName := path.Join(testDirName, fileName)
+	objectName := path.Join(path.Base(testEnv.testDirPath), fileName)
 	bucketName, objectName := setup.GetBucketAndObjectBasedOnTypeOfMount(objectName)
 	rc, err := testEnv.storageClient.Bucket(bucketName).Object(objectName).NewRangeReader(testEnv.ctx, start, size)
 	require.NoError(t, err)

--- a/tools/integration_tests/read_cache/job_chunk_test.go
+++ b/tools/integration_tests/read_cache/job_chunk_test.go
@@ -57,7 +57,7 @@ func (s *jobChunkTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *jobChunkTest) TearDownTest() {

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -52,7 +52,7 @@ func (s *localModificationTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *localModificationTest) TearDownTest() {
@@ -68,7 +68,7 @@ func (s *localModificationTest) TearDownSuite() {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss() {
-	testFileName := testDirName + setup.GenerateRandomString(testFileNameSuffixLength)
+	testFileName := testDirPrefix + setup.GenerateRandomString(testFileNameSuffixLength)
 	operations.CreateFileOfSize(fileSize, path.Join(testEnv.testDirPath, testFileName), s.T())
 
 	// Read file 1st time.

--- a/tools/integration_tests/read_cache/range_read_test.go
+++ b/tools/integration_tests/read_cache/range_read_test.go
@@ -15,6 +15,7 @@ package read_cache
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -53,7 +54,7 @@ func (s *rangeReadTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *rangeReadTest) TearDownTest() {
@@ -88,13 +89,37 @@ func (s *rangeReadTest) TestRangeReadsWithinReadChunkSize() {
 func (s *rangeReadTest) TestRangeReadsBeyondReadChunkSizeWithFileCached() {
 	testFileName := setupFileInTestDir(s.ctx, s.storageClient, largeFileSize, s.T())
 
+	// Read first chunk (0-128KB) to trigger the background file cache download job.
 	expectedOutcome1 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, zeroOffset, s.T())
-	validateFileInCacheDirectory(testFileName, largeFileSize, testEnv.ctx, s.storageClient, s.T())
+
+	// Wait until the background job downloads both the first 8MiB chunk and the second 8MiB-15MiB chunk.
+	// This ensures the read at 10MiB is always a cache hit, making the test deterministic.
+	s.T().Logf("Waiting for file cache Job with data reaching %d bytes", largeFileSize)
+	JobLog := operations.RetryUntil(s.ctx, s.T(), retryFrequency, retryDuration, func() ([]*read_logs.Job, error) {
+		logs := read_logs.GetJobLogsSortedByTimestamp(testEnv.cfg.LogFile, s.T())
+		if len(logs) == 1 {
+			for _, entry := range logs[0].JobEntries {
+				if entry.Offset >= largeFileSize {
+					s.T().Logf("Found file cache Job with sufficient data (offset %d): %v", entry.Offset, logs[0])
+					return logs, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("expected 1 Job with an entry >= %d bytes, found %d jobs", largeFileSize, len(logs))
+	})
+	require.Equal(s.T(), expectedOutcome1.ObjectName, JobLog[0].ObjectName)
+
+	// Read the second chunk at offset 10MiB. This should be a cache hit since the background job
+	// was verified to have downloaded the second chunk (reaching up to 15MiB).
 	expectedOutcome2 := readChunkAndValidateObjectContentsFromGCS(s.ctx, s.storageClient, testFileName, offset10MiB, s.T())
 
+	// Validate results for both reads, verifying the second one is a cache hit.
 	structuredReadLogs := read_logs.GetStructuredLogsSortedByTimestamp(testEnv.cfg.LogFile, s.T())
+	require.Len(s.T(), structuredReadLogs, 2, "Should have exactly 2 read records in logs")
 	validate(expectedOutcome1, structuredReadLogs[0], true, false, 1, s.T())
 	validate(expectedOutcome2, structuredReadLogs[1], false, true, 1, s.T())
+
+	validateFileInCacheDirectory(testFileName, largeFileSize, testEnv.ctx, s.storageClient, s.T())
 	validateCacheSizeWithinLimit(largeFileCacheCapacity, s.T())
 }
 

--- a/tools/integration_tests/read_cache/read_only_test.go
+++ b/tools/integration_tests/read_cache/read_only_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -51,7 +52,7 @@ func (s *readOnlyTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *readOnlyTest) TearDownTest() {
@@ -102,7 +103,7 @@ func (s *readOnlyTest) TestSecondSequentialReadIsCacheHit() {
 func (s *readOnlyTest) TestReadFileSequentiallyLargerThanCacheCapacity() {
 	// Set up a file in test directory of size more than cache capacity.
 	fileName := setup.GenerateRandomString(7)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, fileName, largeFileSize, s.T())
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), fileName, largeFileSize, s.T())
 
 	// Read file 1st time.
 	expectedOutcome1 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, fileName, true, zeroOffset, s.T())
@@ -118,7 +119,7 @@ func (s *readOnlyTest) TestReadFileSequentiallyLargerThanCacheCapacity() {
 func (s *readOnlyTest) TestReadFileRandomlyLargerThanCacheCapacity() {
 	// Set up a file in test directory of size more than cache capacity.
 	fileName := setup.GenerateRandomString(7)
-	client.SetupFileInTestDirectory(s.ctx, s.storageClient, testDirName, fileName, largeFileSize, s.T())
+	client.SetupFileInTestDirectory(s.ctx, s.storageClient, path.Base(testEnv.testDirPath), fileName, largeFileSize, s.T())
 
 	// Do a random read on file.
 	expectedOutcome1 := readFileAndValidateFileIsNotCached(s.ctx, s.storageClient, fileName, false, randomReadOffset, s.T())
@@ -132,7 +133,7 @@ func (s *readOnlyTest) TestReadFileRandomlyLargerThanCacheCapacity() {
 }
 
 func (s *readOnlyTest) TestReadMultipleFilesMoreThanCacheLimit() {
-	fileNames := client.CreateNFilesInDir(s.ctx, s.storageClient, NumberOfFilesMoreThanCacheLimit, testFileName, fileSize, testDirName, s.T())
+	fileNames := client.CreateNFilesInDir(s.ctx, s.storageClient, NumberOfFilesMoreThanCacheLimit, testFileName, fileSize, path.Base(testEnv.testDirPath), s.T())
 
 	expectedOutcome := readMultipleFiles(NumberOfFilesMoreThanCacheLimit, s.ctx, s.storageClient, fileNames, s.T())
 	expectedOutcome = append(expectedOutcome, readMultipleFiles(NumberOfFilesMoreThanCacheLimit, s.ctx, s.storageClient, fileNames, s.T())...)
@@ -144,7 +145,7 @@ func (s *readOnlyTest) TestReadMultipleFilesMoreThanCacheLimit() {
 }
 
 func (s *readOnlyTest) TestReadMultipleFilesWithinCacheLimit() {
-	fileNames := client.CreateNFilesInDir(s.ctx, s.storageClient, NumberOfFilesWithinCacheLimit, testFileName, fileSize, testDirName, s.T())
+	fileNames := client.CreateNFilesInDir(s.ctx, s.storageClient, NumberOfFilesWithinCacheLimit, testFileName, fileSize, path.Base(testEnv.testDirPath), s.T())
 
 	expectedOutcome := readMultipleFiles(NumberOfFilesWithinCacheLimit, s.ctx, s.storageClient, fileNames, s.T())
 	expectedOutcome = append(expectedOutcome, readMultipleFiles(NumberOfFilesWithinCacheLimit, s.ctx, s.storageClient, fileNames, s.T())...)

--- a/tools/integration_tests/read_cache/remount_test.go
+++ b/tools/integration_tests/read_cache/remount_test.go
@@ -52,7 +52,7 @@ func (s *remountTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *remountTest) TearDownTest() {
@@ -70,7 +70,7 @@ func (s *remountTest) TearDownSuite() {
 func readFileAndValidateCacheWithGCSForDynamicMount(bucketName string, ctx context.Context, storageClient *storage.Client, fileName string, checkCacheSize bool, t *testing.T) (expectedOutcome *Expected) {
 	setup.SetDynamicBucketMounted(bucketName)
 	defer setup.SetDynamicBucketMounted("")
-	testEnv.testDirPath = path.Join(rootDir, bucketName, testDirName)
+	testEnv.testDirPath = path.Join(rootDir, bucketName, path.Base(testEnv.testDirPath))
 	expectedOutcome = readFileAndValidateCacheWithGCS(ctx, storageClient, fileName, fileSize, checkCacheSize, t)
 
 	return expectedOutcome

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
@@ -33,7 +34,7 @@ import (
 )
 
 const (
-	testDirName                        = "ReadCacheTest"
+	testDirPrefix                      = "ReadCacheTest"
 	onlyDirMounted                     = "OnlyDirMountReadCache"
 	cacheSubDirectoryName              = "gcsfuse-file-cache"
 	smallContentSize                   = 128 * util.KiB
@@ -60,6 +61,8 @@ const (
 	offset10MiB                        = 10 * util.MiB
 	cacheCapacityForRangeReadTestInMiB = 50
 	GKETempDir                         = "/gcsfuse-tmp"
+	retryFrequency                     = 5 * time.Second // Used in poll frequency for asynchronous test expecation.
+	retryDuration                      = 5 * time.Minute // Used for poll duration for asynchronous test expecation.
 )
 
 var (
@@ -111,7 +114,7 @@ func setupLogFileAndCacheDir(testName string) {
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
 	setup.SetMntDir(mountDir)
-	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(ctx, storageClient, testDirPrefix)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -298,10 +301,10 @@ func TestMain(m *testing.M) {
 		cfg.ReadCache[0].Configs[15].Run = "TestRemountTest"
 
 		cfg.ReadCache[0].Configs[16].Flags = []string{
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
-			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest.*/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest.*/foo* --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest.*/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-include-regex=^" + setup.TestBucket() + "/.*ReadCacheTest.*/foo* --file-cache-exclude-regex=invalid --file-cache-max-size-mb=9 --cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest --log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
 		}
 		cfg.ReadCache[0].Configs[16].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.ReadCache[0].Configs[16].Run = "TestCacheFileForIncludeRegexTest"
@@ -370,11 +373,11 @@ func TestMain(m *testing.M) {
 		mountDir = rootDir
 		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
 		successCode = m.Run()
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirPrefix))
 	}
 
 	// Clean up test directory created.
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirPrefix))
 	os.Exit(successCode)
 }
 

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -77,7 +77,7 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss() {
 		expectedOutcome2 *Expected
 	}
 
-	s.T().Logf("Validating that stale data is served before cache expiry and fresh data (cache miss) is served after expiry.")
+	s.T().Logf("Validating that stale data is served before cache expiry (%d seconds Metadata Cache TTL).", metadataCacheTTlInSec)
 	result := operations.RetryUntil(s.ctx, s.T(), retryFrequency, retryDuration, func() (initialReadState, error) {
 		// Truncate log file created.
 		err := os.Truncate(testEnv.cfg.LogFile, 0)
@@ -100,9 +100,11 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss() {
 		expectedOutcome2 := readFileAndGetExpectedOutcome(testEnv.testDirPath, testFileName, true, zeroOffset, s.T())
 
 		if time.Since(startTime) >= metadataCacheTTlInSec*time.Second {
-			// Retry if the time taken is more (due to GCS Latency or high load) than the metadata cache TTL which would certainly fail the test.
-			return initialReadState{}, fmt.Errorf("failed because it took %v", time.Since(startTime).Seconds())
+			// Retry if the time taken is more (due to GCS Latency or high load) than the metadata cache TTL.
+			// In this scenario, the test would certainly fail as the stale data would not be served.
+			return initialReadState{}, fmt.Errorf("failed: because operation took %v seconds >= %d seconds (Metadata Cache TTL)", time.Since(startTime).Seconds(), metadataCacheTTlInSec)
 		}
+		s.T().Logf("Success: Operation took %v seconds < %d seconds (Metadata Cache TTL)", time.Since(startTime).Seconds(), metadataCacheTTlInSec)
 		return initialReadState{testFileName, expectedOutcome1, expectedOutcome2}, nil
 	})
 
@@ -115,7 +117,7 @@ func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss() {
 	if strings.Compare(expectedOutcome1.content, expectedOutcome2.content) != 0 {
 		s.T().Errorf("content mismatch. Expected old data to be served again.")
 	}
-	// Wait for metadata cache expiry and read the file again.
+	s.T().Logf("Waiting for %d seconds for metadata cache to expire to get cache miss.", metadataCacheTTlInSec)
 	time.Sleep(metadataCacheTTlInSec * time.Second)
 	expectedOutcome3 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, smallContentSize, true, s.T())
 

--- a/tools/integration_tests/read_cache/small_cache_ttl_test.go
+++ b/tools/integration_tests/read_cache/small_cache_ttl_test.go
@@ -16,6 +16,7 @@ package read_cache
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func (s *smallCacheTTLTest) SetupTest() {
 	require.NoError(s.T(), err)
 	// Clean up the cache directory path as gcsfuse don't clean up on mounting.
 	operations.RemoveDir(testEnv.cacheDirPath)
-	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
+	testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
 }
 
 func (s *smallCacheTTLTest) TearDownTest() {
@@ -70,14 +71,45 @@ func (s *smallCacheTTLTest) TearDownSuite() {
 ////////////////////////////////////////////////////////////////////////
 
 func (s *smallCacheTTLTest) TestReadAfterUpdateAndCacheExpiryIsCacheMiss() {
-	testFileName := setupFileInTestDir(s.ctx, s.storageClient, fileSize, s.T())
+	type initialReadState struct {
+		testFileName     string
+		expectedOutcome1 *Expected
+		expectedOutcome2 *Expected
+	}
 
-	// Read file 1st time.
-	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, true, s.T())
-	// Modify the file.
-	modifyFile(s.ctx, s.storageClient, testFileName, s.T())
-	// Read same file again immediately.
-	expectedOutcome2 := readFileAndGetExpectedOutcome(testEnv.testDirPath, testFileName, true, zeroOffset, s.T())
+	s.T().Logf("Validating that stale data is served before cache expiry and fresh data (cache miss) is served after expiry.")
+	result := operations.RetryUntil(s.ctx, s.T(), retryFrequency, retryDuration, func() (initialReadState, error) {
+		// Truncate log file created.
+		err := os.Truncate(testEnv.cfg.LogFile, 0)
+		require.NoError(s.T(), err)
+		// Clean up the cache directory path as gcsfuse don't clean up on mounting.
+		operations.RemoveDir(testEnv.cacheDirPath)
+		testEnv.testDirPath = client.SetupUniqueTestDirectory(s.ctx, s.storageClient, testDirPrefix)
+
+		testFileName := setupFileInTestDir(s.ctx, s.storageClient, fileSize, s.T())
+
+		startTime := time.Now()
+
+		// Read file 1st time.
+		expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, true, s.T())
+
+		// Modify the file.
+		modifyFile(s.ctx, s.storageClient, testFileName, s.T())
+
+		// Read same file again immediately.
+		expectedOutcome2 := readFileAndGetExpectedOutcome(testEnv.testDirPath, testFileName, true, zeroOffset, s.T())
+
+		if time.Since(startTime) >= metadataCacheTTlInSec*time.Second {
+			// Retry if the time taken is more (due to GCS Latency or high load) than the metadata cache TTL which would certainly fail the test.
+			return initialReadState{}, fmt.Errorf("failed because it took %v", time.Since(startTime).Seconds())
+		}
+		return initialReadState{testFileName, expectedOutcome1, expectedOutcome2}, nil
+	})
+
+	testFileName := result.testFileName
+	expectedOutcome1 := result.expectedOutcome1
+	expectedOutcome2 := result.expectedOutcome2
+
 	validateFileSizeInCacheDirectory(testFileName, fileSize, s.T())
 	// Validate that stale data is served from cache in this case.
 	if strings.Compare(expectedOutcome1.content, expectedOutcome2.content) != 0 {

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -424,10 +424,10 @@ read_cache:
         run: TestRemountTest
         run_on_gke: false
       - flags:
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
-          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -156,6 +156,11 @@ func SetupTestDirectory(ctx context.Context, storageClient *storage.Client, test
 	return testDirPath
 }
 
+func SetupUniqueTestDirectory(ctx context.Context, storageClient *storage.Client, testDirPrefix string) string {
+	testDirName := testDirPrefix + "_" + setup.GenerateRandomString(5)
+	return SetupTestDirectory(ctx, storageClient, testDirName)
+}
+
 func CreateNFilesInDir(ctx context.Context, storageClient *storage.Client, numFiles int, fileName string, fileSize int64, dirName string, t *testing.T) (fileNames []string) {
 	for range numFiles {
 		testFileName := fileName + setup.GenerateRandomString(4)


### PR DESCRIPTION
### Description
This PR deflakes the read_cache integration test suite by addressing test run isolation and adding robust retry logic for asynchronous operations.

Key Changes
1. Test Isolation with Unique Directories to get rid of 429 errors causing test slowness.
Migrated all test files in tools/integration_tests/read_cache/ to use unique test directories.
Replaced the deprecated testDirName constant with path.Base(testEnv.testDirPath) to dynamically evaluate the unique directory name created by SetupUniqueTestDirectory (which appends a random suffix).
Updated SetupTest across all files to utilize client.SetupUniqueTestDirectory.
2. Robust Retry Logic for background operations
Implemented operations.RetryUntil in small_cache_ttl_test.go and range_read_test.go to:
Synchronize background file cache downloads before validation.
Ensure test sequences (setup, read, modify, verify) execute within the TTL window deterministically.
Improved log messages to be more accurate (e.g., describing stale data serving before expiry).
### Link to the issue in case of a bug fix.
b/498904776

### Results:
After this change read_cache package is comfortably passing in all release VM(s) whereas on master it was failing on almost ALL VM(s). 

### Testing details
1. Manual - Yes
2. Unit tests - None
3. Integration tests - Part of pre-submit.

### Any backward incompatible change? If so, please explain.
