### PR TITLE
fix(native retries):  fix active timer leaks in gcsfuse codebase.

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -579,10 +579,13 @@ func (p *BufferedReader) Destroy() {
 		p.inflightCallbackWg.Wait()
 	}()
 
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
 	select {
 	case <-done:
 		// Wait completed successfully.
-	case <-time.After(10 * time.Second):
+	case <-timer.C:
 		// If this timeout is reached, it implies that the callback was not called
 		// within 10 seconds, which is highly unexpected. In this scenario, we
 		// proceed with destruction, meaning the in-flight blocks will not be

--- a/internal/gcsx/mrd_instance.go
+++ b/internal/gcsx/mrd_instance.go
@@ -272,9 +272,12 @@ func closePoolWithTimeout(pool *MRDPool, caller string, timeout time.Duration) {
 			pool.Close()
 		}()
 
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
 		select {
 		case <-done:
-		case <-time.After(timeout):
+		case <-timer.C:
 			var objectName string
 			if pool.poolConfig != nil && pool.poolConfig.object != nil {
 				objectName = pool.poolConfig.object.Name

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -78,8 +78,11 @@ func (b *exponentialBackoff) waitWithJitter(ctx context.Context) error {
 
 	nextDuration := b.nextDuration()
 	jitteryBackoffDuration := time.Duration(1 + rand.Int63n(max(1, int64(nextDuration))))
+	timer := time.NewTimer(jitteryBackoffDuration)
+	defer timer.Stop()
+
 	select {
-	case <-time.After(jitteryBackoffDuration):
+	case <-timer.C:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
### Description

This PR resolves three significant active timer leaks in production paths across `storageutil`, `bufferedread`, and `gcsx` packages. By replacing instances of `time.After` within `select` blocks with explicit `time.NewTimer` and `defer timer.Stop()`, we ensure timer resources are immediately cleaned up and returned to the Go runtime when another branch of the `select` statement is chosen.

### Rationale & Problem
In Go, `time.After(duration)` is a convenient wrapper that allocates a `time.Timer` under the hood and returns its receive-only channel. However, **an active timer created by `time.After` cannot be canceled or garbage-collected until it naturally expires**.
When used inside a `select` block alongside other channels (such as context cancellation `<-ctx.Done()` or custom task completion `<-done` channels):
* If the other channel is selected first, the timer is discarded from the select execution but remains registered in the Go runtime timer heap.
* Under heavy concurrent load, timed-out retries, or quick file close/destroy operations, thousands of abandoned timers can pile up, causing **temporary memory bloat** and **high CPU overhead** as the runtime scheduler continuously scans a bloated timer heap.
This PR replaces those unsafe `time.After` patterns with `time.NewTimer`, and uses `defer timer.Stop()` to ensure immediate resource reclamation regardless of which select branch succeeds.

### Link to the issue in case of a bug fix.
b/513209650

### Testing details
1. Manual - Done
2. Unit tests - Pass
3. Integration tests - Part of pre-submits

### Any backward incompatible change? If so, please explain.
NONE
