### PR TITLE
fix: validate object size after upload to detect incomplete writes

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -212,7 +212,7 @@ func (wh *bufferedWriteHandlerImpl) Sync(ctx context.Context) (o *gcs.MinObject,
 			return nil, err
 		}
 		if o.Size != uint64(wh.totalSize) {
-			return nil, fmt.Errorf("could not upload entire data, expected offset %d, Got %d", wh.totalSize, o.Size)
+			return nil, fmt.Errorf("could not upload entire data, expected size %d, got %d", wh.totalSize, o.Size)
 		}
 	}
 	// Release memory used by buffers.
@@ -256,7 +256,7 @@ func (wh *bufferedWriteHandlerImpl) Flush(ctx context.Context) (*gcs.MinObject, 
 	}
 
 	if obj != nil && obj.Size != uint64(wh.totalSize) {
-		return nil, fmt.Errorf("could not upload entire data, expected offset %d, Got %d", wh.totalSize, obj.Size)
+		return nil, fmt.Errorf("could not upload entire data, expected size %d, got %d", wh.totalSize, obj.Size)
 	}
 
 	err = wh.blockPool.ClearFreeBlockChannel(true)

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -255,6 +255,10 @@ func (wh *bufferedWriteHandlerImpl) Flush(ctx context.Context) (*gcs.MinObject, 
 		return nil, fmt.Errorf("BufferedWriteHandler.Flush(): %w", err)
 	}
 
+	if obj != nil && obj.Size != uint64(wh.totalSize) {
+		return nil, fmt.Errorf("could not upload entire data, expected offset %d, Got %d", wh.totalSize, obj.Size)
+	}
+
 	err = wh.blockPool.ClearFreeBlockChannel(true)
 	if err != nil {
 		// Only logging an error in case of resource leak as upload succeeded.

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -317,7 +317,7 @@ func (testSuite *BufferedWriteTest) TestFlush_SizeMismatch_ReturnsError() {
 			obj, err := bwh.Flush(context.Background())
 
 			require.Error(testSuite.T(), err)
-			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected offset 2, Got 0")
+			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected size 2, got 0")
 			assert.Nil(testSuite.T(), obj)
 		})
 	}
@@ -370,7 +370,7 @@ func (testSuite *BufferedWriteTest) TestSync_SizeMismatch_ReturnsError() {
 			obj, err := bwh.Sync(context.Background())
 
 			require.Error(testSuite.T(), err)
-			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected offset 2, Got 0")
+			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected size 2, got 0")
 			assert.Nil(testSuite.T(), obj)
 		})
 	}

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/semaphore"
@@ -262,6 +264,116 @@ func (testSuite *BufferedWriteTest) TestFlushWithSignalUploadFailureDuringWrite(
 	require.Error(testSuite.T(), err)
 	assert.Equal(testSuite.T(), err, errUploadFailure)
 	assert.Nil(testSuite.T(), obj)
+}
+
+func (testSuite *BufferedWriteTest) TestFlush_SizeMismatch_ReturnsError() {
+	testCases := []struct {
+		name       string
+		bucketType gcs.BucketType
+		obj        *gcs.Object
+	}{
+		{
+			name:       "non_zonal",
+			bucketType: gcs.BucketType{Zonal: false},
+		},
+		{
+			name:       "zonal_new_file",
+			bucketType: gcs.BucketType{Zonal: true},
+		},
+		{
+			name:       "zonal_append",
+			bucketType: gcs.BucketType{Zonal: true},
+			obj:        &gcs.Object{Name: "testObject", Size: 0},
+		},
+	}
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			mockBucket := new(storagemock.TestifyMockBucket)
+			mockBucket.On("BucketType").Return(tc.bucketType)
+			writer := &storagemock.Writer{}
+			writer.On("Write", mock.Anything).Return(2, nil)
+			if tc.bucketType.Zonal && tc.obj != nil {
+				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
+			} else {
+				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
+			}
+			mockObj := &gcs.MinObject{Name: "testObject", Size: 0}
+			mockBucket.On("FinalizeUpload", mock.Anything, writer).Return(mockObj, nil)
+			bwh, err := NewBWHandler(&CreateBWHandlerRequest{
+				Object:                   tc.obj,
+				ObjectName:               "testObject",
+				Bucket:                   mockBucket,
+				BlockSize:                blockSize,
+				MaxBlocksPerFile:         10,
+				GlobalMaxBlocksSem:       testSuite.globalSemaphore,
+				ChunkRetryDeadlineSecs:   chunkRetryDeadlineSecs,
+				ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
+				TraceHandle:              tracing.NewNoopTracer(),
+			})
+			require.Nil(testSuite.T(), err)
+			err = bwh.Write(context.Background(), []byte("hi"), 0)
+			require.Nil(testSuite.T(), err)
+
+			obj, err := bwh.Flush(context.Background())
+
+			require.Error(testSuite.T(), err)
+			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected offset 2, Got 0")
+			assert.Nil(testSuite.T(), obj)
+		})
+	}
+}
+
+func (testSuite *BufferedWriteTest) TestSync_SizeMismatch_ReturnsError() {
+	testCases := []struct {
+		name       string
+		bucketType gcs.BucketType
+		obj        *gcs.Object
+	}{
+		{
+			name:       "zonal_new_file",
+			bucketType: gcs.BucketType{Zonal: true},
+		},
+		{
+			name:       "zonal_append",
+			bucketType: gcs.BucketType{Zonal: true},
+			obj:        &gcs.Object{Name: "testObject", Size: 0},
+		},
+	}
+	for _, tc := range testCases {
+		testSuite.Run(tc.name, func() {
+			mockBucket := new(storagemock.TestifyMockBucket)
+			mockBucket.On("BucketType").Return(tc.bucketType)
+			writer := &storagemock.Writer{}
+			writer.On("Write", mock.Anything).Return(2, nil)
+			if tc.bucketType.Zonal && tc.obj != nil {
+				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
+			} else {
+				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
+			}
+			mockObj := &gcs.MinObject{Name: "testObject", Size: 0}
+			mockBucket.On("FlushPendingWrites", mock.Anything, writer).Return(mockObj, nil)
+			bwh, err := NewBWHandler(&CreateBWHandlerRequest{
+				Object:                   tc.obj,
+				ObjectName:               "testObject",
+				Bucket:                   mockBucket,
+				BlockSize:                blockSize,
+				MaxBlocksPerFile:         10,
+				GlobalMaxBlocksSem:       testSuite.globalSemaphore,
+				ChunkRetryDeadlineSecs:   chunkRetryDeadlineSecs,
+				ChunkTransferTimeoutSecs: chunkTransferTimeoutSecs,
+				TraceHandle:              tracing.NewNoopTracer(),
+			})
+			require.Nil(testSuite.T(), err)
+			err = bwh.Write(context.Background(), []byte("hi"), 0)
+			require.Nil(testSuite.T(), err)
+
+			obj, err := bwh.Sync(context.Background())
+
+			require.Error(testSuite.T(), err)
+			assert.Contains(testSuite.T(), err.Error(), "could not upload entire data, expected offset 2, Got 0")
+			assert.Nil(testSuite.T(), obj)
+		})
+	}
 }
 
 func (testSuite *BufferedWriteTest) TestFlushWithMultiBlockWritesAndSignalUploadFailureInBetween() {

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -976,6 +976,13 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("SyncObject: %w", err)
 	}
