### PR TITLE
feat(consistent symlink): adopt dual metadata semantics for standard symlink representation

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -467,7 +467,7 @@ ___
 # Symlink inodes
 Prior to GCSFuse v3.9.0, symlinks were represented by empty Cloud Storage objects. These objects included a custom metadata key, ```gcsfuse_symlink_target```, whose value specified the symlink's target.
 
-From GCSFuse v3.9.0 onwards, the standard GCS representation for symbolic links is adopted. This means symlinks are now non-zero sized GCS objects. They feature the custom metadata key ```goog-reserved-file-is-symlink``` with a value of ```true```, and the symlink's target path is stored directly within the object's content. In other respects they work like a file inode, including receiving the same permissions. **Please note that GCSFuse remains backward compatible with symlinks created by versions prior to v3.9.0.**
+From GCSFuse v3.9.0 onwards, the standard GCS representation for symbolic links is adopted. This means symlinks are now non-zero sized GCS objects. They feature the custom metadata key ```goog-reserved-file-is-symlink``` with a value of ```true```, and the symlink's target path is stored directly within the object's content.In addition, to ensure that older GCSFuse versions can still read these symlinks, the legacy `gcsfuse_symlink_target` metadata key is also populated with the target path. In other respects they work like a file inode, including receiving the same permissions. **Please note that GCSFuse remains backward compatible with symlinks created by versions prior to v3.9.0.**
 
 
 

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -1167,6 +1167,7 @@ func (d *dirInode) CreateChildSymlink(ctx context.Context, name string, target s
 	if d.isStandardSymlinkRepresentationEnabled {
 		childMetadata = map[string]string{
 			StandardSymlinkMetadataKey: "true",
+			SymlinkMetadataKey:         target,
 		}
 		content = target
 	} else {

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -1618,9 +1618,7 @@ func (t *DirTest) TestCreateChildSymlink_StandardSymlinkEnabled() {
 	assert.Equal(t.T(), objName, result.MinObject.Name)
 	// Check metadata for standard symlink
 	assert.Equal(t.T(), "true", result.MinObject.Metadata[StandardSymlinkMetadataKey])
-	// Check that the old metadata key is NOT present
-	_, ok := result.MinObject.Metadata[SymlinkMetadataKey]
-	assert.False(t.T(), ok)
+	assert.Equal(t.T(), target, result.MinObject.Metadata[SymlinkMetadataKey])
 	// Check content for standard symlink (should be target)
 	content, err := storageutil.ReadObject(t.ctx, t.bucket, objName)
 	require.NoError(t.T(), err)

--- a/tools/integration_tests/symlink_handling/symlink_operations_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_operations_test.go
@@ -166,3 +166,18 @@ func (s *BaseSymlinkSuite) TestCopySymlink() {
 	_, err = os.Stat(s.targetPath)
 	s.Assert().NoError(err)
 }
+
+// TestReadStandardSymlinkInLegacyMode tests that a legacy mount can read a standard symlink.
+func (s *LegacySymlinksTestSuite) TestReadStandardSymlinkInLegacyMode() {
+	// Temporarily enable standard symlink creation to create a standard symlink object.
+	s.isStandardSymlink = true
+	defer func() { s.isStandardSymlink = false }()
+	s.createGCSSymlinkObject(s.linkName, s.targetPath)
+	linkPath := path.Join(s.testDirPath, s.linkName)
+
+	// Read the symlink via the legacy mount.
+	result, err := os.Readlink(linkPath)
+
+	s.Require().NoError(err)
+	s.Assert().Equal(s.targetPath, result)
+}

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -117,7 +117,7 @@ func (s *BaseSymlinkSuite) validateBackingGCSObjectForSymlink(linkName, target s
 		s.Assert().Equal(target, string(content), "Standard symlink content should match target")
 		s.Assert().Equal(int64(len(target)), attrs.Size, "Standard symlink size should match target length")
 		_, ok := attrs.Metadata[SymlinkMetadataKey]
-		s.Assert().False(ok, "Standard symlink should not have old metadata key (%s)", SymlinkMetadataKey)
+		s.Assert().True(ok)
 		val, ok := attrs.Metadata[StandardSymlinkMetadataKey]
 		s.Assert().True(ok)
 		s.Assert().Equal("true", val)
@@ -144,7 +144,7 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 
 	var content []byte
 	if s.isStandardSymlink {
-		w.Metadata = map[string]string{StandardSymlinkMetadataKey: "true"}
+		w.Metadata = map[string]string{StandardSymlinkMetadataKey: "true", SymlinkMetadataKey: target}
 		content = []byte(target) // Standard symlinks store target in content
 	} else {
 		w.Metadata = map[string]string{SymlinkMetadataKey: target}


### PR DESCRIPTION
#### Description
This PR updates GCSFuse to use "dual semantics" when creating symbolic links under the standard GCS representation.

Previously, while upcoming GCSFuse version 3.9.0 and later adopted the standard GCS representation (storing the target in the object content and using the `goog-reserved-file-is-symlink` metadata), new symlinks only contained the updated metadata key . This posed a risk for environments with mixed GCSFuse versions, such as GKE clusters during staggered auto-upgrades, where older versions might fail to recognize new symlinks .

To mitigate this, new symbolic links will now maintain both sets of metadata key-value pairs:
* `goog-reserved-file-is-symlink: true` 
* `gcsfuse-symlink-target: <target>` 

Additionally, the target path will continue to be stored in the object content to ensure compatibility with other GCS clients like Storage Transfer Service (STS) .

#### Link to the issue in case of a bug fix.
N/A .

#### Testing details
1. **Manual:** N/A
2. **Unit tests:** N/A
3. **Integration tests:** 
    * Updated `tools/integration_tests/symlink_handling/` to include `TestReadStandardSymlinkInLegacyMode`, which verifies that a legacy GCSFuse mount can successfully read a symlink created with the standard representation 
    * Validated that both metadata keys are correctly populated during symlink creation .

#### Any backward incompatible change? If so, please explain.
No. This change specifically aims to preserve backward compatibility for older GCSFuse versions while transitioning to standard GCS symlink semantics .