### PR TITLE
fix: EIO error on RmDir by implementing Unwrap for gcs.NotFoundError

### DIFF
--- a/internal/storage/gcs/errors.go
+++ b/internal/storage/gcs/errors.go
@@ -35,6 +35,10 @@ func (nfe *NotFoundError) Error() string {
 	return fmt.Sprintf("gcs.NotFoundError: %v", nfe.Err)
 }
 
+func (nfe *NotFoundError) Unwrap() error {
+	return nfe.Err
+}
+
 // A *PreconditionError value is an error that indicates a precondition failed.
 type PreconditionError struct {
 	Err error

--- a/tools/integration_tests/operations/delete_dir_test.go
+++ b/tools/integration_tests/operations/delete_dir_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
@@ -58,5 +59,60 @@ func TestDeleteNonEmptyExplicitDir(t *testing.T) {
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.Name() == NonEmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
 		t.Errorf("Directory is not deleted.")
+	}
+}
+
+func TestRmDirAlreadyDeletedExplicitDirReturnsENOENT(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForOperationTests)
+	dirPath := path.Join(testDir, "explicit_dir_double_delete")
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	// Delete explicit directory first time.
+	err := os.Remove(dirPath)
+	if err != nil {
+		t.Fatalf("Error in deleting empty explicit directory: %v", err)
+	}
+
+	// Delete it again via RmDir, which must return os.ErrNotExist (ENOENT).
+	err = os.Remove(dirPath)
+
+	if err == nil {
+		t.Errorf("Expected ENOENT error when deleting non-existent explicit directory, got nil")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected os.ErrNotExist (ENOENT) error when deleting non-existent explicit directory, got: %v", err)
+	}
+}
+
+func TestRmDirNonExistentDirReturnsENOENT(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForOperationTests)
+	dirPath := path.Join(testDir, "non_existent_dir_rmdir_enoent")
+
+	err := os.Remove(dirPath)
+
+	if err == nil {
+		t.Errorf("Expected ENOENT error when calling RmDir on non-existent path, got nil")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected os.ErrNotExist (ENOENT) error when calling RmDir on non-existent path, got: %v", err)
+	}
+}
+
+func TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT(t *testing.T) {
+	testDir := setup.SetupTestDirectory(DirForOperationTests)
+	dirName := "oob_deleted_explicit_dir"
+	dirPath := path.Join(testDir, dirName)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	if _, err := os.Stat(dirPath); err != nil {
+		t.Fatalf("Error statting explicit directory: %v", err)
+	}
+	client.DeleteDirOnGCS(ctx, storageClient, path.Join(DirForOperationTests, dirName))
+
+	err := os.Remove(dirPath)
+
+	if err == nil {
+		t.Errorf("Expected ENOENT error when deleting out-of-band deleted explicit directory, got nil")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected os.ErrNotExist (ENOENT) error, got: %v", err)
 	}
 }

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	gcsstorage "cloud.google.com/go/storage"
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/googleapis/gax-go/v2"
@@ -118,4 +119,22 @@ func CreateFolderInBucket(ctx context.Context, client *control.StorageControlCli
 	f, err := client.CreateFolder(ctx, req)
 
 	return f, err
+}
+
+func DeleteFolderInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) error {
+	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+	req := &controlpb.DeleteFolderRequest{
+		Name: fmt.Sprintf("projects/_/buckets/%s/folders/%s", bucket, path.Join(rootFolder, folderPath)),
+	}
+	return client.DeleteFolder(ctx, req)
+}
+
+func DeleteDirOnGCS(ctx context.Context, storageClient *gcsstorage.Client, relativeDirPath string) {
+	bucket, rootFolder := setup.GetBucketAndObjectBasedOnTypeOfMount("")
+	gcsObjName := path.Join(rootFolder, relativeDirPath) + "/"
+	_ = getBucketHandle(storageClient, bucket).Object(gcsObjName).Delete(ctx)
+	if controlClient, err := CreateControlClient(ctx); err == nil && controlClient != nil {
+		_ = DeleteFolderInBucket(ctx, controlClient, relativeDirPath)
+		controlClient.Close()
+	}
 }


### PR DESCRIPTION
### Summary
Fixes an issue where calling `RmDir` (or `os.Remove`) on an explicit directory that was deleted out-of-band directly in GCS returned an `input/output error` (`syscall.EIO`) instead of POSIX `ENOENT` (`os.ErrNotExist`).

### Root Cause
When a folder is deleted out-of-band on GCS while still present in GCSFuse's local inode cache, `RmDir` issues a backend call to GCS (`DeleteFolder`), which returns a `codes.NotFound` gRPC error wrapped inside `&gcs.NotFoundError{Err: err}`.

Because `gcs.NotFoundError` lacked an `Unwrap() error` method, Go's standard error unwrapping engine (`errors.As`), which is used internally by `status.FromError(err)` in `error_mapping.go`, hit a wall at `NotFoundError` and could not extract the underlying `codes.NotFound` status code. As a result, the error bypassed status code matching and fell back to `DefaultFSError` (`syscall.EIO`).

### Fix
Implemented the `Unwrap() error` method on `*gcs.NotFoundError` in `internal/storage/gcs/errors.go`. This enables `status.FromError(err)` in the FUSE wrapper layer to automatically unwrap error chains down to `codes.NotFound` and map them correctly to `syscall.ENOENT`.

### Testing
- Added integration test `TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT` in `tools/integration_tests/operations/delete_dir_test.go`.

### Link to the issue in case of a bug fix.
b/527846176
### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - Part of pre-submits both Zonal and Regional

### Any backward incompatible change? If so, please explain.
NONE
