### PR TITLE
test(integration): add script to run migrated tests on mounted directory

### DIFF
--- a/tools/integration_tests/run_migrated_tests_mounted_directory.sh
+++ b/tools/integration_tests/run_migrated_tests_mounted_directory.sh
@@ -1,0 +1,447 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exit on error, treat unset variables as errors, and propagate pipeline errors.
+set -euo pipefail
+
+RUN_ZONAL=false
+RUN_REGIONAL=true
+MOUNTED_DIR=""
+PACKAGE_NAME="" # Default is empty to trigger run-all
+RUN_ALL=false
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+CONFIG_FILE="${SCRIPT_DIR}/test_config.yaml"
+GCSFUSE_BINARY="${SCRIPT_DIR}/../../gcsfuse"
+
+# --- 0. Modular Utility Functions ---
+
+log_info() {
+    echo "[INFO] $(date +"%Y-%m-%d %H:%M:%S"): $1" >&2
+}
+
+log_error() {
+    echo "[ERROR] $(date +"%Y-%m-%d %H:%M:%S"): $1" >&2
+}
+
+fetch_gce_metadata() {
+    PROJECT_ID=$(curl -s -H "Metadata-Flavor: Google" --connect-timeout 1 http://metadata.google.internal/computeMetadata/v1/project/project-id || gcloud config get-value project 2>/dev/null || echo "gcs-fuse-test")
+    [[ "$PROJECT_ID" == *"cloudtop"* ]] && PROJECT_ID="gcs-fuse-test"
+
+    local zone
+    zone=$(curl -s -H "Metadata-Flavor: Google" --connect-timeout 1 http://metadata.google.internal/computeMetadata/v1/instance/zone || gcloud config get-value compute/zone 2>/dev/null || echo "us-central1-a")
+    EXACT_ZONE=$(basename "$zone")
+    BUCKET_LOCATION="${EXACT_ZONE%-*}"
+    BUCKET_LOCATION="${BUCKET_LOCATION:-us-central1}"
+}
+
+create_bucket() {
+    local bucket_type="$1"
+    local package_name="$2"
+
+    if [[ "$bucket_type" == "zonal" ]]; then
+        if [[ "$EXACT_ZONE" != "us-central1-a" && "$EXACT_ZONE" != "us-central1-c" ]]; then
+            log_error "RAPID zonal buckets require instance to be in us-central1-a or us-central1-c. Current zone: $EXACT_ZONE. Cannot run rapid."
+            return 1
+        fi
+    fi
+
+    local safe_pkg="${package_name//_/-}"
+    local bucket_name="gcsfuse-mounted-tests-${safe_pkg:0:20}-${bucket_type}-$(date +%s)"
+    local cmd=("gcloud" "alpha" "storage" "buckets" "create" "gs://${bucket_name}" "--project=${PROJECT_ID}" "--location=${BUCKET_LOCATION}" "--uniform-bucket-level-access")
+
+    if [[ "$bucket_type" == "hns" ]]; then
+        cmd+=("--enable-hierarchical-namespace")
+    elif [[ "$bucket_type" == "zonal" ]]; then
+        cmd+=("--enable-hierarchical-namespace" "--placement=${EXACT_ZONE}" "--default-storage-class=RAPID")
+    fi
+
+    log_info "Creating $bucket_type bucket: $bucket_name..."
+    if ! "${cmd[@]}" > /dev/null; then
+        log_error "Failed to create bucket $bucket_name"
+        return 1
+    fi
+    echo "$bucket_name"
+}
+
+delete_bucket() {
+    local bucket_name="$1"
+    log_info "Deleting bucket: $bucket_name..."
+    gcloud storage rm -r "gs://${bucket_name}" --no-user-output-enabled --verbosity=error || true
+}
+
+usage() {
+    echo "Usage: $0 [OPTIONS]" >&2
+    echo "" >&2
+    echo "Description:" >&2
+    echo "  Runs integration tests for GCSFuse on mounted directories." >&2
+    echo "  Parses test_config.yaml to dynamically mount buckets, run tests with specific flags," >&2
+    echo "  and handles cleanup. Supports both regional (flat/hns) and zonal (rapid) buckets." >&2
+    echo "" >&2
+    echo "Options:" >&2
+    echo "  --zonal                          Enable testing on Zonal (RAPID) buckets." >&2
+    echo "  --no-regional                    Disable testing on Regional (flat/hns) buckets." >&2
+    echo "                                   By default, regional is enabled and zonal is disabled." >&2
+    echo "  --mount-dir <mounted_directory>  Specify a custom mount directory." >&2
+    echo "                                   Defaults to dynamically generating one in /tmp." >&2
+    echo "  --package <package_name>         Run tests for a specific package only." >&2
+    echo "  --all                            Run tests for all packages." >&2
+    echo "  -h, --help                       Show this help message and exit." >&2
+    exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --zonal) RUN_ZONAL=true; shift 1 ;;
+        --no-regional) RUN_REGIONAL=false; shift 1 ;;
+        --mount-dir) MOUNTED_DIR="$2"; shift 2 ;;
+        --package) PACKAGE_NAME="$2"; shift 2 ;;
+        --all) RUN_ALL=true; shift 1 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown parameter passed: $1" >&2; usage ;;
+    esac
+done
+
+# If package name is missing or RUN_ALL is passed, run everything!
+if [ -z "$PACKAGE_NAME" ] || [ "$RUN_ALL" = true ]; then
+    RUN_ALL=true
+fi
+
+# --- 2. Robustness Checks ---  
+if ! command -v yq &> /dev/null; then
+    log_error "'yq' is not installed. Please install it to parse the YAML config."
+    exit 1
+fi
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    log_error "Configuration file not found at $CONFIG_FILE."
+    exit 1
+fi
+
+# Build gcsfuse binary if it doesn't exist
+if [ ! -f "$GCSFUSE_BINARY" ]; then
+    log_info "gcsfuse binary not found at $GCSFUSE_BINARY. Building it now..."
+    (cd "${SCRIPT_DIR}/../.." && go build -o gcsfuse .)
+    if [ ! -f "$GCSFUSE_BINARY" ]; then
+        log_error "Failed to build gcsfuse binary."
+        exit 1
+    fi
+    log_info "Successfully built gcsfuse."
+fi
+
+CONFIG_FILE_ABS="$(readlink -f "$CONFIG_FILE")"
+
+# Determine which packages to run
+if [ "$RUN_ALL" = true ]; then
+    PACKAGES=$(yq 'keys | .[]' "$CONFIG_FILE")
+else
+    PACKAGES="$PACKAGE_NAME"
+fi
+
+# Set bucket types based on flags
+BUCKET_TYPES=()
+if [ "$RUN_REGIONAL" = true ]; then
+    BUCKET_TYPES+=("hns" "flat")
+fi
+if [ "$RUN_ZONAL" = true ]; then
+    BUCKET_TYPES+=("zonal")
+fi
+
+if [ ${#BUCKET_TYPES[@]} -eq 0 ]; then
+    log_error "No bucket types selected. Please enable at least regional or zonal."
+    exit 1
+fi
+
+# Fetch metadata for bucket creation
+fetch_gce_metadata
+log_info "Using Project ID: $PROJECT_ID"
+log_info "Using Bucket Location: $BUCKET_LOCATION"
+
+# --- 3. Cleanup Trap ---
+ACTIVE_MOUNT_DIR=""
+ACTIVE_SEC_MOUNT_DIR=""
+CREATED_BUCKETS=()
+CREATED_FILES=()
+PACKAGE_RUNTIME_STATS=$(mktemp)
+OVERALL_EXIT_CODE=0
+
+cleanup() {
+    set +e
+    if [ -n "$ACTIVE_MOUNT_DIR" ] && mountpoint -q "$ACTIVE_MOUNT_DIR"; then
+        log_info "Unmounting: fusermount -u -z $ACTIVE_MOUNT_DIR"
+        fusermount -u -z "$ACTIVE_MOUNT_DIR" || umount -l "$ACTIVE_MOUNT_DIR" || true
+    fi
+    if [ -n "$ACTIVE_SEC_MOUNT_DIR" ] && mountpoint -q "$ACTIVE_SEC_MOUNT_DIR"; then
+        log_info "Unmounting secondary: fusermount -u -z $ACTIVE_SEC_MOUNT_DIR"
+        fusermount -u -z "$ACTIVE_SEC_MOUNT_DIR" || umount -l "$ACTIVE_SEC_MOUNT_DIR" || true
+    fi
+    for b in "${CREATED_BUCKETS[@]}"; do
+        if [ -n "$b" ]; then
+            delete_bucket "$b"
+        fi
+    done
+    if [ ${#CREATED_FILES[@]} -gt 0 ]; then
+        for f in "${CREATED_FILES[@]}"; do
+            if [ -n "$f" ]; then
+                rm -f "$f"
+            fi
+        done
+    fi
+    rm -f "$PACKAGE_RUNTIME_STATS"
+}
+trap cleanup EXIT
+
+# Reset SECONDS timer
+SECONDS=0
+
+# --- 4. Execution Loop ---
+for CURRENT_PACKAGE in $PACKAGES; do
+    # Read base config for the current package
+    CONFIG_BASE=$(yq ".${CURRENT_PACKAGE}[0]" "$CONFIG_FILE") 
+    if [ -z "$CONFIG_BASE" ] || [ "$CONFIG_BASE" == "null" ]; then
+        log_error "Could not find '${CURRENT_PACKAGE}[0]' entry in $CONFIG_FILE. Skipping..."
+        continue
+    fi
+
+    # Resolve Mounted Directory
+    PKG_MOUNTED_DIR="${MOUNTED_DIR:-$(echo "$CONFIG_BASE" | yq -r '.mounted_directory' | envsubst)}"
+    if [ "$PKG_MOUNTED_DIR" == "null" ] || [ -z "$PKG_MOUNTED_DIR" ]; then
+        PKG_MOUNTED_DIR="/tmp/gcsfuse_mounted_tests_${CURRENT_PACKAGE}"
+        log_info "Mounted directory not specified, using fallback: $PKG_MOUNTED_DIR"
+    fi
+
+    NUM_CONFIGS=$(echo "$CONFIG_BASE" | yq '.configs | length')
+    if [ "$NUM_CONFIGS" == "null" ] || [ "$NUM_CONFIGS" -eq 0 ]; then
+        log_error "Found 0 test configurations for $CURRENT_PACKAGE. Skipping..."
+        continue
+    fi
+
+    GO_TEST_DIR="${SCRIPT_DIR}/${CURRENT_PACKAGE}/..."
+    ACTIVE_MOUNT_DIR="$PKG_MOUNTED_DIR"
+    mkdir -p "$PKG_MOUNTED_DIR"
+
+    for CURRENT_BUCKET_TYPE in "${BUCKET_TYPES[@]}"; do
+        # Create temporary bucket for this package and bucket type
+        PKG_TEST_BUCKET=""
+        BUCKET_CREATED_FLAG=false
+
+        for (( i=0; i<$NUM_CONFIGS; i++ )); do
+            # Reset configuration specific variables
+            unset PROFILE_LABEL PROFILE_SERVICE_NAME KEY_FILE
+            # 1. Check compatibility first!
+            IS_COMPATIBLE=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].compatible.${CURRENT_BUCKET_TYPE}")
+            if [ "$IS_COMPATIBLE" == "false" ]; then
+                continue # Skip this entire configuration set
+            fi
+
+            # Ensure bucket is created lazily (only if there are compatible tests)
+            if [ "$BUCKET_CREATED_FLAG" = false ]; then
+                echo ""
+                echo "#################################################################"
+                echo " TESTING PACKAGE: $CURRENT_PACKAGE | BUCKET TYPE: $CURRENT_BUCKET_TYPE"
+                echo "#################################################################"
+                if ! PKG_TEST_BUCKET=$(create_bucket "$CURRENT_BUCKET_TYPE" "$CURRENT_PACKAGE"); then
+                    log_error "Bucket creation failed, skipping tests for ${CURRENT_BUCKET_TYPE}."
+                    break # Break inner loop, move to next bucket type
+                fi
+                CREATED_BUCKETS+=("$PKG_TEST_BUCKET")
+                BUCKET_CREATED_FLAG=true
+            fi
+
+            TEST_NAME=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].run")
+            NUM_FLAG_SETS=$(echo "$CONFIG_BASE" | yq ".configs[$i].flags | length") 
+            RUN_ON_GKE=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].run_on_gke")
+            
+            # 2. Dual-mount verification
+            NUM_SEC_FLAGS=$(echo "$CONFIG_BASE" | yq ".configs[$i].secondary_flags | length")
+            if [ "$NUM_SEC_FLAGS" == "null" ]; then NUM_SEC_FLAGS=0; fi
+
+            DISPLAY_NAME=${TEST_NAME}
+            if [ "$TEST_NAME" == "null" ] || [ -z "$TEST_NAME" ]; then
+                DISPLAY_NAME="All tests in ${CURRENT_PACKAGE}"
+            fi
+
+            if [ "$RUN_ON_GKE" == "false" ]; then
+                echo -e "\nSkipping: ${DISPLAY_NAME} (Package: $CURRENT_PACKAGE) - run_on_gke is false"
+                continue
+            fi
+
+            for (( j=0; j<$NUM_FLAG_SETS; j++ )); do
+                RAW_FLAGS=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].flags[$j]")
+                if [ "$NUM_SEC_FLAGS" -gt "$j" ]; then
+                    RAW_SEC_FLAGS=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].secondary_flags[$j]")
+                else
+                    RAW_SEC_FLAGS=""
+                fi
+
+                # Export environment variables for envsubst substitution
+                export BUCKET_NAME="$PKG_TEST_BUCKET"
+                export BILLING_PROJECT="${BILLING_PROJECT:-$PROJECT_ID}"
+
+                # 1. Setup Cloud Profiler unique base-36 decreasing labels if requested in the configuration
+                if [[ "$RAW_FLAGS" == *"\${PROFILE_LABEL}"* || "$RAW_SEC_FLAGS" == *"\${PROFILE_LABEL}"* ]]; then
+                    if [ -z "${PROFILE_LABEL:-}" ]; then
+                        export PROFILE_LABEL=$(python3 -c '
+import time
+val = 9223372036854775807 - time.time_ns()
+alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+res = []
+for _ in range(13):
+    res.append(alphabet[val % 36])
+    val //= 36
+print("".join(reversed(res)) + "-cloud-profiler-test")
+')
+                        export PROFILE_SERVICE_NAME="$PROFILE_LABEL"
+                    fi
+                fi
+
+                # 2. Setup GCS Requester Pays credential/key file from Secret Manager if requested
+                if [[ "$RAW_FLAGS" == *"\${KEY_FILE}"* || "$RAW_SEC_FLAGS" == *"\${KEY_FILE}"* ]]; then
+                    if [ -z "${KEY_FILE:-}" ]; then
+                        local key_file_path=$(mktemp /tmp/requester-pays-key-XXXXXX.json)
+                        log_info "Fetching requester-pays service account key from Secret Manager..."
+                        if gcloud secrets versions access latest --secret="requester-pays-tester" --project="${PROJECT_ID}" > "$key_file_path"; then
+                            export KEY_FILE="$key_file_path"
+                            CREATED_FILES+=("$key_file_path")
+                        else
+                            log_error "Failed to fetch requester-pays service account key from Secret Manager!"
+                            rm -f "$key_file_path"
+                        fi
+                    fi
+                fi
+
+                # Perform dynamic variable substitution and comma-to-space mapping
+                RAW_FLAGS=$(echo "$RAW_FLAGS" | envsubst)
+                FLAGS="${RAW_FLAGS//,/ }"
+
+                if [ "$NUM_SEC_FLAGS" -gt "$j" ]; then
+                    RAW_SEC_FLAGS=$(echo "$RAW_SEC_FLAGS" | envsubst)
+                    SEC_FLAGS="${RAW_SEC_FLAGS//,/ }"
+                    IS_DUAL_MOUNT=true
+                else
+                    SEC_FLAGS=""
+                    IS_DUAL_MOUNT=false
+                fi
+
+                # Enforce trace logging
+                FLAGS=$(echo "$FLAGS" | sed -E 's/--log-severity(=| )[a-zA-Z0-9]+//gi')
+                FLAGS="$FLAGS --log-severity=trace"
+                
+                # Check if only_dir is requested
+                ONLY_DIR_KEY=$(echo "$CONFIG_BASE" | yq -r '.only_dir')
+                if [ "$ONLY_DIR_KEY" != "null" ] && [ -n "$ONLY_DIR_KEY" ]; then
+                    export ONLY_DIR="only-dir-mnt"
+                    if [[ "$FLAGS" != *"--only-dir"* ]]; then
+                        FLAGS="$FLAGS --only-dir=${ONLY_DIR}"
+                    fi
+                else
+                    export ONLY_DIR=""
+                fi
+
+                # Add zonal flag if applicable
+                if [ "$CURRENT_BUCKET_TYPE" == "zonal" ]; then
+                    GO_ZONAL_FLAG="--zonal"
+                else
+                    GO_ZONAL_FLAG=""
+                fi
+
+                echo -e "\n--- Running: ${DISPLAY_NAME} (Package: $CURRENT_PACKAGE) ---"
+                echo "--- Flags: ${FLAGS} ---"
+
+                # 1. Mount Primary
+                echo "  Mount Primary: $GCSFUSE_BINARY $FLAGS $PKG_TEST_BUCKET $PKG_MOUNTED_DIR"
+                if mountpoint -q "$PKG_MOUNTED_DIR"; then fusermount -u "$PKG_MOUNTED_DIR"; fi
+                "$GCSFUSE_BINARY" $FLAGS "$PKG_TEST_BUCKET" "$PKG_MOUNTED_DIR" > /dev/null 2>&1
+                
+                # 1.5. Mount Secondary
+                PKG_MOUNTED_DIR_SECONDARY="${PKG_MOUNTED_DIR}_sec"
+                if [ "$IS_DUAL_MOUNT" = true ]; then
+                    ACTIVE_SEC_MOUNT_DIR="$PKG_MOUNTED_DIR_SECONDARY"
+                    mkdir -p "$PKG_MOUNTED_DIR_SECONDARY"
+                    if mountpoint -q "$PKG_MOUNTED_DIR_SECONDARY"; then fusermount -u "$PKG_MOUNTED_DIR_SECONDARY"; fi
+                    echo "  Mount Secondary: $GCSFUSE_BINARY $SEC_FLAGS $PKG_TEST_BUCKET $PKG_MOUNTED_DIR_SECONDARY"
+                    "$GCSFUSE_BINARY" $SEC_FLAGS "$PKG_TEST_BUCKET" "$PKG_MOUNTED_DIR_SECONDARY" > /dev/null 2>&1
+                fi
+
+                # 2. Setup Go Test Command
+                GO_CMD=(go test "$GO_TEST_DIR" -p 1 --integrationTest -v --config-file="$CONFIG_FILE_ABS")
+                if [ -n "$GO_ZONAL_FLAG" ]; then GO_CMD+=("$GO_ZONAL_FLAG"); fi
+
+                if [ "$TEST_NAME" != "null" ] && [ -n "$TEST_NAME" ]; then
+                    if [[ "$TEST_NAME" == Benchmark_* ]]; then
+                        GO_CMD+=(-bench "^${TEST_NAME}$" -run "^$")
+                    else
+                        GO_CMD+=(-run "^${TEST_NAME}$")
+                    fi
+                else
+                    GO_CMD+=(-bench .) 
+                fi
+
+                # Apply skip logic
+                NUM_SKIP=$(echo "$CONFIG_BASE" | yq ".configs[$i].skip | length")
+                if [ "$NUM_SKIP" != "null" ] && [ "$NUM_SKIP" -gt 0 ]; then
+                    SKIP_TESTS=$(echo "$CONFIG_BASE" | yq -r ".configs[$i].skip | join(\"|\")")
+                    GO_CMD+=(-skip "^(${SKIP_TESTS})$")
+                fi
+                
+                # 3. Run Test
+                echo "  Test: GODEBUG=asyncpreemptoff=1 MOUNTED_DIR=\"$PKG_MOUNTED_DIR\" ${IS_DUAL_MOUNT:+MOUNTED_DIR_SECONDARY=\"$PKG_MOUNTED_DIR_SECONDARY\"} ${ONLY_DIR:+ONLY_DIR=\"$ONLY_DIR\"} TEST_BUCKET=\"$PKG_TEST_BUCKET\" BUCKET_NAME=\"$PKG_TEST_BUCKET\" ${BILLING_PROJECT:+BILLING_PROJECT=\"$BILLING_PROJECT\"} ${KEY_FILE:+KEY_FILE=\"$KEY_FILE\"} ${PROFILE_LABEL:+PROFILE_LABEL=\"$PROFILE_LABEL\"} ${PROFILE_SERVICE_NAME:+PROFILE_SERVICE_NAME=\"$PROFILE_SERVICE_NAME\"} ${GO_CMD[*]}"
+                
+                start=$SECONDS
+                exit_code=0
+                if ! env GODEBUG=asyncpreemptoff=1 MOUNTED_DIR="$PKG_MOUNTED_DIR" MOUNTED_DIR_SECONDARY="${IS_DUAL_MOUNT:+$PKG_MOUNTED_DIR_SECONDARY}" ONLY_DIR="$ONLY_DIR" TEST_BUCKET="$PKG_TEST_BUCKET" BUCKET_NAME="$PKG_TEST_BUCKET" BILLING_PROJECT="${BILLING_PROJECT:-}" KEY_FILE="${KEY_FILE:-}" PROFILE_LABEL="${PROFILE_LABEL:-}" PROFILE_SERVICE_NAME="${PROFILE_SERVICE_NAME:-}" "${GO_CMD[@]}"; then
+                    exit_code=1
+                    OVERALL_EXIT_CODE=1
+                    log_error "Tests failed in ${CURRENT_PACKAGE} on bucket type ${CURRENT_BUCKET_TYPE}!"
+                fi
+                end=$SECONDS
+                
+                # Append stats for visualizer
+                echo "${CURRENT_PACKAGE} ${CURRENT_BUCKET_TYPE} ${exit_code} ${start} ${end}" >> "$PACKAGE_RUNTIME_STATS"
+                
+                # 4. Unmount Primary
+                echo "  Unmount: fusermount -u $PKG_MOUNTED_DIR"
+                fusermount -u "$PKG_MOUNTED_DIR"
+
+                # 4.5. Unmount Secondary
+                if [ "$IS_DUAL_MOUNT" = true ]; then
+                    echo "  Unmount Secondary: fusermount -u $PKG_MOUNTED_DIR_SECONDARY"
+                    fusermount -u "$PKG_MOUNTED_DIR_SECONDARY" || true
+                    ACTIVE_SEC_MOUNT_DIR=""
+                fi
+            done
+        done
+    done
+done
+
+ACTIVE_MOUNT_DIR=""
+
+# Print beautiful rich-based summary table
+if [ -f "$PACKAGE_RUNTIME_STATS" ] && [ -s "$PACKAGE_RUNTIME_STATS" ]; then
+    echo -e "\n------ Test Summary Table ------"
+    "${SCRIPT_DIR}/create_package_runtime_table.sh" "$PACKAGE_RUNTIME_STATS" || true
+fi
+
+if [ "$OVERALL_EXIT_CODE" -eq 0 ]; then
+    echo -e "\n========================================================"
+    echo " All Specified Tests Completed Successfully!"
+    echo "========================================================"
+else
+    echo -e "\n========================================================"
+    echo " Some tests failed. Check summary above."
+    echo "========================================================"
+fi
+
+exit "$OVERALL_EXIT_CODE"

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,8 +43,11 @@ import (
 var isPresubmitRun = flag.Bool("presubmit", false, "Boolean flag to indicate if test-run is a presubmit run.")
 var isZonalBucketRun = flag.Bool("zonal", false, "Boolean flag to indicate if test-run should use a zonal bucket.")
 var isPirloBucketRun = flag.Bool("pirlo", false, "Boolean flag to indicate if test-run is for a Pirlo bucket.")
-var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
-var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
+
+// Note: testBucket and mountedDirectory can also be set via BUCKET_NAME and MOUNTED_DIR
+// environment variables respectively. However, command-line flags take precedence.
+var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test. Can also be set via BUCKET_NAME env var.")
+var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test. Can also be set via MOUNTED_DIR env var.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
@@ -145,6 +148,9 @@ func TestOnTPCEndPoint() bool {
 }
 
 func MountedDirectory() string {
+	if *mountedDirectory == "" {
+		*mountedDirectory = os.Getenv("MOUNTED_DIR")
+	}
 	return *mountedDirectory
 }
 
@@ -692,6 +698,9 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, testName string
 func SetGlobalVars(cfg *test_suite.TestConfig) {
 	if cfg.TestBucket == "" {
 		cfg.TestBucket = TestBucket()
+	}
+	if cfg.GKEMountedDirectory == "" {
+		cfg.GKEMountedDirectory = MountedDirectory()
 	}
 	// TODO: clean global variables after test migration to config file completes.
 	testBucket = &cfg.TestBucket


### PR DESCRIPTION
### Description
This PR introduces a new bash script (`tools/integration_tests/run_migrated_tests_mounted_directory.sh`) to automate the execution of integration tests against a mounted GCS directory. 

Key features of the script:
- Parses `test_config.yaml` using `yq` to dynamically extract test configurations, mounted directories, and FUSE flags.
- Automatically builds the `gcsfuse` binary if it is not found before starting the tests.
- Safely handles dynamically creating buckets (supporting `flat`, `hns`, and `zonal` types, mounting the bucket, running the go test command with the appropriate arguments, and unmounting/deleting the temporary buckets via an exit trap.
- Supports running tests for a specific package (`--package`) or all packages (`--all`).
- Supports concurrent dual-mounting for testing configurations that require secondary flags.
- Dynamically skips tests if `run_on_gke` is set to false in the test configuration.
- Automatically enforces trace logging (`--log-severity=trace`) and handles --only-dir logic for specific tests.
- Generates and prints a rich execution summary table at the end of the test suite run.

### Link to the issue in case of a bug fix.
[bug](https://buganizer.corp.google.com/issues/499225878)

### Testing details
1. Manual - Verified the script properly parses the YAML config, mounts the directory, runs the tests, and cleans up the mount afterward.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.
