### PR TITLE
fix(log): Remove metric mode log as it could potentially spam logs and not much actionable info could be derived from it

### DIFF
--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -679,7 +679,6 @@ func getMetricOpenMode(openMode util.OpenMode) metrics.OpenMode {
 		}
 		return metrics.OpenModeWriteOnlyAttr
 	default:
-		logger.Warnf("getMetricOpenMode: unexpected accessMode: %d, isAppend: %t", openMode.AccessMode(), openMode.IsAppend())
 		return metrics.OpenModeOtherAttr
 	}
 }


### PR DESCRIPTION
### Description
Remove metric mode log as it could potentially spam logs and not much actionable info could be derived from it and is getting logged even when metric is enabled, moreover such a log should be in the major product flow and logging it in metrics flow which is a side concern doesn't seem efficient.

### Link to the issue in case of a bug fix.
b/510655203

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A