### PR TITLE
refactor(fs): consolidate write flow to call inode.Write directly

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3209,13 +3209,8 @@ func (fs *fileSystem) WriteFile(
 		}
 		return err
 	}
-	if fs.newConfig.Write.EnableRapidAppends {
-		// Serve the request via the file handle.
-		gcsSynced, err = fh.Write(ctx, op.Data, op.Offset)
-	} else {
-		// Serve the request.
-		gcsSynced, err = in.Write(ctx, op.Data, op.Offset, util.NewOpenMode(util.WriteOnly, 0))
-	}
+	// Serve the request.
+	gcsSynced, err = in.Write(ctx, op.Data, op.Offset, fh.OpenMode())
 	if err != nil {
 		return
 	}

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -367,15 +367,6 @@ func (fh *FileHandle) Read(ctx context.Context, dst []byte, offset int64, sequen
 	return
 }
 
-// Adding the Write() method to fileHandle to be able to pass the fileOpenMode
-// which is used for determining write path. For e.g. in case of append mode for
-// unfinalized objects in zonal buckets, streaming writes is used.
-// Note that the writes are still done at the inode level.
-// LOCKS_REQUIRED(fh.inode)
-func (fh *FileHandle) Write(ctx context.Context, data []byte, offset int64) (bool, error) {
-	return fh.inode.Write(ctx, data, offset, fh.openMode)
-}
-
 ////////////////////////////////////////////////////////////////////////
 // Helpers
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -171,28 +171,6 @@ func createFileInode(
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *fileTest) TestFileHandleWrite() {
-	parent := createDirInode(&t.bucket, &t.clock)
-	config := &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
-	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "test_obj", nil, false)
-	fh := NewFileHandle(in, nil, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), writeMode, &cfg.Config{}, nil, nil, 0)
-	data := []byte("hello")
-
-	_, err := fh.Write(t.ctx, data, 0)
-
-	assert.Nil(t.T(), err)
-	// Validate that write is successful at inode.
-	buf := make([]byte, len(data))
-	n, err := in.Read(t.ctx, buf, 0)
-	buf = buf[:n]
-	// Ignore EOF.
-	if err == io.EOF {
-		err = nil
-	}
-	assert.Nil(t.T(), err)
-	assert.Equal(t.T(), data, buf)
-}
-
 func (t *fileTest) Test_IsValidReadManager_NilReadManager() {
 	parent := createDirInode(&t.bucket, &t.clock)
 	config := &cfg.Config{}


### PR DESCRIPTION
**Description**
This change simplifies the write flow in `fileSystem.WriteFile` by removing the redundant `Write` method in `FileHandle`. Previously, the logic branched based on the `EnableRapidAppends` configuration, with one path calling `fh.Write` and the other calling `in.Write`. 

Since both paths ultimately targeted the same `inode.Write` method, they have been consolidated into a single call: `in.Write(ctx, op.Data, op.Offset, fh.OpenMode())`. This consolidation removes the unnecessary wrapper method in `internal/fs/handle/file.go` and ensures that the `OpenMode` is consistently available to the inode for tracing and metric purposes.

**Link to the issue in case of a bug fix.**
b/507658182

**Testing details**
1. **Manual** - Done
2. **Unit tests** -  NA
3. **Integration tests** - Automated

**Any backward incompatible change? If so, please explain.**
NA