### PR TITLE
feat: Rename FinalizeFileOnClose to FinalizeFileForRapid

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -58,7 +58,7 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			Value: bool(true),
 		},
 	},
-}, "write.finalize-file-on-close": {
+}, "write.finalize-file-for-rapid": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
 			BucketType: "zonal",
@@ -288,14 +288,14 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 			}
 		}
 	}
-	if !v.IsSet("write.finalize-file-on-close") {
-		rules := AllFlagOptimizationRules["write.finalize-file-on-close"]
-		result := getOptimizedValue(&rules, c.Write.FinalizeFileOnClose, profileName, machineType, input, machineTypeToGroupMap)
+	if !v.IsSet("write.finalize-file-for-rapid") {
+		rules := AllFlagOptimizationRules["write.finalize-file-for-rapid"]
+		result := getOptimizedValue(&rules, c.Write.FinalizeFileForRapid, profileName, machineType, input, machineTypeToGroupMap)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(bool); ok {
-				if c.Write.FinalizeFileOnClose != val {
-					c.Write.FinalizeFileOnClose = val
-					optimizedFlags["write.finalize-file-on-close"] = result
+				if c.Write.FinalizeFileForRapid != val {
+					c.Write.FinalizeFileForRapid = val
+					optimizedFlags["write.finalize-file-for-rapid"] = result
 				}
 			}
 		}
@@ -778,7 +778,7 @@ type WriteConfig struct {
 
 	EnableStreamingWrites bool `yaml:"enable-streaming-writes"`
 
-	FinalizeFileOnClose bool `yaml:"finalize-file-on-close"`
+	FinalizeFileForRapid bool `yaml:"finalize-file-for-rapid"`
 
 	GlobalMaxBlocks int64 `yaml:"global-max-blocks"`
 
@@ -1151,9 +1151,9 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.StringP("file-mode", "", "0644", "Permissions bits for files, in octal.")
 
-	flagSet.BoolP("finalize-file-on-close", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
+	flagSet.BoolP("finalize-file-for-rapid", "", false, "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files.")
 
-	if err := flagSet.MarkHidden("finalize-file-on-close"); err != nil {
+	if err := flagSet.MarkHidden("finalize-file-for-rapid"); err != nil {
 		return err
 	}
 
@@ -1744,7 +1744,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("write.finalize-file-on-close", flagSet.Lookup("finalize-file-on-close")); err != nil {
+	if err := v.BindPFlag("write.finalize-file-for-rapid", flagSet.Lookup("finalize-file-for-rapid")); err != nil {
 		return err
 	}
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -257,8 +257,8 @@ func TestApplyOptimizations(t *testing.T) {
 			})
 		}
 	})
-	// Tests for write.finalize-file-on-close
-	t.Run("write.finalize-file-on-close", func(t *testing.T) {
+	// Tests for write.finalize-file-for-rapid
+	t.Run("write.finalize-file-for-rapid", func(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
@@ -271,8 +271,8 @@ func TestApplyOptimizations(t *testing.T) {
 				name:   "user_set",
 				config: Config{},
 				userSetFlags: map[string]any{
-					"write.finalize-file-on-close": true,
-					"machine-type":                 "a2-megagpu-16g",
+					"write.finalize-file-for-rapid": true,
+					"machine-type":                  "a2-megagpu-16g",
 				},
 				input:           &OptimizationInput{BucketType: BucketTypeZonal},
 				expectOptimized: false,
@@ -312,9 +312,9 @@ func TestApplyOptimizations(t *testing.T) {
 				c := tc.config
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
-					c.Write.FinalizeFileOnClose = tc.expectedValue.(bool)
+					c.Write.FinalizeFileForRapid = tc.expectedValue.(bool)
 				} else {
-					c.Write.FinalizeFileOnClose = false
+					c.Write.FinalizeFileForRapid = false
 				}
 
 				v := viper.New()
@@ -325,12 +325,12 @@ func TestApplyOptimizations(t *testing.T) {
 				optimizedFlags := c.ApplyOptimizations(v, tc.input)
 
 				if tc.expectOptimized {
-					assert.Contains(t, optimizedFlags, "write.finalize-file-on-close")
+					assert.Contains(t, optimizedFlags, "write.finalize-file-for-rapid")
 				} else {
-					assert.NotContains(t, optimizedFlags, "write.finalize-file-on-close")
+					assert.NotContains(t, optimizedFlags, "write.finalize-file-for-rapid")
 				}
 				// Use EqualValues to handle the int vs int64 type mismatch for default values.
-				assert.EqualValues(t, tc.expectedValue, c.Write.FinalizeFileOnClose)
+				assert.EqualValues(t, tc.expectedValue, c.Write.FinalizeFileForRapid)
 			})
 		}
 	})

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1287,8 +1287,8 @@ params:
     usage: "Enables streaming uploads during write file operation."
     default: true
 
-  - config-path: "write.finalize-file-on-close"
-    flag-name: "finalize-file-on-close"
+  - config-path: "write.finalize-file-for-rapid"
+    flag-name: "finalize-file-for-rapid"
     type: "bool"
     usage: "Finalizes the files on close for Rapid storage. Appends will be slower on finalized files."
     default: false

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -283,7 +283,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 		expectedWriteGlobalMaxBlocks  int64
 		expectedWriteMaxBlocksPerFile int64
 		expectedEnableRapidWrites     bool
-		expectedFinalizeFileOnClose   bool
+		expectedFinalizeFileForRapid  bool
 	}{
 		{
 			name:                          "Test create-empty-file flag true works when streaming writes are explicitly disabled.",
@@ -434,8 +434,8 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteMaxBlocksPerFile: 1,
 		},
 		{
-			name:                          "Test enable-rapid-writes and finalize-file-on-close flags.",
-			args:                          []string{"gcsfuse", "--enable-rapid-writes=true", "--finalize-file-on-close=true", "abc", "pqr"},
+			name:                          "Test enable-rapid-writes and finalize-file-for-rapid flags.",
+			args:                          []string{"gcsfuse", "--enable-rapid-writes=true", "--finalize-file-for-rapid=true", "abc", "pqr"},
 			expectedCreateEmptyFile:       false,
 			expectedEnableStreamingWrites: true,
 			expectedEnableRapidAppends:    true,
@@ -443,7 +443,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteGlobalMaxBlocks:  4,
 			expectedWriteMaxBlocksPerFile: 1,
 			expectedEnableRapidWrites:     true,
-			expectedFinalizeFileOnClose:   true,
+			expectedFinalizeFileForRapid:  true,
 		},
 	}
 
@@ -466,7 +466,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 				assert.Equal(t, tc.expectedWriteGlobalMaxBlocks, wc.GlobalMaxBlocks)
 				assert.Equal(t, tc.expectedEnableRapidAppends, wc.EnableRapidAppends)
 				assert.Equal(t, tc.expectedEnableRapidWrites, wc.EnableRapidWrites)
-				assert.Equal(t, tc.expectedFinalizeFileOnClose, wc.FinalizeFileOnClose)
+				assert.Equal(t, tc.expectedFinalizeFileForRapid, wc.FinalizeFileForRapid)
 			}
 		})
 	}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3103,9 +3103,9 @@ func (fs *fileSystem) ReadFile(
 		// Flush/Sync Pending streaming writes and issue read within same inode lock.
 		// With rapid buckets, we can read from unfinalized objects as well.
 		// Hence, there is no need to finalize the object from here for rapid buckets.
-		// Hence, if FinalizeFileOnClose is set, then we will call syncFile otherwise
-		// we can call flushFile (as it will not finalize when FinalizeFileOnClose is false) itself.
-		if fh.Inode().Bucket().BucketType().RapidWritesEnabled() && fs.newConfig.Write.FinalizeFileOnClose {
+		// Hence, if FinalizeFileForRapid is set, then we will call syncFile otherwise
+		// we can call flushFile (as it will not finalize when FinalizeFileForRapid is false) itself.
+		if fh.Inode().Bucket().BucketType().RapidWritesEnabled() && fs.newConfig.Write.FinalizeFileForRapid {
 			err = fs.syncFile(ctx, fh.Inode())
 		} else {
 			err = fs.flushFile(ctx, fh.Inode())

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -203,15 +203,15 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// Zonal buckets strictly require the appendable API. For Pirlo buckets, the
 	// appendable API provides file-like semantics (immediate data visibility)
 	// but defers regional durability until the object is finalized. Users can
-	// choose to keep objects unfinalized by setting the FinalizeFileOnClose flag
+	// choose to keep objects unfinalized by setting the FinalizeFileForRapid flag
 	// to false, which allows further appends, but if they keep it unfinalized
 	// it never becomes regionally durable.
 	wc.Append = bh.BucketType().RapidWritesEnabled()
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
-	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
+	// pirlo buckets are. This behavior is controlled by the finalizeFileForRapid flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
 	// Refer: https://github.com/googleapis/google-cloud-go/blob/bf56afb2a15301500b9981ee76ccc5f449e3f545/storage/writer.go#L160
-	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileOnClose
+	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileForRapid
 
 	// Copy the contents to the writer.
 	if _, err = io.Copy(wc, req.Contents); err != nil {
@@ -244,15 +244,15 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	// Zonal buckets strictly require the appendable API. For Pirlo buckets, the
 	// appendable API provides file-like semantics (immediate data visibility)
 	// but defers regional durability until the object is finalized. Users can
-	// choose to keep objects unfinalized by setting the FinalizeFileOnClose flag
+	// choose to keep objects unfinalized by setting the FinalizeFileForRapid flag
 	// to false, which allows further appends, but if they keep it unfinalized
 	// it never becomes regionally durable.
 	wc.Append = bh.BucketType().RapidWritesEnabled()
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
-	// pirlo buckets are. This behavior is controlled by the finalizeFileOnClose flag.
+	// pirlo buckets are. This behavior is controlled by the finalizeFileForRapid flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
 	// Refer: https://github.com/googleapis/google-cloud-go/blob/bf56afb2a15301500b9981ee76ccc5f449e3f545/storage/writer.go#L160
-	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileOnClose
+	wc.FinalizeOnClose = bh.writeConfig.FinalizeFileForRapid
 	return wc, nil
 }
 
@@ -265,7 +265,7 @@ func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	opts := storage.AppendableWriterOpts{
 		ChunkSize:       req.ChunkSize,
 		ProgressFunc:    req.CallBack,
-		FinalizeOnClose: bh.writeConfig.FinalizeFileOnClose,
+		FinalizeOnClose: bh.writeConfig.FinalizeFileForRapid,
 	}
 
 	tw, off, err := obj.NewWriterFromAppendableObject(ctx, &opts) // Takeover writer tw created from offset off.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -596,34 +596,34 @@ func (testSuite *BucketHandleTest) TestBucketHandle_CreateObjectChunkWriter() {
 
 func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 	tests := []struct {
-		name                string
-		bucketType          gcs.BucketType
-		finalizeFileOnClose bool
-		expectedAppend      bool
+		name                 string
+		bucketType           gcs.BucketType
+		finalizeFileForRapid bool
+		expectedAppend       bool
 	}{
 		{
-			name:                "StandardBucket",
-			bucketType:          gcs.BucketType{},
-			finalizeFileOnClose: true,
-			expectedAppend:      false,
+			name:                 "StandardBucket",
+			bucketType:           gcs.BucketType{},
+			finalizeFileForRapid: true,
+			expectedAppend:       false,
 		},
 		{
-			name:                "ZonalBucket",
-			bucketType:          gcs.BucketType{Zonal: true},
-			finalizeFileOnClose: false,
-			expectedAppend:      true,
+			name:                 "ZonalBucket",
+			bucketType:           gcs.BucketType{Zonal: true},
+			finalizeFileForRapid: false,
+			expectedAppend:       true,
 		},
 		{
-			name:                "PirloBucket_RapidEnabled",
-			bucketType:          gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
-			finalizeFileOnClose: true,
-			expectedAppend:      true,
+			name:                 "PirloBucket_RapidEnabled",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			finalizeFileForRapid: true,
+			expectedAppend:       true,
 		},
 		{
-			name:                "PirloBucket_RapidDisabled",
-			bucketType:          gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
-			finalizeFileOnClose: false,
-			expectedAppend:      false,
+			name:                 "PirloBucket_RapidDisabled",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			finalizeFileForRapid: false,
+			expectedAppend:       false,
 		},
 	}
 
@@ -631,7 +631,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 		testSuite.T().Run(tt.name, func(t *testing.T) {
 			createBucketHandle(testSuite, &controlpb.StorageLayout{})
 			testSuite.bucketHandle.bucketType = &tt.bucketType
-			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{FinalizeFileOnClose: tt.finalizeFileOnClose}
+			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{FinalizeFileForRapid: tt.finalizeFileForRapid}
 
 			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), &gcs.CreateObjectRequest{Name: "test_object"}, 1024, nil)
 
@@ -639,7 +639,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 			objWr, ok := w.(*ObjectWriter)
 			require.True(t, ok)
 			assert.Equal(t, tt.expectedAppend, objWr.Append)
-			assert.Equal(t, tt.finalizeFileOnClose, objWr.FinalizeOnClose)
+			assert.Equal(t, tt.finalizeFileForRapid, objWr.FinalizeOnClose)
 		})
 	}
 }


### PR DESCRIPTION
### Description
This PR renames the `finalize-file-on-close` flag to `finalize-file-for-rapid`. This ensures that users who were previously instructed to use the rapid-specific flag do not experience breaking changes.

### Link to the issue in case of a bug fix.
b/512312069

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
