### PR TITLE
feat(pirlo): support rapid writes state and write behavior changes for Pirlo buckets

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -216,8 +216,8 @@ func (wh *bufferedWriteHandlerImpl) Sync(ctx context.Context) (o *gcs.MinObject,
 	// The FlushPendingWrites method synchronizes all bytes currently residing in
 	// the Writer's buffer to Cloud Storage, thereby making them available for
 	// other operations like read.
-	// This functionality is exclusively supported on zonal buckets.
-	if wh.uploadHandler.bucket.BucketType().Zonal {
+	// This functionality is exclusively supported on rapid buckets.
+	if wh.uploadHandler.bucket.BucketType().RapidWritesEnabled() {
 		o, err = wh.uploadHandler.FlushPendingWrites(ctx)
 		if err != nil {
 			return nil, err

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -305,6 +305,15 @@ func (testSuite *BufferedWriteTest) TestFlush_SizeMismatch_ReturnsError() {
 			bucketType: gcs.BucketType{Zonal: true},
 			obj:        &gcs.Object{Name: "testObject", Size: 0},
 		},
+		{
+			name:       "pirlo_new_file_rapid_writes",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+		},
+		{
+			name:       "pirlo_append_rapid_writes",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			obj:        &gcs.Object{Name: "testObject", Size: 0},
+		},
 	}
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
@@ -312,7 +321,7 @@ func (testSuite *BufferedWriteTest) TestFlush_SizeMismatch_ReturnsError() {
 			mockBucket.On("BucketType").Return(tc.bucketType)
 			writer := &storagemock.Writer{}
 			writer.On("Write", mock.Anything).Return(2, nil)
-			if tc.bucketType.Zonal && tc.obj != nil {
+			if (tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled) && tc.obj != nil {
 				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
 			} else {
 				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
@@ -358,6 +367,15 @@ func (testSuite *BufferedWriteTest) TestSync_SizeMismatch_ReturnsError() {
 			bucketType: gcs.BucketType{Zonal: true},
 			obj:        &gcs.Object{Name: "testObject", Size: 0},
 		},
+		{
+			name:       "pirlo_new_file_rapid_writes",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+		},
+		{
+			name:       "pirlo_append_rapid_writes",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			obj:        &gcs.Object{Name: "testObject", Size: 0},
+		},
 	}
 	for _, tc := range testCases {
 		testSuite.Run(tc.name, func() {
@@ -365,7 +383,7 @@ func (testSuite *BufferedWriteTest) TestSync_SizeMismatch_ReturnsError() {
 			mockBucket.On("BucketType").Return(tc.bucketType)
 			writer := &storagemock.Writer{}
 			writer.On("Write", mock.Anything).Return(2, nil)
-			if tc.bucketType.Zonal && tc.obj != nil {
+			if (tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled) && tc.obj != nil {
 				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
 			} else {
 				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
@@ -463,6 +481,16 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			bucketType: gcs.BucketType{Zonal: true},
 			numBlocks:  .5,
 		},
+		{
+			name:       "pirlo_bucket_rapid_writes_2.5_blocks",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			numBlocks:  2.5,
+		},
+		{
+			name:       "pirlo_bucket_rapid_writes_.5_blocks",
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			numBlocks:  .5,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -484,7 +512,7 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 			// Read the object from back door.
 			content, err := storageutil.ReadObject(context.Background(), bwhImpl.uploadHandler.bucket, bwhImpl.uploadHandler.objectName)
-			if tc.bucketType.Zonal {
+			if tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled {
 				require.NotNil(testSuite.T(), o)
 				assert.EqualValues(testSuite.T(), int64(blockSize*tc.numBlocks), o.Size)
 				require.NoError(testSuite.T(), err)

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -321,7 +321,7 @@ func (testSuite *BufferedWriteTest) TestFlush_SizeMismatch_ReturnsError() {
 			mockBucket.On("BucketType").Return(tc.bucketType)
 			writer := &storagemock.Writer{}
 			writer.On("Write", mock.Anything).Return(2, nil)
-			if (tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled) && tc.obj != nil {
+			if tc.bucketType.RapidWritesEnabled() && tc.obj != nil {
 				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
 			} else {
 				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
@@ -383,7 +383,7 @@ func (testSuite *BufferedWriteTest) TestSync_SizeMismatch_ReturnsError() {
 			mockBucket.On("BucketType").Return(tc.bucketType)
 			writer := &storagemock.Writer{}
 			writer.On("Write", mock.Anything).Return(2, nil)
-			if (tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled) && tc.obj != nil {
+			if tc.bucketType.RapidWritesEnabled() && tc.obj != nil {
 				mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(writer, nil)
 			} else {
 				mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
@@ -512,7 +512,7 @@ func (testSuite *BufferedWriteTest) TestSyncPartialBlockTableDriven() {
 			assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 			// Read the object from back door.
 			content, err := storageutil.ReadObject(context.Background(), bwhImpl.uploadHandler.bucket, bwhImpl.uploadHandler.objectName)
-			if tc.bucketType.Zonal || tc.bucketType.Pirlo == gcs.PirloStateRapidWritesEnabled {
+			if tc.bucketType.RapidWritesEnabled() {
 				require.NotNil(testSuite.T(), o)
 				assert.EqualValues(testSuite.T(), int64(blockSize*tc.numBlocks), o.Size)
 				require.NoError(testSuite.T(), err)

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -114,7 +114,7 @@ func (uh *UploadHandler) createObjectWriter(ctx context.Context) (err error) {
 	// We need a new context here, since the first writeFile() call will be complete
 	// (and context will be cancelled) by the time complete upload is done.
 	ctx, uh.cancelFunc = context.WithCancel(uh.traceHandle.PropagateTraceContext(context.Background(), ctx))
-	if uh.bucket.BucketType().Zonal && (uh.obj != nil && uh.obj.Finalized.IsZero()) {
+	if uh.bucket.BucketType().RapidWritesEnabled() && (uh.obj != nil && uh.obj.Finalized.IsZero()) {
 		chunkWriterReq := gcs.CreateObjectChunkWriterRequest{
 			CreateObjectRequest: *req,
 			ChunkSize:           int(uh.blockSize),

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -103,6 +103,26 @@ func (t *UploadHandlerTest) TestCreateObjectWriter_CreateAppendableObjectWriterC
 	t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
 }
 
+func (t *UploadHandlerTest) TestCreateObjectWriter_CreateAppendableObjectWriterCalledForPirlo() {
+	t.createUploadHandlerWithObjectOfGivenSize(objectSize, time.Time{})
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled})
+	t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
+
+	_ = t.uh.createObjectWriter(context.Background())
+
+	t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
+}
+
+func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalledForPirloRapidDisabled() {
+	t.createUploadHandlerWithObjectOfGivenSize(objectSize, time.Time{})
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled})
+	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
+
+	_ = t.uh.createObjectWriter(context.Background())
+
+	t.mockBucket.AssertCalled(t.T(), "CreateObjectChunkWriter", mock.Anything, mock.Anything)
+}
+
 func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalled() {
 	t.createUploadHandlerWithObjectOfGivenSize(0, finalized)
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -103,24 +103,44 @@ func (t *UploadHandlerTest) TestCreateObjectWriter_CreateAppendableObjectWriterC
 	t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
 }
 
-func (t *UploadHandlerTest) TestCreateObjectWriter_CreateAppendableObjectWriterCalledForPirlo() {
-	t.createUploadHandlerWithObjectOfGivenSize(objectSize, time.Time{})
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled})
-	t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
+func (t *UploadHandlerTest) TestCreateObjectWriter_Pirlo() {
+	testCases := []struct {
+		name           string
+		pirloState     gcs.PirloState
+		expectedMethod string
+	}{
+		{
+			name:           "RapidWritesEnabled",
+			pirloState:     gcs.PirloStateRapidWritesEnabled,
+			expectedMethod: "CreateAppendableObjectWriter",
+		},
+		{
+			name:           "RapidWritesDisabled",
+			pirloState:     gcs.PirloStateRapidWritesDisabled,
+			expectedMethod: "CreateObjectChunkWriter",
+		},
+	}
 
-	_ = t.uh.createObjectWriter(context.Background())
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.SetupSubTest()
+			t.createUploadHandlerWithObjectOfGivenSize(objectSize, time.Time{})
+			t.mockBucket.On("BucketType").Return(gcs.BucketType{Pirlo: tc.pirloState})
+			if tc.expectedMethod == "CreateAppendableObjectWriter" {
+				t.mockBucket.On("CreateAppendableObjectWriter", mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
+			} else {
+				t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
+			}
 
-	t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
-}
+			_ = t.uh.createObjectWriter(context.Background())
 
-func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalledForPirloRapidDisabled() {
-	t.createUploadHandlerWithObjectOfGivenSize(objectSize, time.Time{})
-	t.mockBucket.On("BucketType").Return(gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled})
-	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&storagemock.Writer{}, nil)
-
-	_ = t.uh.createObjectWriter(context.Background())
-
-	t.mockBucket.AssertCalled(t.T(), "CreateObjectChunkWriter", mock.Anything, mock.Anything)
+			if tc.expectedMethod == "CreateAppendableObjectWriter" {
+				t.mockBucket.AssertCalled(t.T(), "CreateAppendableObjectWriter", mock.Anything, mock.Anything)
+			} else {
+				t.mockBucket.AssertCalled(t.T(), "CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
 }
 
 func (t *UploadHandlerTest) TestCreateObjectWriter_CreateObjectChunkWriterCalled() {

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -267,7 +267,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		// for non-dynamic mounts, but they are idempotent, so it's safe.
 		bucketType := syncerBucket.BucketType()
 		if serverCfg.ViperConfig != nil {
-			bucketTypeEnum := cfg.GetBucketType(bucketType.Hierarchical, bucketType.Zonal, bucketType.Pirlo)
+			bucketTypeEnum := cfg.GetBucketType(bucketType.Hierarchical, bucketType.Zonal, bucketType.Pirlo != gcs.PirloStateNone)
 			optimizedFlags := serverCfg.NewConfig.ApplyOptimizations(serverCfg.ViperConfig, &cfg.OptimizationInput{
 				BucketType: bucketTypeEnum,
 			})
@@ -3101,16 +3101,12 @@ func (fs *fileSystem) ReadFile(
 	fh.Inode().Lock()
 	if fh.Inode().IsUsingBWH() {
 		// Flush/Sync Pending streaming writes and issue read within same inode lock.
-		if fh.Inode().Bucket().BucketType().IsRapid() {
-			// With rapid buckets, we can read from unfinalized objects as well.
-			// Hence, there is no need to finalize the object from here for rapid buckets.
-			// Hence, if FinalizeFileOnClose is set, then we will call syncFile otherwise
-			// we can call flushFile (as it will not finalize when FinalizeFileOnClose is false) itself.
-			if fs.newConfig.Write.FinalizeFileOnClose {
-				err = fs.syncFile(ctx, fh.Inode())
-			} else {
-				err = fs.flushFile(ctx, fh.Inode())
-			}
+		// With rapid buckets, we can read from unfinalized objects as well.
+		// Hence, there is no need to finalize the object from here for rapid buckets.
+		// Hence, if FinalizeFileOnClose is set, then we will call syncFile otherwise
+		// we can call flushFile (as it will not finalize when FinalizeFileOnClose is false) itself.
+		if fh.Inode().Bucket().BucketType().RapidWritesEnabled() && fs.newConfig.Write.FinalizeFileOnClose {
+			err = fs.syncFile(ctx, fh.Inode())
 		} else {
 			err = fs.flushFile(ctx, fh.Inode())
 		}

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -445,7 +445,7 @@ func (fh *FileHandle) OpenMode() util.OpenMode {
 // the known object size. This allows reading from an object that is being
 // concurrently written to.
 func (fh *FileHandle) shouldSkipSizeChecks(req *gcsx.ReadRequest) bool {
-	if !fh.inode.Bucket().BucketType().IsRapid() {
+	if !fh.inode.Bucket().BucketType().RapidWritesEnabled() {
 		return false
 	}
 	if !fh.readManager.Object().IsUnfinalized() {

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -1220,7 +1220,8 @@ func (t *fileTest) Test_ShouldSkipSizeChecks() {
 		isRapid    bool
 	}{
 		{name: "Zonal", bucketType: gcs.BucketType{Zonal: true}, isRapid: true},
-		{name: "Pirlo", bucketType: gcs.BucketType{Pirlo: true}, isRapid: true},
+		{name: "PirloRapidWriteEnabled", bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled}, isRapid: true},
+		{name: "PirloRapidWriteDisabled", bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled}, isRapid: false},
 		{name: "Standard", bucketType: gcs.BucketType{}, isRapid: false},
 	}
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -448,7 +448,7 @@ func (f *FileInode) SourceGenerationIsAuthoritative() bool {
 	// Source generation is authoritative if:
 	//   1.  No pending writes exists on the inode (both content and bwh are nil).
 	//   2.  The bucket is rapid and there are no pending writes in the temporary file.
-	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().IsRapid() && f.content == nil)
+	return (f.content == nil && f.bwh == nil) || (f.bucket.BucketType().RapidWritesEnabled() && f.content == nil)
 }
 
 // Equivalent to the generation returned by f.Source().
@@ -1189,7 +1189,7 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 	var latestGcsObj *gcs.Object
 	var err error
 	if !f.local {
-		if f.bucket.BucketType().Zonal && openMode.IsAppend() {
+		if f.bucket.BucketType().RapidWritesEnabled() && openMode.IsAppend() {
 			// In case of rapid appends, we will rely on kernel's latest view of the object
 			// instead of reaching out to the server for latest metadata. This is done to avoid
 			// forceful overwrites of local and latest object metadata with possibly stale server
@@ -1245,7 +1245,7 @@ func (f *FileInode) areBufferedWritesSupported(openMode util.OpenMode, obj *gcs.
 	if f.local || obj.Size == 0 {
 		return true
 	}
-	if f.config.Write.EnableRapidAppends && openMode.IsAppend() && f.bucket.BucketType().Zonal && obj.Finalized.IsZero() {
+	if f.config.Write.EnableRapidAppends && openMode.IsAppend() && f.bucket.BucketType().RapidWritesEnabled() && obj.Finalized.IsZero() {
 		return true
 	}
 	logger.Infof("Existing file %s of size %d bytes (non-zero) will use legacy staged writes. "+StreamingWritesSemantics, f.name.String(), obj.Size)

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -85,7 +85,7 @@ func TestFileTestSuite(t *testing.T) {
 		suite.Run(t, &FileTest{bucketType: gcs.BucketType{Zonal: true}})
 	})
 	t.Run("Pirlo", func(t *testing.T) {
-		suite.Run(t, &FileTest{bucketType: gcs.BucketType{Pirlo: true}})
+		suite.Run(t, &FileTest{bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled}})
 	})
 }
 
@@ -262,6 +262,22 @@ func (t *FileTest) TestAreBufferedWritesSupported() {
 			bucketType: gcs.BucketType{},
 			finalized:  finalizedTime,
 			openMode:   WriteMode,
+			supported:  false,
+		},
+		{
+			name:       "AppendToUnfinalizedObjOnPirloWithRapidWritesEnabled",
+			content:    nonNilContents,
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			finalized:  unFinalizedTime,
+			openMode:   AppendMode,
+			supported:  true,
+		},
+		{
+			name:       "AppendToUnfinalizedObjOnPirloWithRapidWritesDisabled",
+			content:    nonNilContents,
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			finalized:  unFinalizedTime,
+			openMode:   AppendMode,
 			supported:  false,
 		},
 		{

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -487,7 +487,7 @@ func (t *gcsReaderTest) Test_ReadAt_ShortReadRetry() {
 		},
 		{
 			name:       "PirloBucket",
-			bucketType: gcs.BucketType{Pirlo: true},
+			bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -59,8 +59,8 @@ func NewSyncer(
 		bucket: bucket,
 	}
 
-	// Zonal buckets and Pirlo buckets with rapid writes enabled do not currently
-	// support Compose, so we always write objects in their entirety.
+	// Rapid buckets do not currently support Compose,
+	// so we always write objects in their entirety.
 	var composeCreator objectCreator
 	if !bucket.BucketType().RapidWritesEnabled() {
 		composeCreator = newComposeObjectCreator(

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -59,10 +59,10 @@ func NewSyncer(
 		bucket: bucket,
 	}
 
-	// Zonal buckets do not currently support Compose, so we always write objects
-	// in their entirety.
+	// Zonal buckets and Pirlo buckets with rapid writes enabled do not currently
+	// support Compose, so we always write objects in their entirety.
 	var composeCreator objectCreator
-	if !bucket.BucketType().Zonal {
+	if !bucket.BucketType().RapidWritesEnabled() {
 		composeCreator = newComposeObjectCreator(
 			tmpObjectPrefix,
 			bucket)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -200,9 +200,13 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	wc = storageutil.SetAttrsInWriter(wc, req)
 	wc.ProgressFunc = req.CallBack
-	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
-	// routes writes to the RAPID storage class instead of the STANDARD class.
-	wc.Append = bh.BucketType().Zonal || (bh.BucketType().Pirlo && bh.writeConfig != nil && bh.writeConfig.EnableRapidWrites)
+	// Zonal buckets strictly require the appendable API. For Pirlo buckets, the
+	// appendable API provides file-like semantics (immediate data visibility)
+	// but defers regional durability until the object is finalized. Users can
+	// choose to keep objects unfinalized by setting the FinalizeFileOnClose flag
+	// to false, which allows further appends, but if they keep it unfinalized
+	// it never becomes regionally durable.
+	wc.Append = bh.BucketType().RapidWritesEnabled()
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
@@ -237,9 +241,13 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	wc.ChunkRetryDeadline = time.Duration(req.ChunkRetryDeadlineSecs) * time.Second
 	wc.ChunkTransferTimeout = time.Duration(req.ChunkTransferTimeoutSecs) * time.Second
 	wc.ProgressFunc = callBack
-	// Zonal buckets strictly require the appendable API. For Pirlo buckets, enabling appendable
-	// routes writes to the RAPID storage class instead of the STANDARD class.
-	wc.Append = bh.BucketType().Zonal || (bh.BucketType().Pirlo && bh.writeConfig != nil && bh.writeConfig.EnableRapidWrites)
+	// Zonal buckets strictly require the appendable API. For Pirlo buckets, the
+	// appendable API provides file-like semantics (immediate data visibility)
+	// but defers regional durability until the object is finalized. Users can
+	// choose to keep objects unfinalized by setting the FinalizeFileOnClose flag
+	// to false, which allows further appends, but if they keep it unfinalized
+	// it never becomes regionally durable.
+	wc.Append = bh.BucketType().RapidWritesEnabled()
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
 	// When writer.Append is false, then this parameter is anyways ignored.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -594,6 +594,56 @@ func (testSuite *BucketHandleTest) TestBucketHandle_CreateObjectChunkWriter() {
 	}
 }
 
+func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
+	tests := []struct {
+		name                string
+		bucketType          gcs.BucketType
+		finalizeFileOnClose bool
+		expectedAppend      bool
+	}{
+		{
+			name:                "StandardBucket",
+			bucketType:          gcs.BucketType{},
+			finalizeFileOnClose: true,
+			expectedAppend:      false,
+		},
+		{
+			name:                "ZonalBucket",
+			bucketType:          gcs.BucketType{Zonal: true},
+			finalizeFileOnClose: false,
+			expectedAppend:      true,
+		},
+		{
+			name:                "PirloBucket_RapidEnabled",
+			bucketType:          gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			finalizeFileOnClose: true,
+			expectedAppend:      true,
+		},
+		{
+			name:                "PirloBucket_RapidDisabled",
+			bucketType:          gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			finalizeFileOnClose: false,
+			expectedAppend:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		testSuite.T().Run(tt.name, func(t *testing.T) {
+			createBucketHandle(testSuite, &controlpb.StorageLayout{})
+			testSuite.bucketHandle.bucketType = &tt.bucketType
+			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{FinalizeFileOnClose: tt.finalizeFileOnClose}
+
+			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), &gcs.CreateObjectRequest{Name: "test_object"}, 1024, nil)
+
+			require.NoError(t, err)
+			objWr, ok := w.(*ObjectWriter)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedAppend, objWr.Append)
+			assert.Equal(t, tt.finalizeFileOnClose, objWr.FinalizeOnClose)
+		})
+	}
+}
+
 func (testSuite *BucketHandleTest) TestBucketHandle_FinalizeUploadSuccess() {
 	createBucketHandle(testSuite, &controlpb.StorageLayout{})
 	var generation0 int64 = 0

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -24,8 +24,11 @@ import (
 type PirloState int
 
 const (
+	// PirloStateNone indicates the bucket is not a Pirlo bucket.
 	PirloStateNone PirloState = iota
+	// PirloStateRapidWritesEnabled indicates it is a Pirlo bucket with rapid writes enabled.
 	PirloStateRapidWritesEnabled
+	// PirloStateRapidWritesDisabled indicates it is a Pirlo bucket with rapid writes disabled.
 	PirloStateRapidWritesDisabled
 )
 

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -21,15 +21,29 @@ import (
 	"golang.org/x/net/context"
 )
 
+type PirloState int
+
+const (
+	PirloStateNone PirloState = iota
+	PirloStateRapidWritesEnabled
+	PirloStateRapidWritesDisabled
+)
+
 // BucketType represents bucket features.
 type BucketType struct {
 	Hierarchical bool
 	Zonal        bool
-	Pirlo        bool
+	Pirlo        PirloState
 }
 
 func (bt BucketType) IsRapid() bool {
-	return bt.Zonal || bt.Pirlo
+	return bt.Zonal || bt.Pirlo != PirloStateNone
+}
+
+// RapidWritesEnabled returns true if the bucket supports rapid writes
+// and they are currently active.
+func (bt BucketType) RapidWritesEnabled() bool {
+	return bt.Zonal || bt.Pirlo == PirloStateRapidWritesEnabled
 }
 
 const (

--- a/internal/storage/gcs/bucket_test.go
+++ b/internal/storage/gcs/bucket_test.go
@@ -24,25 +24,31 @@ func TestBucketType_IsRapid(t *testing.T) {
 	testCases := []struct {
 		name     string
 		zonal    bool
-		pirlo    bool
+		pirlo    PirloState
 		expected bool
 	}{
 		{
 			name:     "Neither Zonal nor Pirlo",
 			zonal:    false,
-			pirlo:    false,
+			pirlo:    PirloStateNone,
 			expected: false,
 		},
 		{
 			name:     "Only Zonal is true",
 			zonal:    true,
-			pirlo:    false,
+			pirlo:    PirloStateNone,
 			expected: true,
 		},
 		{
-			name:     "Only Pirlo is true",
+			name:     "Pirlo Rapid Enabled",
 			zonal:    false,
-			pirlo:    true,
+			pirlo:    PirloStateRapidWritesEnabled,
+			expected: true,
+		},
+		{
+			name:     "Pirlo Rapid Disabled",
+			zonal:    false,
+			pirlo:    PirloStateRapidWritesDisabled,
 			expected: true,
 		},
 	}
@@ -54,6 +60,50 @@ func TestBucketType_IsRapid(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expected, bt.IsRapid())
+		})
+	}
+}
+
+func TestBucketType_RapidWritesEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		zonal    bool
+		pirlo    PirloState
+		expected bool
+	}{
+		{
+			name:     "Neither Zonal nor Pirlo",
+			zonal:    false,
+			pirlo:    PirloStateNone,
+			expected: false,
+		},
+		{
+			name:     "Only Zonal is true",
+			zonal:    true,
+			pirlo:    PirloStateNone,
+			expected: true,
+		},
+		{
+			name:     "Pirlo Rapid Enabled",
+			zonal:    false,
+			pirlo:    PirloStateRapidWritesEnabled,
+			expected: true,
+		},
+		{
+			name:     "Pirlo Rapid Disabled",
+			zonal:    false,
+			pirlo:    PirloStateRapidWritesDisabled,
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bt := BucketType{
+				Zonal: tc.zonal,
+				Pirlo: tc.pirlo,
+			}
+
+			assert.Equal(t, tc.expected, bt.RapidWritesEnabled())
 		})
 	}
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -348,10 +348,19 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 
 	logger.Infof("GetStorageLayout -> (%s) %v msec", bucketName, duration.Milliseconds())
 
+	pirloState := gcs.PirloStateNone
+	if sh.clientConfig.ExperimentalEnablePirlo {
+		if sh.clientConfig.WriteConfig != nil && sh.clientConfig.WriteConfig.EnableRapidWrites {
+			pirloState = gcs.PirloStateRapidWritesEnabled
+		} else {
+			pirloState = gcs.PirloStateRapidWritesDisabled
+		}
+	}
+
 	return &gcs.BucketType{
 		Hierarchical: storageLayout.GetHierarchicalNamespace().GetEnabled(),
 		Zonal:        storageLayout.GetLocationType() == zonalLocationType,
-		Pirlo:        sh.clientConfig.ExperimentalEnablePirlo,
+		Pirlo:        pirloState,
 	}, nil
 }
 

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -174,6 +174,7 @@ func (testSuite *StorageHandleTest) TestBucketHandleWhenBucketDoesNotExistWithNo
 func (testSuite *StorageHandleTest) TestLookupBucketType_PirloEnabled() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 	sc.ExperimentalEnablePirlo = true
+	sc.WriteConfig = &cfg.WriteConfig{EnableRapidWrites: true}
 	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
 	require.NoError(testSuite.T(), err)
 	client := sh.(*storageClient)
@@ -183,7 +184,7 @@ func (testSuite *StorageHandleTest) TestLookupBucketType_PirloEnabled() {
 	bt, err := client.lookupBucketType(TestBucketName)
 
 	assert.NoError(testSuite.T(), err)
-	assert.True(testSuite.T(), bt.Pirlo)
+	assert.Equal(testSuite.T(), gcs.PirloStateRapidWritesEnabled, bt.Pirlo)
 }
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
@@ -904,7 +905,7 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 	tests := []struct {
 		name                 string
 		isZonal              bool
-		isPirlo              bool
+		pirloState           gcs.PirloState
 		billingProject       string
 		folderAPIStallRetry  bool
 		expectFolderRetries  bool
@@ -926,14 +927,14 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 		},
 		{
 			name:                 "PirloBucket_NoBillingProject",
-			isPirlo:              true,
+			pirloState:           gcs.PirloStateRapidWritesEnabled,
 			billingProject:       "",
 			expectFolderRetries:  true,
 			expectGaxRetriesUsed: false,
 		},
 		{
 			name:                 "PirloBucket_WithBillingProject",
-			isPirlo:              true,
+			pirloState:           gcs.PirloStateRapidWritesEnabled,
 			billingProject:       "test-project",
 			expectFolderRetries:  true,
 			expectGaxRetriesUsed: false,
@@ -984,7 +985,7 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 				rawStorageControlClientWithGaxRetries:    mockRawControlClientWithRetries,
 				clientConfig:                             clientConfig,
 			}
-			bucketType := &gcs.BucketType{Zonal: tc.isZonal, Pirlo: tc.isPirlo}
+			bucketType := &gcs.BucketType{Zonal: tc.isZonal, Pirlo: tc.pirloState}
 
 			// Act
 			controlClient := sh.controlClientForBucketHandle(bucketType, tc.billingProject)


### PR DESCRIPTION
### Description
This PR updates GCSFuse to support specialized write behaviors for Pirlo buckets, specifically introducing a state-based approach for rapid writes. It transitions the bucket type classification from a boolean to an enum state and adjusts synchronization, upload, and read logic accordingly.

### **Key Changes**

*   **Pirlo State Enum**: Updated the `Pirlo` field in `BucketType` from a boolean to a `PirloState` enum, which can now represent `PirloStateRapidEnabled` or `PirloStateRapidDisabled`.
*   **Synchronized Flushing**: Modified the buffered write handler to flush pending writes during a sync operation specifically for Pirlo buckets that have rapid writes enabled.
*   **Appendable Object Writer**: Configured the storage handle to use appendable semantics (`wc.Append = true`) for Pirlo buckets only when they are in the rapid writes enabled state.
*   **Compose API Restriction**: Disabled the use of the `Compose` API for Pirlo buckets when rapid writes are enabled, as this API is not supported for those buckets; instead, the system relies on the appendable API.
*   **Read Logic & Size Checks**: Updated the file handle logic to ensure size checks are performed (not skipped) when rapid writes as disabled for pirlo bucket.
*   **Upload Handling**: Adjusted the upload handler to prefer creating an appendable object writer for Pirlo buckets that support rapid writes.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - Updated
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
