### PR TITLE
test(integration_tests): add only_dir configuration to test_config.yaml

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -511,6 +511,7 @@ readdirplus:
 inactive_stream_timeout:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--read-inactive-stream-timeout=1s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
@@ -724,6 +725,7 @@ mounting:
 flag_optimizations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - run: TestMountFails
         flags:
@@ -860,6 +862,7 @@ unsupported_path:
 kernel_list_cache:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--kernel-list-cache-ttl-secs=-1"
@@ -1052,6 +1055,7 @@ symlink_handling:
 negative_stat_cache:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--metadata-cache-negative-ttl-secs=0"
@@ -1081,6 +1085,7 @@ negative_stat_cache:
 managed_folders:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - run: TestManagedFolders_FolderViewPermission
         flags:


### PR DESCRIPTION
### Description
This PR updates `tools/integration_tests/test_config.yaml` to explicitly include the `only_dir: "${ONLY_DIR}"` field for several integration test suites. As noted in recent test framework discussions, the test framework automatically enables the `only_dir` execution mode if the test package contains this field. 

This change ensures the following test suites include the `only_dir` mount configurations int test_config.yaml:
* `inactive_stream_timeout`
* `flag_optimizations`
* `kernel_list_cache`
* `negative_stat_cache`
* `managed_folders`

With this configuration update, we will now be running the `only_dir` tests for all 10 of the test packages that implement `only_dir_mounting` including :
* `local_file`
*`operations`
*`read_cache`
*`rename_dir_limit`
*`requester_pays_bucket`

### Link to the issue in case of a bug fix.
Related to http://b/496966414

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.