### PR TITLE
feat(native-retries): propagate request IDs on storage control retries for easier tracking of attempts in logs

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -27,6 +27,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"github.com/google/uuid"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
@@ -557,7 +558,8 @@ func (bh *bucketHandle) DeleteFolder(ctx context.Context, folderName string) (er
 	var callOptions []gax.CallOption
 
 	err = bh.controlClient.DeleteFolder(ctx, &controlpb.DeleteFolderRequest{
-		Name: fmt.Sprintf(FullFolderPathHNS, bh.bucketName, folderName),
+		Name:      fmt.Sprintf(FullFolderPathHNS, bh.bucketName, folderName),
+		RequestId: uuid.NewString(),
 	}, callOptions...)
 	return
 }
@@ -604,6 +606,7 @@ func (bh *bucketHandle) RenameFolder(ctx context.Context, folderName string, des
 	req := &controlpb.RenameFolderRequest{
 		Name:                fmt.Sprintf(FullFolderPathHNS, bh.bucketName, folderName),
 		DestinationFolderId: destinationFolderId,
+		RequestId:           uuid.NewString(),
 	}
 	resp, err := bh.controlClient.RenameFolder(ctx, req)
 	if err != nil {
@@ -631,7 +634,8 @@ func (bh *bucketHandle) GetFolder(ctx context.Context, req *gcs.GetFolderRequest
 	var callOptions []gax.CallOption
 	var clientFolder *controlpb.Folder
 	clientFolder, err = bh.controlClient.GetFolder(ctx, &controlpb.GetFolderRequest{
-		Name: fmt.Sprintf(FullFolderPathHNS, bh.bucketName, req.Name),
+		Name:      fmt.Sprintf(FullFolderPathHNS, bh.bucketName, req.Name),
+		RequestId: uuid.NewString(),
 	}, callOptions...)
 
 	if err != nil {
@@ -652,6 +656,7 @@ func (bh *bucketHandle) CreateFolder(ctx context.Context, folderName string) (fo
 		Parent:    fmt.Sprintf(FullBucketPathHNS, bh.bucketName),
 		FolderId:  folderName,
 		Recursive: true,
+		RequestId: uuid.NewString(),
 	}
 
 	clientFolder, err := bh.controlClient.CreateFolder(ctx, req)

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -1609,7 +1609,9 @@ func (testSuite *BucketHandleTest) TestDeleteFolderWhenFolderExitForHierarchical
 	})
 	ctx := context.Background()
 	deleteFolderReq := controlpb.DeleteFolderRequest{Name: fmt.Sprintf(FullFolderPathHNS, TestBucketName, TestFolderName)}
-	testSuite.mockClient.On("DeleteFolder", ctx, &deleteFolderReq, mock.Anything).Return(nil)
+	testSuite.mockClient.On("DeleteFolder", ctx, mock.MatchedBy(func(req *controlpb.DeleteFolderRequest) bool {
+		return req.Name == deleteFolderReq.Name
+	}), mock.Anything).Return(nil)
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	err := testSuite.bucketHandle.DeleteFolder(ctx, TestFolderName)
@@ -1624,7 +1626,9 @@ func (testSuite *BucketHandleTest) TestDeleteFolderWhenFolderNotExistForHierarch
 		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
 	})
 	deleteFolderReq := controlpb.DeleteFolderRequest{Name: fmt.Sprintf(FullFolderPathHNS, TestBucketName, missingFolderName)}
-	testSuite.mockClient.On("DeleteFolder", mock.Anything, &deleteFolderReq, mock.Anything).Return(errors.New("mock error"))
+	testSuite.mockClient.On("DeleteFolder", mock.Anything, mock.MatchedBy(func(req *controlpb.DeleteFolderRequest) bool {
+		return req.Name == deleteFolderReq.Name
+	}), mock.Anything).Return(errors.New("mock error"))
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	err := testSuite.bucketHandle.DeleteFolder(ctx, missingFolderName)
@@ -1643,7 +1647,9 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderExistsForHierarchicalB
 	mockFolder := controlpb.Folder{
 		Name: folderPath,
 	}
