### PR TITLE
chore: Add the team to .gemini owners for faster iteration.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo.
 *           @GoogleCloudPlatform/gcsfuse-codeowners
-
-perfmetrics/scripts/testing_on_gke/ @gargnitingoogle @kislaykishore @charith87 @GoogleCloudPlatform/gcsfuse-codeowners
+.gemini @alleaditya @thrivikram-karur-g @PranjalC100 @meet2mky @anushka567 @vipnydav @GoogleCloudPlatform/gcsfuse-codeowners
 perfmetrics/scripts/ @meet2mky @GoogleCloudPlatform/gcsfuse-codeowners
 tools/ @meet2mky @GoogleCloudPlatform/gcsfuse-codeowners


### PR DESCRIPTION
### Description
Add the team to .gemini owners for faster iteration.
Remove Nitin from the list

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No