### PR TITLE
fix(native-retries): Fix duplicate retry logs and unify warnings

### DIFF
--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -26,11 +26,23 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func ShouldRetry(err error) (b bool) {
-	b = storage.ShouldRetry(err)
-	if b {
-		logger.Warnf("Retrying for the error: %v", err)
-		return
+// retryAction defines the classification of a retry decision.
+type retryAction int
+
+const (
+	// noRetry indicates the error is not retryable.
+	noRetry retryAction = iota
+	// retryTransient indicates the error is transient and retryable as per Go-SDK retry policy.
+	retryTransient
+	// retry401 indicates a 401 Unauthorized error which requires a retry due to credentials refresh.
+	retry401
+	// retryUnauthenticated indicates a gRPC Unauthenticated error which requires a retry.
+	retryUnauthenticated
+)
+
+func determineRetryAction(err error) retryAction {
+	if storage.ShouldRetry(err) {
+		return retryTransient
 	}
 
 	// HTTP 401 errors - Invalid Credentials
@@ -42,9 +54,7 @@ func ShouldRetry(err error) (b bool) {
 	// TODO: Please incorporate the correct fix post resolution of the above issue.
 	if typed, ok := err.(*googleapi.Error); ok {
 		if typed.Code == 401 {
-			b = true
-			logger.Warnf("Retrying for error-code 401: %v", err)
-			return
+			return retry401
 		}
 	}
 
@@ -53,12 +63,35 @@ func ShouldRetry(err error) (b bool) {
 	// TODO: Please incorporate the correct fix post resolution of the above issue.
 	if status, ok := status.FromError(err); ok {
 		if status.Code() == codes.Unauthenticated {
-			b = true
-			logger.Warnf("Retrying for UNAUTHENTICATED error: %v", err)
-			return
+			return retryUnauthenticated
 		}
 	}
-	return
+	return noRetry
+}
+
+// ShouldRetryWithoutLogging checks if the error is transient and should be retried.
+// This method is same as ShouldRetry except it doesn't add warning logs.
+func ShouldRetryWithoutLogging(err error) bool {
+	return determineRetryAction(err) != noRetry
+}
+
+// ShouldRetry checks if the given error is transient and should be retried.
+// It logs a warning message with the error details for any retryable error.
+// Returns true if the error is retryable, false otherwise.
+func ShouldRetry(err error) bool {
+	switch determineRetryAction(err) {
+	case retryTransient:
+		logger.Warnf("Retrying for the error: %v", err)
+		return true
+	case retry401:
+		logger.Warnf("Retrying for error-code 401: %v", err)
+		return true
+	case retryUnauthenticated:
+		logger.Warnf("Retrying for UNAUTHENTICATED error: %v", err)
+		return true
+	default:
+		return false
+	}
 }
 
 func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metrics.MetricHandle) bool {

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -287,7 +287,6 @@ func TestShouldRetryWithoutLoggingDoesNotLog(t *testing.T) {
 	assert.Empty(t, buf.String())
 }
 
-
 type fakeMetricHandle struct {
 	metrics.MetricHandle
 

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -15,13 +15,17 @@
 package storageutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
 	"net/url"
+	"os"
+	"sync"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/googleapi"
@@ -148,6 +152,141 @@ func TestShouldRetryReturnsTrueForUnauthenticatedGrpcErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldRetryWithoutLogging(t *testing.T) {
+	// Arrange
+	var err401 = googleapi.Error{
+		Code: 401,
+		Body: "Invalid Credential",
+	}
+	var errUnauthenticated = status.Error(codes.Unauthenticated, "unauthenticated")
+	var err400 = googleapi.Error{
+		Code: 400,
+	}
+
+	// Act
+	res401 := ShouldRetryWithoutLogging(&err401)
+	resUnauthenticated := ShouldRetryWithoutLogging(errUnauthenticated)
+	res400 := ShouldRetryWithoutLogging(&err400)
+
+	// Assert
+	assert.True(t, res401)
+	assert.True(t, resUnauthenticated)
+	assert.False(t, res400)
+}
+
+func TestDetermineRetryAction(t *testing.T) {
+	// Arrange
+	testCases := []struct {
+		name     string
+		err      error
+		expected retryAction
+	}{
+		{
+			name:     "NilError",
+			err:      nil,
+			expected: noRetry,
+		},
+		{
+			name:     "GoogleApiError400",
+			err:      &googleapi.Error{Code: 400},
+			expected: noRetry,
+		},
+		{
+			name:     "GoogleApiError401",
+			err:      &googleapi.Error{Code: 401},
+			expected: retry401,
+		},
+		{
+			name:     "GoogleApiError429",
+			err:      &googleapi.Error{Code: 429},
+			expected: retryTransient,
+		},
+		{
+			name:     "UnauthenticatedGrpcError",
+			err:      status.Error(codes.Unauthenticated, "unauthenticated"),
+			expected: retryUnauthenticated,
+		},
+		{
+			name:     "PermissionDeniedGrpcError",
+			err:      status.Error(codes.PermissionDenied, "permission denied"),
+			expected: noRetry,
+		},
+		{
+			name:     "UnexpectedEOF",
+			err:      io.ErrUnexpectedEOF,
+			expected: retryTransient,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			actual := determineRetryAction(tc.err)
+
+			// Assert
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+// logBuffer is a thread-safe buffer for capturing logs in tests.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestShouldRetryLogsWarning(t *testing.T) {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	var err401 = &googleapi.Error{
+		Code: 401,
+		Body: "Invalid Credential",
+	}
+
+	// Act
+	retry := ShouldRetry(err401)
+
+	// Assert
+	assert.True(t, retry)
+	assert.Contains(t, buf.String(), "WARNING")
+	assert.Contains(t, buf.String(), "Retrying for error-code 401")
+}
+
+func TestShouldRetryWithoutLoggingDoesNotLog(t *testing.T) {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	var err401 = &googleapi.Error{
+		Code: 401,
+		Body: "Invalid Credential",
+	}
+
+	// Act
+	retryNoLog := ShouldRetryWithoutLogging(err401)
+
+	// Assert
+	assert.True(t, retryNoLog)
+	assert.Empty(t, buf.String())
+}
+
 
 type fakeMetricHandle struct {
 	metrics.MetricHandle

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -154,25 +154,47 @@ func TestShouldRetryReturnsTrueForUnauthenticatedGrpcErrors(t *testing.T) {
 }
 
 func TestShouldRetryWithoutLogging(t *testing.T) {
-	// Arrange
-	var err401 = googleapi.Error{
-		Code: 401,
-		Body: "Invalid Credential",
-	}
-	var errUnauthenticated = status.Error(codes.Unauthenticated, "unauthenticated")
-	var err400 = googleapi.Error{
-		Code: 400,
+	testCases := []struct {
+		name           string
+		err            error
+		expectedResult bool
+	}{
+		{
+			name: "401 error - retryable",
+			err: &googleapi.Error{
+				Code: 401,
+				Body: "Invalid Credential",
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "Unauthenticated error - retryable",
+			err:            status.Error(codes.Unauthenticated, "unauthenticated"),
+			expectedResult: true,
+		},
+		{
+			name: "400 error - non-retryable",
+			err: &googleapi.Error{
+				Code: 400,
+			},
+			expectedResult: false,
+		},
 	}
 
-	// Act
-	res401 := ShouldRetryWithoutLogging(&err401)
-	resUnauthenticated := ShouldRetryWithoutLogging(errUnauthenticated)
-	res400 := ShouldRetryWithoutLogging(&err400)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf logBuffer
+			logger.SetOutput(&buf)
+			defer logger.SetOutput(os.Stdout)
 
-	// Assert
-	assert.True(t, res401)
-	assert.True(t, resUnauthenticated)
-	assert.False(t, res400)
+			// Act
+			actualResult := ShouldRetryWithoutLogging(tc.err)
+
+			// Assert
+			assert.Equal(t, tc.expectedResult, actualResult)
+			assert.Empty(t, buf.String())
+		})
+	}
 }
 
 func TestDetermineRetryAction(t *testing.T) {
@@ -253,7 +275,6 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	var buf logBuffer
 	logger.SetOutput(&buf)
 	defer logger.SetOutput(os.Stdout)
-
 	var err401 = &googleapi.Error{
 		Code: 401,
 		Body: "Invalid Credential",
@@ -266,25 +287,6 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	assert.True(t, retry)
 	assert.Contains(t, buf.String(), "WARNING")
 	assert.Contains(t, buf.String(), "Retrying for error-code 401")
-}
-
-func TestShouldRetryWithoutLoggingDoesNotLog(t *testing.T) {
-	// Arrange
-	var buf logBuffer
-	logger.SetOutput(&buf)
-	defer logger.SetOutput(os.Stdout)
-
-	var err401 = &googleapi.Error{
-		Code: 401,
-		Body: "Invalid Credential",
-	}
-
-	// Act
-	retryNoLog := ShouldRetryWithoutLogging(err401)
-
-	// Assert
-	assert.True(t, retryNoLog)
-	assert.Empty(t, buf.String())
 }
 
 type fakeMetricHandle struct {

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -147,7 +147,7 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 		if i == 0 {
 			logger.GetLogFHandler(logLevel)("Calling %s request for %q with deadline=%v", operationName, reqDescription, config.RetryDeadline)
 		} else {
-			logger.GetLogFHandler(logLevel)("Retrying %s for %q with deadline=%v ...", operationName, reqDescription, config.RetryDeadline)
+			logger.GetLogFHandler(logger.LevelWarn)("Retrying %s for %q with deadline=%v ...", operationName, reqDescription, config.RetryDeadline)
 		}
 
 		result, err := apiCall(attemptCtx)
@@ -205,7 +205,7 @@ func ExecuteWithRetryAtLogLevel[T any](
 	apiCall func(attemptCtx context.Context) (T, error),
 	logLevel slog.Level, // Used to log the retry logs at the supplied log level
 ) (T, error) {
-	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, ShouldRetry, logLevel)
+	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, ShouldRetryWithoutLogging, logLevel)
 }
 
 // ExecuteWithRetry retries a given operation but logs all logs at trace level
@@ -216,5 +216,5 @@ func ExecuteWithRetry[T any](
 	reqDescription string,
 	apiCall func(attemptCtx context.Context) (T, error),
 ) (T, error) {
-	return ExecuteWithCustomShouldRetry(ctx, config, operationName, reqDescription, apiCall, ShouldRetry)
+	return ExecuteWithCustomShouldRetry(ctx, config, operationName, reqDescription, apiCall, ShouldRetryWithoutLogging)
 }

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -119,8 +119,9 @@ func NewRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetry
 // It performs time-bound, exponential backoff retries for a given API call.
 // It is expected that the given apiCall returns a structure, and not an HTTP response,
 // so that it does not leave behind any trace of a pending operation on server.
-// It also has an option to control the log level of the logs during retry
-// and accepts a custom shouldRetry predicate function.
+// It also has an option to control the log level of the initial attempt log,
+// while subsequent retries are always logged at Warning level.
+// It also accepts a custom shouldRetry predicate function.
 func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	ctx context.Context,
 	config *RetryConfig,
@@ -128,7 +129,7 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	reqDescription string,
 	apiCall func(attemptCtx context.Context) (T, error),
 	shouldRetry func(err error) bool,
-	logLevel slog.Level, // Used to log the retry logs at the supplied log level
+	logLevel slog.Level, // Used to log the initial attempt at the supplied log level. Subsequent retries are logged at Warning level.
 ) (T, error) {
 	var zero T
 	// If the context is already cancelled, return immediately.
@@ -141,16 +142,18 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 
 	// Create a new backoff controller specific to this api call.
 	backoff := newExponentialBackoff(&config.BackoffConfig)
+	var lastErr error
 	for i := 0; ; i++ {
 		attemptCtx, attemptCancel := context.WithTimeout(parentCtx, config.RetryDeadline)
 
 		if i == 0 {
 			logger.GetLogFHandler(logLevel)("Calling %s request for %q with deadline=%v", operationName, reqDescription, config.RetryDeadline)
 		} else {
-			logger.GetLogFHandler(logger.LevelWarn)("Retrying %s for %q with deadline=%v ...", operationName, reqDescription, config.RetryDeadline)
+			logger.GetLogFHandler(logger.LevelWarn)("Retrying %s for %q with deadline=%v (error: %v) ...", operationName, reqDescription, config.RetryDeadline, lastErr)
 		}
 
 		result, err := apiCall(attemptCtx)
+		lastErr = err
 		// Cancel attemptCtx after it is no longer needed, to free up its resources.
 		attemptCancel()
 
@@ -180,7 +183,7 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	}
 }
 
-// ExecuteWithCustomShouldRetry retries a given operation using a custom shouldRetry predicate, but logs all logs at trace level.
+// ExecuteWithCustomShouldRetry retries a given operation using a custom shouldRetry predicate, logging the initial attempt at trace level.
 func ExecuteWithCustomShouldRetry[T any](
 	ctx context.Context,
 	config *RetryConfig,
@@ -196,19 +199,20 @@ func ExecuteWithCustomShouldRetry[T any](
 // It performs time-bound, exponential backoff retries for a given API call.
 // It is expected that the given apiCall returns a structure, and not an HTTP response,
 // so that it does not leave behind any trace of a pending operation on server.
-// It also has an option to control the log level of the logs during retry
+// It also has an option to control the log level of the initial attempt log,
+// while subsequent retries are always logged at Warning level.
 func ExecuteWithRetryAtLogLevel[T any](
 	ctx context.Context,
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
 	apiCall func(attemptCtx context.Context) (T, error),
-	logLevel slog.Level, // Used to log the retry logs at the supplied log level
+	logLevel slog.Level, // Used to log the initial attempt at the supplied log level. Subsequent retries are logged at Warning level.
 ) (T, error) {
 	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, ShouldRetryWithoutLogging, logLevel)
 }
 
-// ExecuteWithRetry retries a given operation but logs all logs at trace level
+// ExecuteWithRetry retries a given operation, logging the initial attempt at trace level.
 func ExecuteWithRetry[T any](
 	ctx context.Context,
 	config *RetryConfig,

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -17,9 +17,11 @@ package storageutil
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -569,4 +571,37 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_Composition
 	assert.NoError(t.T(), err)
 	assert.Equal(t.T(), "success", result)
 	assert.Equal(t.T(), 3, callCount)
+}
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_LogsErrorContext() {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	var callCount int
+	retryableErr := errors.New("transient failure 429")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "", retryableErr
+		}
+		return "success", nil
+	}
+
+	// We need a shouldRetry function that returns true for retryableErr.
+	customShouldRetry := func(err error) bool {
+		return err.Error() == "transient failure 429"
+	}
+
+	// Act
+	// Call ExecuteWithCustomShouldRetryAtLogLevel with LevelWarn, so we can capture the Retrying log
+	_, err := ExecuteWithCustomShouldRetryAtLogLevel(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry, logger.LevelWarn)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 2, callCount)
+	assert.Contains(t.T(), buf.String(), "Retrying testOp")
+	assert.Contains(t.T(), buf.String(), "testReq")
+	assert.Contains(t.T(), buf.String(), "transient failure 429")
 }

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -578,7 +578,6 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_LogsErrorContext() {
 	var buf logBuffer
 	logger.SetOutput(&buf)
 	defer logger.SetOutput(os.Stdout)
-
 	var callCount int
 	retryableErr := errors.New("transient failure 429")
 	apiCall := func(ctx context.Context) (string, error) {
@@ -588,7 +587,6 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_LogsErrorContext() {
 		}
 		return "success", nil
 	}
-
 	// We need a shouldRetry function that returns true for retryableErr.
 	customShouldRetry := func(err error) bool {
 		return err.Error() == "transient failure 429"


### PR DESCRIPTION
### Description
Fixes a duplicate logging issue during transient retries in GCSFuse, and unifies the warning logs generated during retryable GCS Control Client operations directly within `ExecuteWithCustomShouldRetryAtLogLevel`.

Previously, when running GCSFuse with trace logs enabled, every transient failure resulted in two redundant log entries printed side by side:
1. **Generic WARNING log** (from `custom_retry.go`'s `ShouldRetry`):
   ```json
   {"severity":"WARNING","message":"Retrying for the error: <error details>"}
   ```
2. **Specific TRACE log** (from `retry.go`'s `ExecuteWithCustomShouldRetryAtLogLevel`):
   ```json
   {"severity":"TRACE","message":"Retrying <operation> for <description> with deadline=... ..."}
   ```

### Why this was a problem:
* **Redundant & Messy Logs:** Developers and customers received two separate log lines for the exact same retry event.
* **Inconsistent Severity:** One log entry was marked as `TRACE` and the other as `WARNING`, which is confusing and can trigger false positives in automated alerting systems.
* **Lack of Context:** The generic warning log from `ShouldRetry` did not provide meaningful context regarding which operation failed or which GCS object was being retried.

### Fix
* Introduced `ShouldRetryWithoutLogging` to check error retryability silently without outputting generic warnings.
* Configured the retry runner (`ExecuteWithCustomShouldRetryAtLogLevel`) to dynamically adjust log severity: initial API calls are logged at the caller-provided `logLevel` (e.g. `TRACE`), while actual retry attempts are automatically elevated to `WARNING` level.
* This eliminates the redundant logs, while ensuring that real retries are always logged at the `WARNING` level with complete operational context (operation name, GCS object details, and deadlines).

### Link to the issue
b/514259639

### Testing details
1. **Manual**: Verified that retry logging works consistently and prints singular unified warnings.
2. **Unit tests**: Refactored `custom_retry_test.go` to add robust coverage verifying both `ShouldRetryWithoutLogging` and logging output severity.
3. **Integration tests**: NA

### Any backward incompatible change?
NONE
