### PR TITLE
test(integration): migrate buffered read test pacakge

### DIFF
--- a/tools/integration_tests/buffered_read/fallback_test.go
+++ b/tools/integration_tests/buffered_read/fallback_test.go
@@ -15,6 +15,7 @@
 package buffered_read
 
 import (
+	"log"
 	"os"
 	"path"
 	"syscall"
@@ -36,7 +37,7 @@ import (
 // fallbackSuiteBase provides shared setup and teardown logic for fallback-related test suites.
 type fallbackSuiteBase struct {
 	suite.Suite
-	testFlags *gcsfuseTestFlags
+	flags []string
 }
 
 func (s *fallbackSuiteBase) SetupSuite() {
@@ -44,9 +45,7 @@ func (s *fallbackSuiteBase) SetupSuite() {
 		setupForMountedDirectoryTests()
 		return
 	}
-	configFile := createConfigFile(s.testFlags)
-	flags := []string{"--config-file=" + configFile}
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
 }
 
 func (s *fallbackSuiteBase) SetupTest() {
@@ -59,7 +58,7 @@ func (s *fallbackSuiteBase) TearDownSuite() {
 		setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 		return
 	}
-	setup.UnmountGCSFuse(rootDir)
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
@@ -83,7 +82,7 @@ type RandomReadFallbackSuite struct {
 // the BufferedReader is not created, and reads fall back to the next reader
 // without any buffered reading.
 func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobalPool_NoReaderAdded() {
-	fileSize := 3 * s.testFlags.blockSizeMB * util.MiB
+	fileSize := int64(3 * 8 * util.MiB)
 	chunkSize := int64(1 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
 	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
@@ -104,7 +103,7 @@ func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobal
 
 func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 	const randomReadsThreshold = 3
-	blockSizeInBytes := s.testFlags.blockSizeMB * util.MiB
+	blockSizeInBytes := int64(8 * util.MiB)
 	// Create a file with 4 blocks. We will read backwards from block 3 to 0
 	// to trigger random seek detection.
 	numBlocks := 4
@@ -126,7 +125,7 @@ func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 }
 
 func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
-	blockSizeInBytes := s.testFlags.blockSizeMB * util.MiB
+	blockSizeInBytes := int64(8 * util.MiB)
 	// File size is small, less than one block.
 	fileSize := blockSizeInBytes / 2
 	chunkSize := int64(1 * util.KiB)
@@ -182,46 +181,32 @@ func (s *RandomReadFallbackSuite) TestRandomThenSequential_SwitchesBackToBuffere
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestFallbackSuites(t *testing.T) {
-	// Define base flags for insufficient pool creation tests.
-	baseInsufficientPoolFlags := gcsfuseTestFlags{
-		enableBufferedRead:   true,
-		blockSizeMB:          8,
-		minBlocksPerHandle:   2,
-		globalMaxBlocks:      1, // Less than min-blocks-per-handle
-		maxBlocksPerHandle:   10,
-		startBlocksPerHandle: 2,
-	}
+func TestInsufficientPoolCreationSuite(t *testing.T) {
+	ts := &InsufficientPoolCreationSuite{}
 
-	// Define base flags for random read fallback tests.
-	baseRandomReadFlags := gcsfuseTestFlags{
-		enableBufferedRead:   true,
-		blockSizeMB:          8,
-		maxBlocksPerHandle:   20,
-		startBlocksPerHandle: 2,
-		minBlocksPerHandle:   2,
-	}
-
-	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		suite.Run(t, &InsufficientPoolCreationSuite{fallbackSuiteBase{testFlags: &baseInsufficientPoolFlags}})
-		suite.Run(t, &RandomReadFallbackSuite{fallbackSuiteBase{testFlags: &baseRandomReadFlags}})
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
 		return
 	}
 
-	protocols := []string{clientProtocolHTTP1, clientProtocolGRPC}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
+}
 
-	for _, protocol := range protocols {
-		t.Run(protocol, func(t *testing.T) {
-			// Run the suite for insufficient pool at creation time.
-			insufficientPoolFlags := baseInsufficientPoolFlags
-			insufficientPoolFlags.clientProtocol = protocol
-			suite.Run(t, &InsufficientPoolCreationSuite{fallbackSuiteBase{testFlags: &insufficientPoolFlags}})
+func TestRandomReadFallbackSuite(t *testing.T) {
+	ts := &RandomReadFallbackSuite{}
 
-			// Run the suite for random read fallback scenarios.
-			randomReadFlags := baseRandomReadFlags
-			randomReadFlags.clientProtocol = protocol
-			suite.Run(t, &RandomReadFallbackSuite{fallbackSuiteBase{testFlags: &randomReadFlags}})
-		})
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
 	}
 }

--- a/tools/integration_tests/buffered_read/fallback_test.go
+++ b/tools/integration_tests/buffered_read/fallback_test.go
@@ -82,7 +82,7 @@ type RandomReadFallbackSuite struct {
 // the BufferedReader is not created, and reads fall back to the next reader
 // without any buffered reading.
 func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobalPool_NoReaderAdded() {
-	fileSize := int64(3 * 8 * util.MiB)
+	fileSize := blockSizeInBytes * 3
 	chunkSize := int64(1 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
 	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
@@ -103,7 +103,6 @@ func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobal
 
 func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 	const randomReadsThreshold = 3
-	blockSizeInBytes := int64(8 * util.MiB)
 	// Create a file with 4 blocks. We will read backwards from block 3 to 0
 	// to trigger random seek detection.
 	numBlocks := 4
@@ -125,7 +124,6 @@ func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 }
 
 func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
-	blockSizeInBytes := int64(8 * util.MiB)
 	// File size is small, less than one block.
 	fileSize := blockSizeInBytes / 2
 	chunkSize := int64(1 * util.KiB)

--- a/tools/integration_tests/buffered_read/fallback_test.go
+++ b/tools/integration_tests/buffered_read/fallback_test.go
@@ -41,24 +41,20 @@ type fallbackSuiteBase struct {
 }
 
 func (s *fallbackSuiteBase) SetupSuite() {
-	if setup.MountedDirectory() != "" {
-		setupForMountedDirectoryTests()
-		return
-	}
+	setup.SetUpLogFilePath(s.flags, GKETempDir, "", testEnv.cfg)
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-}
-
-func (s *fallbackSuiteBase) SetupTest() {
-	err := os.Truncate(setup.LogFile(), 0)
-	require.NoError(s.T(), err, "Failed to truncate log file")
+	setup.SetMntDir(mountDir)
 }
 
 func (s *fallbackSuiteBase) TearDownSuite() {
-	if setup.MountedDirectory() != "" {
-		setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
-		return
-	}
 	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *fallbackSuiteBase) SetupTest() {
+	testEnv.testDirPath = setup.SetupTestDirectory(testDirName)
+}
+
+func (s *fallbackSuiteBase) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
@@ -82,6 +78,8 @@ type RandomReadFallbackSuite struct {
 // the BufferedReader is not created, and reads fall back to the next reader
 // without any buffered reading.
 func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobalPool_NoReaderAdded() {
+	err := os.Truncate(setup.LogFile(), 0)
+	require.NoError(s.T(), err, "Failed to truncate log file")
 	fileSize := blockSizeInBytes * 3
 	chunkSize := int64(1 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
@@ -102,6 +100,8 @@ func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobal
 }
 
 func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
+	err := os.Truncate(setup.LogFile(), 0)
+	require.NoError(s.T(), err, "Failed to truncate log file")
 	const randomReadsThreshold = 3
 	// Create a file with 4 blocks. We will read backwards from block 3 to 0
 	// to trigger random seek detection.
@@ -124,6 +124,8 @@ func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 }
 
 func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
+	err := os.Truncate(setup.LogFile(), 0)
+	require.NoError(s.T(), err, "Failed to truncate log file")
 	// File size is small, less than one block.
 	fileSize := blockSizeInBytes / 2
 	chunkSize := int64(1 * util.KiB)
@@ -149,6 +151,8 @@ func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
 // due to random reads, the buffered reader is re-engaged once the read pattern
 // becomes sequential again.
 func (s *RandomReadFallbackSuite) TestRandomThenSequential_SwitchesBackToBufferedRead() {
+	err := os.Truncate(setup.LogFile(), 0)
+	require.NoError(s.T(), err, "Failed to truncate log file")
 	fileSize := int64(20 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
 	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())

--- a/tools/integration_tests/buffered_read/fallback_test.go
+++ b/tools/integration_tests/buffered_read/fallback_test.go
@@ -85,7 +85,7 @@ func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobal
 	fileSize := int64(3 * 8 * util.MiB)
 	chunkSize := int64(1 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
-	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
+	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
 	filePath := path.Join(testDir, fileName)
 
 	// Open and read the file. Since BufferedReader creation should fail, the read
@@ -93,7 +93,7 @@ func (s *InsufficientPoolCreationSuite) TestNewBufferedReader_InsufficientGlobal
 	content, err := operations.ReadChunkFromFile(filePath, chunkSize, 0, os.O_RDONLY|syscall.O_DIRECT)
 
 	require.NoError(s.T(), err, "Failed to read file")
-	client.ValidateObjectChunkFromGCS(ctx, storageClient, path.Base(testDir), fileName, 0, chunkSize, string(content), s.T())
+	client.ValidateObjectChunkFromGCS(testEnv.ctx, testEnv.storageClient, path.Base(testDir), fileName, 0, chunkSize, string(content), s.T())
 	warningMsg := "Failed to create bufferedReader"
 	found := operations.CheckLogFileForMessage(s.T(), warningMsg, setup.LogFile())
 	assert.True(s.T(), found, "Expected warning message not found in log file")
@@ -110,7 +110,7 @@ func (s *RandomReadFallbackSuite) TestRandomRead_Fallback() {
 	fileSize := blockSizeInBytes * int64(numBlocks)
 	chunkSize := int64(1 * util.KiB)
 	testDir := setup.SetupTestDirectory(testDirName)
-	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
+	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
 	filePath := path.Join(testDir, fileName)
 	f, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, 0)
 	require.NoError(s.T(), err)
@@ -130,7 +130,7 @@ func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
 	fileSize := blockSizeInBytes / 2
 	chunkSize := int64(1 * util.KiB)
 	testDir := setup.SetupTestDirectory(testDirName)
-	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
+	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
 	filePath := path.Join(testDir, fileName)
 	f, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, 0)
 	require.NoError(s.T(), err)
@@ -153,7 +153,7 @@ func (s *RandomReadFallbackSuite) TestRandomRead_SmallFile_NoFallback() {
 func (s *RandomReadFallbackSuite) TestRandomThenSequential_SwitchesBackToBufferedRead() {
 	fileSize := int64(20 * util.MiB)
 	testDir := setup.SetupTestDirectory(testDirName)
-	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
+	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
 	filePath := path.Join(testDir, fileName)
 	f, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_DIRECT, 0)
 	require.NoError(s.T(), err)

--- a/tools/integration_tests/buffered_read/helpers_test.go
+++ b/tools/integration_tests/buffered_read/helpers_test.go
@@ -118,7 +118,7 @@ func readAndValidateChunk(f *os.File, testDir, fileName string, offset, chunkSiz
 	_, err := f.ReadAt(readBuffer, offset)
 
 	require.NoError(t, err, "ReadAt failed at offset %d", offset)
-	client.ValidateObjectChunkFromGCS(ctx, storageClient, testDir, fileName, offset, chunkSize, string(readBuffer), t)
+	client.ValidateObjectChunkFromGCS(testEnv.ctx, testEnv.storageClient, testDir, fileName, offset, chunkSize, string(readBuffer), t)
 }
 
 // induceRandomReadFallback performs a sequence of backward reads to trigger the

--- a/tools/integration_tests/buffered_read/sequential_read_test.go
+++ b/tools/integration_tests/buffered_read/sequential_read_test.go
@@ -88,9 +88,9 @@ func (s *SequentialReadSuite) TestSequentialRead() {
 				err := os.Truncate(setup.LogFile(), 0)
 				require.NoError(t, err, "Failed to truncate log file")
 				testDir := setup.SetupTestDirectory(testDirName)
-				fileName := setupFileInTestDir(ctx, storageClient, testDir, fsTest.fileSize, t)
+				fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fsTest.fileSize, t)
 
-				expected := readFileAndValidate(ctx, storageClient, testDir, fileName, true, 0, chunkSize, t)
+				expected := readFileAndValidate(testEnv.ctx, testEnv.storageClient, testDir, fileName, true, 0, chunkSize, t)
 
 				bufferedReadLogEntry := parseAndValidateSingleBufferedReadLog(t)
 				validate(expected, bufferedReadLogEntry, false, t)
@@ -116,7 +116,7 @@ func (s *SequentialReadSuite) TestReadHeaderFooterAndBody() {
 		testDir := setup.SetupTestDirectory(testDirName)
 		fileSize := blockSizeInBytes * 2
 		// Create a file of a given size in the test directory.
-		fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, t)
+		fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, t)
 		filePath := path.Join(testDir, fileName)
 		// Get the actual file size.
 		fi, err := os.Stat(filePath)
@@ -165,10 +165,10 @@ func (s *SequentialReadSuite) TestReadSpanningTwoBlocks() {
 	// Truncate the log file before the read operation.
 	err := os.Truncate(setup.LogFile(), 0)
 	require.NoError(s.T(), err, "Failed to truncate log file")
-	fileName := setupFileInTestDir(ctx, storageClient, testDir, fileSize, s.T())
+	fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fileSize, s.T())
 
 	// readFileAndValidate opens, reads, and closes the file in one go.
-	expected := readFileAndValidate(ctx, storageClient, testDir, fileName, false, readOffset, readSize, s.T())
+	expected := readFileAndValidate(testEnv.ctx, testEnv.storageClient, testDir, fileName, false, readOffset, readSize, s.T())
 
 	bufferedReadLogEntry := parseAndValidateSingleBufferedReadLog(s.T())
 	validate(expected, bufferedReadLogEntry, false, s.T())

--- a/tools/integration_tests/buffered_read/sequential_read_test.go
+++ b/tools/integration_tests/buffered_read/sequential_read_test.go
@@ -41,19 +41,20 @@ type SequentialReadSuite struct {
 }
 
 func (s *SequentialReadSuite) SetupSuite() {
-	if setup.MountedDirectory() != "" {
-		setupForMountedDirectoryTests()
-		return
-	}
+	setup.SetUpLogFilePath(s.flags, GKETempDir, "", testEnv.cfg)
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
+	setup.SetMntDir(mountDir)
 }
 
 func (s *SequentialReadSuite) TearDownSuite() {
-	if setup.MountedDirectory() != "" {
-		setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
-		return
-	}
 	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *SequentialReadSuite) SetupTest() {
+	testEnv.testDirPath = setup.SetupTestDirectory(testDirName)
+}
+
+func (s *SequentialReadSuite) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
@@ -85,6 +86,7 @@ func (s *SequentialReadSuite) TestSequentialRead() {
 
 			s.T().Run(testName, func(t *testing.T) {
 				err := os.Truncate(setup.LogFile(), 0)
+				fmt.Println("pranjall", setup.LogFile())
 				require.NoError(t, err, "Failed to truncate log file")
 				testDir := setup.SetupTestDirectory(testDirName)
 				fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fsTest.fileSize, t)

--- a/tools/integration_tests/buffered_read/sequential_read_test.go
+++ b/tools/integration_tests/buffered_read/sequential_read_test.go
@@ -16,6 +16,7 @@ package buffered_read
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"syscall"
@@ -36,8 +37,7 @@ import (
 
 type SequentialReadSuite struct {
 	suite.Suite
-	// Helper struct with test flags.
-	testFlags *gcsfuseTestFlags
+	flags []string
 }
 
 func (s *SequentialReadSuite) SetupSuite() {
@@ -45,13 +45,7 @@ func (s *SequentialReadSuite) SetupSuite() {
 		setupForMountedDirectoryTests()
 		return
 	}
-	// Create config file.
-	configFile := createConfigFile(s.testFlags)
-	// Create the final flags slice.
-	// The static mounting helper adds --log-file and --log-severity flags, so we only need to add the format.
-	flags := []string{"--config-file=" + configFile}
-	// Mount GCSFuse.
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
 }
 
 func (s *SequentialReadSuite) TearDownSuite() {
@@ -59,7 +53,7 @@ func (s *SequentialReadSuite) TearDownSuite() {
 		setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 		return
 	}
-	setup.UnmountGCSFuse(rootDir)
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
 
@@ -67,7 +61,7 @@ func (s *SequentialReadSuite) TearDownSuite() {
 // Test Cases
 // //////////////////////////////////////////////////////////////////////
 func (s *SequentialReadSuite) TestSequentialRead() {
-	blockSizeInBytes := s.testFlags.blockSizeMB * util.MiB
+	blockSizeInBytes := int64(8 * util.MiB)
 	fileSizeTests := []struct {
 		name     string
 		fileSize int64
@@ -112,7 +106,7 @@ func (s *SequentialReadSuite) TestSequentialRead() {
 // buffered read log entry, indicating efficient handling.
 func (s *SequentialReadSuite) TestReadHeaderFooterAndBody() {
 	// Constants for block and file sizes
-	blockSizeInBytes := s.testFlags.blockSizeMB * util.MiB
+	blockSizeInBytes := int64(8 * util.MiB)
 	// Header and footer sizes (10KB each)
 	headerSize := 10 * util.KiB
 	footerSize := 10 * util.KiB
@@ -160,7 +154,7 @@ func (s *SequentialReadSuite) TestReadHeaderFooterAndBody() {
 // TestReadSpanningTwoBlocks verifies that a read spanning two buffer blocks is
 // handled correctly.
 func (s *SequentialReadSuite) TestReadSpanningTwoBlocks() {
-	blockSizeInBytes := s.testFlags.blockSizeMB * util.MiB
+	blockSizeInBytes := int64(8 * util.MiB)
 	// Ensure file is large enough for multi-block reads.
 	fileSize := 3 * blockSizeInBytes
 	// We want to read 512KB, with 256KB in the first block and 256KB in the second.
@@ -186,30 +180,16 @@ func (s *SequentialReadSuite) TestReadSpanningTwoBlocks() {
 ////////////////////////////////////////////////////////////////////////
 
 func TestSequentialReadSuite(t *testing.T) {
-	// Define the different flag configurations to test against.
-	baseTestFlags := gcsfuseTestFlags{
-		enableBufferedRead:   true,
-		blockSizeMB:          8,
-		maxBlocksPerHandle:   20,
-		startBlocksPerHandle: 1,
-		minBlocksPerHandle:   2,
-	}
+	ts := &SequentialReadSuite{}
 
-	// Run tests for mounted directory if the flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
-		suite.Run(t, &SequentialReadSuite{testFlags: &baseTestFlags})
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
 		return
 	}
 
-	protocols := []string{clientProtocolHTTP1, clientProtocolGRPC}
-
-	for _, protocol := range protocols {
-		// Create a new suite for each protocol.
-		t.Run(protocol, func(t *testing.T) {
-			testFlags := baseTestFlags
-			testFlags.clientProtocol = protocol
-
-			suite.Run(t, &SequentialReadSuite{testFlags: &testFlags})
-		})
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
+		suite.Run(t, ts)
 	}
 }

--- a/tools/integration_tests/buffered_read/sequential_read_test.go
+++ b/tools/integration_tests/buffered_read/sequential_read_test.go
@@ -86,7 +86,6 @@ func (s *SequentialReadSuite) TestSequentialRead() {
 
 			s.T().Run(testName, func(t *testing.T) {
 				err := os.Truncate(setup.LogFile(), 0)
-				fmt.Println("pranjall", setup.LogFile())
 				require.NoError(t, err, "Failed to truncate log file")
 				testDir := setup.SetupTestDirectory(testDirName)
 				fileName := setupFileInTestDir(testEnv.ctx, testEnv.storageClient, testDir, fsTest.fileSize, t)

--- a/tools/integration_tests/buffered_read/sequential_read_test.go
+++ b/tools/integration_tests/buffered_read/sequential_read_test.go
@@ -61,7 +61,6 @@ func (s *SequentialReadSuite) TearDownSuite() {
 // Test Cases
 // //////////////////////////////////////////////////////////////////////
 func (s *SequentialReadSuite) TestSequentialRead() {
-	blockSizeInBytes := int64(8 * util.MiB)
 	fileSizeTests := []struct {
 		name     string
 		fileSize int64
@@ -105,8 +104,6 @@ func (s *SequentialReadSuite) TestSequentialRead() {
 // The key validation is that all these operations should be served from a single
 // buffered read log entry, indicating efficient handling.
 func (s *SequentialReadSuite) TestReadHeaderFooterAndBody() {
-	// Constants for block and file sizes
-	blockSizeInBytes := int64(8 * util.MiB)
 	// Header and footer sizes (10KB each)
 	headerSize := 10 * util.KiB
 	footerSize := 10 * util.KiB
@@ -154,7 +151,6 @@ func (s *SequentialReadSuite) TestReadHeaderFooterAndBody() {
 // TestReadSpanningTwoBlocks verifies that a read spanning two buffer blocks is
 // handled correctly.
 func (s *SequentialReadSuite) TestReadSpanningTwoBlocks() {
-	blockSizeInBytes := int64(8 * util.MiB)
 	// Ensure file is large enough for multi-block reads.
 	fileSize := 3 * blockSizeInBytes
 	// We want to read 512KB, with 256KB in the first block and 256KB in the second.

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -32,14 +33,12 @@ const (
 	testDirName                         = "BufferedReadTest"
 	testFileName                        = "foo"
 	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_buffered_read_test_logs/log.json"
+	// Global block size constant for tests
+	blockSizeInBytes = int64(8 * util.MiB)
 )
 
 var (
 	mountFunc func(*test_suite.TestConfig, []string) error
-	// mount directory is where our tests run.
-	mountDir string
-	// root directory is the directory to be unmounted.
-	rootDir string
 )
 
 type env struct {
@@ -114,16 +113,12 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		// Save mount and root directory variables.
-		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-	// Save mount and root directory variables.
-	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	mountFunc     func(*test_suite.TestConfig, []string) error
+	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -31,27 +31,24 @@ import (
 const (
 	testDirName                         = "BufferedReadTest"
 	testFileName                        = "foo"
-	clientProtocolHTTP1                 = "http1"
-	clientProtocolGRPC                  = "grpc"
 	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_buffered_read_test_logs/log.json"
 )
 
 var (
-	mountFunc     func([]string) error
+	mountFunc     func(*test_suite.TestConfig, []string) error
 	storageClient *storage.Client
 	ctx           context.Context
 	rootDir       string
 )
 
-type gcsfuseTestFlags struct {
-	clientProtocol       string
-	enableBufferedRead   bool
-	blockSizeMB          int64
-	maxBlocksPerHandle   int64
-	startBlocksPerHandle int64
-	minBlocksPerHandle   int64
-	globalMaxBlocks      int64
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	cfg           *test_suite.TestConfig
+	bucketType    string
 }
+
+var testEnv env
 
 ////////////////////////////////////////////////////////////////////////
 // Helpers
@@ -63,43 +60,6 @@ func setupForMountedDirectoryTests() {
 	}
 }
 
-func createConfigFile(flags *gcsfuseTestFlags) string {
-	mountConfig := make(map[string]any)
-	readConfig := make(map[string]any)
-
-	// Only add flags to the config if they have a non-zero/non-default value.
-	// This prevents writing zero values that would override GCSFuse's built-in defaults.
-	if flags.enableBufferedRead {
-		readConfig["enable-buffered-read"] = flags.enableBufferedRead
-	}
-	if flags.blockSizeMB != 0 {
-		readConfig["block-size-mb"] = flags.blockSizeMB
-	}
-	if flags.maxBlocksPerHandle != 0 {
-		readConfig["max-blocks-per-handle"] = flags.maxBlocksPerHandle
-	}
-	if flags.startBlocksPerHandle != 0 {
-		readConfig["start-blocks-per-handle"] = flags.startBlocksPerHandle
-	}
-	if flags.minBlocksPerHandle != 0 {
-		readConfig["min-blocks-per-handle"] = flags.minBlocksPerHandle
-	}
-	if flags.globalMaxBlocks != 0 {
-		readConfig["global-max-blocks"] = flags.globalMaxBlocks
-	}
-	if len(readConfig) > 0 {
-		mountConfig["read"] = readConfig
-	}
-	if flags.clientProtocol != "" {
-		mountConfig["gcs-connection"] = map[string]any{"client-protocol": flags.clientProtocol}
-	}
-	// By default, kernel reader is enabled for zonal buckets. We need to disable it
-	// explicitly to ensure buffered reads are used.
-	mountConfig["file-system"] = map[string]any{"enable-kernel-reader": false}
-	filePath := setup.YAMLConfigFile(mountConfig, "config.yaml")
-	return filePath
-}
-
 ////////////////////////////////////////////////////////////////////////
 // TestMain
 ////////////////////////////////////////////////////////////////////////
@@ -107,8 +67,45 @@ func createConfigFile(flags *gcsfuseTestFlags) string {
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.BufferedRead) == 0 {
+		log.Println("No configuration found for buffered_read tests in config. Using flags instead.")
+		cfg.BufferedRead = make([]test_suite.TestConfig, 1)
+		cfg.BufferedRead[0].TestBucket = setup.TestBucket()
+		cfg.BufferedRead[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.BufferedRead[0].LogFile = setup.LogFile()
+		cfg.BufferedRead[0].Configs = make([]test_suite.ConfigItem, 3)
+
+		cfg.BufferedRead[0].Configs[0].Flags = []string{
+			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+		}
+		cfg.BufferedRead[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.BufferedRead[0].Configs[0].Run = "TestSequentialReadSuite"
+
+		cfg.BufferedRead[0].Configs[1].Flags = []string{
+			"--enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false",
+		}
+		cfg.BufferedRead[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.BufferedRead[0].Configs[1].Run = "TestInsufficientPoolCreationSuite"
+
+		cfg.BufferedRead[0].Configs[2].Flags = []string{
+			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+		}
+		cfg.BufferedRead[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.BufferedRead[0].Configs[2].Run = "TestRandomReadFallbackSuite"
+	}
+
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.BufferedRead[0])
+	testEnv.cfg = &cfg.BufferedRead[0]
+
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
+	ctx = testEnv.ctx
+	storageClient = testEnv.storageClient
+
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
@@ -116,34 +113,19 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// A test bucket must be provided for all tests.
-	if setup.TestBucket() == "" {
-		log.Fatal("The --testbucket flag is required for this test.")
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		rootDir = testEnv.cfg.GKEMountedDirectory
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
-	if setup.MountedDirectory() != "" {
-		rootDir = setup.MountedDirectory()
-		os.Exit(setup.RunTestsForMountedDirectory(setup.MountedDirectory(), m))
-	}
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	rootDir = testEnv.cfg.GCSFuseMountedDirectory
 
-	// Else run tests for testBucket.
-	setup.SetUpTestDirForTestBucketFlag()
-	rootDir = setup.MntDir()
-
-	// Set up the static mounting function.
-	mountFunc = func(flags []string) error {
-		config := &test_suite.TestConfig{
-			TestBucket:              setup.TestBucket(),
-			GKEMountedDirectory:     setup.MountedDirectory(),
-			GCSFuseMountedDirectory: setup.MntDir(),
-			LogFile:                 setup.LogFile(),
-		}
-		return static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
-	}
+	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 
 	// Run the tests.
 	successCode := m.Run()
 
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -32,33 +32,28 @@ import (
 const (
 	testDirName                         = "BufferedReadTest"
 	testFileName                        = "foo"
-	logFileNameForMountedDirectoryTests = "/tmp/gcsfuse_buffered_read_test_logs/log.json"
 	// Global block size constant for tests
 	blockSizeInBytes = int64(8 * util.MiB)
+	GKETempDir       = "/gcsfuse-tmp"
 )
 
 var (
 	mountFunc func(*test_suite.TestConfig, []string) error
+		// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir string
 )
 
 type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
+	testDirPath   string
 	cfg           *test_suite.TestConfig
 	bucketType    string
 }
 
 var testEnv env
-
-////////////////////////////////////////////////////////////////////////
-// Helpers
-////////////////////////////////////////////////////////////////////////
-
-func setupForMountedDirectoryTests() {
-	if setup.MountedDirectory() != "" {
-		setup.SetLogFile(logFileNameForMountedDirectoryTests)
-	}
-}
 
 ////////////////////////////////////////////////////////////////////////
 // TestMain
@@ -77,22 +72,22 @@ func TestMain(m *testing.M) {
 		cfg.BufferedRead[0].Configs = make([]test_suite.ConfigItem, 3)
 
 		cfg.BufferedRead[0].Configs[0].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestBufferedReadSuite.log --log-severity=TRACE",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestBufferedReadSuite.log --log-severity=TRACE",
 		}
 		cfg.BufferedRead[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.BufferedRead[0].Configs[0].Run = "TestSequentialReadSuite"
 
 		cfg.BufferedRead[0].Configs[1].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log --log-severity=TRACE",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log --log-severity=TRACE",
 		}
 		cfg.BufferedRead[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.BufferedRead[0].Configs[1].Run = "TestInsufficientPoolCreationSuite"
 
 		cfg.BufferedRead[0].Configs[2].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false",
+			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log --log-severity=TRACE",
+			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log --log-severity=TRACE",
 		}
 		cfg.BufferedRead[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.BufferedRead[0].Configs[2].Run = "TestRandomReadFallbackSuite"
@@ -113,16 +108,22 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		// Save mount and root directory variables.
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	// Set up test directory.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	// Override GKE specific paths with GCSFuse paths if running in GCE environment.
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
+	// Save mount and root directory variables.
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
+
+	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
-
-	// Run the tests.
 	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	testDirName                         = "BufferedReadTest"
-	testFileName                        = "foo"
+	testDirName  = "BufferedReadTest"
+	testFileName = "foo"
 	// Global block size constant for tests
 	blockSizeInBytes = int64(8 * util.MiB)
 	GKETempDir       = "/gcsfuse-tmp"
@@ -39,7 +39,7 @@ const (
 
 var (
 	mountFunc func(*test_suite.TestConfig, []string) error
-		// mount directory is where our tests run.
+	// mount directory is where our tests run.
 	mountDir string
 	// root directory is the directory to be unmounted.
 	rootDir string

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -36,9 +36,10 @@ const (
 
 var (
 	mountFunc     func(*test_suite.TestConfig, []string) error
-	storageClient *storage.Client
-	ctx           context.Context
-	rootDir       string
+	// mount directory is where our tests run.
+	mountDir string
+	// root directory is the directory to be unmounted.
+	rootDir string
 )
 
 type env struct {
@@ -102,24 +103,27 @@ func TestMain(m *testing.M) {
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.BufferedRead[0])
 	testEnv.cfg = &cfg.BufferedRead[0]
 
+	// 2. Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
-	ctx = testEnv.ctx
-	storageClient = testEnv.storageClient
-
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
+			log.Printf("closeStorageClient failed: %v\n", err)
 		}
 	}()
 
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		rootDir = testEnv.cfg.GKEMountedDirectory
+		// Save mount and root directory variables.
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
+	// Run tests for testBucket
+	// Set up test directory.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-	rootDir = testEnv.cfg.GCSFuseMountedDirectory
+	// Save mount and root directory variables.
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1057,8 +1057,8 @@ buffered_read:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
-          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestBufferedReadSuite.log,--log-severity=TRACE"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestBufferedReadSuite.log,--log-severity=TRACE"
         compatible:
           flat: true
           hns: true
@@ -1066,8 +1066,8 @@ buffered_read:
         run: TestSequentialReadSuite
         run_on_gke: true
       - flags:
-          - "--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false"
-          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE"
         compatible:
           flat: true
           hns: true
@@ -1075,8 +1075,8 @@ buffered_read:
         run: TestInsufficientPoolCreationSuite
         run_on_gke: true
       - flags:
-          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
-          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1052,6 +1052,38 @@ symlink_handling:
           zonal: true
         run_on_gke: true
 
+buffered_read:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestSequentialReadSuite
+        run_on_gke: true
+      - flags:
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestInsufficientPoolCreationSuite
+        run_on_gke: true
+      - flags:
+          - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+          - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestRandomReadFallbackSuite
+        run_on_gke: true
+
 negative_stat_cache:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	ManagedFolders        []TestConfig `yaml:"managed_folders"`
 	ConcurrentOperations  []TestConfig `yaml:"concurrent_operations"`
 	Benchmarking          []TestConfig `yaml:"benchmarking"`
+	BufferedRead          []TestConfig `yaml:"buffered_read"`
 	StaleHandle           []TestConfig `yaml:"stale_handle"`
 	StreamingWrites       []TestConfig `yaml:"streaming_writes"`
 	InactiveStreamTimeout []TestConfig `yaml:"inactive_stream_timeout"`


### PR DESCRIPTION
### Description
This PR migrates the `buffered_read` integration tests to use the new YAML-based test configuration framework.

### Link to the issue in case of a bug fix.
https://buganizer.corp.google.com/issues/499884767

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Passing for the newly migrated buffered read tests.

### Any backward incompatible change? If so, please explain.
No.