### PR TITLE
chore(make): Add lint target and update build path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ override STAGINGVERSION := $(STAGINGVERSIONPREFIX)$(patsubst $(STAGINGVERSIONPRE
 PROJECT ?= $(shell gcloud config get-value project 2>/dev/null)
 .DEFAULT_GOAL := build
 
-.PHONY: generate imports fmt vet build buildTest install test clean-gen clean clean-all build-csi
+.PHONY: generate imports fmt vet lint build buildTest install test clean-gen clean clean-all build-csi
 
 generate:
 	go generate ./...
@@ -52,8 +52,11 @@ fmt: imports
 vet: fmt
 	go vet ./...
 
-build: vet
-	go build .
+lint:
+	golangci-lint run -E=unused --timeout 3m0s --new-from-rev=master
+
+build: vet lint
+	go build ./...
 
 buildTest: vet
 	go test -run=PATTERN_THAT_DOES_NOT_MATCH_ANYTHING ./...

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ fmt: imports
 vet: fmt
 	go vet ./...
 
-lint:
+lint: vet
 	golangci-lint run -E=unused --timeout 3m0s --new-from-rev=master
 
-build: vet lint
+build: lint
 	go build ./...
 
 buildTest: vet


### PR DESCRIPTION
### Description
This PR updates the `Makefile` to add a linting target, improve the build target, and integrate linting into the build process with CI-like behavior:
- Added `lint` to the `.PHONY` list.
- Added a `lint` target that executes `golangci-lint run -E=unused --timeout 3m0s --new-from-rev=master` to match the CI workflow's `only-new-issues: true` behavior.
- Updated the `lint` target to depend on `vet` (which in turn depends on `fmt` and `generate`) to ensure code is generated, formatted, and vetted before linting.
- Updated the `build` target to use `go build ./...` instead of `go build .` to ensure all packages are built recursively.
- Updated the `build` target to depend on `lint`, creating a clean linear chain (`generate` ➔ `imports` ➔ `fmt` ➔ `vet` ➔ `lint` ➔ `build`) so that all checks run automatically during the build process.

### Rationale
It is a best practice to ensure that local development tools (like `make`) are consistent with the CI environment. By adding a `make lint` target that uses the same arguments as CI (`-E=unused`) and limits output to new issues (matching CI's `only-new-issues: true`), developers get the same feedback locally as they would in CI. Making it a dependency of `build` ensures these checks are run before pushing code, and making it depend on `vet` ensures the code is clean and valid before analysis.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
