### PR TITLE
fix(tests): disable only_dir for flag_optimizations and inactive_stream_timeout in GKE

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -511,7 +511,6 @@ readdirplus:
 inactive_stream_timeout:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--read-inactive-stream-timeout=1s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
@@ -725,7 +724,6 @@ mounting:
 flag_optimizations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    only_dir: "${ONLY_DIR}"
     configs:
       - run: TestMountFails
         flags:


### PR DESCRIPTION
### Description
This PR removes the `only_dir` field from the `flag_optimizations` and `inactive_stream_timeout` integration test configurations in `tools/integration_tests/test_config.yaml`. 

### Link to the issue in case of a bug fix.
b/505831192

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
None.