### PR TITLE
ci: declare contents: read on flake-detector workflow

### DIFF
--- a/.github/workflows/flake-detector.yml
+++ b/.github/workflows/flake-detector.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   flake-detector:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Single-job workflow that re-runs `go test` with high counts to flag flakies. Pure read — checkout + apt-install + go build + go test. No pushes or comments. `contents: read` is the right floor.