### PR TITLE
test(integration): migrate negative stat cache tests to common test configuration

### DIFF
--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -33,14 +33,22 @@ type disabledNegativeStatCacheTest struct {
 	suite.Suite
 }
 
+func (s *disabledNegativeStatCacheTest) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(mountDir)
+}
+
+func (s *disabledNegativeStatCacheTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
 func (s *disabledNegativeStatCacheTest) SetupTest() {
 	s.testDir = testDirName + setup.GenerateRandomString(5)
-	mountGCSFuseAndSetupTestDir(s.flags, s.testDir)
+	testEnv.testDirPath = setup.SetupTestDirectory(s.testDir)
 }
 
 func (s *disabledNegativeStatCacheTest) TearDownTest() {
-	setup.CleanUpDir(testEnv.testDirPath)
-	setup.UnmountGCSFuse(testEnv.rootDir)
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -80,16 +88,17 @@ func TestDisabledNegativeStatCacheTest(t *testing.T) {
 	ts := &disabledNegativeStatCacheTest{}
 
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
 	// Define flag set to run the tests.
-	flagsSet := []string{"--metadata-cache-negative-ttl-secs=0"}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 
 	// Run tests.
-	ts.flags = flagsSet
-	log.Printf("Running tests with flags: %s", ts.flags)
-	suite.Run(t, ts)
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/disabled_negative_stat_cache_test.go
@@ -34,8 +34,8 @@ type disabledNegativeStatCacheTest struct {
 }
 
 func (s *disabledNegativeStatCacheTest) SetupSuite() {
-	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	setup.SetMntDir(mountDir)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
 }
 
 func (s *disabledNegativeStatCacheTest) TearDownSuite() {

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -35,8 +35,8 @@ type finiteNegativeStatCacheTest struct {
 }
 
 func (s *finiteNegativeStatCacheTest) SetupSuite() {
-	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	setup.SetMntDir(mountDir)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
 }
 
 func (s *finiteNegativeStatCacheTest) TearDownSuite() {

--- a/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/finite_int_negative_stat_cache_test.go
@@ -34,14 +34,22 @@ type finiteNegativeStatCacheTest struct {
 	suite.Suite
 }
 
+func (s *finiteNegativeStatCacheTest) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(mountDir)
+}
+
+func (s *finiteNegativeStatCacheTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
 func (s *finiteNegativeStatCacheTest) SetupTest() {
 	s.testDir = testDirName + setup.GenerateRandomString(5)
-	mountGCSFuseAndSetupTestDir(s.flags, s.testDir)
+	testEnv.testDirPath = setup.SetupTestDirectory(s.testDir)
 }
 
 func (s *finiteNegativeStatCacheTest) TearDownTest() {
-	setup.CleanUpDir(testEnv.testDirPath)
-	setup.UnmountGCSFuse(testEnv.rootDir)
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -91,16 +99,17 @@ func TestFiniteNegativeStatCacheTest(t *testing.T) {
 	ts := &finiteNegativeStatCacheTest{}
 
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
 	// Define flag set to run the tests.
-	flagsSet := []string{"--metadata-cache-negative-ttl-secs=5"}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 
 	// Run tests.
-	ts.flags = flagsSet
-	log.Printf("Running tests with flags: %s", ts.flags)
-	suite.Run(t, ts)
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -36,8 +36,8 @@ type infiniteNegativeStatCacheTest struct {
 }
 
 func (s *infiniteNegativeStatCacheTest) SetupSuite() {
-	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	setup.SetMntDir(mountDir)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
 }
 
 func (s *infiniteNegativeStatCacheTest) TearDownSuite() {

--- a/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
+++ b/tools/integration_tests/negative_stat_cache/infinite_negative_stat_cache_test.go
@@ -35,14 +35,22 @@ type infiniteNegativeStatCacheTest struct {
 	suite.Suite
 }
 
+func (s *infiniteNegativeStatCacheTest) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(mountDir)
+}
+
+func (s *infiniteNegativeStatCacheTest) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
 func (s *infiniteNegativeStatCacheTest) SetupTest() {
 	s.testDir = testDirName + setup.GenerateRandomString(5)
-	mountGCSFuseAndSetupTestDir(s.flags, s.testDir)
+	testEnv.testDirPath = setup.SetupTestDirectory(s.testDir)
 }
 
 func (s *infiniteNegativeStatCacheTest) TearDownTest() {
-	setup.CleanUpDir(testEnv.testDirPath)
-	setup.UnmountGCSFuse(testEnv.rootDir)
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -112,16 +120,17 @@ func TestInfiniteNegativeStatCacheTest(t *testing.T) {
 	ts := &infiniteNegativeStatCacheTest{}
 
 	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
 	// Define flag set to run the tests.
-	flagsSet := []string{"--metadata-cache-negative-ttl-secs=-1"}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 
 	// Run tests.
-	ts.flags = flagsSet
-	log.Printf("Running tests with flags: %s", ts.flags)
-	suite.Run(t, ts)
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
 }

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -41,11 +41,11 @@ const (
 // variables (which would otherwise be declared with `var` at the package root) should
 // be added as fields to this 'env' struct instead.
 type env struct {
-	mountFunc   func(*test_suite.TestConfig, []string) error
+	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
-	rootDir string
+	rootDir              string
 	storageClient        *storage.Client
 	storageControlClient *control.StorageControlClient
 	ctx                  context.Context

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
 
 const (
@@ -35,36 +36,24 @@ const (
 	onlyDirMounted = "OnlyDirMountNegativeStatCache"
 )
 
-// IMPORTANT: To prevent global variable pollution, enhance code clarity,
-// and avoid inadvertent errors. We strongly suggest that, all new package-level
-// variables (which would otherwise be declared with `var` at the package root) should
-// be added as fields to this 'env' struct instead.
-type env struct {
-	testDirPath string
-	mountFunc   func([]string) error
+var (
+	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
-	rootDir              string
+	rootDir string
+)
+
+type env struct {
 	storageClient        *storage.Client
 	storageControlClient *control.StorageControlClient
 	ctx                  context.Context
+	testDirPath          string
+	cfg                  *test_suite.TestConfig
+	bucketType           string
 }
 
 var testEnv env
-
-////////////////////////////////////////////////////////////////////////
-// Helpers
-////////////////////////////////////////////////////////////////////////
-
-func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
-	if setup.MountedDirectory() != "" {
-		testEnv.mountDir = setup.MountedDirectory()
-	}
-	setup.MountGCSFuseWithGivenMountFunc(flags, testEnv.mountFunc)
-	setup.SetMntDir(testEnv.mountDir)
-	testEnv.testDirPath = setup.SetupTestDirectory(testDirName)
-}
 
 ////////////////////////////////////////////////////////////////////////
 // TestMain
@@ -72,56 +61,85 @@ func mountGCSFuseAndSetupTestDir(flags []string, testDirName string) {
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.NegativeStatCache) == 0 {
+		log.Println("No configuration found for negative_stat_cache tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.NegativeStatCache = make([]test_suite.TestConfig, 1)
+		cfg.NegativeStatCache[0].TestBucket = setup.TestBucket()
+		cfg.NegativeStatCache[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.NegativeStatCache[0].LogFile = setup.LogFile()
+		// Initialize the slice to hold specific test configurations
+		cfg.NegativeStatCache[0].Configs = make([]test_suite.ConfigItem, 3)
+		cfg.NegativeStatCache[0].Configs[0].Flags = []string{"--metadata-cache-negative-ttl-secs=0"}
+		cfg.NegativeStatCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.NegativeStatCache[0].Configs[0].Run = "TestDisabledNegativeStatCacheTest"
+		cfg.NegativeStatCache[0].Configs[1].Flags = []string{"--metadata-cache-negative-ttl-secs=5"}
+		cfg.NegativeStatCache[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.NegativeStatCache[0].Configs[1].Run = "TestFiniteNegativeStatCacheTest"
+		cfg.NegativeStatCache[0].Configs[2].Flags = []string{"--metadata-cache-negative-ttl-secs=-1"}
+		cfg.NegativeStatCache[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.NegativeStatCache[0].Configs[2].Run = "TestInfiniteNegativeStatCacheTest"
+	}
+
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.NegativeStatCache[0])
+	testEnv.cfg = &cfg.NegativeStatCache[0]
 
 	// Create common storage client to be used in test.
-	testEnv.ctx = context.Background()
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
+			log.Printf("closeStorageClient failed: %v\n", err)
 		}
 	}()
 	closeStorageControlClient := client.CreateControlClientWithCancel(&testEnv.ctx, &testEnv.storageControlClient)
 	defer func() {
 		err := closeStorageControlClient()
 		if err != nil {
-			log.Fatalf("closeStorageControlClient failed: %v", err)
+			log.Printf("closeStorageControlClient failed: %v\n", err)
 		}
 	}()
 
-	// If Mounted Directory flag is set, run tests for mounted directory.
-	setup.RunTestsForMountedDirectoryFlag(m)
-	// Else run tests for testBucket.
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		// Save mount and root directory variables.
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+	}
+
+	// Run tests for testBucket
 	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	testEnv.mountDir, testEnv.rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
-	testEnv.mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
 
 	if successCode == 0 {
 		log.Println("Running dynamic mounting tests...")
 		// Save mount directory variable to have path of bucket to run tests.
-		testEnv.mountDir = path.Join(setup.MntDir(), setup.TestBucket())
-		testEnv.mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		mountDir = path.Join(testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.TestBucket)
+		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
 		successCode = m.Run()
 	}
 
 	if successCode == 0 {
 		log.Println("Running only dir mounting tests...")
 		setup.SetOnlyDirMounted(onlyDirMounted + "/")
-		testEnv.mountDir = testEnv.rootDir
-		testEnv.mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
+		mountDir = rootDir
+		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
 		successCode = m.Run()
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), setup.OnlyDirMounted(), testDirName))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, setup.OnlyDirMounted(), testDirName))
 	}
 
 	// Clean up test directory created.
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -36,15 +36,16 @@ const (
 	onlyDirMounted = "OnlyDirMountNegativeStatCache"
 )
 
-var (
-	mountFunc func(*test_suite.TestConfig, []string) error
+// IMPORTANT: To prevent global variable pollution, enhance code clarity,
+// and avoid inadvertent errors. We strongly suggest that, all new package-level
+// variables (which would otherwise be declared with `var` at the package root) should
+// be added as fields to this 'env' struct instead.
+type env struct {
+	mountFunc   func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
 	rootDir string
-)
-
-type env struct {
 	storageClient        *storage.Client
 	storageControlClient *control.StorageControlClient
 	ctx                  context.Context
@@ -107,7 +108,7 @@ func TestMain(m *testing.M) {
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		// Save mount and root directory variables.
-		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
+		testEnv.mountDir, testEnv.rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -116,25 +117,25 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
+	testEnv.mountDir, testEnv.rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
-	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
+	testEnv.mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
 
 	if successCode == 0 {
 		log.Println("Running dynamic mounting tests...")
 		// Save mount directory variable to have path of bucket to run tests.
-		mountDir = path.Join(testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.TestBucket)
-		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
+		testEnv.mountDir = path.Join(testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.TestBucket)
+		testEnv.mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
 		successCode = m.Run()
 	}
 
 	if successCode == 0 {
 		log.Println("Running only dir mounting tests...")
 		setup.SetOnlyDirMounted(onlyDirMounted + "/")
-		mountDir = rootDir
-		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
+		testEnv.mountDir = testEnv.rootDir
+		testEnv.mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
 		successCode = m.Run()
 		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, setup.OnlyDirMounted(), testDirName))
 	}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -997,3 +997,32 @@ symlink_handling:
           hns: true
           zonal: true
         run_on_gke: true
+
+negative_stat_cache:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--metadata-cache-negative-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: "TestDisabledNegativeStatCacheTest"
+        run_on_gke: true
+      - flags:
+          - "--metadata-cache-negative-ttl-secs=5"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: "TestFiniteNegativeStatCacheTest"
+        run_on_gke: true
+      - flags:
+          - "--metadata-cache-negative-ttl-secs=-1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: "TestInfiniteNegativeStatCacheTest"
+        run_on_gke: true

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	FlagOptimizations     []TestConfig `yaml:"flag_optimizations"`
 	UnsupportedPath       []TestConfig `yaml:"unsupported_path"`
 	SymlinkHandling       []TestConfig `yaml:"symlink_handling"`
+	NegativeStatCache     []TestConfig `yaml:"negative_stat_cache"`
 }
 
 // ReadConfigFile returns a Config struct from the YAML file.


### PR DESCRIPTION
### Description
This PR migrates the `negative_stat_cache` integration tests to use the new YAML-based test configuration framework.

### Link to the issue in case of a bug fix.

https://buganizer.corp.google.com/issues/499871015
https://paste.googleplex.com/4532379218739200 Test Details

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Passing for the newly migrated negative stat cache tests.

### Any backward incompatible change? If so, please explain.
No.