### PR TITLE
feat: add support for non-time-based metrics and read/block_size

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3141,6 +3141,12 @@ func (fs *fileSystem) ReadFile(
 		op.Dst, op.BytesRead, err = fh.Read(ctx, op.Dst, op.Offset, fs.sequentialReadSizeMb)
 	}
 
+	if err == nil || err == io.EOF {
+		if op.BytesRead > 0 && fs.metricHandle != nil {
+			fs.metricHandle.ReadBlockSize(ctx, int64(op.BytesRead))
+		}
+	}
+
 	// A FileClobberedError indicates the underlying GCS object has changed,
 	// making the kernel's dentry for this file stale. We use the notifier to
 	// invalidate this entry, providing feedback to the kernel about the dynamic

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -190,6 +190,9 @@ type MetricHandle interface {
 	// GcsRetryCount - The cumulative number of retry requests made to GCS.
 	GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory)
 
+	// ReadBlockSize - The cumulative distribution of the number of block sizes across different bucket boundaries
+	ReadBlockSize(ctx context.Context, val int64)
+
 	// TestUpdownCounter - Test metric for updown counters.
 	TestUpdownCounter(inc int64)
 

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -54,6 +54,8 @@ func (*noopMetrics) GcsRequestLatencies(ctx context.Context, latency time.Durati
 
 func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory) {}
 
+func (*noopMetrics) ReadBlockSize(ctx context.Context, val int64) {}
+
 func (*noopMetrics) TestUpdownCounter(inc int64) {}
 
 func (*noopMetrics) TestUpdownCounterWithAttrs(inc int64, requestType RequestType) {}

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -1041,6 +1041,7 @@ type otelMetrics struct {
 	fileCacheReadLatencies                                                             metric.Int64Histogram
 	fsOpsLatency                                                                       metric.Int64Histogram
 	gcsRequestLatencies                                                                metric.Int64Histogram
+	readBlockSize                                                                      metric.Int64Histogram
 }
 
 func (o *otelMetrics) BufferedReadFallbackTriggerCount(
@@ -1060,8 +1061,7 @@ func (o *otelMetrics) BufferedReadFallbackTriggerCount(
 	}
 }
 
