### PR TITLE
feat(metrics): Add metric capture methods for metadata_cache read count metric

### DIFF
--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -20,6 +20,14 @@ import (
 	"time"
 )
 
+// EntryStatus is a custom type for the entry_status attribute.
+type EntryStatus string
+
+const (
+	EntryStatusNegativeAttr EntryStatus = "negative"
+	EntryStatusPositiveAttr EntryStatus = "positive"
+)
+
 // FsErrorCategory is a custom type for the fs_error_category attribute.
 type FsErrorCategory string
 
@@ -104,6 +112,15 @@ type IoMethod string
 const (
 	IoMethodClosedAttr IoMethod = "closed"
 	IoMethodOpenedAttr IoMethod = "opened"
+)
+
+// LookupDetail is a custom type for the lookup_detail attribute.
+type LookupDetail string
+
+const (
+	LookupDetailFoundAttr      LookupDetail = "found"
+	LookupDetailNotFoundAttr   LookupDetail = "not_found"
+	LookupDetailTtlExpiredAttr LookupDetail = "ttl_expired"
 )
 
 // OpenMode is a custom type for the open_mode attribute.
@@ -213,6 +230,9 @@ type MetricHandle interface {
 
 	// GcsRetryCount - The cumulative number of retry requests made to GCS.
 	GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory)
+
+	// MetadataCacheReadCount - Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence).
+	MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail)
 
 	// ReadBlockSizes - The cumulative distribution of read block sizes across different bucket boundaries
 	ReadBlockSizes(ctx context.Context, value int64)

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -256,6 +256,24 @@
     - "OTHER_ERRORS"
     - "STALLED_READ_REQUEST"
 
+- metric-name: "metadata_cache/read_count"
+  description: "Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."
+  type: "int_counter"
+  attributes:
+  - attribute-name: cache_hit
+    attribute-type: bool
+  - attribute-name: entry_status
+    attribute-type: string
+    values:
+    - positive
+    - negative
+  - attribute-name: lookup_detail
+    attribute-type: string
+    values:
+    - found
+    - ttl_expired
+    - not_found
+
 - metric-name: "read/block_sizes"
   description: "The cumulative distribution of read block sizes across different bucket boundaries"
   type: "int_histogram"

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -57,6 +57,9 @@ func (*noopMetrics) GcsRequestLatencies(ctx context.Context, latency time.Durati
 
 func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory RetryErrorCategory) {}
 
+func (*noopMetrics) MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail) {
+}
+
 func (*noopMetrics) ReadBlockSizes(ctx context.Context, value int64) {}
 
 func (*noopMetrics) TestUpdownCounter(inc int64) {}

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -569,6 +569,18 @@ var (
 	gcsRequestLatenciesGcsMethodUpdateObjectAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
 	gcsRetryCountRetryErrorCategoryOTHERERRORSAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")))
 	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
 	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
 	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
 )
@@ -1074,6 +1086,18 @@ type otelMetrics struct {
 	gcsRequestCountGcsMethodUpdateObjectAtomic                                                            *atomic.Int64
 	gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic                                                      *atomic.Int64
 	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic                                               *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic                          *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic                       *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic                     *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic                          *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic                       *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic                     *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic                         *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic                      *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic                    *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                         *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                      *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                    *atomic.Int64
 	testUpdownCounterAtomic                                                                               *atomic.Int64
 	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                      *atomic.Int64
 	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                      *atomic.Int64
@@ -2495,6 +2519,76 @@ func (o *otelMetrics) GcsRetryCount(
 	}
 }
 