-	testSuite.mockClient.On("GetFolder", ctx, &getFolderReq, mock.Anything).Return(&mockFolder, nil)
+	testSuite.mockClient.On("GetFolder", ctx, mock.MatchedBy(func(req *controlpb.GetFolderRequest) bool {
+		return req.Name == getFolderReq.Name
+	}), mock.Anything).Return(&mockFolder, nil)
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	result, err := testSuite.bucketHandle.GetFolder(ctx, &gcs.GetFolderRequest{Name: TestFolderName})
@@ -1660,7 +1666,9 @@ func (testSuite *BucketHandleTest) TestGetFolderWhenFolderDoesNotExistsForHierar
 	})
 	folderPath := fmt.Sprintf(FullFolderPathHNS, TestBucketName, missingFolderName)
 	getFolderReq := controlpb.GetFolderRequest{Name: folderPath}
-	testSuite.mockClient.On("GetFolder", ctx, &getFolderReq, mock.Anything).Return(nil, status.Error(codes.NotFound, "folder not found"))
+	testSuite.mockClient.On("GetFolder", ctx, mock.MatchedBy(func(req *controlpb.GetFolderRequest) bool {
+		return req.Name == getFolderReq.Name
+	}), mock.Anything).Return(nil, status.Error(codes.NotFound, "folder not found"))
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	result, err := testSuite.bucketHandle.GetFolder(ctx, &gcs.GetFolderRequest{Name: missingFolderName})
@@ -1676,7 +1684,9 @@ func (testSuite *BucketHandleTest) TestRenameFolderWithError() {
 		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
 	})
 	renameFolderReq := controlpb.RenameFolderRequest{Name: fmt.Sprintf(FullFolderPathHNS, TestBucketName, TestFolderName), DestinationFolderId: TestRenameFolder}
-	testSuite.mockClient.On("RenameFolder", mock.Anything, &renameFolderReq, mock.Anything).Return(nil, errors.New("mock error"))
+	testSuite.mockClient.On("RenameFolder", mock.Anything, mock.MatchedBy(func(req *controlpb.RenameFolderRequest) bool {
+		return req.Name == renameFolderReq.Name && req.DestinationFolderId == renameFolderReq.DestinationFolderId
+	}), mock.Anything).Return(nil, errors.New("mock error"))
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	_, err := testSuite.bucketHandle.RenameFolder(ctx, TestFolderName, TestRenameFolder)
@@ -1690,7 +1700,9 @@ func (testSuite *BucketHandleTest) TestCreateFolderWithError() {
 		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
 	})
 	createFolderReq := controlpb.CreateFolderRequest{Parent: fmt.Sprintf(FullBucketPathHNS, TestBucketName), FolderId: TestFolderName, Recursive: true}
-	testSuite.mockClient.On("CreateFolder", context.Background(), &createFolderReq, mock.Anything).Return(nil, errors.New("mock error"))
+	testSuite.mockClient.On("CreateFolder", context.Background(), mock.MatchedBy(func(req *controlpb.CreateFolderRequest) bool {
+		return req.Parent == createFolderReq.Parent && req.FolderId == createFolderReq.FolderId
+	}), mock.Anything).Return(nil, errors.New("mock error"))
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	folder, err := testSuite.bucketHandle.CreateFolder(context.Background(), TestFolderName)
@@ -1708,7 +1720,9 @@ func (testSuite *BucketHandleTest) TestCreateFolderWithGivenName() {
 		Name: fmt.Sprintf(FullFolderPathHNS, TestBucketName, TestFolderName),
 	}
 	createFolderReq := controlpb.CreateFolderRequest{Parent: fmt.Sprintf(FullBucketPathHNS, TestBucketName), FolderId: TestFolderName, Recursive: true}
