### PR TITLE
test(integration): migrate managed_folders tests to common test configuration

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -221,10 +221,12 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 			if ts.bucketPermission == ViewPermission {
 				creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, AdminPermission, setup.TestBucket())
 				creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
-				defer creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 			}
 			ts.managedFoldersPermission = permissions[i][1]
 			suite.Run(t, ts)
+			if ts.bucketPermission == ViewPermission {
+				creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
+			}
 		}
 		t.Cleanup(func() {
 			client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testEnv.testDir, ManagedFolder1), setup.TestBucket())

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -41,52 +41,62 @@ const (
 	CreateTestFile = "createTestFile"
 )
 
-var (
-	bucket         string
-	testDir        string
-	serviceAccount string
-)
-
 // The permission granted by roles at project, bucket, and managed folder
 // levels apply additively (union) throughout the resource hierarchy.
 // Hence, here managed folder will have admin permission throughout all the tests.
 type managedFoldersAdminPermission struct {
 	bucketPermission         string
 	managedFoldersPermission string
+	flags                    []string
 	suite.Suite
 }
 
+func (s *managedFoldersAdminPermission) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
+}
+
+func (s *managedFoldersAdminPermission) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
 func (s *managedFoldersAdminPermission) SetupTest() {
-	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, s.T())
+	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
+	createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
 	if s.managedFoldersPermission != "nil" {
-		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFoldersPermission, s.T())
-		providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFoldersPermission, s.T())
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		// Waiting for 60 seconds for policy changes to propagate. This values we kept based on our experiments.
 		time.Sleep(60 * time.Second)
 	}
 }
 
 func (s *managedFoldersAdminPermission) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 	// Due to bucket view permissions, it prevents cleaning resources outside managed folders. So we are cleaning managed folders resources only.
 	if s.bucketPermission == ViewPermission {
-		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, s.managedFoldersPermission, s.T())
+		revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1))
-		revokePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, s.managedFoldersPermission, s.T())
+		revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder2))
 		return
 	}
 	setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest))
 }
 
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
+
 func (s *managedFoldersAdminPermission) TestCreateObjectInManagedFolder() {
-	testDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
+	testDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	file := path.Join(testDirPath, CreateTestFile)
 
 	createFileForTest(file, s.T())
 }
 
 func (s *managedFoldersAdminPermission) TestDeleteObjectInManagedFolder() {
-	filePath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
+	filePath := path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
 
 	err := os.Remove(filePath)
 	if err != nil {
@@ -101,7 +111,7 @@ func (s *managedFoldersAdminPermission) TestDeleteObjectInManagedFolder() {
 
 // Managed folders will not be deleted, but they will become empty. Default empty managed folders will be hidden.
 func (s *managedFoldersAdminPermission) TestDeleteManagedFolder() {
-	dirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
+	dirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {
@@ -115,7 +125,7 @@ func (s *managedFoldersAdminPermission) TestDeleteManagedFolder() {
 }
 
 func (s *managedFoldersAdminPermission) TestCopyObjectWithInManagedFolder() {
-	testDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
+	testDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	srcCopyFile := path.Join(testDirPath, FileInNonEmptyManagedFoldersTest)
 	destCopyFile := path.Join(testDirPath, DestFile)
 
@@ -131,8 +141,8 @@ func (s *managedFoldersAdminPermission) TestCopyObjectWithInManagedFolder() {
 }
 
 func (s *managedFoldersAdminPermission) TestCopyManagedFolder() {
-	srcDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
-	destDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFolder)
+	srcDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
+	destDirPath := path.Join(testEnv.testDirPath, DestFolder)
 
 	err := operations.CopyDir(srcDirPath, destDirPath)
 
@@ -147,7 +157,7 @@ func (s *managedFoldersAdminPermission) TestCopyManagedFolder() {
 }
 
 func (s *managedFoldersAdminPermission) TestMoveObjectWithInManagedFolder() {
-	testDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
+	testDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	srcMoveFile := path.Join(testDirPath, FileInNonEmptyManagedFoldersTest)
 	destMoveFile := path.Join(testDirPath, DestFile)
 
@@ -167,8 +177,8 @@ func (s *managedFoldersAdminPermission) TestMoveObjectWithInManagedFolder() {
 }
 
 func (s *managedFoldersAdminPermission) TestMoveManagedFolder() {
-	srcDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
-	destDirPath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFolder)
+	srcDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
+	destDirPath := path.Join(testEnv.testDirPath, DestFolder)
 
 	err := operations.Move(srcDirPath, destDirPath)
 
@@ -196,47 +206,29 @@ func (s *managedFoldersAdminPermission) TestListNonEmptyManagedFoldersWithAdminP
 
 func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 	ts := &managedFoldersAdminPermission{}
+	setup.RunTestsOnlyForStaticMount(testEnv.mountDir, t)
 
-	setup.RunTestsOnlyForStaticMount(mountDir, t)
-
-	// Fetch credentials and apply permission on bucket.
-	var localKeyFilePath string
-	serviceAccount, localKeyFilePath = creds_tests.CreateCredentials(ctx)
-	defer func() {
-		if err := os.Remove(localKeyFilePath); err != nil {
-			t.Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, AdminPermission, setup.TestBucket())
+		// Run tests on given {Bucket permission, Managed folder permission}.
+		permissions := [][]string{{AdminPermission, "nil"}, {AdminPermission, IAMRoleForViewPermission}, {AdminPermission, IAMRoleForAdminPermission}, {ViewPermission, IAMRoleForAdminPermission}}
+		for i := range permissions {
+			log.Printf("Running tests with flags, bucket have %s permission and managed folder have %s permissions: %s", permissions[i][0], permissions[i][1], ts.flags)
+			testEnv.bucket, testEnv.testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
+			ts.bucketPermission = permissions[i][0]
+			if ts.bucketPermission == ViewPermission {
+				creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, AdminPermission, setup.TestBucket())
+				creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
+				defer creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
+			}
+			ts.managedFoldersPermission = permissions[i][1]
+			suite.Run(t, ts)
 		}
-	}()
-	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
-
-	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=5", "--stat-cache-ttl=0"}
-	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
-		flags = hnsFlagSet
-		flags = append(flags, "--key-file="+localKeyFilePath, "--stat-cache-ttl=0")
+		t.Cleanup(func() {
+			client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testEnv.testDir, ManagedFolder1), setup.TestBucket())
+			client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testEnv.testDir, ManagedFolder2), setup.TestBucket())
+		})
 	}
-
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	defer setup.UnmountGCSFuse(rootDir)
-	setup.SetMntDir(mountDir)
-
-	// Run tests on given {Bucket permission, Managed folder permission}.
-	permissions := [][]string{{AdminPermission, "nil"}, {AdminPermission, IAMRoleForViewPermission}, {AdminPermission, IAMRoleForAdminPermission}, {ViewPermission, IAMRoleForAdminPermission}}
-
-	for i := range permissions {
-		log.Printf("Running tests with flags, bucket have %s permission and managed folder have %s permissions: %s", permissions[i][0], permissions[i][1], flags)
-		bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
-		ts.bucketPermission = permissions[i][0]
-		if ts.bucketPermission == ViewPermission {
-			creds_tests.RevokePermission(ctx, storageClient, serviceAccount, AdminPermission, setup.TestBucket())
-			creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
-			defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
-		}
-		ts.managedFoldersPermission = permissions[i][1]
-
-		suite.Run(t, ts)
-	}
-	t.Cleanup(func() {
-		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), setup.TestBucket())
-		client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), setup.TestBucket())
-	})
 }

