### PR TITLE
ci(gke): update default tpu reservation for continuous integration runs

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/common/utils.py
+++ b/perfmetrics/scripts/continuous_test/gke/common/utils.py
@@ -25,7 +25,7 @@ DEFAULT_MTU = 8896
 # Default configuration for testing on TPU
 DEFAULT_PROJECT_ID = "gcs-fuse-test-ml"
 DEFAULT_ZONE = "europe-west4-a"
-DEFAULT_RESERVATION_NAME = "cloudtpu-20251107233000-76736260"
+DEFAULT_RESERVATION_NAME = "cloudtpu-20260521143000-1388945208"
 
 
 async def run_command_async(command_list, check=True, cwd=None):

--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/README.md
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/README.md
@@ -102,7 +102,7 @@ Argument                  | Description                                         
 `--machine_type`          | Machine type for the node pool.                                  | `ct6e-standard-4t` (TPU v6e)
 `--node_pool_name`        | Node pool name.                                                  | `ct6e-pool`
 `--gcsfuse_branch`        | GCSFuse branch to build.                                         | `master`
-`--reservation_name`      | Specific reservation to use for the nodes.                       | `cloudtpu-20251107233000-76736260`
+`--reservation_name`      | Specific reservation to use for the nodes.                       | `cloudtpu-20260521143000-1388945208`
 `--no_cleanup`            | If set, resources will NOT be deleted after the test.            | `False`
 `--skip_csi_driver_build` | If set, skips building the CSI driver image (assumes it exists). | `False`
 `--pod_timeout_seconds`   | Timeout in seconds for the pod to complete.                      | `1800` (30 mins)

--- a/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/README.md
+++ b/perfmetrics/scripts/continuous_test/gke/orbax_benchmark/README.md
@@ -55,7 +55,7 @@ Argument                  | Description                                         
 `--machine_type`          | Machine type for the node pool.                                  | `ct6e-standard-4t` (TPU v6e)
 `--node_pool_name`        | Node pool name.                                                  | `ct6e-pool`
 `--gcsfuse_branch`        | GCSFuse branch to build.                                         | `master`
-`--reservation_name`      | Specific reservation to use for the nodes.                       | `cloudtpu-20251107233000-76736260`
+`--reservation_name`      | Specific reservation to use for the nodes.                       | `cloudtpu-20260521143000-1388945208`
 `--no_cleanup`            | If set, resources will NOT be deleted after the test.            | `False`
 `--iterations`            | Number of iterations for the benchmark.                          | `20`
 `--performance_threshold_gbps` | Minimum throughput in GB/s for a successful iteration.      | `13.0`


### PR DESCRIPTION
### Description
Updates the default TPU reservation name used for the continuous integration runs (specifically Orbax benchmarks and machine type tests) under GKE. The reservation has been updated to the newly allocated reservation `cloudtpu-20260521143000-1388945208`.

### Link to the issue in case of a bug fix.
b/515417148

### Testing details
1. Manual - Ran `python3 -m py_compile` on the updated Python files to ensure syntax-correctness. Also executed `make build` locally, which completed successfully.
2. Unit tests - N/A
3. Integration tests - N/A (The reservation updates will execute and apply on the subsequent continuous GKE integration jobs).

### Any backward incompatible change? If so, please explain.
No