-	testSuite.mockClient.On("CreateFolder", context.Background(), &createFolderReq, mock.Anything).Return(&mockFolder, nil)
+	testSuite.mockClient.On("CreateFolder", context.Background(), mock.MatchedBy(func(req *controlpb.CreateFolderRequest) bool {
+		return req.Parent == createFolderReq.Parent && req.FolderId == createFolderReq.FolderId
+	}), mock.Anything).Return(&mockFolder, nil)
 	testSuite.bucketHandle.bucketType = &gcs.BucketType{Hierarchical: true}
 
 	folder, err := testSuite.bucketHandle.CreateFolder(context.Background(), TestFolderName)

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -113,7 +113,7 @@ func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Conte
 		return sccwros.raw.GetStorageLayout(attemptCtx, req, opts...)
 	}
 
-	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, apiCall, logger.LevelInfo)
+	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, logger.LevelInfo)
 }
 
 func (sccwros *storageControlClientWithRetry) DeleteFolder(ctx context.Context,
@@ -128,7 +128,7 @@ func (sccwros *storageControlClientWithRetry) DeleteFolder(ctx context.Context,
 		return struct{}{}, err
 	}
 
-	_, err := storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "DeleteFolder", req.Name, apiCall)
+	_, err := storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "DeleteFolder", req.Name, req.RequestId, apiCall)
 	return err
 }
 
@@ -143,7 +143,7 @@ func (sccwros *storageControlClientWithRetry) GetFolder(ctx context.Context,
 		return sccwros.raw.GetFolder(attemptCtx, req, opts...)
 	}
 
-	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "GetFolder", req.Name, apiCall)
+	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "GetFolder", req.Name, req.RequestId, apiCall)
 }
 
 func (sccwros *storageControlClientWithRetry) RenameFolder(ctx context.Context,
@@ -158,7 +158,7 @@ func (sccwros *storageControlClientWithRetry) RenameFolder(ctx context.Context,
 	}
 
 	reqDescription := fmt.Sprintf("%q to %q", req.Name, req.DestinationFolderId)
-	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "RenameFolder", reqDescription, apiCall)
+	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "RenameFolder", reqDescription, req.RequestId, apiCall)
 }
 
 func (sccwros *storageControlClientWithRetry) CreateFolder(ctx context.Context,
@@ -173,7 +173,7 @@ func (sccwros *storageControlClientWithRetry) CreateFolder(ctx context.Context,
 	}
 
 	reqDescription := fmt.Sprintf("%q in %q", req.FolderId, req.Parent)
-	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "CreateFolder", reqDescription, apiCall)
+	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "CreateFolder", reqDescription, req.RequestId, apiCall)
 }
 
 // newRetryWrapper creates a new StorageControlClient with retry capabilities.

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -197,7 +197,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_NonRetryableError()
 	// Assert
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), layout)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
@@ -346,7 +346,7 @@ func (t *AllApiRetryWrapperTest) TestGetStorageLayout_NonRetryableError() {
 	// Assert
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), layout)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
@@ -409,7 +409,7 @@ func (t *AllApiRetryWrapperTest) TestDeleteFolder_NonRetryableError() {
 
 	// Assert
 	assert.Error(t.T(), err)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
@@ -478,7 +478,7 @@ func (t *AllApiRetryWrapperTest) TestGetFolder_NonRetryableError() {
 	// Assert
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), folder)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
@@ -547,7 +547,7 @@ func (t *AllApiRetryWrapperTest) TestRenameFolder_NonRetryableError() {
 	// Assert
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), op)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
@@ -616,7 +616,7 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_NonRetryableError() {
 	// Assert
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), folder)
-	assert.Contains(t.T(), err.Error(), "failed with a non-retryable error")
+	assert.Contains(t.T(), err.Error(), "failed:")
 	assert.Contains(t.T(), err.Error(), nonRetryableErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -29,6 +29,7 @@ import (
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"cloud.google.com/go/storage/experimental"
+	"github.com/google/uuid"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
@@ -247,7 +248,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// Disable Go SDK retries for this call to let ExecuteWithRetry handle it.
 	sc.SetRetry(storage.WithMaxAttempts(1))
 
-	_, statErr := storageutil.ExecuteWithRetryAtLogLevel(ctx, retryConfig, "Attrs", testObject, apiCall, logger.LevelInfo)
+	_, statErr := storageutil.ExecuteWithRetryAtLogLevel(ctx, retryConfig, "Attrs", testObject, uuid.NewString(), apiCall, logger.LevelInfo)
 
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
@@ -371,7 +372,7 @@ func (sh *storageClient) getStorageLayout(bucketName string) (*controlpb.Storage
 	stoargeLayout, err := sh.storageControlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
 		Name:      fmt.Sprintf("projects/_/buckets/%s/storageLayout", bucketName),
 		Prefix:    "",
-		RequestId: "",
+		RequestId: uuid.NewString(),
 	}, callOptions...)
 
 	return stoargeLayout, err

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/oauth2adapt"
+	"github.com/google/uuid"
 	auth2 "github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"golang.org/x/oauth2"
@@ -64,7 +65,7 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 			return d, err
 		}
 