--- a/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/list_empty_managed_folders_test.go
@@ -46,18 +46,29 @@ const (
 
 type enableEmptyManagedFoldersTrue struct {
 	suite.Suite
+	flags []string
+}
+
+func (s *enableEmptyManagedFoldersTrue) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
+}
+
+func (s *enableEmptyManagedFoldersTrue) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 }
 
 func (s *enableEmptyManagedFoldersTrue) SetupTest() {
-	setup.SetupTestDirectory(TestDirForEmptyManagedFoldersTest)
+	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForEmptyManagedFoldersTest)
 }
 
 func (s *enableEmptyManagedFoldersTrue) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 	// Clean up test directory.
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForEmptyManagedFoldersTest)
-	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
-	client.DeleteManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
-	setup.CleanupDirectoryOnGCS(ctx, storageClient, path.Join(bucket, testDir))
+	client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testDir, EmptyManagedFolder1), setup.TestBucket())
+	client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testDir, EmptyManagedFolder2), setup.TestBucket())
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(bucket, testDir))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -70,8 +81,8 @@ func createDirectoryStructureForEmptyManagedFoldersTest(t *testing.T) {
 	// testBucket/EmptyManagedFoldersTest/simulatedFolder
 	// testBucket/EmptyManagedFoldersTest/testFile
 	bucket, testDir := setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForEmptyManagedFoldersTest)
