### PR TITLE
feat: Add Read Path Support for Pirlo Buckets

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -31,11 +31,19 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			BucketType: "zonal",
 			Value:      int64(DefaultCongestionThreshold()),
 		},
+		{
+			BucketType: "pirlo",
+			Value:      int64(DefaultCongestionThreshold()),
+		},
 	},
 }, "file-system.enable-kernel-reader": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
 			BucketType: "zonal",
+			Value:      bool(true),
+		},
+		{
+			BucketType: "pirlo",
 			Value:      bool(true),
 		},
 	},
@@ -84,11 +92,19 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			BucketType: "zonal",
 			Value:      int64(DefaultMaxBackground()),
 		},
+		{
+			BucketType: "pirlo",
+			Value:      int64(DefaultMaxBackground()),
+		},
 	},
 }, "file-system.max-read-ahead-kb": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
 			BucketType: "zonal",
+			Value:      int64(16384),
+		},
+		{
+			BucketType: "pirlo",
 			Value:      int64(16384),
 		},
 	},

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -63,6 +63,14 @@ func TestApplyOptimizations(t *testing.T) {
 				expectOptimized: true,
 				expectedValue:   DefaultCongestionThreshold(),
 			},
+			{
+				name:            "bucket_type_pirlo",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   DefaultCongestionThreshold(),
+			},
 		}
 
 		for _, tc := range testCases {
@@ -129,6 +137,14 @@ func TestApplyOptimizations(t *testing.T) {
 				config:          Config{Profile: ""},
 				userSetFlags:    map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketTypeZonal},
+				expectOptimized: true,
+				expectedValue:   true,
+			},
+			{
+				name:            "bucket_type_pirlo",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
 				expectOptimized: true,
 				expectedValue:   true,
 			},
@@ -467,6 +483,14 @@ func TestApplyOptimizations(t *testing.T) {
 				expectOptimized: true,
 				expectedValue:   DefaultMaxBackground(),
 			},
+			{
+				name:            "bucket_type_pirlo",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   DefaultMaxBackground(),
+			},
 		}
 
 		for _, tc := range testCases {
@@ -533,6 +557,14 @@ func TestApplyOptimizations(t *testing.T) {
 				config:          Config{Profile: ""},
 				userSetFlags:    map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketTypeZonal},
+				expectOptimized: true,
+				expectedValue:   16384,
+			},
+			{
+				name:            "bucket_type_pirlo",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
 				expectOptimized: true,
 				expectedValue:   16384,
 			},

--- a/cfg/config_util.go
+++ b/cfg/config_util.go
@@ -79,12 +79,15 @@ func IsGKEEnvironment(mountPoint string) bool {
 }
 
 // GetBucketType converts BucketType boolean flags to a BucketType enum.
-// The priority order is: Zonal > Hierarchical > Flat.
+// The priority order is: Zonal > Pirlo > Hierarchical > Flat.
 // This is used to determine bucket-specific optimizations for kernel configs.
 // TODO (b/472597952): Make BucketType in bucket_handle.go as enum
