### PR TITLE
test(cloud_profiler test): Fix Cloud Profiler label and service name parsing for comma-separated for GKE env.

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -848,7 +848,7 @@ func IsDynamicMount(mountDir, rootDir string) bool {
 // ExtractServiceVersionFromFlags parses the cloud-profiler-label from a slice of flag strings.
 func ExtractServiceVersionFromFlags(flags []string) string {
 	// Regex to find --cloud-profiler-label=some_value or --cloud-profiler-label some_value
-	re := regexp.MustCompile(`--cloud-profiler-label[=\s]([^\s]+)`)
+	re := regexp.MustCompile(`--cloud-profiler-label[=\s]([^,\s]+)`)
 	for _, flagSet := range flags {
 		matches := re.FindStringSubmatch(flagSet)
 		// matches[0] is the full match, e.g., "--cloud-profiler-label=v1"
@@ -864,7 +864,7 @@ func ExtractServiceVersionFromFlags(flags []string) string {
 // CloudProfilerServiceNameFromFlags parses the cloud-profiler-service-name from a slice of flag strings.
 func CloudProfilerServiceNameFromFlags(flags []string) string {
 	// Regex to find --cloud-profiler-service-name=some_value or --cloud-profiler-service-name some_value
-	re := regexp.MustCompile(`--cloud-profiler-service-name[=\s]([^\s]+)`)
+	re := regexp.MustCompile(`--cloud-profiler-service-name[=\s]([^,\s]+)`)
 	for _, flagSet := range flags {
 		matches := re.FindStringSubmatch(flagSet)
 		// matches[0] is the full match, e.g., "--cloud-profiler-service-name=v1"


### PR DESCRIPTION
### Description
This change fixes the parsing of Cloud Profiler labels and service names in gcsfuse when they are provided as part of comma-separated GKE mount options.

The modifications were made in the file `tools/integration_tests/util/setup/setup.go` within the **ExtractServiceVersionFromFlags** and **CloudProfilerServiceNameFromFlags** functions. 
Specifically, the regular expression used to capture flag values was updated from **[^\s]+** (which matches any non-whitespace character) to **[^,\s]+** to explicitly exclude commas. This ensures that the parser stops at the next comma, preventing it from incorrectly including subsequent flags in the captured value.

Without this change
```
with_gcp_profiler_service_test.go:134: Waiting for cloud profile to eventually appear for 
service [1kjzx9mh3peea-cloud-profiler-test] and 
version [1kjzx9mh3peea-cloud-profiler-test,--cloud-profiler-service-name=1kjzx9mh3peea-cloud-profiler-test]
```

With this change
```
with_gcp_profiler_service_test.go:134: Waiting for cloud profile to eventually appear for 
service [1kjzx2eudng1c-cloud-profiler-test] and 
version [1kjzx2eudng1c-cloud-profiler-test]
```

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/512210213

### Testing details
1. Manual - via GKE
2. Integration tests - Kokoro

### Any backward incompatible change? If so, please explain.
NA