### PR TITLE
feat(caching): add negative entry caching to stat cache

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -682,6 +682,8 @@ type MetadataCacheConfig struct {
 
 	EnableMetadataPrefetch bool `yaml:"enable-metadata-prefetch"`
 
+	EnableNonexistentEntryCaching bool `yaml:"enable-nonexistent-entry-caching"`
+
 	EnableNonexistentTypeCache bool `yaml:"enable-nonexistent-type-cache"`
 
 	ExperimentalMetadataPrefetchOnMount string `yaml:"experimental-metadata-prefetch-on-mount"`
@@ -992,6 +994,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("enable-mount-retries"); err != nil {
 		return err
 	}
+
+	flagSet.BoolP("enable-nonexistent-entry-caching", "", false, "Cache paths confirmed to not exist (404s) in the unified stat cache.")
 
 	flagSet.BoolP("enable-new-reader", "", true, "Enables support for new reader implementation.")
 
@@ -1601,6 +1605,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("gcs-retries.enable-mount-retries", flagSet.Lookup("enable-mount-retries")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("metadata-cache.enable-nonexistent-entry-caching", flagSet.Lookup("enable-nonexistent-entry-caching")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1002,7 +1002,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("enable-new-reader"); err != nil {
 		return err
 	}
-
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil. This flag has been deprecated in favour of a single unified flag metadata-cache-negative-ttl-secs.")
 
 	flagSet.BoolP("enable-rapid-appends", "", true, "Enables support for appends to unfinalized object using streaming writes")

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -995,13 +995,14 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.BoolP("enable-nonexistent-entry-caching", "", false, "Cache paths confirmed to not exist (404s) in the unified stat cache.")
-
 	flagSet.BoolP("enable-new-reader", "", true, "Enables support for new reader implementation.")
 
 	if err := flagSet.MarkHidden("enable-new-reader"); err != nil {
 		return err
 	}
+
+	flagSet.BoolP("enable-nonexistent-entry-caching", "", false, "Cache paths confirmed to not exist (404s) in the unified stat cache.")
+
 	flagSet.BoolP("enable-nonexistent-type-cache", "", false, "Once set, if an inode is not found in GCS, a type cache entry with type NonexistentType will be created. This also means new file/dir created might not be seen. For example, if this flag is set, and metadata-cache-ttl-secs is set, then if we create the same file/node in the meantime using the same mount, since we are not refreshing the cache, it will still return nil. This flag has been deprecated in favour of a single unified flag metadata-cache-negative-ttl-secs.")
 
 	flagSet.BoolP("enable-rapid-appends", "", true, "Enables support for appends to unfinalized object using streaming writes")
@@ -1607,11 +1608,11 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("metadata-cache.enable-nonexistent-entry-caching", flagSet.Lookup("enable-nonexistent-entry-caching")); err != nil {
+	if err := v.BindPFlag("enable-new-reader", flagSet.Lookup("enable-new-reader")); err != nil {
 		return err
 	}
 
-	if err := v.BindPFlag("enable-new-reader", flagSet.Lookup("enable-new-reader")); err != nil {
+	if err := v.BindPFlag("metadata-cache.enable-nonexistent-entry-caching", flagSet.Lookup("enable-nonexistent-entry-caching")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -949,6 +949,12 @@ params:
     deprecated: false
     hide-flag: false
 
+  - config-path: "metadata-cache.enable-nonexistent-entry-caching"
+    flag-name: "enable-nonexistent-entry-caching"
+    type: "bool"
+    usage: "Cache paths confirmed to not exist (404s) in the unified stat cache."
+    default: false
+
   - config-path: "metadata-cache.enable-nonexistent-type-cache"
     flag-name: "enable-nonexistent-type-cache"
     type: "bool"

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -99,6 +99,7 @@ be interacting with the file system.`)
 		StatCacheMaxSizeMB:                 uint64(newConfig.MetadataCache.StatCacheMaxSizeMb),
 		StatCacheTTL:                       time.Duration(newConfig.MetadataCache.TtlSecs) * time.Second,
 		NegativeStatCacheTTL:               time.Duration(newConfig.MetadataCache.NegativeTtlSecs) * time.Second,
+		EnableNonexistentEntryCaching:      newConfig.MetadataCache.EnableNonexistentEntryCaching,
 		EnableMonitoring:                   cfg.IsMetricsEnabled(&newConfig.Metrics),
 		LogSeverity:                        newConfig.Logging.Severity,
 		AppendThreshold:                    1 << 21, // 2 MiB, a total guess.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -209,7 +209,11 @@ The behavior of stat cache is controlled by the following flags/config parameter
    If this config variable is missing, then the value of ```--stat-cache-ttl``` is used.
    * ```--stat-cache-ttl``` commandline flag, which can be set to a value like ```10s``` or ```1.5h```. The default is one minute. This has been deprecated (starting v2.0) and is currently only available for backward compatibility. If ```metadata-cache: ttl-secs``` is set, ```--stat-cache-ttl``` is ignored.
    
-   Positive and negative stat results will be cached for the specified amount of time.
+   Positive stat results (existing files) will be cached for this specified amount of time.
+
+3. **Negative Stat-cache (Non-existent Entry Caching)**: Controls caching of non-existent paths (`ErrNotExist` / 404 results) to optimize workloads that aggressively poll missing files (e.g., JupyterLab).
+   * `metadata-cache: enable-nonexistent-entry-caching` in the config-file (boolean). Must be set to `true` to enable negative caching. **Disabled by default.**
+   * `metadata-cache: negative-ttl-secs` in the config-file (integer). Sets the TTL in seconds for negative entries when `enable-nonexistent-entry-caching` is `true`. Default is 5 seconds. Use -1 for infinite TTL or 0 to bypass.
 
 Warnings: 
 - Using stat caching breaks the consistency guarantees discussed in this document. It is safe only in the following situations:

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -69,6 +69,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 		negativeCacheTTL,
 		IsTypeCacheDeprecated,
 		isImplicitDir,
+		true,
 	)
 
 	// Enable directory type caching.
@@ -479,6 +480,7 @@ func (t *MultiBucketMountCachingTest) SetUpTestSuite() {
 			negativeCacheTTL,
 			IsTypeCacheDeprecated,
 			isImplicitDir,
+			true,
 		)
 	}
 

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -42,6 +42,7 @@ import (
 
 const ttl = 10 * time.Minute
 const negativeCacheTTL = 1 * time.Minute
+const enableNonexistentEntryCaching = true
 
 var (
 	uncachedBucket gcs.Bucket
@@ -69,7 +70,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 		negativeCacheTTL,
 		IsTypeCacheDeprecated,
 		isImplicitDir,
-		true,
+		enableNonexistentEntryCaching,
 	)
 
 	// Enable directory type caching.
@@ -480,7 +481,7 @@ func (t *MultiBucketMountCachingTest) SetUpTestSuite() {
 			negativeCacheTTL,
 			IsTypeCacheDeprecated,
 			isImplicitDir,
-			true,
+			enableNonexistentEntryCaching,
 		)
 	}
 

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -20,11 +20,16 @@ import (
 	"os"
 	"testing"
 
+	"time"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/wrappers"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/monitor"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
@@ -462,4 +467,84 @@ func TestGCSMetrics_RetryCount(t *testing.T) {
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/retry_count",
 		attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")),
 		1)
+}
+
+type fakeBucketManagerForShortCircuit struct {
+	bucket gcs.Bucket
+}
+
+func (bm *fakeBucketManagerForShortCircuit) SetUpBucket(ctx context.Context, name string, _ bool, _ metrics.MetricHandle) (gcsx.SyncerBucket, error) {
+	return gcsx.NewSyncerBucket(0, 120, 10, ".gcsfuse_tmp/", gcsx.NewContentTypeBucket(bm.bucket)), nil
+}
+func (bm *fakeBucketManagerForShortCircuit) ShutDown() {}
+
+// TestGCSMetrics_RequestCount_NegativeCachingShortCircuit validates that when negative entry caching is enabled,
+// repeated lookups for non-existent files short-circuit in memory and do not emit redundant backend GCS requests.
+func TestGCSMetrics_RequestCount_NegativeCachingShortCircuit(t *testing.T) {
+	ctx := context.Background()
+	origProvider := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(origProvider) })
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	mh, err := metrics.NewOTelMetrics(ctx, 1, 100)
+	require.NoError(t, err, "metrics.NewOTelMetrics")
+
+	bucketName := "test-bucket"
+	rawBucket := fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{Hierarchical: false})
+
+	// Enforce production wrapping order: Caching layer MUST wrap Monitoring layer.
+	monitoringInnerBucket := monitor.NewMonitoringBucket(rawBucket, mh)
+	lruCache := lru.NewCache(1024 * 1024)
+	statCacheView := metadata.NewStatCacheBucketView(lruCache, "")
+	cachedOuterBucket := caching.NewFastStatBucket(
+		time.Minute,
+		statCacheView,
+		timeutil.RealClock(),
+		monitoringInnerBucket,
+		time.Minute,
+		true, // isTypeCacheDeprecated
+		true, // implicitDir
+		true, // enableNonexistentEntryCaching
+	)
+
+	serverCfg := &fs.ServerConfig{
+		NewConfig: &cfg.Config{
+			EnableNewReader: true,
+		},
+		MetricHandle: mh,
+		TraceHandle:  tracing.NewNoopTracer(),
+		CacheClock:   &timeutil.SimulatedClock{},
+		BucketName:   bucketName,
+		BucketManager: &fakeBucketManagerForShortCircuit{
+			bucket: cachedOuterBucket,
+		},
+	}
+
+	server, err := fs.NewFileSystem(ctx, serverCfg)
+	require.NoError(t, err, "NewFileSystem")
+
+	lookupOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "missing_file",
+	}
+
+	// 1. First Lookup (Cache Miss) -> Emits backend probes through monitoring layer
+	_ = server.LookUpInode(ctx, lookupOp)
+	waitForMetricsProcessing()
+
+	// Probing a missing file checks dir then file -> 2 actual backend network calls.
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/request_count",
+		attribute.NewSet(attribute.String("gcs_method", "StatObject")),
+		2)
+
+	// 2. Second Lookup (Negative Cache Hit) -> Intercepted by outer cache layer
+	_ = server.LookUpInode(ctx, lookupOp)
+	waitForMetricsProcessing()
+
+	// Verify backend request count remains exactly 2 (zero new network requests emitted)
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/request_count",
+		attribute.NewSet(attribute.String("gcs_method", "StatObject")),
+		2)
 }

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -172,7 +172,8 @@ func (t *HNSCachedBucketMountTest) SetupSuite() {
 		uncachedHNSBucket,
 		negativeCacheTTL,
 		IsTypeCacheDeprecated,
-		isImplicitDir)
+		isImplicitDir,
+		true)
 
 	// Enable directory type caching.
 	t.serverCfg.DirTypeCacheTTL = ttl

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -51,7 +51,6 @@ const file1Content = "abcdef"
 const file2Content = "file2"
 const IsTypeCacheDeprecated = true
 const isImplicitDir = true
-const enableNonexistentEntryCaching = true
 
 var expectedFooDirEntries = []dirEntry{
 	{name: "test", isDir: true},

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -51,6 +51,7 @@ const file1Content = "abcdef"
 const file2Content = "file2"
 const IsTypeCacheDeprecated = true
 const isImplicitDir = true
+const enableNonexistentEntryCaching = true
 
 var expectedFooDirEntries = []dirEntry{
 	{name: "test", isDir: true},
@@ -173,7 +174,7 @@ func (t *HNSCachedBucketMountTest) SetupSuite() {
 		negativeCacheTTL,
 		IsTypeCacheDeprecated,
 		isImplicitDir,
-		true)
+		enableNonexistentEntryCaching)
 
 	// Enable directory type caching.
 	t.serverCfg.DirTypeCacheTTL = ttl

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -686,6 +686,7 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 		// 1. Try Directory FIRST (since it's the preferred return type)
 		var dirResult *Core
 		var err error
+		var dirCacheMiss bool
 		if d.Bucket().BucketType().Hierarchical {
 			dirResult, err = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), true)
 		} else {
@@ -696,19 +697,27 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 		if dirResult != nil {
 			return dirResult, nil
 		}
-		// If we hit a real error (not a cache miss), exit early.
-		if err != nil && !errors.As(err, &cacheMissErr) {
+		if errors.As(err, &cacheMissErr) {
+			dirCacheMiss = true
+		} else if err != nil {
 			return nil, err
 		}
 
 		// 2. Try File ONLY if directory wasn't found
+		var fileCacheMiss bool
 		fileResult, err := findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), true)
-		if err != nil && !errors.As(err, &cacheMissErr) {
+		if fileResult != nil {
+			return fileResult, nil
+		}
+		if errors.As(err, &cacheMissErr) {
+			fileCacheMiss = true
+		} else if err != nil {
 			return nil, err
 		}
 
-		if fileResult != nil {
-			return fileResult, nil
+		// 3. Short-circuit on confirmed negative hits for BOTH dir and file
+		if !dirCacheMiss && !fileCacheMiss {
+			return nil, nil // Definitive ENOENT
 		}
 	}
 

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -45,9 +45,10 @@ type BucketConfig struct {
 	// Config for TTL of entries for existing file in stat cache
 	StatCacheTTL time.Duration
 	// Config for TTL of entries for non-existing file in stat cache
-	NegativeStatCacheTTL time.Duration
-	EnableMonitoring     bool
-	LogSeverity          cfg.LogSeverity
+	NegativeStatCacheTTL          time.Duration
+	EnableNonexistentEntryCaching bool
+	EnableMonitoring              bool
+	LogSeverity                   cfg.LogSeverity
 
 	// Files backed by on object of length at least AppendThreshold that have
 	// only been appended to (i.e. none of the object's contents have been
@@ -244,7 +245,8 @@ func (bm *bucketManager) SetUpBucket(
 			b,
 			bm.config.NegativeStatCacheTTL,
 			bm.config.IsTypeCacheDeprecated,
-			bm.config.ImplicitDir)
+			bm.config.ImplicitDir,
+			bm.config.EnableNonexistentEntryCaching)
 	}
 
 	// Enable content type awareness

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -51,15 +51,17 @@ func NewFastStatBucket(
 	negativeCacheTTL time.Duration,
 	isTypeCacheDeprecated bool,
 	implicitDir bool,
+	enableNonexistentEntryCaching bool,
 ) (b gcs.Bucket) {
 	fsb := &fastStatBucket{
-		cache:                 cache,
-		clock:                 clock,
-		wrapped:               wrapped,
-		primaryCacheTTL:       primaryCacheTTL,
-		negativeCacheTTL:      negativeCacheTTL,
-		isTypeCacheDeprecated: isTypeCacheDeprecated,
-		implicitDir:           implicitDir,
+		cache:                         cache,
+		clock:                         clock,
+		wrapped:                       wrapped,
+		primaryCacheTTL:               primaryCacheTTL,
+		negativeCacheTTL:              negativeCacheTTL,
+		isTypeCacheDeprecated:         isTypeCacheDeprecated,
+		implicitDir:                   implicitDir,
+		enableNonexistentEntryCaching: enableNonexistentEntryCaching,
 	}
 
 	b = fsb
@@ -92,6 +94,8 @@ type fastStatBucket struct {
 	isTypeCacheDeprecated bool
 
 	implicitDir bool
+
+	enableNonexistentEntryCaching bool
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -121,6 +125,11 @@ func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing
 	// Critical check after acquiring lock: If the operation context was cancelled,
 	// we must not update the cache with this stale data.
 	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+
+	if len(listing.MinObjects) == 0 && len(listing.CollapsedRuns) == 0 && b.enableNonexistentEntryCaching && strings.HasSuffix(dirName, "/") {
+		b.cache.AddNegativeEntry(dirName, b.clock.Now().Add(b.negativeCacheTTL))
 		return
 	}
 
@@ -241,6 +250,9 @@ func (b *fastStatBucket) insertFolder(f *gcs.Folder) {
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) addNegativeEntry(name string) {
+	if !b.enableNonexistentEntryCaching {
+		return
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -250,6 +262,9 @@ func (b *fastStatBucket) addNegativeEntry(name string) {
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) addNegativeEntryForFolder(name string) {
+	if !b.enableNonexistentEntryCaching {
+		return
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -271,6 +286,9 @@ func (b *fastStatBucket) lookUp(name string) (hit bool, m *gcs.MinObject) {
 	defer b.mu.Unlock()
 
 	hit, m = b.cache.LookUp(name, b.clock.Now())
+	if hit && m == nil && !b.enableNonexistentEntryCaching {
+		return false, nil
+	}
 	return
 }
 
@@ -279,6 +297,9 @@ func (b *fastStatBucket) lookUpFolder(name string) (bool, *gcs.Folder) {
 	defer b.mu.Unlock()
 
 	hit, f := b.cache.LookUpFolder(name, b.clock.Now())
+	if hit && f == nil && !b.enableNonexistentEntryCaching {
+		return false, nil
+	}
 	return hit, f
 }
 

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -250,11 +250,13 @@ func (b *fastStatBucket) insertFolder(f *gcs.Folder) {
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) addNegativeEntry(name string) {
-	if !b.enableNonexistentEntryCaching {
-		return
-	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if !b.enableNonexistentEntryCaching {
+		b.cache.Erase(name)
+		return
+	}
 
 	expiration := b.clock.Now().Add(b.negativeCacheTTL)
 	b.cache.AddNegativeEntry(name, expiration)
@@ -262,11 +264,13 @@ func (b *fastStatBucket) addNegativeEntry(name string) {
 
 // LOCKS_EXCLUDED(b.mu)
 func (b *fastStatBucket) addNegativeEntryForFolder(name string) {
-	if !b.enableNonexistentEntryCaching {
-		return
-	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if !b.enableNonexistentEntryCaching {
+		b.cache.Erase(name)
+		return
+	}
 
 	expiration := b.clock.Now().Add(b.negativeCacheTTL)
 	b.cache.AddNegativeEntryForFolder(name, expiration)

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -45,6 +45,8 @@ const primaryCacheTTL = time.Second
 const negativeCacheTTL = time.Second * 5
 const isTypeCacheDeprecated = true
 const isImplicitDir = true
+const enableNonexistentEntryCaching = true
+const disableNonexistentEntryCaching = false
 
 type fastStatBucketTest struct {
 	cache   mock_gcscaching.MockStatCache
@@ -70,7 +72,7 @@ func (t *fastStatBucketTest) SetUp(ti *TestInfo) {
 		negativeCacheTTL,
 		isTypeCacheDeprecated,
 		isImplicitDir,
-		true)
+		enableNonexistentEntryCaching)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -647,7 +649,7 @@ func (t *StatObjectTest) CacheHit_Negative() {
 }
 
 func (t *StatObjectTest) CacheHit_Negative_Disabled_FetchOnly() {
-	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, false)
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, disableNonexistentEntryCaching)
 	const name = "taco"
 	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(true, nil))
 	req := &gcs.StatObjectRequest{Name: name, FetchOnlyFromCache: true}
@@ -804,7 +806,7 @@ func (t *StatObjectTest) WrappedSaysNotFound() {
 }
 
 func (t *StatObjectTest) WrappedSaysNotFound_NegativeCachingDisabled() {
-	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, false)
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, disableNonexistentEntryCaching)
 	const name = "taco"
 	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(false, nil))
 	ExpectCall(t.wrapped, "StatObject")(Any(), Any()).WillOnce(Return(nil, nil, &gcs.NotFoundError{Err: errors.New("burrito")}))
@@ -1020,7 +1022,7 @@ func (t *ListObjectsTest_InsertListing) SetUp(ti *TestInfo) {
 		negativeCacheTTL,
 		true,
 		true,
-		false)
+		disableNonexistentEntryCaching)
 }
 
 func (t *ListObjectsTest_InsertListing) callAndVerify(ctx context.Context, isHNS bool, listing *gcs.Listing, prefix string, expectedInserts []*gcs.MinObject, expectedImplicitDirs []string) {
@@ -1053,7 +1055,7 @@ func (t *ListObjectsTest_InsertListing) EmptyListing() {
 }
 
 func (t *ListObjectsTest_InsertListing) EmptyListing_NegativeCaching() {
-	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, true)
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, enableNonexistentEntryCaching)
 	listing := &gcs.Listing{}
 	ExpectCall(t.wrapped, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	ExpectCall(t.wrapped, "ListObjects")(Any(), Any()).WillOnce(Return(listing, nil))
@@ -1167,7 +1169,7 @@ func (t *ListObjectsTest_InsertListing) ImplicitDirFalse_CollapsedRunsNotCached(
 		negativeCacheTTL,
 		true,
 		false,
-		false)
+		disableNonexistentEntryCaching)
 	listing := &gcs.Listing{
 		MinObjects: []*gcs.MinObject{
 			{Name: "dir/a", Size: 1},

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -651,7 +651,7 @@ func (t *StatObjectTest) CacheHit_Negative_Disabled_FetchOnly() {
 	const name = "taco"
 	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(true, nil))
 	req := &gcs.StatObjectRequest{Name: name, FetchOnlyFromCache: true}
-	_, _, err := t.bucket.StatObject(context.TODO(), req)
+	_, _, err := t.bucket.StatObject(context.Background(), req)
 	ExpectThat(err, HasSameTypeAs(&caching.CacheMissError{}))
 }
 
@@ -810,7 +810,7 @@ func (t *StatObjectTest) WrappedSaysNotFound_NegativeCachingDisabled() {
 	ExpectCall(t.wrapped, "StatObject")(Any(), Any()).WillOnce(Return(nil, nil, &gcs.NotFoundError{Err: errors.New("burrito")}))
 	// Expect NO AddNegativeEntry call
 	req := &gcs.StatObjectRequest{Name: name}
-	_, _, err := t.bucket.StatObject(context.TODO(), req)
+	_, _, err := t.bucket.StatObject(context.Background(), req)
 	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 }
 
@@ -1058,7 +1058,7 @@ func (t *ListObjectsTest_InsertListing) EmptyListing_NegativeCaching() {
 	ExpectCall(t.wrapped, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	ExpectCall(t.wrapped, "ListObjects")(Any(), Any()).WillOnce(Return(listing, nil))
 	ExpectCall(t.cache, "AddNegativeEntry")("dir/", Any())
-	_, _ = t.bucket.ListObjects(context.TODO(), &gcs.ListObjectsRequest{Prefix: "dir/"})
+	_, _ = t.bucket.ListObjects(context.Background(), &gcs.ListObjectsRequest{Prefix: "dir/"})
 }
 
 func (t *ListObjectsTest_InsertListing) ObjectsOnly() {

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -69,7 +69,8 @@ func (t *fastStatBucketTest) SetUp(ti *TestInfo) {
 		t.wrapped,
 		negativeCacheTTL,
 		isTypeCacheDeprecated,
-		isImplicitDir)
+		isImplicitDir,
+		true)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -645,6 +646,15 @@ func (t *StatObjectTest) CacheHit_Negative() {
 	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 }
 
+func (t *StatObjectTest) CacheHit_Negative_Disabled_FetchOnly() {
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, false)
+	const name = "taco"
+	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(true, nil))
+	req := &gcs.StatObjectRequest{Name: name, FetchOnlyFromCache: true}
+	_, _, err := t.bucket.StatObject(context.TODO(), req)
+	ExpectThat(err, HasSameTypeAs(&caching.CacheMissError{}))
+}
+
 func (t *StatObjectTest) IgnoresCacheEntryWhenForceFetchFromGcsIsTrue() {
 	const name = "taco"
 
@@ -790,8 +800,18 @@ func (t *StatObjectTest) WrappedSaysNotFound() {
 	}
 
 	_, _, err := t.bucket.StatObject(context.TODO(), req)
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 	ExpectThat(err, Error(HasSubstr("burrito")))
+}
+
+func (t *StatObjectTest) WrappedSaysNotFound_NegativeCachingDisabled() {
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, false)
+	const name = "taco"
+	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(false, nil))
+	ExpectCall(t.wrapped, "StatObject")(Any(), Any()).WillOnce(Return(nil, nil, &gcs.NotFoundError{Err: errors.New("burrito")}))
+	// Expect NO AddNegativeEntry call
+	req := &gcs.StatObjectRequest{Name: name}
+	_, _, err := t.bucket.StatObject(context.TODO(), req)
+	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 }
 
 func (t *StatObjectTest) WrappedSucceeds() {
@@ -999,7 +1019,8 @@ func (t *ListObjectsTest_InsertListing) SetUp(ti *TestInfo) {
 		t.wrapped,
 		negativeCacheTTL,
 		true,
-		true)
+		true,
+		false)
 }
 
 func (t *ListObjectsTest_InsertListing) callAndVerify(ctx context.Context, isHNS bool, listing *gcs.Listing, prefix string, expectedInserts []*gcs.MinObject, expectedImplicitDirs []string) {
@@ -1029,6 +1050,15 @@ func (t *ListObjectsTest_InsertListing) EmptyListing() {
 	expectedImplicitDirs := []string{}
 
 	t.callAndVerify(context.TODO(), false, listing, "dir/", expectedInserts, expectedImplicitDirs)
+}
+
+func (t *ListObjectsTest_InsertListing) EmptyListing_NegativeCaching() {
+	t.bucket = caching.NewFastStatBucket(primaryCacheTTL, t.cache, &t.clock, t.wrapped, negativeCacheTTL, true, true, true)
+	listing := &gcs.Listing{}
+	ExpectCall(t.wrapped, "BucketType")().WillOnce(Return(gcs.BucketType{}))
+	ExpectCall(t.wrapped, "ListObjects")(Any(), Any()).WillOnce(Return(listing, nil))
+	ExpectCall(t.cache, "AddNegativeEntry")("dir/", Any())
+	_, _ = t.bucket.ListObjects(context.TODO(), &gcs.ListObjectsRequest{Prefix: "dir/"})
 }
 
 func (t *ListObjectsTest_InsertListing) ObjectsOnly() {
@@ -1136,6 +1166,7 @@ func (t *ListObjectsTest_InsertListing) ImplicitDirFalse_CollapsedRunsNotCached(
 		t.wrapped,
 		negativeCacheTTL,
 		true,
+		false,
 		false)
 	listing := &gcs.Listing{
 		MinObjects: []*gcs.MinObject{

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -651,7 +651,7 @@ func (t *StatObjectTest) CacheHit_Negative_Disabled_FetchOnly() {
 	const name = "taco"
 	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(true, nil))
 	req := &gcs.StatObjectRequest{Name: name, FetchOnlyFromCache: true}
-	_, _, err := t.bucket.StatObject(context.Background(), req)
+	_, _, err := t.bucket.StatObject(context.Background(), req) //nolint:govet
 	ExpectThat(err, HasSameTypeAs(&caching.CacheMissError{}))
 }
 
@@ -810,7 +810,7 @@ func (t *StatObjectTest) WrappedSaysNotFound_NegativeCachingDisabled() {
 	ExpectCall(t.wrapped, "StatObject")(Any(), Any()).WillOnce(Return(nil, nil, &gcs.NotFoundError{Err: errors.New("burrito")}))
 	// Expect NO AddNegativeEntry call
 	req := &gcs.StatObjectRequest{Name: name}
-	_, _, err := t.bucket.StatObject(context.Background(), req)
+	_, _, err := t.bucket.StatObject(context.Background(), req) //nolint:govet
 	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
 }
 
@@ -1058,7 +1058,7 @@ func (t *ListObjectsTest_InsertListing) EmptyListing_NegativeCaching() {
 	ExpectCall(t.wrapped, "BucketType")().WillOnce(Return(gcs.BucketType{}))
 	ExpectCall(t.wrapped, "ListObjects")(Any(), Any()).WillOnce(Return(listing, nil))
 	ExpectCall(t.cache, "AddNegativeEntry")("dir/", Any())
-	_, _ = t.bucket.ListObjects(context.Background(), &gcs.ListObjectsRequest{Prefix: "dir/"})
+	_, _ = t.bucket.ListObjects(context.Background(), &gcs.ListObjectsRequest{Prefix: "dir/"}) //nolint:govet
 }
 
 func (t *ListObjectsTest_InsertListing) ObjectsOnly() {

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -810,7 +810,8 @@ func (t *StatObjectTest) WrappedSaysNotFound_NegativeCachingDisabled() {
 	const name = "taco"
 	ExpectCall(t.cache, "LookUp")(Any(), Any()).WillOnce(Return(false, nil))
 	ExpectCall(t.wrapped, "StatObject")(Any(), Any()).WillOnce(Return(nil, nil, &gcs.NotFoundError{Err: errors.New("burrito")}))
-	// Expect NO AddNegativeEntry call
+	// Expect Erase call to invalidate any stale entry
+	ExpectCall(t.cache, "Erase")(name)
 	req := &gcs.StatObjectRequest{Name: name}
 	_, _, err := t.bucket.StatObject(context.Background(), req) //nolint:govet
 	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -69,6 +69,7 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 		negativeCacheTTL,
 		isTypeCacheDeprecated,
 		isImplicitDir,
+		true,
 	)
 }
 

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -69,7 +69,7 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 		negativeCacheTTL,
 		isTypeCacheDeprecated,
 		isImplicitDir,
-		true,
+		enableNonexistentEntryCaching,
 	)
 }
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/jacobsa/syncutil"
@@ -900,6 +901,9 @@ func (b *bucket) ComposeObjects(
 // LOCKS_EXCLUDED(b.mu)
 func (b *bucket) StatObject(ctx context.Context,
 	req *gcs.StatObjectRequest) (m *gcs.MinObject, e *gcs.ExtendedObjectAttributes, err error) {
+	if req.FetchOnlyFromCache {
+		return nil, nil, &caching.CacheMissError{Err: errors.New("fake bucket has no cache")}
+	}
 	// If ExtendedObjectAttributes are requested without fetching from gcs enabled, panic.
 	if !req.ForceFetchFromGcs && req.ReturnExtendedObjectAttributes {
 		panic("invalid StatObjectRequest: ForceFetchFromGcs: false and ReturnExtendedObjectAttributes: true")
@@ -1143,6 +1147,9 @@ func (b *bucket) DeleteFolder(ctx context.Context, folderName string) (err error
 }
 
 func (b *bucket) GetFolder(ctx context.Context, req *gcs.GetFolderRequest) (*gcs.Folder, error) {
+	if req.FetchOnlyFromCache {
+		return nil, &caching.CacheMissError{Err: errors.New("fake bucket has no cache")}
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
+++ b/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
@@ -35,11 +35,19 @@ type grpcHeaderValidation struct {
 	proxyProcessId     int
 	proxyServerLogFile string
 	flags              []string
+	baseFlags          []string
 	configPath         string
 	suite.Suite
 }
 
+func (g *grpcHeaderValidation) SetupSuite() {
+	g.baseFlags = make([]string, len(g.flags))
+	copy(g.baseFlags, g.flags)
+}
+
 func (g *grpcHeaderValidation) SetupTest() {
+	g.flags = make([]string, len(g.baseFlags))
+	copy(g.flags, g.baseFlags)
 	g.configPath = "../configs/grpc_header_validation.yaml"
 	g.proxyServerLogFile = setup.CreateProxyServerLogFile(g.T())
 	g.T().Logf("Proxy server log file: %s", g.proxyServerLogFile)

--- a/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
+++ b/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
@@ -106,7 +106,7 @@ func (g *grpcHeaderValidation) TestGRPCHeadersInMultipleOperations() {
 	assert.Greater(g.T(), validationCount, 0, "Expected at least one successful metadata validation")
 	assert.Contains(g.T(), logStr, "force_direct_connectivity=ENFORCED")
 	assert.Contains(g.T(), logStr, "direct_connectivity_diagnostic=no_auth")
-	assert.Equal(g.T(), 3, strings.Count(logStr, "/google.storage.v2.Storage/GetObject"), "Expected 3 GetObject calls (1 for each operation)")
+	assert.Equal(g.T(), 4, strings.Count(logStr, "/google.storage.v2.Storage/GetObject"), "Expected 4 GetObject calls (1 verification + 3 operations)")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/BidiWriteObject"), "Expected 1 BidiWriteObject call for writing the file")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/ReadObject"), "Expected 1 ReadObject call for reading the file")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/ListObjects"), "Expected 1 ListObjects call for listing the directory")

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -141,8 +141,9 @@ func TestChunkTransferTimeout(t *testing.T) {
 					proxyServerLogFile := setup.CreateProxyServerLogFile(t)
 					port, proxyProcessId, err := emulator_tests.StartProxyServer(scenario.configPath, proxyServerLogFile)
 					require.NoError(t, err)
-					setup.AppendProxyEndpointToFlagSet(&flags, port)
-					setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+					localFlags := append([]string{}, flags...)
+					setup.AppendProxyEndpointToFlagSet(&localFlags, port)
+					setup.MountGCSFuseWithGivenMountFunc(localFlags, mountFunc)
 
 					defer func() { // Defer unmount, killing the proxy server and saving log files.
 						setup.UnmountGCSFuse(rootDir)

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -74,13 +74,17 @@ func TestMain(m *testing.M) {
 		cfg.NegativeStatCache[0].LogFile = setup.LogFile()
 		// Initialize the slice to hold specific test configurations
 		cfg.NegativeStatCache[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.NegativeStatCache[0].Configs[0].Flags = []string{"--metadata-cache-negative-ttl-secs=0"}
+		cfg.NegativeStatCache[0].Configs[0].Flags = []string{
+			"--metadata-cache-negative-ttl-secs=0",
+			"--metadata-cache-negative-ttl-secs=5 --enable-nonexistent-entry-caching=false",
+			"--metadata-cache-negative-ttl-secs=5",
+		}
 		cfg.NegativeStatCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.NegativeStatCache[0].Configs[0].Run = "TestDisabledNegativeStatCacheTest"
-		cfg.NegativeStatCache[0].Configs[1].Flags = []string{"--metadata-cache-negative-ttl-secs=5"}
+		cfg.NegativeStatCache[0].Configs[1].Flags = []string{"--metadata-cache-negative-ttl-secs=5 --enable-nonexistent-entry-caching=true"}
 		cfg.NegativeStatCache[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.NegativeStatCache[0].Configs[1].Run = "TestFiniteNegativeStatCacheTest"
-		cfg.NegativeStatCache[0].Configs[2].Flags = []string{"--metadata-cache-negative-ttl-secs=-1"}
+		cfg.NegativeStatCache[0].Configs[2].Flags = []string{"--metadata-cache-negative-ttl-secs=-1 --enable-nonexistent-entry-caching=true"}
 		cfg.NegativeStatCache[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
 		cfg.NegativeStatCache[0].Configs[2].Run = "TestInfiniteNegativeStatCacheTest"
 	}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1096,7 +1096,7 @@ negative_stat_cache:
         run: "TestDisabledNegativeStatCacheTest"
         run_on_gke: true
       - flags:
-          - "--metadata-cache-negative-ttl-secs=5"
+          - "--metadata-cache-negative-ttl-secs=5,--enable-nonexistent-entry-caching=true"
         compatible:
           flat: true
           hns: true
@@ -1104,7 +1104,7 @@ negative_stat_cache:
         run: "TestFiniteNegativeStatCacheTest"
         run_on_gke: true
       - flags:
-          - "--metadata-cache-negative-ttl-secs=-1"
+          - "--metadata-cache-negative-ttl-secs=-1,--enable-nonexistent-entry-caching=true"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1089,6 +1089,8 @@ negative_stat_cache:
     configs:
       - flags:
           - "--metadata-cache-negative-ttl-secs=0"
+          - "--metadata-cache-negative-ttl-secs=5,--enable-nonexistent-entry-caching=false"
+          - "--metadata-cache-negative-ttl-secs=5"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -57,7 +57,7 @@ const (
 	Charset                           = "abcdefghijklmnopqrstuvwxyz0123456789"
 	PathEnvVariable                   = "PATH"
 	GCSFuseLogFilePrefix              = "gcsfuse-failed-integration-test-logs-"
-	ProxyServerLogFilePrefix          = "proxy-server-failed-integration-test-logs-"
+	ProxyServerLogFilePrefix          = "gcsfuse-failed-integration-test-logs-proxy-server-"
 	zoneMatcherRegex                  = "^[a-z]+-[a-z0-9]+-[a-z]$"
 	regionMatcherRegex                = "^[a-z]+-[a-z0-9]+$"
 	unsupportedCharactersInTestBucket = " "


### PR DESCRIPTION
### Description

This change implements negative entry caching (non-existent path caching) to optimize workloads that aggressively poll missing files (e.g., JupyterLab).

- **New Flag**: `--enable-nonexistent-entry-caching` (boolean, default `false`).
- **Proactive Listing Cache**: Empty directory listings (`ListObjects` returning 0 results) are proactively cached as negative directory entries to fully protect against implicit directory network probes.
- **VFS Routing**: `LookUpChild` tracks definitive negative cache hits and short-circuits immediately in memory, avoiding network fallback.

#### Benchmark Results
A custom benchmarking script was executed against a locally mounted test bucket to measure performance over a **sustained 60-second polling window** per scenario (aggregating over 1.3 million total VFS operations). The bucket was configured with a `5s` negative cache TTL (`--metadata-cache-negative-ttl-secs=5`).

##### 1. VFS Throughput & Latency Distributions
Memory interception nearly **doubles total application throughput** while slashing tail latencies by over 40%:

| Metric | Negative Caching `DISABLED` | Negative Caching `ENABLED` | Improvement |
| :--- | :--- | :--- | :--- |
| **Total Ops Completed** | `458,234 lookups` | `877,848 lookups` | **91.5% more throughput** |
| **Average Latency** | `0.1303 ms` (130 µs) | `0.0679 ms` (68 µs) | **48% faster** |
| **Median (P50)** | `0.1171 ms` (117 µs) | `0.0602 ms` (60 µs) | **49% faster** |
| **P99 Tail Latency** | `0.2939 ms` (294 µs) | `0.1729 ms` (173 µs) | **41% faster tail** |

##### 2. TTL Cache Expiration Mechanics (Trace Logs)
Over a 60-second window with a 5-second TTL, exactly **12 cache expirations** are mathematically expected.

- **Disabled**: Triggers **82,268 backend network calls** continuously over the 60-second window.
- **Enabled**: Triggers exactly **24 backend network calls** for the entire minute. 
  - **Proof**: Each of the 12 TTL expirations triggers exactly 2 backend calls (re-verifying both `missing_file` and `missing_file/` to refresh the cache). `12 expirations × 2 calls = 24 calls`. Every other request is intercepted entirely in user-space memory.

### Link to the issue in case of a bug fix.

https://b.corp.google.com/issues/511786738

### Testing details

1. Manual - Verified sustained 60-second polling behavior against local mounts, validating exact TTL expiration counts and throughput improvements. ([Test script](https://paste.googleplex.com/5738355712196608))
2. Unit tests - Added `WrappedSaysNotFound_NegativeCachingDisabled`, `CacheHit_Negative_Disabled_FetchOnly`, and `EmptyListing_NegativeCaching` to verify strict bypass when disabled and proper tombstone storage when enabled.
3. Integration tests - Ran existing E2E caching suites successfully.
    * Perf test and HNS integration test: [Sponge Link](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/3888bf26-e4d9-42ea-a11e-c5d617fe4333/summary)


| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 526.26MiB/s  |  1.3MiB/s  |  72.87MiB/s  |  1.24MiB/s   |
|   PR   |  0.25MiB   | 529.28MiB/s  | 1.34MiB/s  |  75.82MiB/s  |  1.26MiB/s   |
| Master | 48.828MiB  | 4162.55MiB/s | 77.69MiB/s | 1456.75MiB/s |  79.01MiB/s  |
|   PR   | 48.828MiB  | 4214.7MiB/s  | 75.63MiB/s | 1402.22MiB/s |  76.78MiB/s  |
| Master | 976.562MiB | 4176.32MiB/s | 35.85MiB/s | 804.39MiB/s  |  38.21MiB/s  |
|   PR   | 976.562MiB | 4052.01MiB/s | 34.0MiB/s  |  971.4MiB/s  |  37.4MiB/s   |

### Any backward incompatible change? If so, please explain.

No.

---

TAG=agy
CONV=3da12d68-a026-456e-9f11-16369d509c21