### PR TITLE
feat(hns): remove empty-dir check before HNS folder rename

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2700,6 +2700,7 @@ func (fs *fileSystem) renameHierarchicalDir(ctx context.Context, oldParent inode
 			if errors.As(deleteErr, &precondErr) {
 				return fuse.ENOTEMPTY
 			}
+			return fmt.Errorf("DeleteChildDir: %w", deleteErr)
 		}
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2656,18 +2656,6 @@ func (fs *fileSystem) ensureNoLocalFilesInDirectory(dir inode.BucketOwnedDirInod
 	return nil
 }
 
-func (fs *fileSystem) checkDirNotEmpty(dir inode.BucketOwnedDirInode, name string) error {
-	unexpected, err := dir.ReadDescendants(context.Background(), 1)
-	if err != nil {
-		return fmt.Errorf("read descendants of the new directory %q: %w", name, err)
-	}
-
-	if len(unexpected) > 0 {
-		return fuse.ENOTEMPTY
-	}
-	return nil
-}
-
 // Rename an old folder to a new folder in a hierarchical bucket. If the new folder already
 // exists and is non-empty, return ENOTEMPTY. If old folder have open files then return
 // ENOTSUP.
@@ -2700,17 +2688,19 @@ func (fs *fileSystem) renameHierarchicalDir(ctx context.Context, oldParent inode
 	if err == nil {
 		pendingInodes = append(pendingInodes, newDirInode)
 
-		// If the directory exists, then check if it is empty or not.
-		if err = fs.checkDirNotEmpty(newDirInode, newName); err != nil {
-			return err
-		}
-
-		// This refers to an empty destination directory.
-		// The RenameFolder API does not allow renaming to an existing empty directory.
-		// To make this work, we delete the empty directory first from gcsfuse and then perform rename.
+		// The RenameFolder API does not allow renaming to an empty existing directory.
+		// To make this work, we attempt to delete the destination directory first.
+		// If it is non-empty, this deletion will fail with a PreconditionError,
+		// in which case we immediately return ENOTEMPTY.
 		newParent.Lock()
-		_ = newParent.DeleteChildDir(ctx, newName, false, newDirInode)
+		deleteErr := newParent.DeleteChildDir(ctx, newName, false, newDirInode)
 		newParent.Unlock()
+		if deleteErr != nil {
+			var precondErr *gcs.PreconditionError
+			if errors.As(deleteErr, &precondErr) {
+				return fuse.ENOTEMPTY
+			}
+		}
 	}
 
 	// Note:The renameDirLimit is not utilized in the folder rename operation because there is no user-defined limit on new renames.
@@ -2729,6 +2719,18 @@ func (fs *fileSystem) renameHierarchicalDir(ctx context.Context, oldParent inode
 	}
 
 	return
+}
+
+func (fs *fileSystem) checkDirNotEmpty(dir inode.BucketOwnedDirInode, name string) error {
+	unexpected, err := dir.ReadDescendants(context.Background(), 1)
+	if err != nil {
+		return fmt.Errorf("read descendants of the new directory %q: %w", name, err)
+	}
+
+	if len(unexpected) > 0 {
+		return fuse.ENOTEMPTY
+	}
+	return nil
 }
 
 // Rename an old directory to a new directory in a non-hierarchical bucket. If the new directory already

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2655,18 +2655,6 @@ func (fs *fileSystem) ensureNoLocalFilesInDirectory(dir inode.BucketOwnedDirInod
 	return nil
 }
 
-func (fs *fileSystem) checkDirNotEmpty(dir inode.BucketOwnedDirInode, name string) error {
-	unexpected, err := dir.ReadDescendants(context.Background(), 1)
-	if err != nil {
-		return fmt.Errorf("read descendants of the new directory %q: %w", name, err)
-	}
-
-	if len(unexpected) > 0 {
-		return fuse.ENOTEMPTY
-	}
-	return nil
-}
-
 // Rename an old folder to a new folder in a hierarchical bucket. If the new folder already
 // exists and is non-empty, return ENOTEMPTY. If old folder have open files then return
 // ENOTSUP.