-	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder1), bucket)
-	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, EmptyManagedFolder2), bucket)
+	client.CreateManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testDir, EmptyManagedFolder1), bucket)
+	client.CreateManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, path.Join(testDir, EmptyManagedFolder2), bucket)
 	operations.CreateDirectory(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, SimulatedFolder), t)
 	f := operations.CreateFile(path.Join(setup.MntDir(), TestDirForEmptyManagedFoldersTest, File), setup.FilePermission_0600, t)
 	operations.CloseFileShouldNotThrowError(t, f)
@@ -144,38 +155,16 @@ func (s *enableEmptyManagedFoldersTrue) TestListDirectoryForEmptyManagedFolders(
 	}
 }
 
-func getMountConfigForEmptyManagedFolders() map[string]any {
-	mountConfig := map[string]any{
-		"list": map[string]any{
-			"enable-empty-managed-folders": true,
-		},
-	}
-	return mountConfig
-}
-
 // //////////////////////////////////////////////////////////////////////
 // Test Function (Runs once before all tests)
 // //////////////////////////////////////////////////////////////////////
 func TestEnableEmptyManagedFoldersTrue(t *testing.T) {
 	ts := &enableEmptyManagedFoldersTrue{}
 
-	// Run tests for mountedDirectory only if --mountedDirectory  and --testBucket flag is set.
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running tests with flags: %s", ts.flags)
 		suite.Run(t, ts)
-		return
 	}
-
-	configFile := setup.YAMLConfigFile(getMountConfigForEmptyManagedFolders(), "config.yaml")
-	flags := []string{"--implicit-dirs", "--config-file=" + configFile}
-
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	defer func() {
-		setup.SetMntDir(rootDir)
-		setup.UnMountBucket()
-	}()
-	setup.SetMntDir(mountDir)
-
-	// Run tests.
-	log.Printf("Running tests with flags: %s", flags)
-	suite.Run(t, ts)
 }

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -20,32 +20,44 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/dynamic_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
+type env struct {
+	ctx           context.Context
+	storageClient *storage.Client
+	controlClient *control.StorageControlClient
+	bucketType    string
+	cfg           *test_suite.TestConfig
+	mountFunc     func(*test_suite.TestConfig, []string) error
+	// Mount directory is where our tests run.
+	mountDir string
+	// Root directory is the directory to be unmounted.
+	rootDir          string
+	serviceAccount   string
+	localKeyFilePath string
+	bucket           string
+	testDir          string
+	testDirPath      string
+}
+
 const (
 	onlyDirMounted = "TestManagedFolderOnlyDir"
 )
 
-var (
-	mountFunc func([]string) error
-	// Mount directory is where our tests run.
-	mountDir string
-	// Root directory is the directory to be unmounted.
-	rootDir       string
-	storageClient *storage.Client
-	controlClient *control.StorageControlClient
-	ctx           context.Context
-)
+var testEnv env
 
 ////////////////////////////////////////////////////////////////////////
 // TestMain
