### PR TITLE
fix: cleanup preconditionErrors field

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1159,7 +1159,6 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 					Gid:                     -1,
 					IgnoreInterrupts:        true,
 					InactiveMrdCacheSize:    1000,
-					PreconditionErrors:      true,
 					Uid:                     -1,
 					ExperimentalEnablePirlo: true,
 				},


### PR DESCRIPTION
Missed as part of preconditionErrors cleanup