### PR TITLE
fix(native retries): add validation checks and usage description updates for GCS retry configs

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1219,7 +1219,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the number of times an operation will be retried if it fails, preventing endless retry loops. A value of 0 indicates no limit.")
+	flagSet.IntP("max-retry-attempts", "", 0, "It sets a limit on the total number of attempts (including the initial call) made for an operation if it fails, preventing endless retry loops. For example, a value of 5 means up to 5 total attempts (1 initial call plus 4 retries). A value of 0 indicates unlimited attempts.")
 
 	flagSet.DurationP("max-retry-duration", "", 0*time.Nanosecond, "This is currently unused.")
 
@@ -1227,7 +1227,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.DurationP("max-retry-sleep", "", 30000000000*time.Nanosecond, "The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry continues with this specified maximum value.")
+	flagSet.DurationP("max-retry-sleep", "", 30000000000*time.Nanosecond, "The maximum backoff sleep duration allowed between retry attempts. Once the exponential backoff exceeds this limit, subsequent retries will use this constant sleep value.")
 
 	flagSet.IntP("metadata-cache-negative-ttl-secs", "", 5, "The negative-ttl-secs value in seconds to be used for expiring negative entries in metadata-cache. It can be set to -1 for no-ttl, 0 for no cache and > 0 for ttl-controlled negative entries in metadata-cache. Any value set below -1 will throw an error.")
 
@@ -1339,7 +1339,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("rename-dir-limit", "", 0, "Allow rename a directory containing fewer descendants than this limit.")
 
-	flagSet.Float64P("retry-multiplier", "", 2, "Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.")
+	flagSet.Float64P("retry-multiplier", "", 2, "The multiplier factor by which the retry backoff duration increases after each failed attempt. For example, a multiplier of 2.0 doubles the backoff sleep duration for each subsequent retry.")
 
 	flagSet.BoolP("reuse-token-from-url", "", true, "If false, the token acquired from token-url is not reused.")
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -732,23 +732,25 @@ params:
     flag-name: "max-retry-attempts"
     type: "int"
     usage: >-
-      It sets a limit on the number of times an operation will be retried if it
-      fails, preventing endless retry loops. A value of 0 indicates no limit.
+      It sets a limit on the total number of attempts (including the initial call) made for an operation if it fails,
+      preventing endless retry loops. For example, a value of 5 means up to 5 total attempts (1 initial call plus 4 retries).
+      A value of 0 indicates unlimited attempts.
     default: "0"
 
   - config-path: "gcs-retries.max-retry-sleep"
     flag-name: "max-retry-sleep"
     type: "duration"
     usage: >-
-      The maximum duration allowed to sleep in a retry loop with exponential
-      backoff for failed requests to GCS backend. Once the backoff duration
-      exceeds this limit, the retry continues with this specified maximum value.
+      The maximum backoff sleep duration allowed between retry attempts.
+      Once the exponential backoff exceeds this limit, subsequent retries will use this constant sleep value.
     default: "30s"
 
   - config-path: "gcs-retries.multiplier"
     flag-name: "retry-multiplier"
     type: "float64"
-    usage: Param for exponential backoff algorithm, which is used to increase waiting time b/w two consecutive retries.
+    usage: >-
+      The multiplier factor by which the retry backoff duration increases after each failed attempt.
+      For example, a multiplier of 2.0 doubles the backoff sleep duration for each subsequent retry.
     default: 2
 
   - config-path: "gcs-retries.read-stall.enable"

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -419,6 +419,9 @@ func isValidMaxRetryAttempts(maxRetryAttempts int64) error {
 	if maxRetryAttempts < 0 {
 		return fmt.Errorf("invalid value for max-retry-attempts: %d; should be >= 0 (0 for unlimited)", maxRetryAttempts)
 	}
+	if maxRetryAttempts > math.MaxInt {
+		return fmt.Errorf("invalid value for max-retry-attempts: %d; exceeds maximum supported value (%d)", maxRetryAttempts, math.MaxInt)
+	}
 	return nil
 }
 

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/spf13/viper"
@@ -369,6 +370,24 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 		return fmt.Errorf("error parsing chunk-transfer-timeout-secs config: %w", err)
 	}
 
