### PR TITLE
feat(native retries): Add hidden enable-native-retries flag for GKE native mount retries

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -636,6 +636,8 @@ type GcsRetriesConfig struct {
 
 	ChunkTransferTimeoutSecs int64 `yaml:"chunk-transfer-timeout-secs"`
 
+	EnableMountRetries bool `yaml:"enable-mount-retries"`
+
 	ExperimentalNonrapidFolderApiStallRetry bool `yaml:"experimental-nonrapid-folder-api-stall-retry"`
 
 	MaxRetryAttempts int64 `yaml:"max-retry-attempts"`
@@ -984,6 +986,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.BoolP("enable-metadata-prefetch", "", false, "Enables background prefetching of object metadata when a directory is first opened.  This reduces latency for subsequent file lookups by pre-filling the metadata cache.")
+
+	flagSet.BoolP("enable-mount-retries", "", false, "If true, enables retry logic in GCSFuse during the mount sequence  for additional errors (such as metadata server readiness delays, IAM propagation  delays, and temporary bucket non-existence). Intended specifically for the  GKE GCSFuse CSI Driver.")
+
+	if err := flagSet.MarkHidden("enable-mount-retries"); err != nil {
+		return err
+	}
 
 	flagSet.BoolP("enable-new-reader", "", true, "Enables support for new reader implementation.")
 
@@ -1589,6 +1597,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metadata-cache.enable-metadata-prefetch", flagSet.Lookup("enable-metadata-prefetch")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-retries.enable-mount-retries", flagSet.Lookup("enable-mount-retries")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -721,6 +721,17 @@ params:
     default: "10"
     hide-flag: true
 
+  - config-path: "gcs-retries.enable-mount-retries"
+    flag-name: "enable-mount-retries"
+    type: "bool"
+    usage: >-
+      If true, enables retry logic in GCSFuse during the mount sequence 
+      for additional errors (such as metadata server readiness delays, IAM propagation 
+      delays, and temporary bucket non-existence). Intended specifically for the 
+      GKE GCSFuse CSI Driver.
+    default: false
+    hide-flag: true
+
   - config-path: "gcs-retries.experimental-nonrapid-folder-api-stall-retry"
     flag-name: "experimental-nonrapid-folder-api-stall-retry"
     type: "bool"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -835,6 +835,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   120,
 					ChunkTransferTimeoutSecs: 10,
+					EnableMountRetries:       false,
 					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
@@ -857,6 +858,7 @@ func TestValidateConfigFile_GCSRetries(t *testing.T) {
 					ExperimentalNonrapidFolderApiStallRetry: true,
 					ChunkRetryDeadlineSecs:                  180,
 					ChunkTransferTimeoutSecs:                20,
+					EnableMountRetries:                      false,
 					MaxRetryAttempts:                        math.MaxInt,
 					MaxRetrySleep:                           30 * time.Second,
 					Multiplier:                              2,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2103,6 +2103,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   120,
 					ChunkTransferTimeoutSecs: 30,
+					EnableMountRetries:       false,
 					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
@@ -2124,6 +2125,7 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 				GcsRetries: cfg.GcsRetriesConfig{
 					ChunkRetryDeadlineSecs:   360,
 					ChunkTransferTimeoutSecs: 10,
+					EnableMountRetries:       false,
 					MaxRetryAttempts:         math.MaxInt,
 					MaxRetrySleep:            30 * time.Second,
 					Multiplier:               2,
@@ -2146,9 +2148,32 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 					ExperimentalNonrapidFolderApiStallRetry: true,
 					ChunkRetryDeadlineSecs:                  120,
 					ChunkTransferTimeoutSecs:                10,
+					EnableMountRetries:                      false,
 					MaxRetryAttempts:                        math.MaxInt,
 					MaxRetrySleep:                           30 * time.Second,
 					Multiplier:                              2,
+					ReadStall: cfg.ReadStallGcsRetriesConfig{
+						Enable:              true,
+						InitialReqTimeout:   20 * time.Second,
+						MinReqTimeout:       1500 * time.Millisecond,
+						MaxReqTimeout:       1200 * time.Second,
+						ReqIncreaseRate:     15,
+						ReqTargetPercentile: 0.99,
+					},
+				},
+			},
+		},
+		{
+			name: "Test with enable-mount-retries explicitly true",
+			args: []string{"gcsfuse", "--enable-mount-retries=true", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsRetries: cfg.GcsRetriesConfig{
+					ChunkRetryDeadlineSecs:   120,
+					ChunkTransferTimeoutSecs: 10,
+					EnableMountRetries:       true,
+					MaxRetryAttempts:         math.MaxInt,
+					MaxRetrySleep:            30 * time.Second,
+					Multiplier:               2,
 					ReadStall: cfg.ReadStallGcsRetriesConfig{
 						Enable:              true,
 						InitialReqTimeout:   20 * time.Second,


### PR DESCRIPTION
### Description

This PR introduces a new hidden boolean flag, `enable-mount-retries` (default: `false`), to support native GCSFuse mount retries under GKE environments, as described in the GCSFuse X GKE Native Retries design (go/gcsfuse-gke-native-retries).
### Key Changes
1. **Configuration Schema (`cfg/params.yaml`)**:
   - Added `gcs-retries.enable-mount-retries` as a hidden boolean flag under `gcs-retries` section.
   - Defaulted to `false`.
   - Positioned alphabetically to keep parameters sorted in ascending order.
2. **Test Suite Coverage (`cmd/config_validation_test.go` & `cmd/root_test.go`)**:
   - Updated default GCSFuse configuration validation expectations to include `EnableMountRetries: false`.
   - Added a new unit test `"Test with enable-mount-retries explicitly true"` to verify CLI flag parsing works as expected when overridden.

### Link to the issue in case of a bug fix.
b/504517897

### Testing details
1. Manual - NA
2. Unit tests - Added
3. Integration tests - Part of Presubmit

### Any backward incompatible change? If so, please explain.
NONE