-		domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", apiCall, logger.LevelInfo)
+		domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, logger.LevelInfo)
 		if err != nil {
 			logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)
 			// Setting default universe domain to googleapis.com in case we are unable to fetch the domain.

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -79,16 +79,16 @@ func ShouldRetryWithoutLogging(err error) bool {
 // logging the retry warning with RetryContext (operation, object, attempt, invocation ID).
 // Returns true if the error is retryable, false otherwise.
 func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
-	if ShouldRetryWithoutLogging(err) {
-		if retryCtx != nil {
-			logger.Warnf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
-				retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
-		} else {
-			logger.Warnf("Retrying for error: %v", err)
-		}
-		return true
+	if !ShouldRetryWithoutLogging(err) {
+		return false
 	}
-	return false
+	if retryCtx != nil {
+		logger.Warnf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
+			retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
+	} else {
+		logger.Warnf("Retrying for error: %v", err)
+	}
+	return true
 }
 
 func ShouldRetryWithMonitoringAndRetryContext(

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -88,10 +88,6 @@ func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool
 		}
 		return true
 	}
-	if retryCtx != nil {
-		logger.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, with error: %v",
-			retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt, err)
-	}
 	return false
 }
 

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -82,12 +82,12 @@ func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool
 	if !ShouldRetryWithoutLogging(err) {
 		return false
 	}
-	if retryCtx != nil {
-		logger.Warnf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
-			retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
-	} else {
+	if retryCtx == nil {
 		logger.Warnf("Retrying for error: %v", err)
+		return true
 	}
+	logger.Warnf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
+		retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
 	return true
 }
 

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -76,28 +76,23 @@ func ShouldRetryWithoutLogging(err error) bool {
 }
 
 // ShouldRetryWithRetryContext checks if the given error is transient and should be retried,
-// logging the retry warning with RetryContext (operation, bucket, object, attempt, invocation ID).
+// logging the retry warning with RetryContext (operation, object, attempt, invocation ID).
 // Returns true if the error is retryable, false otherwise.
 func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
-	var prefix string
-	switch determineRetryAction(err) {
-	case retryTransient:
-		prefix = "Retrying for transient error"
-	case retry401:
-		prefix = "Retrying for error-code 401"
-	case retryUnauthenticated:
-		prefix = "Retrying for UNAUTHENTICATED error"
-	default:
-		return false
+	if ShouldRetryWithoutLogging(err) {
+		if retryCtx != nil {
+			logger.Warnf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
+				retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
+		} else {
+			logger.Warnf("Retrying for error: %v", err)
+		}
+		return true
 	}
-
 	if retryCtx != nil {
-		logger.Warnf("%s: %v, InvocationID: %s, Attempt: %d, Op: %s, Object: %q",
-			prefix, err, retryCtx.InvocationID, retryCtx.Attempt, retryCtx.Operation, retryCtx.Object)
-	} else {
-		logger.Warnf("%s: %v", prefix, err)
+		logger.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, with error: %v",
+			retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt, err)
 	}
-	return true
+	return false
 }
 
 func ShouldRetryWithMonitoringAndRetryContext(

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -287,7 +287,7 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	// Assert
 	assert.True(t, retry)
 	assert.Contains(t, buf.String(), "WARNING")
-	assert.Contains(t, buf.String(), "Retrying for error-code 401")
+	assert.Contains(t, buf.String(), "Retrying for error: googleapi: got HTTP response code 401")
 }
 
 func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
