### PR TITLE
test(integration): migrate 4 non-gke packages to common test configuration

### DIFF
--- a/tools/integration_tests/mount_timeout/mount_access_test.go
+++ b/tools/integration_tests/mount_timeout/mount_access_test.go
@@ -87,10 +87,10 @@ func (testSuite *MountAccessTest) TestMountingWithMinimalAccessSucceeds() {
 			testSuite.T().Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
 		}
 	}()
-	creds_tests.ApplyCustomRoleToServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, setup.TestBucket())
-	defer creds_tests.RevokeCustomRoleFromServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, setup.TestBucket())
+	creds_tests.ApplyCustomRoleToServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, testBucket)
+	defer creds_tests.RevokeCustomRoleFromServiceAccountOnBucket(gCtx, gStorageClient, serviceAccount, listPermCustomRoleName, testBucket)
 
-	err := testSuite.mountWithKeyFile(setup.TestBucket(), localKeyFilePath)
+	err := testSuite.mountWithKeyFile(testBucket, localKeyFilePath)
 
 	assert.NoError(testSuite.T(), err)
 }

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -46,6 +47,8 @@ var (
 	gStorageClient *storage.Client
 
 	gCtx context.Context
+
+	testBucket string
 )
 
 const (
@@ -138,6 +141,24 @@ func TestMain(m *testing.M) {
 			log.Fatalf("LookPath(fusermount): %p", err)
 		}
 	}
+
+	// Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.MountTimeout) == 0 {
+		log.Println("No configuration found for mount_timeout tests in config. Using flags instead.")
+		cfg.MountTimeout = make([]test_suite.TestConfig, 1)
+		cfg.MountTimeout[0].TestBucket = setup.TestBucket()
+		cfg.MountTimeout[0].GKEMountedDirectory = setup.MountedDirectory()
+	}
+
+	// Skip for GKE or mounted directory tests.
+	if cfg.MountTimeout[0].GKEMountedDirectory != "" {
+		log.Print("These tests will not run for mountedDirectory flag.")
+		os.Exit(0)
+	}
+
+	testBucket = cfg.MountTimeout[0].TestBucket
+
 	gCtx = context.Background()
 
 	// Create storage client for direct bucket access.

--- a/tools/integration_tests/mounting/main_test.go
+++ b/tools/integration_tests/mounting/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
 )
 
@@ -45,6 +46,21 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Fatalf("LookPath(fusermount): %p", err)
 		}
+	}
+
+	// Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.Mounting) == 0 {
+		log.Println("No configuration found for mounting tests in config. Using flags instead.")
+		cfg.Mounting = make([]test_suite.TestConfig, 1)
+		cfg.Mounting[0].TestBucket = setup.TestBucket()
+		cfg.Mounting[0].GKEMountedDirectory = setup.MountedDirectory()
+	}
+
+	// Skip for GKE or mounted directory tests.
+	if cfg.Mounting[0].GKEMountedDirectory != "" {
+		log.Print("These tests will not run for mountedDirectory flag.")
+		os.Exit(0)
 	}
 
 	if setup.TestInstalledPackage() {

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -25,14 +25,32 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
-	testDirName           = "ReadOnlyCredsTest"
+	testDirName           = "ReadonlyCredsTest"
 	testFileName          = "fileName.txt"
 	content               = "write content."
 	permissionDeniedError = "permission denied"
 )
+
+var (
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir string
+)
+
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
+
+var testEnv env
 
 ////////////////////////////////////////////////////////////////////////
 // TestMain
@@ -40,32 +58,54 @@ const (
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
 
-	if setup.MountedDirectory() != "" {
-		log.Println("These tests will not run with mounted directory..")
-		return
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.ReadonlyCreds) == 0 {
+		log.Println("No configuration found for readonly_creds tests in config. Using flags instead.")
+		cfg.ReadonlyCreds = make([]test_suite.TestConfig, 1)
+		cfg.ReadonlyCreds[0].TestBucket = setup.TestBucket()
+		cfg.ReadonlyCreds[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.ReadonlyCreds[0].Configs = make([]test_suite.ConfigItem, 1)
+		cfg.ReadonlyCreds[0].Configs[0].Flags = []string{"--implicit-dirs=true", "--implicit-dirs=false"}
+		cfg.ReadonlyCreds[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 	}
 
-	// Create test directory.
-	ctx := context.Background()
-	var storageClient *storage.Client
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.ReadonlyCreds[0])
+	testEnv.cfg = &cfg.ReadonlyCreds[0]
+
+	// 2. Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
-			log.Printf("closeStorageClient failed: %v", err)
+			log.Printf("closeStorageClient failed: %v\n", err)
 		}
 	}()
-	client.SetupTestDirectory(ctx, storageClient, testDirName)
+
+	// 3. Skip for GKE or mounted directory tests.
+	if cfg.ReadonlyCreds[0].GKEMountedDirectory != "" {
+		log.Print("These tests will not run for mountedDirectory flag.")
+		os.Exit(0)
+	}
+
+	// Create test directory on GCS before dropping privileges.
+	client.SetupTestDirectory(testEnv.ctx, testEnv.storageClient, testDirName)
 
 	// Run tests for testBucket
