### PR TITLE
test(operations): add retries to file and dir attribute tests

### DIFF
--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -16,6 +16,8 @@
 package operations_test
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -25,72 +27,90 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-const DirAttrTest = "dirAttrTest"
-const PrefixFileInDirAttrTest = "fileInDirAttrTest"
-const NumberOfFilesInDirAttrTest = 2
-const BytesWrittenInFile = 14
+const (
+	DirAttrTest                = "dirAttrTest"
+	PrefixFileInDirAttrTest    = "fileInDirAttrTest"
+	NumberOfFilesInDirAttrTest = 2
+	BytesWrittenInFile         = 14
+	retryFrequency             = 10 * time.Second
+	retryDuration              = 3 * time.Minute
+)
 
-func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCreateTime time.Time, byteSize int64, t *testing.T) {
+func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCreateTime time.Time, byteSize int64, t *testing.T) error {
 	oStat, err := os.Stat(objName)
 
 	if err != nil {
-		t.Errorf("os.Stat error: %s, %v", objName, err)
+		return fmt.Errorf("stat object %q failed: %w", objName, err)
 	}
 	statObjName := path.Join(setup.MntDir(), DirForOperationTests, oStat.Name())
 	if objName != statObjName {
-		t.Errorf("File name not matched in os.Stat, found: %s, expected: %s", statObjName, objName)
+		return fmt.Errorf("object name mismatch: got %q, want %q", statObjName, objName)
 	}
 
 	statModTime := oStat.ModTime()
-	if (preCreateTime.After(statModTime)) || (postCreateTime.Before(statModTime)) {
-		t.Errorf("File modification time not in the expected time-range")
+	if preCreateTime.After(statModTime) || postCreateTime.Before(statModTime) {
+		return fmt.Errorf("object modification time %v is not within expected range [%v, %v]", statModTime, preCreateTime, postCreateTime)
 	}
 
 	if oStat.Size() != byteSize {
-		t.Errorf("File size is not %v bytes, found size: %d bytes", BytesWrittenInFile, oStat.Size())
+		return fmt.Errorf("object size mismatch: got %d bytes, want %d bytes", oStat.Size(), byteSize)
 	}
+	t.Logf("Attributes for %q are correct. ModTime: %v (expected range: [%v, %v])", objName, statModTime, preCreateTime, postCreateTime)
+	return nil
 }
 
 func TestFileAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	// kernel time can be slightly out of sync of time.Now(), so using
-	// operations.TimeSlop to adjust pre and post create time.
-	// Ref: https://github.com/golang/go/issues/33510
-	preCreateTime := time.Now().Add(-operations.TimeSlop)
-	fileName := path.Join(testDir, tempFileName)
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	postCreateTime := time.Now().Add(+operations.TimeSlop)
+	t.Logf("Verifying file attributes. Expecting: correct name, size = %d bytes, and mod time within window.", BytesWrittenInFile)
+	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
+		fileName := path.Join(testDir, operations.GetRandomName(t))
+		// kernel time can be slightly out of sync of time.Now(), so using
+		// operations.TimeSlop to adjust pre and post create time.
+		// Ref: https://github.com/golang/go/issues/33510
+		preCreateTime := time.Now().Add(-operations.TimeSlop)
+		operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+		postCreateTime := time.Now().Add(+operations.TimeSlop)
 
-	// The file size in createTempFile() is BytesWrittenInFile bytes
-	// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
-	checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, t)
+		// The file size in createTempFile() is BytesWrittenInFile bytes
+		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
+		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, t)
+		return err == nil, err
+	})
 }
 
 func TestEmptyDirAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	// kernel time can be slightly out of sync of time.Now(), so using
-	// operations.TimeSlop to adjust pre and post create time.
-	// Ref: https://github.com/golang/go/issues/33510
-	preCreateTime := time.Now().Add(-operations.TimeSlop)
-	dirName := path.Join(testDir, DirAttrTest)
-	operations.CreateDirectoryWithNFiles(0, dirName, "", t)
-	postCreateTime := time.Now().Add(operations.TimeSlop)
+	t.Log("Verifying empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(t))
+		// kernel time can be slightly out of sync of time.Now(), so using
+		// operations.TimeSlop to adjust pre and post create time.
+		// Ref: https://github.com/golang/go/issues/33510
+		preCreateTime := time.Now().Add(-operations.TimeSlop)
+		operations.CreateDirectoryWithNFiles(0, dirName, "", t)
+		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-	checkIfObjectAttrIsCorrect(path.Join(testDir, DirAttrTest), preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		return err == nil, err
+	})
 }
 
 func TestNonEmptyDirAttributes(t *testing.T) {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	// kernel time can be slightly out of sync of time.Now(), so using
-	// operations.TimeSlop to adjust pre and post create time.
-	// Ref: https://github.com/golang/go/issues/33510
-	preCreateTime := time.Now().Add(-operations.TimeSlop)
-	dirName := path.Join(testDir, DirAttrTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
-	postCreateTime := time.Now().Add(operations.TimeSlop)
+	t.Log("Verifying non-empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(t))
+		// kernel time can be slightly out of sync of time.Now(), so using
+		// operations.TimeSlop to adjust pre and post create time.
+		// Ref: https://github.com/golang/go/issues/33510
+		preCreateTime := time.Now().Add(-operations.TimeSlop)
+		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
+		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-	checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		return err == nil, err
+	})
 }


### PR DESCRIPTION
**Overview**
This PR improves the robustness and reliability of the integration tests in `file_and_dir_attributes_test.go` by introducing retry mechanisms.

**Key Changes**
* **Test Flakiness Mitigation:** Added `operations.RetryUntil` loops with a 3-minute timeout to `TestFileAttributes`, `TestEmptyDirAttributes`, and `TestNonEmptyDirAttributes` to handle eventual consistency issues.
* **Error Handling Refactoring:** Refactored `checkIfObjectAttrIsCorrect` to return a standard `error` instead of immediately failing the test with `t.Errorf` or `t.Fatalf`, allowing the new retry loop to evaluate failures gracefully and try again.

### Link to the issue in case of a bug fix.
https://buganizer.corp.google.com/issues/500256856

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
