### PR TITLE
fix(direct path verification): Updating direct path enforcement strategy

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -59,7 +59,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 10 * time.Second
+	directPathDetectionTimeout          = 15 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )
@@ -205,7 +205,7 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketZonal bool, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -225,12 +225,15 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 	setRetryConfig(ctx, sc, clientConfig)
 
-	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
+	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
 		if status.Code(verifyErr) == codes.DeadlineExceeded {
 			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
 		} else {
 			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
+		}
+		if !isbucketZonal {
+			return nil, verifyErr
 		}
 	} else {
 		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
@@ -251,7 +254,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 
-	verifyCtx, verifyCancel := context.WithTimeout(ctx, time.Millisecond)
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, directPathDetectionTimeout)
 	defer verifyCancel()
 
 	// Retrieving object attrs through Go Storage Client.
@@ -433,13 +436,13 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	var err error
 	if isbucketZonal {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName, billingProject)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, true, bucketName, billingProject)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.GRPC {
-		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, bucketName, billingProject)
+		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, isbucketZonal, bucketName, billingProject)
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.HTTP1 || sh.clientConfig.ClientProtocol == cfg.HTTP2 {
@@ -452,13 +455,13 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	return nil, fmt.Errorf("invalid client-protocol requested: %s", sh.clientConfig.ClientProtocol)
 }
 
-func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, bucketName string, billingProject string) (*storage.Client, error) {
+func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, isbucketZonal bool, bucketName string, billingProject string) (*storage.Client, error) {
 	if sh.grpcClient != nil {
 		return sh.grpcClient, nil
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName, billingProject)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, false, bucketName, billingProject)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -40,9 +40,7 @@ import (
 	"golang.org/x/oauth2"
 	option "google.golang.org/api/option"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 
 	// Side effect to run grpc client with direct-path on gcp machine.
 	_ "google.golang.org/grpc/balancer/rls"
@@ -227,11 +225,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-		if status.Code(verifyErr) == codes.DeadlineExceeded {
-			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
-		} else {
-			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
-		}
+		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
 		if !isbucketZonal {
 			return nil, verifyErr
 		}
@@ -442,7 +436,7 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.GRPC {
-		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, isbucketZonal, bucketName, billingProject)
+		return sh.createNonBidiGRPCClientWithHttpFallback(ctx, bucketName, billingProject)
 	}
 
 	if sh.clientConfig.ClientProtocol == cfg.HTTP1 || sh.clientConfig.ClientProtocol == cfg.HTTP2 {
@@ -455,13 +449,13 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	return nil, fmt.Errorf("invalid client-protocol requested: %s", sh.clientConfig.ClientProtocol)
 }
 
-func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, isbucketZonal bool, bucketName string, billingProject string) (*storage.Client, error) {
+func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Context, bucketName string, billingProject string) (*storage.Client, error) {
 	if sh.grpcClient != nil {
 		return sh.grpcClient, nil
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, false, bucketName, billingProject)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, false, bucketName, billingProject)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil


### PR DESCRIPTION
### Description
Updating the direct path enforcement strategy:
- For zonal buckets, log direct path verification status but do not block client creation on it
- For non-zonal buckets, block grpc client creation on direct path verification status. In case of failure in detecting direct path status, fallback to http client would happen based on the set grpc-strategy

Also, updated the timeout to 15 seconds for direct path verification

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Done

### Any backward incompatible change? If so, please explain.
