### PR TITLE
feat(patch): Patch fixes 3.8.2

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -282,14 +282,12 @@ func (p *BufferedReader) prepareQueueForOffset(offset int64) {
 //     reached, or an error occurs.
 //
 // LOCKS_EXCLUDED(p.mu)
-func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcsx.ReadResponse, error) {
-	resp := gcsx.ReadResponse{}
+func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (resp gcsx.ReadResponse, err error) {
 	reqID := uuid.New()
 	start := time.Now()
 	readOffset := req.Offset
 	blockIdx := readOffset / p.config.PrefetchBlockSizeBytes
 	var bytesRead int
-	var err error
 
 	logger.Tracef("%.13v <- ReadAt(%s:/%s, %d, %d, %d, %d)", reqID, p.bucket.Name(), p.object.Name, p.handleID, readOffset, len(req.Buffer), blockIdx)
 
@@ -305,23 +303,32 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcs
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	var dataSlices [][]byte
+	var entriesToCallback []*blockQueueEntry
 	defer func() {
 		dur := time.Since(start)
 		p.metricHandle.BufferedReadReadLatency(ctx, dur)
 		p.metricHandle.GcsReadBytesCount(int64(bytesRead))
+
 		if err == nil || errors.Is(err, io.EOF) {
 			logger.Tracef("%.13v -> ReadAt(): Ok(%v)", reqID, dur)
+			// Setting the return response.
+			resp.Data = dataSlices
+			resp.Callback = func() { p.callback(entriesToCallback) }
+			resp.Size = bytesRead
+		} else if errors.Is(err, gcsx.FallbackToAnotherReader) {
+			// When falling back, we must immediately release the blocks we've acquired references to.
+			p.releaseInflightBlocks(entriesToCallback)
+			resp = gcsx.ReadResponse{}
 		}
 	}()
 
 	if err = p.handleRandomRead(readOffset); err != nil {
-		return resp, fmt.Errorf("BufferedReader.ReadAt: handleRandomRead: %w", err)
+		err = fmt.Errorf("BufferedReader.ReadAt: handleRandomRead: %w", err)
+		return
 	}
 
 	prefetchTriggered := false
-
-	var dataSlices [][]byte
-	var entriesToCallback []*blockQueueEntry
 	for bytesRead < len(req.Buffer) {
 		p.prepareQueueForOffset(readOffset)
 
@@ -329,7 +336,8 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcs
 			if err = p.freshStart(readOffset); err != nil {
 				logger.Warnf("Fallback to another reader for object %q, handle %d, due to freshStart failure: %v", p.object.Name, p.handleID, err)
 				p.metricHandle.BufferedReadFallbackTriggerCount(1, "insufficient_memory")
-				return resp, gcsx.FallbackToAnotherReader
+				err = gcsx.FallbackToAnotherReader
+				return
 			}
 			prefetchTriggered = true
 		}
@@ -393,10 +401,19 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (gcs
 		}
 	}
 
-	resp.Data = dataSlices
-	resp.Callback = func() { p.callback(entriesToCallback) }
-	resp.Size = bytesRead
-	return resp, err
+	return
+}
+
+// releaseInflightBlocks immediately invokes the callback for a list of block
+// entries and waits for them to complete. This is used when a read operation
+// must fall back to another reader, ensuring that any blocks referenced during
+// the failed attempt are properly released before proceeding.
+// LOCKS_REQUIRED(p.mu)
+func (p *BufferedReader) releaseInflightBlocks(entries []*blockQueueEntry) {
+	p.mu.Unlock()
+	defer p.mu.Lock()
+
+	p.callback(entries)
 }
 
 // callback is called when the FUSE library is finished with buffer slices that

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -1634,6 +1634,38 @@ func (t *BufferedReaderTest) TestReadAtResumesAfterFallbackWhenReadBecomesSequen
 	t.bucket.AssertExpectations(t.T())
 }
 
