### PR TITLE
ci(actions): auto-label new PRs with execute-integration-tests

### DIFF
--- a/.github/workflows/auto-add-label-on-prs.yml
+++ b/.github/workflows/auto-add-label-on-prs.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Add execute-integration-tests label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             try {

--- a/.github/workflows/auto-add-label-on-prs.yml
+++ b/.github/workflows/auto-add-label-on-prs.yml
@@ -1,0 +1,28 @@
+name: Auto-label New PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-default-labels:
+    runs-on: ubuntu-latest
+    # This permission is required to add labels to the PR
+    permissions:
+      pull-requests: write 
+      issues: write
+    steps:
+      - name: Add execute-integration-tests label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['execute-integration-tests']
+              });
+            } catch (error) {
+              console.log(`Unable to add 'execute-integration-tests' label (e.g., restricted permissions or fork PR): ${error.message}. Silently skipping.`);
+            }


### PR DESCRIPTION
### Description

This PR introduces an automated, time-optimized integration testing requirement for all newly opened PRs to catch regressions early and reduce developer toil.

Specifically, it:
1. Adds a GitHub Actions workflow (`auto-add-label-on-prs.yml`) to automatically apply the `execute-integration-tests` label to new PRs.

By applying this label by default, we ensure that integration tests are executed, preventing PR submissions without E2E test validation.

### Link to the issue in case of a bug fix.

[bug](https://buganizer.corp.google.com/issues/511967946)

### Testing details

1. Manual - Verified the GitHub actions script syntax and the Kokoro `build.sh` bash logic.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

No.