+	if v.IsSet("gcs-retries.max-retry-attempts") {
+		if err = isValidMaxRetryAttempts(config.GcsRetries.MaxRetryAttempts); err != nil {
+			return fmt.Errorf("error parsing max-retry-attempts config: %w", err)
+		}
+	}
+
+	if v.IsSet("gcs-retries.multiplier") {
+		if err = isValidMultiplier(config.GcsRetries.Multiplier); err != nil {
+			return fmt.Errorf("error parsing retry-multiplier config: %w", err)
+		}
+	}
+
+	if v.IsSet("gcs-retries.max-retry-sleep") {
+		if err = isValidMaxRetrySleep(config.GcsRetries.MaxRetrySleep); err != nil {
+			return fmt.Errorf("error parsing max-retry-sleep config: %w", err)
+		}
+	}
+
 	if err = isValidMetricsConfig(&config.Metrics); err != nil {
 		return fmt.Errorf("error parsing metrics config: %w", err)
 	}
@@ -393,5 +412,26 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 		return fmt.Errorf("error parsing optimize profile config: %w", err)
 	}
 
+	return nil
+}
+
+func isValidMaxRetryAttempts(maxRetryAttempts int64) error {
+	if maxRetryAttempts < 0 {
+		return fmt.Errorf("invalid value for max-retry-attempts: %d; should be >= 0 (0 for unlimited)", maxRetryAttempts)
+	}
+	return nil
+}
+
+func isValidMultiplier(multiplier float64) error {
+	if multiplier < 1.0 {
+		return fmt.Errorf("invalid value for retry-multiplier: %f; should be >= 1.0", multiplier)
+	}
+	return nil
+}
+
+func isValidMaxRetrySleep(maxRetrySleep time.Duration) error {
+	if maxRetrySleep <= 0 {
+		return fmt.Errorf("invalid value for max-retry-sleep: %v; should be > 0", maxRetrySleep)
+	}
 	return nil
 }

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -433,8 +433,8 @@ func isValidMultiplier(multiplier float64) error {
 }
 
 func isValidMaxRetrySleep(maxRetrySleep time.Duration) error {
-	if maxRetrySleep <= 0 {
-		return fmt.Errorf("invalid value for max-retry-sleep: %v; should be > 0", maxRetrySleep)
+	if maxRetrySleep < 0 {
+		return fmt.Errorf("invalid value for max-retry-sleep: %v; should be >= 0", maxRetrySleep)
 	}
 	return nil
 }

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -373,6 +373,30 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid_zero_max_retry_sleep",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 10,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				Metrics: MetricsConfig{
+					Workers:    3,
+					BufferSize: 256,
+				},
+				FileSystem: FileSystemConfig{KernelListCacheTtlSecs: 30},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetrySleep: 0 * time.Second,
+				},
+				Mrd: MrdConfig{
+					PoolSize: 4,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -661,15 +685,6 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsRetries: GcsRetriesConfig{
 					MaxRetrySleep: -10 * time.Second,
-				},
-			},
-		},
-		{
-			name: "Invalid zero max-retry-sleep",
-			config: &Config{
-				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
-				GcsRetries: GcsRetriesConfig{
-					MaxRetrySleep: 0 * time.Second,
 				},
 			},
 		},
@@ -1420,6 +1435,7 @@ func Test_isValidMaxRetrySleep_ValidScenarios(t *testing.T) {
 		name          string
 		maxRetrySleep time.Duration
 	}{
+		{"valid_sleep_zero", 0 * time.Second},
 		{"valid_sleep_seconds", 30 * time.Second},
 		{"valid_sleep_milliseconds", 500 * time.Millisecond},
 	}