+func (t *BufferedReaderTest) TestReadAtFallbackOnSecondBlockDownloadFailure() {
+	// 1. Config: 1 block prefetch, file size is 3 blocks.
+	t.config.InitialPrefetchBlockCnt = 1
+	t.config.MaxPrefetchBlockCnt = 1
+	t.config.MinBlocksPerHandle = 1
+	t.object.Size = uint64(3 * testPrefetchBlockSizeBytes)
+	reader, err := NewBufferedReader(&BufferedReaderOptions{
+		Object:             t.object,
+		Bucket:             t.bucket,
+		Config:             t.config,
+		GlobalMaxBlocksSem: t.globalMaxBlocksSem,
+		WorkerPool:         t.workerPool,
+		MetricHandle:       t.metricHandle,
+		ReadTypeClassifier: t.readTypeClassifier})
+	require.NoError(t.T(), err)
+	t.bucket.On("Name").Return("test-bucket").Maybe()
+	// 2. Mock GCS: First block succeeds, second fails.
+	// freshStart for block 0 will succeed.
+	t.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(r *gcs.ReadObjectRequest) bool { return r.Range.Start == 0 })).Return(createFakeReaderWithOffset(t.T(), int(testPrefetchBlockSizeBytes), 0), nil).Once()
+
+	// 3. Act: Read spanning 2 blocks.
+	readSize := testPrefetchBlockSizeBytes + 10
+	resp, err := reader.ReadAt(t.ctx, &gcsx.ReadRequest{Buffer: make([]byte, readSize), Offset: 0})
+
+	// 4. Assert: Fallback error is returned and response is empty.
+	assert.ErrorIs(t.T(), err, gcsx.FallbackToAnotherReader, "ReadAt should fall back when the second block download fails")
+	assert.Nil(t.T(), resp.Data, "Response data should be nil on fallback")
+	assert.Zero(t.T(), resp.Size, "Response size should be zero on fallback")
+	assert.Nil(t.T(), resp.Callback, "Response callback should be nil on fallback")
+	t.bucket.AssertExpectations(t.T())
+}
+
 func (t *BufferedReaderTest) TestReadAtFallbackOnFreshStartFailure() {
 	t.config.MaxPrefetchBlockCnt = 2
 	t.config.InitialPrefetchBlockCnt = 2

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -40,7 +40,9 @@ import (
 	"golang.org/x/oauth2"
 	option "google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	// Side effect to run grpc client with direct-path on gcp machine.
 	_ "google.golang.org/grpc/balancer/rls"
@@ -224,6 +226,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
+	defer unSetDirectPathEnvVariable()
 
 	var clientOpts []option.ClientOption
 	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
@@ -234,21 +237,20 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
 	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
 
-	// Create client with DirectPath enforced
-	detectionCtx, cancel := context.WithTimeout(ctx, directPathDetectionTimeout)
-	defer cancel()
-	sc, err = storage.NewGRPCClient(detectionCtx, clientOpts...)
-	if err != nil {
-		unSetDirectPathEnvVariable()
+	if sc, err = storage.NewGRPCClient(ctx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
-	} else {
-		setRetryConfig(ctx, sc, clientConfig)
 	}
+	setRetryConfig(ctx, sc, clientConfig)
 
-	err = verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc)
-	unSetDirectPathEnvVariable()
-	if err != nil {
-		return nil, err
+	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
+	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc); verifyErr != nil {
+		if status.Code(verifyErr) == codes.DeadlineExceeded {
+			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
+		} else {
+			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
+		}
+	} else {
+		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
 
 	return sc, nil
@@ -259,7 +261,14 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	logger.Infof("Verifying DirectPath connectivity for bucket %q with stat call", bucketName)
 	// Apply detection retry config for initial verification
 	setDPDetectionRetryConfig(ctx, sc, clientConfig)
-	verifyCtx, verifyCancel := context.WithTimeout(ctx, directPathDetectionTimeout)
+
+	// Restore the production level retry config.
+	defer func() {
+		logger.Infof("Applying production retry config after DirectPath verification.")
+		setRetryConfig(ctx, sc, clientConfig)
+	}()
+
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, time.Millisecond)
 	defer verifyCancel()
 
 	// Retrieving object attrs through Go Storage Client.
@@ -269,14 +278,9 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
-		// DirectPath verification failed
-		sc.Close()
 		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
 	}
 
-	logger.Infof("DirectPath verification successful for bucket %q, applying production retry config", bucketName)
-	// DirectPath is working! Now apply production retry config for actual usage.
-	setRetryConfig(ctx, sc, clientConfig)
 	return nil
 }
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -53,8 +53,7 @@ const (
 	dynamicReadReqIncreaseRateEnv   = "DYNAMIC_READ_REQ_INCREASE_RATE"
 	dynamicReadReqInitialTimeoutEnv = "DYNAMIC_READ_REQ_INITIAL_TIMEOUT"
 
-	zonalLocationType         = "zone"
-	stallTimeoutForDirectPath = 60 * time.Second
+	zonalLocationType = "zone"
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
@@ -83,22 +82,6 @@ type storageClient struct {
 	rawStorageControlClientWithGaxRetries *control.StorageControlClient
 	// storageControlClient is with retry for GetStorageLayout and with handling for billing project.
 	storageControlClient StorageControlClient
-	directPathDetector   *gRPCDirectPathDetector
-}
-
-type gRPCDirectPathDetector struct {
-	clientOptions []option.ClientOption
-}
-
-// isDirectPathPossible checks if gRPC direct connectivity is available for a specific bucket
-// from the environment where the client is running. A `nil` error represents Direct Connectivity was
-// detected.
-func (pd *gRPCDirectPathDetector) isDirectPathPossible(ctx context.Context, bucketName string) error {
-	newCtx, cancel := context.WithTimeout(ctx, stallTimeoutForDirectPath)
-	defer cancel()
-
-	// The storage library will see the timeout in 'newCtx' and abort the request if it takes too long.
-	return storage.CheckDirectConnectivitySupported(newCtx, bucketName, pd.clientOptions...)
 }
 
 // Return clientOpts for both gRPC client and control client.
@@ -433,7 +416,6 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		rawStorageControlClientWithGaxRetries:    rawStorageControlClientWithGaxRetries,
 		storageControlClient:                     controlClient,
 		clientConfig:                             clientConfig,
-		directPathDetector:                       &gRPCDirectPathDetector{clientOptions: clientOpts},
 	}
 	return
 }
