### PR TITLE
fix(requester pays): Fix requester pays for gRPC and also setup integration tests with gRPC with explicit SA.

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/metadata"
 )
 
 const FullFolderPathHNS = "projects/_/buckets/%s/folders/%s"
@@ -43,6 +44,7 @@ type bucketHandle struct {
 	bucketType           *gcs.BucketType
 	controlClient        StorageControlClient
 	finalizeFileForRapid bool
+	billingProject       string
 }
 
 func (bh *bucketHandle) Name() string {
@@ -375,6 +377,10 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 	if err != nil {
 		err = fmt.Errorf("error while setting attribute selection for List Object query :%w", err)
 		return
+	}
+
+	if bh.billingProject != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-goog-user-project", bh.billingProject)
 	}
 
 	itr := bh.bucket.Objects(ctx, query) // Returning iterator to the list of objects.

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -120,8 +120,6 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 		clientOpts = append(clientOpts, experimental.WithGRPCBidiReads())
 	}
 
-
-
 	if clientConfig.LocalSocketAddress != "" {
 		dialer := &net.Dialer{}
 		// The port can be 0, in which case the OS will choose a local port.

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -85,7 +85,7 @@ type storageClient struct {
 }
 
 // Return clientOpts for both gRPC client and control client.
-func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, billingProject string) (clientOpts []option.ClientOption, err error) {
+func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool) (clientOpts []option.ClientOption, err error) {
 	// Add custom endpoint if provided.
 	if clientConfig.CustomEndpoint != "" {
 		clientOpts = append(clientOpts, option.WithEndpoint(storageutil.StripScheme(clientConfig.CustomEndpoint)))
@@ -120,9 +120,7 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 		clientOpts = append(clientOpts, experimental.WithGRPCBidiReads())
 	}
 
-	if billingProject != "" {
-		clientOpts = append(clientOpts, option.WithQuotaProject(billingProject))
-	}
+
 
 	if clientConfig.LocalSocketAddress != "" {
 		dialer := &net.Dialer{}
@@ -213,7 +211,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 
 	var clientOpts []option.ClientOption
-	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig, billingProject)
+	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
@@ -393,7 +391,7 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "localhost") {
 		// For control client, we don't pass billingProject to avoid setting it globally via option.WithQuotaProject.
 		// The wrapper storageControlClientWithBillingProject will manually add it to the context for supported calls.
-		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false, "")
+		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 		}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -85,7 +85,7 @@ type storageClient struct {
 }
 
 // Return clientOpts for both gRPC client and control client.
-func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool) (clientOpts []option.ClientOption, err error) {
+func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, billingProject string) (clientOpts []option.ClientOption, err error) {
 	// Add custom endpoint if provided.
 	if clientConfig.CustomEndpoint != "" {
 		clientOpts = append(clientOpts, option.WithEndpoint(storageutil.StripScheme(clientConfig.CustomEndpoint)))
@@ -118,6 +118,10 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 	// Additional client options.
 	if enableBidiConfig {
 		clientOpts = append(clientOpts, experimental.WithGRPCBidiReads())
+	}
+
+	if billingProject != "" {
+		clientOpts = append(clientOpts, option.WithQuotaProject(billingProject))
 	}
 
 	if clientConfig.LocalSocketAddress != "" {
@@ -203,13 +207,13 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
 
 	var clientOpts []option.ClientOption
-	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
+	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig, billingProject)
 	if err != nil {
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
@@ -228,7 +232,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		setRetryConfig(ctx, sc, clientConfig)
 	}
 
-	err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc)
+	err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject)
 	unSetDirectPathEnvVariable()
 	if err != nil {
 		return nil, err
@@ -237,7 +241,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	return sc, nil
 }
 
-func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil.StorageClientConfig, bucketName string, sc *storage.Client) error {
+func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil.StorageClientConfig, bucketName string, sc *storage.Client, billingProject string) error {
 	// Verify DirectPath connection by performing an stat call on the bucket
 	logger.Infof("Verifying DirectPath connectivity for bucket %q with stat call", bucketName)
 	// Apply detection retry config for initial verification
@@ -248,7 +252,11 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// Retrieving object attrs through Go Storage Client.
 	var notFoundError *gcs.NotFoundError
 	var testObject = "gcsfuse-dp-object"
-	_, statErr := sc.Bucket(bucketName).Object(testObject).Attrs(verifyCtx)
+	bucketHandle := sc.Bucket(bucketName)
+	if billingProject != "" {
+		bucketHandle = bucketHandle.UserProject(billingProject)
+	}
+	_, statErr := bucketHandle.Object(testObject).Attrs(verifyCtx)
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
@@ -383,7 +391,9 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	// Control-client is needed for folder APIs and for getting storage-layout of the bucket.
 	// GetStorageLayout API is not supported for storage-testbench, which are identified by custom-endpoint containing localhost.
 	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "localhost") {
-		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false)
+		// For control client, we don't pass billingProject to avoid setting it globally via option.WithQuotaProject.
+		// The wrapper storageControlClientWithBillingProject will manually add it to the context for supported calls.
+		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false, "")
 		if err != nil {
 			return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 		}