@@ -54,58 +66,94 @@ var (
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
-	ctx = context.Background()
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
-	closeControlClient := client.CreateControlClientWithCancel(&ctx, &controlClient)
+	// 1. Load and parse the common configuration.
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.ManagedFolders) == 0 {
+		log.Println("No configuration found for managed_folders tests in config. Using flags instead.")
+		// Populate the config manually.
+		cfg.ManagedFolders = make([]test_suite.TestConfig, 1)
+		cfg.ManagedFolders[0].TestBucket = setup.TestBucket()
+		cfg.ManagedFolders[0].GKEMountedDirectory = setup.MountedDirectory()
+		cfg.ManagedFolders[0].LogFile = setup.LogFile()
+		// Initialize the slice to hold 15 specific test configurations
+		cfg.ManagedFolders[0].Configs = make([]test_suite.ConfigItem, 3)
+		cfg.ManagedFolders[0].Configs[0].Flags = []string{"--implicit-dirs --key-file=${KEY_FILE} --rename-dir-limit=3"}
+		cfg.ManagedFolders[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ManagedFolders[0].Configs[0].Run = "TestManagedFolders_FolderViewPermission"
+		cfg.ManagedFolders[0].Configs[1].Flags = []string{"--implicit-dirs --enable-empty-managed-folders"}
+		cfg.ManagedFolders[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ManagedFolders[0].Configs[1].Run = "TestEnableEmptyManagedFoldersTrue"
+		cfg.ManagedFolders[0].Configs[2].Flags = []string{"--implicit-dirs --key-file=${KEY_FILE} --rename-dir-limit=5 --stat-cache-ttl=0"}
+		cfg.ManagedFolders[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		cfg.ManagedFolders[0].Configs[2].Run = "TestManagedFolders_FolderAdminPermission"
+	}
+
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.ManagedFolders[0])
+	testEnv.cfg = &cfg.ManagedFolders[0]
+
+	// 2. Create storage client before running tests.
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
+	closeControlClient := client.CreateControlClientWithCancel(&testEnv.ctx, &testEnv.controlClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
-			log.Fatalf("closeStorageClient failed: %v", err)
+			log.Printf("closeStorageClient failed: %v\n", err)
 		}
 		err = closeControlClient()
 		if err != nil {
-			log.Fatalf("closeControlClient failed: %v", err)
+			log.Printf("closeControlClient failed: %v\n", err)
 		}
 	}()
 
-	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+	// Fetch credentials and apply permission on bucket.
+	testEnv.serviceAccount, testEnv.localKeyFilePath = creds_tests.CreateCredentials(testEnv.ctx)
+	defer func() {
+		if err := os.Remove(testEnv.localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", testEnv.localKeyFilePath, err)
+		}
+	}()
 
-	if setup.MountedDirectory() != "" {
+	for i, testCase := range cfg.ManagedFolders[0].Configs {
+		// Replace the placeholder with the actual key file path.
+		cfg.ManagedFolders[0].Configs[i].Flags[0] = strings.ReplaceAll(testCase.Flags[0], "${KEY_FILE}", testEnv.localKeyFilePath)
+	}
+
+	// 3. these tests won't run with mountedDirectory.
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		log.Printf("These tests will not run with mounted directory..")
 		return
 	}
 
-	// Else run tests for testBucket.
+	// Run tests for testBucket
 	// Set up test directory.
-	setup.SetUpTestDirForTestBucketFlag()
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	testEnv.mountDir, testEnv.rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
-	mountFunc = static_mounting.MountGcsfuseWithStaticMounting
+	testEnv.mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
 	successCode := m.Run()
-	setup.SaveLogFileInCaseOfFailure(successCode)
-
-	if successCode == 0 {
-		log.Println("Running only dir mounting tests...")
-		setup.SetOnlyDirMounted(onlyDirMounted + "/")
-		client.CreateManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
-		defer client.DeleteManagedFoldersInBucket(ctx, controlClient, onlyDirMounted, setup.TestBucket())
-		mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDir
-		successCode = m.Run()
-		setup.SaveLogFileInCaseOfFailure(successCode)
-		setup.SetOnlyDirMounted("")
-	}
 
 	if successCode == 0 {
 		log.Println("Running dynamic mounting tests...")
 		// Save mount directory variable to have path of bucket to run tests.
-		mountDir = path.Join(setup.MntDir(), setup.TestBucket())
-		mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMounting
+		testEnv.mountDir = path.Join(testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.TestBucket)
+		testEnv.mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
 		successCode = m.Run()
-		setup.SaveLogFileInCaseOfFailure(successCode)
 	}
 
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(onlyDirMounted + "/")
+		testEnv.mountDir = testEnv.rootDir
+		testEnv.mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
+		successCode = m.Run()
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, setup.OnlyDirMounted(), TestDirForManagedFolderTest))
+	}
+
+	// Clean up test directory created.
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, TestDirForManagedFolderTest))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/managed_folders/view_permissions_test.go
+++ b/tools/integration_tests/managed_folders/view_permissions_test.go
@@ -44,21 +44,37 @@ const (
 // levels apply additively (union) throughout the resource hierarchy.
 // Hence, here managed folder will have view permission throughout all the tests.
 type managedFoldersViewPermission struct {
+	flags []string
 	suite.Suite
+}
+
+func (s *managedFoldersViewPermission) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
+	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
+}
+
+func (s *managedFoldersViewPermission) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
 }
 
 func (s *managedFoldersViewPermission) SetupTest() {
 }
 
 func (s *managedFoldersViewPermission) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 }
