### PR TITLE
feat(pirlo): add enable-rapid-writes and optimize finalize-file-on-close for pirlo

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -58,6 +58,17 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			Value: bool(true),
 		},
 	},
+}, "write.finalize-file-on-close": {
+	BucketTypeOptimization: []shared.BucketTypeOptimization{
+		{
+			BucketType: "zonal",
+			Value:      bool(false),
+		},
+		{
+			BucketType: "pirlo",
+			Value:      bool(true),
+		},
+	},
 }, "implicit-dirs": {
 	MachineBasedOptimization: []shared.MachineBasedOptimization{
 		{
@@ -273,6 +284,18 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 				if c.FileCache.CacheFileForRangeRead != val {
 					c.FileCache.CacheFileForRangeRead = val
 					optimizedFlags["file-cache.cache-file-for-range-read"] = result
+				}
+			}
+		}
+	}
+	if !v.IsSet("write.finalize-file-on-close") {
+		rules := AllFlagOptimizationRules["write.finalize-file-on-close"]
+		result := getOptimizedValue(&rules, c.Write.FinalizeFileOnClose, profileName, machineType, input, machineTypeToGroupMap)
+		if result.Optimized {
+			if val, ok := result.FinalValue.(bool); ok {
+				if c.Write.FinalizeFileOnClose != val {
+					c.Write.FinalizeFileOnClose = val
+					optimizedFlags["write.finalize-file-on-close"] = result
 				}
 			}
 		}
@@ -749,9 +772,11 @@ type WriteConfig struct {
 
 	EnableRapidAppends bool `yaml:"enable-rapid-appends"`
 
+	EnableRapidWrites bool `yaml:"enable-rapid-writes"`
+
 	EnableStreamingWrites bool `yaml:"enable-streaming-writes"`
 
-	FinalizeFileForRapid bool `yaml:"finalize-file-for-rapid"`
+	FinalizeFileOnClose bool `yaml:"finalize-file-on-close"`
 
 	GlobalMaxBlocks int64 `yaml:"global-max-blocks"`
 
@@ -970,6 +995,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.BoolP("enable-rapid-appends", "", true, "Enables support for appends to unfinalized object using streaming writes")
 
+	flagSet.BoolP("enable-rapid-writes", "", false, "For pirlo, toggles between using STANDARD class and RAPID class for writes.")
+
 	flagSet.BoolP("enable-read-stall-retry", "", true, "To turn on/off retries for stalled read requests. This is based on a timeout that changes depending on how long similar requests took in the past.")
 
 	if err := flagSet.MarkHidden("enable-read-stall-retry"); err != nil {
@@ -1116,9 +1143,9 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
 
-	flagSet.BoolP("finalize-file-for-rapid", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
+	flagSet.BoolP("finalize-file-on-close", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
 
-	if err := flagSet.MarkHidden("finalize-file-for-rapid"); err != nil {
+	if err := flagSet.MarkHidden("finalize-file-on-close"); err != nil {
 		return err
 	}
 
@@ -1577,6 +1604,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	if err := v.BindPFlag("write.enable-rapid-writes", flagSet.Lookup("enable-rapid-writes")); err != nil {
+		return err
+	}
+
 	if err := v.BindPFlag("gcs-retries.read-stall.enable", flagSet.Lookup("enable-read-stall-retry")); err != nil {
 		return err
 	}
@@ -1701,7 +1732,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("write.finalize-file-for-rapid", flagSet.Lookup("finalize-file-for-rapid")); err != nil {
+	if err := v.BindPFlag("write.finalize-file-on-close", flagSet.Lookup("finalize-file-on-close")); err != nil {
 		return err
 	}
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -257,6 +257,83 @@ func TestApplyOptimizations(t *testing.T) {
 			})
 		}
 	})
+	// Tests for write.finalize-file-on-close
+	t.Run("write.finalize-file-on-close", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			config          Config
+			userSetFlags    map[string]any
+			input           *OptimizationInput
+			expectOptimized bool
+			expectedValue   any
+		}{
+			{
+				name:   "user_set",
+				config: Config{},
+				userSetFlags: map[string]any{
+					"write.finalize-file-on-close": true,
+					"machine-type":                 "a2-megagpu-16g",
+				},
+				input:           &OptimizationInput{BucketType: BucketTypeZonal},
+				expectOptimized: false,
+				expectedValue:   true,
+			},
+			{
+				name:   "no_optimization",
+				config: Config{Profile: "non_existent_profile"},
+				userSetFlags: map[string]any{
+					"machine-type": "low-end-machine",
+				},
+				input:           nil,
+				expectOptimized: false,
+				expectedValue:   false,
+			},
+			{
+				name:            "bucket_type_zonal",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypeZonal},
+				expectOptimized: true,
+				expectedValue:   false,
+			},
+			{
+				name:            "bucket_type_pirlo",
+				config:          Config{Profile: ""},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// We need a copy of the config for each test case.
+				c := tc.config
+				// Set the default or non-default value on the config object.
+				if tc.name == "user_set" {
+					c.Write.FinalizeFileOnClose = tc.expectedValue.(bool)
+				} else {
+					c.Write.FinalizeFileOnClose = false
+				}
+
+				v := viper.New()
+				for key, val := range tc.userSetFlags {
+					v.Set(key, val)
+				}
+
+				optimizedFlags := c.ApplyOptimizations(v, tc.input)
+
+				if tc.expectOptimized {
+					assert.Contains(t, optimizedFlags, "write.finalize-file-on-close")
+				} else {
+					assert.NotContains(t, optimizedFlags, "write.finalize-file-on-close")
+				}
+				// Use EqualValues to handle the int vs int64 type mismatch for default values.
+				assert.EqualValues(t, tc.expectedValue, c.Write.FinalizeFileOnClose)
+			})
+		}
+	})
 	// Tests for implicit-dirs
 	t.Run("implicit-dirs", func(t *testing.T) {
 		testCases := []struct {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -293,7 +293,7 @@ func TestApplyOptimizations(t *testing.T) {
 				config:          Config{Profile: ""},
 				userSetFlags:    map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketTypeZonal},
-				expectOptimized: true,
+				expectOptimized: false,
 				expectedValue:   false,
 			},
 			{

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1262,18 +1262,30 @@ params:
     usage: "Enables support for appends to unfinalized object using streaming writes"
     default: true
 
+  - config-path: "write.enable-rapid-writes"
+    flag-name: "enable-rapid-writes"
+    type: "bool"
+    usage: "For pirlo, toggles between using STANDARD class and RAPID class for writes."
+    default: false
+
   - config-path: "write.enable-streaming-writes"
     flag-name: "enable-streaming-writes"
     type: "bool"
     usage: "Enables streaming uploads during write file operation."
     default: true
 
-  - config-path: "write.finalize-file-for-rapid"
-    flag-name: "finalize-file-for-rapid"
+  - config-path: "write.finalize-file-on-close"
+    flag-name: "finalize-file-on-close"
     type: "bool"
     usage: "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files."
     default: false
     hide-flag: true
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: "zonal"
+          value: false
+        - bucket-type: "pirlo"
+          value: true
 
   - config-path: "write.global-max-blocks"
     flag-name: "write-global-max-blocks"

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -171,6 +171,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		LocalSocketAddress:                      newConfig.GcsConnection.ExperimentalLocalSocketAddress,
 		EnableGrpcMetrics:                       newConfig.Metrics.ExperimentalEnableGrpcMetrics,
 		IsGKE:                                   isGKE,
+		WriteConfig:                             &newConfig.Write,
 	}
 	logger.Infof("UserAgent = %s\n", storageClientConfig.UserAgent)
 	storageHandle, err = storage.NewStorageHandle(context.Background(), storageClientConfig, newConfig.GcsConnection.BillingProject)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -105,7 +105,6 @@ be interacting with the file system.`)
 		ChunkRetryDeadlineSecs:             newConfig.GcsRetries.ChunkRetryDeadlineSecs,
 		ChunkTransferTimeoutSecs:           newConfig.GcsRetries.ChunkTransferTimeoutSecs,
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
-		FinalizeFileForRapid:               newConfig.Write.FinalizeFileForRapid,
 		DisableListAccessCheck:             newConfig.DisableListAccessCheck,
 		DummyIOCfg:                         newConfig.DummyIo,
 		IsTypeCacheDeprecated:              newConfig.EnableTypeCacheDeprecation,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -282,6 +282,8 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 		expectedWriteBlockSizeMB      int64
 		expectedWriteGlobalMaxBlocks  int64
 		expectedWriteMaxBlocksPerFile int64
+		expectedEnableRapidWrites     bool
+		expectedFinalizeFileOnClose   bool
 	}{
 		{
 			name:                          "Test create-empty-file flag true works when streaming writes are explicitly disabled.",
@@ -431,6 +433,18 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteGlobalMaxBlocks:  16,
 			expectedWriteMaxBlocksPerFile: 1,
 		},
+		{
+			name:                          "Test enable-rapid-writes and finalize-file-on-close flags.",
+			args:                          []string{"gcsfuse", "--enable-rapid-writes=true", "--finalize-file-on-close=true", "abc", "pqr"},
+			expectedCreateEmptyFile:       false,
+			expectedEnableStreamingWrites: true,
+			expectedEnableRapidAppends:    true,
+			expectedWriteBlockSizeMB:      32,
+			expectedWriteGlobalMaxBlocks:  4,
+			expectedWriteMaxBlocksPerFile: 1,
+			expectedEnableRapidWrites:     true,
+			expectedFinalizeFileOnClose:   true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -451,6 +465,8 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 				assert.Equal(t, tc.expectedWriteBlockSizeMB, wc.BlockSizeMb)
 				assert.Equal(t, tc.expectedWriteGlobalMaxBlocks, wc.GlobalMaxBlocks)
 				assert.Equal(t, tc.expectedEnableRapidAppends, wc.EnableRapidAppends)
+				assert.Equal(t, tc.expectedEnableRapidWrites, wc.EnableRapidWrites)
+				assert.Equal(t, tc.expectedFinalizeFileOnClose, wc.FinalizeFileOnClose)
 			}
 		})
 	}

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -113,7 +113,7 @@ func (cht *cacheHandleTest) SetupTest() {
 	storageHandle := cht.fakeStorage.CreateStorageHandle()
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
-	cht.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
+	cht.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 	assert.Nil(cht.T(), err)
 
 	// Create test object in the bucket.

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -74,7 +74,7 @@ func initializeCacheHandlerTestArgs(t *testing.T, fileCacheConfig *cfg.FileCache
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
 	ctx := context.Background()
-	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
+	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 	require.NoError(t, err)
 
 	// Create test object in the bucket.

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -67,7 +67,7 @@ func (dt *downloaderTest) setupHelper() {
 	mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(&controlpb.StorageLayout{}, nil)
 	ctx := context.Background()
-	dt.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
+	dt.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 	ExpectEq(nil, err)
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -141,7 +141,7 @@ func TestParallelDownloads(t *testing.T) {
 			cache, cacheDir := configureCache(t, 2*tc.objectSize)
 			storageHandle := configureFakeStorage(t)
 			ctx := context.Background()
-			bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
+			bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 			assert.Nil(t, err)
 			minObj, content := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", tc.objectSize)
 			fileCacheConfig := &cfg.FileCacheConfig{
@@ -184,7 +184,7 @@ func TestMultipleConcurrentDownloads(t *testing.T) {
 	storageHandle := configureFakeStorage(t)
 	cache, cacheDir := configureCache(t, 30*util.MiB)
 	ctx := context.Background()
-	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "", false)
+	bucket, err := storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
 	assert.Nil(t, err)
 	minObj1, content1 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/foo.txt", 10*util.MiB)
 	minObj2, content2 := createObjectInStoreAndInitCache(t, cache, bucket, "path/in/gcs/bar.txt", 5*util.MiB)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3101,9 +3101,9 @@ func (fs *fileSystem) ReadFile(
 		if fh.Inode().Bucket().BucketType().IsRapid() {
 			// With rapid buckets, we can read from unfinalized objects as well.
 			// Hence, there is no need to finalize the object from here for rapid buckets.
-			// Hence, if FinalizeFileForRapid is set, then we will call syncFile otherwise
-			// we can call flushFile (as it will not finalize when FinalizeFileForRapid is false) itself.
-			if fs.newConfig.Write.FinalizeFileForRapid {
+			// Hence, if FinalizeFileOnClose is set, then we will call syncFile otherwise
+			// we can call flushFile (as it will not finalize when FinalizeFileOnClose is false) itself.
+			if fs.newConfig.Write.FinalizeFileOnClose {
 				err = fs.syncFile(ctx, fh.Inode())
 			} else {
 				err = fs.flushFile(ctx, fh.Inode())

--- a/internal/fs/grpc_metrics_test.go
+++ b/internal/fs/grpc_metrics_test.go
@@ -303,7 +303,7 @@ func createTestFileSystemWithGrpcMetrics(ctx context.Context, t *testing.T, para
 	// Poke the storage client to trigger internal DirectPath checks with a short timeout.
 	// This prevents the subsequent real operations from hanging for 60s.
 	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	_, _ = sh.BucketHandle(shortCtx, "test-bucket", "", false)
+	_, _ = sh.BucketHandle(shortCtx, "test-bucket", "")
 	cancel()
 
 	bucketName := "test-bucket"

--- a/internal/fs/grpc_metrics_test.go
+++ b/internal/fs/grpc_metrics_test.go
@@ -295,6 +295,7 @@ func createTestFileSystemWithGrpcMetrics(ctx context.Context, t *testing.T, para
 		IsGKE:             true,
 		AnonymousAccess:   true,
 		MetricHandle:      mh,
+		WriteConfig:       &cfg.WriteConfig{},
 	}
 
 	sh, err := storage.NewStorageHandle(ctx, clientConfig, "")

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -69,8 +69,6 @@ type BucketConfig struct {
 	ChunkRetryDeadlineSecs   int64
 	ChunkTransferTimeoutSecs int64
 	TmpObjectPrefix          string
-	// Used in Zonal buckets to determine if objects should be finalized or not.
-	FinalizeFileForRapid bool
 
 	// Disable Initial ListObject API check during the mount operation.
 	DisableListAccessCheck bool
@@ -185,7 +183,7 @@ func (bm *bucketManager) SetUpBucket(
 	if name == canned.FakeBucketName {
 		b = canned.MakeFakeBucket(ctx)
 	} else {
-		b, err = bm.storageHandle.BucketHandle(ctx, name, bm.config.BillingProject, bm.config.FinalizeFileForRapid)
+		b, err = bm.storageHandle.BucketHandle(ctx, name, bm.config.BillingProject)
 		if err != nil {
 			err = fmt.Errorf("BucketHandle: %w", err)
 			return

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -61,7 +61,7 @@ func (t *BucketManagerTest) SetUp(_ *TestInfo) {
 			LocationType:          "zone",
 		}, nil)
 	ctx := context.Background()
-	t.bucket, err = t.storageHandle.BucketHandle(ctx, TestBucketName, "", false)
+	t.bucket, err = t.storageHandle.BucketHandle(ctx, TestBucketName, "")
 
 	AssertNe(nil, t.bucket)
 	AssertEq(nil, err)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -202,7 +202,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	wc.ProgressFunc = req.CallBack
 	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
 	// routes writes to the RAPID storage class instead of the STANDARD class.
-	wc.Append = bh.BucketType().Zonal || bh.writeConfig.EnableRapidWrites
+	wc.Append = bh.BucketType().Zonal || (bh.BucketType().Pirlo && bh.writeConfig != nil && bh.writeConfig.EnableRapidWrites)
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
@@ -239,7 +239,7 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc.ProgressFunc = callBack
 	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
 	// routes writes to the RAPID storage class instead of the STANDARD class.
-	wc.Append = bh.BucketType().Zonal || bh.writeConfig.EnableRapidWrites
+	wc.Append = bh.BucketType().Zonal || (bh.BucketType().Pirlo && bh.writeConfig != nil && bh.writeConfig.EnableRapidWrites)
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
 	// When writer.Append is false, then this parameter is anyways ignored.

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -28,6 +28,7 @@ import (
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"google.golang.org/api/iterator"
@@ -39,12 +40,12 @@ const FullBucketPathHNS = "projects/_/buckets/%s"
 
 type bucketHandle struct {
 	gcs.Bucket
-	bucket               *storage.BucketHandle
-	bucketName           string
-	bucketType           *gcs.BucketType
-	controlClient        StorageControlClient
-	finalizeFileForRapid bool
-	billingProject       string
+	bucket         *storage.BucketHandle
+	bucketName     string
+	bucketType     *gcs.BucketType
+	controlClient  StorageControlClient
+	billingProject string
+	writeConfig    *cfg.WriteConfig
 }
 
 func (bh *bucketHandle) Name() string {
@@ -199,12 +200,14 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	wc = storageutil.SetAttrsInWriter(wc, req)
 	wc.ProgressFunc = req.CallBack
-	// All objects in zonal buckets must be appendable.
-	wc.Append = bh.BucketType().Zonal
-	// Objects in zonal buckets should not be finalized by default. Finalize them if finalizeFileForRapid is set to true.
-	// When writer.Append is false,then this parameter is anyways ignored.
-	// Refer: https://github.com/googleapis/google-cloud-go/blob/main/storage/writer.go#L135
-	wc.FinalizeOnClose = bh.finalizeFileForRapid
+	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
+	// routes writes to the RAPID storage class instead of the STANDARD class.
+	wc.Append = bh.BucketType().Zonal || bh.writeConfig.EnableRapidWrites
+	// By default, objects in zonal buckets are not finalized on close, whereas objects in
+	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
+	// When writer.Append is false, then this parameter is anyways ignored.
+	// Refer: https://github.com/googleapis/google-cloud-go/blob/bf56afb2a15301500b9981ee76ccc5f449e3f545/storage/writer.go#L160
+	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileOnClose
 
 	// Copy the contents to the writer.
 	if _, err = io.Copy(wc, req.Contents); err != nil {
@@ -234,13 +237,14 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc.ChunkRetryDeadline = time.Duration(req.ChunkRetryDeadlineSecs) * time.Second
 	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	wc.ProgressFunc = callBack
-	// All objects in zonal buckets must be appendable.
-	wc.Append = bh.BucketType().Zonal
-	// Objects in zonal buckets should not be finalized by default. Finalize them if finalizeFileForRapid is set to true.
+	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
+	// routes writes to the RAPID storage class instead of the STANDARD class.
+	wc.Append = bh.BucketType().Zonal || bh.writeConfig.EnableRapidWrites
+	// By default, objects in zonal buckets are not finalized on close, whereas objects in
+	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
-	// Refer: https://github.com/googleapis/google-cloud-go/blob/main/storage/writer.go#L135
-	wc.FinalizeOnClose = bh.finalizeFileForRapid
-
+	// Refer: https://github.com/googleapis/google-cloud-go/blob/bf56afb2a15301500b9981ee76ccc5f449e3f545/storage/writer.go#L160
+	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileOnClose
 	return wc, nil
 }
 
@@ -253,7 +257,7 @@ func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	opts := storage.AppendableWriterOpts{
 		ChunkSize:       req.ChunkSize,
 		ProgressFunc:    req.CallBack,
-		FinalizeOnClose: bh.finalizeFileForRapid,
+		FinalizeOnClose: bh.writeConfig.FinalizeFileOnClose,
 	}
 
 	tw, off, err := obj.NewWriterFromAppendableObject(ctx, &opts) // Takeover writer tw created from offset off.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -71,7 +71,7 @@ func createBucketHandle(testSuite *BucketHandleTest, resp *controlpb.StorageLayo
 
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(resp, nil)
-	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", false)
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "")
 	testSuite.bucketHandle.controlClient = testSuite.mockClient
 
 	assert.NotNil(testSuite.T(), testSuite.bucketHandle)
@@ -1513,7 +1513,7 @@ func (testSuite *BucketHandleTest) TestBucketHandleWithError() {
 
 	// Test when the client returns an error.
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).Return(x, errors.New("mocked error"))
-	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", false)
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "")
 
 	assert.Nil(testSuite.T(), testSuite.bucketHandle)
 	assert.Contains(testSuite.T(), err.Error(), "mocked error")
@@ -1529,7 +1529,7 @@ func (testSuite *BucketHandleTest) TestBucketHandleWithRapidAppendsEnabled() {
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).Return(&controlpb.StorageLayout{}, nil)
 	testSuite.mockClient.On("getClient", mock.Anything, mock.Anything).Return(&storage.Client{}, nil)
 
-	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "", false)
+	testSuite.bucketHandle, err = testSuite.storageHandle.BucketHandle(context.Background(), TestBucketName, "")
 
 	assert.NotNil(testSuite.T(), testSuite.bucketHandle)
 	assert.Nil(testSuite.T(), err)

--- a/internal/storage/fake_storage_util.go
+++ b/internal/storage/fake_storage_util.go
@@ -68,7 +68,7 @@ func (f *fakeStorage) CreateStorageHandle() (sh StorageHandle) {
 		grpcClient:               f.fakeStorageServer.Client(),
 		grpcClientWithBidiConfig: f.fakeStorageServer.Client(),
 		storageControlClient:     f.mockClient,
-		clientConfig:             storageutil.StorageClientConfig{ClientProtocol: f.protocol},
+		clientConfig:             storageutil.StorageClientConfig{ClientProtocol: f.protocol, WriteConfig: &cfg.WriteConfig{}},
 	}
 	return
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -68,7 +68,7 @@ type StorageHandle interface {
 	// to that project rather than to the bucket's owning project.
 	//
 	// A user-project is required for all operations on Requester Pays buckets.
-	BucketHandle(ctx context.Context, bucketName string, billingProject string, finalizeFileForRapid bool) (bh *bucketHandle, err error)
+	BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error)
 }
 
 type storageClient struct {
@@ -504,7 +504,7 @@ func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType
 	return withBillingProject(controlClientWithoutBillingProject, billingProject)
 }
 
-func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string, finalizeFileForRapid bool) (bh *bucketHandle, err error) {
+func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error) {
 	var client *storage.Client
 	bucketType, err := sh.lookupBucketType(bucketName)
 	if err != nil {
@@ -523,12 +523,12 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 	controlClient := sh.controlClientForBucketHandle(bucketType, billingProject)
 
 	bh = &bucketHandle{
-		bucket:               storageBucketHandle,
-		bucketName:           bucketName,
-		controlClient:        controlClient,
-		bucketType:           bucketType,
-		finalizeFileForRapid: finalizeFileForRapid,
-		billingProject:       billingProject,
+		bucket:         storageBucketHandle,
+		bucketName:     bucketName,
+		controlClient:  controlClient,
+		bucketType:     bucketType,
+		billingProject: billingProject,
+		writeConfig:    sh.clientConfig.WriteConfig,
 	}
 
 	return

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -126,7 +126,7 @@ func (testSuite *StorageHandleTest) controlClientCallOptionsWithRetry() *control
 func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithEmptyBillingProject() {
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockStorageLayout(gcs.BucketType{})
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, "", false)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, "")
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Nil(testSuite.T(), err)
@@ -139,7 +139,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithEm
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("bucket does not exist"))
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, "", false)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, "")
 
 	assert.NotNil(testSuite.T(), err)
 	assert.Nil(testSuite.T(), bucketHandle)
@@ -149,7 +149,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketExistsWithNonEmpty
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockStorageLayout(gcs.BucketType{Hierarchical: true})
 
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, projectID, false)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, TestBucketName, projectID)
 
 	assert.NotNil(testSuite.T(), bucketHandle)
 	assert.Nil(testSuite.T(), err)
@@ -165,7 +165,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNo
 	storageHandle := testSuite.fakeStorage.CreateStorageHandle()
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("bucket does not exist"))
-	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, projectID, false)
+	bucketHandle, err := storageHandle.BucketHandle(testSuite.ctx, invalidBucketName, projectID)
 
 	assert.Nil(testSuite.T(), bucketHandle)
 	assert.NotNil(testSuite.T(), err)
@@ -349,7 +349,7 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtoco
 	sh := fakeStorage.CreateStorageHandle()
 	defer fakeStorage.ShutDown()
 	assert.NotNil(testSuite.T(), sh)
-	bh, err := sh.BucketHandle(testSuite.ctx, TestBucketName, projectID, false)
+	bh, err := sh.BucketHandle(testSuite.ctx, TestBucketName, projectID)
 
 	assert.Nil(testSuite.T(), bh)
 	assert.NotNil(testSuite.T(), err)

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -94,6 +94,8 @@ type StorageClientConfig struct {
 
 	// IsGKE inspects the mountPoint and indicates if running in a GKE environment.
 	IsGKE bool
+
+	WriteConfig *cfg.WriteConfig
 }
 
 func CreateHttpClient(storageClientConfig *StorageClientConfig, tokenSrc oauth2.TokenSource) (httpClient *http.Client, err error) {

--- a/internal/storage/storageutil/test_util.go
+++ b/internal/storage/storageutil/test_util.go
@@ -50,5 +50,6 @@ func GetDefaultStorageClientConfig(keyFile string) (clientConfig StorageClientCo
 			ReqIncreaseRate:     15,
 			ReqTargetPercentile: 0.99,
 		},
+		WriteConfig: &cfg.WriteConfig{},
 	}
 }

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -91,7 +91,7 @@ func TestApplyOptimizations(t *testing.T) {
 				config:          Config{Profile: "{{.Name}}"},
 				userSetFlags:    map[string]any{},
 				input:           nil,
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" .Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{.Value}},
 			},
 		{{- end }}
@@ -105,7 +105,7 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "{{$machineType}}",
 				},
 				input:           nil,
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $mbo.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$mbo.Value}},
 			},
 		{{- end }}
@@ -116,7 +116,7 @@ func TestApplyOptimizations(t *testing.T) {
 				config: Config{Profile: ""},
 				userSetFlags: map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $bto.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$bto.Value}},
 			},
 		{{- end }}
@@ -131,7 +131,7 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "{{$machineType}}",
 				},
 				input:           nil,
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $profile.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$profile.Value}},
 			},
 		{{- end }}
@@ -143,7 +143,7 @@ func TestApplyOptimizations(t *testing.T) {
 				config: Config{Profile: "{{$profile.Name}}"},
 				userSetFlags: map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $profile.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$profile.Value}},
 			},
 		{{- end }}
@@ -158,7 +158,7 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "{{$machineType}}",
 				},
 				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $mbo.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$mbo.Value}},
 			},
 		{{- end }}
@@ -172,7 +172,7 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "{{$machineType}}",
 				},
 				input:           nil,
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $mbo.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$mbo.Value}},
 			},
 			{{- $unrelatedProfile := "aiml-training" -}}
@@ -190,7 +190,7 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "{{$machineType}}",
 				},
 				input:           nil,
-				expectOptimized: true,
+				expectOptimized: {{if ne (printf "%v" $mbo.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$mbo.Value}},
 			},
 			{{- end }}


### PR DESCRIPTION
### Description
This PR introduces the `enable-rapid-writes` flag and refactors the file finalization logic to support optimizations for Pirlo buckets.

#### Key Changes
*   **Added `enable-rapid-writes` flag**: This new flag allows users to toggle between the **STANDARD** and **RAPID** storage classes when writing to Pirlo buckets.
*   **Renamed and Optimized `finalize-file-on-close`**: The `finalize-file-for-rapid` flag has been renamed to `finalize-file-on-close`. Additionally, bucket-type optimizations have been added, it now defaults to `true` for **pirlo** buckets and `false` for **zonal** buckets when not explicitly set.
*   **Architectural Refactor for Optimization**: The `finalize-file-on-close` parameter was removed from the `BucketHandle` function signature. Instead, it is now retrieved directly from the `WriteConfig` within the `StorageClientConfig`. This ensures that the correctly optimized value (determined during configuration binding) is used by the bucket handle rather than a stale or unoptimized parameter.

### Link to the issue in case of a bug fix.
b/498246786

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
