### PR TITLE
refactor(inode): remove unused openMode parameter from Write method

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3214,7 +3214,7 @@ func (fs *fileSystem) WriteFile(
 		gcsSynced, err = fh.Write(ctx, op.Data, op.Offset)
 	} else {
 		// Serve the request.
-		gcsSynced, err = in.Write(ctx, op.Data, op.Offset, util.NewOpenMode(util.WriteOnly, 0))
+		gcsSynced, err = in.Write(ctx, op.Data, op.Offset)
 	}
 	if err != nil {
 		return

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -373,7 +373,7 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 // Note that the writes are still done at the inode level.
 // LOCKS_REQUIRED(fh.inode)
 func (fh *FileHandle) Write(ctx context.Context, data []byte, offset int64) (bool, error) {
-	return fh.inode.Write(ctx, data, offset, fh.openMode)
+	return fh.inode.Write(ctx, data, offset)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -600,7 +600,7 @@ func (t *fileTest) Test_ReadWithReadManager_ReadManagerInvalidatedByGenerationCh
 
 	// Now, update the object in GCS, which changes its generation.
 	in.Lock()
-	gcsSynced, err := in.Write(t.ctx, content2, 0, writeMode)
+	gcsSynced, err := in.Write(t.ctx, content2, 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	gcsSynced, err = in.Sync(t.ctx)
@@ -643,7 +643,7 @@ func (t *fileTest) Test_Read_ReaderInvalidatedByGenerationChange() {
 
 	// Now, update the object in GCS, which changes its generation.
 	in.Lock()
-	gcsSynced, err := in.Write(t.ctx, content2, 0, writeMode)
+	gcsSynced, err := in.Write(t.ctx, content2, 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	gcsSynced, err = in.Sync(t.ctx)
@@ -719,7 +719,7 @@ func (t *fileTest) Test_ReadWithMrdKernelReader_NotAuthoritative() {
 	in := createFileInode(t.T(), &zonalBucket, &t.clock, &cfg.Config{FileSystem: cfg.FileSystemConfig{EnableKernelReader: true}}, parent, "test_obj", originalData, false)
 	// Make inode dirty.
 	in.Lock()
-	_, err := in.Write(t.ctx, []byte("dirty"), 0, writeMode) // 5 bytes
+	_, err := in.Write(t.ctx, []byte("dirty"), 0) // 5 bytes
 	in.Unlock()
 	require.NoError(t.T(), err)
 	// After write, content should be "dirtydata".

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -666,8 +666,7 @@ func (f *FileInode) Read(
 func (f *FileInode) Write(
 	ctx context.Context,
 	data []byte,
-	offset int64,
-	openMode util.OpenMode) (bool, error) {
+	offset int64) (bool, error) {
 	if f.bwh != nil {
 		return f.writeUsingBufferedWrites(ctx, data, offset)
 	}

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -199,7 +199,7 @@ func (t *FileMockBucketTest) TestSync_RemoteAppendClobber() {
 	t.createLockedInode(fileName, emptyGCSFile)
 	assert.False(t.T(), t.in.IsLocal())
 	// Dirty the file.
-	_, err := t.in.Write(t.ctx, []byte("data"), 0, util.NewOpenMode(util.WriteOnly, 0))
+	_, err := t.in.Write(t.ctx, []byte("data"), 0)
 	require.NoError(t.T(), err)
 	// Mock StatObject to return same generation but larger size (remote append).
 	// Current size is 0 (emptyGCSFile).
@@ -227,7 +227,7 @@ func (t *FileMockBucketTest) TestSync_GenerationMismatchClobber() {
 	t.createLockedInode(fileName, emptyGCSFile)
 	assert.False(t.T(), t.in.IsLocal())
 	// Dirty the file.
-	_, err := t.in.Write(t.ctx, []byte("data"), 0, util.NewOpenMode(util.WriteOnly, 0))
+	_, err := t.in.Write(t.ctx, []byte("data"), 0)
 	require.NoError(t.T(), err)
 	// Mock StatObject to return different generation.
 	t.bucket.On("StatObject", t.ctx, mock.AnythingOfType("*gcs.StatObjectRequest")).

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -192,7 +192,7 @@ func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnZeroSize
 
 func (t *FileStreamingWritesCommon) TestflushUsingBufferedWriteHandlerOnNonZeroSizeDoesNotRecreatesBwhOnInitAgain() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	err = t.in.flushUsingBufferedWriteHandler(context.Background())
@@ -228,7 +228,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 
 func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritativeReturnsTrueAfterWriteForZonalBuckets() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.True(t.T(), t.in.SourceGenerationIsAuthoritative())
@@ -236,7 +236,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSourceGenerationIsAuthoritative
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsPromotesInodeToNonLocal() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("pizza"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("pizza"), 0)
 	assert.NoError(t.T(), err)
 	require.False(t.T(), gcsSynced)
 
@@ -252,7 +252,7 @@ func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZon
 
 func (t *FileStreamingWritesZonalBucketTest) TestSyncPendingBufferedWritesForZonalBucketsUpdatesSrcSize() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
@@ -278,7 +278,7 @@ func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsTrue
 
 func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWriteForNonZonalBuckets() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -287,7 +287,7 @@ func (t *FileStreamingWritesTest) TestSourceGenerationIsAuthoritativeReturnsFals
 
 func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotPromoteInodeToNonLocal() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -301,7 +301,7 @@ func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucket
 
 func (t *FileStreamingWritesTest) TestSyncPendingBufferedWritesForNonZonalBucketsDoesNotUpdateSrcSize() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("foobar"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), uint64(0), t.in.src.Size)
@@ -343,7 +343,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 			createTime := t.clock.Now()
 			t.clock.AdvanceTime(15 * time.Minute)
 			// Sequential Write at offset 0
-			gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0)
 			require.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
 			require.NotNil(t.T(), t.in.bwh)
@@ -355,7 +355,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesToLocalFileFallBackToTempF
 
 			// Out of order write.
 			mtime := t.clock.Now()
-			gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), tc.offset, WriteMode)
+			gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), tc.offset)
 			require.Nil(t.T(), err)
 			assert.True(t.T(), gcsSynced)
 
@@ -384,7 +384,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 	assert.True(t.T(), t.in.IsLocal())
 	createTime := t.in.mtimeClock.Now()
 	// Out of order write.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 6, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 6)
 	require.Nil(t.T(), err)
 	assert.True(t.T(), gcsSynced)
 	// Ensure bwh cleared and temp file created.
@@ -398,7 +398,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 
 	// Ordered write.
 	mtime := t.clock.Now()
-	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 0, WriteMode)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 0)
 	require.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -421,7 +421,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWriteFollowedByOrderedWrite() {
 
 func (t *FileStreamingWritesTest) TestOutOfOrderWritesOnClobberedFileThrowsError() {
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), t.in.bwh)
 	assert.False(t.T(), gcsSynced)
@@ -430,7 +430,7 @@ func (t *FileStreamingWritesTest) TestOutOfOrderWritesOnClobberedFileThrowsError
 	objWritten, err := storageutil.CreateObject(t.ctx, t.bucket, fileName, []byte("taco"))
 	require.Nil(t.T(), err)
 
-	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 10, WriteMode)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 10)
 
 	require.Error(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -458,7 +458,7 @@ func (t *FileStreamingWritesTest) TestUnlinkLocalFileAfterWrite() {
 	assert.True(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
 	// Write some content.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
 	assert.False(t.T(), gcsSynced)
@@ -476,7 +476,7 @@ func (t *FileStreamingWritesTest) TestUnlinkEmptySyncedFile() {
 	assert.False(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
 	// Write some content to temp file.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0)
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), t.in.bwh)
 	assert.False(t.T(), gcsSynced)
@@ -512,7 +512,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndFlush() {
 			}
 			t.createBufferedWriteHandler()
 			// Write some content to temp file.
-			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0)
 			assert.Nil(t.T(), err)
 			assert.NotNil(t.T(), t.in.bwh)
 			assert.False(t.T(), gcsSynced)
@@ -673,7 +673,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndSync() {
 			}
 			t.createBufferedWriteHandler()
 			// Write some content to temp file.
-			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0)
 			assert.Nil(t.T(), err)
 			assert.NotNil(t.T(), t.in.bwh)
 			assert.False(t.T(), gcsSynced)
@@ -704,7 +704,7 @@ func (t *FileStreamingWritesTest) TestWriteToFileAndSync() {
 func (t *FileStreamingWritesTest) TestSourceGenerationSizeForLocalFileIsReflected() {
 	t.createBufferedWriteHandler()
 	assert.True(t.T(), t.in.IsLocal())
-	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, WriteMode)
+	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0)
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -719,7 +719,7 @@ func (t *FileStreamingWritesTest) TestSourceGenerationSizeForSyncedFileIsReflect
 	t.createInode(emptyGCSFile)
 	assert.False(t.T(), t.in.IsLocal())
 	t.createBufferedWriteHandler()
-	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, WriteMode)
+	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0)
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -733,7 +733,7 @@ func (t *FileStreamingWritesTest) TestTruncateOnFileUsingTempFileDoesNotRecreate
 	t.createBufferedWriteHandler()
 	assert.True(t.T(), t.in.IsLocal())
 	// Out of order write.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 2, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 2)
 	require.Nil(t.T(), err)
 	assert.True(t.T(), gcsSynced)
 	// Ensure bwh cleared and temp file created.
