### PR TITLE
feat(CI/CD Test Migration): Execute E2E tests from config file

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -23,6 +23,7 @@ usage() {
   echo "    --test-installed-package                     Test installed gcsfuse package. (Default: false)"
   echo "    --install-package-from-path   <path>         Google Cloud Storage bucket path for GCSFuse package for testing (e.g. gs://<bucket-name>/my-gcsfuse-package.rpm)"
   echo "                                                 This option is mutually exclusive with --test-installed-package. (Default: "")"
+  echo "    --use-common-config                          Run test packages with the common config being used for GKE/GCSFuse test packages. (Default: true)"
   echo "    --skip-non-essential-tests                   Skip non-essential tests inside packages. (Default: false)"
   echo "    --test-on-tpc-endpoint                       Run tests on TPC endpoint. (Default: false)"
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
@@ -126,6 +127,7 @@ fi
 SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 TEST_INSTALLED_PACKAGE=false
 BUCKET_LOCATION=""
+USE_COMMON_CONFIG=true
 PROJECT_ID=""
 INSTALL_PACKAGE_FROM_PATH=""
 RUN_TEST_ON_TPC_ENDPOINT=false
@@ -140,7 +142,7 @@ FLAKE_ATTEMPTS=1
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,use-common-config,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -175,6 +177,10 @@ while (( $# >= 1 )); do
         --install-package-from-path)
             INSTALL_PACKAGE_FROM_PATH="$2"
             shift 2
+            ;;
+        --use-common-config)
+            USE_COMMON_CONFIG=true
+            shift
             ;;
         --skip-non-essential-tests)
             SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
