### PR TITLE
feat(native retries): add support for custom should-retry predicates in ExecuteWithRetries

### DIFF
--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -112,17 +112,19 @@ func NewRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetry
 	}
 }
 
-// ExecuteWithRetryAtLogLevel encapsulates the retry logic over a given operation.
+// ExecuteWithCustomShouldRetryAtLogLevel encapsulates the retry logic over a given operation.
 // It performs time-bound, exponential backoff retries for a given API call.
 // It is expected that the given apiCall returns a structure, and not an HTTP response,
 // so that it does not leave behind any trace of a pending operation on server.
 // It also has an option to control the log level of the logs during retry
-func ExecuteWithRetryAtLogLevel[T any](
+// and accepts a custom shouldRetry predicate function.
+func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	ctx context.Context,
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
 	apiCall func(attemptCtx context.Context) (T, error),
+	shouldRetry func(err error) bool,
 	logLevel slog.Level, // Used to log the retry logs at the supplied log level
 ) (T, error) {
 	var zero T
@@ -158,7 +160,7 @@ func ExecuteWithRetryAtLogLevel[T any](
 		}
 
 		// If the error is not retryable, return it immediately.
-		if !ShouldRetry(err) {
+		if !shouldRetry(err) {
 			return zero, fmt.Errorf("%s for %q failed with a non-retryable error: %w", operationName, reqDescription, err)
 		}
 
@@ -175,6 +177,34 @@ func ExecuteWithRetryAtLogLevel[T any](
 	}
 }
 
+// ExecuteWithCustomShouldRetry retries a given operation using a custom shouldRetry predicate, but logs all logs at trace level.
+func ExecuteWithCustomShouldRetry[T any](
+	ctx context.Context,
+	config *RetryConfig,
+	operationName string,
+	reqDescription string,
+	apiCall func(attemptCtx context.Context) (T, error),
+	shouldRetry func(err error) bool,
+) (T, error) {
+	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, shouldRetry, logger.LevelTrace)
+}
+
+// ExecuteWithRetryAtLogLevel encapsulates the retry logic over a given operation.
+// It performs time-bound, exponential backoff retries for a given API call.
+// It is expected that the given apiCall returns a structure, and not an HTTP response,
+// so that it does not leave behind any trace of a pending operation on server.
+// It also has an option to control the log level of the logs during retry
+func ExecuteWithRetryAtLogLevel[T any](
+	ctx context.Context,
+	config *RetryConfig,
+	operationName string,
+	reqDescription string,
+	apiCall func(attemptCtx context.Context) (T, error),
+	logLevel slog.Level, // Used to log the retry logs at the supplied log level
+) (T, error) {
+	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, ShouldRetry, logLevel)
+}
+
 // ExecuteWithRetry retries a given operation but logs all logs at trace level
 func ExecuteWithRetry[T any](
 	ctx context.Context,
@@ -183,5 +213,5 @@ func ExecuteWithRetry[T any](
 	reqDescription string,
 	apiCall func(attemptCtx context.Context) (T, error),
 ) (T, error) {
-	return ExecuteWithRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, logger.LevelTrace)
+	return ExecuteWithCustomShouldRetry(ctx, config, operationName, reqDescription, apiCall, ShouldRetry)
 }

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -495,3 +495,78 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_MaxAttemptsReached() {
 	assert.Contains(t.T(), err.Error(), "failed after 2 attempts")
 	assert.Equal(t.T(), 2, callCount, "apiCall should have been called exactly 2 times")
 }
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_SuccessWithCustomPredicate() {
+	// Arrange
+	var callCount int
+	customErr := errors.New("my custom transient error")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "", customErr
+		}
+		return "success", nil
+	}
+	customShouldRetry := func(err error) bool {
+		return errors.Is(err, customErr)
+	}
+
+	// Act
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), "success", result)
+	assert.Equal(t.T(), 2, callCount)
+}
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_FailWithCustomPredicate() {
+	// Arrange
+	var callCount int
+	defaultRetryableErr := status.Error(codes.Unavailable, "server unavailable")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		return "", defaultRetryableErr
+	}
+	// A custom predicate that rejects everything (returns false)
+	customShouldRetry := func(err error) bool {
+		return false
+	}
+
+	// Act
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+
+	// Assert
+	assert.ErrorIs(t.T(), err, defaultRetryableErr)
+	assert.Empty(t.T(), result)
+	assert.Equal(t.T(), 1, callCount)
+}
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_CompositionWithDefault() {
+	// Arrange
+	var callCount int
+	customErr := errors.New("my custom transient error")
+	defaultRetryableErr := status.Error(codes.Unavailable, "server unavailable")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "", defaultRetryableErr
+		}
+		if callCount == 2 {
+			return "", customErr
+		}
+		return "success", nil
+	}
+	// Wrap default ShouldRetry and also allow customErr
+	customShouldRetry := func(err error) bool {
+		return ShouldRetry(err) || errors.Is(err, customErr)
+	}
+
+	// Act
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), "success", result)
+	assert.Equal(t.T(), 3, callCount)
+}


### PR DESCRIPTION
### Description

Adding `ExecuteWithCustomShouldRetry` and `ExecuteWithCustomShouldRetry` for mount retries in GKE on additional error codes. We will wrap the current should retry method with different error codes for GKE native retries feature.

### Link to the issue in case of a bug fix.
b/513130886

### Testing details
1. Manual - Yes
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