+func (o *otelMetrics) MetadataCacheReadCount(
+	inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail) {
+	if inc < 0 {
+		logger.Errorf("Counter metric metadata_cache/read_count received a negative increment: %d", inc)
+		return
+	}
+	switch cacheHit {
+	case true:
+		switch entryStatus {
+		case EntryStatusNegativeAttr:
+			switch lookupDetail {
+			case LookupDetailFoundAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic.Add(inc)
+			case LookupDetailNotFoundAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic.Add(inc)
+			case LookupDetailTtlExpiredAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic.Add(inc)
+			default:
+				updateUnrecognizedAttribute(string(lookupDetail))
+				return
+			}
+		case EntryStatusPositiveAttr:
+			switch lookupDetail {
+			case LookupDetailFoundAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic.Add(inc)
+			case LookupDetailNotFoundAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic.Add(inc)
+			case LookupDetailTtlExpiredAttr:
+				o.metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic.Add(inc)
+			default:
+				updateUnrecognizedAttribute(string(lookupDetail))
+				return
+			}
+		default:
+			updateUnrecognizedAttribute(string(entryStatus))
+			return
+		}
+	case false:
+		switch entryStatus {
+		case EntryStatusNegativeAttr:
+			switch lookupDetail {
+			case LookupDetailFoundAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic.Add(inc)
+			case LookupDetailNotFoundAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic.Add(inc)
+			case LookupDetailTtlExpiredAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic.Add(inc)
+			default:
+				updateUnrecognizedAttribute(string(lookupDetail))
+				return
+			}
+		case EntryStatusPositiveAttr:
+			switch lookupDetail {
+			case LookupDetailFoundAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic.Add(inc)
+			case LookupDetailNotFoundAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic.Add(inc)
+			case LookupDetailTtlExpiredAttr:
+				o.metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic.Add(inc)
+			default:
+				updateUnrecognizedAttribute(string(lookupDetail))
+				return
+			}
+		default:
+			updateUnrecognizedAttribute(string(entryStatus))
+			return
+		}
+	}
+}
+
 func (o *otelMetrics) ReadBlockSizes(
 	ctx context.Context, value int64) {
 	record := histogramRecord{ctx: ctx, instrument: o.readBlockSizes, value: value}
@@ -3043,6 +3137,19 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 
 	var gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
 		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic atomic.Int64
+
+	var metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic atomic.Int64
 
 	var testUpdownCounterAtomic atomic.Int64
 
@@ -3644,12 +3751,31 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err16 := meter.Int64Histogram("read/block_sizes",
+	_, err16 := meter.Int64ObservableCounter("metadata_cache/read_count",
+		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
+		metric.WithUnit(""),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic, metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic, metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic, metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic, metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic, metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic, metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic, metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic, metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic, metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic, metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic, metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet)
+			conditionallyObserve(obsrv, &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic, metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet)
+			return nil
+		}))
+
+	readBlockSizes, err17 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err17 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err18 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3657,7 +3783,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err18 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err19 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3666,7 +3792,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4140,35 +4266,47 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
 		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
 		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
-		gcsReadBytesCountAtomic:                                    &gcsReadBytesCountAtomic,
-		gcsReadCountReadTypeParallelAtomic:                         &gcsReadCountReadTypeParallelAtomic,
-		gcsReadCountReadTypeRandomAtomic:                           &gcsReadCountReadTypeRandomAtomic,
-		gcsReadCountReadTypeSequentialAtomic:                       &gcsReadCountReadTypeSequentialAtomic,
-		gcsReadCountReadTypeUnknownAtomic:                          &gcsReadCountReadTypeUnknownAtomic,
-		gcsReaderCountIoMethodClosedAtomic:                         &gcsReaderCountIoMethodClosedAtomic,
-		gcsReaderCountIoMethodOpenedAtomic:                         &gcsReaderCountIoMethodOpenedAtomic,
-		gcsRequestCountGcsMethodComposeObjectsAtomic:               &gcsRequestCountGcsMethodComposeObjectsAtomic,
-		gcsRequestCountGcsMethodCopyObjectAtomic:                   &gcsRequestCountGcsMethodCopyObjectAtomic,
-		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic: &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
-		gcsRequestCountGcsMethodCreateFolderAtomic:                 &gcsRequestCountGcsMethodCreateFolderAtomic,
-		gcsRequestCountGcsMethodCreateObjectAtomic:                 &gcsRequestCountGcsMethodCreateObjectAtomic,
-		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:      &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
-		gcsRequestCountGcsMethodDeleteFolderAtomic:                 &gcsRequestCountGcsMethodDeleteFolderAtomic,
-		gcsRequestCountGcsMethodDeleteObjectAtomic:                 &gcsRequestCountGcsMethodDeleteObjectAtomic,
-		gcsRequestCountGcsMethodFinalizeUploadAtomic:               &gcsRequestCountGcsMethodFinalizeUploadAtomic,
-		gcsRequestCountGcsMethodFlushPendingWritesAtomic:           &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
-		gcsRequestCountGcsMethodGetFolderAtomic:                    &gcsRequestCountGcsMethodGetFolderAtomic,
-		gcsRequestCountGcsMethodListObjectsAtomic:                  &gcsRequestCountGcsMethodListObjectsAtomic,
-		gcsRequestCountGcsMethodMoveObjectAtomic:                   &gcsRequestCountGcsMethodMoveObjectAtomic,
-		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:      &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
-		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:      &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
-		gcsRequestCountGcsMethodNewReaderAtomic:                    &gcsRequestCountGcsMethodNewReaderAtomic,
-		gcsRequestCountGcsMethodRenameFolderAtomic:                 &gcsRequestCountGcsMethodRenameFolderAtomic,
-		gcsRequestCountGcsMethodStatObjectAtomic:                   &gcsRequestCountGcsMethodStatObjectAtomic,
-		gcsRequestCountGcsMethodUpdateObjectAtomic:                 &gcsRequestCountGcsMethodUpdateObjectAtomic,
-		gcsRequestLatencies:                                        gcsRequestLatencies,
-		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:           &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
-		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:    &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
+		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
+		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
+		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,
+		gcsReadCountReadTypeSequentialAtomic:                                               &gcsReadCountReadTypeSequentialAtomic,
+		gcsReadCountReadTypeUnknownAtomic:                                                  &gcsReadCountReadTypeUnknownAtomic,
+		gcsReaderCountIoMethodClosedAtomic:                                                 &gcsReaderCountIoMethodClosedAtomic,
+		gcsReaderCountIoMethodOpenedAtomic:                                                 &gcsReaderCountIoMethodOpenedAtomic,
+		gcsRequestCountGcsMethodComposeObjectsAtomic:                                       &gcsRequestCountGcsMethodComposeObjectsAtomic,
+		gcsRequestCountGcsMethodCopyObjectAtomic:                                           &gcsRequestCountGcsMethodCopyObjectAtomic,
+		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic:                         &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
+		gcsRequestCountGcsMethodCreateFolderAtomic:                                         &gcsRequestCountGcsMethodCreateFolderAtomic,
+		gcsRequestCountGcsMethodCreateObjectAtomic:                                         &gcsRequestCountGcsMethodCreateObjectAtomic,
+		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:                              &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
+		gcsRequestCountGcsMethodDeleteFolderAtomic:                                         &gcsRequestCountGcsMethodDeleteFolderAtomic,
+		gcsRequestCountGcsMethodDeleteObjectAtomic:                                         &gcsRequestCountGcsMethodDeleteObjectAtomic,
+		gcsRequestCountGcsMethodFinalizeUploadAtomic:                                       &gcsRequestCountGcsMethodFinalizeUploadAtomic,
+		gcsRequestCountGcsMethodFlushPendingWritesAtomic:                                   &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
+		gcsRequestCountGcsMethodGetFolderAtomic:                                            &gcsRequestCountGcsMethodGetFolderAtomic,
+		gcsRequestCountGcsMethodListObjectsAtomic:                                          &gcsRequestCountGcsMethodListObjectsAtomic,
+		gcsRequestCountGcsMethodMoveObjectAtomic:                                           &gcsRequestCountGcsMethodMoveObjectAtomic,
+		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:                              &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
+		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:                              &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
+		gcsRequestCountGcsMethodNewReaderAtomic:                                            &gcsRequestCountGcsMethodNewReaderAtomic,
+		gcsRequestCountGcsMethodRenameFolderAtomic:                                         &gcsRequestCountGcsMethodRenameFolderAtomic,
+		gcsRequestCountGcsMethodStatObjectAtomic:                                           &gcsRequestCountGcsMethodStatObjectAtomic,
+		gcsRequestCountGcsMethodUpdateObjectAtomic:                                         &gcsRequestCountGcsMethodUpdateObjectAtomic,
+		gcsRequestLatencies:                                                                gcsRequestLatencies,
+		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:                                   &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
+		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:                            &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic:       &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic:    &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic:  &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic:       &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic:    &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic:  &metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic:      &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic:   &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic: &metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic:      &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic:   &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
+		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic: &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic,
 		readBlockSizes:          readBlockSizes,
 		testUpdownCounterAtomic: &testUpdownCounterAtomic,
 		testUpdownCounterWithAttrsRequestTypeAttr1Atomic: &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -5493,6 +5493,165 @@ func TestGcsRetryCount(t *testing.T) {
 	}
 }
 
