### PR TITLE
fix(bufferedwrite): correct out-of-order write detection for stale truncated offsets

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -141,7 +141,7 @@ func (wh *bufferedWriteHandlerImpl) Write(ctx context.Context, data []byte, offs
 	if err != nil {
 		return
 	}
-	if offset != wh.totalSize && offset != wh.truncatedSize {
+	if offset != wh.totalSize && (offset != wh.truncatedSize || wh.totalSize >= wh.truncatedSize) {
 		logger.Errorf("BufferedWriteHandler.OutOfOrderError for object: %s, expectedOffset: %d, actualOffset: %d",
 			wh.uploadHandler.objectName, wh.totalSize, offset)
 		return ErrOutOfOrderWrite
@@ -188,6 +188,13 @@ func (wh *bufferedWriteHandlerImpl) appendBuffer(ctx context.Context, data []byt
 	}
 
 	wh.totalSize += int64(dataWritten)
+
+	// If the file size has surpassed the truncation point, the truncation requirement
+	// is fulfilled and we can safely discard the stale offset.
+	if wh.truncatedSize != -1 && wh.totalSize >= wh.truncatedSize {
+		wh.truncatedSize = -1
+	}
+
 	return
 }
 

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -141,6 +141,10 @@ func (wh *bufferedWriteHandlerImpl) Write(ctx context.Context, data []byte, offs
 	if err != nil {
 		return
 	}
+	// Once we write past the truncated size, any writes starting from the truncated
+	// offset are considered out of order. For example, if a file is truncated to 10
+	// bytes, and we write 10 bytes starting from offset 5, the total size becomes 15.
+	// A subsequent write at offset 10 (the truncated size) will be rejected as an out of order write.
 	if offset != wh.totalSize && (offset != wh.truncatedSize || wh.totalSize >= wh.truncatedSize) {
 		logger.Errorf("BufferedWriteHandler.OutOfOrderError for object: %s, expectedOffset: %d, actualOffset: %d",
 			wh.uploadHandler.objectName, wh.totalSize, offset)

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -222,6 +222,26 @@ func (testSuite *BufferedWriteTest) TestWriteAfterTruncateAtCurrentSize() {
 	assert.Equal(testSuite.T(), int64(20), testSuite.bwh.WriteFileInfo().TotalSize)
 }
 
+func (testSuite *BufferedWriteTest) TestOutOfOrderWriteAtStaleTruncatedSize() {
+	err := testSuite.bwh.Write(context.Background(), []byte("hello"), 0)
+	require.Nil(testSuite.T(), err)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
+	// Truncate to a larger size
+	err = testSuite.bwh.Truncate(10)
+	require.NoError(testSuite.T(), err)
+	// Write past the truncated size (from offset 5, writing 10 bytes -> totalSize = 15)
+	err = testSuite.bwh.Write(context.Background(), []byte("0123456789"), 5)
+	require.Nil(testSuite.T(), err)
+	require.Equal(testSuite.T(), int64(-1), bwhImpl.truncatedSize)
+	require.Equal(testSuite.T(), int64(15), bwhImpl.totalSize)
+
+	// Attempt to seek backwards and write exactly at the stale truncatedSize (10)
+	err = testSuite.bwh.Write(context.Background(), []byte("abc"), 10)
+
+	require.Error(testSuite.T(), err)
+	assert.Equal(testSuite.T(), ErrOutOfOrderWrite, err)
+}
+
 func (testSuite *BufferedWriteTest) TestFlushWithNonNilCurrentBlock() {
 	err := testSuite.bwh.Write(context.Background(), []byte("hi"), 0)
 	require.Nil(testSuite.T(), err)
@@ -396,7 +416,8 @@ func (testSuite *BufferedWriteTest) TestFlushWithNonZeroTruncatedLengthForEmptyO
 	_, err := testSuite.bwh.Flush(context.Background())
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
+	assert.Equal(testSuite.T(), int64(10), bwhImpl.totalSize)
+	assert.Equal(testSuite.T(), int64(-1), bwhImpl.truncatedSize)
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjectSize() {
@@ -408,7 +429,8 @@ func (testSuite *BufferedWriteTest) TestFlushWithTruncatedLengthGreaterThanObjec
 	_, err = testSuite.bwh.Flush(context.Background())
 
 	assert.NoError(testSuite.T(), err)
-	assert.Equal(testSuite.T(), bwhImpl.truncatedSize, bwhImpl.totalSize)
+	assert.Equal(testSuite.T(), int64(10), bwhImpl.totalSize)
+	assert.Equal(testSuite.T(), int64(-1), bwhImpl.truncatedSize)
 }
 
 func (testSuite *BufferedWriteTest) TestTruncateWithLesserSize() {


### PR DESCRIPTION
### Description
This PR fixes a bug in the streaming writes path where an out of order write could incorrectly bypass the `ErrOutOfOrderWrite` safeguard. 

Previously, if an application truncated a file upwards, wrote past that truncation point, and then performed a backward seek exactly to the `truncatedSize`, the out-of-order check would evaluate to false. This bypassed the safe fallback to legacy staged writes and caused the new data to be incorrectly appended to the end of the file.

The fix ensures that `truncatedSize` is only treated as a valid offset if the file's `totalSize` has not yet surpassed it. Once `wh.totalSize >= wh.truncatedSize`, any subsequent write at the `truncatedSize` offset is correctly identified as a backward seek, safely returning `ErrOutOfOrderWrite` and triggering the local staged writes fallback.

### Link to the issue in case of a bug fix.
b/498246786

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No