### PR TITLE
fix: Making dp check more reliable

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -237,7 +237,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		RetryMultiplier:  1.5,
 		MaxRetryAttempts: directPathDetectionMaxAttempts,
 	}
-	retryConfig := storageutil.NewRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration, 1*time.Second)
+	retryConfig := storageutil.NewRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration, storageutil.DefaultInitialBackoff)
 
 	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
 		return bucketHandle.Object(testObject).Attrs(attemptCtx)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -234,7 +234,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 
 	dpClientConfig := &storageutil.StorageClientConfig{
 		MaxRetrySleep:    directPathDetectionMaxBackoff,
-		RetryMultiplier:  1.5,
+		RetryMultiplier:  clientConfig.RetryMultiplier,
 		MaxRetryAttempts: directPathDetectionMaxAttempts,
 	}
 	retryConfig := storageutil.NewRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration, storageutil.DefaultInitialBackoff)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -202,6 +202,12 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 
+	// Set the production level retry config.
+	defer func() {
+		logger.Infof("Applying production retry config after DirectPath verification.")
+		setRetryConfig(ctx, sc, clientConfig)
+	}()
+
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
 		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
@@ -218,12 +224,6 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil.StorageClientConfig, bucketName string, sc *storage.Client, billingProject string) error {
 	// Verify DirectPath connection by performing an stat call on the bucket
 	logger.Infof("Verifying DirectPath connectivity for bucket %q with stat call", bucketName)
-
-	// Restore the production level retry config.
-	defer func() {
-		logger.Infof("Applying production retry config after DirectPath verification.")
-		setRetryConfig(ctx, sc, clientConfig)
-	}()
 
 	var notFoundError *gcs.NotFoundError
 	var testObject = "gcsfuse-dp-object"

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,7 +57,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 15 * time.Second
+	directPathDetectionTimeout          = 10 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )
@@ -239,8 +239,6 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil.StorageClientConfig, bucketName string, sc *storage.Client, billingProject string) error {
 	// Verify DirectPath connection by performing an stat call on the bucket
 	logger.Infof("Verifying DirectPath connectivity for bucket %q with stat call", bucketName)
-	// Apply detection retry config for initial verification
-	setDPDetectionRetryConfig(ctx, sc, clientConfig)
 
 	// Restore the production level retry config.
 	defer func() {
@@ -248,17 +246,29 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 
-	verifyCtx, verifyCancel := context.WithTimeout(ctx, directPathDetectionTimeout)
-	defer verifyCancel()
-
-	// Retrieving object attrs through Go Storage Client.
 	var notFoundError *gcs.NotFoundError
 	var testObject = "gcsfuse-dp-object"
 	bucketHandle := sc.Bucket(bucketName)
 	if billingProject != "" {
 		bucketHandle = bucketHandle.UserProject(billingProject)
 	}
-	_, statErr := bucketHandle.Object(testObject).Attrs(verifyCtx)
+
+	dpClientConfig := &storageutil.StorageClientConfig{
+		MaxRetrySleep:    directPathDetectionMaxBackoff,
+		RetryMultiplier:  1.5,
+		MaxRetryAttempts: directPathDetectionMaxAttempts,
+	}
+	retryConfig := storageutil.NewRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration, 1*time.Second)
+
+	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
+		return bucketHandle.Object(testObject).Attrs(attemptCtx)
+	}
+
+	// Disable Go SDK retries for this call to let ExecuteWithRetry handle it.
+	sc.SetRetry(storage.WithMaxAttempts(1))
+
+	_, statErr := storageutil.ExecuteWithRetryAtLogLevel(ctx, retryConfig, "Attrs", testObject, apiCall, logger.LevelInfo)
+
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -57,7 +57,7 @@ const (
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
 	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 10 * time.Second
+	directPathDetectionTimeout          = 15 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
 	directPathDetectionMaxRetryDuration = 1 * time.Minute
 )

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -183,14 +183,14 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
 	defer unSetDirectPathEnvVariable()
 
 	var clientOpts []option.ClientOption