+
+////////////////////////////////////////////////////////////////////////
+// Test scenarios
+////////////////////////////////////////////////////////////////////////
 
 func (s *managedFoldersViewPermission) TestListNonEmptyManagedFolders() {
 	listNonEmptyManagedFolders(s.T())
 }
 
 func (s *managedFoldersViewPermission) TestCreateObjectInManagedFolder() {
-	filePath := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder2, DestFile)
+	filePath := path.Join(testEnv.testDirPath, ManagedFolder2, DestFile)
 
 	// The error must happen either at file creation or file handle close.
 	file, err := os.Create(filePath)
@@ -70,7 +86,7 @@ func (s *managedFoldersViewPermission) TestCreateObjectInManagedFolder() {
 }
 
 func (s *managedFoldersViewPermission) TestDeleteObjectFromManagedFolder() {
-	err := os.Remove(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest))
+	err := os.Remove(path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest))
 
 	if err == nil {
 		s.T().Errorf("File from managed folder gets deleted with view only permission.")
@@ -80,7 +96,7 @@ func (s *managedFoldersViewPermission) TestDeleteObjectFromManagedFolder() {
 }
 
 func (s *managedFoldersViewPermission) TestDeleteNonEmptyManagedFolder() {
-	err := os.RemoveAll(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1))
+	err := os.RemoveAll(path.Join(testEnv.testDirPath, ManagedFolder1))
 
 	if err == nil {
 		s.T().Errorf("Managed folder deleted with view only permission.")
@@ -90,43 +106,43 @@ func (s *managedFoldersViewPermission) TestDeleteNonEmptyManagedFolder() {
 }
 
 func (s *managedFoldersViewPermission) TestMoveManagedFolder() {
-	srcDir := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
-	destDir := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFolder)
+	srcDir := path.Join(testEnv.testDirPath, ManagedFolder1)
+	destDir := path.Join(testEnv.testDirPath, DestFolder)
 
 	moveAndCheckErrForViewPermission(srcDir, destDir, s.T())
 }
 
 func (s *managedFoldersViewPermission) TestMoveObjectWithInManagedFolder() {
-	srcFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
-	destFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, DestFile)
+	srcFile := path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
+	destFile := path.Join(testEnv.testDirPath, ManagedFolder1, DestFile)
 
 	moveAndCheckErrForViewPermission(srcFile, destFile, s.T())
 }
 
 func (s *managedFoldersViewPermission) TestMoveObjectOutOfManagedFolder() {
-	srcFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
-	destFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFile)
+	srcFile := path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
+	destFile := path.Join(testEnv.testDirPath, DestFile)
 
 	moveAndCheckErrForViewPermission(srcFile, destFile, s.T())
 }
 
 func (s *managedFoldersViewPermission) TestCopyNonEmptyManagedFolder() {
-	srcDir := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1)
-	destDir := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFolder)
+	srcDir := path.Join(testEnv.testDirPath, ManagedFolder1)
+	destDir := path.Join(testEnv.testDirPath, DestFolder)
 
 	copyDirAndCheckErrForViewPermission(srcDir, destDir, s.T())
 }
 
 func (s *managedFoldersViewPermission) TestCopyObjectWithInManagedFolder() {
-	srcFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
-	destFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, DestFile)
+	srcFile := path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
+	destFile := path.Join(testEnv.testDirPath, ManagedFolder1, DestFile)
 
 	copyObjectAndCheckErrForViewPermission(srcFile, destFile, s.T())
 }
 
 func (s *managedFoldersViewPermission) TestCopyObjectOutOfManagedFolder() {
-	srcFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
-	destFile := path.Join(setup.MntDir(), TestDirForManagedFolderTest, DestFile)
+	srcFile := path.Join(testEnv.testDirPath, ManagedFolder1, FileInNonEmptyManagedFoldersTest)
+	destFile := path.Join(testEnv.testDirPath, DestFile)
 
 	copyObjectAndCheckErrForViewPermission(srcFile, destFile, s.T())
 }