@@ -1438,7 +1454,6 @@ func Test_isValidMaxRetrySleep_ErrorScenarios(t *testing.T) {
 		name          string
 		maxRetrySleep time.Duration
 	}{
-		{"invalid_sleep_zero", 0 * time.Second},
 		{"invalid_sleep_negative", -10 * time.Second},
 	}
 

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -345,6 +345,32 @@ func TestValidateConfigSuccessful(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid_max_retry_attempts_and_multiplier",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 10,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				Metrics: MetricsConfig{
+					Workers:    3,
+					BufferSize: 256,
+				},
+				FileSystem: FileSystemConfig{KernelListCacheTtlSecs: 30},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetryAttempts: 3,
+					Multiplier:       2.0,
+					MaxRetrySleep:    30 * time.Second,
+				},
+				Mrd: MrdConfig{
+					PoolSize: 4,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -597,6 +623,42 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 				},
 				GcsConnection: GcsConnectionConfig{
 					SequentialReadSizeMb: 200,
+				},
+			},
+		},
+		{
+			name: "Invalid negative max-retry-attempts",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetryAttempts: -3,
+				},
+			},
+		},
+		{
+			name: "Invalid multiplier less than 1.0",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsRetries: GcsRetriesConfig{
+					Multiplier: 0.8,
+				},
+			},
+		},
+		{
+			name: "Invalid negative max-retry-sleep",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetrySleep: -10 * time.Second,
+				},
+			},
+		},
+		{
+			name: "Invalid zero max-retry-sleep",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetrySleep: 0 * time.Second,
 				},
 			},
 		},
