### PR TITLE
feat: reintroduce finalize-file-for-rapid as deprecated alias

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -776,6 +776,8 @@ type WriteConfig struct {
 
 	EnableStreamingWrites bool `yaml:"enable-streaming-writes"`
 
+	FinalizeFileForRapid bool `yaml:"finalize-file-for-rapid"`
+
 	FinalizeFileOnClose bool `yaml:"finalize-file-on-close"`
 
 	GlobalMaxBlocks int64 `yaml:"global-max-blocks"`
@@ -1142,6 +1144,16 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
+
+	flagSet.BoolP("finalize-file-for-rapid", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
+
+	if err := flagSet.MarkDeprecated("finalize-file-for-rapid", "Please use --finalize-file-on-close instead."); err != nil {
+		return err
+	}
+
+	if err := flagSet.MarkHidden("finalize-file-for-rapid"); err != nil {
+		return err
+	}
 
 	flagSet.BoolP("finalize-file-on-close", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
 
@@ -1729,6 +1741,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.file-mode", flagSet.Lookup("file-mode")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("write.finalize-file-for-rapid", flagSet.Lookup("finalize-file-for-rapid")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1274,6 +1274,15 @@ params:
     usage: "Enables streaming uploads during write file operation."
     default: true
 
+  - config-path: "write.finalize-file-for-rapid"
+    flag-name: "finalize-file-for-rapid"
+    type: "bool"
+    usage: "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files."
+    default: false
+    deprecated: true
+    deprecation-warning: "Please use --finalize-file-on-close instead."
+    hide-flag: true
+
   - config-path: "write.finalize-file-on-close"
     flag-name: "finalize-file-on-close"
     type: "bool"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,14 @@ of Cloud Storage FUSE, see https://cloud.google.com/storage/docs/gcs-fuse.`,
 			); err != nil {
 				return fmt.Errorf("error while unmarshalling config: %w", err)
 			}
+
+			// Map the deprecated write.finalize-file-for-rapid flag to write.finalize-file-on-close before validation and optimizations.
+			if !viperConfig.IsSet("write.finalize-file-on-close") && viperConfig.IsSet("write.finalize-file-for-rapid") {
+				val := mountInfo.config.Write.FinalizeFileForRapid
+				viperConfig.Set("write.finalize-file-on-close", val)
+				mountInfo.config.Write.FinalizeFileOnClose = val
+			}
+
 			if err := cfg.ValidateConfig(viperConfig, mountInfo.config); err != nil {
 				return fmt.Errorf("invalid config: %w", err)
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -445,6 +445,28 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedEnableRapidWrites:     true,
 			expectedFinalizeFileOnClose:   true,
 		},
+		{
+			name:                          "Test finalize-file-for-rapid fallback.",
+			args:                          []string{"gcsfuse", "--finalize-file-for-rapid=true", "abc", "pqr"},
+			expectedCreateEmptyFile:       false,
+			expectedEnableStreamingWrites: true,
+			expectedEnableRapidAppends:    true,
+			expectedWriteBlockSizeMB:      32,
+			expectedWriteGlobalMaxBlocks:  4,
+			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileOnClose:   true,
+		},
+		{
+			name:                          "Test finalize-file-on-close precedence over deprecated flag.",
+			args:                          []string{"gcsfuse", "--finalize-file-for-rapid=true", "--finalize-file-on-close=false", "abc", "pqr"},
+			expectedCreateEmptyFile:       false,
+			expectedEnableStreamingWrites: true,
+			expectedEnableRapidAppends:    true,
+			expectedWriteBlockSizeMB:      32,
+			expectedWriteGlobalMaxBlocks:  4,
+			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileOnClose:   false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### Description
This PR reintroduces the `finalize-file-for-rapid` flag as a deprecated and hidden alias for the new `finalize-file-on-close` flag. This ensures that users who were previously instructed to use the rapid-specific flag do not experience breaking changes.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
