### PR TITLE
fix: prevent symlink attack in log file creation

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -51,7 +51,6 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
-	"syscall"
 )
 
 const (
@@ -442,7 +441,7 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 		var stderrFile *os.File
 		if newConfig.Logging.FilePath != "" {
 			stderrFileName := string(newConfig.Logging.FilePath) + ".stderr"
-			if stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0644); err != nil {
+			if stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND|unix.O_NOFOLLOW, 0644); err != nil {
 				return err
 			}
 		}

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
+	"syscall"
 )
 
 const (
@@ -441,7 +442,7 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 		var stderrFile *os.File
 		if newConfig.Logging.FilePath != "" {
 			stderrFileName := string(newConfig.Logging.FilePath) + ".stderr"
-			if stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644); err != nil {
+			if stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND|syscall.O_NOFOLLOW, 0644); err != nil {
 				return err
 			}
 		}

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -498,30 +498,27 @@ func TestMount_StderrNoFollowSymlink(t *testing.T) {
 	logFile := tempDir + "/stderr.log"
 	baseLogPath := tempDir + "/symlink.log"
 	symlinkPath := baseLogPath + ".stderr" // This is the file gcsfuse will try to open
-
 	// Create a dummy log file
 	f, err := os.Create(logFile)
-	assert.NoError(t, err)
-	assert.NoError(t, f.Close())
-
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 	// Create a symlink at the expected stderr file path pointing to the dummy log file
 	err = os.Symlink(logFile, symlinkPath)
-	assert.NoError(t, err)
-
+	require.NoError(t, err)
 	newConfig := &cfg.Config{
 		Logging: cfg.LoggingConfig{
 			FilePath: cfg.ResolvedPath(baseLogPath),
 		},
 		Foreground: false,
 	}
-
 	mountInfo := &mountInfo{
 		config: newConfig,
 	}
 
 	err = Mount(mountInfo, "mybucket", tempDir)
-	assert.Error(t, err)
+
+	require.Error(t, err)
 	// Since os.OpenFile happens *before* daemonize.Run, the error should be returned directly.
 	// We expect "too many levels of symbolic links" to be inside the error string.
-	assert.Contains(t, err.Error(), "too many levels of symbolic links")
+	require.Contains(t, err.Error(), "too many levels of symbolic links")
 }

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -502,7 +502,7 @@ func TestMount_StderrNoFollowSymlink(t *testing.T) {
 	// Create a dummy log file
 	f, err := os.Create(logFile)
 	assert.NoError(t, err)
-	f.Close()
+	assert.NoError(t, f.Close())
 
 	// Create a symlink at the expected stderr file path pointing to the dummy log file
 	err = os.Symlink(logFile, symlinkPath)

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -492,3 +492,36 @@ func (t *MainTest) TestForwardedEnvVars_NotPassedWhenUnset() {
 		assert.NotContains(t.T(), unexpectedForwardedEnvVars, name, "unexpected env var %q was forwarded", name)
 	}
 }
+
+func TestMount_StderrNoFollowSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := tempDir + "/stderr.log"
+	baseLogPath := tempDir + "/symlink.log"
+	symlinkPath := baseLogPath + ".stderr" // This is the file gcsfuse will try to open
+
+	// Create a dummy log file
+	f, err := os.Create(logFile)
+	assert.NoError(t, err)
+	f.Close()
+
+	// Create a symlink at the expected stderr file path pointing to the dummy log file
+	err = os.Symlink(logFile, symlinkPath)
+	assert.NoError(t, err)
+
+	newConfig := &cfg.Config{
+		Logging: cfg.LoggingConfig{
+			FilePath: cfg.ResolvedPath(baseLogPath),
+		},
+		Foreground: false,
+	}
+
+	mountInfo := &mountInfo{
+		config: newConfig,
+	}
+
+	err = Mount(mountInfo, "mybucket", tempDir)
+	assert.Error(t, err)
+	// Since os.OpenFile happens *before* daemonize.Run, the error should be returned directly.
+	// We expect "too many levels of symbolic links" to be inside the error string.
+	assert.Contains(t, err.Error(), "too many levels of symbolic links")
+}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fsutil"
 	"github.com/jacobsa/timeutil"
+	"syscall"
 )
 
 // Mount the file system based on the supplied arguments, returning a