@@ -525,17 +507,6 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 	client, err = sh.getClient(ctx, bucketType.Zonal, bucketName)
 	if err != nil {
 		return nil, err
-	}
-
-	if bucketType.Zonal || sh.clientConfig.ClientProtocol == cfg.GRPC {
-		if sh.directPathDetector != nil {
-			logger.Infof("Checking for DirectPath connectivity for bucket %q", bucketName)
-			if err := sh.directPathDetector.isDirectPathPossible(ctx, bucketName); err != nil {
-				logger.Warnf("Direct path connectivity unavailable for %s, reason: %v", bucketName, err)
-			} else {
-				logger.Infof("Successfully connected over gRPC DirectPath for %s", bucketName)
-			}
-		}
 	}
 
 	storageBucketHandle := client.Bucket(bucketName)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -40,9 +40,7 @@ import (
 	"golang.org/x/oauth2"
 	option "google.golang.org/api/option"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 
 	// Side effect to run grpc client with direct-path on gcp machine.
 	_ "google.golang.org/grpc/balancer/rls"
@@ -60,7 +58,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 10 * time.Second
+	directPathDetectionTimeout          = 15 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )
@@ -222,7 +220,7 @@ func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientCo
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, enableBidiConfig bool, bucketName string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketZonal bool, enableBidiConfig bool, bucketName string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -242,12 +240,11 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 	setRetryConfig(ctx, sc, clientConfig)
 
-	// TODO(b/503624405): Make the direct-path verification fatal after making the dummy-stat reliable.
+	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc); verifyErr != nil {
-		if status.Code(verifyErr) == codes.DeadlineExceeded {
-			logger.Info("DirectPath verification timed out, continuing without DirectPath verification: %v", verifyErr)
-		} else {
-			logger.Warnf("DirectPath verification failed, continuing without DirectPath: %v", verifyErr)
+		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
+		if !isbucketZonal {
+			return nil, verifyErr
 		}
 	} else {
 		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
@@ -268,7 +265,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 
-	verifyCtx, verifyCancel := context.WithTimeout(ctx, time.Millisecond)
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, directPathDetectionTimeout)
 	defer verifyCancel()
 
 	// Retrieving object attrs through Go Storage Client.
@@ -445,7 +442,7 @@ func (sh *storageClient) getClient(ctx context.Context, isbucketZonal bool, buck
 	var err error
 	if isbucketZonal {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, true, bucketName)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isbucketZonal, true, bucketName)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
@@ -470,7 +467,7 @@ func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Con
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, bucketName)
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, false, bucketName)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -341,43 +341,6 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 	assert.Contains(testSuite.T(), err.Error(), "invalid client-protocol requested: test-protocol")
 }
 
-func (testSuite *StorageHandleTest) TestNewStorageHandleDirectPathDetector() {
-	testCases := []struct {
-		name           string
-		clientProtocol cfg.Protocol
-	}{
-		{
-			name:           "grpcWithNonNilDirectPathDetector",
-			clientProtocol: cfg.GRPC,
-		},
-		{
-			name:           "http1WithNilDirectPathDetector",
-			clientProtocol: cfg.HTTP1,
-		},
-		{
-			name:           "http2WithNilDirectPathDetector",
-			clientProtocol: cfg.HTTP2,
-		},
-	}
-
-	for _, tc := range testCases {
-		testSuite.Run(tc.name, func() {
-			sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-			sc.ExperimentalEnableJsonRead = true
-			sc.ClientProtocol = tc.clientProtocol
-
-			handleCreated, err := NewStorageHandle(testSuite.ctx, sc, "")
-			assert.Nil(testSuite.T(), err)
-			assert.NotNil(testSuite.T(), handleCreated)
-
-			storageClient, ok := handleCreated.(*storageClient)
-			assert.True(testSuite.T(), ok)
-
-			assert.NotNil(testSuite.T(), storageClient.directPathDetector)
-		})
-	}
-}
-
 func (testSuite *StorageHandleTest) TestUnSetDirectPathEnvVariable() {
 	// Set the environment variable
 	testSuite.T().Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true")


### PR DESCRIPTION
# Patch fixes


* fix(buffered_reader): Fixing a memory leak in buffered reader (https://github.com/GoogleCloudPlatform/gcsfuse/pull/4638)


direct path verification (changes across 3 PRs) - 
* feat(dp-check): removing older cp check utility (https://github.com/GoogleCloudPlatform/gcsfuse/pull/4494)
* fix(direct path verification): Updating direct path enforcement strategy (https://github.com/GoogleCloudPlatform/gcsfuse/pull/4635)
* feat: making direct-path verification non-fatal until dummy-stat calls becomes reliable (https://github.com/GoogleCloudPlatform/gcsfuse/pull/4628)