### PR TITLE
test(integration): remove unused mount configs

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -69,6 +69,7 @@ list_large_dir:
 operations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
@@ -223,6 +224,7 @@ cloud_profiler:
 requester_pays_bucket:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--billing-project=gcs-fuse-test-ml"
@@ -657,7 +659,6 @@ interrupt:
 log_rotation:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # To be removed
     configs:
       - flags:
           - "--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress=false,--log-severity=trace"
@@ -837,8 +838,6 @@ flag_optimizations:
 unsupported_path:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    only_dir: "${ONLY_DIR}"
-    log_file: # Optional
     configs:
       - flags:
           - "--implicit-dirs,--client-protocol=grpc,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"


### PR DESCRIPTION
### Description
* **Fix `unsupported_path` suite:** Removed `only_dir` and `log_file` configurations from the `unsupported_path` suite in `test_config.yaml`. This prevents test frameworks from automatically executing this package with `only_dir` mounts, avoiding immediate setup crashes caused by GCS object leaks.
* **Clean up `test_config.yaml`:** Removed the unused `log_file` parameter from the `log_rotation` suite and added `only_dir` where required (`operations`, `requester_pays_bucket`).

### Link to the issue in case of a bug fix.
Fixes b/496966414

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.