@@ -314,11 +314,10 @@ func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
 	assert.True(t, retry)
 	logMsg := buf.String()
 	assert.Contains(t, logMsg, "WARNING")
-	assert.Contains(t, logMsg, "Retrying for error-code 401")
-	assert.Contains(t, logMsg, "Invalid Credential")
-	assert.Contains(t, logMsg, "Op: GetObject, Object: ")
+	assert.Contains(t, logMsg, "Retrying GetObject for")
 	assert.Contains(t, logMsg, "some/file.txt")
-	assert.Contains(t, logMsg, "Attempt: 3")
+	assert.Contains(t, logMsg, "Invalid Credential")
+	assert.Contains(t, logMsg, "Attempt: 4")
 	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")
 }
 
@@ -339,7 +338,7 @@ func TestShouldRetryLogsWarningWithNilRetryContext(t *testing.T) {
 	assert.True(t, retry)
 	logMsg := buf.String()
 	assert.Contains(t, logMsg, "WARNING")
-	assert.Contains(t, logMsg, "Retrying for error-code 401: googleapi: Error 401: Invalid Credential")
+	assert.Contains(t, logMsg, "Retrying for error: googleapi: Error 401: Invalid Credential")
 	assert.NotContains(t, logMsg, "Op:")
 	assert.NotContains(t, logMsg, "Object:")
 	assert.NotContains(t, logMsg, "Attempt:")

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -127,6 +127,7 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
+	requestID string,
 	apiCall func(attemptCtx context.Context) (T, error),
 	shouldRetry func(err error) bool,
 	logLevel slog.Level, // Used to log the initial attempt at the supplied log level. Subsequent retries are logged at Warning level.
@@ -143,13 +144,12 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 	// Create a new backoff controller specific to this api call.
 	backoff := newExponentialBackoff(&config.BackoffConfig)
 	var lastErr error
-	for i := 0; ; i++ {
+	for attemptNum := 1; ; attemptNum++ {
 		attemptCtx, attemptCancel := context.WithTimeout(parentCtx, config.RetryDeadline)
-
-		if i == 0 {
-			logger.GetLogFHandler(logLevel)("Calling %s request for %q with deadline=%v", operationName, reqDescription, config.RetryDeadline)
+		if attemptNum == 1 {
+			logger.GetLogFHandler(logLevel)("Calling %s for %q: InvocationID: %s, Attempt: %d, with deadline=%v", operationName, reqDescription, requestID, attemptNum, config.RetryDeadline)
 		} else {
-			logger.GetLogFHandler(logger.LevelWarn)("Retrying %s for %q with deadline=%v (error: %v) ...", operationName, reqDescription, config.RetryDeadline, lastErr)
+			logger.GetLogFHandler(logger.LevelWarn)("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v", operationName, reqDescription, requestID, attemptNum, lastErr)
 		}
 
 		result, err := apiCall(attemptCtx)
@@ -161,24 +161,24 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 			return result, nil
 		}
 
-		if config.MaxAttempts > 0 && i+1 >= config.MaxAttempts {
-			return zero, fmt.Errorf("%s for %q failed after %d attempts (last server/client error = %v)", operationName, reqDescription, config.MaxAttempts, err)
+		if config.MaxAttempts > 0 && attemptNum >= config.MaxAttempts {
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, MaxAttempts: %d, with error: %w", operationName, reqDescription, requestID, attemptNum, config.MaxAttempts, err)
 		}
 
 		// If the error is not retryable, return it immediately.
 		if !shouldRetry(err) {
-			return zero, fmt.Errorf("%s for %q failed with a non-retryable error: %w", operationName, reqDescription, err)
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, with error: %w", operationName, reqDescription, requestID, attemptNum, err)
 		}
 
 		// If the parent context is cancelled/timed-out, we should stop retrying.
 		if parentCtx.Err() != nil {
-			return zero, fmt.Errorf("%s for %q failed after multiple retries (last server/client error = %v): %w", operationName, reqDescription, err, parentCtx.Err())
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, parentCtx.Err())
 		}
 
 		// Do a jittery backoff after each retry.
 		parentCtxErr := backoff.waitWithJitter(parentCtx)
 		if parentCtxErr != nil {
-			return zero, fmt.Errorf("%s for %q failed after multiple retries (last server/client error = %v): %w", operationName, reqDescription, err, parentCtxErr)
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, parentCtxErr)
 		}
 	}
 }
