### PR TITLE
docs(storage): clarify zonal bucket write semantics in Bucket interface

### DIFF
--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -103,13 +103,18 @@ type Bucket interface {
 		req *CreateObjectRequest) (*Object, error)
 
 	// CreateObjectChunkWriter creates a *storage.Writer that can be used for
-	// resumable uploads. The new object will be available for reading after the
-	// writer is closed (object is finalised).
+	// chunked uploads. Depending on the underlying bucket's capabilities, it is
+	// used for either resumable uploads or appendable object uploads. For standard
+	// resumable uploads, the object becomes available for reading only after the
+	// writer is closed (finalized). For appendable uploads, the unfinalized
+	// object is available for reading immediately.
 	CreateObjectChunkWriter(ctx context.Context, req *CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (Writer, error)
 
-	// CreateAppendableObjectWriter creates a *storage.Writer to an object which has been
-	// partially flushed to GCS, but not finalized. All bytes written will be appended
-	// continuing from the offset passed via the CreateObjectChunkWriterRequest.
+	// CreateAppendableObjectWriter creates a *storage.Writer for "Takeover"
+	// operations. It allows appending to an existing, unfinalized object by
+	// leveraging its specific generation number. Unlike a standard new file upload,
+	// this attaches to an existing unfinalized stream. All bytes written will be
+	// appended continuing from the offset passed via the CreateObjectChunkWriterRequest.
 	CreateAppendableObjectWriter(ctx context.Context,
 		req *CreateObjectChunkWriterRequest) (Writer, error)
 

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -110,9 +110,9 @@ type Bucket interface {
 	// object is available for reading immediately.
 	CreateObjectChunkWriter(ctx context.Context, req *CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (Writer, error)
 
-	// CreateAppendableObjectWriter creates a *storage.Writer for "Takeover"
+	// CreateAppendableObjectWriter creates a Writer for "Takeover"
 	// operations. It allows appending to an existing, unfinalized object by
-	// leveraging its specific generation number. Unlike a standard new file upload,
+	// leveraging its specific generation number. Unlike a standard new object upload,
 	// this attaches to an existing unfinalized stream. All bytes written will be
 	// appended continuing from the offset passed via the CreateObjectChunkWriterRequest.
 	CreateAppendableObjectWriter(ctx context.Context,


### PR DESCRIPTION
### Description
The current documentation in `internal/storage/gcs/bucket.go` for the Bucket interface is misleading regarding how writes are handled for different bucket types.

Specifically:

- `CreateObjectChunkWriter` is not just for resumable uploads; it is the primary method for both standard resumable uploads and appendable uploads used by Zonal Buckets. The Go SDK switches behavior based on the Append flag: when Append is true, it uses the BidiWriteObject API required for Zonal Buckets. And also the objects via appendable uploads can be read even before they are finalized.
- `CreateAppendableObjectWriter` is specifically intended for "Takeover" operations. It allows the client to attach to an existing, unfinalized stream by specifying its generation number.

This PR updates the method comments to reflect these distinctions clearly.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