@@ -137,40 +153,28 @@ func (s *managedFoldersViewPermission) TestCopyObjectOutOfManagedFolder() {
 func TestManagedFolders_FolderViewPermission(t *testing.T) {
 	ts := &managedFoldersViewPermission{}
 
-	// Fetch credentials and apply permission on bucket.
-	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(ctx)
-	defer func() {
-		if err := os.Remove(localKeyFilePath); err != nil {
-			t.Logf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
-		}
-	}()
-	creds_tests.ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
-	defer creds_tests.RevokePermission(ctx, storageClient, serviceAccount, ViewPermission, setup.TestBucket())
+	creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
+	defer creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 
-	flags := []string{"--implicit-dirs", "--key-file=" + localKeyFilePath, "--rename-dir-limit=3"}
-	if hnsFlagSet, err := setup.AddHNSFlagForHierarchicalBucket(ctx, storageClient); err == nil {
-		flags = hnsFlagSet
-		flags = append(flags, "--key-file="+localKeyFilePath)
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		testEnv.bucket, testEnv.testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
+		// Create directory structure for testing.
+		createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, t)
+		defer cleanup(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, testEnv.bucket, testEnv.testDir, testEnv.serviceAccount, IAMRoleForViewPermission, t)
+
+		// Run tests.
+		log.Printf("Running tests with flags and managed folder have nil permissions: %s", ts.flags)
+		suite.Run(t, ts)
+
+		// Provide storage.objectViewer role to managed folders.
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, IAMRoleForViewPermission, t)
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, IAMRoleForViewPermission, t)
+		// Waiting for 60 seconds for policy changes to propagate. This values we kept based on our experiments.
+		time.Sleep(60 * time.Second)
+
+		log.Printf("Running tests with flags and managed folder have view permissions: %s", ts.flags)
+		suite.Run(t, ts)
 	}
-	setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
-	defer setup.UnmountGCSFuse(rootDir)
-	setup.SetMntDir(mountDir)
-
-	bucket, testDir = setup.GetBucketAndObjectBasedOnTypeOfMount(TestDirForManagedFolderTest)
-	// Create directory structure for testing.
-	createDirectoryStructureForNonEmptyManagedFolders(ctx, storageClient, controlClient, t)
-	defer cleanup(ctx, storageClient, controlClient, bucket, testDir, serviceAccount, IAMRoleForViewPermission, t)
-
-	// Run tests.
-	log.Printf("Running tests with flags and managed folder have nil permissions: %s", flags)
-	suite.Run(t, ts)
-
-	// Provide storage.objectViewer role to managed folders.
-	providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder1), serviceAccount, IAMRoleForViewPermission, t)
-	providePermissionToManagedFolder(bucket, path.Join(testDir, ManagedFolder2), serviceAccount, IAMRoleForViewPermission, t)
-	// Waiting for 60 seconds for policy changes to propagate. This values we kept based on our experiments.
-	time.Sleep(60 * time.Second)
-
-	log.Printf("Running tests with flags and managed folder have view permissions: %s", flags)
-	suite.Run(t, ts)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -71,10 +71,10 @@ operations:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
-        - "--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
-        - "--experimental-enable-json-read,--enable-atomic-rename-object"
-        - "--client-protocol=grpc,--implicit-dirs,--enable-atomic-rename-object,--enable-metadata-prefetch"
+          - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+          - "--experimental-enable-json-read,--enable-atomic-rename-object"
+          - "--client-protocol=grpc,--implicit-dirs,--enable-atomic-rename-object,--enable-metadata-prefetch"
         compatible:
           flat: true
           hns: true
@@ -316,20 +316,20 @@ read_cache:
           zonal: true
         run: TestCacheFileForRangeReadTrueTest
         run_on_gke: true
