### PR TITLE
feat(metrics): Read block size metric gen code and tpl changes

### DIFF
--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -190,7 +190,7 @@ type MetricHandle interface {
 	// GcsRetryCount - The cumulative number of retry requests made to GCS.
 	GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory)
 
-	// ReadBlockSizes - The cumulative distribution of the number of block sizes across different bucket boundaries
+	// ReadBlockSizes - The cumulative distribution of read block sizes across different bucket boundaries
 	ReadBlockSizes(ctx context.Context, value int64)
 
 	// TestUpdownCounter - Test metric for updown counters.

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -190,6 +190,9 @@ type MetricHandle interface {
 	// GcsRetryCount - The cumulative number of retry requests made to GCS.
 	GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory)
 
+	// ReadBlockSizes - The cumulative distribution of the number of block sizes across different bucket boundaries
+	ReadBlockSizes(ctx context.Context, value int64)
+
 	// TestUpdownCounter - Test metric for updown counters.
 	TestUpdownCounter(inc int64)
 

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -236,6 +236,27 @@
     - "OTHER_ERRORS"
     - "STALLED_READ_REQUEST"
 
+- metric-name: "read/block_sizes"
+  description: "The cumulative distribution of the number of block sizes across different bucket boundaries"
+  type: "int_histogram"
+  unit: "By"
+  boundaries: &bytes_boundaries # in bytes
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+  - 262144
+  - 524288
+  - 1048576
+  - 2097152
+  - 4194304
+  - 8388608
+  - 16777216
+  - 33554432
+  - 67108864
+  - 134217728
+
 - metric-name: "test/updown_counter"
   description: "Test metric for updown counters."
   type: "int_up_down_counter"

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -11,7 +11,7 @@
 - metric-name: "buffered_read/read_latency"
   description: "The cumulative distribution of latencies for ReadAt calls served by the buffered reader."
   unit: "us"
-  type: "int_histogram"
+  type: "time_histogram"
   boundaries: &microseconds_boundaries
   - 50
   - 100
@@ -63,7 +63,7 @@
 
 - metric-name: "file_cache/read_latencies"
   description: "The cumulative distribution of the file cache read latencies along with cache hit - true/false."
-  type: "int_histogram"
+  type: "time_histogram"
   unit: "us"
   boundaries: *microseconds_boundaries
   attributes:
@@ -132,7 +132,7 @@
 
 - metric-name: "fs/ops_latency"
   description: "The cumulative distribution of file system operation latencies"
-  type: "int_histogram"
+  type: "time_histogram"
   unit: "us"
   boundaries: *microseconds_boundaries
   attributes:
@@ -205,7 +205,7 @@
 
 - metric-name: "gcs/request_latencies"
   description: "The cumulative distribution of the GCS request latencies."
-  type: "int_histogram"
+  type: "time_histogram"
   unit: "ms"
   boundaries: &millisecond_boundaries
   - 100

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -237,7 +237,7 @@
     - "STALLED_READ_REQUEST"
 
 - metric-name: "read/block_sizes"
-  description: "The cumulative distribution of the number of block sizes across different bucket boundaries"
+  description: "The cumulative distribution of read block sizes across different bucket boundaries"
   type: "int_histogram"
   unit: "By"
   boundaries: &bytes_boundaries # in bytes

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -54,6 +54,8 @@ func (*noopMetrics) GcsRequestLatencies(ctx context.Context, latency time.Durati
 
 func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory) {}
 