@@ -419,17 +429,17 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	return
 }
 
-func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, bucketName string) (*storage.Client, error) {
+func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, bucketName string, billingProject string) (*storage.Client, error) {
 	var err error
 	if isbucketZonal {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.GRPC {
-		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, bucketName)
+		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, bucketName, billingProject)
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.HTTP1 || sh.clientConfig.ClientProtocol == cfg.HTTP2 {
@@ -442,13 +452,13 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	return nil, fmt.Errorf("invalid client-protocol requested: %s", sh.clientConfig.ClientProtocol)
 }
 
-func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, bucketName string) (*storage.Client, error) {
+func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, bucketName string, billingProject string) (*storage.Client, error) {
 	if sh.grpcClient != nil {
 		return sh.grpcClient, nil
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil
@@ -503,7 +513,7 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		return nil, fmt.Errorf("storageLayout call failed: %s", err)
 	}
 
-	client, err = sh.getClient(ctx, bucketType.Zonal, bucketName)
+	client, err = sh.getClient(ctx, bucketType.Zonal, bucketName, billingProject)
 	if err != nil {
 		return nil, err
 	}
@@ -520,6 +530,7 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		controlClient:        controlClient,
 		bucketType:           bucketType,
 		finalizeFileForRapid: finalizeFileForRapid,
+		billingProject:       billingProject,
 	}
 
 	return

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -390,7 +390,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientWithSocketAddress() {
 	testSuite.clientConfig.LocalSocketAddress = "127.0.0.1"
 	testSuite.clientConfig.AnonymousAccess = true
 	ctx := context.Background()
-	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false, "")
+	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false)
 	require.NoError(testSuite.T(), err)
 	controlClient, err := storageutil.CreateGRPCControlClient(ctx, clientOpts, false)
 	require.NoError(testSuite.T(), err)
@@ -421,7 +421,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientWithInvalidSocketAddress
 	ctx := context.Background()
 
 	// Attempt to create client options, which should fail.
-	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false, "")
+	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false)
 
 	assert.Error(testSuite.T(), err)
 	assert.Nil(testSuite.T(), clientOpts)
@@ -684,7 +684,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndEna
 func (testSuite *StorageHandleTest) TestCreateClientOptionForGRPCClient() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -694,7 +694,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_Without
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 	sc.EnableGoogleLibAuth = false
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -714,7 +714,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTra
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 	sc.TracingEnabled = true
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -723,12 +723,12 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTra
 func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTracingAddsOneOption() {
 	scWithoutTracing := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithoutTracing.TracingEnabled = false
-	optsWithoutTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutTracing, false, "")
+	optsWithoutTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutTracing, false)
 	assert.Nil(testSuite.T(), err)
 	scWithTracing := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithTracing.TracingEnabled = true
 
-	optsWithTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithTracing, false, "")
+	optsWithTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithTracing, false)
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithTracing)
@@ -746,14 +746,14 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithGrp
 	scWithMetrics.ClientProtocol = cfg.GRPC
 	scWithMetrics.EnableGrpcMetrics = true
 
-	optsWithMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithMetrics, false, "")
+	optsWithMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithMetrics, false)
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithMetrics)
 
 	scWithoutMetrics := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithoutMetrics.ClientProtocol = cfg.GRPC
 	scWithoutMetrics.EnableGrpcMetrics = false
-	optsWithoutMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutMetrics, false, "")
+	optsWithoutMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutMetrics, false)
 	require.NoError(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithoutMetrics)
 }
@@ -803,7 +803,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_AuthFai
 			sc.ClientProtocol = cfg.GRPC
 			tt.modifyConfig(&sc)
 
-			clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
+			clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
 
 			assert.Error(t, err)
 			assert.Nil(t, clientOption)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -390,7 +390,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientWithSocketAddress() {
 	testSuite.clientConfig.LocalSocketAddress = "127.0.0.1"
 	testSuite.clientConfig.AnonymousAccess = true
 	ctx := context.Background()
-	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false)
+	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false, "")
 	require.NoError(testSuite.T(), err)
 	controlClient, err := storageutil.CreateGRPCControlClient(ctx, clientOpts, false)
 	require.NoError(testSuite.T(), err)
@@ -421,7 +421,7 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientWithInvalidSocketAddress
 	ctx := context.Background()
 
 	// Attempt to create client options, which should fail.
-	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false)
+	clientOpts, err := createClientOptionForGRPCClient(ctx, testSuite.clientConfig, false, "")
 
 	assert.Error(testSuite.T(), err)
 	assert.Nil(testSuite.T(), clientOpts)
@@ -684,7 +684,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndEna
 func (testSuite *StorageHandleTest) TestCreateClientOptionForGRPCClient() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -694,7 +694,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_Without
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 	sc.EnableGoogleLibAuth = false
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -714,7 +714,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTra
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 	sc.TracingEnabled = true
 
-	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
+	clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), clientOption)
@@ -723,12 +723,12 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTra
 func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithTracingAddsOneOption() {
 	scWithoutTracing := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithoutTracing.TracingEnabled = false
-	optsWithoutTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutTracing, false)
+	optsWithoutTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutTracing, false, "")
 	assert.Nil(testSuite.T(), err)
 	scWithTracing := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithTracing.TracingEnabled = true
 