@@ -853,7 +853,7 @@ func (t *FileStreamingWritesTest) TestWriteUsingBufferedWritesFails() {
 		},
 	}
 
-	gcsSynced, err := t.in.Write(context.Background(), []byte("hello"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(context.Background(), []byte("hello"), 0)
 
 	require.Error(t.T(), err)
 	assert.False(t.T(), gcsSynced)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -302,7 +302,7 @@ func (t *FileTest) TestInitialSourceGeneration() {
 }
 
 func (t *FileTest) TestSourceGenerationSizeAfterWriteDoesNotChange() {
-	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0, WriteMode)
+	gcsSynced, err := t.in.Write(context.Background(), []byte(setup.GenerateRandomString(5)), 0)
 	require.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -318,7 +318,7 @@ func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsTrue() {
 }
 
 func (t *FileTest) TestSourceGenerationIsAuthoritativeReturnsFalseAfterWrite() {
-	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("taco"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -329,7 +329,7 @@ func (t *FileTest) TestSyncPendingBufferedWritesReturnsNilAndNoOpForNonStreaming
 	contents, err := storageutil.ReadObject(t.ctx, t.bucket, t.in.Name().GcsObjectName())
 	require.NoError(t.T(), err)
 	assert.Equal(t.T(), t.initialContents, string(contents))
-	gcsSynced, err := t.in.Write(t.ctx, []byte("bar"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("bar"), 0)
 	assert.NoError(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -503,7 +503,7 @@ func (t *FileTest) TestWrite() {
 	assert.Equal(t.T(), "taco", t.initialContents)
 
 	// Overwite a byte.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("p"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("p"), 0)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -511,7 +511,7 @@ func (t *FileTest) TestWrite() {
 	t.clock.AdvanceTime(time.Second)
 	writeTime := t.clock.Now()
 
-	gcsSynced, err = t.in.Write(t.ctx, []byte("burrito"), 4, WriteMode)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("burrito"), 4)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -629,7 +629,7 @@ func (t *FileTest) TestWriteThenSync() {
 			t.clock.AdvanceTime(time.Second)
 			writeTime := t.clock.Now()
 
-			gcsSynced, err := t.in.Write(t.ctx, []byte("p"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("p"), 0)
 			assert.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
 
@@ -707,7 +707,7 @@ func (t *FileTest) TestWriteToLocalFileThenSync() {
 			// Write some content to temp file.
 			t.clock.AdvanceTime(time.Second)
 			writeTime := t.clock.Now()
-			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("tacos"), 0)
 			assert.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
 			t.clock.AdvanceTime(time.Second)
@@ -841,7 +841,7 @@ func (t *FileTest) TestAppendThenSync() {
 			t.clock.AdvanceTime(time.Second)
 			writeTime := t.clock.Now()
 
-			gcsSynced, err := t.in.Write(t.ctx, []byte("burrito"), int64(len("taco")), AppendMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("burrito"), int64(len("taco")))
 			assert.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
 
@@ -911,7 +911,7 @@ func (t *FileTest) TestAppendToUnfinalizedObjInZB() {
 	t.createBufferedWriteHandler(true, AppendMode)
 	assert.NotNil(t.T(), t.in.bwh)
 
-	gcsSynced, err := t.in.Write(t.ctx, []byte("juice"), int64(len(t.initialContents)), AppendMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("juice"), int64(len(t.initialContents)))
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -1101,7 +1101,7 @@ func (t *FileTest) TestTruncateDownwardForLocalFileShouldUpdateLocalFileAttribut
 	err = t.in.CreateEmptyTempFile(t.ctx)
 	assert.Nil(t.T(), err)
 	// Write some data to the local file.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("burrito"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("burrito"), 0)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	// Validate the new data is written correctly.
@@ -1150,7 +1150,7 @@ func (t *FileTest) TestTruncateUpwardForLocalFileWhenStreamingWritesAreEnabled()
 
 			if tc.performWrite {
 				t.createBufferedWriteHandler(true, WriteMode)
-				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 				assert.Nil(t.T(), err)
 				assert.False(t.T(), gcsSynced)
 				assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1204,7 +1204,7 @@ func (t *FileTest) TestTruncateUpwardForEmptyGCSFileWhenStreamingWritesAreEnable
 
 			if tc.performWrite {
 				t.createBufferedWriteHandler(true, WriteMode)
-				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 				assert.Nil(t.T(), err)
 				assert.False(t.T(), gcsSynced)
 				assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1274,7 +1274,7 @@ func (t *FileTest) TestTruncateDownwardWhenStreamingWritesAreEnabled() {
 			assert.Equal(t.T(), uint64(0), attrs.Size)
 
 			t.createBufferedWriteHandler(true, WriteMode)
-			gcsSynced, err := t.in.Write(t.ctx, []byte("hihello"), 0, WriteMode)
+			gcsSynced, err := t.in.Write(t.ctx, []byte("hihello"), 0)
 			assert.Nil(t.T(), err)
 			assert.False(t.T(), gcsSynced)
 			assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1440,7 +1440,7 @@ func (t *FileTest) TestSetMtime_ContentDirty() {
 	var attrs fuseops.InodeAttributes
 
 	// Dirty the content.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("a"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("a"), 0)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 
@@ -1754,7 +1754,7 @@ func (t *FileTest) TestReadFileWhenStreamingWritesAreEnabled() {
 
 			if tc.performWrite {
 				t.createBufferedWriteHandler(tc.fileType != LocalFile, WriteMode)
-				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+				gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 				assert.Nil(t.T(), err)
 				assert.False(t.T(), gcsSynced)
 				assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1807,7 +1807,7 @@ func (t *FileTest) TestWriteToLocalFileWhenStreamingWritesAreEnabled() {
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 	t.createBufferedWriteHandler(true, WriteMode)
 
-	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -1823,13 +1823,13 @@ func (t *FileTest) TestMultipleWritesToLocalFileWhenStreamingWritesAreEnabled() 
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 	t.createBufferedWriteHandler(true, WriteMode)
 
-	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.NotNil(t.T(), t.in.bwh)
 	assert.Equal(t.T(), int64(2), t.in.bwh.WriteFileInfo().TotalSize)
 
-	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 2, WriteMode)
+	gcsSynced, err = t.in.Write(t.ctx, []byte("hello"), 2)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.Equal(t.T(), int64(7), t.in.bwh.WriteFileInfo().TotalSize)
@@ -1846,7 +1846,7 @@ func (t *FileTest) TestWriteToEmptyGCSFileWhenStreamingWritesAreEnabled() {
 	createTime := t.in.mtimeClock.Now()
 	t.createBufferedWriteHandler(true, WriteMode)
 
-	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
@@ -1877,7 +1877,7 @@ func (t *FileTest) TestSetMtimeOnEmptyGCSFileAfterWritesWhenStreamingWritesAreEn
 	t.in.config = &cfg.Config{Write: *getWriteConfig()}
 	t.createBufferedWriteHandler(true, WriteMode)
 	// Initiate write call.
-	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0, WriteMode)
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hi"), 0)
 	assert.Nil(t.T(), err)
 	assert.False(t.T(), gcsSynced)
 	assert.NotNil(t.T(), t.in.bwh)


### PR DESCRIPTION
### Description
This PR removes the `openMode` parameter from the `FileInode.Write` method in `internal/fs/inode/file.go`. The parameter was redundant as it was not being utilized within the function body.

### Link to the issue in case of a bug fix.
b/507248537

### Testing details
1. Manual - Done
2. Unit tests - Updated
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