+func (*noopMetrics) ReadBlockSizes(ctx context.Context, value int64) {}
+
 func (*noopMetrics) TestUpdownCounter(inc int64) {}
 
 func (*noopMetrics) TestUpdownCounterWithAttrs(inc int64, requestType RequestType) {}

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -3474,7 +3474,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		}))
 
 	readBlockSizes, err15 := meter.Int64Histogram("read/block_sizes",
-		metric.WithDescription("The cumulative distribution of the number of block sizes across different bucket boundaries"),
+		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -1041,6 +1041,7 @@ type otelMetrics struct {
 	fileCacheReadLatencies                                                             metric.Int64Histogram
 	fsOpsLatency                                                                       metric.Int64Histogram
 	gcsRequestLatencies                                                                metric.Int64Histogram
+	readBlockSizes                                                                     metric.Int64Histogram
 }
 
 func (o *otelMetrics) BufferedReadFallbackTriggerCount(
@@ -1062,8 +1063,7 @@ func (o *otelMetrics) BufferedReadFallbackTriggerCount(
 
 func (o *otelMetrics) BufferedReadReadLatency(
 	ctx context.Context, latency time.Duration) {
-	var record histogramRecord
-	record = histogramRecord{ctx: ctx, instrument: o.bufferedReadReadLatency, value: latency.Microseconds()}
+	record := histogramRecord{ctx: ctx, instrument: o.bufferedReadReadLatency, value: latency.Microseconds()}
 
 	select {
 	case o.ch <- record: // Do nothing
@@ -2372,6 +2372,16 @@ func (o *otelMetrics) GcsRetryCount(
 	}
 }
 
+func (o *otelMetrics) ReadBlockSizes(
+	ctx context.Context, value int64) {
+	record := histogramRecord{ctx: ctx, instrument: o.readBlockSizes, value: value}
+
+	select {
+	case o.ch <- record: // Do nothing
+	default: // Unblock writes to channel if it's full.
+	}
+}
+
 func (o *otelMetrics) TestUpdownCounter(
 	inc int64) {
 	o.testUpdownCounterAtomic.Add(inc)
@@ -3463,7 +3473,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err15 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	readBlockSizes, err15 := meter.Int64Histogram("read/block_sizes",
+		metric.WithDescription("The cumulative distribution of the number of block sizes across different bucket boundaries"),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
+
+	_, err16 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3471,7 +3486,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err16 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err17 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3480,7 +3495,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -3963,9 +3978,10 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsRequestLatencies:                                        gcsRequestLatencies,
 		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:           &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
 		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:    &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
-		testUpdownCounterAtomic:                                    &testUpdownCounterAtomic,
-		testUpdownCounterWithAttrsRequestTypeAttr1Atomic:           &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,
-		testUpdownCounterWithAttrsRequestTypeAttr2Atomic:           &testUpdownCounterWithAttrsRequestTypeAttr2Atomic,
+		readBlockSizes:          readBlockSizes,
+		testUpdownCounterAtomic: &testUpdownCounterAtomic,
+		testUpdownCounterWithAttrsRequestTypeAttr1Atomic: &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,
+		testUpdownCounterWithAttrsRequestTypeAttr2Atomic: &testUpdownCounterWithAttrsRequestTypeAttr2Atomic,
 	}, nil
 }
 

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -219,7 +219,7 @@ func TestBufferedReadReadLatency(t *testing.T) {
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 	assert.Equal(t, uint64(len(latencies)), dp.Count)
-	assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
+	assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
 }
 
 func TestFileCacheReadBytesCount(t *testing.T) {
@@ -475,7 +475,7 @@ func TestFileCacheReadLatencies(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
+			assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
 		})
 	}
 }
@@ -4565,7 +4565,7 @@ func TestFsOpsLatency(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
+			assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
 		})
 	}
 }
@@ -5188,7 +5188,7 @@ func TestGcsRequestLatencies(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, int64(totalLatency.Milliseconds()), dp.Sum)
+			assert.Equal(t, totalLatency.Milliseconds(), dp.Sum)
 		})
 	}
 }

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -219,7 +219,7 @@ func TestBufferedReadReadLatency(t *testing.T) {
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 	assert.Equal(t, uint64(len(latencies)), dp.Count)
-	assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
+	assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
 }
 
 func TestFileCacheReadBytesCount(t *testing.T) {
@@ -475,7 +475,7 @@ func TestFileCacheReadLatencies(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
+			assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
 		})
 	}
 }
@@ -4565,7 +4565,7 @@ func TestFsOpsLatency(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, totalLatency.Microseconds(), dp.Sum)
+			assert.Equal(t, int64(totalLatency.Microseconds()), dp.Sum)
 		})
 	}
 }
