### PR TITLE
fix(integration_tests): prevent overwriting MntDir in GKE executions

### DIFF
--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -61,7 +61,9 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	if testEnv.cfg.GCSFuseMountedDirectory != "" {
+		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	}
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 

--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -61,9 +61,7 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	if testEnv.cfg.GCSFuseMountedDirectory != "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
@@ -112,6 +110,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -119,7 +118,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -54,9 +54,7 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
@@ -105,7 +103,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -114,7 +112,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/stale_handle/setup_test.go
+++ b/tools/integration_tests/stale_handle/setup_test.go
@@ -35,6 +35,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
+	rootDir string
 )
 
 type env struct {
@@ -98,13 +99,13 @@ func TestMain(m *testing.M) {
 	// flags to be set, as stale handle tests validates content from the bucket.
 	// Note: These tests by default can only be run for non streaming mounts.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-	mountDir = setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/stale_handle/setup_test.go
+++ b/tools/integration_tests/stale_handle/setup_test.go
@@ -35,7 +35,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
-	rootDir string
+	rootDir  string
 )
 
 type env struct {

--- a/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
@@ -44,9 +44,7 @@ type staleFileHandleCommon struct {
 
 func (s *staleFileHandleCommon) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = SetupTestDirectory(testEnv.ctx, testEnv.storageClient, testDirName)
 	s.data = setup.GenerateRandomString(5 * util.MiB)
 }

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -36,6 +36,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
+	rootDir string
 )
 
 type env struct {
@@ -99,7 +100,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -108,7 +109,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir = setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -36,7 +36,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
-	rootDir string
+	rootDir  string
 )
 
 type env struct {

--- a/tools/integration_tests/unfinalized_object/tailing_reads_test.go
+++ b/tools/integration_tests/unfinalized_object/tailing_reads_test.go
@@ -51,9 +51,7 @@ func (s *unfinalizedObjectTailingReads) TearDownSuite() {
 
 func (s *unfinalizedObjectTailingReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -53,9 +53,7 @@ func (s *unfinalizedObjectOperations) TearDownSuite() {
 
 func (s *unfinalizedObjectOperations) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -65,9 +65,7 @@ func (s *unfinalizedObjectReads) TearDownSuite() {
 
 func (s *unfinalizedObjectReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 


### PR DESCRIPTION
### Description
This PR fixes an issue across multiple integration test suites (`benchmarking`, `dentry_cache`, `stale_handle`, and `unfinalized_object`) where `setup.MntDir` was being overwritten by an empty `GCSFuseMountedDirectory` during GKE test executions. 

The test setups have been refactored to handle mount directories more robustly:
- `mountDir` and `rootDir` are now explicitly initialized to `testEnv.cfg.GKEMountedDirectory` for GKE test runs, and fall back to `testEnv.cfg.GCSFuseMountedDirectory` for non-GKE test runs inside `TestMain`.
- The `SetupSuite` and `mountGCSFuseAndSetupTestDir` functions have been updated to use `setup.SetMntDir(mountDir)` instead of pulling directly from `testEnv.cfg.GCSFuseMountedDirectory`, ensuring the correctly initialized directory is always used.

### Link to the issue in case of a bug fix.
Fixes b/496956438

https://paste.googleplex.com/5608452220125184 Link for tests

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - (Tests passing in GKE environment)

### Any backward incompatible change? If so, please explain.
No.