-	optsWithTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithTracing, false)
+	optsWithTracing, err := createClientOptionForGRPCClient(context.TODO(), &scWithTracing, false, "")
 
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithTracing)
@@ -746,14 +746,14 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_WithGrp
 	scWithMetrics.ClientProtocol = cfg.GRPC
 	scWithMetrics.EnableGrpcMetrics = true
 
-	optsWithMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithMetrics, false)
+	optsWithMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithMetrics, false, "")
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithMetrics)
 
 	scWithoutMetrics := storageutil.GetDefaultStorageClientConfig(keyFile)
 	scWithoutMetrics.ClientProtocol = cfg.GRPC
 	scWithoutMetrics.EnableGrpcMetrics = false
-	optsWithoutMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutMetrics, false)
+	optsWithoutMetrics, err := createClientOptionForGRPCClient(context.TODO(), &scWithoutMetrics, false, "")
 	require.NoError(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), optsWithoutMetrics)
 }
@@ -803,7 +803,7 @@ func (testSuite *StorageHandleTest) Test_CreateClientOptionForGRPCClient_AuthFai
 			sc.ClientProtocol = cfg.GRPC
 			tt.modifyConfig(&sc)
 
-			clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false)
+			clientOption, err := createClientOptionForGRPCClient(context.TODO(), &sc, false, "")
 
 			assert.Error(t, err)
 			assert.Nil(t, clientOption)

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -95,12 +95,27 @@ func TestMain(m *testing.M) {
 		cfg.RequesterPaysBucket[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
 	}
 
-	// Replace ${BILLING_PROJECT} placeholder in flags with the default billing project.
-	// when not running in GKE environment.
+	testEnv.ctx = context.Background()
+
+	// When not running in GKE environment.
 	if cfg.RequesterPaysBucket[0].GKEMountedDirectory == "" {
+		// Replace ${BILLING_PROJECT} placeholder in flags with the default billing project.
 		for i := range cfg.RequesterPaysBucket[0].Configs {
 			for j := range cfg.RequesterPaysBucket[0].Configs[i].Flags {
 				cfg.RequesterPaysBucket[0].Configs[i].Flags[j] = strings.ReplaceAll(cfg.RequesterPaysBucket[0].Configs[i].Flags[j], "${BILLING_PROJECT}", targetBillingProject)
+			}
+		}
+		// Setup service account credentials for requester-pays testing.
+		_, localKeyFilePath := creds_tests.CreateCredentialsForSA(testEnv.ctx, requesterPaysServiceAccountName, requesterPaysCredsSecretName)
+		defer func() {
+			if err := os.Remove(localKeyFilePath); err != nil {
+				log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+			}
+		}()
+		setup.SetKeyFile(localKeyFilePath)
+		for i := range cfg.RequesterPaysBucket[0].Configs {
+			for j := range cfg.RequesterPaysBucket[0].Configs[i].Flags {
+				cfg.RequesterPaysBucket[0].Configs[i].Flags[j] = strings.ReplaceAll(cfg.RequesterPaysBucket[0].Configs[i].Flags[j], "${KEY_FILE}", localKeyFilePath)
 			}
 		}
 	}
@@ -121,9 +136,6 @@ func TestMain(m *testing.M) {
 	}
 	setup.SetBillingProject(billingProject)
 
-	testEnv.ctx = context.Background()
-	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.RequesterPaysBucket[0])
-
 	// Create storage client before running tests.
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
@@ -133,10 +145,11 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// Temporarily enable --requester-pays metadata flag for the test bucket.
 	testEnv.bucketName = strings.Split(cfg.RequesterPaysBucket[0].TestBucket, "/")[0]
-	client.MustEnableRequesterPays(testEnv.storageClient, testEnv.ctx, testEnv.bucketName)
-	defer client.MustDisableRequesterPays(testEnv.storageClient, testEnv.ctx, testEnv.bucketName)
+	wasEnabled := client.MustEnableRequesterPays(testEnv.storageClient, testEnv.ctx, testEnv.bucketName)
+	if wasEnabled {
+		defer client.MustDisableRequesterPays(testEnv.storageClient, testEnv.ctx, testEnv.bucketName)
+	}
 
 	// To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	// flags to be set, as RequesterPaysBucket tests validates content from the bucket.
@@ -144,24 +157,10 @@ func TestMain(m *testing.M) {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.RequesterPaysBucket[0].GKEMountedDirectory, m))
 	}
 
-	// Setup service account credentials for requester-pays testing.
-	_, localKeyFilePath := creds_tests.CreateCredentialsForSA(testEnv.ctx, requesterPaysServiceAccountName, requesterPaysCredsSecretName)
-	defer func() {
-		if err := os.Remove(localKeyFilePath); err != nil {
-			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
-		}
-	}()
-
-	for i := range cfg.RequesterPaysBucket[0].Configs {
-		for j := range cfg.RequesterPaysBucket[0].Configs[i].Flags {
-			cfg.RequesterPaysBucket[0].Configs[i].Flags[j] = strings.ReplaceAll(cfg.RequesterPaysBucket[0].Configs[i].Flags[j], "${KEY_FILE}", localKeyFilePath)
-		}
-	}
-
 	// Run tests for testBucket
 	// Build the flag sets dynamically from the config.