+func TestMetadataCacheReadCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "cache_hit_true_entry_status_negative_lookup_detail_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "negative", "found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_true_entry_status_negative_lookup_detail_not_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "negative", "not_found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_true_entry_status_negative_lookup_detail_ttl_expired",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "negative", "ttl_expired")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")): 5,
+			},
+		},
+		{
+			name: "cache_hit_true_entry_status_positive_lookup_detail_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "positive", "found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_true_entry_status_positive_lookup_detail_not_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "positive", "not_found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_true_entry_status_positive_lookup_detail_ttl_expired",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "positive", "ttl_expired")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_negative_lookup_detail_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "negative", "found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_negative_lookup_detail_not_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "negative", "not_found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_negative_lookup_detail_ttl_expired",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "negative", "ttl_expired")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_positive_lookup_detail_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "positive", "found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_positive_lookup_detail_not_found",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "positive", "not_found")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")): 5,
+			},
+		},
+		{
+			name: "cache_hit_false_entry_status_positive_lookup_detail_ttl_expired",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, false, "positive", "ttl_expired")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(5, true, "negative", "found")
+				m.MetadataCacheReadCount(2, true, "negative", "not_found")
+				m.MetadataCacheReadCount(3, true, "negative", "found")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")): 8,
+				attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheReadCount(-5, true, "negative", "found")
+				m.MetadataCacheReadCount(2, true, "negative", "found")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")): 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["metadata_cache/read_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "metadata_cache/read_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "metadata_cache/read_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
 func TestReadBlockSizes(t *testing.T) {
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()


### PR DESCRIPTION
### Description
Add metric capture(handle or interface) methods for metadata_cache read count metric .

### Link to the issue in case of a bug fix.
b/512000913

### Testing details
1. Manual - NA
2. Unit tests - Added unittests cover testing the methods added for capturing the metrics.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A