@@ -5188,7 +5188,7 @@ func TestGcsRequestLatencies(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, totalLatency.Milliseconds(), dp.Sum)
+			assert.Equal(t, int64(totalLatency.Milliseconds()), dp.Sum)
 		})
 	}
 }

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -5262,6 +5262,31 @@ func TestGcsRetryCount(t *testing.T) {
 	}
 }
 
+func TestReadBlockSizes(t *testing.T) {
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
+	var totalValue int64
+	values := []int64{100, 200}
+
+	for _, value := range values {
+		m.ReadBlockSizes(ctx, value)
+		totalValue += value
+	}
+	waitForMetricsProcessing()
+
+	metrics := gatherHistogramMetrics(ctx, t, rd)
+	metric, ok := metrics["read/block_sizes"]
+	require.True(t, ok, "read/block_sizes metric not found")
+
+	s := attribute.NewSet()
+	expectedKey := s.Encoded(encoder)
+	dp, ok := metric[expectedKey]
+	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
+	assert.Equal(t, uint64(len(values)), dp.Count)
+	assert.Equal(t, totalValue, dp.Sum)
+}
+
 func TestTestUpdownCounter(t *testing.T) {
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -70,20 +70,18 @@ type TemplateData struct {
 
 // Helper functions for the template.
 var funcMap = template.FuncMap{
-	"toPascal":         toPascal,
-	"toCamel":          toCamel,
-	"getVarName":       getVarName,
-	"getAtomicName":    getAtomicName,
-	"getGoType":        getGoType,
-	"getAttrConstName": getAttrConstName,
-	"getUnitMethod":    getUnitMethod,
-	"joinInts":         joinInts,
-	"isCounter":        func(m Metric) bool { return m.Type == "int_counter" },
-	"isUpDownCounter":  func(m Metric) bool { return m.Type == "int_up_down_counter" },
-	"isHistogram":      func(m Metric) bool { return m.Type == "int_histogram" },
-	"isTimeHistogram": func(m Metric) bool {
-		return m.Type == "int_histogram" && (m.Unit == "us" || m.Unit == "ms" || m.Unit == "s")
-	},
+	"toPascal":                    toPascal,
+	"toCamel":                     toCamel,
+	"getVarName":                  getVarName,
+	"getAtomicName":               getAtomicName,
+	"getGoType":                   getGoType,
+	"getAttrConstName":            getAttrConstName,
+	"getUnitMethod":               getUnitMethod,
+	"joinInts":                    joinInts,
+	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
+	"isUpDownCounter":             func(m Metric) bool { return m.Type == "int_up_down_counter" },
+	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" },
+	"isTimeHistogram":             isTimeHistogram,
 	"buildSwitches":               buildSwitches,
 	"getTestName":                 getTestName,
 	"getTestFuncArgs":             getTestFuncArgs,
@@ -160,6 +158,10 @@ func getUnitMethod(unit string) string {
 		// Assumes the value is already in the correct unit if not time-based.
 		return ""
 	}
+}
+
+func isTimeHistogram(m Metric) bool {
+	return m.Type == "int_histogram" && (m.Unit == "us" || m.Unit == "ms" || m.Unit == "s")
 }
 
 func joinInts(nums []int64) string {
@@ -397,10 +399,14 @@ func buildSwitches(metric Metric) string {
 				varName := getVarName(metric.Name, combo)
 				unitMethod := getUnitMethod(metric.Unit)
 				valVar := "latency"
-				if unitMethod == "" && metric.Unit != "us" && metric.Unit != "ms" && metric.Unit != "s" {
+				if unitMethod == "" {
 					valVar = "value"
 				}
-				fmt.Fprintf(&builder, "%srecord = histogramRecord{ctx: ctx, instrument: o.%s, value: %s%s, attributes: %s}\n", indent, toCamel(metric.Name), valVar, unitMethod, varName)
+				valueStr := fmt.Sprintf("%s%s", valVar, unitMethod)
+				if metric.Unit == "s" {
+					valueStr = fmt.Sprintf("int64(%s)", valueStr)
+				}
+				fmt.Fprintf(&builder, "%srecord = histogramRecord{ctx: ctx, instrument: o.%s, value: %s, attributes: %s}\n", indent, toCamel(metric.Name), valueStr, varName)
 			}
 			return
 		}
@@ -436,10 +442,14 @@ func buildSwitches(metric Metric) string {
 		if metric.Type == "int_histogram" {
 			unitMethod := getUnitMethod(metric.Unit)
 			valVar := "latency"
-			if unitMethod == "" && metric.Unit != "us" && metric.Unit != "ms" && metric.Unit != "s" {
+			if unitMethod == "" {
 				valVar = "value"
 			}
-			fmt.Fprintf(&builder, "\trecord := histogramRecord{ctx: ctx, instrument: o.%s, value: %s%s}\n", toCamel(metric.Name), valVar, unitMethod)
+			valueStr := fmt.Sprintf("%s%s", valVar, unitMethod)
+			if metric.Unit == "s" {
+				valueStr = fmt.Sprintf("int64(%s)", valueStr)
+			}
+			fmt.Fprintf(&builder, "\trecord := histogramRecord{ctx: ctx, instrument: o.%s, value: %s}\n", toCamel(metric.Name), valueStr)
 		} else if metric.Type == "int_counter" || metric.Type == "int_up_down_counter" {
 			atomicName := getAtomicName(metric.Name, AttrCombination{})
 			fmt.Fprintf(&builder, "\to.%s.Add(inc)\n", atomicName)

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -70,17 +70,20 @@ type TemplateData struct {
 
 // Helper functions for the template.
 var funcMap = template.FuncMap{
-	"toPascal":                    toPascal,
-	"toCamel":                     toCamel,
-	"getVarName":                  getVarName,
-	"getAtomicName":               getAtomicName,
-	"getGoType":                   getGoType,
-	"getAttrConstName":            getAttrConstName,
-	"getUnitMethod":               getUnitMethod,
-	"joinInts":                    joinInts,
-	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
-	"isUpDownCounter":             func(m Metric) bool { return m.Type == "int_up_down_counter" },
-	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" },
+	"toPascal":         toPascal,
+	"toCamel":          toCamel,
+	"getVarName":       getVarName,
+	"getAtomicName":    getAtomicName,
+	"getGoType":        getGoType,
+	"getAttrConstName": getAttrConstName,
+	"getUnitMethod":    getUnitMethod,
+	"joinInts":         joinInts,
+	"isCounter":        func(m Metric) bool { return m.Type == "int_counter" },
+	"isUpDownCounter":  func(m Metric) bool { return m.Type == "int_up_down_counter" },
+	"isHistogram":      func(m Metric) bool { return m.Type == "int_histogram" },
+	"isTimeHistogram": func(m Metric) bool {
+		return m.Type == "int_histogram" && (m.Unit == "us" || m.Unit == "ms" || m.Unit == "s")
+	},
 	"buildSwitches":               buildSwitches,
 	"getTestName":                 getTestName,
 	"getTestFuncArgs":             getTestFuncArgs,
@@ -263,9 +266,9 @@ func generateCombinations(attributes []Attribute) []AttrCombination {
 }
 
 func handleDefaultInSwitchCase(level int, attrName string, builder *strings.Builder) {
-	builder.WriteString(fmt.Sprintf("%sdefault:\n", strings.Repeat("\t", level+2)))
-	builder.WriteString(fmt.Sprintf("%supdateUnrecognizedAttribute(string(%s))\n", strings.Repeat("\t", level+3), toCamel(attrName)))
-	builder.WriteString(fmt.Sprintf("%sreturn\n", strings.Repeat("\t", level+3)))
+	fmt.Fprintf(builder, "%sdefault:\n", strings.Repeat("\t", level+2))
+	fmt.Fprintf(builder, "%supdateUnrecognizedAttribute(string(%s))\n", strings.Repeat("\t", level+3), toCamel(attrName))
+	fmt.Fprintf(builder, "%sreturn\n", strings.Repeat("\t", level+3))
 }
 
 func validateMetric(m Metric) error {
@@ -389,18 +392,22 @@ func buildSwitches(metric Metric) string {
 			indent := strings.Repeat("\t", level+1)
 			if metric.Type == "int_counter" || metric.Type == "int_up_down_counter" {
 				atomicName := getAtomicName(metric.Name, combo)
-				builder.WriteString(fmt.Sprintf("%so.%s.Add(inc)\n", indent, atomicName))
+				fmt.Fprintf(&builder, "%so.%s.Add(inc)\n", indent, atomicName)
 			} else { // histogram
 				varName := getVarName(metric.Name, combo)
 				unitMethod := getUnitMethod(metric.Unit)
-				builder.WriteString(fmt.Sprintf("%srecord = histogramRecord{ctx: ctx,instrument: o.%s, value: latency%s, attributes: %s}\n", indent, toCamel(metric.Name), unitMethod, varName))
+				valVar := "latency"
+				if unitMethod == "" && metric.Unit != "us" && metric.Unit != "ms" && metric.Unit != "s" {
+					valVar = "value"
+				}
+				fmt.Fprintf(&builder, "%srecord = histogramRecord{ctx: ctx, instrument: o.%s, value: %s%s, attributes: %s}\n", indent, toCamel(metric.Name), valVar, unitMethod, varName)
 			}
 			return
 		}
 
 		attr := metric.Attributes[level]
 		indent := strings.Repeat("\t", level+1)
-		builder.WriteString(fmt.Sprintf("%sswitch %s {\n", indent, toCamel(attr.Name)))
+		fmt.Fprintf(&builder, "%sswitch %s {\n", indent, toCamel(attr.Name))
 
 		var values []string
 		isBool := attr.Type == "bool"
@@ -415,25 +422,32 @@ func buildSwitches(metric Metric) string {
 			if !isBool {
 				caseVal = getAttrConstName(attr.Type, val)
 			}
-			builder.WriteString(fmt.Sprintf("%scase %s:\n", strings.Repeat("\t", level+2), caseVal))
+			fmt.Fprintf(&builder, "%scase %s:\n", strings.Repeat("\t", level+2), caseVal)
 			currentCombo := append(combo, AttrValuePair{Name: attr.Name, Type: attr.Type, Value: val})
 			recorder(level+1, currentCombo)
 		}
 		if !isBool {
 			handleDefaultInSwitchCase(level, attr.Name, &builder)
 		}
-		builder.WriteString(fmt.Sprintf("%s}\n", indent))
+		fmt.Fprintf(&builder, "%s}\n", indent)
 	}
 
 	if len(metric.Attributes) == 0 {
 		if metric.Type == "int_histogram" {
 			unitMethod := getUnitMethod(metric.Unit)
-			builder.WriteString(fmt.Sprintf("\trecord = histogramRecord{ctx: ctx, instrument: o.%s, value: latency%s}\n", toCamel(metric.Name), unitMethod))
+			valVar := "latency"
+			if unitMethod == "" && metric.Unit != "us" && metric.Unit != "ms" && metric.Unit != "s" {
+				valVar = "value"
+			}
+			fmt.Fprintf(&builder, "\trecord := histogramRecord{ctx: ctx, instrument: o.%s, value: %s%s}\n", toCamel(metric.Name), valVar, unitMethod)
 		} else if metric.Type == "int_counter" || metric.Type == "int_up_down_counter" {
 			atomicName := getAtomicName(metric.Name, AttrCombination{})
-			builder.WriteString(fmt.Sprintf("\to.%s.Add(inc)\n", atomicName))
+			fmt.Fprintf(&builder, "\to.%s.Add(inc)\n", atomicName)
 		}
 	} else {
+		if metric.Type == "int_histogram" {
+			builder.WriteString("\tvar record histogramRecord\n")
+		}
 		recorder(0, AttrCombination{})
 	}
 

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -80,7 +80,7 @@ var funcMap = template.FuncMap{
 	"joinInts":                    joinInts,
 	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
 	"isUpDownCounter":             func(m Metric) bool { return m.Type == "int_up_down_counter" },
-	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" },
+	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" || m.Type == "time_histogram" },
 	"isTimeHistogram":             isTimeHistogram,
 	"buildSwitches":               buildSwitches,
 	"getTestName":                 getTestName,
@@ -161,7 +161,7 @@ func getUnitMethod(unit string) string {
 }
 
 func isTimeHistogram(m Metric) bool {
-	return m.Type == "int_histogram" && (m.Unit == "us" || m.Unit == "ms" || m.Unit == "s")
+	return m.Type == "time_histogram"
 }
 
 func joinInts(nums []int64) string {
@@ -280,11 +280,11 @@ func validateMetric(m Metric) error {
 	if m.Description == "" {
 		return fmt.Errorf("description is required for metric %q", m.Name)
 	}
-	if m.Type != "int_counter" && m.Type != "int_histogram" && m.Type != "int_up_down_counter" {
-		return fmt.Errorf("type for metric %q must be 'int_counter', 'int_histogram', or 'int_up_down_counter', got %q", m.Name, m.Type)
+	if m.Type != "int_counter" && m.Type != "int_histogram" && m.Type != "time_histogram" && m.Type != "int_up_down_counter" {
+		return fmt.Errorf("type for metric %q must be 'int_counter', 'int_histogram', 'time_histogram', or 'int_up_down_counter', got %q", m.Name, m.Type)
 	}
 
-	if m.Type == "int_histogram" {
+	if m.Type == "int_histogram" || m.Type == "time_histogram" {
 		if len(m.Boundaries) == 0 {
 			return fmt.Errorf("boundaries are required for histogram metric %q", m.Name)
 		}
@@ -439,7 +439,7 @@ func buildSwitches(metric Metric) string {
 	}
 
 	if len(metric.Attributes) == 0 {
-		if metric.Type == "int_histogram" {
+		if metric.Type == "int_histogram" || metric.Type == "time_histogram" {
 			unitMethod := getUnitMethod(metric.Unit)
 			valVar := "latency"
 			if unitMethod == "" {
@@ -455,7 +455,7 @@ func buildSwitches(metric Metric) string {
 			fmt.Fprintf(&builder, "\to.%s.Add(inc)\n", atomicName)
 		}
 	} else {
-		if metric.Type == "int_histogram" {
+		if metric.Type == "int_histogram" || metric.Type == "time_histogram" {
 			builder.WriteString("\tvar record histogramRecord\n")
 		}
 		recorder(0, AttrCombination{})

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -81,7 +81,7 @@ var funcMap = template.FuncMap{
 	"isCounter":                   func(m Metric) bool { return m.Type == "int_counter" },
 	"isUpDownCounter":             func(m Metric) bool { return m.Type == "int_up_down_counter" },
 	"isHistogram":                 func(m Metric) bool { return m.Type == "int_histogram" || m.Type == "time_histogram" },
-	"isTimeHistogram":             isTimeHistogram,
+	"isTimeHistogram":             func(m Metric) bool { return m.Type == "time_histogram" },
 	"buildSwitches":               buildSwitches,
 	"getTestName":                 getTestName,
 	"getTestFuncArgs":             getTestFuncArgs,
@@ -158,10 +158,6 @@ func getUnitMethod(unit string) string {
 		// Assumes the value is already in the correct unit if not time-based.
 		return ""
 	}
-}
-
-func isTimeHistogram(m Metric) bool {
-	return m.Type == "time_histogram"
 }
 
 func joinInts(nums []int64) string {

--- a/tools/metrics-gen/main.go
+++ b/tools/metrics-gen/main.go
@@ -439,7 +439,8 @@ func buildSwitches(metric Metric) string {
 	}
 
 	if len(metric.Attributes) == 0 {
-		if metric.Type == "int_histogram" || metric.Type == "time_histogram" {
+		switch metric.Type {
+		case "int_histogram", "time_histogram":
 			unitMethod := getUnitMethod(metric.Unit)
 			valVar := "latency"
 			if unitMethod == "" {
@@ -450,7 +451,7 @@ func buildSwitches(metric Metric) string {
 				valueStr = fmt.Sprintf("int64(%s)", valueStr)
 			}
 			fmt.Fprintf(&builder, "\trecord := histogramRecord{ctx: ctx, instrument: o.%s, value: %s}\n", toCamel(metric.Name), valueStr)
-		} else if metric.Type == "int_counter" || metric.Type == "int_up_down_counter" {
+		case "int_counter", "int_up_down_counter":
 			atomicName := getAtomicName(metric.Name, AttrCombination{})
 			fmt.Fprintf(&builder, "\to.%s.Add(inc)\n", atomicName)
 		}

--- a/tools/metrics-gen/metric_handle.tpl
+++ b/tools/metrics-gen/metric_handle.tpl
@@ -41,7 +41,7 @@ type MetricHandle interface {
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, latency time.Duration
+			ctx context.Context, {{if isTimeHistogram .}}latency time.Duration{{else}}value int64{{end}}
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/noop_metrics.tpl
+++ b/tools/metrics-gen/noop_metrics.tpl
@@ -26,7 +26,7 @@ type noopMetrics struct {}
 		{{- if or (isCounter .) (isUpDownCounter .) -}}
 			inc int64
 		{{- else -}}
-			ctx context.Context, latency time.Duration
+			ctx context.Context, {{if isTimeHistogram .}}latency time.Duration{{else}}value int64{{end}}
 		{{- end }}
 		{{- if .Attributes}}, {{end}}
 		{{- range $i, $attr := .Attributes -}}

--- a/tools/metrics-gen/otel_metrics.tpl
+++ b/tools/metrics-gen/otel_metrics.tpl
@@ -75,7 +75,7 @@ func (o *otelMetrics) {{toPascal .Name}}(
 	{{- if or (isCounter .) (isUpDownCounter .)}}
 		inc int64
 	{{- else }}
-		ctx context.Context, latency time.Duration
+		ctx context.Context, {{if isTimeHistogram .}}latency time.Duration{{else}}value int64{{end}}
 	{{- end }}
 	{{- if .Attributes}}, {{end}}
 	{{- range $i, $attr := .Attributes -}}
@@ -90,7 +90,6 @@ func (o *otelMetrics) {{toPascal .Name}}(
 	{{- end}}
 	{{buildSwitches .}}
 {{- else }}
-	var record histogramRecord
 	{{buildSwitches .}}
 	select {
 	  case o.ch <- record: // Do nothing

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -232,7 +232,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	{{- if .Attributes}}
 	tests := []struct {
 		name      string
-		latencies []time.Duration
+		{{if isTimeHistogram .}}latencies []time.Duration{{else}}values []int64{{end}}
 		{{- range .Attributes}}
 		{{toCamel .Name}} {{getGoType .Type}}
 		{{- end}}
@@ -241,7 +241,11 @@ func Test{{toPascal .Name}}(t *testing.T) {
 		{{- range $combination := (index $.AttrCombinations $metric.Name)}}
 		{
 			name:      "{{getTestName $combination}}",
+			{{if isTimeHistogram $metric -}}
 			latencies: []time.Duration{100 * time.{{getLatencyUnit $metric.Unit}}, 200 * time.{{getLatencyUnit $metric.Unit}}},
+			{{- else -}}
+			values: []int64{100, 200},
+			{{- end}}
 			{{- range $pair := $combination}}
 			{{toCamel $pair.Name}}: {{if eq $pair.Type "bool"}}{{$pair.Value}}{{else}}"{{$pair.Value}}"{{end}},
 			{{- end}}
@@ -254,12 +258,21 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			ctx := context.Background()
 			encoder := attribute.DefaultEncoder()
 			m, rd := setupOTel(ctx, t)
+			{{if isTimeHistogram . -}}
 			var totalLatency time.Duration
 
 			for _, latency := range tc.latencies {
 				m.{{toPascal .Name}}(ctx, latency, {{getTestFuncArgsForHistogram "tc" .Attributes}})
 				totalLatency += latency
 			}
+			{{- else -}}
+			var totalValue int64
+
+			for _, value := range tc.values {
+				m.{{toPascal .Name}}(ctx, value, {{getTestFuncArgsForHistogram "tc" .Attributes}})
+				totalValue += value
+			}
+			{{- end}}
 			waitForMetricsProcessing()
 
 			metrics := gatherHistogramMetrics(ctx, t, rd)
@@ -275,14 +288,15 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			expectedKey := s.Encoded(encoder)
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
-			assert.Equal(t, uint64(len(tc.latencies)), dp.Count)
-			assert.Equal(t, totalLatency.{{getLatencyMethod .Unit}}(), dp.Sum)
+			assert.Equal(t, uint64(len(tc.{{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
+			assert.Equal(t, {{if isTimeHistogram .}}totalLatency.{{getLatencyMethod .Unit}}(){{else}}totalValue{{end}}, dp.Sum)
 		})
 	}
 	{{- else}}
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()
 	m, rd := setupOTel(ctx, t)
+	{{if isTimeHistogram . -}}
 	var totalLatency time.Duration
 	latencies := []time.Duration{100 * time.{{getLatencyUnit .Unit}}, 200 * time.{{getLatencyUnit .Unit}}}
 
@@ -290,6 +304,15 @@ func Test{{toPascal .Name}}(t *testing.T) {
 		m.{{toPascal .Name}}(ctx, latency)
 		totalLatency += latency
 	}
+	{{- else -}}
+	var totalValue int64
+	values := []int64{100, 200}
+
+	for _, value := range values {
+		m.{{toPascal .Name}}(ctx, value)
+		totalValue += value
+	}
+	{{- end}}
 	waitForMetricsProcessing()
 
 	metrics := gatherHistogramMetrics(ctx, t, rd)
@@ -300,8 +323,8 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	expectedKey := s.Encoded(encoder)
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
-	assert.Equal(t, uint64(len(latencies)), dp.Count)
-	assert.Equal(t, totalLatency.{{getLatencyMethod .Unit}}(), dp.Sum)
+	assert.Equal(t, uint64(len({{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
+	assert.Equal(t, {{if isTimeHistogram .}}totalLatency.{{getLatencyMethod .Unit}}(){{else}}totalValue{{end}}, dp.Sum)
 	{{- end}}
 }
 {{end}}

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -289,7 +289,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.{{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
-			assert.Equal(t, {{if isTimeHistogram .}}totalLatency.{{getLatencyMethod .Unit}}(){{else}}totalValue{{end}}, dp.Sum)
+			assert.Equal(t, {{if isTimeHistogram .}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalValue{{end}}, dp.Sum)
 		})
 	}
 	{{- else}}
@@ -324,7 +324,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 	assert.Equal(t, uint64(len({{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
-	assert.Equal(t, {{if isTimeHistogram .}}totalLatency.{{getLatencyMethod .Unit}}(){{else}}totalValue{{end}}, dp.Sum)
+	assert.Equal(t, {{if isTimeHistogram .}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalValue{{end}}, dp.Sum)
 	{{- end}}
 }
 {{end}}

--- a/tools/metrics-gen/otel_metrics_test.tpl
+++ b/tools/metrics-gen/otel_metrics_test.tpl
@@ -289,7 +289,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 			dp, ok := metric[expectedKey]
 			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 			assert.Equal(t, uint64(len(tc.{{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
-			assert.Equal(t, {{if isTimeHistogram .}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalValue{{end}}, dp.Sum)
+			assert.Equal(t, {{if isTimeHistogram .}}{{if eq .Unit "s"}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalLatency.{{getLatencyMethod .Unit}}(){{end}}{{else}}totalValue{{end}}, dp.Sum)
 		})
 	}
 	{{- else}}
@@ -324,7 +324,7 @@ func Test{{toPascal .Name}}(t *testing.T) {
 	dp, ok := metric[expectedKey]
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 	assert.Equal(t, uint64(len({{if isTimeHistogram .}}latencies{{else}}values{{end}})), dp.Count)
-	assert.Equal(t, {{if isTimeHistogram .}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalValue{{end}}, dp.Sum)
+	assert.Equal(t, {{if isTimeHistogram .}}{{if eq .Unit "s"}}int64(totalLatency.{{getLatencyMethod .Unit}}()){{else}}totalLatency.{{getLatencyMethod .Unit}}(){{end}}{{else}}totalValue{{end}}, dp.Sum)
 	{{- end}}
 }
 {{end}}


### PR DESCRIPTION
### Description
Adding the metric gen code for read/block_sizes metric.
This is a histogram metric and the details for the metric are available in metrics.yaml .

### Link to the issue in case of a bug fix.
b/504892196

### Testing details
1. Manual - NA
2. Unit tests - Auto generated unittests have been added and need to pass.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A