### PR TITLE
feat(metrics): track streaming write fallback with reasons

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1025,7 +1025,8 @@ func (fs *fileSystem) mintInode(ic inode.Core, parInodeCtx context.Context) (in 
 			fs.newConfig,
 			fs.globalMaxWriteBlocksSem,
 			fs.mrdCache,
-			fs.traceHandle)
+			fs.traceHandle,
+			fs.metricHandle)
 	}
 
 	// Place it in our map of IDs to inodes.

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -164,7 +164,7 @@ func createFileInode(
 		semaphore.NewWeighted(100),
 		nil,
 		tracing.NewNoopTracer(),
-		nil,
+		metrics.NewNoopMetrics(),
 	)
 }
 

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -164,6 +164,7 @@ func createFileInode(
 		semaphore.NewWeighted(100),
 		nil,
 		tracing.NewNoopTracer(),
+		nil,
 	)
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -268,7 +268,7 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer()) // mrdCache
+		tracing.NewNoopTracer(), nil) // mrdCache
 	return
 }
 

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -33,6 +33,7 @@ import (
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -268,7 +269,8 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer(), nil) // mrdCache
+		tracing.NewNoopTracer(),
+		metrics.NewNoopMetrics()) // mrdCache
 	return
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -33,8 +33,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
-	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -128,9 +128,9 @@ type FileInode struct {
 	globalMaxWriteBlocksSem *semaphore.Weighted
 
 	// mrdInstance manages the MultiRangeDownloader instances for this inode.
-	mrdInstance *gcsx.MrdInstance
+	mrdInstance  *gcsx.MrdInstance
 	metricHandle metrics.MetricHandle
-	traceHandle tracing.TraceHandle
+	traceHandle  tracing.TraceHandle
 }
 
 var _ Inode = &FileInode{}
@@ -1103,7 +1103,6 @@ func (f *FileInode) Truncate(
 	}
 	return false, f.truncateUsingTempFile(ctx, size)
 }
-
 
 // recordFallback maps util.OpenMode to metrics.OpenMode and records the fallback metric.
 func (f *FileInode) recordFallback(openMode util.OpenMode, reason metrics.WriteFallbackReason) {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -34,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
@@ -128,6 +129,7 @@ type FileInode struct {
 
 	// mrdInstance manages the MultiRangeDownloader instances for this inode.
 	mrdInstance *gcsx.MrdInstance
+	metricHandle metrics.MetricHandle
 	traceHandle tracing.TraceHandle
 }
 
@@ -154,7 +156,8 @@ func NewFileInode(
 	cfg *cfg.Config,
 	globalMaxBlocksSem *semaphore.Weighted,
 	mrdCache *lru.Cache,
-	traceHandle tracing.TraceHandle) (f *FileInode) {
+	traceHandle tracing.TraceHandle,
+	metricHandle metrics.MetricHandle) (f *FileInode) {
 	// Set up the basic struct.
 	var minObj gcs.MinObject
 	if m != nil {
@@ -174,6 +177,7 @@ func NewFileInode(
 		config:                  cfg,
 		globalMaxWriteBlocksSem: globalMaxBlocksSem,
 		traceHandle:             traceHandle,
+		metricHandle:            metricHandle,
 	}
 
 	if f.bucket.BucketType().Zonal {
@@ -669,7 +673,7 @@ func (f *FileInode) Write(
 	offset int64,
 	openMode util.OpenMode) (bool, error) {
 	if f.bwh != nil {
-		return f.writeUsingBufferedWrites(ctx, data, offset)
+		return f.writeUsingBufferedWrites(ctx, data, offset, openMode)
 	}
 
 	return false, f.writeUsingTempFile(ctx, data, offset)
@@ -699,7 +703,7 @@ func (f *FileInode) writeUsingTempFile(ctx context.Context, data []byte, offset 
 // Helper function to serve write for file using buffered writes handler.
 //
 // LOCKS_REQUIRED(f.mu)
-func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64) (_ bool, err error) {
+func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, offset int64, openMode util.OpenMode) (_ bool, err error) {
 	bytes := int64(len(data))
 	ctx, finishSpan := f.traceHandle.TraceUpload(ctx, tracing.WriteFileStreaming, f.src.Name, &bytes, &err)
 	defer finishSpan()
@@ -714,6 +718,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	// Fall back to temp file for Out-Of-Order Writes.
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
 		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
+		f.recordFallback(openMode, metrics.WriteFallbackReasonOutOfOrderAttr)
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
@@ -1058,6 +1063,7 @@ func (f *FileInode) truncateUsingBufferedWriteHandler(ctx context.Context, size 
 	// If truncate size is less than the total file size resulting in OutOfOrder write, finalize and fall back to temp file.
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
 		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
+		f.recordFallback(util.NewOpenMode(util.WriteOnly, 0), metrics.WriteFallbackReasonOutOfOrderAttr)
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
@@ -1098,6 +1104,32 @@ func (f *FileInode) Truncate(
 	return false, f.truncateUsingTempFile(ctx, size)
 }
 
+
+// recordFallback maps util.OpenMode to metrics.OpenMode and records the fallback metric.
+func (f *FileInode) recordFallback(openMode util.OpenMode, reason metrics.WriteFallbackReason) {
+	if f.metricHandle == nil {
+		return
+	}
+	var metricOpenMode metrics.OpenMode
+	switch openMode.AccessMode() {
+	case util.ReadWrite:
+		if openMode.IsAppend() {
+			metricOpenMode = metrics.OpenModeReadWriteAppendAttr
+		} else {
+			metricOpenMode = metrics.OpenModeReadWriteAttr
+		}
+	case util.WriteOnly:
+		if openMode.IsAppend() {
+			metricOpenMode = metrics.OpenModeWriteOnlyAppendAttr
+		} else {
+			metricOpenMode = metrics.OpenModeWriteOnlyAttr
+		}
+	}
+	if metricOpenMode != "" {
+		f.metricHandle.FsStreamingWriteFallbackCount(1, metricOpenMode, reason)
+	}
+}
+
 // Ensures cache content on read if content cache enabled
 func (f *FileInode) CacheEnsureContent(ctx context.Context) (err error) {
 	if f.localFileCache {
@@ -1136,6 +1168,9 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 
 	tempFileInUse := f.content != nil
 	if !f.config.Write.EnableStreamingWrites || tempFileInUse {
+		if !tempFileInUse {
+			f.recordFallback(openMode, metrics.WriteFallbackReasonNotEnabledAttr)
+		}
 		// bwh should not be initialized under these conditions.
 		return false, nil
 	}
@@ -1181,9 +1216,11 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 				"limit (set by --write-global-max-blocks) has been reached. To allow more concurrent files "+
 				"to use streaming writes, consider increasing this limit if sufficient memory is available. "+
 				"For more details on memory usage, see: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#writes", f.name.String())
+			f.recordFallback(openMode, metrics.WriteFallbackReasonConcurrentLimitBreachedAttr)
 			return false, nil
 		}
 		if err != nil {
+			f.recordFallback(openMode, metrics.WriteFallbackReasonOtherAttr)
 			return false, fmt.Errorf("failed to create bufferedWriteHandler: %w", err)
 		}
 		f.bwh.SetMtime(f.mtimeClock.Now())
@@ -1201,5 +1238,6 @@ func (f *FileInode) areBufferedWritesSupported(openMode util.OpenMode, obj *gcs.
 		return true
 	}
 	logger.Infof("Existing file %s of size %d bytes (non-zero) will use legacy staged writes. "+StreamingWritesSemantics, f.name.String(), obj.Size)
+	f.recordFallback(openMode, metrics.WriteFallbackReasonExistingFileAttr)
 	return false
 }

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -119,7 +119,7 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer())
+		tracing.NewNoopTracer(), nil)
 
 	// Create empty file for local inode created above.
 	err := t.in.CreateEmptyTempFile(t.ctx)
@@ -156,7 +156,7 @@ func (t *FileMockBucketTest) createGCSBackedFileInode(backingObj *gcs.MinObject)
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer())
+		tracing.NewNoopTracer(), nil)
 	f.Lock()
 	return f
 }

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -29,6 +29,7 @@ import (
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
@@ -119,7 +120,8 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer(), nil)
+		tracing.NewNoopTracer(),
+		metrics.NewNoopMetrics())
 
 	// Create empty file for local inode created above.
 	err := t.in.CreateEmptyTempFile(t.ctx)
