### PR TITLE
feat: making direct-path verification non-fatal until dummy-stat calls becomes reliable

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,7 +57,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 5 * time.Minute
+	directPathDetectionTimeout          = 10 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )
@@ -203,7 +203,7 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string, skipDirectPathEnforcement bool) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -215,31 +215,22 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	if !skipDirectPathEnforcement {
-		// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
-	}
+	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
+	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
 
-	var creationCtx context.Context
-	var cancel context.CancelFunc
-	if skipDirectPathEnforcement {
-		creationCtx = ctx
-	} else {
-		// Create client with DirectPath enforced
-		creationCtx, cancel = context.WithTimeout(ctx, directPathDetectionTimeout)
-		defer cancel()
-	}
+	creationCtx, cancel := context.WithTimeout(ctx, directPathDetectionTimeout)
+	defer cancel()
 
 	if sc, err = storage.NewGRPCClient(creationCtx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 	setRetryConfig(ctx, sc, clientConfig)
 
-	if !skipDirectPathEnforcement {
-		err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject)
-		if err != nil {
-			return nil, err
-		}
+	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
+	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
+		logger.Warnf("DirectPath verification failed, continuing without DirectPath guarantee: %v", verifyErr)
+		// Apply production retry config since verification skipped it on failure.
+		setRetryConfig(ctx, sc, clientConfig)
 	}
 
 	return sc, nil
@@ -264,8 +255,6 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
-		// DirectPath verification failed
-		sc.Close()
 		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
 	}
 
@@ -437,7 +426,7 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	var err error
 	if isbucketZonal {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject, true)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
@@ -462,7 +451,7 @@ func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Con
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject, false)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -40,7 +40,9 @@ import (
 	"golang.org/x/oauth2"
 	option "google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	// Side effect to run grpc client with direct-path on gcp machine.
 	_ "google.golang.org/grpc/balancer/rls"
@@ -225,9 +227,14 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-		logger.Warnf("DirectPath verification failed, continuing without DirectPath guarantee: %v", verifyErr)
-		// Apply production retry config since verification skipped it on failure.
-		setRetryConfig(ctx, sc, clientConfig)
+
+		if status.Code(verifyErr) == codes.DeadlineExceeded {
+			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
+		} else {
+			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
+		}
+	} else {
+		logger.Infof("DirectPath verification succeeded, continuing with DirectPath")
 	}
 
 	return sc, nil
@@ -238,7 +245,14 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	logger.Infof("Verifying DirectPath connectivity for bucket %q with stat call", bucketName)
 	// Apply detection retry config for initial verification
 	setDPDetectionRetryConfig(ctx, sc, clientConfig)
-	verifyCtx, verifyCancel := context.WithTimeout(ctx, directPathDetectionTimeout)
+
+	// Restore the production level retry config.
+	defer func() {
+		logger.Infof("Applying production retry config after DirectPath verification.")
+		setRetryConfig(ctx, sc, clientConfig)
+	}()
+
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, time.Millisecond)
 	defer verifyCancel()
 
 	// Retrieving object attrs through Go Storage Client.
@@ -255,9 +269,6 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
 	}
 
-	logger.Infof("DirectPath verification successful for bucket %q, applying production retry config", bucketName)
-	// DirectPath is working! Now apply production retry config for actual usage.
-	setRetryConfig(ctx, sc, clientConfig)
 	return nil
 }
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -218,10 +218,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
 	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
 
-	creationCtx, cancel := context.WithTimeout(ctx, directPathDetectionTimeout)
-	defer cancel()
-
-	if sc, err = storage.NewGRPCClient(creationCtx, clientOpts...); err != nil {
+	if sc, err = storage.NewGRPCClient(ctx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 	setRetryConfig(ctx, sc, clientConfig)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -203,7 +203,7 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string, skipDirectPathEnforcement bool) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -214,24 +214,34 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	if !skipDirectPathEnforcement {
+		// Add DirectPath enforcement - client creation will fail if DirectPath is not available
+		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	}
 
-	// Create client with DirectPath enforced
-	detectionCtx, cancel := context.WithTimeout(ctx, directPathDetectionTimeout)
-	defer cancel()
-	sc, err = storage.NewGRPCClient(detectionCtx, clientOpts...)
+	var creationCtx context.Context
+	var cancel context.CancelFunc
+	if skipDirectPathEnforcement {
+		creationCtx = ctx
+	} else {
+		// Create client with DirectPath enforced
+		creationCtx, cancel = context.WithTimeout(ctx, directPathDetectionTimeout)
+		defer cancel()
+	}
+
+	sc, err = storage.NewGRPCClient(creationCtx, clientOpts...)
+	unSetDirectPathEnvVariable()
 	if err != nil {
-		unSetDirectPathEnvVariable()
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	} else {
 		setRetryConfig(ctx, sc, clientConfig)
 	}
 
-	err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject)
-	unSetDirectPathEnvVariable()
-	if err != nil {
-		return nil, err
+	if !skipDirectPathEnforcement {
+		err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return sc, nil
@@ -429,7 +439,7 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	var err error
 	if isbucketZonal {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject, true)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
@@ -454,7 +464,7 @@ func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Con
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject, false)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -227,14 +227,13 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-
 		if status.Code(verifyErr) == codes.DeadlineExceeded {
 			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
 		} else {
 			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
 		}
 	} else {
-		logger.Infof("DirectPath verification succeeded, continuing with DirectPath")
+		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
 
 	return sc, nil

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,7 +57,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 10 * time.Second
+	directPathDetectionTimeout          = 5 * time.Minute
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -207,6 +207,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
+	defer unSetDirectPathEnvVariable()
 
 	var clientOpts []option.ClientOption
 	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
@@ -229,13 +230,10 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		defer cancel()
 	}
 
-	sc, err = storage.NewGRPCClient(creationCtx, clientOpts...)
-	unSetDirectPathEnvVariable()
-	if err != nil {
+	if sc, err = storage.NewGRPCClient(creationCtx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
-	} else {
-		setRetryConfig(ctx, sc, clientConfig)
 	}
+	setRetryConfig(ctx, sc, clientConfig)
 
 	if !skipDirectPathEnforcement {
 		err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject)


### PR DESCRIPTION
### Description
- Making direct-path verification (during mount) non-fatal to stop mount failure because of unreliable dummy-stat calls. We may need to increase overall timeout with stall support to make the dummy-stat call reliable.
- Removing the ctx-timeout while client creation, given it's necessary for grpc traffic and we don't want to fail because of delay in client creation.

### Link to the issue in case of a bug fix.
b/503303141

### Testing details
1. Manual - Yes, verified manually. (a) grpc with error in dummy-stat (b) rapid with error in dummy-stat (c) grpc with success in dummy-stat (d) rapid with success in dummy-stat
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