+
+	if newObj != nil && f.content != nil {
+		if st, statErr := f.content.Stat(); statErr == nil && newObj.Size != uint64(st.Size) {
+			return fmt.Errorf("could not upload entire data, expected size %d, Got %d", st.Size, newObj.Size)
+		}
+	}
+
 	minObj := storageutil.ConvertObjToMinObject(newObj)
 	// If we wrote out a new object, we need to update our state.
 	f.updateInodeStateAfterFlush(minObj)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -978,8 +978,13 @@ func (f *FileInode) syncUsingContent(ctx context.Context) (err error) {
 	}
 
 	if newObj != nil && f.content != nil {
-		if st, statErr := f.content.Stat(); statErr == nil && newObj.Size != uint64(st.Size) {
-			return fmt.Errorf("could not upload entire data, expected size %d, Got %d", st.Size, newObj.Size)
+		st, statErr := f.content.Stat()
+		if statErr != nil {
+			return fmt.Errorf("SyncObject: stat temp file for size validation: %w", statErr)
+		}
+
+		if newObj.Size != uint64(st.Size) {
+			return fmt.Errorf("SyncObject: could not upload entire data, expected size %d, got %d", st.Size, newObj.Size)
 		}
 	}
 

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -185,7 +185,7 @@ func (t *FileMockBucketTest) TestFlushLocalFile_SizeMismatch_ReturnsError() {
 	err = t.in.Flush(t.ctx)
 
 	require.Error(t.T(), err)
-	assert.Contains(t.T(), err.Error(), "could not upload entire data, expected size 4, Got 2")
+	assert.Contains(t.T(), err.Error(), "could not upload entire data, expected size 4, got 2")
 }
 
 func (t *FileMockBucketTest) TestFlushSyncedFileForceFetchObjectFromGCS() {

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -173,6 +173,21 @@ func (t *FileMockBucketTest) TestFlushLocalFileDoesNotForceFetchObjectFromGCS() 
 	t.bucket.AssertExpectations(t.T())
 }
 
+func (t *FileMockBucketTest) TestFlushLocalFile_SizeMismatch_ReturnsError() {
+	assert.True(t.T(), t.in.IsLocal())
+	// Write some data so that the local temp file size becomes 4
+	_, err := t.in.Write(t.ctx, []byte("data"), 0, util.NewOpenMode(util.WriteOnly, 0))
+	require.NoError(t.T(), err)
+	// Mock CreateObject to return an object with a mismatched size
+	t.bucket.On("CreateObject", t.ctx, mock.AnythingOfType("*gcs.CreateObjectRequest")).
+		Return(&gcs.Object{Name: fileName, Size: 2}, nil)
+
+	err = t.in.Flush(t.ctx)
+
+	require.Error(t.T(), err)
+	assert.Contains(t.T(), err.Error(), "could not upload entire data, expected size 4, Got 2")
+}
+
 func (t *FileMockBucketTest) TestFlushSyncedFileForceFetchObjectFromGCS() {
 	// Expect a CreateObject call because createLockedInode creates a synced file
 	// inode (backed by GCS object).


### PR DESCRIPTION
### Description
This change introduces a validation check immediately following file upload operations to ensure data integrity.

It has been observed that the backend can occasionally return a successful "OK" status for a write stream closure, even if the data persistence failed. In these cases, the resulting object is recorded with a size of `0` despite the client having transmitted non-empty data.

To prevent these failures from being silently ignored, GCSFuse now explicitly validates the object size returned by the server against the expected size during Flush and Sync operations.

### Link to the issue in case of a bug fix.
b/508075834

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