-	clientOpts, err = createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
+	clientOpts, err := createClientOptionForGRPCClient(ctx, clientConfig, enableBidiConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
@@ -198,7 +198,8 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
 	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
 
-	if sc, err = storage.NewGRPCClient(ctx, clientOpts...); err != nil {
+	sc, err := storage.NewGRPCClient(ctx, clientOpts...)
+	if err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -182,26 +182,6 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 	sc.SetRetry(retryOpts...)
 }
 
-// setDPDetectionRetryConfig applies a lenient retry configuration for DirectPath detection phase.
-// This config is designed to fail fast during the initial connection check.
-func setDPDetectionRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *storageutil.StorageClientConfig) {
-	detectionRetryOpts := []storage.RetryOption{
-		storage.WithBackoff(gax.Backoff{
-			Max:        directPathDetectionMaxBackoff,
-			Multiplier: 1.5, // Gentle multiplier for fast detection
-		}),
-		storage.WithMaxAttempts(directPathDetectionMaxAttempts),
-		storage.WithPolicy(storage.RetryAlways),
-		storage.WithErrorFunc(func(err error) bool {
-			// More permissive during detection to allow quick failure
-			return storageutil.ShouldRetryWithMonitoring(ctx, err, clientConfig.MetricHandle)
-		}),
-		storage.WithMaxRetryDuration(directPathDetectionMaxRetryDuration),
-	}
-
-	sc.SetRetry(detectionRetryOpts...)
-}
-
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
 func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (sc *storage.Client, err error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
@@ -221,7 +201,6 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	if sc, err = storage.NewGRPCClient(ctx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
-	setRetryConfig(ctx, sc, clientConfig)
 
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -97,6 +97,8 @@ type RetryConfig struct {
 	RetryDeadline time.Duration
 	// Total duration allowed across all the attempts.
 	TotalRetryBudget time.Duration
+	// Max attempts to make for the operation.
+	MaxAttempts int
 	// Config for managing backoff durations in-between retry attempts.
 	BackoffConfig exponentialBackoffConfig
 }
@@ -107,6 +109,7 @@ func NewRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetry
 	return &RetryConfig{
 		RetryDeadline:    retryDeadline,
 		TotalRetryBudget: totalRetryBudget,
+		MaxAttempts:      clientConfig.MaxRetryAttempts,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    initialBackoff,
 			max:        clientConfig.MaxRetrySleep,
@@ -154,6 +157,10 @@ func ExecuteWithRetryAtLogLevel[T any](
 
 		if err == nil {
 			return result, nil
+		}
+
+		if config.MaxAttempts > 0 && i+1 >= config.MaxAttempts {
+			return zero, fmt.Errorf("%s for %q failed after %d attempts (last server/client error = %v)", operationName, reqDescription, config.MaxAttempts, err)
 		}
 
 		// If the error is not retryable, return it immediately.

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -427,3 +427,22 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextAlreadyCan
 	assert.ErrorIs(t.T(), err, context.Canceled)
 	assert.Equal(t.T(), 0, callCount, "apiCall should not have been executed")
 }
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_MaxAttemptsReached() {
+	// Arrange
+	var callCount int
+	t.retryConfig.MaxAttempts = 2
+	retryableErr := status.Error(codes.Unavailable, "server unavailable")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		return "", retryableErr
+	}
+
+	// Act
+	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Contains(t.T(), err.Error(), "failed after 2 attempts")
+	assert.Equal(t.T(), 2, callCount, "apiCall should have been called exactly 2 times")
+}


### PR DESCRIPTION


### Description
Make the stat call during dp check more reliable by using executeWithRetry method to handle stall and failure scenarios.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - Added as applicable
3. Integration tests - Already present

### Any backward incompatible change? If so, please explain.