-func (o *otelMetrics) BufferedReadReadLatency(
-	ctx context.Context, latency time.Duration) {
+func (o *otelMetrics) BufferedReadReadLatency(ctx context.Context, latency time.Duration) {
 	var record histogramRecord
 	record = histogramRecord{ctx: ctx, instrument: o.bufferedReadReadLatency, value: latency.Microseconds()}
 
@@ -1130,8 +1130,7 @@ func (o *otelMetrics) FileCacheReadCount(
 	}
 }
 
-func (o *otelMetrics) FileCacheReadLatencies(
-	ctx context.Context, latency time.Duration, cacheHit bool) {
+func (o *otelMetrics) FileCacheReadLatencies(ctx context.Context, latency time.Duration, cacheHit bool) {
 	var record histogramRecord
 	switch cacheHit {
 	case true:
@@ -2118,8 +2117,7 @@ func (o *otelMetrics) FsOpsErrorCount(
 	}
 }
 
-func (o *otelMetrics) FsOpsLatency(
-	ctx context.Context, latency time.Duration, fsOp FsOp) {
+func (o *otelMetrics) FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp) {
 	var record histogramRecord
 	switch fsOp {
 	case FsOpBatchForgetAttr:
@@ -2302,8 +2300,7 @@ func (o *otelMetrics) GcsRequestCount(
 	}
 }
 
-func (o *otelMetrics) GcsRequestLatencies(
-	ctx context.Context, latency time.Duration, gcsMethod GcsMethod) {
+func (o *otelMetrics) GcsRequestLatencies(ctx context.Context, latency time.Duration, gcsMethod GcsMethod) {
 	var record histogramRecord
 	switch gcsMethod {
 	case GcsMethodComposeObjectsAttr:
@@ -2369,6 +2366,16 @@ func (o *otelMetrics) GcsRetryCount(
 	default:
 		updateUnrecognizedAttribute(string(retryErrorCategory))
 		return
+	}
+}
+
+func (o *otelMetrics) ReadBlockSize(ctx context.Context, val int64) {
+	var record histogramRecord
+	record = histogramRecord{ctx: ctx, instrument: o.readBlockSize, value: val}
+
+	select {
+	case o.ch <- record: // Do nothing
+	default: // Unblock writes to channel if it's full.
 	}
 }
 
@@ -3463,7 +3470,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err15 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	readBlockSize, err15 := meter.Int64Histogram("read/block_size",
+		metric.WithDescription("The cumulative distribution of the number of block sizes across different bucket boundaries"),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(8, 16, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072))
+
+	_, err16 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3471,7 +3483,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err16 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err17 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3480,7 +3492,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -3963,9 +3975,10 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsRequestLatencies:                                        gcsRequestLatencies,
 		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:           &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
 		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:    &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
-		testUpdownCounterAtomic:                                    &testUpdownCounterAtomic,
-		testUpdownCounterWithAttrsRequestTypeAttr1Atomic:           &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,
-		testUpdownCounterWithAttrsRequestTypeAttr2Atomic:           &testUpdownCounterWithAttrsRequestTypeAttr2Atomic,
+		readBlockSize:           readBlockSize,
+		testUpdownCounterAtomic: &testUpdownCounterAtomic,
+		testUpdownCounterWithAttrsRequestTypeAttr1Atomic: &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,
+		testUpdownCounterWithAttrsRequestTypeAttr2Atomic: &testUpdownCounterWithAttrsRequestTypeAttr2Atomic,
 	}, nil
 }
 

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -5262,6 +5262,31 @@ func TestGcsRetryCount(t *testing.T) {
 	}
 }
 
+func TestReadBlockSize(t *testing.T) {
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
+	var totalVal int64
+	vals := []int64{100, 200}
+
+	for _, val := range vals {
+		m.ReadBlockSize(ctx, val)
+		totalVal += val
+	}
+	waitForMetricsProcessing()
+
+	metrics := gatherHistogramMetrics(ctx, t, rd)
+	metric, ok := metrics["read/block_size"]
+	require.True(t, ok, "read/block_size metric not found")
+
+	s := attribute.NewSet()
+	expectedKey := s.Encoded(encoder)
+	dp, ok := metric[expectedKey]
+	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
+	assert.Equal(t, uint64(len(vals)), dp.Count)
+	assert.Equal(t, totalVal, dp.Sum)
+}
+
 func TestTestUpdownCounter(t *testing.T) {
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -81,6 +81,7 @@ var funcMap = template.FuncMap{
 	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
 	"isUpDownCounter":             func(m Metric) bool { return m.Type == "int_up_down_counter" },
 	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" },
+	"isTimeBased":                 isTimeBased,
 	"buildSwitches":               buildSwitches,
 	"getTestName":                 getTestName,
 	"getTestFuncArgs":             getTestFuncArgs,
@@ -157,6 +158,10 @@ func getUnitMethod(unit string) string {
 		// Assumes the value is already in the correct unit if not time-based.
 		return ""
 	}
+}
+
+func isTimeBased(unit string) bool {
+	return unit == "us" || unit == "ms" || unit == "s"
 }
 
 func joinInts(nums []int64) string {
@@ -392,8 +397,12 @@ func buildSwitches(metric Metric) string {
 				builder.WriteString(fmt.Sprintf("%so.%s.Add(inc)\n", indent, atomicName))
 			} else { // histogram
 				varName := getVarName(metric.Name, combo)
-				unitMethod := getUnitMethod(metric.Unit)
-				builder.WriteString(fmt.Sprintf("%srecord = histogramRecord{ctx: ctx,instrument: o.%s, value: latency%s, attributes: %s}\n", indent, toCamel(metric.Name), unitMethod, varName))
+				if isTimeBased(metric.Unit) {
+					unitMethod := getUnitMethod(metric.Unit)
+					builder.WriteString(fmt.Sprintf("%srecord = histogramRecord{ctx: ctx,instrument: o.%s, value: latency%s, attributes: %s}\n", indent, toCamel(metric.Name), unitMethod, varName))
+				} else {
+					builder.WriteString(fmt.Sprintf("%srecord = histogramRecord{ctx: ctx,instrument: o.%s, value: val, attributes: %s}\n", indent, toCamel(metric.Name), varName))
+				}
 			}
 			return
 		}
@@ -427,8 +436,12 @@ func buildSwitches(metric Metric) string {
 
 	if len(metric.Attributes) == 0 {
 		if metric.Type == "int_histogram" {
-			unitMethod := getUnitMethod(metric.Unit)
-			builder.WriteString(fmt.Sprintf("\trecord = histogramRecord{ctx: ctx, instrument: o.%s, value: latency%s}\n", toCamel(metric.Name), unitMethod))
+			if isTimeBased(metric.Unit) {
+				unitMethod := getUnitMethod(metric.Unit)
+				builder.WriteString(fmt.Sprintf("\trecord = histogramRecord{ctx: ctx, instrument: o.%s, value: latency%s}\n", toCamel(metric.Name), unitMethod))
+			} else {
+				builder.WriteString(fmt.Sprintf("\trecord = histogramRecord{ctx: ctx, instrument: o.%s, value: val}\n", toCamel(metric.Name)))
+			}
 		} else if metric.Type == "int_counter" || metric.Type == "int_up_down_counter" {
 			atomicName := getAtomicName(metric.Name, AttrCombination{})
 			builder.WriteString(fmt.Sprintf("\to.%s.Add(inc)\n", atomicName))

--- a/tools/metrics-gen/metric_handle.tpl
+++ b/tools/metrics-gen/metric_handle.tpl
@@ -41,7 +41,11 @@ type MetricHandle interface {
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, latency time.Duration
+			{{- if isTimeBased .Unit -}}
+				ctx context.Context, latency time.Duration
+			{{- else -}}
+				ctx context.Context, val int64
+			{{- end -}}
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/noop_metrics.tpl
+++ b/tools/metrics-gen/noop_metrics.tpl
@@ -26,7 +26,11 @@ type noopMetrics struct {}
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, latency time.Duration
+			{{- if isTimeBased .Unit -}}
+				ctx context.Context, latency time.Duration
+			{{- else -}}
+				ctx context.Context, val int64
+			{{- end -}}
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/otel_metrics.tpl
+++ b/tools/metrics-gen/otel_metrics.tpl
@@ -75,7 +75,11 @@ func (o *otelMetrics) {{toPascal .Name}}(
 	{{- if or (isCounter .) (isUpDownCounter .)}}
 		inc int64
 	{{- else }}
-		ctx context.Context, latency time.Duration
+		{{- if isTimeBased .Unit -}}
+			ctx context.Context, latency time.Duration
+		{{- else -}}
+			ctx context.Context, val int64
+		{{- end -}}
 	{{- end }}
 	{{- if .Attributes}}, {{end}}
 	{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -232,7 +232,11 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	{{- if .Attributes}}
 	tests := []struct {
 		name      string
+		{{- if isTimeBased .Unit}}
 		latencies []time.Duration
+		{{- else}}
+		vals []int64
+		{{- end}}
 		{{- range .Attributes}}
 		{{toCamel .Name}} {{getGoType .Type}}
 		{{- end}}
@@ -241,7 +245,11 @@ func Test{{toPascal .Name}}(t *testing.T) {
 		{{- range $combination := (index $.AttrCombinations $metric.Name)}}
 		{
 			name:      "{{getTestName $combination}}",
+			{{- if isTimeBased $metric.Unit}}
 			latencies: []time.Duration{100 * time.{{getLatencyUnit $metric.Unit}}, 200 * time.{{getLatencyUnit $metric.Unit}}},
+			{{- else}}
+			vals: []int64{100, 200},
+			{{- end}}
 			{{- range $pair := $combination}}
 			{{toCamel $pair.Name}}: {{if eq $pair.Type "bool"}}{{$pair.Value}}{{else}}"{{$pair.Value}}"{{end}},
 			{{- end}}
@@ -254,12 +262,21 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			ctx := context.Background()
 			encoder := attribute.DefaultEncoder()
 			m, rd := setupOTel(ctx, t)
+			{{- if isTimeBased .Unit}}
 			var totalLatency time.Duration
 
 			for _, latency := range tc.latencies {
 				m.{{toPascal .Name}}(ctx, latency, {{getTestFuncArgsForHistogram "tc" .Attributes}})
 				totalLatency += latency
 			}
+			{{- else}}
+			var totalVal int64
+
+			for _, val := range tc.vals {
+				m.{{toPascal .Name}}(ctx, val, {{getTestFuncArgsForHistogram "tc" .Attributes}})
+				totalVal += val
+			}
+			{{- end}}
 			waitForMetricsProcessing()
 
 			metrics := gatherHistogramMetrics(ctx, t, rd)
@@ -275,14 +292,20 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			expectedKey := s.Encoded(encoder)
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
+			{{- if isTimeBased .Unit}}
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
 			assert.Equal(t, totalLatency.{{getLatencyMethod .Unit}}(), dp.Sum)
+			{{- else}}
+			assert.Equal(t, uint64(len(tc.vals)), dp.Count)
+			assert.Equal(t, totalVal, dp.Sum)
+			{{- end}}
 		})
 	}
 	{{- else}}
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()
 	m, rd := setupOTel(ctx, t)
+	{{- if isTimeBased .Unit}}
 	var totalLatency time.Duration
 	latencies := []time.Duration{100 * time.{{getLatencyUnit .Unit}}, 200 * time.{{getLatencyUnit .Unit}}}
 
@@ -290,6 +313,15 @@ func Test{{toPascal .Name}}(t *testing.T) {
 		m.{{toPascal .Name}}(ctx, latency)
 		totalLatency += latency
 	}
+	{{- else}}
+	var totalVal int64
+	vals := []int64{100, 200}
+
+	for _, val := range vals {
+		m.{{toPascal .Name}}(ctx, val)
+		totalVal += val
+	}
+	{{- end}}
 	waitForMetricsProcessing()
 
 	metrics := gatherHistogramMetrics(ctx, t, rd)
@@ -300,8 +332,13 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	expectedKey := s.Encoded(encoder)
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
+	{{- if isTimeBased .Unit}}
 	assert.Equal(t, uint64(len(latencies)), dp.Count)
 	assert.Equal(t, totalLatency.{{getLatencyMethod .Unit}}(), dp.Sum)
+	{{- else}}
+	assert.Equal(t, uint64(len(vals)), dp.Count)
+	assert.Equal(t, totalVal, dp.Sum)
+	{{- end}}
 	{{- end}}
 }
 {{end}}


### PR DESCRIPTION
This PR updates the `tools/metrics-gen` code generator to properly support non-time-based metrics such as the `read/block_size` bytes histogram added in `metrics.yaml`. It regenerates the metrics boilerplate and updates `internal/fs/fs.go` to capture the read block size on successful `ReadFile` operations.

---
*PR created automatically by Jules for task [3549506533573433487](https://jules.google.com/task/3549506533573433487) started by @thrivikram-karur-g*