@@ -189,10 +189,11 @@ func ExecuteWithCustomShouldRetry[T any](
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
+	requestID string,
 	apiCall func(attemptCtx context.Context) (T, error),
 	shouldRetry func(err error) bool,
 ) (T, error) {
-	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, shouldRetry, logger.LevelTrace)
+	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, requestID, apiCall, shouldRetry, logger.LevelTrace)
 }
 
 // ExecuteWithRetryAtLogLevel encapsulates the retry logic over a given operation.
@@ -206,10 +207,11 @@ func ExecuteWithRetryAtLogLevel[T any](
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
+	requestID string,
 	apiCall func(attemptCtx context.Context) (T, error),
 	logLevel slog.Level, // Used to log the initial attempt at the supplied log level. Subsequent retries are logged at Warning level.
 ) (T, error) {
-	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, apiCall, ShouldRetryWithoutLogging, logLevel)
+	return ExecuteWithCustomShouldRetryAtLogLevel(ctx, config, operationName, reqDescription, requestID, apiCall, ShouldRetryWithoutLogging, logLevel)
 }
 
 // ExecuteWithRetry retries a given operation, logging the initial attempt at trace level.
@@ -218,7 +220,8 @@ func ExecuteWithRetry[T any](
 	config *RetryConfig,
 	operationName string,
 	reqDescription string,
+	requestID string,
 	apiCall func(attemptCtx context.Context) (T, error),
 ) (T, error) {
-	return ExecuteWithCustomShouldRetry(ctx, config, operationName, reqDescription, apiCall, ShouldRetryWithoutLogging)
+	return ExecuteWithCustomShouldRetry(ctx, config, operationName, reqDescription, requestID, apiCall, ShouldRetryWithoutLogging)
 }

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -266,7 +267,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_SuccessOnFirstAttempt()
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.NoError(t.T(), err)
@@ -287,7 +288,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_SuccessAfterRetry() {
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.NoError(t.T(), err)
@@ -305,7 +306,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_FailureOnNonRetryableEr
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, nonRetryableErr)
@@ -327,7 +328,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_RetryableThenNonRetryab
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, nonRetryableErr)
@@ -353,7 +354,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
 	}
 
 	// Act
-	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "Expected context.DeadlineExceeded because each attempt is designed to "+
@@ -373,7 +374,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_TotalRetryBudgetExceede
 	}
 
 	// Act
-	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from the total retry budget timeout")
@@ -404,7 +405,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutSho
 	// The parent context will be checked within ExecuteWithRetry before the first attempt,
 	// but the attempt will still proceed. The attempt's context will expire
 	// due to the parent's timeout.
-	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from the parent context's timeout")
@@ -431,7 +432,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutBet
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from the parent context's timeout")
@@ -454,7 +455,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutLon
 	}
 
 	// Act
-	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", apiCall)
+	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from context created in ExecuteWithRetry")
@@ -472,7 +473,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextAlreadyCan
 	}
 
 	// Act
-	_, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", apiCall)
+	_, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, context.Canceled)
@@ -490,11 +491,13 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_MaxAttemptsReached() {
 	}
 
 	// Act
-	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall)
+	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
 
 	// Assert
 	assert.Error(t.T(), err)
-	assert.Contains(t.T(), err.Error(), "failed after 2 attempts")
+	assert.Contains(t.T(), err.Error(), "testOp for \"testReq\" failed: ")
+	assert.Contains(t.T(), err.Error(), "InvocationID: test-request-id")
+	assert.Contains(t.T(), err.Error(), "Attempt: 2")
 	assert.Equal(t.T(), 2, callCount, "apiCall should have been called exactly 2 times")
 }
 