@@ -192,7 +193,7 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 	}
 
 	if newConfig.Logging.WireLog != "" {
-		wireLog, err := os.Create(string(newConfig.Logging.WireLog))
+		wireLog, err := os.OpenFile(string(newConfig.Logging.WireLog), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
 		if err == nil {
 			mountCfg.WireLogger = wireLog
 		} else {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -34,7 +34,7 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fsutil"
 	"github.com/jacobsa/timeutil"
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 // Mount the file system based on the supplied arguments, returning a
@@ -193,7 +193,7 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 	}
 
 	if newConfig.Logging.WireLog != "" {
-		wireLog, err := os.OpenFile(string(newConfig.Logging.WireLog), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
+		wireLog, err := os.OpenFile(string(newConfig.Logging.WireLog), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|unix.O_NOFOLLOW, 0644)
 		if err == nil {
 			mountCfg.WireLogger = wireLog
 		} else {

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -17,6 +17,8 @@ package cmd
 import (
 	"testing"
 
+	"os"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/stretchr/testify/assert"
 )
@@ -147,4 +149,30 @@ func TestGetFuseMountConfig_EnableReaddirplus(t *testing.T) {
 			assert.Equal(t, tc.expectedValue, fuseMountCfg.EnableReaddirplus)
 		})
 	}
+}
+
+func TestGetFuseMountConfig_WireLogNoFollowSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := tempDir + "/wire.log"
+	symlinkPath := tempDir + "/symlink.log"
+
+	// Create a dummy log file
+	f, err := os.Create(logFile)
+	assert.NoError(t, err)
+	f.Close()
+
+	// Create a symlink pointing to the log file
+	err = os.Symlink(logFile, symlinkPath)
+	assert.NoError(t, err)
+
+	newConfig := &cfg.Config{
+		Logging: cfg.LoggingConfig{
+			WireLog: cfg.ResolvedPath(symlinkPath),
+		},
+	}
+
+	// This should fail to create the wire logger because of unix.O_NOFOLLOW
+	fuseMountCfg := getFuseMountConfig("mybucket", newConfig)
+
+	assert.Nil(t, fuseMountCfg.WireLogger)
 }

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -159,7 +159,7 @@ func TestGetFuseMountConfig_WireLogNoFollowSymlink(t *testing.T) {
 	// Create a dummy log file
 	f, err := os.Create(logFile)
 	assert.NoError(t, err)
-	f.Close()
+	assert.NoError(t, f.Close())
 
 	// Create a symlink pointing to the log file
 	err = os.Symlink(logFile, symlinkPath)

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetFuseMountConfig_MountOptionsFormattedCorrectly(t *testing.T) {
@@ -155,16 +156,13 @@ func TestGetFuseMountConfig_WireLogNoFollowSymlink(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := tempDir + "/wire.log"
 	symlinkPath := tempDir + "/symlink.log"
-
 	// Create a dummy log file
 	f, err := os.Create(logFile)
-	assert.NoError(t, err)
-	assert.NoError(t, f.Close())
-
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 	// Create a symlink pointing to the log file
 	err = os.Symlink(logFile, symlinkPath)
-	assert.NoError(t, err)
-
+	require.NoError(t, err)
 	newConfig := &cfg.Config{
 		Logging: cfg.LoggingConfig{
 			WireLog: cfg.ResolvedPath(symlinkPath),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"golang.org/x/sys/unix"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -67,7 +68,7 @@ func InitLogFile(newLogConfig cfg.LoggingConfig, fsName string) error {
 	if newLogConfig.FilePath != "" {
 		f, err = os.OpenFile(
 			string(newLogConfig.FilePath),
-			os.O_WRONLY|os.O_CREATE|os.O_APPEND,
+			os.O_WRONLY|os.O_CREATE|os.O_APPEND|unix.O_NOFOLLOW,
 			0644,
 		)
 		if err != nil {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -577,7 +577,7 @@ func TestInitLogFile_NoFollowSymlink(t *testing.T) {
 	// Create a dummy log file
 	f, err := os.Create(logFile)
 	assert.NoError(t, err)
-	f.Close()
+	assert.NoError(t, f.Close())
 
 	// Create a symlink pointing to the log file
 	err = os.Symlink(logFile, symlinkPath)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 
+	"os"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -565,4 +567,27 @@ func TestGetLogFHandler(t *testing.T) {
 		expectedTraceRegex := expectedLogRegex(t, "text", "TRACE", message)
 		assert.Regexp(t, expectedTraceRegex, logs[1])
 	})
+}
+
+func TestInitLogFile_NoFollowSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := tempDir + "/main.log"
+	symlinkPath := tempDir + "/symlink.log"
+
+	// Create a dummy log file
+	f, err := os.Create(logFile)
+	assert.NoError(t, err)
+	f.Close()
+
+	// Create a symlink pointing to the log file
+	err = os.Symlink(logFile, symlinkPath)
+	assert.NoError(t, err)
+
+	newLogConfig := cfg.LoggingConfig{
+		FilePath: cfg.ResolvedPath(symlinkPath),
+	}
+
+	err = InitLogFile(newLogConfig, "mybucket")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many levels of symbolic links")
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -573,21 +573,19 @@ func TestInitLogFile_NoFollowSymlink(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := tempDir + "/main.log"
 	symlinkPath := tempDir + "/symlink.log"
-
 	// Create a dummy log file
 	f, err := os.Create(logFile)
-	assert.NoError(t, err)
-	assert.NoError(t, f.Close())
-
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 	// Create a symlink pointing to the log file
 	err = os.Symlink(logFile, symlinkPath)
-	assert.NoError(t, err)
-
+	require.NoError(t, err)
 	newLogConfig := cfg.LoggingConfig{
 		FilePath: cfg.ResolvedPath(symlinkPath),
 	}
 
 	err = InitLogFile(newLogConfig, "mybucket")
-	assert.Error(t, err)
+
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too many levels of symbolic links")
 }


### PR DESCRIPTION
This PR fixes a reported symlink attack vulnerability in the `cmd/` package.

Specifically:
- In `cmd/mount.go`, the `--wire-log` file is now opened using `os.OpenFile` with the `syscall.O_NOFOLLOW` flag instead of `os.Create`.
- In `cmd/legacy_main.go`, the daemon `.stderr` log file is opened with the `syscall.O_NOFOLLOW` flag.

This prevents an unprivileged user from triggering arbitrary file overwrites on the host when gcsfuse runs as root, addressing the reported Container-to-Host escape vector.

---
*PR created automatically by Jules for task [451784451141055946](https://jules.google.com/task/451784451141055946) started by @vadlakondaswetha*