+	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.RequesterPaysBucket[0])
 	flags := setup.BuildFlagSets(cfg.RequesterPaysBucket[0], bucketType, "")
-
 	setup.SetUpTestDirForTestBucket(&cfg.RequesterPaysBucket[0])
 
 	log.Println("Running static mounting tests...")

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -26,6 +26,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -35,6 +36,20 @@ import (
 const (
 	testDirName        = "RequesterPaysBucketTests"
 	onlyDirTestDirName = "OnlyDirRequesterPaysBucketTests"
+
+	// requesterPaysServiceAccountName is the name of the service account used for requester-pays testing.
+	// This service account must exist in the active GCP project where tests are run
+	// (e.g., "gcs-fuse-test" or "gcs-fuse-test-ml").
+	// The test expects a JSON key for this SA to be stored in Secret Manager
+	// within the same project, under the secret name specified by requesterPaysCredsSecretName.
+	// Note: The user or service account running the test package, as well as the
+	// requester-pays service account (requester-pays-tester), must be granted the
+	// Storage Admin and Service Usage Consumer roles on the project.
+	// For example, adding the Service Usage Consumer role to
+	// requester-pays-tester@gcs-fuse-test-ml.iam.gserviceaccount.com in the gcs-fuse-test-ml project.
+	requesterPaysServiceAccountName = "requester-pays-tester"
+	requesterPaysCredsSecretName    = "requester-pays-tester"
+	targetBillingProject            = "gcs-fuse-test-ml"
 )
 
 // To prevent global variable pollution, enhance code clarity,
@@ -73,10 +88,38 @@ func TestMain(m *testing.M) {
 		cfg.RequesterPaysBucket[0].GKEMountedDirectory = setup.MountedDirectory()
 		cfg.RequesterPaysBucket[0].Configs = make([]test_suite.ConfigItem, 1)
 		cfg.RequesterPaysBucket[0].Configs[0].Flags = []string{
-			"--billing-project=gcs-fuse-test-ml",
+			"--billing-project=${BILLING_PROJECT} --key-file=${KEY_FILE}",
+			"--billing-project=${BILLING_PROJECT} --client-protocol=grpc --key-file=${KEY_FILE}",
+			"--billing-project=${BILLING_PROJECT} --client-protocol=grpc --grpc-path-strategy=direct-path-only --key-file=${KEY_FILE}",
 		}
 		cfg.RequesterPaysBucket[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
 	}
+
+	// Replace ${BILLING_PROJECT} placeholder in flags with the default billing project.
+	// when not running in GKE environment.
+	if cfg.RequesterPaysBucket[0].GKEMountedDirectory == "" {
+		for i := range cfg.RequesterPaysBucket[0].Configs {
+			for j := range cfg.RequesterPaysBucket[0].Configs[i].Flags {
+				cfg.RequesterPaysBucket[0].Configs[i].Flags[j] = strings.ReplaceAll(cfg.RequesterPaysBucket[0].Configs[i].Flags[j], "${BILLING_PROJECT}", targetBillingProject)
+			}
+		}
+	}
+
+	// Extract billing project from flags.
+	var billingProject string
+	for _, flag := range cfg.RequesterPaysBucket[0].Configs[0].Flags {
+		if strings.Contains(flag, "--billing-project=") {
+			parts := strings.Split(flag, "--billing-project=")
+			if len(parts) > 1 {
+				billingProject = strings.Fields(parts[1])[0]
+				break
+			}
+		}
+	}
+	if billingProject == "" {
+		log.Fatal("Billing project is not set. It must be set using environment variables in GKE envrionment and by replacing the '${BILLING_PROJECT}' string in non-GKE environements.")
+	}
+	setup.SetBillingProject(billingProject)
 
 	testEnv.ctx = context.Background()
 	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.RequesterPaysBucket[0])
@@ -99,6 +142,20 @@ func TestMain(m *testing.M) {
 	// flags to be set, as RequesterPaysBucket tests validates content from the bucket.
 	if cfg.RequesterPaysBucket[0].GKEMountedDirectory != "" && cfg.RequesterPaysBucket[0].TestBucket != "" {
 		os.Exit(setup.RunTestsForMountedDirectory(cfg.RequesterPaysBucket[0].GKEMountedDirectory, m))
+	}
+
+	// Setup service account credentials for requester-pays testing.
+	_, localKeyFilePath := creds_tests.CreateCredentialsForSA(testEnv.ctx, requesterPaysServiceAccountName, requesterPaysCredsSecretName)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
+
+	for i := range cfg.RequesterPaysBucket[0].Configs {
+		for j := range cfg.RequesterPaysBucket[0].Configs[i].Flags {
+			cfg.RequesterPaysBucket[0].Configs[i].Flags[j] = strings.ReplaceAll(cfg.RequesterPaysBucket[0].Configs[i].Flags[j], "${KEY_FILE}", localKeyFilePath)
+		}
 	}
 
 	// Run tests for testBucket

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -46,10 +46,10 @@ const (
 	// requester-pays service account (requester-pays-tester), must be granted the
 	// Storage Admin and Service Usage Consumer roles on the project.
 	// For example, adding the Service Usage Consumer role to
-	// requester-pays-tester@gcs-fuse-test-ml.iam.gserviceaccount.com in the gcs-fuse-test-ml project.
+	// requester-pays-tester@gcs-fuse-test.iam.gserviceaccount.com in the gcs-fuse-test project.
 	requesterPaysServiceAccountName = "requester-pays-tester"
 	requesterPaysCredsSecretName    = "requester-pays-tester"
-	targetBillingProject            = "gcs-fuse-test-ml"
+	targetBillingProject            = "gcs-fuse-test"
 )
 
 // To prevent global variable pollution, enhance code clarity,

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -126,7 +126,13 @@ func TestMain(m *testing.M) {
 		if strings.Contains(flag, "--billing-project=") {
 			parts := strings.Split(flag, "--billing-project=")
 			if len(parts) > 1 {
-				billingProject = strings.Fields(parts[1])[0]
+				// Split by comma first in case flags are comma-separated.
+				val := strings.Split(parts[1], ",")[0]
+				// Then take the first field in case they are space-separated.
+				fields := strings.Fields(val)
+				if len(fields) > 0 {
+					billingProject = fields[0]
+				}
 				break
 			}
 		}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -225,7 +225,10 @@ requester_pays_bucket:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-          - "--billing-project=gcs-fuse-test-ml"
+          # Set the 'BILLING_PROJECT' environment variable for GKE
+          - "--billing-project=${BILLING_PROJECT},--key-file=${KEY_FILE}"
+          - "--billing-project=${BILLING_PROJECT},--client-protocol=grpc,--key-file=${KEY_FILE}"
+          - "--billing-project=${BILLING_PROJECT},--client-protocol=grpc,--grpc-path-strategy=direct-path-only,--key-file=${KEY_FILE}"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -198,7 +198,7 @@ func CreateUnfinalizedObject(ctx context.Context, t *testing.T, client *storage.
 
 // setRequesterPays sets requester-pays flag to given boolean for the given bucket.
 func setRequesterPays(storageClient *storage.Client, ctx context.Context, bucketName string, enable bool) error {
-	bucket := storageClient.Bucket(bucketName)
+	bucket := getBucketHandle(storageClient, bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		RequesterPays: enable,
 	}
@@ -209,11 +209,24 @@ func setRequesterPays(storageClient *storage.Client, ctx context.Context, bucket
 	return nil
 }
 
-// MustEnableRequesterPays enables requester-pays for the given bucket and panics if it fails.
-func MustEnableRequesterPays(storageClient *storage.Client, ctx context.Context, bucketName string) {
+// MustEnableRequesterPays enables requester-pays for the given bucket if not already enabled.
+// Returns true if it actually enabled it, false if it was already enabled.
+func MustEnableRequesterPays(storageClient *storage.Client, ctx context.Context, bucketName string) bool {
+	bucket := getBucketHandle(storageClient, bucketName)
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("MustEnableRequesterPays: failed to get bucket attrs for %s: %v", bucketName, err))
+	}
+
+	if attrs.RequesterPays {
+		log.Printf("Requester pays is already enabled for bucket %s. Skipping enable.", bucketName)
+		return false
+	}
+
 	if err := setRequesterPays(storageClient, ctx, bucketName, true); err != nil {
 		panic(fmt.Sprintf("MustEnableRequesterPays: failed to enable requester-pays for bucket %s: %v", bucketName, err))
 	}
+	return true
 }
 
 // MustDisableRequesterPays disables requester-pays for the given bucket and panics if it fails.

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -67,9 +67,17 @@ func ShouldRetryForTest(err error) (b bool) {
 }
 
 func CreateHttp1StorageClient(ctx context.Context) (*storage.Client, error) {
-	defaultTokenSrc, err := google.DefaultTokenSource(ctx, storagev1.DevstorageFullControlScope)
+	var tokenSrc oauth2.TokenSource
+	var err error
+
+	if kf := setup.KeyFile(); kf != "" {
+		tokenSrc, err = getTokenSrc(kf)
+	} else {
+		tokenSrc, err = google.DefaultTokenSource(ctx, storagev1.DevstorageFullControlScope)
+	}
+
 	if err != nil {
-		return nil, fmt.Errorf("unable to create default token source: %w", err)
+		return nil, fmt.Errorf("unable to create token source: %w", err)
 	}
 
 	httpClient := &http.Client{
@@ -80,7 +88,7 @@ func CreateHttp1StorageClient(ctx context.Context) (*storage.Client, error) {
 				MaxIdleConnsPerHost: 100,
 				TLSNextProto:        make(map[string]func(authority string, c *tls.Conn) http.RoundTripper), // Disables HTTP/2 transport.
 			},
-			Source: defaultTokenSrc,
+			Source: tokenSrc,
 		},
 		Timeout: 0, // No timeout.
 	}
@@ -108,7 +116,16 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 		client, err = storage.NewClient(ctx, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithTokenSource(ts))
 	} else {
 		if setup.IsZonalBucketRun() {
-			client, err = storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())
+			var opts []option.ClientOption
+			opts = append(opts, experimental.WithGRPCBidiReads())
+			if kf := setup.KeyFile(); kf != "" {
+				ts, err := getTokenSrc(kf)
+				if err != nil {
+					return nil, err
+				}
+				opts = append(opts, option.WithTokenSource(ts))
+			}
+			client, err = storage.NewGRPCClient(ctx, opts...)
 		} else {
 			client, err = CreateHttp1StorageClient(ctx)
 		}

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -88,6 +88,14 @@ func CreateHttp1StorageClient(ctx context.Context) (*storage.Client, error) {
 	return storage.NewClient(ctx, option.WithHTTPClient(httpClient))
 }
 
+func getBucketHandle(client *storage.Client, bucketName string) *storage.BucketHandle {
+	b := client.Bucket(bucketName)
+	if bp := setup.BillingProject(); bp != "" {
+		b = b.UserProject(bp)
+	}
+	return b
+}
+
 func CreateStorageClient(ctx context.Context) (client *storage.Client, err error) {
 	// Create new storage client.
 	if setup.TestOnTPCEndPoint() {
@@ -145,7 +153,7 @@ func ReadObjectFromGCS(ctx context.Context, client *storage.Client, object strin
 		return "", fmt.Errorf("client is nil")
 	}
 	// Create storage reader to read from GCS.
-	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+	rc, err := getBucketHandle(client, bucket).Object(object).NewReader(ctx)
 	if err != nil {
 		return "", fmt.Errorf("Object(%q).NewReader: %w", object, err)
 	}
@@ -165,7 +173,7 @@ func ReadChunkFromGCS(ctx context.Context, client *storage.Client, object string
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
 	// Create storage reader to read from GCS.
-	rc, err := client.Bucket(bucket).Object(object).NewRangeReader(ctx, offset, size)
+	rc, err := getBucketHandle(client, bucket).Object(object).NewRangeReader(ctx, offset, size)
 	if err != nil {
 		return "", fmt.Errorf("Object(%q).NewReader: %w", object, err)
 	}
@@ -187,7 +195,7 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 
 	// Changes specific to zonal bucket
 	var attrs *storage.BucketAttrs
-	attrs, err = client.Bucket(o.BucketName()).Attrs(ctx)
+	attrs, err = getBucketHandle(client, o.BucketName()).Attrs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get attributes for bucket %q: %w", o.BucketName(), err)
 	}
@@ -208,7 +216,7 @@ func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Cli
 func WriteToObject(ctx context.Context, client *storage.Client, object, content string, precondition storage.Conditions) error {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
-	o := client.Bucket(bucket).Object(object)
+	o := getBucketHandle(client, bucket).Object(object)
 	if !reflect.DeepEqual(precondition, storage.Conditions{}) {
 		o = o.If(precondition)
 	}
@@ -236,7 +244,7 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 
 func CreateFinalizedObjectOnGCS(ctx context.Context, client *storage.Client, object, content string) error {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
-	o := client.Bucket(bucket).Object(object)
+	o := getBucketHandle(client, bucket).Object(object)
 
 	// Upload an object with storage.Writer with finalizeOnClose=true
 	wc := o.NewWriter(ctx)
@@ -305,7 +313,7 @@ func DeleteObjectOnGCS(ctx context.Context, client *storage.Client, objectName s
 	bucket, _ := setup.GetBucketAndObjectBasedOnTypeOfMount("")
 
 	// Get handle to the object
-	object := client.Bucket(bucket).Object(objectName)
+	object := getBucketHandle(client, bucket).Object(objectName)
 
 	// Delete the object
 	err := object.Delete(ctx)
@@ -323,7 +331,7 @@ func DeleteAllObjectsWithPrefix(ctx context.Context, client *storage.Client, pre
 
 	// Get an object iterator
 	query := &storage.Query{Prefix: prefix}
-	objectItr := client.Bucket(bucket).Objects(ctx, query)
+	objectItr := getBucketHandle(client, bucket).Objects(ctx, query)
 
 	// Create a buffered channel to receive errors from goroutines
 	errChan := make(chan error, 100)
@@ -371,7 +379,7 @@ func DeleteAllObjectsWithPrefix(ctx context.Context, client *storage.Client, pre
 func StatObject(ctx context.Context, client *storage.Client, object string) (*storage.ObjectAttrs, error) {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
-	attrs, err := client.Bucket(bucket).Object(object).Attrs(ctx)
+	attrs, err := getBucketHandle(client, bucket).Object(object).Attrs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +390,7 @@ func StatObject(ctx context.Context, client *storage.Client, object string) (*st
 // Handles gzip compression if requested.
 func UploadGcsObjectWithPreconditions(ctx context.Context, client *storage.Client, localPath, bucketName, objectName string, uploadGzipEncoded bool, preconditions *storage.Conditions) error {
 	// Create a writer to upload the object.
-	obj := client.Bucket(bucketName).Object(objectName)
+	obj := getBucketHandle(client, bucketName).Object(objectName)
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
@@ -473,7 +481,7 @@ func CopyFileInBucketWithPreconditions(ctx context.Context, storageClient *stora
 }
 
 func DeleteBucket(ctx context.Context, client *storage.Client, bucketName string) error {
-	bucket := client.Bucket(bucketName)
+	bucket := getBucketHandle(client, bucketName)
 
 	// Iterate through objects and delete them
 	query := &storage.Query{}
@@ -504,7 +512,7 @@ func DeleteBucket(ctx context.Context, client *storage.Client, bucketName string
 func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, object string, precondition storage.Conditions) (*storage.Writer, error) {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
-	o := client.Bucket(bucket).Object(object)
+	o := getBucketHandle(client, bucket).Object(object)
 	if !reflect.DeepEqual(precondition, storage.Conditions{}) {
 		o = o.If(precondition)
 	}
@@ -519,7 +527,7 @@ func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, 
 
 func AppendableWriter(ctx context.Context, client *storage.Client, object string, gen int64) (*storage.Writer, error) {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
-	obj := client.Bucket(bucket).Object(object)
+	obj := getBucketHandle(client, bucket).Object(object)
 
 	tw, _, err := obj.Generation(gen).NewWriterFromAppendableObject(ctx, &storage.AppendableWriterOpts{})
 	return tw, err
@@ -546,7 +554,7 @@ func CreateGcsDir(ctx context.Context, client *storage.Client, dirName, bucketNa
 
 func uploadGcsObjectWithPreconditionsWithoutIntermediateDelays(ctx context.Context, client *storage.Client, localPath, bucketName, objectName string, uploadGzipEncoded bool, preconditions *storage.Conditions) error {
 	// Create a writer to upload the object.
-	obj := client.Bucket(bucketName).Object(objectName)
+	obj := getBucketHandle(client, bucketName).Object(objectName)
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
@@ -651,7 +659,7 @@ func ListDirectory(ctx context.Context, client *storage.Client, bucketName, pref
 		prefix += "/"
 	}
 
-	bucket := client.Bucket(bucketName)
+	bucket := getBucketHandle(client, bucketName)
 
 	var entries []string
 	var mu sync.Mutex

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -61,45 +61,7 @@ func projectID(ctx context.Context) string {
 
 func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath string) {
 	log.Println("Running credentials tests...")
-
-	id := projectID(ctx)
-
-	// Service account id format is name@project-id.iam.gserviceaccount.com
-	serviceAccount = NameOfServiceAccount + "@" + id + ".iam.gserviceaccount.com"
-
-	// Download credentials
-	client, err := secretmanager.NewClient(ctx)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
-	}
-	defer func() {
-		if err := client.Close(); err != nil {
-			log.Printf("Failed to close secret manager client: %v", err)
-		}
-	}()
-	req := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", id, CredentialsSecretName),
-	}
-	creds, err := client.AccessSecretVersion(ctx, req)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while fetching key file %v", err))
-	}
-
-	// Create and write creds to local file.
-	file, err := os.CreateTemp("", "creds-*.json")
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while creating temp credentials file %v", err))
-	}
-	localKeyFilePath = file.Name()
-	_, err = file.Write(creds.Payload.Data)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
-	}
-	if err := file.Close(); err != nil {
-		log.Printf("Failed to close credentials file: %v", err)
-	}
-
-	return
+	return CreateCredentialsForSA(ctx, NameOfServiceAccount, CredentialsSecretName)
 }
 
 func CreateCredentialsForSA(ctx context.Context, serviceAccountName, saCredentialsSecretName string) (serviceAccountEmail, localKeyFilePath string) {
@@ -110,7 +72,7 @@ func CreateCredentialsForSA(ctx context.Context, serviceAccountName, saCredentia
 	// Service account id format is name@project-id.iam.gserviceaccount.com
 	serviceAccountEmail = serviceAccountName + "@" + projID + ".iam.gserviceaccount.com"
 
-	// Download credentials
+	// Create secretmanager client to download service account credential file.
 	smClient, err := secretmanager.NewClient(ctx)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -32,7 +32,6 @@ import (
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
@@ -73,7 +72,11 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
 	}
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			log.Printf("Failed to close secret manager client: %v", err)
+		}
+	}()
 	req := &secretmanagerpb.AccessSecretVersionRequest{
 		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", id, CredentialsSecretName),
 	}
@@ -92,7 +95,52 @@ func CreateCredentials(ctx context.Context) (serviceAccount, localKeyFilePath st
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
 	}
-	operations.CloseFile(file)
+	if err := file.Close(); err != nil {
+		log.Printf("Failed to close credentials file: %v", err)
+	}
+
+	return
+}
+
+func CreateCredentialsForSA(ctx context.Context, serviceAccountName, saCredentialsSecretName string) (serviceAccountEmail, localKeyFilePath string) {
+	log.Printf("Creating credentials for %s...", serviceAccountName)
+
+	projID := projectID(ctx)
+
+	// Service account id format is name@project-id.iam.gserviceaccount.com
+	serviceAccountEmail = serviceAccountName + "@" + projID + ".iam.gserviceaccount.com"
+
+	// Download credentials
+	smClient, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Failed to create secret manager client: %v", err))
+	}
+	defer func() {
+		if err := smClient.Close(); err != nil {
+			log.Printf("Failed to close secret manager client: %v", err)
+		}
+	}()
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projID, saCredentialsSecretName),
+	}
+	secretVersion, err := smClient.AccessSecretVersion(ctx, req)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error while fetching key file %v", err))
+	}
+
+	// Create and write creds to local file.
+	keyFile, err := os.CreateTemp("", "creds-*.json")
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error while creating temp credentials file %v", err))
+	}
+	localKeyFilePath = keyFile.Name()
+	_, err = keyFile.Write(secretVersion.Payload.Data)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error while writing credentials to local file %v", err))
+	}
+	if err := keyFile.Close(); err != nil {
+		log.Printf("Failed to close key file: %v", err)
+	}
 
 	return
 }

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -69,7 +69,16 @@ var (
 	sbinFile             string
 	onlyDirMounted       string
 	dynamicBucketMounted string
+	billingProject       string
 )
+
+func BillingProject() string {
+	return billingProject
+}
+
+func SetBillingProject(bp string) {
+	billingProject = bp
+}
 
 // Run the shell script to prepare the testData in the specified bucket.
 // First argument will be name of scipt script
@@ -563,7 +572,11 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage client: %w", err)
 	}
-	attrs, err := storageClient.Bucket(testBucket).Attrs(ctx)
+	bucket := storageClient.Bucket(testBucket)
+	if billingProject != "" {
+		bucket = bucket.UserProject(billingProject)
+	}
+	attrs, err := bucket.Attrs(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get bucket attributes: %w", err)
 	}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -37,6 +37,7 @@ import (
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 var isPresubmitRun = flag.Bool("presubmit", false, "Boolean flag to indicate if test-run is a presubmit run.")
@@ -70,6 +71,7 @@ var (
 	onlyDirMounted       string
 	dynamicBucketMounted string
 	billingProject       string
+	keyFile              string
 )
 
 func BillingProject() string {
@@ -78,6 +80,14 @@ func BillingProject() string {
 
 func SetBillingProject(bp string) {
 	billingProject = bp
+}
+
+func KeyFile() string {
+	return keyFile
+}
+
+func SetKeyFile(kf string) {
+	keyFile = kf
 }
 
 // Run the shell script to prepare the testData in the specified bucket.
@@ -501,6 +511,9 @@ func CleanupDirectoryOnGCS(ctx context.Context, client *storage.Client, director
 	bucketAndDirPath := strings.Split(directoryPathOnGCS, "/")
 	bucket, dirPath := bucketAndDirPath[0], bucketAndDirPath[1]
 	bucketHandle := client.Bucket(bucket)
+	if bp := BillingProject(); bp != "" {
+		bucketHandle = bucketHandle.UserProject(bp)
+	}
 
 	it := bucketHandle.Objects(ctx, &storage.Query{Prefix: dirPath + "/"})
 	for {
@@ -568,7 +581,12 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	testBucket = strings.Split(testBucket, "/")[0]
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	storageClient, err := storage.NewGRPCClient(ctx, experimental.WithGRPCBidiReads())
+	var opts []option.ClientOption
+	opts = append(opts, experimental.WithGRPCBidiReads())
+	if keyFile != "" {
+		opts = append(opts, option.WithCredentialsFile(keyFile))
+	}
+	storageClient, err := storage.NewGRPCClient(ctx, opts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage client: %w", err)
 	}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -32,6 +32,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/storage/experimental"
+	auth2 "github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
 	"go.opentelemetry.io/contrib/detectors/gcp"
@@ -584,7 +585,11 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	var opts []option.ClientOption
 	opts = append(opts, experimental.WithGRPCBidiReads())
 	if keyFile != "" {
-		opts = append(opts, option.WithCredentialsFile(keyFile))
+		cred, err := auth2.GetCredentials(keyFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to get credentials: %w", err)
+		}
+		opts = append(opts, option.WithAuthCredentials(cred))
 	}
 	storageClient, err := storage.NewGRPCClient(ctx, opts...)
 	if err != nil {


### PR DESCRIPTION

### Description
This PR fixes a bug in gRPC protocol requester pays feature. Where the billing project is not populated correctly causing errors of the following types.

```
InvalidArgument desc = Bucket is a requester pays bucket but no user project provided.\nerror details: name = BadRequest field =  desc = Bucket is a requester pays bucket but no user project provided."}
```
### Testing
Created separate SA with the required permission to test the requester pays feature correctly. Previously ran tests used overly Privileged account which had `resourcemanager.projects.createBillingAssignment` permission on the project to which the bucket in test belonged. This causes the the requester pays tests to pass even if the billing project is not provided thus masking the failures.

The SA and relevant permissions have been setup accordingly for the `gcs-fuse-test` and `gcs-fuse-test-ml` prjoects.

Tests are passing on GKE as well: https://b.corp.google.com/issues/500550846#comment19

### Link to the issue in case of a bug fix.
b/500550846

### Testing details
1. Manual - Yes
2. Unit tests - NA
3. Integration tests - Yes

### Any backward incompatible change? If so, please explain.
NONE