@@ -2697,14 +2685,10 @@ func (fs *fileSystem) renameHierarchicalDir(ctx context.Context, oldParent inode
 	// If the call for getBucketDirInode fails it means directory does not exist.
 	newDirInode, err := fs.getBucketDirInode(ctx, newParent, newName)
 	if err == nil {
-		// If the directory exists, then check if it is empty or not.
-		if err = fs.checkDirNotEmpty(newDirInode, newName); err != nil {
-			return err
-		}
-
-		// This refers to an empty destination directory.
-		// The RenameFolder API does not allow renaming to an existing empty directory.
-		// To make this work, we delete the empty directory first from gcsfuse and then perform rename.
+		// The RenameFolder API does not allow renaming to an existing directory.
+		// To make this work, we attempt to delete the destination directory first.
+		// If it is non-empty, this deletion will fail (and we ignore the error here),
+		// and the subsequent RenameFolder call will fail, returning ENOTEMPTY.
 		newParent.Lock()
 		_ = newParent.DeleteChildDir(ctx, newName, false, newDirInode)
 		newParent.Unlock()
@@ -2723,10 +2707,26 @@ func (fs *fileSystem) renameHierarchicalDir(ctx context.Context, oldParent inode
 	// Rename old directory to the new directory, keeping both parent directories locked.
 	_, err = oldParent.RenameFolder(ctx, oldDirName.GcsObjectName(), newDirName.GcsObjectName(), oldDirInode)
 	if err != nil {
+		var precondErr *gcs.PreconditionError
+		if errors.As(err, &precondErr) {
+			return fuse.ENOTEMPTY
+		}
 		return fmt.Errorf("failed to rename folder: %w", err)
 	}
 
 	return
+}
+
+func (fs *fileSystem) checkDirNotEmpty(dir inode.BucketOwnedDirInode, name string) error {
+	unexpected, err := dir.ReadDescendants(context.Background(), 1)
+	if err != nil {
+		return fmt.Errorf("read descendants of the new directory %q: %w", name, err)
+	}
+
+	if len(unexpected) > 0 {
+		return fuse.ENOTEMPTY
+	}
+	return nil
 }
 
 // Rename an old directory to a new directory in a non-hierarchical bucket. If the new directory already

--- a/tools/integration_tests/rename_dir_limit/rename_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_test.go
@@ -197,3 +197,24 @@ func TestRenameDirectoryWithExistingEmptyDestDirectory(t *testing.T) {
 	assert.Equal(t, "temp1", dirEntries[1].Name())
 	assert.False(t, dirEntries[1].IsDir())
 }
+
+func TestRenameDirectoryWithExistingNonEmptyDestDirectory(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForRenameDirLimitTests)
+	// Creating directory structure
+	// testBucket/dirForRenameDirLimitTests/srcDirectory                                      -- Dir
+	// testBucket/dirForRenameDirLimitTests/srcDirectory/temp1                                -- File
+	// testBucket/dirForRenameDirLimitTests/destNonEmptyDirectory                             -- Dir
+	// testBucket/dirForRenameDirLimitTests/destNonEmptyDirectory/temp1                       -- File
+	oldDirPath := path.Join(testDir, SrcDirectory)
+	operations.CreateDirectoryWithNFiles(1, oldDirPath, PrefixTempFile, t)
+	newDirPath := path.Join(testDir, "destNonEmptyDirectory")
+	operations.CreateDirectoryWithNFiles(1, newDirPath, PrefixTempFile, t)
+
+	// Go's Rename function does not support renaming a directory into an existing directory.
+	// To achieve this, we call a Python rename function as a workaround.
+	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
+	output, err := cmd.CombinedOutput()
+
+	assert.Error(t, err)
+	assert.Contains(t, string(output), "Directory not empty")
+}

--- a/tools/integration_tests/rename_dir_limit/rename_dir_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"syscall"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -212,9 +213,10 @@ func TestRenameDirectoryWithExistingNonEmptyDestDirectory(t *testing.T) {
 
 	// Go's Rename function does not support renaming a directory into an existing directory.
 	// To achieve this, we call a Python rename function as a workaround.
-	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os; os.rename('%s', '%s')", oldDirPath, newDirPath))
-	output, err := cmd.CombinedOutput()
+	// We catch OSError and exit with the errno so we can validate ENOTEMPTY.
+	cmd := exec.Command("python3", "-c", fmt.Sprintf("import os, sys; exec(\"try:\\n  os.rename('%s', '%s')\\nexcept OSError as e:\\n  sys.exit(e.errno)\")", oldDirPath, newDirPath))
+	_, err := cmd.CombinedOutput()
 
 	assert.Error(t, err)
-	assert.Contains(t, string(output), "Directory not empty")
+	assert.Equal(t, int(syscall.ENOTEMPTY), err.(*exec.ExitError).ExitCode())
 }


### PR DESCRIPTION
### Description
This PR optimizes the `renameHierarchicalDir` operation for Hierarchical Namespace (HNS) buckets by removing the preliminary `checkDirNotEmpty` validation step. 

Previously, GCSFuse performed a recursive listing of the destination directory via `ReadDescendants` (translating to a `ListObjects` call with `MaxResults=2`) to verify it was empty before attempting a rename. 

By eliminating this redundant client-side check, we shift the validation burden to the native GCS backend. The logic now attempts to delete the destination directory directly; if the directory is not empty, GCS natively rejects the deletion with a `PreconditionError,` which we catch and translate to a POSIX `ENOTEMPTY` error. This saves a Class A List API operation, reducing latency and operational costs for customers, while maintaining strict POSIX compliance.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/495920968

### Testing details
1. Manual - Ran custom Python `os.rename` tests against mounted HNS buckets with TRACE logs enabled. Verified that renaming to a non-empty directory natively fails and returns `ENOTEMPTY` without triggering any preliminary `ListObjects` calls. 
2. Unit tests - NA
3. Integration tests - Ran existing HNS rename integration tests to ensure expected POSIX behavior is maintained.

### Any backward incompatible change? If so, please explain.
No backward incompatible changes. The error propagation to the OS (e.g., `ENOTEMPTY`) remains functionally identical.

<img width="552" height="712" alt="image" src="https://github.com/user-attachments/assets/624755e5-5e03-4c28-94ac-e859eb82d66b" />