-func GetBucketType(hierarchical, zonal bool) BucketType {
+func GetBucketType(hierarchical, zonal, pirlo bool) BucketType {
 	if zonal {
 		return BucketTypeZonal
+	}
+	if pirlo {
+		return BucketTypePirlo
 	}
 	if hierarchical {
 		return BucketTypeHierarchical

--- a/cfg/config_util_test.go
+++ b/cfg/config_util_test.go
@@ -242,6 +242,7 @@ func TestGetBucketType(t *testing.T) {
 		name         string
 		hierarchical bool
 		zonal        bool
+		pirlo        bool
 		expected     BucketType
 	}{
 		{
@@ -249,6 +250,12 @@ func TestGetBucketType(t *testing.T) {
 			hierarchical: true,
 			zonal:        true,
 			expected:     BucketTypeZonal,
+		},
+		{
+			name:         "Pirlo and Hierarchical (pirlo takes priority)",
+			hierarchical: true,
+			pirlo:        true,
+			expected:     BucketTypePirlo,
 		},
 		{
 			name:         "Hierarchical bucket",
@@ -266,10 +273,10 @@ func TestGetBucketType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetBucketType(tt.hierarchical, tt.zonal)
+			result := GetBucketType(tt.hierarchical, tt.zonal, tt.pirlo)
 			if result != tt.expected {
-				t.Errorf("GetBucketType(%v, %v) = %v; want %v",
-					tt.hierarchical, tt.zonal, result, tt.expected)
+				t.Errorf("GetBucketType(%v, %v, %v) = %v; want %v",
+					tt.hierarchical, tt.zonal, tt.pirlo, result, tt.expected)
 			}
 		})
 	}

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -386,6 +386,8 @@ params:
       bucket-type-optimization:
         - bucket-type: "zonal"
           value: "DefaultCongestionThreshold()"
+        - bucket-type: "pirlo"
+          value: "DefaultCongestionThreshold()"
 
   - config-path: "file-system.dir-mode"
     flag-name: "dir-mode"
@@ -409,6 +411,8 @@ params:
     optimizations:
       bucket-type-optimization:
         - bucket-type: "zonal"
+          value: true
+        - bucket-type: "pirlo"
           value: true
 
   - config-path: "file-system.experimental-enable-dentry-cache"
@@ -517,6 +521,8 @@ params:
       bucket-type-optimization:
         - bucket-type: "zonal"
           value: "DefaultMaxBackground()"
+        - bucket-type: "pirlo"
+          value: "DefaultMaxBackground()"
 
   - config-path: "file-system.max-read-ahead-kb"
     flag-name: "max-read-ahead-kb"
@@ -530,6 +536,8 @@ params:
     optimizations:
       bucket-type-optimization:
         - bucket-type: "zonal"
+          value: 16384 # 16 MiB
+        - bucket-type: "pirlo"
           value: 16384 # 16 MiB
 
   - config-path: "file-system.precondition-errors"

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -153,6 +153,9 @@ const (
 	// BucketTypeZonal represents a zonal bucket with single-zone storage.
 	BucketTypeZonal BucketType = "zonal"
 
+	// BucketTypePirlo represents a pirlo bucket.
+	BucketTypePirlo BucketType = "pirlo"
+
 	// BucketTypeHierarchical represents a bucket with hierarchical namespace enabled.
 	BucketTypeHierarchical BucketType = "hierarchical"
 
@@ -162,5 +165,5 @@ const (
 
 // IsValid returns true if the BucketType is one of the defined valid types.
 func (bt BucketType) IsValid() bool {
-	return bt == BucketTypeZonal || bt == BucketTypeHierarchical || bt == BucketTypeFlat
+	return bt == BucketTypeZonal || bt == BucketTypePirlo || bt == BucketTypeHierarchical || bt == BucketTypeFlat
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -267,7 +267,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		// for non-dynamic mounts, but they are idempotent, so it's safe.
 		bucketType := syncerBucket.BucketType()
 		if serverCfg.ViperConfig != nil {
-			bucketTypeEnum := cfg.GetBucketType(bucketType.Hierarchical, bucketType.Zonal)
+			bucketTypeEnum := cfg.GetBucketType(bucketType.Hierarchical, bucketType.Zonal, bucketType.Pirlo)
 			optimizedFlags := serverCfg.NewConfig.ApplyOptimizations(serverCfg.ViperConfig, &cfg.OptimizationInput{
 				BucketType: bucketTypeEnum,
 			})
@@ -3096,9 +3096,9 @@ func (fs *fileSystem) ReadFile(
 	fh.Inode().Lock()
 	if fh.Inode().IsUsingBWH() {
 		// Flush/Sync Pending streaming writes and issue read within same inode lock.
-		if fh.Inode().Bucket().BucketType().Zonal {
-			// With zonal buckets, we can read from unfinalized objects as well.
-			// Hence, there is no need to finalize the object from here for zonal buckets.
+		if fh.Inode().Bucket().BucketType().IsRapid() {
+			// With rapid buckets, we can read from unfinalized objects as well.
+			// Hence, there is no need to finalize the object from here for rapid buckets.
 			// Hence, if FinalizeFileForRapid is set, then we will call syncFile otherwise
 			// we can call flushFile (as it will not finalize when FinalizeFileForRapid is false) itself.
 			if fs.newConfig.Write.FinalizeFileForRapid {

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -454,7 +454,7 @@ func (fh *FileHandle) OpenMode() util.OpenMode {
 // the known object size. This allows reading from an object that is being
 // concurrently written to.
 func (fh *FileHandle) shouldSkipSizeChecks(req *gcsx.ReadRequest) bool {
-	if !fh.inode.Bucket().BucketType().Zonal {
+	if !fh.inode.Bucket().BucketType().IsRapid() {
 		return false
 	}
 	if !fh.readManager.Object().IsUnfinalized() {

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -1167,17 +1167,26 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 		openMode          util.OpenMode
 		offset            int64
 		bufferSize        int
-		isRapidBucket     bool
+		bucketType        gcs.BucketType
 		expectedToSkip    bool
 		useNilReadManager bool
 	}{
 		{
-			name:           "All conditions met: unfinalized, direct I/O, positive offset, extends beyond size",
+			name:           "All conditions met (zonal bucket): unfinalized, direct I/O, positive offset, extends beyond size",
 			object:         unfinalizedObject,
 			openMode:       directIOReadMode,
 			offset:         50,
 			bufferSize:     60, // 50 + 60 > 100
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
+			expectedToSkip: true,
+		},
+		{
+			name:           "All conditions met (pirlo bucket): unfinalized, direct I/O, positive offset, extends beyond size",
+			object:         unfinalizedObject,
+			openMode:       directIOReadMode,
+			offset:         50,
+			bufferSize:     60, // 50 + 60 > 100
+			bucketType:     gcs.BucketType{Pirlo: true},
 			expectedToSkip: true,
 		},
 		{
@@ -1186,7 +1195,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         50,
 			bufferSize:     60,
-			isRapidBucket:  false,
+			bucketType:     gcs.BucketType{},
 			expectedToSkip: false,
 		},
 		{
@@ -1195,7 +1204,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         50,
 			bufferSize:     60,
-			isRapidBucket:  false,
+			bucketType:     gcs.BucketType{},
 			expectedToSkip: false,
 		},
 		{
@@ -1204,7 +1213,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         50,
 			bufferSize:     60,
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: false,
 		},
 		{
@@ -1213,7 +1222,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       readOnlyMode,
 			offset:         50,
 			bufferSize:     60,
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: false,
 		},
 		{
@@ -1222,7 +1231,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         -10,
 			bufferSize:     20,
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: false,
 		},
 		{
@@ -1231,7 +1240,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         50,
 			bufferSize:     50, // 50 + 50 <= 100
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: false,
 		},
 		{
@@ -1240,7 +1249,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         100,
 			bufferSize:     0,
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: false,
 		},
 		{
@@ -1249,7 +1258,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         100,
 			bufferSize:     10, // 100 + 10 > 100
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: true,
 		},
 		{
@@ -1258,7 +1267,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 			openMode:       directIOReadMode,
 			offset:         101,
 			bufferSize:     10, // 101 + 10 > 100
-			isRapidBucket:  true,
+			bucketType:     gcs.BucketType{Zonal: true},
 			expectedToSkip: true,
 		},
 	}
@@ -1270,7 +1279,7 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 				/*appendThreshold=*/ 1,
 				/*chunkRetryDeadlineSecs=*/ 120,
 				/*chunkTransferTimeoutSecs=*/ 10,
-				".gcsfuse_tmp/", fake.NewFakeBucket(&t.clock, "some_bucket", gcs.BucketType{Zonal: tc.isRapidBucket}),
+				".gcsfuse_tmp/", fake.NewFakeBucket(&t.clock, "some_bucket", tc.bucketType),
 			)
 			parent := createDirInode(&t.bucket, &t.clock)
 			config := &cfg.Config{}

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -1167,140 +1167,114 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 		openMode          util.OpenMode
 		offset            int64
 		bufferSize        int
-		bucketType        gcs.BucketType
-		expectedToSkip    bool
+		expectedForRapid  bool
 		useNilReadManager bool
 	}{
 		{
-			name:           "All conditions met (zonal bucket): unfinalized, direct I/O, positive offset, extends beyond size",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     60, // 50 + 60 > 100
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: true,
+			name:             "All conditions met: unfinalized, direct I/O, positive offset, extends beyond size",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           50,
+			bufferSize:       60, // 50 + 60 > 100
+			expectedForRapid: true,
 		},
 		{
-			name:           "All conditions met (pirlo bucket): unfinalized, direct I/O, positive offset, extends beyond size",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     60, // 50 + 60 > 100
-			bucketType:     gcs.BucketType{Pirlo: true},
-			expectedToSkip: true,
+			name:             "Finalized object: should not skip",
+			object:           finalizedObject,
+			openMode:         directIOReadMode,
+			offset:           50,
+			bufferSize:       60,
+			expectedForRapid: false,
 		},
 		{
-			name:           "non_rapid_bucket_finalized_attr_set",
-			object:         finalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     60,
-			bucketType:     gcs.BucketType{},
-			expectedToSkip: false,
+			name:             "Not direct I/O: should not skip",
+			object:           unfinalizedObject,
+			openMode:         readOnlyMode,
+			offset:           50,
+			bufferSize:       60,
+			expectedForRapid: false,
 		},
 		{
-			name:           "non_rapid_bucket_finalized_attr_unset",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     60,
-			bucketType:     gcs.BucketType{},
-			expectedToSkip: false,
+			name:             "Negative offset: should not skip",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           -10,
+			bufferSize:       20,
+			expectedForRapid: false,
 		},
 		{
-			name:           "Finalized object: should not skip",
-			object:         finalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     60,
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: false,
+			name:             "Read within size: should not skip",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           50,
+			bufferSize:       50, // 50 + 50 <= 100
+			expectedForRapid: false,
 		},
 		{
-			name:           "Not direct I/O: should not skip",
-			object:         unfinalizedObject,
-			openMode:       readOnlyMode,
-			offset:         50,
-			bufferSize:     60,
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: false,
+			name:             "Read exactly at size boundary: should not skip",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           100,
+			bufferSize:       0,
+			expectedForRapid: false,
 		},
 		{
-			name:           "Negative offset: should not skip",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         -10,
-			bufferSize:     20,
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: false,
+			name:             "Read starts at size and extends: should skip",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           100,
+			bufferSize:       10, // 100 + 10 > 100
+			expectedForRapid: true,
 		},
 		{
-			name:           "Read within size: should not skip",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         50,
-			bufferSize:     50, // 50 + 50 <= 100
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: false,
-		},
-		{
-			name:           "Read exactly at size boundary: should not skip",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         100,
-			bufferSize:     0,
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: false,
-		},
-		{
-			name:           "Read starts at size and extends: should skip",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         100,
-			bufferSize:     10, // 100 + 10 > 100
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: true,
-		},
-		{
-			name:           "Read starts before size and extends: should skip",
-			object:         unfinalizedObject,
-			openMode:       directIOReadMode,
-			offset:         101,
-			bufferSize:     10, // 101 + 10 > 100
-			bucketType:     gcs.BucketType{Zonal: true},
-			expectedToSkip: true,
+			name:             "Read starts before size and extends: should skip",
+			object:           unfinalizedObject,
+			openMode:         directIOReadMode,
+			offset:           101,
+			bufferSize:       10, // 101 + 10 > 100
+			expectedForRapid: true,
 		},
 	}
+	bucketTypes := []struct {
+		name       string
+		bucketType gcs.BucketType
+		isRapid    bool
+	}{
+		{name: "Zonal", bucketType: gcs.BucketType{Zonal: true}, isRapid: true},
+		{name: "Pirlo", bucketType: gcs.BucketType{Pirlo: true}, isRapid: true},
+		{name: "Standard", bucketType: gcs.BucketType{}, isRapid: false},
+	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func() {
-			// Setup test bucket.
-			t.bucket = gcsx.NewSyncerBucket(
-				/*appendThreshold=*/ 1,
-				/*chunkRetryDeadlineSecs=*/ 120,
-				/*chunkTransferTimeoutSecs=*/ 10,
-				".gcsfuse_tmp/", fake.NewFakeBucket(&t.clock, "some_bucket", tc.bucketType),
-			)
-			parent := createDirInode(&t.bucket, &t.clock)
-			config := &cfg.Config{}
-			in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, tc.object.Name, nil, false)
-			fh := NewFileHandle(in, nil, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), tc.openMode, config, nil, nil, 0)
-			if tc.useNilReadManager {
-				fh.readManager = nil
+	for _, bt := range bucketTypes {
+		for _, tc := range testCases {
+			t.Run(bt.name+"_"+tc.name, func() {
+				// Setup test bucket.
+				t.bucket = gcsx.NewSyncerBucket(
+					/*appendThreshold=*/ 1,
+					/*chunkRetryDeadlineSecs=*/ 120,
+					/*chunkTransferTimeoutSecs=*/ 10,
+					".gcsfuse_tmp/", fake.NewFakeBucket(&t.clock, "some_bucket", bt.bucketType),
+				)
+				parent := createDirInode(&t.bucket, &t.clock)
+				config := &cfg.Config{}
+				in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, tc.object.Name, nil, false)
+				fh := NewFileHandle(in, nil, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), tc.openMode, config, nil, nil, 0)
+				if tc.useNilReadManager {
+					fh.readManager = nil
+					req := &gcsx.ReadRequest{Offset: tc.offset, Buffer: make([]byte, tc.bufferSize)}
+					assert.Panics(t.T(), func() { fh.shouldSkipSizeChecks(req) })
+					return
+				}
+				rmConfig := &read_manager.ReadManagerConfig{Config: config}
+				fh.readManager = read_manager.NewReadManager(tc.object, &t.bucket, rmConfig)
 				req := &gcsx.ReadRequest{Offset: tc.offset, Buffer: make([]byte, tc.bufferSize)}
-				assert.Panics(t.T(), func() { fh.shouldSkipSizeChecks(req) })
-				return
-			}
 
-			rmConfig := &read_manager.ReadManagerConfig{Config: config}
-			fh.readManager = read_manager.NewReadManager(tc.object, &t.bucket, rmConfig)
+				skip := fh.shouldSkipSizeChecks(req)
 
-			req := &gcsx.ReadRequest{Offset: tc.offset, Buffer: make([]byte, tc.bufferSize)}
-
-			skip := fh.shouldSkipSizeChecks(req)
-
-			assert.Equal(t.T(), tc.expectedToSkip, skip)
-		})
+				expected := tc.expectedForRapid && bt.isRapid
+				assert.Equal(t.T(), expected, skip)
+			})
+		}
 	}
 }
 func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -176,7 +176,7 @@ func NewFileInode(
 		traceHandle:             traceHandle,
 	}
 
-	if f.bucket.BucketType().Zonal {
+	if f.bucket.BucketType().IsRapid() {
 		var err error
 		f.mrdInstance = gcsx.NewMrdInstance(&minObj, bucket, mrdCache, id, cfg)
 		f.MRDWrapper, err = gcsx.NewMultiRangeDownloaderWrapper(bucket, &minObj, cfg, mrdCache)
@@ -442,8 +442,8 @@ func (f *FileInode) GetMRDInstance() *gcsx.MrdInstance {
 func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
-	//   2.  The bucket is zonal and there are no pending writes in the temporary file.
-	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().Zonal && f.content == nil)
+	//   2.  The bucket is rapid and there are no pending writes in the temporary file.
+	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().IsRapid() && f.content == nil)
 }
 
 // Equivalent to the generation returned by f.Source().

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -84,6 +84,9 @@ func TestFileTestSuite(t *testing.T) {
 	t.Run("Zonal", func(t *testing.T) {
 		suite.Run(t, &FileTest{bucketType: gcs.BucketType{Zonal: true}})
 	})
+	t.Run("Pirlo", func(t *testing.T) {
+		suite.Run(t, &FileTest{bucketType: gcs.BucketType{Pirlo: true}})
+	})
 }
 
 func (t *FileTest) SetupSubTest() {

--- a/internal/gcsx/client_readers/gcs_reader.go
+++ b/internal/gcsx/client_readers/gcs_reader.go
@@ -82,10 +82,10 @@ func NewGCSReader(obj *gcs.MinObject, bucket gcs.Bucket, config *GCSReaderConfig
 }
 
 // Detects whether the read was short or not and returns whether it should be retried or not.
-// Reads would only be retried in case of zonal buckets and when the read data was less than requested (& object size)
+// Reads would only be retried in case of rapid buckets and when the read data was less than requested (& object size)
 // and there was no error apart from EOF or short reads.
 func shouldRetryForShortRead(err error, bytesRead int, p []byte, offset int64, objectSize uint64, bucketType gcs.BucketType, skipSizeChecks bool) bool {
-	if !bucketType.Zonal {
+	if !bucketType.IsRapid() {
 		return false
 	}
 
@@ -160,7 +160,7 @@ func (gr *GCSReader) read(ctx context.Context, readReq *gcsx.GCSReaderRequest) (
 		// at this lock and hence the earlier calculated value of readerType might not be valid once they
 		// acquire the lock. Hence, needs to be calculated again.
 		// We recalculate the read type if the expected offset has changed. This is important for both
-		// zonal and regional buckets. For zonal buckets, it allows switching to MRD for high-performance
+		// rapid and regional buckets. For rapid buckets, it allows switching to MRD for high-performance
 		// random reads. For regional buckets, it helps in adjusting the prefetch window for the range
 		// reader when the read pattern changes.
 		if readReq.ExpectedOffset != gr.readTypeClassifier.NextExpectedOffset() {
@@ -186,7 +186,7 @@ func (gr *GCSReader) read(ctx context.Context, readReq *gcsx.GCSReaderRequest) (
 
 // readerType specifies the go-sdk interface to use for reads.
 func (gr *GCSReader) readerType(readType int64, bucketType gcs.BucketType) ReaderType {
-	if readType == metrics.ReadTypeRandom && bucketType.Zonal {
+	if readType == metrics.ReadTypeRandom && bucketType.IsRapid() {
 		return MultiRangeReaderType
 	}
 	return RangeReaderType

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -476,39 +476,51 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 	}
 }
 
-func (t *gcsReaderTest) Test_ReadAt_MRDShortReadOnZonal() {
-	// Re-initialize GCSReader with initialOffset 1 to force Random read type.
-	t.gcsReader = NewGCSReader(t.object, t.mockBucket, &GCSReaderConfig{
-		MetricHandle:       metrics.NewNoopMetrics(),
-		TraceHandle:        tracing.NewNoopTracer(),
-		MrdWrapper:         nil,
-		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1),
-	})
-	t.object.Size = 200
-	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: true})
-	testContent := testUtil.GenerateRandomBytes(int(t.object.Size))
-	fakeMRDWrapper, err := gcsx.NewMultiRangeDownloaderWrapper(t.mockBucket, t.object, &cfg.Config{}, nil)
-	require.NoError(t.T(), err)
-	t.gcsReader.mrr.mrdWrapper = fakeMRDWrapper
+func (t *gcsReaderTest) Test_ReadAt_ShortReadRetry() {
+	testCases := []struct {
+		name       string
+		bucketType gcs.BucketType
+	}{
+		{
+			name:       "ZonalBucket",
+			bucketType: gcs.BucketType{Zonal: true},
+		},
+		{
+			name:       "PirloBucket",
+			bucketType: gcs.BucketType{Pirlo: true},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.SetupTest()
+			defer t.TearDownTest()
+			// Re-initialize GCSReader with initialOffset 1 to force Random read type.
+			t.gcsReader = NewGCSReader(t.object, t.mockBucket, &GCSReaderConfig{
+				MetricHandle:       metrics.NewNoopMetrics(),
+				TraceHandle:        tracing.NewNoopTracer(),
+				MrdWrapper:         nil,
+				Config:             nil,
+				ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1),
+			})
+			t.object.Size = 200
+			t.mockBucket.On("BucketType", mock.Anything).Return(tc.bucketType)
+			testContent := testUtil.GenerateRandomBytes(int(t.object.Size))
+			fakeMRDWrapper, err := gcsx.NewMultiRangeDownloaderWrapper(t.mockBucket, t.object, &cfg.Config{}, nil)
+			require.NoError(t.T(), err)
+			t.gcsReader.mrr.mrdWrapper = fakeMRDWrapper
+			buf := make([]byte, t.object.Size-1)
+			// Rapid buckets will use MRD and get a short read, then retry and get the full read.
+			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithShortRead(t.object, testContent), nil).Once()
+			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloader(t.object, testContent), nil).Once()
 
-	// First call to NewMultiRangeDownloader will return a short read, which will trigger a retry.
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithShortRead(t.object, testContent), nil).Once()
-	// Second call for retry will return the full content.
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloader(t.object, testContent), nil).Once()
-	buf := make([]byte, t.object.Size-1)
+			readResponse := t.readAt(t.ctx, &gcsx.ReadRequest{Buffer: buf, Offset: 1})
 
-	// Act
-	readResponse := t.readAt(t.ctx, &gcsx.ReadRequest{
-		Buffer: buf,
-		Offset: 1,
-	})
-
-	// Assert
-	assert.Equal(t.T(), int(t.object.Size)-1, readResponse.Size)
-	assert.Equal(t.T(), testContent[1:], buf)
-	assert.Equal(t.T(), int64(t.object.Size), t.gcsReader.readTypeClassifier.NextExpectedOffset())
-	t.mockBucket.AssertExpectations(t.T())
+			assert.Equal(t.T(), int(t.object.Size)-1, readResponse.Size)
+			assert.Equal(t.T(), testContent[1:], buf)
+			assert.Equal(t.T(), int64(t.object.Size), t.gcsReader.readTypeClassifier.NextExpectedOffset())
+			t.mockBucket.AssertExpectations(t.T())
+		})
+	}
 }
 
 func (t *gcsReaderTest) Test_ReadAt_ParallelRandomReads() {

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -28,6 +28,10 @@ type BucketType struct {
 	Pirlo        bool
 }
 
+func (bt BucketType) IsRapid() bool {
+	return bt.Zonal || bt.Pirlo
+}
+
 const (
 	// ReqIdField is the key for the value of
 	// GCS req-id in context.

--- a/internal/storage/gcs/bucket_test.go
+++ b/internal/storage/gcs/bucket_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketType_IsRapid(t *testing.T) {
+	testCases := []struct {
+		name     string
+		zonal    bool
+		pirlo    bool
+		expected bool
+	}{
+		{
+			name:     "Neither Zonal nor Pirlo",
+			zonal:    false,
+			pirlo:    false,
+			expected: false,
+		},
+		{
+			name:     "Only Zonal is true",
+			zonal:    true,
+			pirlo:    false,
+			expected: true,
+		},
+		{
+			name:     "Only Pirlo is true",
+			zonal:    false,
+			pirlo:    true,
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bt := BucketType{
+				Zonal: tc.zonal,
+				Pirlo: tc.pirlo,
+			}
+
+			assert.Equal(t, tc.expected, bt.IsRapid())
+		})
+	}
+}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -427,9 +427,9 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	return
 }
 
-func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, bucketName string, billingProject string) (*storage.Client, error) {
+func (sh *storageClient) getClient(ctx context.Context, isBucketRapid bool, bucketName string, billingProject string) (*storage.Client, error) {
 	var err error
-	if isbucketZonal {
+	if isBucketRapid {
 		if sh.grpcClientWithBidiConfig == nil {
 			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, true, bucketName, billingProject)
 		}
@@ -486,11 +486,11 @@ func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType
 	}
 
 	var controlClientWithoutBillingProject StorageControlClient
-	if bucketType.Zonal || sh.clientConfig.ExperimentalNonrapidFolderApiStallRetry {
+	if bucketType.IsRapid() || sh.clientConfig.ExperimentalNonrapidFolderApiStallRetry {
 		// sh.storageControlClient already contains handling for billing project,
 		// and enhanced retries for GetStorageLayout API call. Extending it here for
 		// retries for folder APIs.
-		// For zonal buckets, wrap the control client with retry-on-all-APIs.
+		// For rapid buckets, wrap the control client with retry-on-all-APIs.
 		controlClientWithoutBillingProject = withRetryOnAllAPIs(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig)
 	} else {
 		// Apply GAX retries to the raw storage control client and returns a copy of it,
@@ -511,7 +511,7 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 		return nil, fmt.Errorf("storageLayout call failed: %s", err)
 	}
 
-	client, err = sh.getClient(ctx, bucketType.Zonal, bucketName, billingProject)
+	client, err = sh.getClient(ctx, bucketType.IsRapid(), bucketName, billingProject)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -203,7 +203,7 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketZonal bool, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -226,7 +226,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
 		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
-		if !isbucketZonal {
+		if !isbucketRapid {
 			return nil, verifyErr
 		}
 	} else {
@@ -431,7 +431,7 @@ func (sh *storageClient) getClient(ctx context.Context, isBucketRapid bool, buck
 	var err error
 	if isBucketRapid {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, true, bucketName, billingProject)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isBucketRapid, true, bucketName, billingProject)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -904,6 +904,7 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 	tests := []struct {
 		name                 string
 		isZonal              bool
+		isPirlo              bool
 		billingProject       string
 		folderAPIStallRetry  bool
 		expectFolderRetries  bool
@@ -919,6 +920,20 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 		{
 			name:                 "ZonalBucket_WithBillingProject",
 			isZonal:              true,
+			billingProject:       "test-project",
+			expectFolderRetries:  true,
+			expectGaxRetriesUsed: false,
+		},
+		{
+			name:                 "PirloBucket_NoBillingProject",
+			isPirlo:              true,
+			billingProject:       "",
+			expectFolderRetries:  true,
+			expectGaxRetriesUsed: false,
+		},
+		{
+			name:                 "PirloBucket_WithBillingProject",
+			isPirlo:              true,
 			billingProject:       "test-project",
 			expectFolderRetries:  true,
 			expectGaxRetriesUsed: false,
@@ -969,7 +984,7 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 				rawStorageControlClientWithGaxRetries:    mockRawControlClientWithRetries,
 				clientConfig:                             clientConfig,
 			}
-			bucketType := &gcs.BucketType{Zonal: tc.isZonal}
+			bucketType := &gcs.BucketType{Zonal: tc.isZonal, Pirlo: tc.isPirlo}
 
 			// Act
 			controlClient := sh.controlClientForBucketHandle(bucketType, tc.billingProject)

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -127,7 +127,7 @@ func validateParam(param Param) error {
 
 	// Validate bucket-based optimizations if present.
 	if param.Optimizations != nil {
-		validBucketTypes := []string{"zonal", "hierarchical", "flat"}
+		validBucketTypes := []string{"zonal", "hierarchical", "flat", "pirlo"}
 		for _, bto := range param.Optimizations.BucketTypeOptimization {
 			if !slices.Contains(validBucketTypes, bto.BucketType) {
 				return fmt.Errorf("invalid bucket-type %q for flag %s; must be one of: %v",

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -201,6 +201,8 @@ params:
           value: false
         - bucket-type: flat
           value: true
+        - bucket-type: pirlo
+          value: true
   - config-path: "file-system.max-read-ahead-kb"
     flag-name: "max-read-ahead-kb"
     type: "int"
@@ -213,6 +215,8 @@ params:
         - bucket-type: hierarchical
           value: 2048
         - bucket-type: flat
+          value: 2048
+        - bucket-type: pirlo
           value: 2048
       machine-based-optimization:
         - group: high-performance
@@ -265,6 +269,7 @@ params:
 				{BucketType: "zonal", Value: true},
 				{BucketType: "hierarchical", Value: false},
 				{BucketType: "flat", Value: true},
+				{BucketType: "pirlo", Value: true},
 			},
 		}
 		assert.Equal(t, "file-system.enable-kernel-reader", param.ConfigPath)
@@ -281,6 +286,7 @@ params:
 				{BucketType: "zonal", Value: 1024},
 				{BucketType: "hierarchical", Value: 2048},
 				{BucketType: "flat", Value: 2048},
+				{BucketType: "pirlo", Value: 2048},
 			},
 			MachineBasedOptimization: []shared.MachineBasedOptimization{
 				{Group: "high-performance", Value: 2048},


### PR DESCRIPTION
### Description
This change implements the read path support for Pirlo buckets by categorizing them as "rapid" buckets, consistent with the treatment of zonal buckets. This classification enables high-performance read features and specialized handling required for these bucket types.

### Link to the issue in case of a bug fix.
b/503161174

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
