### PR TITLE
test: Remove leftover PreconditionErrors config

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1159,7 +1159,6 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 					Gid:                     -1,
 					IgnoreInterrupts:        true,
 					InactiveMrdCacheSize:    1000,
-					PreconditionErrors:      true,
 					Uid:                     -1,
 					ExperimentalEnablePirlo: true,
 				},


### PR DESCRIPTION
### Description
This PR removes the usage of `PreconditionErrors` config from `root_test.go` that was left even after `--preconditon-errors` flag was removed from GCSFuse.

### Link to the issue in case of a bug fix.
b/499886011

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
