### PR TITLE
perf(tests): segregate distributed write and local tests

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -59,7 +59,6 @@ if [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_read" ]; then
   
   if [ -d "$TOOLS_DIR" ]; then
     echo "Running Distributed READ Micro-Benchmark from gcsfuse-tools..."
-
     START_TIME=$SECONDS
     "$TOOLS_DIR/distributed-micro-benchmark/kokoro_run.sh" --commit "$commitId" --read || PERF_BENCHMARKS_FAILED=1
     print_duration "Distributed READ Benchmark" "$START_TIME"
@@ -74,9 +73,9 @@ if [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_read" ]; then
   fi
 
 # =================================================================
-# 2) DISTRIBUTED WRITE BENCHMARK + LOCAL PERF TESTS
+# 2) DISTRIBUTED WRITE BENCHMARK
 # =================================================================
-elif [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_write_and_local_tests" ]; then
+elif [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_write" ]; then
   TOOLS_DIR="${KOKORO_ARTIFACTS_DIR}/github/gcsfuse-tools"
   PERF_BENCHMARKS_FAILED=0
   
@@ -89,7 +88,16 @@ elif [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_write_and_local_tests" ];
     echo "ERROR: gcsfuse-tools directory not found!"
     PERF_BENCHMARKS_FAILED=1
   fi
-  
+
+  if [ $PERF_BENCHMARKS_FAILED -ne 0 ]; then
+    echo "Distributed WRITE benchmarks have failed."
+    exit 1
+  fi
+
+# =================================================================
+# 3) LOCAL PERFORMANCE TESTS
+# =================================================================
+elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   # --- Execute local performance tests ---
   echo "Building and installing gcsfuse..."
   BUILD_START=$SECONDS
@@ -179,13 +187,8 @@ elif [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_write_and_local_tests" ];
   
   print_duration "Rename Benchmark" "$RENAME_START"
 
-  if [ $PERF_BENCHMARKS_FAILED -ne 0 ]; then
-    echo "Distributed WRITE benchmarks have failed."
-    exit 1
-  fi
-
 # =================================================================
-# 3) ZONAL PERFORMANCE TESTS
+# 4) ZONAL PERFORMANCE TESTS
 # =================================================================
 elif [ "${BENCHMARK_TYPE:-}" == "distributed_benchmark_zonal" ]; then
   echo "Running Zonal Performance Tests..."

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+action {
+  define_artifacts {
+    regex: "gcsfuse-logs-fio-hns.txt"
+    regex: "gcsfuse-logs-ls-hns.txt"
+    regex: "gcsfuse-logs-fio-flat.txt"
+    regex: "gcsfuse-logs-ls-flat.txt"
+    regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
+    regex: "**/*sponge_log.*"
+    strip_prefix: "github/gcsfuse/perfmetrics/scripts"
+  }
+}
+
+timeout_mins: 300
+build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh"
+
+env_vars {
+  key: "BENCHMARK_TYPE"
+  value: "local_tests"
+}

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/write_distributed.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/write_distributed.cfg
@@ -12,22 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-action {
- define_artifacts {
- regex: "gcsfuse-logs-fio-hns.txt"
- regex: "gcsfuse-logs-ls-hns.txt"
- regex: "gcsfuse-logs-fio-flat.txt"
- regex: "gcsfuse-logs-ls-flat.txt"
- regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
- regex: "**/*sponge_log.*"
- strip_prefix: "github/gcsfuse/perfmetrics/scripts"
- }
-}
-
 timeout_mins: 300
 build_file: "gcsfuse/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh"
 
 env_vars {
   key: "BENCHMARK_TYPE"
-  value: "distributed_benchmark_write_and_local_tests"
+  value: "distributed_benchmark_write"
 }


### PR DESCRIPTION
### Segregate distributed write and local performance tests

This change further parallelizes the Kokoro periodic performance tests by segregating the **distributed write benchmarks** from the **local performance tests** (Flat bucket, HNS bucket, and Rename benchmarks). This split is intended to resolve timeout issues currently affecting the write tests.

#### Key Changes

**1. Refactored Subjobs**
*   **Split `write_distributed_and_local_tests`**: The combined subjob has been divided into two separate configurations: `write_distributed.cfg` and `local_tests.cfg`.

**2. Build Script Updates (`build.sh`)**
*   The logic in `perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh` has been updated to recognize the new `BENCHMARK_TYPE` values: `distributed_benchmark_write` and `local_tests`.
*   This ensures that the distributed write benchmark runs in a clean environment without the overhead of building and executing the local test suite.