-	setup.SetUpTestDirForTestBucketFlag()
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	// Override GKE specific paths with GCSFuse paths if running in GCE environment.
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
+	// Save mount and root directory variables.
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
+
+	flags := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, "")
 	// Test for viewer permission on test bucket.
-	flags := [][]string{{"--implicit-dirs=true"}, {"--implicit-dirs=false"}}
-	successCode := creds_tests.RunTestsForKeyFileAndGoogleApplicationCredentialsEnvVarSet(ctx, storageClient, flags, "objectViewer", m)
+	successCode := creds_tests.RunTestsForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", m)
 
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -45,7 +45,6 @@ var (
 type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
-	testDirPath   string
 	cfg           *test_suite.TestConfig
 	bucketType    string
 }

--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	// 2. Not running mounted directory tests.
 	if cfg.ReleaseVersion[0].GKEMountedDirectory != "" {
 		log.Print("These tests will not run for mountedDirectory flag.")
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	// 3. The release_version test doesn't mount anything, but it needs the gcsfuse binary.

--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -20,19 +20,31 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	if setup.MountedDirectory() != "" {
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.ReleaseVersion) == 0 {
+		log.Println("No configuration found for release_version tests in config. Using flags instead.")
+		cfg.ReleaseVersion = make([]test_suite.TestConfig, 1)
+		cfg.ReleaseVersion[0].TestBucket = setup.TestBucket()
+		cfg.ReleaseVersion[0].GKEMountedDirectory = setup.MountedDirectory()
+	}
+
+	// 2. Not running mounted directory tests.
+	if cfg.ReleaseVersion[0].GKEMountedDirectory != "" {
 		log.Print("These tests will not run for mountedDirectory flag.")
 		os.Exit(1)
 	}
 
-	setup.SetUpTestDirForTestBucketFlag()
+	// 3. The release_version test doesn't mount anything, but it needs the gcsfuse binary.
+	setup.SetUpTestDirForTestBucket(&cfg.ReleaseVersion[0])
 
+	// 4. Run tests.
 	successCode := m.Run()
-
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -668,6 +668,55 @@ log_rotation:
           zonal: true
         run_on_gke: false
 
+readonly_creds:
+- mounted_directory: "${MOUNTED_DIR}"
+  test_bucket: "${BUCKET_NAME}"
+  configs:
+    - flags:
+      - "--implicit-dirs=true"
+      - "--implicit-dirs=false"
+      compatible:
+        flat: true
+        hns: true
+        zonal: true
+      run_on_gke: false
+
+mount_timeout:
+- mounted_directory: "${MOUNTED_DIR}"
+  test_bucket: "${BUCKET_NAME}"
+  configs:
+    - flags:
+      - ""
+      compatible:
+        flat: true
+        hns: true
+        zonal: true
+      run_on_gke: false
+
+release_version:
+- mounted_directory: "${MOUNTED_DIR}"
+  test_bucket: "${BUCKET_NAME}"
+  configs:
+    - flags:
+      - ""
+      compatible:
+        flat: true
+        hns: true
+        zonal: true
+      run_on_gke: false
+
+mounting:
+- mounted_directory: "${MOUNTED_DIR}"
+  test_bucket: "${BUCKET_NAME}"
+  configs:
+    - flags:
+      - ""
+      compatible:
+        flat: true
+        hns: true
+        zonal: true
+      run_on_gke: false
+
 flag_optimizations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -83,6 +83,9 @@ type Config struct {
 	FlagOptimizations     []TestConfig `yaml:"flag_optimizations"`
 	UnsupportedPath       []TestConfig `yaml:"unsupported_path"`
 	SymlinkHandling       []TestConfig `yaml:"symlink_handling"`
+	ReadonlyCreds         []TestConfig `yaml:"readonly_creds"`
+	ReleaseVersion        []TestConfig `yaml:"release_version"`
+	Mounting              []TestConfig `yaml:"mounting"`
 }
 
 // ReadConfigFile returns a Config struct from the YAML file.


### PR DESCRIPTION
### Description
This PR migrates 4 integration test packages (`readonly_creds`, `mount_timeout`, `release_version`, and `mounting`) to use the common YAML-based test configuration framework.

Key changes include:
- Updated the `TestMain` functions across the 4 packages to load configurations via `test_suite.ReadConfigFile(setup.ConfigFile())`, falling back to flags if not provided.
- Added test suite definitions for `readonly_creds`, `mount_timeout`, `release_version`, and `mounting` in `tools/integration_tests/test_config.yaml`, establishing their flag configurations, bucket compatibilities (`flat`, `hns`, `zonal`), and explicitly disabling them for GKE executions (`run_on_gke: false`).
- Added the corresponding structs (`ReadonlyCreds`, `ReleaseVersion`, `Mounting`, etc.) to the `Config` struct in `tools/integration_tests/util/test_suite/config.go`.
- Refactored `readonly_creds_test.go` to use `creds_tests.RunTestsForDifferentAuthMethods` instead of the older key file-specific method.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/499888095
https://b.corp.google.com/issues/499888275
https://b.corp.google.com/issues/458531458
https://b.corp.google.com/issues/499888097

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Passing for the newly migrated packages.

### Any backward incompatible change? If so, please explain.
No.