@@ -156,7 +158,8 @@ func (t *FileMockBucketTest) createGCSBackedFileInode(backingObj *gcs.MinObject)
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer(), nil)
+		tracing.NewNoopTracer(),
+		metrics.NewNoopMetrics())
 	f.Lock()
 	return f
 }

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -154,7 +154,7 @@ func (t *FileStreamingWritesCommon) createInode(fileType string) {
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer())
+		tracing.NewNoopTracer(), nil)
 
 	// Set buffered write config for created inode.
 	t.in.config = &cfg.Config{Write: cfg.WriteConfig{

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
@@ -154,7 +155,8 @@ func (t *FileStreamingWritesCommon) createInode(fileType string) {
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer(), nil)
+		tracing.NewNoopTracer(),
+		metrics.NewNoopMetrics())
 
 	// Set buffered write config for created inode.
 	t.in.config = &cfg.Config{Write: cfg.WriteConfig{

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -167,7 +167,8 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer(), nil)
+		tracing.NewNoopTracer(),
+		metrics.NewNoopMetrics())
 
 	t.in.Lock()
 }

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -167,7 +167,7 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 		&cfg.Config{},
 		semaphore.NewWeighted(math.MaxInt64),
 		nil,
-		tracing.NewNoopTracer())
+		tracing.NewNoopTracer(), nil)
 
 	t.in.Lock()
 }


### PR DESCRIPTION
Adds metric collection for `FsStreamingWriteFallbackCount` to capture the instances where GCSFuse falls back from streaming writes to legacy staged writes, categorized by the reason (e.g. out of order write, concurrent limit breached, existing file, not enabled).

- Added `metricHandle` to `FileInode`.
- Created `recordFallback` method to map `util.OpenMode` to the metric's open mode attribute and emit the counter metric.
- Plumbed the metric into `InitBufferedWriteHandlerIfEligible`, `writeUsingBufferedWrites`, and `truncateUsingBufferedWriteHandler`.
- Updated tests and production callers of `NewFileInode` to pass `metricHandle`.

---
*PR created automatically by Jules for task [3954475046352711424](https://jules.google.com/task/3954475046352711424) started by @thrivikram-karur-g*