@@ -1247,6 +1309,77 @@ func TestValidateProfile(t *testing.T) {
 
 			err := ValidateConfig(viper.New(), &c)
 
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_isValidMaxRetryAttempts(t *testing.T) {
+	testCases := []struct {
+		name             string
+		maxRetryAttempts int64
+		wantErr          bool
+	}{
+		{"valid_attempts_zero", 0, false},
+		{"valid_attempts_positive", 5, false},
+		{"invalid_attempts_negative", -3, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxRetryAttempts(tc.maxRetryAttempts)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_isValidMultiplier(t *testing.T) {
+	testCases := []struct {
+		name       string
+		multiplier float64
+		wantErr    bool
+	}{
+		{"valid_multiplier_standard", 2.0, false},
+		{"valid_multiplier_minimum", 1.0, false},
+		{"invalid_multiplier_too_low", 0.8, true},
+		{"invalid_multiplier_negative", -1.5, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMultiplier(tc.multiplier)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_isValidMaxRetrySleep(t *testing.T) {
+	testCases := []struct {
+		name          string
+		maxRetrySleep time.Duration
+		wantErr       bool
+	}{
+		{"valid_sleep_seconds", 30 * time.Second, false},
+		{"valid_sleep_milliseconds", 500 * time.Millisecond, false},
+		{"invalid_sleep_zero", 0 * time.Second, true},
+		{"invalid_sleep_negative", -10 * time.Second, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxRetrySleep(tc.maxRetrySleep)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -1328,16 +1328,31 @@ func TestValidateProfile(t *testing.T) {
 	}
 }
 
-func Test_isValidMaxRetryAttempts(t *testing.T) {
+func Test_isValidMaxRetryAttempts_ValidScenarios(t *testing.T) {
 	testCases := []struct {
 		name             string
 		maxRetryAttempts int64
-		wantErr          bool
 	}{
-		{"valid_attempts_zero", 0, false},
-		{"valid_attempts_positive", 5, false},
-		{"invalid_attempts_negative", -3, true},
-		{"valid_attempts_max_int", int64(math.MaxInt), false},
+		{"valid_attempts_zero", 0},
+		{"valid_attempts_positive", 5},
+		{"valid_attempts_max_int", int64(math.MaxInt)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxRetryAttempts(tc.maxRetryAttempts)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_isValidMaxRetryAttempts_ErrorScenarios(t *testing.T) {
+	testCases := []struct {
+		name             string
+		maxRetryAttempts int64
+	}{
+		{"invalid_attempts_negative", -3},
 	}
 
 	// math.MaxInt is math.MaxInt64 on 64-bit systems and math.MaxInt32 on 32-bit systems.
@@ -1348,66 +1363,86 @@ func Test_isValidMaxRetryAttempts(t *testing.T) {
 		testCases = append(testCases, struct {
 			name             string
 			maxRetryAttempts int64
-			wantErr          bool
-		}{"invalid_attempts_exceeds_max_int", maxIntVal + 1, true})
+		}{"invalid_attempts_exceeds_max_int", maxIntVal + 1})
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := isValidMaxRetryAttempts(tc.maxRetryAttempts)
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+
+			assert.Error(t, err)
 		})
 	}
 }
 
-func Test_isValidMultiplier(t *testing.T) {
+func Test_isValidMultiplier_ValidScenarios(t *testing.T) {
 	testCases := []struct {
 		name       string
 		multiplier float64
-		wantErr    bool
 	}{
-		{"valid_multiplier_standard", 2.0, false},
-		{"valid_multiplier_minimum", 1.0, false},
-		{"invalid_multiplier_too_low", 0.8, true},
-		{"invalid_multiplier_negative", -1.5, true},
+		{"valid_multiplier_standard", 2.0},
+		{"valid_multiplier_minimum", 1.0},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := isValidMultiplier(tc.multiplier)
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+
+			assert.NoError(t, err)
 		})
 	}
 }
 
-func Test_isValidMaxRetrySleep(t *testing.T) {
+func Test_isValidMultiplier_ErrorScenarios(t *testing.T) {
+	testCases := []struct {
+		name       string
+		multiplier float64
+	}{
+		{"invalid_multiplier_too_low", 0.8},
+		{"invalid_multiplier_negative", -1.5},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMultiplier(tc.multiplier)
+
+			assert.Error(t, err)
+		})
+	}
+}
+
+func Test_isValidMaxRetrySleep_ValidScenarios(t *testing.T) {
 	testCases := []struct {
 		name          string
 		maxRetrySleep time.Duration
-		wantErr       bool
 	}{
-		{"valid_sleep_seconds", 30 * time.Second, false},
-		{"valid_sleep_milliseconds", 500 * time.Millisecond, false},
-		{"invalid_sleep_zero", 0 * time.Second, true},
-		{"invalid_sleep_negative", -10 * time.Second, true},
+		{"valid_sleep_seconds", 30 * time.Second},
+		{"valid_sleep_milliseconds", 500 * time.Millisecond},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := isValidMaxRetrySleep(tc.maxRetrySleep)
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_isValidMaxRetrySleep_ErrorScenarios(t *testing.T) {
+	testCases := []struct {
+		name          string
+		maxRetrySleep time.Duration
+	}{
+		{"invalid_sleep_zero", 0 * time.Second},
+		{"invalid_sleep_negative", -10 * time.Second},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxRetrySleep(tc.maxRetrySleep)
+
+			assert.Error(t, err)
 		})
 	}
 }

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -15,6 +15,7 @@
 package cfg
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -632,6 +633,15 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
 				GcsRetries: GcsRetriesConfig{
 					MaxRetryAttempts: -3,
+				},
+			},
+		},
+		{
+			name: "Invalid too large max-retry-attempts",
+			config: &Config{
+				Logging: LoggingConfig{LogRotate: validLogRotateConfig()},
+				GcsRetries: GcsRetriesConfig{
+					MaxRetryAttempts: math.MaxInt64,
 				},
 			},
 		},
@@ -1327,6 +1337,19 @@ func Test_isValidMaxRetryAttempts(t *testing.T) {
 		{"valid_attempts_zero", 0, false},
 		{"valid_attempts_positive", 5, false},
 		{"invalid_attempts_negative", -3, true},
+		{"valid_attempts_max_int", int64(math.MaxInt), false},
+	}
+
+	// math.MaxInt is math.MaxInt64 on 64-bit systems and math.MaxInt32 on 32-bit systems.
+	// We can only test the "exceeds math.MaxInt" case on 32-bit systems because on 64-bit systems,
+	// math.MaxInt exceeds the capacity of int64 when we add 1 (it overflows).
+	if int64(math.MaxInt) < math.MaxInt64 {
+		maxIntVal := int64(math.MaxInt)
+		testCases = append(testCases, struct {
+			name             string
+			maxRetryAttempts int64
+			wantErr          bool
+		}{"invalid_attempts_exceeds_max_int", maxIntVal + 1, true})
 	}
 
 	for _, tc := range testCases {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -16,6 +16,7 @@ package cfg
 
 import (
 	"math"
+	"math/bits"
 	"testing"
 	"time"
 
@@ -1355,17 +1356,6 @@ func Test_isValidMaxRetryAttempts_ErrorScenarios(t *testing.T) {
 		{"invalid_attempts_negative", -3},
 	}
 
-	// math.MaxInt is math.MaxInt64 on 64-bit systems and math.MaxInt32 on 32-bit systems.
-	// We can only test the "exceeds math.MaxInt" case on 32-bit systems because on 64-bit systems,
-	// math.MaxInt exceeds the capacity of int64 when we add 1 (it overflows).
-	if int64(math.MaxInt) < math.MaxInt64 {
-		maxIntVal := int64(math.MaxInt)
-		testCases = append(testCases, struct {
-			name             string
-			maxRetryAttempts int64
-		}{"invalid_attempts_exceeds_max_int", maxIntVal + 1})
-	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := isValidMaxRetryAttempts(tc.maxRetryAttempts)
@@ -1373,6 +1363,20 @@ func Test_isValidMaxRetryAttempts_ErrorScenarios(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func Test_isValidMaxRetryAttempts_ExceedsMaxInt_ErrorScenario(t *testing.T) {
+	// math.MaxInt is math.MaxInt64 on 64-bit systems and math.MaxInt32 on 32-bit systems.
+	// We can only test the "exceeds math.MaxInt" case on 32-bit systems because on 64-bit systems,
+	// incrementing math.MaxInt overflows int64.
+	if is64Bit := bits.UintSize == 64; is64Bit {
+		t.Skip("Skipping on 64-bit systems because math.MaxInt exceeds the capacity of int64 when incremented.")
+	}
+
+	maxIntVal := int64(math.MaxInt)
+	err := isValidMaxRetryAttempts(maxIntVal + 1)
+
+	assert.Error(t, err)
 }
 
 func Test_isValidMultiplier_ValidScenarios(t *testing.T) {

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -100,7 +100,6 @@ type RetryConfig struct {
 
 // NewRetryConfig creates a new RetryConfig.
 func NewRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetryBudget, initialBackoff time.Duration) *RetryConfig {
-	// TODO: Add checks for non negative value initialization.
 	return &RetryConfig{
 		RetryDeadline:    retryDeadline,
 		TotalRetryBudget: totalRetryBudget,


### PR DESCRIPTION
### Description
This PR adds missing input validation checks for existing public GCS retry configuration flags (`max-retry-attempts`, `max-retry-sleep`, and `retry-multiplier`) to ensure stable execution and prevent incorrect user inputs. It also updates their usage descriptions to be clearer and more accurate.

Previously, some of the retry-related flags in `gcs-retries` did not have strict validation checks, potentially allowing negative values or unsupported ranges. Additionally, the usage documentation in the CLI help was very brief and didn't explain the exact behavior of some flags.

Added validation checks in `ValidateConfig` to ensure:
- `max-retry-attempts` is not negative (0 meaning unlimited).
- `retry-multiplier` is at least 1.0.
- `max-retry-sleep` is strictly positive (> 0).
Updated the descriptions for these parameters in `cfg/params.yaml` to provide clear examples and clarify behavior (e.g., explaining that `max-retry-attempts` includes the initial call).
### Key Changes
1. **Configuration Schema (`cfg/params.yaml`)**:
   - Clarified descriptions for `max-retry-attempts`, `max-retry-sleep`, and `multiplier`.
2. **Config Validation (`cfg/validate.go`)**:
   - Added `isValidMaxRetryAttempts`, `isValidMultiplier`, and `isValidMaxRetrySleep` with proper constraints.
3. **Unit Tests (`cfg/validate_test.go`)**:
   - Added successful and error scenarios in `TestValidateConfig` covering these new bound checks.
   - Added direct unit tests for the newly introduced validation helpers.

Public Documentation: https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/cli-options

### Link to the issue in case of a bug fix.
b/512674033

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