@@ -722,15 +728,29 @@ test_package() {
   local attempt_number="$4"
 
   # Build go package test command.
-  local go_test_cmd_parts=("GODEBUG=asyncpreemptoff=1" "go" "test" "-v" "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m" "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}")
-  if ${SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE}; then
-    go_test_cmd_parts+=("-short")
+  local go_test_cmd_parts=()
+
+  if ${USE_COMMON_CONFIG}; then
+    go_test_cmd_parts+=("BUCKET_NAME=${bucket_name}")
   fi
+  go_test_cmd_parts+=("GODEBUG=asyncpreemptoff=1" "go" "test" "-v" "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m" "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}")
   if [[ "$package_name" == "benchmarking" ]]; then
     go_test_cmd_parts+=("-bench=." "-benchtime=100x")
   fi
+  if ${SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE}; then
+    go_test_cmd_parts+=("-short")
+  fi
   # Test Binary flags after this.
-  go_test_cmd_parts+=("-args" "--integrationTest" "--testbucket=${bucket_name}")
+  go_test_cmd_parts+=("-args" "--integrationTest")
+
+  if ${USE_COMMON_CONFIG}; then
+    local config_file_path
+    config_file_path=$(realpath "${INTEGRATION_TEST_PACKAGE_DIR}/test_config.yaml")
+    go_test_cmd_parts+=("--config-file=${config_file_path}")
+  else
+    go_test_cmd_parts+=("--testbucket=${bucket_name}")
+  fi
+
   if ${TEST_INSTALLED_PACKAGE}; then
     go_test_cmd_parts+=("--testInstalledPackage")
   fi
@@ -754,6 +774,7 @@ test_package() {
   test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_attempt_${attempt_number}.txt")
   # Run the package test command and capture log output with runtime stats.
   log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt: $attempt_number)"
+  log_info "Test Command: $go_test_cmd"
 
   if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
     exit_code=1

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -23,7 +23,6 @@ usage() {
   echo "    --test-installed-package                     Test installed gcsfuse package. (Default: false)"
   echo "    --install-package-from-path   <path>         Google Cloud Storage bucket path for GCSFuse package for testing (e.g. gs://<bucket-name>/my-gcsfuse-package.rpm)"
   echo "                                                 This option is mutually exclusive with --test-installed-package. (Default: "")"
-  echo "    --use-common-config                          Run test packages with the common config being used for GKE/GCSFuse test packages. (Default: true)"
   echo "    --skip-non-essential-tests                   Skip non-essential tests inside packages. (Default: false)"
   echo "    --test-on-tpc-endpoint                       Run tests on TPC endpoint. (Default: false)"
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
@@ -127,7 +126,6 @@ fi
 SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=false
 TEST_INSTALLED_PACKAGE=false
 BUCKET_LOCATION=""
-USE_COMMON_CONFIG=true
 PROJECT_ID=""
 INSTALL_PACKAGE_FROM_PATH=""
 RUN_TEST_ON_TPC_ENDPOINT=false
@@ -142,7 +140,7 @@ FLAKE_ATTEMPTS=1
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,use-common-config,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -177,10 +175,6 @@ while (( $# >= 1 )); do
         --install-package-from-path)
             INSTALL_PACKAGE_FROM_PATH="$2"
             shift 2
-            ;;
-        --use-common-config)
-            USE_COMMON_CONFIG=true
-            shift
             ;;
         --skip-non-essential-tests)
             SKIP_NON_ESSENTIAL_TESTS_ON_PACKAGE=true
@@ -727,13 +721,17 @@ test_package() {
   local bucket_type="$3"
   local attempt_number="$4"
 
-  # Build go package test command.
-  local go_test_cmd_parts=()
+  local config_file_path
+  config_file_path=$(realpath "${INTEGRATION_TEST_PACKAGE_DIR}/test_config.yaml")
 
-  if ${USE_COMMON_CONFIG}; then
-    go_test_cmd_parts+=("BUCKET_NAME=${bucket_name}")
-  fi
-  go_test_cmd_parts+=("GODEBUG=asyncpreemptoff=1" "go" "test" "-v" "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m" "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}")
+  # Build go package test command.
+  local go_test_cmd_parts=(
+    "BUCKET_NAME=${bucket_name}"
+    "GODEBUG=asyncpreemptoff=1"
+    "go" "test" "-v"
+    "-timeout=${INTEGRATION_TEST_PACKAGE_TIMEOUT_IN_MINS}m"
+    "${INTEGRATION_TEST_PACKAGE_DIR}/${package_name}"
+  )
   if [[ "$package_name" == "benchmarking" ]]; then
     go_test_cmd_parts+=("-bench=." "-benchtime=100x")
   fi
@@ -742,14 +740,7 @@ test_package() {
   fi
   # Test Binary flags after this.
   go_test_cmd_parts+=("-args" "--integrationTest")
-
-  if ${USE_COMMON_CONFIG}; then
-    local config_file_path
-    config_file_path=$(realpath "${INTEGRATION_TEST_PACKAGE_DIR}/test_config.yaml")
-    go_test_cmd_parts+=("--config-file=${config_file_path}")
-  else
-    go_test_cmd_parts+=("--testbucket=${bucket_name}")
-  fi
+  go_test_cmd_parts+=("--config-file=${config_file_path}")
 
   if ${TEST_INSTALLED_PACKAGE}; then
     go_test_cmd_parts+=("--testInstalledPackage")
@@ -774,7 +765,6 @@ test_package() {
   test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_attempt_${attempt_number}.txt")
   # Run the package test command and capture log output with runtime stats.
   log_info_locked "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt: $attempt_number)"
-  log_info_locked "Test Command: $go_test_cmd"
 
   if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
     exit_code=1

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -773,18 +773,18 @@ test_package() {
   go_test_cmd=$(printf "%q " "${go_test_cmd_parts[@]}")
   test_package_log_file=$(create_file_helper "running_package_logs/${bucket_type}/${package_name}_attempt_${attempt_number}.txt")
   # Run the package test command and capture log output with runtime stats.
-  log_info "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt: $attempt_number)"
-  log_info "Test Command: $go_test_cmd"
+  log_info_locked "Started running test package [$package_name] for bucket type [$bucket_type] with bucket name [$bucket_name] (Attempt: $attempt_number)"
+  log_info_locked "Test Command: $go_test_cmd"
 
   if ! eval "$go_test_cmd" > "$test_package_log_file" 2>&1; then
     exit_code=1
     if [[ "$attempt_number" -lt "$FLAKE_ATTEMPTS" ]]; then
-      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). Will retry."
+      log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). Will retry."
     else
-      log_info "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). No more retries."
+      log_info_locked "Failed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number). No more retries."
     fi
   else
-    log_info "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number)"
+    log_info_locked "Passed test package [$package_name] for bucket type [$bucket_type] (Attempt: $attempt_number)"
   fi
 
   local end=$SECONDS


### PR DESCRIPTION
### Description

This PR updates the `improved_run_e2e_tests.sh` script to support running end-to-end integration tests using the new configuration file method via a common configuration file (`test_config.yaml`). It also updates the test execution logic to correctly parse and utilize this configuration, facilitating a smoother transition from legacy flags to the new configuration-based approach.

### Bug: https://buganizer.corp.google.com/issues/438068131

### Testing Details

1.  **Integration Tests**: Via kokoro