-#        TODO: Enable Ram cache tests after bug b/383682524 is fixed
-#      - flags:
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE"
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct"
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE"
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct,--client-protocol=grpc"
-#          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
-#        compatible:
-#          flat: true
-#          hns: true
-#          zonal: true
-#        run: TestCacheFileForRangeReadTrueWithRamCache
-#        run_on_gke: true
+      #        TODO: Enable Ram cache tests after bug b/383682524 is fixed
+      #      - flags:
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE"
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct"
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE"
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct,--client-protocol=grpc"
+      #          - "--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadTrueWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
+      #        compatible:
+      #          flat: true
+      #          hns: true
+      #          zonal: true
+      #        run: TestCacheFileForRangeReadTrueWithRamCache
+      #        run_on_gke: true
       - flags:
           - "--implicit-dirs,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--implicit-dirs,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -339,15 +339,15 @@ read_cache:
           zonal: true
         run: TestCacheFileForRangeReadFalseTest
         run_on_gke: true
-#      - flags:
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE"
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
-#        compatible:
-#          flat: true
-#          hns: true
-#          zonal: true
-#        run: TestCacheFileForRangeReadFalseWithRamCache
-#        run_on_gke: true
+      #      - flags:
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE"
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
+      #        compatible:
+      #          flat: true
+      #          hns: true
+      #          zonal: true
+      #        run: TestCacheFileForRangeReadFalseWithRamCache
+      #        run_on_gke: true
       - flags:
           - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false"
@@ -359,17 +359,17 @@ read_cache:
           zonal: true
         run: TestCacheFileForRangeReadFalseWithParallelDownloads
         run_on_gke: true
-#      - flags:
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE"
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct"
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
-#          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct,--client-protocol=grpc"
-#        compatible:
-#          flat: true
-#          hns: true
-#          zonal: true
-#        run: TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache
-#        run_on_gke: true
+      #      - flags:
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE"
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct"
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
+      #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache.log,--log-severity=TRACE,--file-cache-enable-o-direct,--client-protocol=grpc"
+      #        compatible:
+      #          flat: true
+      #          hns: true
+      #          zonal: true
+      #        run: TestCacheFileForRangeReadFalseWithParallelDownloadsAndRamCache
+      #        run_on_gke: true
       - flags:
           - "--file-cache-max-size-mb=48,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestJobChunkTest,--log-file=/gcsfuse-tmp/TestJobChunkTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=48,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestJobChunkTest,--log-file=/gcsfuse-tmp/TestJobChunkTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -508,8 +508,8 @@ inactive_stream_timeout:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--read-inactive-stream-timeout=1s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
-        - "--read-inactive-stream-timeout=1s,--client-protocol=grpc,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
+          - "--read-inactive-stream-timeout=1s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
+          - "--read-inactive-stream-timeout=1s,--client-protocol=grpc,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
         compatible:
           flat: true
           hns: true
@@ -517,7 +517,7 @@ inactive_stream_timeout:
         run: TestTimeoutEnabledSuite
         run_on_gke: true
       - flags:
-        - "--read-inactive-stream-timeout=0s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log"
+          - "--read-inactive-stream-timeout=0s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log"
         compatible:
           flat: true
           hns: true
@@ -534,65 +534,65 @@ benchmarking:
           - "--stat-cache-ttl=0"
           - "--stat-cache-ttl=0 --client-protocol=grpc"
         compatible:
-              flat: true
-              hns: true
-              zonal: true
+          flat: true
+          hns: true
+          zonal: true
         run: "Benchmark_Stat"
         run_on_gke: true
       - flags:
           - "--stat-cache-ttl=0,--enable-atomic-rename-object"
           - "--stat-cache-ttl=0,--enable-atomic-rename-object,--client-protocol=grpc"
         compatible:
-              flat: true
-              hns: true
-              zonal: true
+          flat: true
+          hns: true
+          zonal: true
         run: "Benchmark_Rename"
         run_on_gke: true
       - flags:
           - "--stat-cache-ttl=0"
           - "--client-protocol=grpc,--stat-cache-ttl=0"
         compatible:
-              flat: true
-              hns: true
-              zonal: true
+          flat: true
+          hns: true
+          zonal: true
         run: "Benchmark_Delete"
         run_on_gke: true
 
 dentry_cache:
- - mounted_directory: "${MOUNTED_DIR}"
-   test_bucket: "${BUCKET_NAME}"
-   configs:
-     - flags:
-       - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=2"
-       compatible:
-         flat: true
-         hns: true
-         zonal: true
-       run: TestStatWithDentryCacheEnabledTest
-       run_on_gke: true
-     - flags:
-       - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
-       compatible:
-         flat: true
-         hns: true
-         zonal: true
-       run: TestDeleteOperationTest
-       run_on_gke: true
-     - flags:
-       - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
-       compatible:
-         flat: true
-         hns: true
-         zonal: true
-       run: TestNotifierTest
-       run_on_gke: true
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=2"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestStatWithDentryCacheEnabledTest
+        run_on_gke: true
+      - flags:
+          - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestDeleteOperationTest
+        run_on_gke: true
+      - flags:
+          - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestNotifierTest
+        run_on_gke: true
 
 read_gcs_algo:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        # Do not enable fileCache as we want to test gcs read flow.
+          # Do not enable fileCache as we want to test gcs read flow.
           - "--implicit-dirs"
         compatible:
           flat: true
@@ -605,8 +605,8 @@ unfinalized_object:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--metadata-cache-ttl-secs=-1"
-        - "--metadata-cache-ttl-secs=-1,--enable-kernel-reader=false"
+          - "--metadata-cache-ttl-secs=-1"
+          - "--metadata-cache-ttl-secs=-1,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: false
@@ -614,8 +614,8 @@ unfinalized_object:
         run: TestUnfinalizedObjectReadTest
         run_on_gke: true
       - flags:
-        - "--metadata-cache-ttl-secs=0"
-        - "--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
+          - "--metadata-cache-ttl-secs=0"
+          - "--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: false
@@ -623,8 +623,8 @@ unfinalized_object:
         run: TestUnfinalizedObjectOperationTest
         run_on_gke: true
       - flags:
-        - "--metadata-cache-ttl-secs=2"
-        - "--metadata-cache-ttl-secs=2,--enable-kernel-reader=false"
+          - "--metadata-cache-ttl-secs=2"
+          - "--metadata-cache-ttl-secs=2,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: false
@@ -637,7 +637,7 @@ interrupt:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        #TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
+          #TODO(b/417136852): Enable this test for Zonal Bucket also once read start working.
           - "--enable-streaming-writes"
         compatible:
           flat: true
@@ -786,25 +786,25 @@ flag_optimizations:
         run_on_gke: false
 
 unsupported_path:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  only_dir: "${ONLY_DIR}"
-  log_file: # Optional
-  configs:
-  - flags:
-    - "--implicit-dirs,--client-protocol=grpc,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
-    compatible:
-      flat: true
-      hns: true
-      zonal: false
-    run_on_gke: true
-  - flags:
-    - "--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
-    compatible:
-      flat: true
-      hns: true
-      zonal: true
-    run_on_gke: true
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
+    log_file: # Optional
+    configs:
+      - flags:
+          - "--implicit-dirs,--client-protocol=grpc,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: false
+        run_on_gke: true
+      - flags:
+          - "--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: true
 
 kernel_list_cache:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -921,7 +921,7 @@ monitoring:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-        - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
+          - "--prometheus-port=9190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -929,7 +929,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: false
       - flags:
-        - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
+          - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -937,7 +937,7 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: false
       - flags:
-        - "--prometheus-port=9191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
+          - "--prometheus-port=9191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -945,7 +945,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
       - flags:
-        - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
+          - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -953,7 +953,7 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
+          - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=9192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: false
@@ -961,7 +961,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:
-        - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
+          - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
@@ -969,7 +969,7 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:
-        - "--prometheus-port=9193 --log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
+          - "--prometheus-port=9193 --log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
         compatible:
           flat: false
           hns: false
@@ -1026,3 +1026,32 @@ negative_stat_cache:
           zonal: true
         run: "TestInfiniteNegativeStatCacheTest"
         run_on_gke: true
+
+managed_folders:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - run: TestManagedFolders_FolderViewPermission
+        flags:
+          - "--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=3"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - run: TestEnableEmptyManagedFoldersTrue
+        flags:
+          - "--implicit-dirs,--enable-empty-managed-folders"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - run: TestManagedFolders_FolderAdminPermission
+        flags:
+          - "--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=5,--stat-cache-ttl=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false


### PR DESCRIPTION
### Description
Migrate managed folder tests to common test config. These tests do not run in GKE environment and same is reflected in the common config. Some restructuring of the code was done so it conforms to the standard way of writing the tests in GCSFuse repo.

### Link to the issue in case of a bug fix.
b/499888974

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - via KOKORO

### Any backward incompatible change? If so, please explain.
NA