@@ -514,7 +517,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_SuccessWith
 	}
 
 	// Act
-	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall, customShouldRetry)
 
 	// Assert
 	assert.NoError(t.T(), err)
@@ -536,7 +539,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_FailWithCus
 	}
 
 	// Act
-	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall, customShouldRetry)
 
 	// Assert
 	assert.ErrorIs(t.T(), err, defaultRetryableErr)
@@ -559,13 +562,13 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_Composition
 		}
 		return "success", nil
 	}
-	// Wrap default ShouldRetry and also allow customErr
+	// Wrap default ShouldRetryWithoutLogging and also allow customErr
 	customShouldRetry := func(err error) bool {
 		return ShouldRetryWithRetryContext(err, nil) || errors.Is(err, customErr)
 	}
 
 	// Act
-	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry)
+	result, err := ExecuteWithCustomShouldRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall, customShouldRetry)
 
 	// Assert
 	assert.NoError(t.T(), err)
@@ -594,7 +597,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_LogsErrorContext() {
 
 	// Act
 	// Call ExecuteWithCustomShouldRetryAtLogLevel with LevelWarn, so we can capture the Retrying log
-	_, err := ExecuteWithCustomShouldRetryAtLogLevel(context.Background(), t.retryConfig, "testOp", "testReq", apiCall, customShouldRetry, logger.LevelWarn)
+	_, err := ExecuteWithCustomShouldRetryAtLogLevel(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall, customShouldRetry, logger.LevelWarn)
 
 	// Assert
 	assert.NoError(t.T(), err)
@@ -602,4 +605,68 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_LogsErrorContext() {
 	assert.Contains(t.T(), buf.String(), "Retrying testOp")
 	assert.Contains(t.T(), buf.String(), "testReq")
 	assert.Contains(t.T(), buf.String(), "transient failure 429")
+}
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_AttemptNumberIncreases() {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	var callCount int
+	retryableErr := errors.New("transient failure")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount < 3 {
+			return "", retryableErr
+		}
+		return "success", nil
+	}
+	customShouldRetry := func(err error) bool {
+		return err.Error() == "transient failure"
+	}
+
+	// Act
+	_, err := ExecuteWithCustomShouldRetryAtLogLevel(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall, customShouldRetry, logger.LevelWarn)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 3, callCount)
+	logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t.T(), logLines, 3)
+	// Chronological assertion: attempt 2 (line index 1) must come before attempt 3 (line index 2).
+	assert.Contains(t.T(), logLines[1], "Attempt: 2")
+	assert.Contains(t.T(), logLines[2], "Attempt: 3")
+}
+
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_RequestIDSameAcrossRetries() {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	var callCount int
+	retryableErr := errors.New("transient failure")
+	apiCall := func(ctx context.Context) (string, error) {
+		callCount++
+		if callCount < 3 {
+			return "", retryableErr
+		}
+		return "success", nil
+	}
+	customShouldRetry := func(err error) bool {
+		return err.Error() == "transient failure"
+	}
+	expectedRequestID := "unique-request-id-12345"
+
+	// Act
+	_, err := ExecuteWithCustomShouldRetryAtLogLevel(context.Background(), t.retryConfig, "testOp", "testReq", expectedRequestID, apiCall, customShouldRetry, logger.LevelWarn)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), 3, callCount)
+	logLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t.T(), logLines, 3)
+	// Verify that the request ID is identical and present across every single attempt (initial call log + retries)
+	for _, line := range logLines {
+		assert.Contains(t.T(), line, "InvocationID: "+expectedRequestID)
+	}
 }


### PR DESCRIPTION
### Description
This PR introduces request tracking context propagation across all retry execution pathways and hierarchical namespace (HNS) folder operations. It stamps every storage operation event, retry warning, and returned failure log with its corresponding unique request_id, making log correlation, diagnostic tracking, and end-to-end operational debugging significantly easier.

### Link to the issue in case of a bug fix.
b/515611772

### Testing details
1. Manual - NA
2. Unit tests - Yes
3. Integration tests - Part of pre-submit

### Any backward incompatible change? If so, please explain.
