### PR TITLE
fix(native retries): align exponential backoff with GAX and fix max sleep bound

### DIFF
--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -49,8 +49,6 @@ type exponentialBackoff struct {
 	config exponentialBackoffConfig
 	// Duration for next backoff. Capped at max. Returned by next().
 	next time.Duration
-	// Duration waited in previous backoff.
-	prev time.Duration
 }
 
 // newExponentialBackoff returns a new exponentialBackoff given
@@ -80,9 +78,6 @@ func (b *exponentialBackoff) waitWithJitter(ctx context.Context) error {
 
 	nextDuration := b.nextDuration()
 	jitteryBackoffDuration := time.Duration(1 + rand.Int63n(int64(nextDuration)))
-	// Ensure that the backoff duration goes up at the rate of at least the multiplier.
-	jitteryBackoffDuration = max(jitteryBackoffDuration, time.Duration(float64(b.prev)*b.config.multiplier))
-	b.prev = jitteryBackoffDuration
 	select {
 	case <-time.After(jitteryBackoffDuration):
 		return nil

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -77,7 +77,7 @@ func (b *exponentialBackoff) waitWithJitter(ctx context.Context) error {
 	}
 
 	nextDuration := b.nextDuration()
-	jitteryBackoffDuration := time.Duration(1 + rand.Int63n(int64(nextDuration)))
+	jitteryBackoffDuration := time.Duration(1 + rand.Int63n(max(1, int64(nextDuration))))
 	select {
 	case <-time.After(jitteryBackoffDuration):
 		return nil

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -122,7 +122,7 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_NoContextCancelled() {
 	elapsed := time.Since(start)
 
 	assert.NoError(t.T(), err)
-	// The function should wait for a duration higher than initial, but not too high.
+	// The function should wait for a random duration bounded by initial (plus OS scheduler latency).
 	// Keeping a somewhat loose limit to avoid failing because of go itself taking around 10ms sometimes
 	// to return.
 	assert.LessOrEqual(t.T(), elapsed, initial*3, "waitWithJitter should not wait excessively long")
@@ -139,18 +139,25 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BackoffGrowth() {
 	})
 	ctx := context.Background()
 
-	// First call to establish the initial backoff.
+	expectedNext := initial
+
+	start := time.Now()
 	err := b.waitWithJitter(ctx)
+	elapsed := time.Since(start)
 	assert.NoError(t.T(), err)
 
-	// Subsequent calls should execute without error.
+	expectedNext = time.Duration(float64(expectedNext) * multiplier)
+	assert.Equal(t.T(), expectedNext, b.next)
+	assert.LessOrEqual(t.T(), elapsed, maxValue*2)
+
 	for range 3 {
 		start := time.Now()
 		err := b.waitWithJitter(ctx)
 		elapsed := time.Since(start)
 		require.NoError(t.T(), err)
 
-		// The backoff should also be capped by the max value (with headroom for OS scheduler).
+		expectedNext = time.Duration(float64(expectedNext) * multiplier)
+		assert.Equal(t.T(), expectedNext, b.next)
 		require.LessOrEqual(t.T(), elapsed, maxValue*2)
 	}
 }
@@ -178,7 +185,7 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BoundsRespectMax() {
 		require.NoError(t.T(), err)
 		// Measured wait time should be capped by max ceiling.
 		// We add a 50ms buffer to ensure tests don't flake due to OS scheduler latency.
-		require.LessOrEqual(t.T(), elapsed, maxValue*2+50*time.Millisecond)
+		require.LessOrEqual(t.T(), elapsed, maxValue+50*time.Millisecond)
 	}
 }
 

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -101,36 +101,33 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_ContextCancelled() {
 	elapsed := time.Since(start)
 
 	assert.ErrorIs(t.T(), err, context.Canceled)
-	// The function should return almost immediately.
-	assert.Less(t.T(), elapsed, initial, "waitWithJitter should return quickly when context is cancelled")
+	// The function should return almost immediately without backoff sleep.
+	assert.Less(t.T(), elapsed, 20*time.Millisecond, "waitWithJitter should return quickly when context is cancelled")
 }
 
 func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_NoContextCancelled() {
-	initial := 5 * time.Millisecond // A short duration to ensure it waits. Making it any shorter can cause random failures
-	// because context cancel itself takes about a millisecond.
+	initial := 100 * time.Millisecond // Much larger than OS scheduler latency
 	maxValue := 5 * initial
 	b := newExponentialBackoff(&exponentialBackoffConfig{
 		initial:    initial,
 		max:        maxValue,
 		multiplier: 2.0,
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
 	start := time.Now()
 	err := b.waitWithJitter(ctx)
 	elapsed := time.Since(start)
 
 	assert.NoError(t.T(), err)
-	// The function should wait for a random duration bounded by initial (plus OS scheduler latency).
-	// Keeping a somewhat loose limit to avoid failing because of go itself taking around 10ms sometimes
-	// to return.
-	assert.LessOrEqual(t.T(), elapsed, initial*3, "waitWithJitter should not wait excessively long")
+	// Strict bound: allows at most 120ms for a max 100ms sleep.
+	assert.LessOrEqual(t.T(), elapsed, initial+20*time.Millisecond, "waitWithJitter should not wait excessively long")
 }
 
-func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BackoffGrowth() {
-	initial := 2 * time.Millisecond
-	maxValue := 50 * time.Millisecond
+func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_FirstAttemptBackoffGrowth() {
+	// Arrange
+	initial := 100 * time.Millisecond // Much larger than OS scheduler latency.
+	maxValue := 500 * time.Millisecond
 	multiplier := 2.0
 	b := newExponentialBackoff(&exponentialBackoffConfig{
 		initial:    initial,
@@ -141,24 +138,47 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BackoffGrowth() {
 
 	expectedNext := initial
 
+	// Act
 	start := time.Now()
 	err := b.waitWithJitter(ctx)
 	elapsed := time.Since(start)
+
+	// Assert
 	assert.NoError(t.T(), err)
 
-	expectedNext = time.Duration(float64(expectedNext) * multiplier)
+	expectedNext = min(maxValue, time.Duration(float64(expectedNext)*multiplier))
 	assert.Equal(t.T(), expectedNext, b.next)
-	assert.LessOrEqual(t.T(), elapsed, maxValue*2)
+	assert.LessOrEqual(t.T(), elapsed, initial+20*time.Millisecond)
+}
 
-	for range 3 {
+func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_ConsecutiveAttemptsBackoffGrowth() {
+	// Arrange
+	initial := 100 * time.Millisecond // Much larger than OS scheduler latency.
+	maxValue := 500 * time.Millisecond
+	multiplier := 2.0
+	b := newExponentialBackoff(&exponentialBackoffConfig{
+		initial:    initial,
+		max:        maxValue,
+		multiplier: multiplier,
+	})
+	ctx := context.Background()
+
+	expectedNext := initial
+
+	for range 4 {
+		// Act
 		start := time.Now()
 		err := b.waitWithJitter(ctx)
 		elapsed := time.Since(start)
+
+		currentBackoff := expectedNext
+
+		// Assert
 		require.NoError(t.T(), err)
 
-		expectedNext = time.Duration(float64(expectedNext) * multiplier)
+		expectedNext = min(maxValue, time.Duration(float64(expectedNext)*multiplier))
 		assert.Equal(t.T(), expectedNext, b.next)
-		require.LessOrEqual(t.T(), elapsed, maxValue*2)
+		require.LessOrEqual(t.T(), elapsed, currentBackoff+20*time.Millisecond)
 	}
 }
 
@@ -172,6 +192,7 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BoundsRespectMax() {
 		max:        maxValue,
 		multiplier: multiplier,
 	})
+	expectedNext := initial
 	ctx := context.Background()
 
 	// Call many times to let it saturate the max value and test the ceiling bounds
@@ -181,11 +202,13 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BoundsRespectMax() {
 		err := b.waitWithJitter(ctx)
 		elapsed := time.Since(start)
 
+		currentBackoff := expectedNext
+
 		// Assert
 		require.NoError(t.T(), err)
-		// Measured wait time should be capped by max ceiling.
-		// We add a 50ms buffer to ensure tests don't flake due to OS scheduler latency.
-		require.LessOrEqual(t.T(), elapsed, maxValue+50*time.Millisecond)
+		expectedNext = min(maxValue, time.Duration(float64(expectedNext)*multiplier))
+		// Measured wait time should be capped by current backoff ceiling plus a scheduler safety margin.
+		require.LessOrEqual(t.T(), elapsed, currentBackoff+20*time.Millisecond)
 	}
 }
 
@@ -222,11 +245,11 @@ type ExecuteWithRetryTestSuite struct {
 
 func (t *ExecuteWithRetryTestSuite) SetupTest() {
 	t.retryConfig = &RetryConfig{
-		RetryDeadline:    500 * time.Microsecond,
-		TotalRetryBudget: 2000 * time.Microsecond,
+		RetryDeadline:    50 * time.Millisecond,
+		TotalRetryBudget: 200 * time.Millisecond,
 		BackoffConfig: exponentialBackoffConfig{
-			initial:    1 * time.Microsecond,
-			max:        100 * time.Microsecond,
+			initial:    1 * time.Millisecond,
+			max:        10 * time.Millisecond,
 			multiplier: 2,
 		},
 	}
@@ -312,7 +335,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_RetryableThenNonRetryab
 
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
 	// Arrange
-	stallDuration := t.retryConfig.RetryDeadline + 10*time.Millisecond
+	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
 	var callCount int
 	apiCall := func(ctx context.Context) (string, error) {
 		callCount++
@@ -320,7 +343,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
 		select {
 		case <-time.After(stallDuration):
 			// This case should not be hit, as the context deadline
-			// is shorter by 10ms than stallDuration.
+			// is shorter than stallDuration.
 			return "", errors.New("simulated apiCall finished before context timeout")
 		case <-ctx.Done():
 			return "", ctx.Err()
@@ -339,9 +362,9 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_TotalRetryBudgetExceede
 	// Arrange
 	var callCount int
 	// Set a short total retry budget.
-	t.retryConfig.TotalRetryBudget = 500 * time.Microsecond
-	t.retryConfig.RetryDeadline = 100 * time.Microsecond
-	t.retryConfig.BackoffConfig.initial = 1 * time.Microsecond // Ensure backoff pushes it over the edge.
+	t.retryConfig.TotalRetryBudget = 30 * time.Millisecond
+	t.retryConfig.RetryDeadline = 10 * time.Millisecond
+	t.retryConfig.BackoffConfig.initial = 2 * time.Millisecond // Ensure backoff pushes it over the edge.
 	apiCall := func(ctx context.Context) (string, error) {
 		callCount++
 		return "", status.Error(codes.Unavailable, "server unavailable")
@@ -358,11 +381,11 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_TotalRetryBudgetExceede
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutShorterThanRetryDeadline() {
 	// Arrange
 	var callCount int
-	t.retryConfig.RetryDeadline = 1000 * time.Microsecond
-	t.retryConfig.TotalRetryBudget = 10000 * time.Microsecond
-	stallDuration := t.retryConfig.RetryDeadline + 1000*time.Microsecond
+	t.retryConfig.RetryDeadline = 100 * time.Millisecond
+	t.retryConfig.TotalRetryBudget = 1000 * time.Millisecond
+	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
 	// Set a parent context timeout that is shorter than the total retry budget.
-	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.RetryDeadline-500*time.Microsecond)
+	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.RetryDeadline-50*time.Millisecond)
 	defer cancel()
 	apiCall := func(ctx context.Context) (string, error) {
 		callCount++
@@ -390,9 +413,9 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutSho
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutBetweenDeadlines() {
 	// Arrange
 	var callCount int
-	stallDuration := t.retryConfig.RetryDeadline + 5*time.Microsecond
+	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
 	// Set a parent context timeout that is longer than one attempt but shorter than the total budget.
-	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.RetryDeadline+50*time.Microsecond)
+	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.RetryDeadline+50*time.Millisecond)
 	defer cancel()
 	apiCall := func(ctx context.Context) (string, error) {
 		callCount++
@@ -416,8 +439,8 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutBet
 
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutLongerThanBudget() {
 	// Arrange
-	stallDuration := t.retryConfig.RetryDeadline + 5*time.Microsecond
-	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.TotalRetryBudget+100*time.Microsecond)
+	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
+	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.TotalRetryBudget+100*time.Millisecond)
 	defer cancel()
 	apiCall := func(ctx context.Context) (string, error) {
 		select {

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -142,24 +142,43 @@ func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BackoffGrowth() {
 	// First call to establish the initial backoff.
 	err := b.waitWithJitter(ctx)
 	assert.NoError(t.T(), err)
-	var lastBackoff time.Duration
 
-	// Subsequent calls should demonstrate exponential growth.
+	// Subsequent calls should execute without error.
 	for range 3 {
+		start := time.Now()
 		err := b.waitWithJitter(ctx)
+		elapsed := time.Since(start)
 		require.NoError(t.T(), err)
 
-		// The new backoff should be at least the last backoff times the multiplier.
-		// Due to jitter, it can be larger, so we check for >=
-		expectedMinBackoff := time.Duration(float64(lastBackoff) * multiplier)
-		require.GreaterOrEqual(t.T(), b.prev, expectedMinBackoff)
+		// The backoff should also be capped by the max value (with headroom for OS scheduler).
+		require.LessOrEqual(t.T(), elapsed, maxValue*2)
+	}
+}
 
-		// The backoff should also be capped by the max value.
-		if b.prev > maxValue {
-			require.Equal(t.T(), b.prev, maxValue)
-		}
+func (t *ExponentialBackoffTestSuite) TestWaitWithJitter_BoundsRespectMax() {
+	// Arrange
+	initial := 5 * time.Millisecond
+	maxValue := 20 * time.Millisecond
+	multiplier := 2.0
+	b := newExponentialBackoff(&exponentialBackoffConfig{
+		initial:    initial,
+		max:        maxValue,
+		multiplier: multiplier,
+	})
+	ctx := context.Background()
 
-		lastBackoff = b.prev
+	// Call many times to let it saturate the max value and test the ceiling bounds
+	for range 20 {
+		// Act
+		start := time.Now()
+		err := b.waitWithJitter(ctx)
+		elapsed := time.Since(start)
+
+		// Assert
+		require.NoError(t.T(), err)
+		// Measured wait time should be capped by max ceiling.
+		// We add a 50ms buffer to ensure tests don't flake due to OS scheduler latency.
+		require.LessOrEqual(t.T(), elapsed, maxValue*2+50*time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
### Description
This PR refactors the `exponentialBackoff` implementation in `internal/storage/storageutil/retry.go` to remove redundant state and align it with the standard GAX (Google API Extensions) implementation. It also fixes a bug where the sleep duration could exceed the configured `max-retry-sleep`.
## Changes
### `internal/storage/storageutil/retry.go`
- Removed the `prev` field from the `exponentialBackoff` struct.
- Removed the logic that forced the next jittery backoff to be at least `prev * multiplier`. This logic failed to respect the `max` cap and could cause sleep durations to exceed `max-retry-sleep`.
- The implementation now matches the "Full Jitter" strategy used in `github.com/googleapis/gax-go/v2`.
### `internal/storage/storageutil/retry_test.go`
- Updated `TestWaitWithJitter_BackoffGrowth` to use timing-based assertions (`time.Since`) instead of inspecting the removed internal `prev` field. This makes the test less dependent on implementation details.
- Added a new test `TestWaitWithJitter_BoundsRespectMax` to verify that the wait time is correctly capped by the max value over multiple iterations, preventing the growth bug we fixed.
- Fixed multiple other tests where the test related time durations were way less than the OS Schedular overhead durations reflecting incorrect test assertions.
## Why
The previous implementation could cause sleep durations to exceed `max-retry-sleep` because the `prev * multiplier` logic did not apply the max cap

Ref: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

### Link to the issue in case of a bug fix.
b/510286165

### Testing details
1. Manual - Added unit test for validation
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
